### PR TITLE
Make path suffix optional in frontend gallery router.

### DIFF
--- a/graylog2-web-interface/docs/StyleGuideWrapper.tsx
+++ b/graylog2-web-interface/docs/StyleGuideWrapper.tsx
@@ -55,7 +55,7 @@ type Props = {
 
 const StyleGuideWrapper = ({ children }: Props) => {
   const router = createBrowserRouter([{
-    path: '/',
+    path: '/:url?',
     element: (
       <CurrentUserContext.Provider value={adminUser}>
         <GraylogThemeProvider initialThemeModeOverride="teint">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the router wrapping components in the frontend component gallery had only a single route with a static path (`/`) configured, leading to errors with components when deployed, as the path is different (`/frontend-documentation`). This PR is adding an optional path suffix to the route.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.