### PR TITLE
Setting `networkMode` to `always` for TanStack Query. (`5.0`)

### DIFF
--- a/changelog/unreleased/issue-15913.toml
+++ b/changelog/unreleased/issue-15913.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Disable offline detection for REST API client."
+
+issues = ["15913"]
+pulls = ["15914"]
+

--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -29,6 +29,7 @@ const defaultOptions = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      networkMode: 'always' as const,
     },
   },
 };

--- a/graylog2-web-interface/src/contexts/LoginQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/LoginQueryClientProvider.tsx
@@ -26,6 +26,7 @@ const options = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      networkMode: 'always' as const,
     },
   },
 };


### PR DESCRIPTION
**Note:** This is a backport of #15914 to `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is setting the default [Network Mode](https://tanstack.com/query/v4/docs/react/guides/network-mode) to `always` for TanStack Query. This disables pausing of requests when offline detection kicks in. Offline detection kicking in although not desired has been reported for users on isolated networks using Firefox.

Fixes #15913.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.