### PR TITLE
add email_attributes to AD config

### DIFF
--- a/changelog/unreleased/issue-15652.toml
+++ b/changelog/unreleased/issue-15652.toml
@@ -1,6 +1,6 @@
 type = "fixed"
-message = "Restore mail attribute for AD authentication."
+message = "Fix email_attributes error message in AD auth server edit form."
 
-issues = ["15536"]
-pulls = [""]
+issues = ["15652"]
+pulls = ["15655","15877"]
 

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackendConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/backend/ADAuthServiceBackendConfig.java
@@ -32,6 +32,7 @@ import org.graylog.security.authservice.ldap.LDAPTransportSecurity;
 import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.security.encryption.EncryptedValue;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,7 @@ public abstract class ADAuthServiceBackendConfig implements AuthServiceBackendCo
     private static final String FIELD_USER_SEARCH_PATTERN = "user_search_pattern";
     private static final String FIELD_USER_NAME_ATTRIBUTE = "user_name_attribute";
     private static final String FIELD_USER_FULL_NAME_ATTRIBUTE = "user_full_name_attribute";
+    private static final String FIELD_EMAIL_ATTRIBUTES = "email_attributes";
 
     @JsonProperty(FIELD_SERVERS)
     public abstract ImmutableList<HostAndPort> servers();
@@ -77,6 +79,10 @@ public abstract class ADAuthServiceBackendConfig implements AuthServiceBackendCo
 
     @JsonProperty(FIELD_USER_FULL_NAME_ATTRIBUTE)
     public abstract String userFullNameAttribute();
+
+    @Nullable
+    @JsonProperty(FIELD_EMAIL_ATTRIBUTES)
+    public abstract ImmutableList<String> emailAttributes();
 
     @Override
     public void validate(ValidationResult result) {
@@ -133,7 +139,8 @@ public abstract class ADAuthServiceBackendConfig implements AuthServiceBackendCo
                     .systemUserPassword(EncryptedValue.createUnset())
                     .userSearchPattern(ADAuthServiceBackend.AD_DEFAULT_USER_SEARCH_PATTERN.toNormalizedString())
                     .userNameAttribute(ADAuthServiceBackend.AD_USER_PRINCIPAL_NAME)
-                    .userFullNameAttribute(ADAuthServiceBackend.AD_DISPLAY_NAME);
+                    .userFullNameAttribute(ADAuthServiceBackend.AD_DISPLAY_NAME)
+                    .emailAttributes(ImmutableList.of("mail"));
         }
 
         @JsonProperty(FIELD_SERVERS)
@@ -162,6 +169,9 @@ public abstract class ADAuthServiceBackendConfig implements AuthServiceBackendCo
 
         @JsonProperty(FIELD_USER_FULL_NAME_ATTRIBUTE)
         public abstract Builder userFullNameAttribute(String userFullNameAttribute);
+
+        @JsonProperty(FIELD_EMAIL_ATTRIBUTES)
+        public abstract Builder emailAttributes(List<String> emailAttributes);
 
         public abstract ADAuthServiceBackendConfig build();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `email_attributes` to AD auth server config

## Description
Add `email_attributes` to AD auth server config to restore compatibility with LDAP. Frontend expects to be able to treat them the same when executing `test server connection` and `test user login` in the edit form.

Resolves #15652
