### PR TITLE
Make sure that `boolean` fields are returned as `true`|`false` in aggregations. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-14661.toml
+++ b/changelog/unreleased/issue-14661.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Make sure that `boolean` fields are returned as `true`|`false` in aggregations on Opensearch 2.4+."
+
+issues = ["14661"]
+pulls = ["15809"]

--- a/changelog/unreleased/issue-14661.toml
+++ b/changelog/unreleased/issue-14661.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Make sure that `boolean` fields are returned as `true`|`false` in aggregations on Opensearch 2.4+."
 
 issues = ["14661"]
-pulls = ["15809"]
+pulls = ["15816"]

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/SearchAggregationsIT.java
@@ -729,6 +729,27 @@ public class SearchAggregationsIT {
         assertThat(rowValues).containsExactly(List.of(5300.0f, 5300.0f));
     }
 
+    @ContainerMatrixTest
+    void testBooleanFieldsAreReturnedAsTrueOrFalse() {
+        final Pivot pivot = Pivot.builder()
+                .rollup(true)
+                .rowGroups(Values.builder().field("test_boolean").build(), Values.builder().field("user_id").build())
+                .series(Count.builder().build())
+                .build();
+
+        final ValidatableResponse validatableResponse = execute(pivot);
+
+        validatableResponse.rootPath(PIVOT_PATH)
+                .body("rows", hasSize(4));
+
+        final String searchTypeResult = PIVOT_PATH + ".rows";
+        validatableResponse
+                .rootPath(searchTypeResult)
+                .body(pathToMetricResult(List.of("true", "6476752"), List.of("count()")), equalTo(1))
+                .body(pathToMetricResult(List.of("false", "6469981"), List.of("count()")), equalTo(1))
+                .body(pathToMetricResult("(Empty Value)", "count()"), equalTo(998));
+    }
+
     private String listToGroovy(Collection<String> strings) {
         final List<String> quotedStrings = strings.stream()
                 .map(string -> "'" + string + "'")

--- a/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/random-http-logs.json
+++ b/full-backend-tests/src/test/resources/org/graylog/plugins/views/aggregations/random-http-logs.json
@@ -22,7 +22,8 @@
             "http_response_code": 200,
             "streams": [
               "000000000000000000000001"
-            ]
+            ],
+            "test_boolean": true
           }
         }
       ]
@@ -49,7 +50,8 @@
             "http_response_code": 200,
             "streams": [
               "000000000000000000000001"
-            ]
+            ],
+            "test_boolean": false
           }
         }
       ]

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
@@ -181,7 +181,7 @@ public class OSValuesHandler extends OSPivotBucketSpecHandler<Values> {
             return ImmutableList.of((String)key);
         }
 
-        return ImmutableList.of(String.valueOf(key));
+        return ImmutableList.of(bucket.getKeyAsString());
     }
 
     private ImmutableList<String> splitKeys(String keys) {


### PR DESCRIPTION
**Note:** This is a backport of #15809 to `5.1`

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, in aggregations on Opensearch 2.4+, boolean field values were returned as [`1` or `0` instead of `true` or `false`](https://opensearch.org/docs/2.3/opensearch/supported-field-types/boolean/#boolean-values-in-aggregations-and-scripts). This is related to the way extraction of keys from multi-terms aggregations was implemented. This PR is fixing this and making sure that `Bucket#getKeyAsString` is used.

Fixes #14661.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.