### PR TITLE
Limitting retrieval of all entities from DB. Using memoize instead of…

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageLastOpenedIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageLastOpenedIT.java
@@ -56,10 +56,13 @@ public class StartPageLastOpenedIT {
         api.users().createUser(user);
     }
 
+    //This test has to be the only test in this class.
+    //Because of the memoization in Catalog, we cannot guarantee that after search/dashboard creation it will be immediately visible in the catalog.
+    //Keeping this test independent prevents us from using unnecessary sleep of a few seconds.
     @ContainerMatrixTest
     void testCreateLastOpenedItem() {
-        api.postWithResource("/views/search", user,"org/graylog/plugins/views/startpage-save-search-request.json", 201);
-        api.postWithResource("/views", user,"org/graylog/plugins/views/startpage-views-request.json", 200);
+        api.postWithResource("/views/search", user, "org/graylog/plugins/views/startpage-save-search-request.json", 201);
+        api.postWithResource("/views", user, "org/graylog/plugins/views/startpage-views-request.json", 200);
 
         var validatableResponse = api.get("/views", user, Map.of(), 200);
         var id = validatableResponse.extract().jsonPath().get("views[0].id").toString();

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageLastOpenedIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageLastOpenedIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views;
+
+import org.graylog.testing.completebackend.Lifecycle;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.Users;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.core.StringContains.containsString;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS)
+public class StartPageLastOpenedIT {
+    private final GraylogApis api;
+
+    private static final Users.User user = new Users.User(
+            "john.doe2",
+            "asdfgh",
+            "John",
+            "Doe",
+            "john.doe2@example.com",
+            false,
+            30_000,
+            "Europe/Vienna",
+            Collections.emptyList(),
+            List.of(RestPermissions.DASHBOARDS_CREATE)
+    );
+
+    public StartPageLastOpenedIT(GraylogApis api) {
+        this.api = api;
+    }
+
+    @BeforeAll
+    public void init() {
+        api.users().createUser(user);
+    }
+
+    @ContainerMatrixTest
+    void testCreateLastOpenedItem() {
+        api.postWithResource("/views/search", user,"org/graylog/plugins/views/startpage-save-search-request.json", 201);
+        api.postWithResource("/views", user,"org/graylog/plugins/views/startpage-views-request.json", 200);
+
+        var validatableResponse = api.get("/views", user, Map.of(), 200);
+        var id = validatableResponse.extract().jsonPath().get("views[0].id").toString();
+
+        api.get("/views/" + id, user, Map.of(), 200);
+        validatableResponse = api.get("/startpage/lastOpened", user, Map.of(), 200);
+        validatableResponse.assertThat().body("lastOpened[0].grn", containsString(id));
+    }
+
+}

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageRecentActivityIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/StartPageRecentActivityIT.java
@@ -16,60 +16,26 @@
  */
 package org.graylog.plugins.views;
 
+import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.completebackend.apis.Streams;
 import org.graylog.testing.completebackend.apis.Users;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog2.plugin.streams.StreamRuleType;
-import org.graylog2.shared.security.RestPermissions;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.core.StringContains.containsString;
 
-@ContainerMatrixTestsConfiguration
-public class StartPageIT {
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS)
+public class StartPageRecentActivityIT {
+
     private final GraylogApis api;
 
-    private static final Users.User user = new Users.User(
-            "john.doe2",
-            "asdfgh",
-            "John",
-            "Doe",
-            "john.doe2@example.com",
-            false,
-            30_000,
-            "Europe/Vienna",
-            Collections.emptyList(),
-            List.of(RestPermissions.DASHBOARDS_CREATE)
-    );
-
-    public StartPageIT(GraylogApis api) {
+    public StartPageRecentActivityIT(GraylogApis api) {
         this.api = api;
     }
-
-    @BeforeAll
-    public void init() {
-        api.users().createUser(this.user);
-    }
-
-    @ContainerMatrixTest
-    void testCreateLastOpenedItem() {
-        api.postWithResource("/views/search", user,"org/graylog/plugins/views/startpage-save-search-request.json", 201);
-        api.postWithResource("/views", user,"org/graylog/plugins/views/startpage-views-request.json", 200);
-
-        var validatableResponse = api.get("/views", user, Map.of(), 200);
-        var id = validatableResponse.extract().jsonPath().get("views[0].id").toString();
-
-        api.get("/views/" + id, user, Map.of(), 200);
-        validatableResponse = api.get("/startpage/lastOpened", user, Map.of(), 200);
-        validatableResponse.assertThat().body("lastOpened[0].grn", containsString(id));
-    }
-
 
     @ContainerMatrixTest
     void testCreateRecentActivity() {


### PR DESCRIPTION
… innefficient cache.

## Description
Previous implementation had a bug - it fetched data about all entities in the DB for each access to a new entity id in a quickly expiring cache (1s).

```                .build(new CacheLoader<>() {
                    @Override
                    public Optional<Entry> load(String id) {
                        var catalog = contentPackService.getEntityExcerpts();
                        (...)
                    }
                });
```
This approach has been modified.
getEntityExcerpts() method is still called, which is wrong, but its results are at least memoized, so that all entity titles are resolved with this one DB call, not many of them, as before.
/nocl

## Motivation and Context
Improve performance before a better approach is agreed on and implemented.

## How Has This Been Tested?
Manually and by running modified unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

