### PR TITLE
Fixing the lifecycle phase for antrun in DataNode so that the test-jar is not pulled in during the wrong phase

### DIFF
--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -575,7 +575,7 @@
                 <executions>
                     <execution>
                         <id>fix-opensearch-config-permissions</id>
-                        <phase>process-resources</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -871,6 +871,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- there is a bug in maven causing it to resolve test-jar types
+                 at compile time rather than test-compile. Move the compilation
+                 of the test classes earlier in the build cycle and also generate the -tests.jar earlier
+                 see: https://stackoverflow.com/questions/4786881/why-is-test-jar-dependency-required-for-mvn-compile -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -871,22 +871,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- there is a bug in maven causing it to resolve test-jar types
-                 at compile time rather than test-compile. Move the compilation
-                 of the test classes earlier in the build cycle and also generate the -tests.jar earlier
-                 see: https://stackoverflow.com/questions/4786881/why-is-test-jar-dependency-required-for-mvn-compile -->
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -899,7 +883,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
                         <goals>
                             <!-- Building a test-jar allows us to share common test infrastructure classes like
                               ~  elasticsearch test base classes in other maven modules. (e.g. plugins)

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -883,6 +883,7 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <phase>compile</phase>
                         <goals>
                             <!-- Building a test-jar allows us to share common test infrastructure classes like
                               ~  elasticsearch test base classes in other maven modules. (e.g. plugins)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix problems using the graylog2-tests.jar in the data node.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

