### PR TITLE
Decreasing z-index of login background. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-15884.toml
+++ b/changelog/unreleased/issue-15884.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Decreasing z-index of login background."
+
+issues = ["15884"]
+pulls = ["15901"]

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -37,6 +37,7 @@ const Background = styled.div`
 `;
 
 const BackgroundText = styled.div`
+  z-index: -1;
   display: flex;
   flex-direction: column;
   position: absolute;


### PR DESCRIPTION
**Note:** This is a backport of #15887 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is decreasing the z-index of the login background so it does not cover the public notifications shown on the login page.

Fixes #15884.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.