### PR TITLE
Adding `percentage` metric to aggregations.

### DIFF
--- a/changelog/unreleased/pr-15738.toml
+++ b/changelog/unreleased/pr-15738.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Implementing `percentage` metric for aggregations."
+
+pulls = ["15738"]
+issues = ["6763"]

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
@@ -747,10 +747,10 @@ public class SearchAggregationsIT {
         final String searchTypeResult = PIVOT_PATH + ".rows";
         validatableResponse
                 .rootPath(searchTypeResult)
-                .body(pathToMetricResult("GET", "percentage(,COUNT)"), equalTo(0.86))
-                .body(pathToMetricResult("DELETE", "percentage(,COUNT)"), equalTo(0.052))
-                .body(pathToMetricResult("POST", "percentage(,COUNT)"), equalTo(0.045))
-                .body(pathToMetricResult("PUT", "percentage(,COUNT)"), equalTo(0.043));
+                .body(pathToMetricResult("GET", "percentage(,COUNT)"), equalTo(0.86f))
+                .body(pathToMetricResult("DELETE", "percentage(,COUNT)"), equalTo(0.052f))
+                .body(pathToMetricResult("POST", "percentage(,COUNT)"), equalTo(0.045f))
+                .body(pathToMetricResult("PUT", "percentage(,COUNT)"), equalTo(0.043f));
     }
 
     @ContainerMatrixTest
@@ -764,15 +764,15 @@ public class SearchAggregationsIT {
         final ValidatableResponse validatableResponse = execute(pivot);
 
         validatableResponse.rootPath(PIVOT_PATH)
-                .body("rows", hasSize(4));
+                .body("rows", hasSize(5));
 
         final String searchTypeResult = PIVOT_PATH + ".rows";
         validatableResponse
                 .rootPath(searchTypeResult)
-                .body(pathToMetricResult("GET", "percentage(http_method,COUNT)"), equalTo(0.86))
-                .body(pathToMetricResult("DELETE", "percentage(http_method,COUNT)"), equalTo(0.052))
-                .body(pathToMetricResult("POST", "percentage(http_method,COUNT)"), equalTo(0.045))
-                .body(pathToMetricResult("PUT", "percentage(http_method,COUNT)"), equalTo(0.043));
+                .body(pathToMetricResult("GET", "percentage(http_method,COUNT)"), equalTo(0.86f))
+                .body(pathToMetricResult("DELETE", "percentage(http_method,COUNT)"), equalTo(0.052f))
+                .body(pathToMetricResult("POST", "percentage(http_method,COUNT)"), equalTo(0.045f))
+                .body(pathToMetricResult("PUT", "percentage(http_method,COUNT)"), equalTo(0.043f));
     }
 
     @ContainerMatrixTest
@@ -786,15 +786,15 @@ public class SearchAggregationsIT {
         final ValidatableResponse validatableResponse = execute(pivot);
 
         validatableResponse.rootPath(PIVOT_PATH)
-                .body("rows", hasSize(4));
+                .body("rows", hasSize(5));
 
         final String searchTypeResult = PIVOT_PATH + ".rows";
         validatableResponse
                 .rootPath(searchTypeResult)
-                .body(pathToMetricResult("GET", "percentage(took_ms,SUM)"), equalTo(0.86))
-                .body(pathToMetricResult("DELETE", "percentage(took_ms,SUM)"), equalTo(0.052))
-                .body(pathToMetricResult("POST", "percentage(took_ms,SUM)"), equalTo(0.045))
-                .body(pathToMetricResult("PUT", "percentage(took_ms,SUM)"), equalTo(0.043));
+                .body(pathToMetricResult("GET", "percentage(took_ms,SUM)"), equalTo(0.689713f))
+                .body(pathToMetricResult("DELETE", "percentage(took_ms,SUM)"), equalTo(0.04857759715519431f))
+                .body(pathToMetricResult("POST", "percentage(took_ms,SUM)"), equalTo(0.148501397002794f))
+                .body(pathToMetricResult("PUT", "percentage(took_ms,SUM)"), equalTo(0.11320802641605283f));
     }
 
     private String listToGroovy(Collection<String> strings) {

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
@@ -776,6 +776,28 @@ public class SearchAggregationsIT {
     }
 
     @ContainerMatrixTest
+    void testPercentageMetricWithCountOnFieldForColumnPivotOnly() {
+        final Pivot pivot = Pivot.builder()
+                .rollup(true)
+                .columnGroups(Values.builder().field("http_method").build())
+                .series(Percentage.builder().strategy(Percentage.Strategy.COUNT).field("http_method").build())
+                .build();
+
+        final ValidatableResponse validatableResponse = execute(pivot);
+
+        validatableResponse.rootPath(PIVOT_PATH)
+                .body("rows", hasSize(1));
+
+        final String searchTypeResult = PIVOT_PATH + ".rows";
+        validatableResponse
+                .rootPath(searchTypeResult)
+                .body(pathToMetricResult(List.of(), List.of("GET", "percentage(http_method,COUNT)")), equalTo(0.86f))
+                .body(pathToMetricResult(List.of(), List.of("DELETE", "percentage(http_method,COUNT)")), equalTo(0.052f))
+                .body(pathToMetricResult(List.of(), List.of("POST", "percentage(http_method,COUNT)")), equalTo(0.045f))
+                .body(pathToMetricResult(List.of(), List.of("PUT", "percentage(http_method,COUNT)")), equalTo(0.043f));
+    }
+
+    @ContainerMatrixTest
     void testPercentageMetricWithSumOnField() {
         final Pivot pivot = Pivot.builder()
                 .rollup(true)

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
@@ -41,6 +41,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Latest;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Min;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.StdDev;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
@@ -54,9 +55,9 @@ import org.graylog.storage.elasticsearch7.views.export.RequestStrategy;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESEventList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESMessageList;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivot;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotBucketSpecHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
-import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivot;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets.ESDateRangeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets.ESTimeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets.ESValuesHandler;
@@ -66,6 +67,7 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESCount
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESLatestHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESMaxHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESMinHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESPercentageHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESPercentilesHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESStdDevHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series.ESSumHandler;
@@ -100,6 +102,7 @@ public class ViewsESBackendModule extends ViewsModule {
         registerPivotSeriesHandler(Sum.NAME, ESSumHandler.class);
         registerPivotSeriesHandler(SumOfSquares.NAME, ESSumOfSquaresHandler.class);
         registerPivotSeriesHandler(Variance.NAME, ESVarianceHandler.class);
+        registerPivotSeriesHandler(Percentage.NAME, ESPercentageHandler.class);
         registerPivotSeriesHandler(Percentile.NAME, ESPercentilesHandler.class);
         registerPivotSeriesHandler(Latest.NAME, ESLatestHandler.class);
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -48,6 +48,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ESPivot implements ESSearchTypeHandler<Pivot> {
@@ -92,7 +93,8 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                 .forEach(result -> {
                     switch (result.placement()) {
                         case PIVOT -> metrics.forEach(metric -> metric.subAggregation(result.aggregationBuilder()));
-                        case ROOT -> rootAggregation.subAggregation(result.aggregationBuilder());
+                        case ROOT ->
+                                Optional.ofNullable(rootAggregation).ifPresent(root -> root.subAggregation(result.aggregationBuilder()));
                     }
                 });
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -39,7 +39,6 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.Search
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,33 +128,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
-    }
-
-    private List<Tuple2<String, List<BucketSpec>>> groupByConsecutiveType(List<BucketSpec> pivots) {
-        final List<Tuple2<String, List<BucketSpec>>> groups = new ArrayList<>();
-
-        List<BucketSpec> currentBuckets = new ArrayList<>();
-        String currentType = null;
-
-        for (BucketSpec bucketSpec : pivots) {
-            if (bucketSpec.type().equals(currentType)) {
-                currentBuckets.add(bucketSpec);
-            } else {
-                if (!currentBuckets.isEmpty()) {
-                    groups.add(new Tuple2<>(currentType, currentBuckets));
-                }
-
-                currentBuckets = new ArrayList<>();
-                currentBuckets.add(bucketSpec);
-                currentType = bucketSpec.type();
-            }
-        }
-
-        if (!currentBuckets.isEmpty()) {
-            groups.add(new Tuple2<>(currentType, currentBuckets));
-        }
-
-        return groups;
     }
 
     private BucketSpecHandler.CreatedAggregations<AggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, ESGeneratedQueryContext queryContext) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -160,7 +160,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         return BucketSpecHandler.CreatedAggregations.create(root, leaf, metrics);
     }
 
-
     private Stream<SeriesAggregationBuilder> seriesStream(Pivot pivot, ESGeneratedQueryContext queryContext, String reason) {
         return pivot.series()
                 .stream()
@@ -228,7 +227,6 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
         for (BucketSpec bucketSpec : pivots) {
             result = result.flatMap((tuple) -> {
                 final ESPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
-
                 return bucketHandler.extractBuckets(pivot, bucketSpec, tuple);
             });
         }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
@@ -41,7 +41,7 @@ public abstract class ESPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGG
         aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
     }
 
-    protected Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
         return aggTypes(queryContext, pivot).getSubAggregation(spec, aggregations);
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
@@ -24,7 +24,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpecHandler;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
@@ -32,7 +31,7 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import java.util.stream.Stream;
 
 public abstract class ESPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_RESULT extends Aggregation>
-        implements SeriesSpecHandler<SPEC_TYPE, AggregationBuilder, SearchResponse, AGGREGATION_RESULT, ESSearchTypeHandler<Pivot>, ESGeneratedQueryContext> {
+        implements SeriesSpecHandler<SPEC_TYPE, SeriesAggregationBuilder, SearchResponse, AGGREGATION_RESULT, ESSearchTypeHandler<Pivot>, ESGeneratedQueryContext> {
 
     protected AggTypes aggTypes(ESGeneratedQueryContext queryContext, Pivot pivot) {
         return (AggTypes) queryContext.contextMap().get(pivot.id());

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/SeriesAggregationBuilder.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/SeriesAggregationBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7.views.searchtypes.pivot;
+
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
+
+enum Placement {
+    ROOT,
+    PIVOT
+}
+
+public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Placement placement) {
+    public static SeriesAggregationBuilder root(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROOT);
+    }
+
+    public static SeriesAggregationBuilder pivot(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.PIVOT);
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/SeriesAggregationBuilder.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/SeriesAggregationBuilder.java
@@ -20,7 +20,9 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.A
 
 enum Placement {
     ROOT,
-    PIVOT
+    ROW,
+    COLUMN,
+    METRIC
 }
 
 public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Placement placement) {
@@ -28,7 +30,15 @@ public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Pl
         return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROOT);
     }
 
-    public static SeriesAggregationBuilder pivot(AggregationBuilder aggregationBuilder) {
-        return new SeriesAggregationBuilder(aggregationBuilder, Placement.PIVOT);
+    public static SeriesAggregationBuilder metric(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.METRIC);
+    }
+
+    public static SeriesAggregationBuilder row(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROW);
+    }
+
+    public static SeriesAggregationBuilder column(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.COLUMN);
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESAverageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESAverageHandler.java
@@ -37,7 +37,7 @@ public class ESAverageHandler extends ESPivotSeriesSpecHandler<Average, Avg> {
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final AvgAggregationBuilder avg = AggregationBuilders.avg(name).field(avgSpec.field());
         record(queryContext, pivot, avgSpec, name, Avg.class);
-        return List.of(SeriesAggregationBuilder.pivot(avg));
+        return List.of(SeriesAggregationBuilder.metric(avg));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESAverageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESAverageHandler.java
@@ -19,25 +19,25 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Avg;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESAverageHandler extends ESPivotSeriesSpecHandler<Average, Avg> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final AvgAggregationBuilder avg = AggregationBuilders.avg(name).field(avgSpec.field());
         record(queryContext, pivot, avgSpec, name, Avg.class);
-        return Optional.of(avg);
+        return List.of(SeriesAggregationBuilder.pivot(avg));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCardinalityHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCardinalityHandler.java
@@ -36,7 +36,7 @@ public class ESCardinalityHandler extends ESPivotSeriesSpecHandler<Cardinality, 
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final CardinalityAggregationBuilder card = AggregationBuilders.cardinality(name).field(cardinalitySpec.field());
         record(queryContext, pivot, cardinalitySpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Cardinality.class);
-        return List.of(SeriesAggregationBuilder.pivot(card));
+        return List.of(SeriesAggregationBuilder.metric(card));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCardinalityHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCardinalityHandler.java
@@ -19,24 +19,24 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Cardinality;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESCardinalityHandler extends ESPivotSeriesSpecHandler<Cardinality, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Cardinality> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final CardinalityAggregationBuilder card = AggregationBuilders.cardinality(name).field(cardinalitySpec.field());
         record(queryContext, pivot, cardinalitySpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Cardinality.class);
-        return Optional.of(card);
+        return List.of(SeriesAggregationBuilder.pivot(card));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
@@ -57,7 +57,7 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
             // the request was for a field count, we have to add a value_count sub aggregation
             final ValueCountAggregationBuilder value = AggregationBuilders.count(name).field(field);
             record(queryContext, pivot, count, name, ValueCount.class);
-            return List.of(SeriesAggregationBuilder.pivot(value));
+            return List.of(SeriesAggregationBuilder.metric(value));
         }
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.XContentBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregations;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
@@ -33,14 +32,15 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.m
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> {
@@ -48,16 +48,16 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
 
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count count, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count count, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final String field = count.field();
         if (field == null) {
             // doc_count is always present in elasticsearch's bucket aggregations, no need to add it
-            return Optional.empty();
+            return List.of();
         } else {
             // the request was for a field count, we have to add a value_count sub aggregation
             final ValueCountAggregationBuilder value = AggregationBuilders.count(name).field(field);
             record(queryContext, pivot, count, name, ValueCount.class);
-            return Optional.of(value);
+            return List.of(SeriesAggregationBuilder.pivot(value));
         }
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
@@ -83,7 +83,7 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
     }
 
     @Override
