### PR TITLE
Let server container fail on guice errors

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -144,7 +144,11 @@ public class NodeContainerFactory {
                 .withEnv("GRAYLOG_ENABLE_DEBUG_RESOURCES", "true") // see RestResourcesModule#addDebugResources
 
                 .waitingFor(new WaitAllStrategy()
-                        .withStrategy(new WaitForSuccessOrFailureStrategy().withSuccessAndFailures(".*Graylog server up and running.*", ".*Exception while running migrations.*", ".*Graylog startup failed.*"))
+                        .withStrategy(new WaitForSuccessOrFailureStrategy().withSuccessAndFailures(
+                                ".*Graylog server up and running.*",
+                                ".*Exception while running migrations.*",
+                                ".*Graylog startup failed.*",
+                                ".*Guice/MissingImplementation.*"))
                         // To be able to search for data we need the index ranges to be computed. Since this is an async
                         // background job, we need to wait until they have been created.
                         .withStrategy(new HttpWaitStrategy()


### PR DESCRIPTION
This change lets tests fail early on guice errors instead of waiting for the timeout.

/nocl