### PR TITLE
Fix link for alert replay in mail notification template.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -50,7 +50,7 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
             "Description: ${event_definition_description}\n" +
             "Type:        ${event_definition_type}\n" +
             "--- [Event] --------------------------------------\n" +
-            "Alert Replay:         ${http_external_uri}/alerts/${event.id}/replay-search\n" +
+            "Alert Replay:         ${http_external_uri}alerts/${event.id}/replay-search\n" +
             "Timestamp:            ${event.timestamp}\n" +
             "Message:              ${event.message}\n" +
             "Source:               ${event.source}\n" +

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -31,7 +31,7 @@ Title:       \${event_definition_title}
 Description: \${event_definition_description}
 Type:        \${event_definition_type}
 --- [Event] --------------------------------------
-Alert Replay:         \${http_external_uri}/alerts/\${event.id}/replay-search
+Alert Replay:         \${http_external_uri}alerts/\${event.id}/replay-search
 Timestamp:            \${event.timestamp}
 Message:              \${event.message}
 Source:               \${event.source}
@@ -61,7 +61,7 @@ const DEFAULT_HTML_BODY_TEMPLATE = `<table width="100%" border="0" cellpadding="
 </tbody></table>
 <br /><table width="100%" border="0" cellpadding="10" cellspacing="0" style="background-color:#f9f9f9;border:none;line-height:1.2"><tbody>
 <tr><th colspan="2" style="background-color:#e6e6e6;line-height:1.5">Event</th></tr>
-<tr><td>Alert Replay</td><td>\${http_external_uri}/alerts/\${event.id}/replay-search</td></tr>
+<tr><td>Alert Replay</td><td>\${http_external_uri}alerts/\${event.id}/replay-search</td></tr>
 <tr><td width="200px">Timestamp</td><td>\${event.timestamp}</td></tr>
 <tr><td>Message</td><td>\${event.message}</td></tr>
 <tr><td>Source</td><td>\${event.source}</td></tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing an error which slipped in with https://github.com/Graylog2/graylog2-server/pull/15922. Since the `http_external_uri` always ends with a slash, we do not need to include in the altert replay URL.

/nocl