-    protected Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
         final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
         if (objects == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
@@ -50,7 +50,7 @@ public class ESLatestHandler extends ESPivotSeriesSpecHandler<Latest, ParsedFilt
                         .fetchSource(latestSpec.field(), null)
                         .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC)));
         record(queryContext, pivot, latestSpec, name, ParsedFilter.class);
-        return List.of(SeriesAggregationBuilder.pivot(latest));
+        return List.of(SeriesAggregationBuilder.metric(latest));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESLatestHandler.java
@@ -22,7 +22,6 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchR
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.SearchHit;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.SearchHits;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
@@ -32,8 +31,10 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.SortOrder
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -42,14 +43,14 @@ public class ESLatestHandler extends ESPivotSeriesSpecHandler<Latest, ParsedFilt
 
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Latest latestSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Latest latestSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final FilterAggregationBuilder latest = AggregationBuilders.filter(name, QueryBuilders.existsQuery(latestSpec.field()))
                 .subAggregation(AggregationBuilders.topHits(AGG_NAME)
                         .size(1)
                         .fetchSource(latestSpec.field(), null)
                         .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC)));
         record(queryContext, pivot, latestSpec, name, ParsedFilter.class);
-        return Optional.of(latest);
+        return List.of(SeriesAggregationBuilder.pivot(latest));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMaxHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMaxHandler.java
@@ -19,24 +19,24 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESMaxHandler extends ESPivotSeriesSpecHandler<Max, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Max> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final MaxAggregationBuilder max = AggregationBuilders.max(name).field(maxSpec.field());
         record(queryContext, pivot, maxSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Max.class);
-        return Optional.of(max);
+        return List.of(SeriesAggregationBuilder.pivot(max));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMaxHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMaxHandler.java
@@ -36,7 +36,7 @@ public class ESMaxHandler extends ESPivotSeriesSpecHandler<Max, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final MaxAggregationBuilder max = AggregationBuilders.max(name).field(maxSpec.field());
         record(queryContext, pivot, maxSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Max.class);
-        return List.of(SeriesAggregationBuilder.pivot(max));
+        return List.of(SeriesAggregationBuilder.metric(max));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMinHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMinHandler.java
@@ -19,24 +19,24 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Min;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESMinHandler extends ESPivotSeriesSpecHandler<Min, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Min> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final MinAggregationBuilder min = AggregationBuilders.min(name).field(minSpec.field());
         record(queryContext, pivot, minSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Min.class);
-        return Optional.of(min);
+        return List.of(SeriesAggregationBuilder.pivot(min));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMinHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESMinHandler.java
@@ -36,7 +36,7 @@ public class ESMinHandler extends ESPivotSeriesSpecHandler<Min, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final MinAggregationBuilder min = AggregationBuilders.min(name).field(minSpec.field());
         record(queryContext, pivot, minSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Min.class);
-        return List.of(SeriesAggregationBuilder.pivot(min));
+        return List.of(SeriesAggregationBuilder.metric(min));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -59,9 +59,9 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         var aggregation = createNestedSeriesAggregation(name, pivot, percentage, searchTypeHandler, queryContext);
         return Stream.concat(
-                Stream.concat(aggregation.stream(),
-                        aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))),
-                aggregation.stream().map(r -> SeriesAggregationBuilder.column(r.aggregationBuilder()))
+                aggregation.stream(),
+                aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))
+                //aggregation.stream().map(r -> SeriesAggregationBuilder.row(r.aggregationBuilder()))
         ).toList();
     }
 
@@ -123,7 +123,8 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
             value = valueCount.getValue();
         }
 
-        var rootResult = extractNestedSeriesAggregation(pivot, percentage, InitialBucket.create(searchResult), esGeneratedQueryContext);
+        var initialBucket = esGeneratedQueryContext.rowBucket().orElseGet(() -> InitialBucket.create(searchResult));
+        var rootResult = extractNestedSeriesAggregation(pivot, percentage, initialBucket, esGeneratedQueryContext);
         var nestedSeriesResult = handleNestedSeriesResults(pivot, percentage, searchResult, rootResult, searchTypeHandler, esGeneratedQueryContext);
 
         return nestedSeriesResult.map(result -> {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -1,0 +1,117 @@
+package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
+
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.XContentBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregations;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.missing.Missing;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ValueCount;
+import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
+import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.jooq.lambda.tuple.Tuple2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, ValueCount> {
+    private static final Logger LOG = LoggerFactory.getLogger(ESCountHandler.class);
+
+    @Nonnull
+    @Override
+    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Stream<Value> doHandleResult(Pivot pivot,
+                                        Percentage percentage,
+                                        SearchResponse searchResult,
+                                        ValueCount valueCount,
+                                        ESSearchTypeHandler<Pivot> searchTypeHandler,
+                                        ESGeneratedQueryContext esGeneratedQueryContext) {
+        final long value;
+        if (valueCount == null) {
+            LOG.error("Unexpected null aggregation result, returning 0 for the count. This is a bug.");
+            value = 0;
+        } else if (valueCount instanceof MultiBucketsAggregation.Bucket) {
+            value = ((MultiBucketsAggregation.Bucket) valueCount).getDocCount();
+        } else if (valueCount instanceof Aggregations) {
+            value = searchResult.getHits().getTotalHits().value;
+        } else {
+            value = valueCount.getValue();
+        }
+
+        var totalCount = searchResult.getHits().getTotalHits().value;
+        var bucketPercentage = (double) value / totalCount;
+        return Stream.of(Value.create(percentage.id(), Percentage.NAME, bucketPercentage));
+    }
+
+    @Override
+    protected Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
+        final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
+        if (objects == null) {
+            if (aggregations instanceof MultiBucketsAggregation.Bucket) {
+                return createValueCount(((MultiBucketsAggregation.Bucket) aggregations).getDocCount());
+            } else if (aggregations instanceof Missing) {
+                return createValueCount(((Missing) aggregations).getDocCount());
+            }
+        } else {
+            // try to saved sub aggregation type. this might fail if we refer to the total result of the entire result instead of a specific
+            // value_count aggregation. we'll handle that special case in doHandleResult above
+            return aggregations.getAggregations().get(objects.v1);
+        }
+
+        return null;
+    }
+
+    private Aggregation createValueCount(final Long docCount) {
+        return new ValueCount() {
+            @Override
+            public long getValue() {
+                return docCount;
+            }
+
+            @Override
+            public double value() {
+                return docCount;
+            }
+
+            @Override
+            public String getValueAsString() {
+                return docCount.toString();
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public String getType() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> getMetadata() {
+                return null;
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+                return null;
+            }
+        };
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -18,7 +18,6 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
@@ -63,19 +62,6 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
                 aggregation.stream(),
                 aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))
         ).toList();
-    }
-
-    private SeriesSpec nestedSeriesSpec(Percentage percentage) {
-        return switch (percentage.strategy().orElse(Percentage.Strategy.COUNT)) {
-            case SUM -> {
-                var seriesSpecBuilder = Sum.builder().id(percentage.id());
-                yield percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
-            }
-            case COUNT -> {
-                var seriesSpecBuilder = Count.builder().id(percentage.id());
-                yield percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
-            }
-        };
     }
 
     private List<SeriesAggregationBuilder> createNestedSeriesAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -6,7 +6,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.XContentBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregations;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
