### PR TITLE
Implement constant for more actions title in entity lists.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/Constants.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/Constants.ts
@@ -19,3 +19,5 @@ export const CELL_PADDING = 5; // px
 export const BULK_SELECT_COLUMN_WIDTH = 20; // px
 export const DEFAULT_COL_MIN_WIDTH = 150; // px
 export const DEFAULT_COL_WIDTH = 1; // fraction, similar to CSS unit fr.
+export const MORE_ACTIONS_TITLE = 'More';
+export const MORE_ACTIONS_HOVER_TITLE = 'More actions';

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -34,6 +34,7 @@ import { EventDefinitionsActions } from 'stores/event-definitions/EventDefinitio
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { MORE_ACTIONS_TITLE, MORE_ACTIONS_HOVER_TITLE } from 'components/common/EntityDataTable/Constants';
 
 import type { EventDefinition } from '../event-definitions-types';
 
@@ -173,7 +174,8 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
                      entityType="event_definition"
                      onClick={() => setShowEntityShareModal(true)}
                      bsSize="xsmall" />
-        <OverlayDropdownButton title="More"
+        <OverlayDropdownButton title={MORE_ACTIONS_TITLE}
+                               buttonTitle={MORE_ACTIONS_HOVER_TITLE}
                                bsSize="xsmall"
                                dropdownZIndex={1000}>
           {showActions() && (

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationActions.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotificationActions.tsx
@@ -27,6 +27,7 @@ import { EventNotificationsActions } from 'stores/event-notifications/EventNotif
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { MORE_ACTIONS_TITLE, MORE_ACTIONS_HOVER_TITLE } from 'components/common/EntityDataTable/Constants';
 
 type Props = {
   isTestLoading: boolean,
@@ -78,7 +79,8 @@ const EventNotificationActions = ({ isTestLoading, notification, refetchEventNot
                      onClick={() => setShowShareNotification(notification)}
                      bsSize="xsmall" />
 
-        <OverlayDropdownButton title="More"
+        <OverlayDropdownButton title={MORE_ACTIONS_TITLE}
+                               buttonTitle={MORE_ACTIONS_HOVER_TITLE}
                                bsSize="xsmall"
                                dropdownZIndex={1000}>
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -33,6 +33,7 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import OverlayDropdownButton from 'components/common/OverlayDropdownButton';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { MORE_ACTIONS_TITLE, MORE_ACTIONS_HOVER_TITLE } from 'components/common/EntityDataTable/Constants';
 
 import StreamModal from '../StreamModal';
 
@@ -154,9 +155,9 @@ const StreamActions = ({
                    entityType="stream"
                    onClick={toggleEntityShareModal}
                    bsSize="xsmall" />
-      <OverlayDropdownButton title="More"
+      <OverlayDropdownButton title={MORE_ACTIONS_TITLE}
                              bsSize="xsmall"
-                             buttonTitle="More actions"
+                             buttonTitle={MORE_ACTIONS_HOVER_TITLE}
                              disabled={isNotEditable}
                              dropdownZIndex={1000}>
         <IfPermitted permissions={[`streams:changestate:${stream.id}`, `streams:edit:${stream.id}`]} anyPermissions>

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
@@ -29,6 +29,7 @@ import iterateConfirmationHooks from 'views/hooks/IterateConfirmationHooks';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import usePaginationQueryParameter from 'hooks/usePaginationQueryParameter';
 import usePluginEntities from 'hooks/usePluginEntities';
+import { MORE_ACTIONS_TITLE, MORE_ACTIONS_HOVER_TITLE } from 'components/common/EntityDataTable/Constants';
 
 // eslint-disable-next-line no-alert
 const defaultDashboardDeletionHook = async (view: View) => window.confirm(`Are you sure you want to delete "${view.title}"?`);
@@ -74,7 +75,7 @@ const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
                    entityId={dashboard.id}
                    entityType="dashboard"
                    onClick={() => setShowShareModal(true)} />
-      <OverlayDropdownButton bsSize="xsmall" title="More" buttonTitle="More actions">
+      <OverlayDropdownButton bsSize="xsmall" title={MORE_ACTIONS_TITLE} buttonTitle={MORE_ACTIONS_HOVER_TITLE}>
         {dashboardActions.length > 0 ? (
           <>
             {dashboardActions}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the past we had the problem that the naming of the "More action" button in entity lists varied.
With this PR we are creating a constant which can be reused in suitable lists.

/nocl