### PR TITLE
Exempt the associated_assets Field from Traffic Accounting

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
@@ -39,4 +39,6 @@ public class GraylogSchemaFields {
     public static final String FIELD_ILLUMINATE_GIM_TAGS = "gim_tags";
     public static final String FIELD_ILLUMINATE_GIM_VERSION = "gim_version";
 
+    public static final String FIELD_ASSOCIATED_ASSETS = "associated_assets";
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -76,6 +76,7 @@ import static org.graylog.schema.GraylogSchemaFields.FIELD_ILLUMINATE_GIM_EVENT_
 import static org.graylog.schema.GraylogSchemaFields.FIELD_ILLUMINATE_GIM_TAGS;
 import static org.graylog.schema.GraylogSchemaFields.FIELD_ILLUMINATE_GIM_VERSION;
 import static org.graylog.schema.GraylogSchemaFields.FIELD_ILLUMINATE_TAGS;
+import static org.graylog.schema.GraylogSchemaFields.FIELD_ASSOCIATED_ASSETS;
 import static org.graylog2.plugin.Tools.buildElasticSearchTimeFormat;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -228,7 +229,8 @@ public class Message implements Messages, Indexable {
             FIELD_ILLUMINATE_GIM_EVENT_TYPE,
             FIELD_ILLUMINATE_GIM_EVENT_TYPE_CODE,
             FIELD_ILLUMINATE_GIM_TAGS,
-            FIELD_ILLUMINATE_GIM_VERSION
+            FIELD_ILLUMINATE_GIM_VERSION,
+            FIELD_ASSOCIATED_ASSETS
     );
 
     private static final ImmutableSet<String> CORE_MESSAGE_FIELDS = ImmutableSet.of(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As part of the Asset Enrichment feature's to search for messages by Assets, the `associated_assets` field can be added by Graylog for some messages.

Pitch: https://graylogdocumentation.atlassian.net/wiki/spaces/EST/pages/2870706205/Design+Asset+Search

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Graylog added fields, which we use internally, should not be counted for user volume totals.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

