### PR TITLE
Fix wrong attribute in session

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -81,22 +81,17 @@ public class MongoDbSession extends PersistedImpl {
         return null;
     }
 
-    public void setAttributes(Map<Object, Object> attributes) {
-        fields.put("attributes", transformAttributes(attributes));
-    }
-
     @SuppressForbidden("Deliberate use of ObjectOutputStream")
-    public static byte[] transformAttributes(Map attributes) {
+    public void setAttributes(Map<Object, Object> attributes) {
         try {
             final ByteArrayOutputStream bos = new ByteArrayOutputStream();
             // FIXME: This could break backward compatibility if different Java versions are being used.
             final ObjectOutputStream oos = new ObjectOutputStream(bos);
             oos.writeObject(attributes);
             oos.close();
-            return bos.toByteArray();
+            fields.put("attributes", bos.toByteArray());
         } catch (IOException e) {
-            LOG.error("too bad :(", e);
-            return null;
+            LOG.error("Error serializing into binary stream for attributes in Mongo: {}", e.getMessage(), e);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -64,19 +64,20 @@ public class MongoDbSession extends PersistedImpl {
 
     @SuppressForbidden("Deliberate use of ObjectInputStream")
     public Map<Object, Object> getAttributes() {
-        final Object attributes = fields.get("attributes");
-        if (attributes == null) {
-            return null;
-        }
-        final ByteArrayInputStream bis = new ByteArrayInputStream((byte[]) attributes);
         try {
+            final Object attributes = fields.get("attributes");
+            if (attributes == null) {
+                return null;
+            }
+            final ByteArrayInputStream bis = new ByteArrayInputStream((byte[]) attributes);
+
             // FIXME: This could break backward compatibility if different Java versions are being used.
             final ObjectInputStream ois = new ObjectInputStream(bis);
             final Object o = ois.readObject();
             return (Map<Object, Object>) o;
         } catch (IOException e) {
             LOG.error("little io. wow.", e);
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | ClassCastException e) {
             LOG.error("wrong thingy in db", e);
         }
         return null;

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -76,7 +76,7 @@ public class MongoDbSession extends PersistedImpl {
             final Object o = ois.readObject();
             return (Map<Object, Object>) o;
         } catch (Exception e) {
-            LOG.error("Error deserializing binary stream for attributes from Mongo: " + e.getMessage(), e);
+            LOG.error("Error deserializing binary stream for attributes from Mongo: {}", e.getMessage(), e);
         }
         return null;
     }

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -75,26 +75,28 @@ public class MongoDbSession extends PersistedImpl {
             final ObjectInputStream ois = new ObjectInputStream(bis);
             final Object o = ois.readObject();
             return (Map<Object, Object>) o;
-        } catch (IOException e) {
-            LOG.error("little io. wow.", e);
-        } catch (ClassNotFoundException | ClassCastException e) {
-            LOG.error("wrong thingy in db", e);
+        } catch (Exception e) {
+            LOG.error("Error deserializing binary stream for attributes from Mongo: " + e.getMessage(), e);
         }
         return null;
     }
 
-    @SuppressForbidden("Deliberate use of ObjectOutputStream")
     public void setAttributes(Map<Object, Object> attributes) {
+        fields.put("attributes", transformAttributes(attributes));
+    }
 
+    @SuppressForbidden("Deliberate use of ObjectOutputStream")
+    public static byte[] transformAttributes(Map attributes) {
         try {
             final ByteArrayOutputStream bos = new ByteArrayOutputStream();
             // FIXME: This could break backward compatibility if different Java versions are being used.
             final ObjectOutputStream oos = new ObjectOutputStream(bos);
             oos.writeObject(attributes);
             oos.close();
-            fields.put("attributes", bos.toByteArray());
+            return bos.toByteArray();
         } catch (IOException e) {
             LOG.error("too bad :(", e);
+            return null;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSessionDAO.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSessionDAO.java
@@ -60,10 +60,7 @@ public class MongoDbSessionDAO extends CachingSessionDAO {
         fields.put("last_access_time", session.getLastAccessTime());
         fields.put("timeout", session.getTimeout());
         Map<String, Object> attributes = Maps.newHashMap();
-        for (Object key : session.getAttributeKeys()) {
-            attributes.put(key.toString(), session.getAttribute(key));
-        }
-        fields.put("attributes", attributes);
+        fields.put("attributes", MongoDbSession.transformAttributes(attributes));
         final MongoDbSession dbSession = new MongoDbSession(fields);
         final String objectId = mongoDBSessionService.saveWithoutValidation(dbSession);
         LOG.debug("Created session {}", objectId);

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSessionDAO.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSessionDAO.java
@@ -59,9 +59,12 @@ public class MongoDbSessionDAO extends CachingSessionDAO {
         fields.put("start_timestamp", session.getStartTimestamp());
         fields.put("last_access_time", session.getLastAccessTime());
         fields.put("timeout", session.getTimeout());
-        Map<String, Object> attributes = Maps.newHashMap();
-        fields.put("attributes", MongoDbSession.transformAttributes(attributes));
+        Map<Object, Object> attributes = Maps.newHashMap();
+        for (Object key : session.getAttributeKeys()) {
+            attributes.put(key.toString(), session.getAttribute(key));
+        }
         final MongoDbSession dbSession = new MongoDbSession(fields);
+        dbSession.setAttributes(attributes);
         final String objectId = mongoDBSessionService.saveWithoutValidation(dbSession);
         LOG.debug("Created session {}", objectId);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A customer had problems logging in and found the following constellation in MongoDB for a session:

`
{
    "attributes" : {
    },
}
`

instead of `"attributes" : BinData(0, "rO0ABXNyABFqYXZhLnV...`

This created problems during login:

```cluster-graylog3-1     | 2023-06-19 11:44:42,787 ERROR: org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper - Unhandled exception in REST resource

cluster-graylog3-1     | java.lang.ClassCastException: class com.mongodb.BasicDBObject cannot be cast to class [B (com.mongodb.BasicDBObject is in unnamed module of loader 'app'; [B is in module java.base of loader 'bootstrap')

cluster-graylog3-1     | 	at org.graylog2.security.MongoDbSession.getAttributes(MongoDbSession.java:69) ~[graylog.jar:?]

cluster-graylog3-1     | 	at org.graylog2.security.MongoDbSession.getUserIdAttribute(MongoDbSession.java:99) ~[graylog.jar:?]
```

Probably a race condition which was emphasized by using a replicaSet on MongoDB brought this up for the first time now. The root problem is, that during session creation, an invalid state is written for `attributes` that is not cleared up in time by the first update on the session before another read. This seems to be no issue if only reading/writing from the main MongoDB node, but the error could be reproduced in this setting using the debugger.


/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

