### PR TITLE
Fix join / substring pipeline function parameter name (#15891)

### DIFF
--- a/changelog/unreleased/issue-11868.toml
+++ b/changelog/unreleased/issue-11868.toml
@@ -1,0 +1,10 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix join() and substring() pipeline function parameter names."
+
+issues = ["11868"]
+pulls = [""]
+

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Join.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Join.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.pipelineprocessor.functions.strings;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
-import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.StringUtils;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
@@ -50,7 +49,7 @@ public class Join extends AbstractFunction<String> {
                 .transform(Ints::saturatedCast)
                 .description("The first index to start joining from. It is an error to pass in an index larger than the number of elements")
                 .build();
-        endIndexParam = ParameterDescriptor.integer("end", Integer.class).optional()
+        endIndexParam = ParameterDescriptor.integer("indexEnd", Integer.class).optional()
                 .transform(Ints::saturatedCast)
                 .description("The index to stop joining from (exclusive). It is an error to pass in an index larger than the number of elements")
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Substring.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/Substring.java
@@ -36,7 +36,7 @@ public class Substring extends AbstractFunction<String> {
     public Substring() {
         valueParam = ParameterDescriptor.string("value").description("The string to extract from").build();
         startParam = ParameterDescriptor.integer("start").description("The position to start from, negative means count back from the end of the String by this many characters").build();
-        endParam = ParameterDescriptor.integer("end").optional().description("The position to end at (exclusive), negative means count back from the end of the String by this many characters, defaults to length of the input string").build();
+        endParam = ParameterDescriptor.integer("indexEnd").optional().description("The position to end at (exclusive), negative means count back from the end of the String by this many characters, defaults to length of the input string").build();
     }
 
     @Override


### PR DESCRIPTION
We cannot use `end` because it's a reserved keyword in the pipeline language and causes a syntax error.

Instead of adding special handling for the `end` keyword to the pipeline rule language we just rename the parameter to `indexEnd`.

This shouldn't break existing rules, because they could've never been saved.

Fixes #11868

(cherry picked from commit af1a0879f75f93e605c2adf1e239dacc8dd097c4)



