### PR TITLE
Move `@testing-library/user-event` into `jest-preset-graylog` package.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -116,7 +116,6 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^13.5.0",
     "@types/chroma-js": "^2.1.3",
     "@types/clipboard": "^2.0.7",
     "@types/crossfilter": "0.0.34",

--- a/graylog2-web-interface/packages/jest-preset-graylog/package.json
+++ b/graylog2-web-interface/packages/jest-preset-graylog/package.json
@@ -15,6 +15,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "^8.0.0",
+    "@testing-library/user-event": "^13.5.0",
     "@types/enzyme": "3.10.12",
     "babel-jest": "29.5.0",
     "enzyme": "3.11.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are moving the `@testing-library/user-event` dependency into the `jest-preset-graylog` package, since the package contains all test related dependencies.

/nocl