@@ -15,14 +14,15 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.m
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, ValueCount> {
@@ -30,8 +30,8 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
 
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
-        return Optional.empty();
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+        return List.of();
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -61,7 +61,6 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
         return Stream.concat(
                 aggregation.stream(),
                 aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))
-                //aggregation.stream().map(r -> SeriesAggregationBuilder.row(r.aggregationBuilder()))
         ).toList();
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -32,13 +32,13 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.m
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.InitialBucket;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -122,7 +122,7 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
             value = valueCount.getValue();
         }
 
-        var rootResult = extractNestedSeriesAggregation(pivot, percentage, createMultiBucket(searchResult), esGeneratedQueryContext);
+        var rootResult = extractNestedSeriesAggregation(pivot, percentage, InitialBucket.create(searchResult), esGeneratedQueryContext);
         var nestedSeriesResult = handleNestedSeriesResults(pivot, percentage, searchResult, rootResult, searchTypeHandler, esGeneratedQueryContext);
 
         return nestedSeriesResult.map(result -> {
@@ -130,35 +130,6 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
                     return value / totalResult.doubleValue();
                 })
                 .map(bucketPercentage -> Value.create(percentage.id(), Percentage.NAME, bucketPercentage));
-    }
-
-    private MultiBucketsAggregation.Bucket createMultiBucket(SearchResponse searchResult) {
-        return new MultiBucketsAggregation.Bucket() {
-            @Override
-            public Object getKey() {
-                return null;
-            }
-
-            @Override
-            public String getKeyAsString() {
-                return null;
-            }
-
-            @Override
-            public long getDocCount() {
-                return searchResult.getHits().getTotalHits().value;
-            }
-
-            @Override
-            public Aggregations getAggregations() {
-                return searchResult.getAggregations();
-            }
-
-            @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                return null;
-            }
-        };
     }
 
     private Aggregation extractNestedSeriesAggregation(Pivot pivot, Percentage percentage, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentageHandler.java
@@ -59,8 +59,9 @@ public class ESPercentageHandler extends ESPivotSeriesSpecHandler<Percentage, Va
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         var aggregation = createNestedSeriesAggregation(name, pivot, percentage, searchTypeHandler, queryContext);
         return Stream.concat(
-                aggregation.stream(),
-                aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))
+                Stream.concat(aggregation.stream(),
+                        aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))),
+                aggregation.stream().map(r -> SeriesAggregationBuilder.column(r.aggregationBuilder()))
         ).toList();
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentilesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentilesHandler.java
@@ -37,7 +37,7 @@ public class ESPercentilesHandler extends ESPivotSeriesSpecHandler<Percentile, P
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final PercentilesAggregationBuilder percentiles = AggregationBuilders.percentiles(name).field(percentileSpec.field()).percentiles(percentileSpec.percentile());
         record(queryContext, pivot, percentileSpec, name, Percentiles.class);
-        return List.of(SeriesAggregationBuilder.pivot(percentiles));
+        return List.of(SeriesAggregationBuilder.metric(percentiles));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentilesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESPercentilesHandler.java
@@ -19,25 +19,25 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Percentiles;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESPercentilesHandler extends ESPivotSeriesSpecHandler<Percentile, Percentiles> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final PercentilesAggregationBuilder percentiles = AggregationBuilders.percentiles(name).field(percentileSpec.field()).percentiles(percentileSpec.percentile());
         record(queryContext, pivot, percentileSpec, name, Percentiles.class);
-        return Optional.of(percentiles);
+        return List.of(SeriesAggregationBuilder.pivot(percentiles));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESStdDevHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESStdDevHandler.java
@@ -37,7 +37,7 @@ public class ESStdDevHandler extends ESPivotSeriesSpecHandler<StdDev, ExtendedSt
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder stddev = AggregationBuilders.extendedStats(name).field(stddevSpec.field());
         record(queryContext, pivot, stddevSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(stddev));
+        return List.of(SeriesAggregationBuilder.metric(stddev));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESStdDevHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESStdDevHandler.java
@@ -19,25 +19,25 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.StdDev;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESStdDevHandler extends ESPivotSeriesSpecHandler<StdDev, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder stddev = AggregationBuilders.extendedStats(name).field(stddevSpec.field());
         record(queryContext, pivot, stddevSpec, name, ExtendedStats.class);
-        return Optional.of(stddev);
+        return List.of(SeriesAggregationBuilder.pivot(stddev));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumHandler.java
@@ -36,7 +36,7 @@ public class ESSumHandler extends ESPivotSeriesSpecHandler<Sum, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final SumAggregationBuilder sum = AggregationBuilders.sum(name).field(sumSpec.field());
         record(queryContext, pivot, sumSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Sum.class);
-        return List.of(SeriesAggregationBuilder.pivot(sum));
+        return List.of(SeriesAggregationBuilder.metric(sum));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumHandler.java
@@ -19,24 +19,24 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESSumHandler extends ESPivotSeriesSpecHandler<Sum, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Sum> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final SumAggregationBuilder sum = AggregationBuilders.sum(name).field(sumSpec.field());
         record(queryContext, pivot, sumSpec, name, org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.Sum.class);
-        return Optional.of(sum);
+        return List.of(SeriesAggregationBuilder.pivot(sum));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumOfSquaresHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumOfSquaresHandler.java
@@ -37,7 +37,7 @@ public class ESSumOfSquaresHandler extends ESPivotSeriesSpecHandler<SumOfSquares
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder sumOfSquares = AggregationBuilders.extendedStats(name).field(sumOfSquaresSpec.field());
         record(queryContext, pivot, sumOfSquaresSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(sumOfSquares));
+        return List.of(SeriesAggregationBuilder.metric(sumOfSquares));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumOfSquaresHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESSumOfSquaresHandler.java
@@ -19,25 +19,25 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.SumOfSquares;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESSumOfSquaresHandler extends ESPivotSeriesSpecHandler<SumOfSquares, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder sumOfSquares = AggregationBuilders.extendedStats(name).field(sumOfSquaresSpec.field());
         record(queryContext, pivot, sumOfSquaresSpec, name, ExtendedStats.class);
-        return Optional.of(sumOfSquares);
+        return List.of(SeriesAggregationBuilder.pivot(sumOfSquares));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESVarianceHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESVarianceHandler.java
@@ -37,7 +37,7 @@ public class ESVarianceHandler extends ESPivotSeriesSpecHandler<Variance, Extend
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder variance = AggregationBuilders.extendedStats(name).field(varianceSpec.field());
         record(queryContext, pivot, varianceSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(variance));
+        return List.of(SeriesAggregationBuilder.metric(variance));
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESVarianceHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESVarianceHandler.java
@@ -19,25 +19,25 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.series;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Variance;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
+import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class ESVarianceHandler extends ESPivotSeriesSpecHandler<Variance, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, ESSearchTypeHandler<Pivot> searchTypeHandler, ESGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder variance = AggregationBuilders.extendedStats(name).field(varianceSpec.field());
         record(queryContext, pivot, varianceSpec, name, ExtendedStats.class);
-        return Optional.of(variance);
+        return List.of(SeriesAggregationBuilder.pivot(variance));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
@@ -41,21 +41,24 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Latest;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Min;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.StdDev;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.SumOfSquares;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Variance;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.OpenSearchBackend;
 import org.graylog.storage.opensearch2.views.export.OpenSearchExportBackend;
 import org.graylog.storage.opensearch2.views.export.RequestStrategy;
+import org.graylog.storage.opensearch2.views.export.SearchAfter;
 import org.graylog.storage.opensearch2.views.searchtypes.OSEventList;
 import org.graylog.storage.opensearch2.views.searchtypes.OSMessageList;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivot;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotBucketSpecHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivot;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.buckets.OSDateRangeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.buckets.OSTimeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.buckets.OSValuesHandler;
