### PR TITLE
Add renewal policy configuration to pre-flight UI.

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
@@ -18,7 +18,6 @@ package org.graylog.datanode.bootstrap;
 
 import com.github.joschi.jadconfig.guice.NamedConfigParametersModule;
 import com.github.rvesse.airline.annotations.Option;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
@@ -55,7 +54,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -163,7 +161,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
     }
 
     private Injector getPreflightInjector(List<Module> preflightCheckModules) {
-        final Injector injector = Guice.createInjector(
+        return Guice.createInjector(
                 new IsDevelopmentBindings(),
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
                 new ConfigurationModule(configuration),
@@ -175,7 +173,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
                         preflightCheckModules.forEach(binder::install);
                     }
                 });
-        return injector;
     }
 
     private void setNettyNativeDefaults(PathConfiguration pathConfiguration) {
@@ -192,10 +189,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
     @Override
     protected void startCommand() {
         final String systemInformation = Tools.getSystemInformation();
-        final Map<String, Object> auditEventContext = ImmutableMap.of(
-                "version", version.toString(),
-                "java", systemInformation
-        );
 
         final OS os = OS.getOs();
 

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -62,6 +62,7 @@ import org.graylog2.shared.bindings.ServerStatusBindings;
 import org.graylog2.shared.bindings.SharedPeriodicalBindings;
 import org.graylog2.shared.bindings.ValidatorModule;
 import org.graylog2.shared.initializers.ServiceManagerListener;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.security.SecurityBindings;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
@@ -172,6 +173,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
         modules.add(new PreflightWebModule());
         modules.add(new ObjectMapperModule(chainingClassLoader));
         modules.add(new SchedulerBindings());
+        modules.add((binder) -> binder.bind(ChainingClassLoader.class).toInstance(chainingClassLoader));
 
         final Injector preflightInjector = getPreflightInjector(modules);
         GuiceInjectorHolder.setInjector(preflightInjector);

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightWebModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightWebModule.java
@@ -25,12 +25,15 @@ import org.graylog.security.certutil.keystore.storage.KeystoreContentMover;
 import org.graylog.security.certutil.keystore.storage.SinglePasswordKeystoreContentMover;
 import org.graylog2.bindings.providers.MongoConnectionProvider;
 import org.graylog2.bootstrap.preflight.web.PreflightBoot;
+import org.graylog2.bootstrap.preflight.web.resources.CertificateRenewalPolicyResource;
 import org.graylog2.bootstrap.preflight.web.resources.PreflightAssetsResource;
 import org.graylog2.bootstrap.preflight.web.resources.PreflightResource;
 import org.graylog2.bootstrap.preflight.web.resources.PreflightStatusResource;
+import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.cluster.NodeServiceImpl;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.periodical.Periodical;
@@ -47,6 +50,7 @@ public class PreflightWebModule extends Graylog2Module {
         bind(MongoConnection.class).toProvider(MongoConnectionProvider.class);
         bind(NodeService.class).to(NodeServiceImpl.class);
         bind(KeystoreContentMover.class).to(SinglePasswordKeystoreContentMover.class).asEagerSingleton();
+        bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class);
 
         bind(PreflightConfigService.class).to(PreflightConfigServiceImpl.class);
         bind(PreflightBoot.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightWebModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightWebModule.java
@@ -56,6 +56,7 @@ public class PreflightWebModule extends Graylog2Module {
         bind(PreflightBoot.class).asEagerSingleton();
 
         addPreflightRestResource(PreflightResource.class);
+        addPreflightRestResource(CertificateRenewalPolicyResource.class);
         addPreflightRestResource(PreflightStatusResource.class);
         addPreflightRestResource(PreflightAssetsResource.class);
 

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
@@ -1,0 +1,37 @@
+package org.graylog2.bootstrap.preflight.web.resources;
+
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.bootstrap.preflight.PreflightConstants;
+import org.graylog2.plugin.certificates.RenewalPolicy;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path(PreflightConstants.API_PREFIX + "renewal_policy")
+@Produces(MediaType.APPLICATION_JSON)
+public class CertificateRenewalPolicyResource {
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public CertificateRenewalPolicyResource(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @GET
+    public RenewalPolicy get() {
+        return this.clusterConfigService.get(RenewalPolicy.class);
+    }
+
+    @POST
+    @Path("/create")
+    @NoAuditEvent("No Audit Event needed")
+    public void set(@NotNull RenewalPolicy renewalPolicy) {
+        this.clusterConfigService.write(renewalPolicy);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.bootstrap.preflight.web.resources;
 
 import org.graylog2.audit.jersey.NoAuditEvent;

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/CertificateRenewalPolicyResource.java
@@ -29,7 +29,6 @@ public class CertificateRenewalPolicyResource {
     }
 
     @POST
-    @Path("/create")
     @NoAuditEvent("No Audit Event needed")
     public void set(@NotNull RenewalPolicy renewalPolicy) {
         this.clusterConfigService.write(renewalPolicy);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/certificates/RenewalPolicy.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/certificates/RenewalPolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.plugin.certificates;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/certificates/RenewalPolicy.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/certificates/RenewalPolicy.java
@@ -1,0 +1,20 @@
+package org.graylog2.plugin.certificates;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.Locale;
+
+public record RenewalPolicy(@JsonProperty("mode") @NotNull Mode mode,
+                            @JsonProperty("certificate_lifetime") @NotNull String certificateLifetime) {
+    public enum Mode {
+        AUTOMATIC,
+        MANUAL;
+
+        @JsonCreator
+        public static Mode create(String value) {
+            return Mode.valueOf(value.toUpperCase(Locale.ROOT));
+        }
+    }
+}

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -180,6 +180,7 @@
   "resolutions": {
     "immer": "9.0.6",
     "nth-check": "2.0.1",
-    "glob-parent": "5.1.2"
+    "glob-parent": "5.1.2",
+    "@emotion/utils": "1.2.0"
   }
 }

--- a/graylog2-web-interface/src/preflight/Constants.ts
+++ b/graylog2-web-interface/src/preflight/Constants.ts
@@ -20,6 +20,10 @@ export const CONFIGURATION_STEPS = {
     key: 'CA_CONFIGURATION',
     description: 'Configure a certificate authority',
   },
+  RENEWAL_POLICY_CONFIGURATION: {
+    key: 'RENEWAL_POLICY_CONFIGURATION',
+    description: 'Configure a renewal policy',
+  },
   CERTIFICATE_PROVISIONING: {
     key: 'CERTIFICATE_PROVISIONING',
     description: 'Provision certificates for your data nodes',
@@ -33,6 +37,7 @@ export const CONFIGURATION_STEPS = {
 
 export const CONFIGURATION_STEPS_ORDER = [
   CONFIGURATION_STEPS.CA_CONFIGURATION.key,
+  CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key,
   CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key,
   CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key,
 ];

--- a/graylog2-web-interface/src/preflight/Constants.ts
+++ b/graylog2-web-interface/src/preflight/Constants.ts
@@ -33,7 +33,7 @@ export const CONFIGURATION_STEPS = {
     key: 'CONFIGURATION_FINISHED',
     description: 'All data nodes are secured and reachable',
   },
-};
+} as const;
 
 export const CONFIGURATION_STEPS_ORDER = [
   CONFIGURATION_STEPS.CA_CONFIGURATION.key,

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
@@ -23,6 +23,7 @@ import type { IconName } from 'components/common/Icon';
 import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
 import { List, Grid } from 'preflight/components/common';
+import RenewalPolicyConfiguration from 'preflight/components/ConfigurationWizard/RenewalPolicyConfiguration';
 
 import CertificateProvisioning from './CertificateProvisioning';
 import CAConfiguration from './CAConfiguration';
@@ -90,6 +91,7 @@ const ConfigurationWizard = ({ setIsWaitingForStartup }: Props) => {
       </Grid.Col>
       <Grid.Col span={12} md={6} orderMd={1}>
         {activeStepKey === CONFIGURATION_STEPS.CA_CONFIGURATION.key && <CAConfiguration />}
+        {activeStepKey === CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key && <RenewalPolicyConfiguration />}
         {activeStepKey === CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key && <CertificateProvisioning />}
         {activeStepKey === CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key && <ConfigurationFinished setIsWaitingForStartup={setIsWaitingForStartup} />}
       </Grid.Col>

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import styled, { css, useTheme } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
 
 import useConfigurationStep from 'preflight/hooks/useConfigurationStep';
 import { CONFIGURATION_STEPS, CONFIGURATION_STEPS_ORDER } from 'preflight/Constants';
@@ -24,6 +25,7 @@ import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
 import { List, Grid } from 'preflight/components/common';
 import RenewalPolicyConfiguration from 'preflight/components/ConfigurationWizard/RenewalPolicyConfiguration';
+import type { ConfigurationStep } from 'preflight/types';
 
 import CertificateProvisioning from './CertificateProvisioning';
 import CAConfiguration from './CAConfiguration';
@@ -35,7 +37,7 @@ const StepIcon = styled(Icon)<{ $color: string }>(({ $color, theme }) => css`
   border-radius: 50%;
 `);
 
-const stepIcon = (stepKey, activeStepKey, theme): { name: IconName, color: string } => {
+const stepIcon = (stepKey: ConfigurationStep, activeStepKey: ConfigurationStep, theme: DefaultTheme): { name: IconName, color: string } => {
   const stepIndex = CONFIGURATION_STEPS_ORDER.findIndex((key) => key === stepKey);
   const activeStepIndex = CONFIGURATION_STEPS_ORDER.findIndex((key) => key === activeStepKey);
 

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { Formik, Form, Field } from 'formik';
 import styled from 'styled-components';

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { Formik, Form, Field } from 'formik';
+import styled from 'styled-components';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import moment from 'moment';
+
+import { Title, Space, Button, Group, NumberInput } from 'preflight/components/common';
+import UserNotification from 'preflight/util/UserNotification';
+import fetch from 'logic/rest/FetchProvider';
+import { qualifyUrl } from 'util/URLUtils';
+import Select from 'preflight/components/common/Select';
+
+const RENEWAL_POLICY_QUERY_KEY = ['data_node_renewal_policy'];
+
+const createPolicy = (caData: FormValues) => fetch(
+  'POST',
+  qualifyUrl('/api/renewal_policy/create'),
+  caData,
+  false,
+);
+
+const StyledForm = styled(Form)`
+  > div:not(:last-child) {
+    margin-bottom: 10px;
+  }
+`;
+
+const MINIMUM_LIFETIME = moment.duration(2, 'hours');
+
+const validateForm = (formValues: FormValues) => {
+  const duration = moment.duration(formValues.lifetime_value, formValues.lifetime_unit);
+
+  return duration.subtract(MINIMUM_LIFETIME).asMilliseconds() < 0
+    ? {
+      lifetime_value: `Must be at least ${MINIMUM_LIFETIME.humanize()}`,
+    }
+    : {};
+};
+
+type FormValues = {
+  renewal_policy: 'Automatic' | 'Manual',
+  lifetime_value: number,
+  lifetime_unit: 'hours' | 'days' | 'months' | 'years',
+}
+const unitOptions = [
+  { label: 'Hour(s)', value: 'hours' },
+  { label: 'Day(s)', value: 'days' },
+  { label: 'Month(s)', value: 'months' },
+  { label: 'Year(s)', value: 'years' },
+];
+
+const defaultFormValues = {
+  renewal_policy: 'Automatic',
+  lifetime_value: 30,
+  lifetime_unit: 'days',
+};
+
+const RenewalPolicyConfiguration = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate: onSubmit } = useMutation(createPolicy, {
+    onSuccess: () => {
+      UserNotification.success('CA created successfully');
+      queryClient.invalidateQueries(RENEWAL_POLICY_QUERY_KEY);
+    },
+    onError: (error) => {
+      UserNotification.error(`CA creation failed with error: ${error}`);
+    },
+  });
+
+  return (
+    <>
+      <Title order={3}>Configure Renewal Policy</Title>
+      <p>
+        In this step you can configure if certificates which are close to expiration should be renewed automatically or manually.<br />
+        If you choose manual renewal, a system notification will show up when the expiration date is near, requiring you to confirm renewal.
+      </p>
+      <Space h="md" />
+      <Formik initialValues={defaultFormValues} onSubmit={(formValues: FormValues) => onSubmit(formValues)} validate={validateForm}>
+        {({ isSubmitting, isValid, setFieldValue }) => (
+          <StyledForm>
+            <Field name="renewal_policy">
+              {({ field: { value, name } }) => (
+                <Select placeholder="Select Renewal Policy"
+                        data={['Automatic', 'Manual']}
+                        required
+                        value={value}
+                        onChange={(newPolicy) => setFieldValue(name, newPolicy)}
+                        label="Renewal Policy" />
+              )}
+            </Field>
+            <Group>
+              <Field name="lifetime_value">
+                {({ field: { name, value }, meta: { error } }) => (
+                  <NumberInput value={value}
+                               onChange={(newValue) => setFieldValue(name, newValue)}
+                               label="Certificate lifetime"
+                               required
+                               placeholder="Enter lifetime"
+                               error={error}
+                               step={1} />
+                )}
+              </Field>
+              <Field name="lifetime_unit">
+                {({ field: { name, value } }) => (
+                  <Select placeholder="Select Unit"
+                          data={unitOptions}
+                          required
+                          label="Unit"
+                          value={value}
+                          onChange={(unit) => setFieldValue(name, unit)} />
+                )}
+              </Field>
+            </Group>
+            <Button disabled={isSubmitting || !isValid} type="submit">
+              {isSubmitting ? 'Creating policy...' : 'Create policy'}
+            </Button>
+          </StyledForm>
+        )}
+      </Formik>
+    </>
+
+  );
+};
+
+export default RenewalPolicyConfiguration;

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
@@ -26,7 +26,7 @@ const createPolicy = ({ renewal_policy, lifetime_unit, lifetime_value }: FormVal
 
   return fetch(
     'POST',
-    qualifyUrl('/api/renewal_policy/create'),
+    qualifyUrl('/api/renewal_policy'),
     payload,
     false,
   );

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
@@ -9,8 +9,7 @@ import UserNotification from 'preflight/util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import Select from 'preflight/components/common/Select';
-
-const RENEWAL_POLICY_QUERY_KEY = ['data_node_renewal_policy'];
+import { QUERY_KEY as RENEWAL_POLICY_QUERY_KEY } from 'preflight/hooks/useRenewalPolicy';
 
 type FormValues = {
   renewal_policy: 'Automatic' | 'Manual',
@@ -67,11 +66,11 @@ const RenewalPolicyConfiguration = () => {
 
   const { mutate: onSubmit } = useMutation(createPolicy, {
     onSuccess: () => {
-      UserNotification.success('CA created successfully');
+      UserNotification.success('Renewal policy created successfully');
       queryClient.invalidateQueries(RENEWAL_POLICY_QUERY_KEY);
     },
     onError: (error) => {
-      UserNotification.error(`CA creation failed with error: ${error}`);
+      UserNotification.error(`Renewal policy creation failed with error: ${error}`);
     },
   });
 

--- a/graylog2-web-interface/src/preflight/components/common/Select.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Select.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { useContext } from 'react';
+import type { SelectProps } from '@mantine/core';
+import { Select as MantineSelect } from '@mantine/core';
+import { ThemeContext } from 'styled-components';
+
+const Select = ({ children, ...otherProps }: SelectProps) => {
+  const theme = useContext(ThemeContext);
+  const SelectStyles = () => ({
+    input: {
+      color: theme.colors.input.color,
+      backgroundColor: theme.colors.input.background,
+      borderColor: theme.colors.input.border,
+    },
+    dropdown: {
+      color: theme.colors.input.color,
+      backgroundColor: theme.colors.input.background,
+    },
+  });
+
+  return (
+    <MantineSelect {...otherProps}
+                   styles={SelectStyles}>
+      {children}
+    </MantineSelect>
+  );
+};
+
+export default Select;

--- a/graylog2-web-interface/src/preflight/components/common/Select.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Select.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useContext } from 'react';
 import type { SelectProps } from '@mantine/core';

--- a/graylog2-web-interface/src/preflight/components/common/index.ts
+++ b/graylog2-web-interface/src/preflight/components/common/index.ts
@@ -30,6 +30,7 @@ export { default as MenuItem } from './MenuItem';
 export { default as MenuTarget } from './mantine/MenuTarget';
 export { default as Row } from './Row';
 export { default as Section } from './Section';
+export { default as Select } from './Select';
 export { default as Space } from './Space';
 export { default as Tabs } from './Tabs';
 export { default as Title } from './Title';

--- a/graylog2-web-interface/src/preflight/components/common/mantine/imports.ts
+++ b/graylog2-web-interface/src/preflight/components/common/mantine/imports.ts
@@ -22,6 +22,7 @@ export {
   Divider,
   Group,
   Header,
+  NumberInput,
   Text,
   UnstyledButton,
   Collapse,

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
@@ -94,7 +94,21 @@ describe('useConfigurationStep', () => {
     }));
   });
 
-  it('should define certificate provisioning step as active step, when CA has not been provisioned', async () => {
+  it('should define renewal policy creation step as active step, when none is configured', async () => {
+    asMock(useDataNodesCA).mockReturnValue({
+      ...useDataNodesResult,
+      data: { id: 'ca-id', type: 'ca-type' },
+    });
+
+    const { result, waitFor } = renderHook(() => useConfigurationStep());
+
+    await waitFor(() => expect(result.current).toEqual({
+      step: CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key,
+      isLoading: false,
+    }));
+  });
+
+  it('should define certificate provisioning step as active step, when data nodes have not been provisioned', async () => {
     asMock(useDataNodesCA).mockReturnValue({
       ...useDataNodesResult,
       data: { id: 'ca-id', type: 'ca-type' },
@@ -132,7 +146,7 @@ describe('useConfigurationStep', () => {
     }));
   });
 
-  it('should define success step as active step, when CA been provisioned', async () => {
+  it('should define success step as active step, when data nodes have been provisioned', async () => {
     asMock(useDataNodesCA).mockReturnValue({
       ...useDataNodesResult,
       data: { id: 'ca-id', type: 'ca-type' },

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
@@ -21,11 +21,13 @@ import { CONFIGURATION_STEPS } from 'preflight/Constants';
 import asMock from 'helpers/mocking/AsMock';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import { dataNodes } from 'fixtures/dataNodes';
+import useRenewalPolicy from 'preflight/hooks/useRenewalPolicy';
 
 import useConfigurationStep from './useConfigurationStep';
 
 jest.mock('preflight/hooks/useDataNodes');
 jest.mock('preflight/hooks/useDataNodesCA');
+jest.mock('preflight/hooks/useRenewalPolicy');
 jest.mock('logic/rest/FetchProvider');
 
 describe('useConfigurationStep', () => {
@@ -43,9 +45,17 @@ describe('useConfigurationStep', () => {
     error: undefined,
   };
 
+  const useRenewalPolicyResult = {
+    data: undefined,
+    isInitialLoading: false,
+    isFetching: false,
+    error: undefined,
+  };
+
   beforeEach(() => {
     asMock(useDataNodes).mockReturnValue(useDataNodesResult);
     asMock(useDataNodesCA).mockReturnValue(useDataNodesCAResult);
+    asMock(useRenewalPolicy).mockReturnValue(useRenewalPolicyResult);
   });
 
   it('should return isLoading: true when data nodes are loading', async () => {
@@ -106,6 +116,14 @@ describe('useConfigurationStep', () => {
       }],
     });
 
+    asMock(useRenewalPolicy).mockReturnValue({
+      ...useRenewalPolicyResult,
+      data: {
+        mode: 'AUTOMATIC',
+        certificate_lifetime: 'P30D',
+      },
+    });
+
     const { result, waitFor } = renderHook(() => useConfigurationStep());
 
     await waitFor(() => expect(result.current).toEqual({
@@ -134,6 +152,14 @@ describe('useConfigurationStep', () => {
         type: 'DATANODE',
         status: 'CONNECTED',
       }],
+    });
+
+    asMock(useRenewalPolicy).mockReturnValue({
+      ...useRenewalPolicyResult,
+      data: {
+        mode: 'AUTOMATIC',
+        certificate_lifetime: 'P30D',
+      },
     });
 
     const { result, waitFor } = renderHook(() => useConfigurationStep());

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
@@ -18,20 +18,25 @@
 import { useMemo } from 'react';
 
 import { CONFIGURATION_STEPS, DATA_NODES_STATUS } from 'preflight/Constants';
-import type { DataNodes, ConfigurationStep, DataNodesCA } from 'preflight/types';
+import type { DataNodes, ConfigurationStep, DataNodesCA, RenewalPolicy } from 'preflight/types';
 import useDataNodes from 'preflight/hooks/useDataNodes';
+import useRenewalPolicy from 'preflight/hooks/useRenewalPolicy';
 
 import useDataNodesCA from './useDataNodesCA';
 
-const configurationStep = (dataNodes: DataNodes, dataNodesCA: DataNodesCA) => {
+const configurationStep = (dataNodes: DataNodes, dataNodesCA: DataNodesCA, renewalPolicy: RenewalPolicy) => {
   if (!dataNodesCA) {
     return CONFIGURATION_STEPS.CA_CONFIGURATION.key;
+  }
+
+  if (!renewalPolicy) {
+    return CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key;
   }
 
   const finishedProvisioning = !dataNodes.some((dataNode) => dataNode.status !== DATA_NODES_STATUS.CONNECTED.key);
 
   if (!finishedProvisioning) {
-    return CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key;
+    return CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key;
   }
 
   return CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key;
@@ -40,10 +45,11 @@ const configurationStep = (dataNodes: DataNodes, dataNodesCA: DataNodesCA) => {
 const useConfigurationStep = (): { step: ConfigurationStep | undefined, isLoading: boolean } => {
   const { data: dataNodes, isInitialLoading: isLoadingDataNodes } = useDataNodes();
   const { data: dataNodesCA, isInitialLoading: isLoadingCAStatus } = useDataNodesCA();
-  const step = configurationStep(dataNodes, dataNodesCA);
+  const { data: renewalPolicy, isInitialLoading: isLoadingRenewalPolicy } = useRenewalPolicy();
+  const step = configurationStep(dataNodes, dataNodesCA, renewalPolicy);
 
   return useMemo(() => {
-    if (isLoadingDataNodes || isLoadingCAStatus) {
+    if (isLoadingDataNodes || isLoadingCAStatus || isLoadingRenewalPolicy) {
       return ({ isLoading: true, step: undefined });
     }
 

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
@@ -31,7 +31,7 @@ const configurationStep = (dataNodes: DataNodes, dataNodesCA: DataNodesCA) => {
   const finishedProvisioning = !dataNodes.some((dataNode) => dataNode.status !== DATA_NODES_STATUS.CONNECTED.key);
 
   if (!finishedProvisioning) {
-    return CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key;
+    return CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key;
   }
 
   return CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key;

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
@@ -57,7 +57,7 @@ const useConfigurationStep = (): { step: ConfigurationStep | undefined, isLoadin
       isLoading: false,
       step,
     });
-  }, [isLoadingCAStatus, isLoadingDataNodes, step]);
+  }, [isLoadingCAStatus, isLoadingDataNodes, isLoadingRenewalPolicy, step]);
 };
 
 export default useConfigurationStep;

--- a/graylog2-web-interface/src/preflight/hooks/useRenewalPolicy.ts
+++ b/graylog2-web-interface/src/preflight/hooks/useRenewalPolicy.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import type { RenewalPolicy } from 'preflight/types';
+import type FetchError from 'logic/errors/FetchError';
+import fetch from 'logic/rest/FetchProvider';
+import { qualifyUrl } from 'util/URLUtils';
+
+export const QUERY_KEY = ['data-nodes', 'renewal-policy'];
+const fetchRenewalPolicy = (): Promise<RenewalPolicy> => (
+  fetch('GET', qualifyUrl('/api/renewal_policy'), undefined, false)
+);
+
+const useRenewalPolicy = (): {
+  data: RenewalPolicy,
+  isFetching: boolean,
+  error: FetchError,
+  isInitialLoading: boolean
+} => {
+  const {
+    data,
+    isFetching,
+    error,
+    isInitialLoading,
+  } = useQuery<RenewalPolicy, FetchError>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchRenewalPolicy,
+    initialData: undefined,
+    retry: 3000,
+  });
+
+  return { data, isFetching, error, isInitialLoading };
+};
+
+export default useRenewalPolicy;

--- a/graylog2-web-interface/src/preflight/types.ts
+++ b/graylog2-web-interface/src/preflight/types.ts
@@ -38,4 +38,9 @@ export type DataNodesCA = {
   type: string,
 }
 
+export type RenewalPolicy = {
+  mode: 'AUTOMATIC' | 'MANUAL',
+  certificate_lifetime: string,
+}
+
 export type ConfigurationStep = typeof CONFIGURATION_STEPS[keyof typeof CONFIGURATION_STEPS]['key']

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1698,12 +1698,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
   integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
-"@emotion/utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
-  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
-
-"@emotion/utils@^1.2.0":
+"@emotion/utils@1.2.0", "@emotion/utils@^1.0.0", "@emotion/utils@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
   integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding the UI & backend capabilities to configure a simple renewal policy for certificates during certificate provisioning in the pre-flight UI. Currently, it requires configuring:

  - a renewal mode: automatic or manual
  - the certificate lifetime

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/Graylog2/graylog2-server/assets/41929/6c521da6-df5e-4108-bac7-e6d010e16b5f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.