### PR TITLE
Improve readability of hover legend in aggregations. (backport of #15888 for `5.0`)

### DIFF
--- a/changelog/unreleased/issue-15084.toml
+++ b/changelog/unreleased/issue-15084.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Improve readability of hover legend in aggregations."
+
+issues = ["15084"]
+pulls = ["15888"]

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import type { DefaultTheme } from 'styled-components';
-import { withTheme } from 'styled-components';
+import styled, { css, withTheme } from 'styled-components';
 import { merge } from 'lodash';
 import { Overlay, RootCloseWrapper } from 'react-overlays';
 
@@ -34,6 +34,21 @@ import styles from './GenericPlot.lazy.css';
 
 import InteractiveContext from '../contexts/InteractiveContext';
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
+
+const StyledPlot = styled(Plot)(({ theme }) => css`
+  .hoverlayer .hovertext {
+    rect {
+      fill: ${theme.colors.global.contentBackground} !important;
+      opcity: 0.9 !important;
+    }
+    .name {
+      fill: ${theme.colors.global.textDefault} !important;
+    }
+    path {
+      stroke: ${theme.colors.global.contentBackground} !important;
+    }
+  }
+`);
 
 type LegendConfig = {
   name: string,
@@ -243,15 +258,15 @@ class GenericPlot extends React.Component<GenericPlotProps, State> {
                 <RenderCompletionCallback.Consumer>
                   {(onRenderComplete) => (
                     <>
-                      <Plot data={newChartData}
-                            useResizeHandler
-                            layout={interactive ? plotLayout : merge({}, nonInteractiveLayout, plotLayout)}
-                            style={style}
-                            onAfterPlot={onRenderComplete}
-                            onClick={interactive ? null : () => false}
-                            onLegendClick={interactive ? this._onLegendClick : () => false}
-                            onRelayout={interactive ? this._onRelayout : () => false}
-                            config={config} />
+                      <StyledPlot data={newChartData}
+                                  useResizeHandler
+                                  layout={interactive ? plotLayout : merge({}, nonInteractiveLayout, plotLayout)}
+                                  style={style}
+                                  onAfterPlot={onRenderComplete}
+                                  onClick={interactive ? null : () => false}
+                                  onLegendClick={interactive ? this._onLegendClick : () => false}
+                                  onRelayout={interactive ? this._onRelayout : () => false}
+                                  config={config} />
                       {legendConfig && (
                         <RootCloseWrapper event="mousedown"
                                           onRootClose={this._onCloseColorPopup}>


### PR DESCRIPTION
**Please note:** This is a backport of #15888 for `5.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this change the hover labels in aggregations were sometimes hard to read.

Before:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/33bc0518-6d87-44dd-80b6-d89d09cd24a2)

After:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/0810fd2c-1732-4e09-b787-9f5c73b605dc)

Fixes https://github.com/Graylog2/graylog2-server/issues/15084
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/4337

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
