### PR TITLE
GL shutdown on catchable OutOfMemoryError

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -36,6 +36,7 @@ import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
 import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
+import org.graylog2.bootstrap.uncaughtexeptions.DefaultUncaughtExceptionHandlerCreator;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.cluster.leader.FakeLeaderElectionModule;
 import org.graylog2.cluster.leader.LeaderElectionModule;
@@ -178,6 +179,7 @@ public class ServerBindings extends Graylog2Module {
     }
 
     private void bindSingletons() {
+        bind(DefaultUncaughtExceptionHandlerCreator.class).asEagerSingleton();
         bind(SystemJobManager.class).toProvider(SystemJobManagerProvider.class);
         bind(DefaultSecurityManager.class).toProvider(DefaultSecurityManagerProvider.class).asEagerSingleton();
         bind(SystemJobFactory.class).toProvider(SystemJobFactoryProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/uncaughtexeptions/DefaultUncaughtExceptionHandlerCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/uncaughtexeptions/DefaultUncaughtExceptionHandlerCreator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bootstrap.uncaughtexeptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class DefaultUncaughtExceptionHandlerCreator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultUncaughtExceptionHandlerCreator.class);
+
+    public DefaultUncaughtExceptionHandlerCreator() {
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            if (!(e instanceof ThreadDeath)) {
+                defaultHandling(t, e);
+                if (e instanceof OutOfMemoryError) {
+                    outOfMemoryHandling(t);
+                }
+            }
+        });
+    }
+
+    private void outOfMemoryHandling(final Thread t) {
+        LOG.error("OutOfMemoryError encountered in thread " + t.getName() + ", Graylog instance will be shut down.");
+        final Runtime runtime = Runtime.getRuntime();
+        LOG.info("Free JVM memory : " + runtime.freeMemory());
+        LOG.info("Total JVM memory : " + runtime.totalMemory());
+        LOG.info("Max JVM memory : " + runtime.maxMemory());
+
+        System.exit(1);
+    }
+
+    private void defaultHandling(final Thread t, final Throwable e) {
+        //see ThreadGrooup.uncaughtException -> we don't want to remove the well-known "printStackTrace" uncaught exception handling
+        System.err.print("Exception in thread \""
+                + t.getName() + "\" ");
+        e.printStackTrace(System.err);
+    }
+}


### PR DESCRIPTION
## Description
It was decided that we want to make an attempt to catch OutOfMemoryError and shutdown GL.
DefaultUncaughtExceptionHandler mechanism was used for that task.
/nocl

## Motivation and Context
See #4980.
Despite the OutOfMemoryError in AbstractIOReactor, GL continues to operate.
The reactor is STOPPED and is not useful at all at this point.

## How Has This Been Tested?
Manually, with Jan's trick to simulate OutOfMemoryError in AbstractIOReactor.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

