### PR TITLE
Update info text for empty aggregations.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.tsx
@@ -19,6 +19,8 @@ import styled, { css } from 'styled-components';
 
 import { Button } from 'components/bootstrap';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
+import { UPDATE_WIDGET_BTN_TEXT } from 'views/components/widgets/SaveOrCancelButtons';
+import { UPDATE_WIDGET_PREVIEW_BTN_TEXT } from 'views/components/aggregationwizard/ElementsConfigurationActions';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 
@@ -51,9 +53,11 @@ const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
   const interactive = useContext(InteractiveContext);
   const text = editing
     ? (
-      <p>You are now editing the widget.<br />
+      <p>
+        You are now editing the widget.<br />
         To see results, add at least one metric. You can group data by adding rows/columns.<br />
-        To finish, click &quot;Save&quot; to save, &quot;Cancel&quot; to abandon changes.
+        You can preview widget search results by clicking on &quot;{UPDATE_WIDGET_PREVIEW_BTN_TEXT}&quot;.<br />
+        To finish, click &quot;{UPDATE_WIDGET_BTN_TEXT}&quot; to save, &quot;Cancel&quot; to abandon changes.
       </p>
     )
     : (<p>Please {interactive ? <Button bsStyle="info" onClick={toggleEdit}>Edit</Button> : 'edit'} the widget to see results here.</p>);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfigurationActions.tsx
@@ -26,6 +26,8 @@ import AggregationElementSelect from 'views/components/aggregationwizard/Aggrega
 import aggregationElements from './aggregationElementDefinitions';
 import type { WidgetConfigFormValues } from './WidgetConfigForm';
 
+export const UPDATE_WIDGET_PREVIEW_BTN_TEXT = 'Update preview';
+
 const aggregationElementsByKey = Object.fromEntries(aggregationElements.map((element) => ([element.key, element])));
 
 const StyledButtonToolbar = styled(ButtonToolbar)`
@@ -68,7 +70,7 @@ const ElementsConfigurationActions = () => {
       </SelectContainer>
 
       <Button bsStyle="info" className="pull-right" type="submit" disabled={!isValid || isUpdatingPreview || !dirty}>
-        {isUpdatingPreview ? <Spinner text="Updating preview..." delay={0} /> : 'Update preview'}
+        {isUpdatingPreview ? <Spinner text="Updating preview..." delay={0} /> : UPDATE_WIDGET_PREVIEW_BTN_TEXT}
       </Button>
     </StyledButtonToolbar>
   );

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
@@ -21,6 +21,8 @@ import WidgetEditApplyAllChangesContext from 'views/components/contexts/WidgetEd
 import { ModalSubmit } from 'components/common';
 import DisableSubmissionStateContext from 'views/components/contexts/DisableSubmissionStateContext';
 
+export const UPDATE_WIDGET_BTN_TEXT = 'Update widget';
+
 type Props = {
   onCancel: () => void,
   onSubmit: () => void,
@@ -44,7 +46,7 @@ const SaveOrCancelButtons = ({ onSubmit, onCancel }: Props) => {
 
   return (
     <ModalSubmit isAsyncSubmit
-                 submitButtonText="Update widget"
+                 submitButtonText={UPDATE_WIDGET_BTN_TEXT}
                  submitLoadingText="Updating widget..."
                  onSubmit={_onSubmit}
                  submitButtonType="button"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/10921 the info we display for empty aggregations contained outdated button names. This PR is updating the text.

Fixes https://github.com/Graylog2/graylog2-server/issues/10921
/nocl