### PR TITLE
Making value rendering consistent. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-15778.toml
+++ b/changelog/unreleased/issue-15778.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Render values consistently between normal and full screen mode."
+
+issues = ["15778"]
+pulls = ["15864"]
+

--- a/graylog2-web-interface/src/views/components/Value.tsx
+++ b/graylog2-web-interface/src/views/components/Value.tsx
@@ -27,7 +27,6 @@ import TypeSpecificValue from './TypeSpecificValue';
 import InteractiveContext from './contexts/InteractiveContext';
 
 type Props = {
-  children?: React.ReactNode,
   field: string,
   value: any,
   render?: ValueRenderer,
@@ -40,14 +39,14 @@ const ValueActionTitle = styled.span`
 
 const defaultRenderer: ValueRenderer = ({ value }: ValueRendererProps) => value;
 
-const InteractiveValue = ({ children, field, value, render, type }: Props) => {
+const InteractiveValue = ({ field, value, render, type }: Props) => {
   const queryId = useActiveQueryId();
   const RenderComponent: ValueRenderer = useMemo(() => render ?? ((props: ValueRendererProps) => props.value), [render]);
   const Component = useCallback(({ value: componentValue }) => <RenderComponent field={field} value={componentValue} />, [RenderComponent, field]);
   const element = <TypeSpecificValue field={field} value={value} type={type} render={Component} />;
 
   return (
-    <ValueActions element={children || element} field={field} queryId={queryId} type={type} value={value}>
+    <ValueActions element={element} field={field} queryId={queryId} type={type} value={value}>
       <ValueActionTitle data-testid="value-actions-title">
         {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
       </ValueActionTitle>
@@ -56,23 +55,21 @@ const InteractiveValue = ({ children, field, value, render, type }: Props) => {
 };
 
 InteractiveValue.defaultProps = {
-  children: null,
   render: defaultRenderer,
 };
 
-const Value = ({ children, field, value, render = defaultRenderer, type = FieldType.Unknown }: Props) => {
+const Value = ({ field, value, render = defaultRenderer, type = FieldType.Unknown }: Props) => {
   return (
     <InteractiveContext.Consumer>
       {(interactive) => ((interactive)
-        ? <InteractiveValue field={field} value={value} render={render} type={type}>{children}</InteractiveValue>
-        : <span><TypeSpecificValue field={field} value={value} type={type} /></span>)}
+        ? <InteractiveValue field={field} value={value} render={render} type={type} />
+        : <span><TypeSpecificValue field={field} value={value} render={render} type={type} /></span>)}
     </InteractiveContext.Consumer>
   );
 };
 
 Value.defaultProps = {
   render: defaultRenderer,
-  children: null,
 };
 
 export default Value;

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -147,7 +147,7 @@ const PlotLegend = ({ children, config, chartData, labelMapper = defaultLabelMap
     const defaultColor = value === eventsDisplayName ? EVENT_COLOR : undefined;
     const isFunction = isLabelAFunction(value, series[0]);
     const field = (fieldMapper ?? defaultFieldMapper)(isFunction);
-    const val = field !== null ? <Value type={FieldType.Unknown} value={value} field={field}>{value}</Value> : value;
+    const val = field !== null ? <Value type={FieldType.Unknown} value={value} field={field} /> : value;
 
     return (
       <LegendCell key={value}>


### PR DESCRIPTION
**Note:** This is a backport of #15864 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue when the `Value` component is used in non-interactive modes (e.g. full screen mode). The underlying reason is that the `Value` component is not passing the `render` prop when in non-interactive, leading to type/user-specific formattings being skipped.

Fixes #15778.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.