### PR TITLE
Ensure className prop is not undefined when using it in template string.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Tooltip.jsx
@@ -127,7 +127,7 @@ Tooltip.propTypes = {
 };
 
 Tooltip.defaultProps = {
-  className: undefined,
+  className: '',
   placement: 'right',
   positionTop: undefined,
   positionLeft: undefined,

--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -203,7 +203,7 @@ class DataTable extends React.Component {
       data = <p>Filter does not match any data.</p>;
     } else {
       data = (
-        <StyledTable className={`table ${className}`}>
+        <StyledTable className={`table ${className ?? ''}`}>
           <thead>
             {this.getFormattedHeaders()}
           </thead>

--- a/graylog2-web-interface/src/components/common/ExpandableList.tsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.tsx
@@ -37,7 +37,7 @@ const ExpandableList = ({ children, className }: Props) => (
 );
 
 ExpandableList.defaultProps = {
-  className: undefined,
+  className: '',
 };
 
 ExpandableList.propTypes = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing a few cases where `className` is used in a template string, but could be undefined.
We ensure it no longer can be undefined. This is a good practice since `${undefined}` result in the following string: `undefined`.

/nocl