@@ -65,14 +68,13 @@ import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSCountHan
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSLatestHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSMaxHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSMinHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSPercentageHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSPercentilesHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSStdDevHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSSumHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSSumOfSquaresHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.series.OSVarianceHandler;
-import org.graylog.storage.opensearch2.views.export.SearchAfter;
 import org.graylog2.storage.SearchVersion;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
 
 public class ViewsOSBackendModule extends ViewsModule {
     private final SearchVersion supportedSearchVersion;
@@ -101,6 +103,7 @@ public class ViewsOSBackendModule extends ViewsModule {
         registerPivotSeriesHandler(Sum.NAME, OSSumHandler.class);
         registerPivotSeriesHandler(SumOfSquares.NAME, OSSumOfSquaresHandler.class);
         registerPivotSeriesHandler(Variance.NAME, OSVarianceHandler.class);
+        registerPivotSeriesHandler(Percentage.NAME, OSPercentageHandler.class);
         registerPivotSeriesHandler(Percentile.NAME, OSPercentilesHandler.class);
         registerPivotSeriesHandler(Latest.NAME, OSLatestHandler.class);
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -17,7 +17,6 @@
 package org.graylog.storage.opensearch2.views;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog.plugins.views.search.Filter;
@@ -29,9 +28,11 @@ import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -39,12 +40,14 @@ import java.util.Set;
 
 public class OSGeneratedQueryContext implements GeneratedQueryContext {
     private final OpenSearchBackend openSearchBackend;
-    private final Map<String, SearchSourceBuilder> searchTypeQueries = Maps.newHashMap();
-    private final Map<Object, Object> contextMap = Maps.newHashMap();
+    private final Map<String, SearchSourceBuilder> searchTypeQueries;
+    private final Map<Object, Object> contextMap;
     private final Set<SearchError> errors;
     private final SearchSourceBuilder ssb;
 
     private final FieldTypesLookup fieldTypes;
+
+    private final MultiBucketsAggregation.Bucket rowBucket;
 
     @AssistedInject
     public OSGeneratedQueryContext(
@@ -56,6 +59,26 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
         this.ssb = ssb;
         this.fieldTypes = fieldTypes;
         this.errors = new HashSet<>(validationErrors);
+        this.rowBucket = null;
+        this.contextMap = new HashMap<>();
+        this.searchTypeQueries = new HashMap<>();
+    }
+
+    private OSGeneratedQueryContext(OpenSearchBackend openSearchBackend,
+                                    SearchSourceBuilder ssb,
+                                    Set<SearchError> errors,
+                                    FieldTypesLookup fieldTypes,
+                                    MultiBucketsAggregation.Bucket rowBucket,
+                                    Map<String, SearchSourceBuilder> searchTypeQueries,
+                                    Map<Object, Object> contextMap) {
+        this.openSearchBackend = openSearchBackend;
+        this.ssb = ssb;
+        this.errors = errors;
+        this.fieldTypes = fieldTypes;
+        this.rowBucket = rowBucket;
+        this.searchTypeQueries = searchTypeQueries;
+        this.contextMap = contextMap;
+
     }
 
     public interface Factory {
@@ -112,5 +135,13 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
     @Override
     public Collection<SearchError> errors() {
         return errors;
+    }
+
+    public OSGeneratedQueryContext withRowBucket(MultiBucketsAggregation.Bucket rowBucket) {
+        return new OSGeneratedQueryContext(openSearchBackend, ssb, errors, fieldTypes, rowBucket, searchTypeQueries, contextMap);
+    }
+
+    public Optional<MultiBucketsAggregation.Bucket> rowBucket() {
+        return Optional.ofNullable(this.rowBucket);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -39,7 +39,6 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSource
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,33 +123,6 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
         final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
         searchSourceBuilder.aggregation(startTimestamp);
         searchSourceBuilder.aggregation(endTimestamp);
-    }
-
-    private List<Tuple2<String, List<BucketSpec>>> groupByConsecutiveType(List<BucketSpec> pivots) {
-        final List<Tuple2<String, List<BucketSpec>>> groups = new ArrayList<>();
-
-        List<BucketSpec> currentBuckets = new ArrayList<>();
-        String currentType = null;
-
-        for (BucketSpec bucketSpec : pivots) {
-            if (bucketSpec.type().equals(currentType)) {
-                currentBuckets.add(bucketSpec);
-            } else {
-                if (!currentBuckets.isEmpty()) {
-                    groups.add(new Tuple2<>(currentType, currentBuckets));
-                }
-
-                currentBuckets = new ArrayList<>();
-                currentBuckets.add(bucketSpec);
-                currentType = bucketSpec.type();
-            }
-        }
-
-        if (!currentBuckets.isEmpty()) {
-            groups.add(new Tuple2<>(currentType, currentBuckets));
-        }
-
-        return groups;
     }
 
     private BucketSpecHandler.CreatedAggregations<AggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, OSGeneratedQueryContext queryContext) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -96,7 +96,7 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                         case ROW -> rootAggregation.subAggregation(result.aggregationBuilder());
                         case ROOT -> {
                             if (!generateRollups) {
-                                rootAggregation.subAggregation(result.aggregationBuilder());
+                                searchSourceBuilder.aggregation(result.aggregationBuilder());
                             }
                         }
                     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -22,17 +22,16 @@ import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpecHandler;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 
 import java.util.stream.Stream;
 
 public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_RESULT extends Aggregation>
-        implements SeriesSpecHandler<SPEC_TYPE, AggregationBuilder, SearchResponse, AGGREGATION_RESULT, OSSearchTypeHandler<Pivot>, OSGeneratedQueryContext> {
+        implements SeriesSpecHandler<SPEC_TYPE, SeriesAggregationBuilder, SearchResponse, AGGREGATION_RESULT, OSSearchTypeHandler<Pivot>, OSGeneratedQueryContext> {
 
     protected AggTypes aggTypes(OSGeneratedQueryContext queryContext, Pivot pivot) {
         return (AggTypes) queryContext.contextMap().get(pivot.id());

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -41,7 +41,7 @@ public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGG
         aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
     }
 
-    protected Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
         return aggTypes(queryContext, pivot).getSubAggregation(spec, aggregations);
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/SeriesAggregationBuilder.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/SeriesAggregationBuilder.java
@@ -20,7 +20,9 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggrega
 
 enum Placement {
     ROOT,
-    PIVOT
+    ROW,
+    COLUMN,
+    METRIC
 }
 
 public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Placement placement) {
@@ -28,7 +30,15 @@ public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Pl
         return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROOT);
     }
 
-    public static SeriesAggregationBuilder pivot(AggregationBuilder aggregationBuilder) {
-        return new SeriesAggregationBuilder(aggregationBuilder, Placement.PIVOT);
+    public static SeriesAggregationBuilder metric(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.METRIC);
+    }
+
+    public static SeriesAggregationBuilder row(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROW);
+    }
+
+    public static SeriesAggregationBuilder column(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.COLUMN);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/SeriesAggregationBuilder.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/SeriesAggregationBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.views.searchtypes.pivot;
+
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
+
+enum Placement {
+    ROOT,
+    PIVOT
+}
+
+public record SeriesAggregationBuilder(AggregationBuilder aggregationBuilder, Placement placement) {
+    public static SeriesAggregationBuilder root(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.ROOT);
+    }
+
+    public static SeriesAggregationBuilder pivot(AggregationBuilder aggregationBuilder) {
+        return new SeriesAggregationBuilder(aggregationBuilder, Placement.PIVOT);
+    }
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSAverageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSAverageHandler.java
@@ -37,7 +37,7 @@ public class OSAverageHandler extends OSPivotSeriesSpecHandler<Average, Avg> {
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final AvgAggregationBuilder avg = AggregationBuilders.avg(name).field(avgSpec.field());
         record(queryContext, pivot, avgSpec, name, Avg.class);
-        return List.of(SeriesAggregationBuilder.pivot(avg));
+        return List.of(SeriesAggregationBuilder.metric(avg));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSAverageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSAverageHandler.java
@@ -18,26 +18,26 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
-import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Avg;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSAverageHandler extends OSPivotSeriesSpecHandler<Average, Avg> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Average avgSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final AvgAggregationBuilder avg = AggregationBuilders.avg(name).field(avgSpec.field());
         record(queryContext, pivot, avgSpec, name, Avg.class);
-        return Optional.of(avg);
+        return List.of(SeriesAggregationBuilder.pivot(avg));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCardinalityHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCardinalityHandler.java
@@ -18,25 +18,25 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Cardinality;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
-import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSCardinalityHandler extends OSPivotSeriesSpecHandler<Cardinality, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Cardinality> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final CardinalityAggregationBuilder card = AggregationBuilders.cardinality(name).field(cardinalitySpec.field());
         record(queryContext, pivot, cardinalitySpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Cardinality.class);
-        return Optional.of(card);
+        return List.of(SeriesAggregationBuilder.pivot(card));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCardinalityHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCardinalityHandler.java
@@ -36,7 +36,7 @@ public class OSCardinalityHandler extends OSPivotSeriesSpecHandler<Cardinality, 
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Cardinality cardinalitySpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final CardinalityAggregationBuilder card = AggregationBuilders.cardinality(name).field(cardinalitySpec.field());
         record(queryContext, pivot, cardinalitySpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Cardinality.class);
-        return List.of(SeriesAggregationBuilder.pivot(card));
+        return List.of(SeriesAggregationBuilder.metric(card));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.common.xcontent.XContentBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregations;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
@@ -33,14 +32,15 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> {
@@ -48,16 +48,16 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
 
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count count, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count count, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final String field = count.field();
         if (field == null) {
             // doc_count is always present in elasticsearch's bucket aggregations, no need to add it
-            return Optional.empty();
+            return List.of();
         } else {
             // the request was for a field count, we have to add a value_count sub aggregation
             final ValueCountAggregationBuilder value = AggregationBuilders.count(name).field(field);
             record(queryContext, pivot, count, name, ValueCount.class);
-            return Optional.of(value);
+            return List.of(SeriesAggregationBuilder.pivot(value));
         }
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
@@ -57,7 +57,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
             // the request was for a field count, we have to add a value_count sub aggregation
             final ValueCountAggregationBuilder value = AggregationBuilders.count(name).field(field);
             record(queryContext, pivot, count, name, ValueCount.class);
-            return List.of(SeriesAggregationBuilder.pivot(value));
+            return List.of(SeriesAggregationBuilder.metric(value));
         }
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
@@ -83,7 +83,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
     }
 
     @Override
-    protected Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
         final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
         if (objects == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSLatestHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSLatestHandler.java
@@ -50,7 +50,7 @@ public class OSLatestHandler extends OSPivotSeriesSpecHandler<Latest, ParsedFilt
                         .fetchSource(latestSpec.field(), null)
                         .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC)));
         record(queryContext, pivot, latestSpec, name, ParsedFilter.class);
-        return List.of(SeriesAggregationBuilder.pivot(latest));
+        return List.of(SeriesAggregationBuilder.metric(latest));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSLatestHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSLatestHandler.java
@@ -22,7 +22,6 @@ import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRespons
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHit;
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHits;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.filter.ParsedFilter;
@@ -32,8 +31,10 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.sort.SortOrder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -42,14 +43,14 @@ public class OSLatestHandler extends OSPivotSeriesSpecHandler<Latest, ParsedFilt
 
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Latest latestSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Latest latestSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final FilterAggregationBuilder latest = AggregationBuilders.filter(name, QueryBuilders.existsQuery(latestSpec.field()))
                 .subAggregation(AggregationBuilders.topHits(AGG_NAME)
                         .size(1)
                         .fetchSource(latestSpec.field(), null)
                         .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC)));
         record(queryContext, pivot, latestSpec, name, ParsedFilter.class);
-        return Optional.of(latest);
+        return List.of(SeriesAggregationBuilder.pivot(latest));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMaxHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMaxHandler.java
@@ -36,7 +36,7 @@ public class OSMaxHandler extends OSPivotSeriesSpecHandler<Max, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final MaxAggregationBuilder max = AggregationBuilders.max(name).field(maxSpec.field());
         record(queryContext, pivot, maxSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Max.class);
-        return List.of(SeriesAggregationBuilder.pivot(max));
+        return List.of(SeriesAggregationBuilder.metric(max));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMaxHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMaxHandler.java
@@ -18,25 +18,25 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
-import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSMaxHandler extends OSPivotSeriesSpecHandler<Max, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Max> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Max maxSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final MaxAggregationBuilder max = AggregationBuilders.max(name).field(maxSpec.field());
         record(queryContext, pivot, maxSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Max.class);
-        return Optional.of(max);
+        return List.of(SeriesAggregationBuilder.pivot(max));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMinHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMinHandler.java
@@ -36,7 +36,7 @@ public class OSMinHandler extends OSPivotSeriesSpecHandler<Min, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final MinAggregationBuilder min = AggregationBuilders.min(name).field(minSpec.field());
         record(queryContext, pivot, minSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Min.class);
