### PR TITLE
Only display query input suggestions while input has focus.

### DIFF
--- a/changelog/unreleased/issue-12165.toml
+++ b/changelog/unreleased/issue-12165.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Do not show query input suggestions when using `Add to query` field value action.
+
+issues = ["12165"]
+pulls = ["15885"]

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -100,7 +100,7 @@ const _onLoadEditor = (editor: Editor, isInitialTokenizerUpdate: React.MutableRe
     editor.commands.removeCommands(['find', 'indent', 'outdent']);
 
     editor.session.on('tokenizerUpdate', (_input, { bgTokenizer: { currentLine, lines } }) => {
-      if (!isInitialTokenizerUpdate.current) {
+      if (editor.isFocused() && !isInitialTokenizerUpdate.current) {
         editor.completers.forEach((completer) => {
           if (completer?.shouldShowCompletions(currentLine, lines)) {
             editor.execCommand('startAutocomplete');

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -71,7 +71,6 @@ export type Completer = {
 export type Editor = {
   commands: Commands,
   completer: Completer,
-
   completers: Array<AutoCompleter>,
   execCommand: (command: string) => void,
   session: Session,
@@ -79,6 +78,7 @@ export type Editor = {
   setFontSize: (newFontSize: number) => void,
   getValue: () => string,
   setValue: (newValue: string) => void,
+  isFocused: () => boolean,
 };
 
 export type CompletionResult = {


### PR DESCRIPTION
**Please note:** this  PR needs a backport for `5.0` and `5.1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were showing the query input suggestions on every `tokenizerUpdate`. This event will be triggered even when we extend the query by using the "Add to query" field value action.

With this change we also consider if the query input is focussed and only show suggestions in this case.

Fixes https://github.com/Graylog2/graylog2-server/issues/12165

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