-        return List.of(SeriesAggregationBuilder.pivot(min));
+        return List.of(SeriesAggregationBuilder.metric(min));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMinHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSMinHandler.java
@@ -18,25 +18,25 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Min;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
-import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSMinHandler extends OSPivotSeriesSpecHandler<Min, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Min> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Min minSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final MinAggregationBuilder min = AggregationBuilders.min(name).field(minSpec.field());
         record(queryContext, pivot, minSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Min.class);
-        return Optional.of(min);
+        return List.of(SeriesAggregationBuilder.pivot(min));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
@@ -1,2 +1,216 @@
-package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;public class OSPercentageHandler {
+package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
+
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.common.xcontent.XContentBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregations;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ParsedSum;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ValueCount;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class OSPercentageHandler extends OSPivotSeriesSpecHandler<Percentage, ValueCount> {
+    private static final Logger LOG = LoggerFactory.getLogger(OSCountHandler.class);
+    private final OSCountHandler osCountHandler;
+    private final OSSumHandler osSumHandler;
+
+    @Inject
+    public OSPercentageHandler(OSCountHandler osCountHandler, OSSumHandler osSumHandler) {
+        this.osCountHandler = osCountHandler;
+        this.osSumHandler = osSumHandler;
+    }
+
+    @Nonnull
+    @Override
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentage percentage, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+        var aggregation = createNestedSeriesAggregation(name, pivot, percentage, searchTypeHandler, queryContext);
+        return Stream.concat(
+                aggregation.stream(),
+                aggregation.stream().map(r -> SeriesAggregationBuilder.root(r.aggregationBuilder()))
+        ).toList();
+    }
+
+    private List<SeriesAggregationBuilder> createNestedSeriesAggregation(String name, Pivot pivot, Percentage percentage, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+        return switch (percentage.strategy().orElse(Percentage.Strategy.COUNT)) {
+            case SUM -> {
+                var seriesSpecBuilder = Sum.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osSumHandler.createAggregation(name, pivot, seriesSpec, searchTypeHandler, queryContext);
+            }
+            case COUNT -> {
+                var seriesSpecBuilder = Count.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osCountHandler.createAggregation(name, pivot, seriesSpec, searchTypeHandler, queryContext);
+            }
+        };
+    }
+
+    private Stream<Value> handleNestedSeriesResults(Pivot pivot,
+                                                    Percentage percentage,
+                                                    SearchResponse searchResult,
+                                                    Object seriesResult,
+                                                    OSSearchTypeHandler<Pivot> searchTypeHandler,
+                                                    OSGeneratedQueryContext esGeneratedQueryContext) {
+        return switch (percentage.strategy().orElse(Percentage.Strategy.COUNT)) {
+            case SUM -> {
+                var seriesSpecBuilder = Sum.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osSumHandler.handleResult(pivot, seriesSpec, searchResult, seriesResult, searchTypeHandler, esGeneratedQueryContext);
+            }
+            case COUNT -> {
+                var seriesSpecBuilder = Count.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osCountHandler.handleResult(pivot, seriesSpec, searchResult, seriesResult, searchTypeHandler, esGeneratedQueryContext);
+            }
+        };
+    }
+
+    @Override
+    public Stream<Value> doHandleResult(Pivot pivot,
+                                        Percentage percentage,
+                                        SearchResponse searchResult,
+                                        ValueCount valueCount,
+                                        OSSearchTypeHandler<Pivot> searchTypeHandler,
+                                        OSGeneratedQueryContext esGeneratedQueryContext) {
+        final long value;
+        if (valueCount == null) {
+            LOG.error("Unexpected null aggregation result, returning 0 for the count. This is a bug.");
+            value = 0;
+        } else if (valueCount instanceof MultiBucketsAggregation.Bucket) {
+            value = ((MultiBucketsAggregation.Bucket) valueCount).getDocCount();
+        } else if (valueCount instanceof Aggregations) {
+            value = searchResult.getHits().getTotalHits().value;
+        } else {
+            value = valueCount.getValue();
+        }
+
+        var rootResult = extractNestedSeriesAggregation(pivot, percentage, createMultiBucket(searchResult), esGeneratedQueryContext);
+        var nestedSeriesResult = handleNestedSeriesResults(pivot, percentage, searchResult, rootResult, searchTypeHandler, esGeneratedQueryContext);
+
+        return nestedSeriesResult.map(result -> {
+                    var totalResult = (Number) result.value();
+                    return value / totalResult.doubleValue();
+                })
+                .map(bucketPercentage -> Value.create(percentage.id(), Percentage.NAME, bucketPercentage));
+    }
+
+    private MultiBucketsAggregation.Bucket createMultiBucket(SearchResponse searchResult) {
+        return new MultiBucketsAggregation.Bucket() {
+            @Override
+            public Object getKey() {
+                return null;
+            }
+
+            @Override
+            public String getKeyAsString() {
+                return null;
+            }
+
+            @Override
+            public long getDocCount() {
+                return searchResult.getHits().getTotalHits().value;
+            }
+
+            @Override
+            public Aggregations getAggregations() {
+                return searchResult.getAggregations();
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                return null;
+            }
+        };
+    }
+
+    private Aggregation extractNestedSeriesAggregation(Pivot pivot, Percentage percentage, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
+        return switch (percentage.strategy().orElse(Percentage.Strategy.COUNT)) {
+            case SUM -> {
+                var seriesSpecBuilder = Sum.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osSumHandler.extractAggregationFromResult(pivot, seriesSpec, aggregations, queryContext);
+            }
+            case COUNT -> {
+                var seriesSpecBuilder = Count.builder().id(percentage.id());
+                var seriesSpec = percentage.field().map(seriesSpecBuilder::field).orElse(seriesSpecBuilder).build();
+
+                yield osCountHandler.extractAggregationFromResult(pivot, seriesSpec, aggregations, queryContext);
+            }
+        };
+    }
+
+    @Override
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
+        var result = extractNestedSeriesAggregation(pivot, (Percentage) spec, aggregations, queryContext);
+        if (result instanceof ValueCount) {
+            return result;
+        }
+        if (result instanceof ParsedSum sum) {
+            return createValueCount(sum.getValue());
+        }
+
+        throw new IllegalStateException("Unable to parse result: " + result);
+    }
+
+    private Aggregation createValueCount(final Double value) {
+        return new ValueCount() {
+            @Override
+            public long getValue() {
+                return value.longValue();
+            }
+
+            @Override
+            public double value() {
+                return value;
+            }
+
+            @Override
+            public String getValueAsString() {
+                return value.toString();
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+
+            @Override
+            public String getType() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> getMetadata() {
+                return null;
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) {
+                return null;
+            }
+        };
+    }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
@@ -1,0 +1,2 @@
+package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;public class OSPercentageHandler {
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentageHandler.java
@@ -109,7 +109,7 @@ public class OSPercentageHandler extends OSPivotSeriesSpecHandler<Percentage, Va
                                         SearchResponse searchResult,
                                         ValueCount valueCount,
                                         OSSearchTypeHandler<Pivot> searchTypeHandler,
-                                        OSGeneratedQueryContext esGeneratedQueryContext) {
+                                        OSGeneratedQueryContext osGeneratedQueryContext) {
         final long value;
         if (valueCount == null) {
             LOG.error("Unexpected null aggregation result, returning 0 for the count. This is a bug.");
@@ -122,8 +122,9 @@ public class OSPercentageHandler extends OSPivotSeriesSpecHandler<Percentage, Va
             value = valueCount.getValue();
         }
 
-        var rootResult = extractNestedSeriesAggregation(pivot, percentage, InitialBucket.create(searchResult), esGeneratedQueryContext);
-        var nestedSeriesResult = handleNestedSeriesResults(pivot, percentage, searchResult, rootResult, searchTypeHandler, esGeneratedQueryContext);
+        var initialBucket = osGeneratedQueryContext.rowBucket().orElseGet(() -> InitialBucket.create(searchResult));
+        var rootResult = extractNestedSeriesAggregation(pivot, percentage, initialBucket, osGeneratedQueryContext);
+        var nestedSeriesResult = handleNestedSeriesResults(pivot, percentage, searchResult, rootResult, searchTypeHandler, osGeneratedQueryContext);
 
         return nestedSeriesResult.map(result -> {
                     var totalResult = (Number) result.value();

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentilesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentilesHandler.java
@@ -18,26 +18,26 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
-import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Percentiles;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.PercentilesAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSPercentilesHandler extends OSPivotSeriesSpecHandler<Percentile, Percentiles> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final PercentilesAggregationBuilder percentiles = AggregationBuilders.percentiles(name).field(percentileSpec.field()).percentiles(percentileSpec.percentile());
         record(queryContext, pivot, percentileSpec, name, Percentiles.class);
-        return Optional.of(percentiles);
+        return List.of(SeriesAggregationBuilder.pivot(percentiles));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentilesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSPercentilesHandler.java
@@ -37,7 +37,7 @@ public class OSPercentilesHandler extends OSPivotSeriesSpecHandler<Percentile, P
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Percentile percentileSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final PercentilesAggregationBuilder percentiles = AggregationBuilders.percentiles(name).field(percentileSpec.field()).percentiles(percentileSpec.percentile());
         record(queryContext, pivot, percentileSpec, name, Percentiles.class);
-        return List.of(SeriesAggregationBuilder.pivot(percentiles));
+        return List.of(SeriesAggregationBuilder.metric(percentiles));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSStdDevHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSStdDevHandler.java
@@ -37,7 +37,7 @@ public class OSStdDevHandler extends OSPivotSeriesSpecHandler<StdDev, ExtendedSt
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder stddev = AggregationBuilders.extendedStats(name).field(stddevSpec.field());
         record(queryContext, pivot, stddevSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(stddev));
+        return List.of(SeriesAggregationBuilder.metric(stddev));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSStdDevHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSStdDevHandler.java
@@ -18,26 +18,26 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.StdDev;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
-import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSStdDevHandler extends OSPivotSeriesSpecHandler<StdDev, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, StdDev stddevSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder stddev = AggregationBuilders.extendedStats(name).field(stddevSpec.field());
         record(queryContext, pivot, stddevSpec, name, ExtendedStats.class);
-        return Optional.of(stddev);
+        return List.of(SeriesAggregationBuilder.pivot(stddev));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumHandler.java
@@ -18,25 +18,25 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
-import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSSumHandler extends OSPivotSeriesSpecHandler<Sum, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Sum> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final SumAggregationBuilder sum = AggregationBuilders.sum(name).field(sumSpec.field());
         record(queryContext, pivot, sumSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Sum.class);
-        return Optional.of(sum);
+        return List.of(SeriesAggregationBuilder.pivot(sum));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumHandler.java
@@ -36,7 +36,7 @@ public class OSSumHandler extends OSPivotSeriesSpecHandler<Sum, org.graylog.shad
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Sum sumSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final SumAggregationBuilder sum = AggregationBuilders.sum(name).field(sumSpec.field());
         record(queryContext, pivot, sumSpec, name, org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Sum.class);
-        return List.of(SeriesAggregationBuilder.pivot(sum));
+        return List.of(SeriesAggregationBuilder.metric(sum));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumOfSquaresHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumOfSquaresHandler.java
@@ -18,26 +18,26 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.SumOfSquares;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
-import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSSumOfSquaresHandler extends OSPivotSeriesSpecHandler<SumOfSquares, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder sumOfSquares = AggregationBuilders.extendedStats(name).field(sumOfSquaresSpec.field());
         record(queryContext, pivot, sumOfSquaresSpec, name, ExtendedStats.class);
-        return Optional.of(sumOfSquares);
+        return List.of(SeriesAggregationBuilder.pivot(sumOfSquares));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumOfSquaresHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSSumOfSquaresHandler.java
@@ -37,7 +37,7 @@ public class OSSumOfSquaresHandler extends OSPivotSeriesSpecHandler<SumOfSquares
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, SumOfSquares sumOfSquaresSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder sumOfSquares = AggregationBuilders.extendedStats(name).field(sumOfSquaresSpec.field());
         record(queryContext, pivot, sumOfSquaresSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(sumOfSquares));
+        return List.of(SeriesAggregationBuilder.metric(sumOfSquares));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSVarianceHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSVarianceHandler.java
@@ -37,7 +37,7 @@ public class OSVarianceHandler extends OSPivotSeriesSpecHandler<Variance, Extend
     public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder variance = AggregationBuilders.extendedStats(name).field(varianceSpec.field());
         record(queryContext, pivot, varianceSpec, name, ExtendedStats.class);
-        return List.of(SeriesAggregationBuilder.pivot(variance));
+        return List.of(SeriesAggregationBuilder.metric(variance));
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSVarianceHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSVarianceHandler.java
@@ -18,26 +18,26 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot.series;
 
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Variance;
-import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
-import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStats;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class OSVarianceHandler extends OSPivotSeriesSpecHandler<Variance, ExtendedStats> {
     @Nonnull
     @Override
-    public Optional<AggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
+    public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Variance varianceSpec, OSSearchTypeHandler<Pivot> searchTypeHandler, OSGeneratedQueryContext queryContext) {
         final ExtendedStatsAggregationBuilder variance = AggregationBuilders.extendedStats(name).field(varianceSpec.field());
         record(queryContext, pivot, varianceSpec, name, ExtendedStats.class);
-        return Optional.of(variance);
+        return List.of(SeriesAggregationBuilder.pivot(variance));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -87,6 +87,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Latest;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Min;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentage;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Percentile;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.StdDev;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
@@ -186,6 +187,7 @@ public class ViewsBindings extends ViewsModule {
         registerPivotAggregationFunction(Sum.NAME, "Sum", Sum.class);
         registerPivotAggregationFunction(SumOfSquares.NAME, "Sum of Squares", SumOfSquares.class);
         registerPivotAggregationFunction(Variance.NAME, "Variance", Variance.class);
+        registerPivotAggregationFunction(Percentage.NAME, "Percentage", Percentage.class);
         registerPivotAggregationFunction(Percentile.NAME, "Percentile", Percentile.class);
         registerPivotAggregationFunction(Latest.NAME, "Latest Value", Latest.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SeriesSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SeriesSpec.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
@@ -44,11 +43,8 @@ public interface SeriesSpec extends PivotSpec {
     @Nullable
     String id();
 
-    @JsonProperty
-    String field();
-
     default String literal() {
-        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+        return type() + "()";
     }
 
     @JsonAutoDetect
@@ -59,9 +55,6 @@ public interface SeriesSpec extends PivotSpec {
         @JsonProperty
         private String id;
 
-        @JsonProperty
-        private String field;
-
         private Map<String, Object> props = Maps.newHashMap();
 
         @Override
@@ -69,14 +62,12 @@ public interface SeriesSpec extends PivotSpec {
             return type;
         }
 
+
         @Nullable
         @Override
         public String id() {
             return id;
         }
-
-        @Override
-        public String field() { return field; }
 
         @JsonAnySetter
         public void setProperties(String key, Object value) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SeriesSpecHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SeriesSpecHandler.java
@@ -20,7 +20,7 @@ import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
 import org.graylog.plugins.views.search.engine.SearchTypeHandler;
 
 import javax.annotation.Nonnull;
-import java.util.Optional;
+import java.util.List;
 
 /**
  * Implementations of this class contribute handlers for series to concrete implementations of {@link Pivot the pivot search type}.
@@ -35,12 +35,12 @@ public interface SeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_BUI
 
     @SuppressWarnings("unchecked")
     @Nonnull
-    default Optional<AGGREGATION_BUILDER> createAggregation(String name, Pivot pivot, SeriesSpec seriesSpec, SearchTypeHandler searchTypeHandler, GeneratedQueryContext queryContext) {
+    default List<AGGREGATION_BUILDER> createAggregation(String name, Pivot pivot, SeriesSpec seriesSpec, SearchTypeHandler searchTypeHandler, GeneratedQueryContext queryContext) {
         return doCreateAggregation(name, pivot, (SPEC_TYPE) seriesSpec, (SEARCHTYPE_HANDLER) searchTypeHandler, (QUERY_CONTEXT) queryContext);
     }
 
     @Nonnull
-    Optional<AGGREGATION_BUILDER> doCreateAggregation(String name, Pivot pivot, SPEC_TYPE seriesSpec, SEARCHTYPE_HANDLER searchTypeHandler, QUERY_CONTEXT queryContext);
+    List<AGGREGATION_BUILDER> doCreateAggregation(String name, Pivot pivot, SPEC_TYPE seriesSpec, SEARCHTYPE_HANDLER searchTypeHandler, QUERY_CONTEXT queryContext);
 
     @SuppressWarnings("unchecked")
     default Object handleResult(Pivot pivot, SeriesSpec seriesSpec, Object queryResult, Object aggregationResult, SearchTypeHandler searchTypeHandler, GeneratedQueryContext queryContext) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Average.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Average.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = Average.Builder.class)
 public abstract class Average implements SeriesSpec {
     public static final String NAME = "avg";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Average.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class Average implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Average implements SeriesSpec {
 
         @Override
         public Average build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Cardinality.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Cardinality.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = Cardinality.Builder.class)
 public abstract class Cardinality implements SeriesSpec {
     public static final String NAME = "card";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Cardinality.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class Cardinality implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Cardinality implements SeriesSpec {
 
         @Override
         public Cardinality build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Count.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Count.java
@@ -33,16 +33,21 @@ import java.util.Optional;
 @JsonDeserialize(builder = Count.Builder.class)
 public abstract class Count implements SeriesSpec {
     public static final String NAME = "count";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @Nullable
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Count.Builder().type(NAME);
@@ -60,7 +65,6 @@ public abstract class Count implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(@Nullable String field);
 
@@ -70,7 +74,7 @@ public abstract class Count implements SeriesSpec {
 
         @Override
         public Count build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + Strings.nullToEmpty(field()) + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Latest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Latest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = Latest.Builder.class)
 public abstract class Latest implements SeriesSpec {
     public static final String NAME = "latest";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Latest.Builder builder() {
         return new AutoValue_Latest.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class Latest implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Latest implements SeriesSpec {
 
         @Override
         public Latest build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Max.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Max.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = Max.Builder.class)
 public abstract class Max implements SeriesSpec {
     public static final String NAME = "max";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Max.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class Max implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Max implements SeriesSpec {
 
         @Override
         public Max build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Min.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Min.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,17 +31,22 @@ import java.util.Optional;
 @JsonDeserialize(builder = Min.Builder.class)
 public abstract class Min implements SeriesSpec {
     public static final String NAME = "min";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
 
-    public static Min.Builder builder() {
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
+
+    public static Builder builder() {
         return new AutoValue_Min.Builder().type(NAME);
     }
 
@@ -55,7 +61,6 @@ public abstract class Min implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Min implements SeriesSpec {
 
         @Override
         public Min build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -1,0 +1,49 @@
+package org.graylog.plugins.views.search.searchtypes.pivot.series;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+
+import java.util.Optional;
+
+@AutoValue
+@JsonTypeName(Percentage.NAME)
+@JsonDeserialize(builder = Percentage.Builder.class)
+public abstract class Percentage implements SeriesSpec {
+    public static final String NAME = "percentage";
+
+    @Override
+    public abstract String type();
+
+    @Override
+    public abstract String id();
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    public abstract static class Builder extends SeriesSpecBuilder<Percentage, Builder> {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_Percentage.Builder();
+        }
+
+        @Override
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        abstract Optional<String> id();
+
+        abstract Percentage autoBuild();
+
+        @Override
+        public Percentage build() {
+            if (id().isEmpty()) {
+                id(NAME + "()");
+            }
+            return autoBuild();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -51,6 +51,10 @@ public abstract class Percentage implements SeriesSpec {
     @JsonProperty
     public abstract Optional<String> field();
 
+    public static Builder builder() {
+        return new AutoValue_Percentage.Builder().type(Percentage.NAME);
+    }
+
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder extends SeriesSpecBuilder<Percentage, Builder> {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -51,6 +51,11 @@ public abstract class Percentage implements SeriesSpec {
     @JsonProperty
     public abstract Optional<String> field();
 
+    @Override
+    public String literal() {
+        return type() + "(" + field().map(Strings::nullToEmpty).orElse("") + "," + strategy().orElse(Strategy.COUNT) + ")";
+    }
+
     public static Builder builder() {
         return new AutoValue_Percentage.Builder().type(Percentage.NAME);
     }
@@ -89,7 +94,7 @@ public abstract class Percentage implements SeriesSpec {
         @Override
         public Percentage build() {
             if (id().isEmpty()) {
-                id(NAME + "()");
+                id(NAME + "(" + field().map(Strings::nullToEmpty).orElse("") + "," + strategy().orElse(Strategy.COUNT) + ")");
             }
 
             if (strategy().filter(Strategy.SUM::equals).isPresent() && field().isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import javax.annotation.Nullable;
@@ -65,8 +66,12 @@ public abstract class Percentage implements SeriesSpec {
 
         abstract Optional<String> id();
 
-        @JsonProperty
         public abstract Builder field(@Nullable String field);
+
+        @JsonProperty("field")
+        public Builder nonEmptyField(@Nullable String field) {
+            return field(Strings.emptyToNull(field));
+        }
 
         abstract Optional<String> field();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
@@ -37,7 +37,6 @@ public abstract class Percentile implements SeriesSpec {
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
 
@@ -64,7 +63,6 @@ public abstract class Percentile implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -78,7 +76,7 @@ public abstract class Percentile implements SeriesSpec {
 
         @Override
         public Percentile build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + "," + percentile().toString() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SeriesSpecBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SeriesSpecBuilder.java
@@ -23,7 +23,4 @@ public abstract class SeriesSpecBuilder<V, B> extends TypedBuilder<V, B> {
 
     @JsonProperty
     public abstract B id(String id);
-
-    @JsonProperty
-    public abstract B field(String field);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/StdDev.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/StdDev.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = StdDev.Builder.class)
 public abstract class StdDev implements SeriesSpec {
     public static final String NAME = "stddev";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static StdDev.Builder builder() {
         return new AutoValue_StdDev.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class StdDev implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class StdDev implements SeriesSpec {
 
         @Override
         public StdDev build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Sum.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Sum.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -37,9 +38,13 @@ public abstract class Sum implements SeriesSpec {
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Sum.Builder().type(NAME);
@@ -56,7 +61,6 @@ public abstract class Sum implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -66,7 +70,7 @@ public abstract class Sum implements SeriesSpec {
 
         @Override
         public Sum build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SumOfSquares.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SumOfSquares.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = SumOfSquares.Builder.class)
 public abstract class SumOfSquares implements SeriesSpec {
     public static final String NAME = "sumofsquares";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static SumOfSquares.Builder builder() {
         return new AutoValue_SumOfSquares.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class SumOfSquares implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class SumOfSquares implements SeriesSpec {
 
         @Override
         public SumOfSquares build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Variance.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Variance.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 
 import java.util.Optional;
@@ -30,15 +31,20 @@ import java.util.Optional;
 @JsonDeserialize(builder = Variance.Builder.class)
 public abstract class Variance implements SeriesSpec {
     public static final String NAME = "variance";
+
     @Override
     public abstract String type();
 
     @Override
     public abstract String id();
 
-    @Override
     @JsonProperty
     public abstract String field();
+
+    @Override
+    public String literal() {
+        return type() + "(" + Strings.nullToEmpty(field()) + ")";
+    }
 
     public static Variance.Builder builder() {
         return new AutoValue_Variance.Builder().type(NAME);
@@ -55,7 +61,6 @@ public abstract class Variance implements SeriesSpec {
         @JsonProperty
         public abstract Builder id(String id);
 
-        @Override
         @JsonProperty
         public abstract Builder field(String field);
 
@@ -65,7 +70,7 @@ public abstract class Variance implements SeriesSpec {
 
         @Override
         public Variance build() {
-            if (!id().isPresent()) {
+            if (id().isEmpty()) {
                 id(NAME + "(" + field() + ")");
             }
             return autoBuild();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/MetricToSeriesSpecMapperTest.java
@@ -56,7 +56,7 @@ class MetricToSeriesSpecMapperTest {
         assertThat(result)
                 .isNotNull()
                 .isInstanceOf(Average.class)
-                .satisfies(a -> assertEquals("took_ms", a.field()))
+                .satisfies(a -> assertEquals("took_ms", ((Average) a).field()))
                 .satisfies(a -> assertEquals(Average.NAME, a.type()));
     }
 

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -25,6 +25,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import InputField from 'views/components/fieldtypes/InputField';
 import NodeField from 'views/components/fieldtypes/NodeField';
 import StreamsField from 'views/components/fieldtypes/StreamsField';
+import PercentageField from 'views/components/fieldtypes/PercentageField';
 
 import EmptyValue from './EmptyValue';
 import CustomPropTypes from './CustomPropTypes';
@@ -67,6 +68,7 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
     case 'input': return <InputField value={String(value)} />;
     case 'node': return <NodeField value={String(value)} />;
     case 'streams': return <StreamsField value={value} />;
+    case 'percentage': return <PercentageField value={value} />;
     default: return _formatValue(field, value, truncate, render, type);
   }
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -41,7 +41,7 @@ export type MetricFormValues = {
   field: string | undefined,
   name?: string | undefined,
   percentile?: number | undefined,
-  strategy?: 'SUM' | 'COUNT',
+  strategy?: string,
 };
 
 export type GroupingDirection = 'row' | 'column';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/WidgetConfigForm.tsx
@@ -41,6 +41,7 @@ export type MetricFormValues = {
   field: string | undefined,
   name?: string | undefined,
   percentile?: number | undefined,
+  strategy?: 'SUM' | 'COUNT',
 };
 
 export type GroupingDirection = 'row' | 'column';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -172,6 +172,7 @@ const Metric = ({ index }: Props) => {
                              properties={percentageRequiredFieldOptions}
                              name={name}
                              value={value}
+                             menuPortalTarget={document.body}
                              ariaLabel="Select a field" />
               </Input>
             )}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -38,6 +38,11 @@ const Wrapper = styled.div``;
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
 
 const percentileOptions = [25.0, 50.0, 75.0, 90.0, 95.0, 99.0].map((value) => ({ label: value, value }));
+const percentageStrategyOptions = [
+  { label: 'Document Count', value: 'COUNT' },
+  { label: 'Field Sum', value: 'SUM' },
+];
+const percentageRequiredFieldOptions = [Properties.Numeric];
 
 const Metric = ({ index }: Props) => {
   const metricFieldSelectRef = useRef(null);
@@ -53,6 +58,7 @@ const Metric = ({ index }: Props) => {
   const isFieldRequired = !['count', 'percentage'].includes(currentFunction);
 
   const isPercentile = currentFunction === 'percentile';
+  const isPercentage = currentFunction === 'percentage';
   const requiresNumericField = !['card', 'count', 'latest'].includes(currentFunction);
   const requiredProperties = requiresNumericField
     ? [Properties.Numeric]
@@ -131,6 +137,46 @@ const Metric = ({ index }: Props) => {
             </Input>
           )}
         </Field>
+      )}
+      {isPercentage && (
+        <>
+          <Field name={`metrics.${index}.strategy`}>
+            {({ field: { name, value, onChange }, meta: { error } }) => (
+              <Input id="metric-percentage-strategy-select"
+                     label="Strategy"
+                     error={error}
+                     labelClassName="col-sm-3"
+                     wrapperClassName="col-sm-9">
+                <Select options={percentageStrategyOptions}
+                        clearable={false}
+                        name={name}
+                        value={value}
+                        aria-label="Select strategy"
+                        size="small"
+                        menuPortalTarget={document.body}
+                        onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
+              </Input>
+            )}
+          </Field>
+          <Field name={`metrics.${index}.field`}>
+            {({ field: { name, value, onChange }, meta: { error } }) => (
+              <Input id="metric-field"
+                     label="Field"
+                     error={error}
+                     labelClassName="col-sm-3"
+                     wrapperClassName="col-sm-9">
+                <FieldSelect id="metric-field-select"
+                             selectRef={metricFieldSelectRef}
+                             onChange={(fieldName) => onChange({ target: { name, value: fieldName } })}
+                             clearable={!isFieldRequired}
+                             properties={percentageRequiredFieldOptions}
+                             name={name}
+                             value={value}
+                             ariaLabel="Select a field" />
+              </Input>
+            )}
+          </Field>
+        </>
       )}
       <FormikInput id="name"
                    label={<>Name <Opt /></>}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -42,7 +42,6 @@ const percentageStrategyOptions = [
   { label: 'Document Count', value: 'COUNT' },
   { label: 'Field Sum', value: 'SUM' },
 ];
-const percentageRequiredFieldOptions = [Properties.Numeric];
 
 const Metric = ({ index }: Props) => {
   const metricFieldSelectRef = useRef(null);
@@ -52,14 +51,15 @@ const Metric = ({ index }: Props) => {
     .sort(sortByLabel)), [functions, isLoading]);
 
   const { values: { metrics }, errors: { metrics: metricsError }, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
-  const currentFunction = metrics[index].function;
+  const currentMetric = metrics[index];
+  const currentFunction = currentMetric.function;
 
   const hasFieldOption = currentFunction !== 'percentage';
   const isFieldRequired = !['count', 'percentage'].includes(currentFunction);
 
   const isPercentile = currentFunction === 'percentile';
   const isPercentage = currentFunction === 'percentage';
-  const requiresNumericField = !['card', 'count', 'latest'].includes(currentFunction);
+  const requiresNumericField = (isPercentage && currentMetric.strategy === 'SUM') || !['card', 'count', 'latest', 'percentage'].includes(currentFunction);
   const requiredProperties = requiresNumericField
     ? [Properties.Numeric]
     : [];
@@ -169,7 +169,7 @@ const Metric = ({ index }: Props) => {
                              selectRef={metricFieldSelectRef}
                              onChange={(fieldName) => onChange({ target: { name, value: fieldName } })}
                              clearable={!isFieldRequired}
-                             properties={percentageRequiredFieldOptions}
+                             properties={requiredProperties}
                              name={name}
                              value={value}
                              menuPortalTarget={document.body}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -150,7 +150,7 @@ const Metric = ({ index }: Props) => {
                 <Select options={percentageStrategyOptions}
                         clearable={false}
                         name={name}
-                        value={value}
+                        value={value ?? 'COUNT'}
                         aria-label="Select strategy"
                         size="small"
                         menuPortalTarget={document.body}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -49,7 +49,8 @@ const Metric = ({ index }: Props) => {
   const { values: { metrics }, errors: { metrics: metricsError }, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
   const currentFunction = metrics[index].function;
 
-  const isFieldRequired = currentFunction !== 'count';
+  const hasFieldOption = currentFunction !== 'percentage';
+  const isFieldRequired = !['count', 'percentage'].includes(currentFunction);
 
   const isPercentile = currentFunction === 'percentile';
   const requiresNumericField = !['card', 'count', 'latest'].includes(currentFunction);
@@ -91,6 +92,7 @@ const Metric = ({ index }: Props) => {
           </Input>
         )}
       </Field>
+      {hasFieldOption && (
       <Field name={`metrics.${index}.field`}>
         {({ field: { name, value, onChange }, meta: { error } }) => (
           <Input id="metric-field"
@@ -109,6 +111,7 @@ const Metric = ({ index }: Props) => {
           </Input>
         )}
       </Field>
+      )}
       {isPercentile && (
         <Field name={`metrics.${index}.percentile`}>
           {({ field: { name, value, onChange }, meta: { error } }) => (

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -46,7 +46,7 @@ const validateMetrics = (values: WidgetConfigFormValues) => {
       metricError.function = 'Function is required.';
     }
 
-    const isFieldRequired = metric.function && metric.function !== 'count';
+    const isFieldRequired = metric.function && !['count', 'percentage'].includes(metric.function);
 
     if (isFieldRequired && !metric.field) {
       metricError.field = `Field is required for function ${metric.function}.`;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -46,7 +46,7 @@ const validateMetrics = (values: WidgetConfigFormValues) => {
       metricError.function = 'Function is required.';
     }
 
-    const isFieldRequired = metric.function !== 'count' && (metric.function !== 'percentage' || metric.strategy !== 'COUNT');
+    const isFieldRequired = metric.function !== 'count' && (metric.function !== 'percentage' || metric.strategy === 'SUM');
 
     if (isFieldRequired && !metric.field) {
       metricError.field = `Field is required for function ${metric.function}.`;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -62,14 +62,22 @@ const validateMetrics = (values: WidgetConfigFormValues) => {
   return hasErrors(metricsErrors) ? { metrics: metricsErrors } : {};
 };
 
+const parameterForMetric = (metric: MetricFormValues) => {
+  switch (metric.function) {
+    case 'percentage': return metric.strategy;
+    case 'percentile': return metric.percentile;
+    default: return undefined;
+  }
+};
+
 const metricsToSeries = (formMetrics: Array<MetricFormValues>) => formMetrics
-  .map((metric) => Series.create(metric.function, metric.field, metric.percentile)
+  .map((metric) => Series.create(metric.function, metric.field, parameterForMetric(metric))
     .toBuilder()
     .config(SeriesConfig.empty().toBuilder().name(metric.name).build())
     .build());
 
 export const seriesToMetrics = (series: Array<Series>) => series.map((s: Series) => {
-  const { type: func, field, percentile } = parseSeries(s.function) ?? {};
+  const { type: func, field, percentile, strategy } = parseSeries(s.function) ?? {};
 
   const metric = {
     function: func,
@@ -83,6 +91,13 @@ export const seriesToMetrics = (series: Array<Series>) => series.map((s: Series)
     return {
       ...metric,
       percentile: parsedPercentile,
+    };
+  }
+
+  if (strategy) {
+    return {
+      ...metric,
+      strategy,
     };
   }
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -70,8 +70,10 @@ const parameterForMetric = (metric: MetricFormValues) => {
   }
 };
 
+const emptyToUndefined = (s: string) => (s?.trim() === '' ? undefined : s);
+
 const metricsToSeries = (formMetrics: Array<MetricFormValues>) => formMetrics
-  .map((metric) => Series.create(metric.function, metric.field, parameterForMetric(metric))
+  .map((metric) => Series.create(metric.function, emptyToUndefined(metric.field), parameterForMetric(metric))
     .toBuilder()
     .config(SeriesConfig.empty().toBuilder().name(metric.name).build())
     .build());

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricElement.ts
@@ -46,7 +46,7 @@ const validateMetrics = (values: WidgetConfigFormValues) => {
       metricError.function = 'Function is required.';
     }
 
-    const isFieldRequired = metric.function && !['count', 'percentage'].includes(metric.function);
+    const isFieldRequired = metric.function !== 'count' && (metric.function !== 'percentage' || metric.strategy !== 'COUNT');
 
     if (isFieldRequired && !metric.field) {
       metricError.field = `Field is required for function ${metric.function}.`;

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -98,14 +98,14 @@ const DataTableEntry = ({ columnPivots, fields, series, columnPivotValues, value
   const classes = 'message-group';
   const activeQuery = useActiveQueryId();
 
-  const fieldColumns = fields.toSeq().toJS().map(({ field: fieldName, source }, i) => _c(
+  const fieldColumns = fields.toArray().map(({ field: fieldName, source }, i) => _c(
     fieldName,
     item[fieldName],
     fullValuePathForField(fieldName, valuePath).slice(0, i + 1),
     source,
   ));
-  const columnPivotFields = flatten(columnPivotValues.map((columnPivotValueKeys) => {
-    const translatedPath = flatten(columnPivotValueKeys.map((value, idx) => [columnPivots[idx], value]));
+  const columnPivotFields = columnPivotValues.flatMap((columnPivotValueKeys) => {
+    const translatedPath = columnPivotValueKeys.flatMap((value, idx) => [columnPivots[idx], value]);
     const parentValuePath = [...valuePath];
 
     for (let i = 0; i < translatedPath.length; i += 2) {
@@ -119,27 +119,25 @@ const DataTableEntry = ({ columnPivots, fields, series, columnPivotValues, value
 
       return _c(effectiveName, value, fullValuePathForField(fn, parentValuePath), fn);
     });
-  }));
+  });
 
   const columns = flatten([fieldColumns, columnPivotFields]);
 
   return (
-    (
-      <tr className={`fields-row ${classes}`}>
-        {columns.map(({ field, value, path, source }, idx) => {
-          const key = `${activeQuery}-${field}=${value}-${idx}`;
+    <tr className={`fields-row ${classes}`}>
+      {columns.map(({ field, value, path, source }, idx) => {
+        const key = `${activeQuery}-${field}=${value}-${idx}`;
 
-          return (
-            <Column key={key}
-                    field={field}
-                    value={value}
-                    type={fieldTypeFor(columnNameToField(field, series), types)}
-                    valuePath={path.slice()}
-                    source={source} />
-          );
-        })}
-      </tr>
-    )
+        return (
+          <Column key={key}
+                  field={field}
+                  value={value}
+                  type={fieldTypeFor(columnNameToField(field, series), types)}
+                  valuePath={path.slice()}
+                  source={source} />
+        );
+      })}
+    </tr>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/fieldtypes/PercentageField.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/PercentageField.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+import numeral from 'numeral';
+import styled from 'styled-components';
+
+type Props = {
+  value: number,
+}
+
+const NumberCell = styled.span`
+  float: right;
+`;
+
+const PercentageField = ({ value }: Props) => {
+  const formatted = useMemo(() => numeral(value).format('0.00%'), [value]);
+
+  return <NumberCell title={String(value)}>{formatted}</NumberCell>;
+};
+
+export default PercentageField;

--- a/graylog2-web-interface/src/views/components/fieldtypes/PercentageField.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/PercentageField.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo } from 'react';
 import numeral from 'numeral';

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.ts
@@ -34,6 +34,7 @@ export type Definition = {
   type: string,
   field?: string,
   percentile?: string,
+  strategy?: string,
 };
 
 const parametersRegex = /\((.+)\)/;
@@ -45,6 +46,10 @@ const definitionFor = (type: string, parameters: Array<string>): Definition => {
 
   if (type === 'percentile') {
     return { type, field, percentile: parameter };
+  }
+
+  if (type === 'percentage') {
+    return { type, field, strategy: parameter };
   }
 
   return { type, field };

--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
@@ -35,7 +35,7 @@ const AggregateActionHandler: ThunkActionHandler<{ widget?: Widget }> = ({
     .newId()
     .config(AggregationWidgetConfig.builder()
       .rowPivots([pivotForField(field, type)])
-      .series([Series.forFunction('count()')])
+      .series([Series.forFunction('count()'), Series.forFunction('percentage()')])
       .visualization(DataTable.type)
       .build());
   const newWidget = duplicateCommonWidgetSettings(newWidgetBuilder, widget).build();

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.ts
@@ -103,4 +103,5 @@ export const FieldTypes = {
   BINARY: createType('binary', []),
   GEO_POINT: createType('geo-point', []),
   IP: createType('ip', [Properties.Enumerable]),
+  PERCENTAGE: createType('percentage', []),
 };

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.ts
@@ -103,5 +103,5 @@ export const FieldTypes = {
   BINARY: createType('binary', []),
   GEO_POINT: createType('geo-point', []),
   IP: createType('ip', [Properties.Enumerable]),
-  PERCENTAGE: createType('percentage', []),
+  PERCENTAGE: createType('percentage', [Properties.Numeric]),
 };

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
@@ -25,11 +25,12 @@ const typePreservingFunctions = ['avg', 'min', 'max', 'percentile'];
 const constantTypeFunctions = {
   card: FieldTypes.LONG,
   count: FieldTypes.LONG,
+  percentage: FieldTypes.PERCENTAGE,
 };
 
 const inferTypeForSeries = (series: Series, types: (FieldTypeMappingsList | Array<FieldTypeMapping>)): FieldTypeMapping => {
   const definition = parseSeries(series.function);
-  const newMapping = (type) => FieldTypeMapping.create(series.function, type);
+  const newMapping = (type: FieldType) => FieldTypeMapping.create(series.function, type);
 
   if (definition === null) {
     return newMapping(FieldType.Unknown);
@@ -42,7 +43,7 @@ const inferTypeForSeries = (series: Series, types: (FieldTypeMappingsList | Arra
   }
 
   if (typePreservingFunctions.includes(type)) {
-    const mapping = types && types.find((t) => (t.name === field));
+    const mapping = types?.find((t: FieldTypeMapping) => (t.name === field));
 
     if (!mapping) {
       return newMapping(FieldType.Unknown);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing a `percentage` metric, which retrieves a value between 0 and 1 to reflect the relative share of the current bucket in relation to the total set of documents. It allows configuring two strategies:

  - `count` (default): Returns the relative share of documents in this bucket compared to the total set of documents. Takes an optional field, which would be used to count only documents containing this field.
  - `sum`: Takes a mandatory field name and returns the relative sum of all values of this field in this bucket compared to the total sum of all field values in the total set of documents.

![image](https://github.com/Graylog2/graylog2-server/assets/41929/bd335bff-423e-48a2-a2e2-650350603ad6)

The total set of documents depends on the aggregation configured. When only row pivots are configured, the total set of documents is what the current time range/query returns. When column pivots are configured, the total set of documents is the set of documents contained in the buckets returned by row pivots. This allows e.g. returning the relative distribution of column pivots over time.

![image](https://github.com/Graylog2/graylog2-server/assets/41929/751de415-78ba-476e-b5e7-d25fe8d62f1a)

In addition, this PR is adding a `percentage` metric automatically for the aggregation generated by the `Show Top Values` action.

Fixes #6763.
Fixes #7822.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.