### PR TITLE
Typos and fixes in variable names and documentation

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
@@ -449,11 +449,11 @@ public class InputFacadeTest {
 
         final Input input = inputService.find("5ae2eb0a3d27464477f0fd8b");
         EntityDescriptor entityDescriptor = EntityDescriptor.create(ModelId.of(input.getId()), ModelTypes.INPUT_V1);
-        EntityDescriptor expectedEntitiyDescriptorWhois = EntityDescriptor.create(ModelId.of("dead-beef"), ModelTypes.LOOKUP_TABLE_V1);
-        EntityDescriptor expectedEntitiyDescriptorTor = EntityDescriptor.create(ModelId.of("dead-feed"), ModelTypes.LOOKUP_TABLE_V1);
+        EntityDescriptor expectedEntityDescriptorWhois = EntityDescriptor.create(ModelId.of("dead-beef"), ModelTypes.LOOKUP_TABLE_V1);
+        EntityDescriptor expectedEntityDescriptorTor = EntityDescriptor.create(ModelId.of("dead-feed"), ModelTypes.LOOKUP_TABLE_V1);
         Graph<EntityDescriptor> graph = facade.resolveNativeEntity(entityDescriptor);
-        assertThat(graph.nodes()).contains(expectedEntitiyDescriptorWhois);
-        assertThat(graph.nodes()).contains(expectedEntitiyDescriptorTor);
+        assertThat(graph.nodes()).contains(expectedEntityDescriptorWhois);
+        assertThat(graph.nodes()).contains(expectedEntityDescriptorTor);
     }
 
     @Test

--- a/graylog2-web-interface/CONTRIBUTING.md
+++ b/graylog2-web-interface/CONTRIBUTING.md
@@ -142,7 +142,7 @@ We currently have a few internal packages, used for the core application and all
 - `stylelint-config-graylog` contains our custom stylelint configuration, based on the default stylelint config.
 
 ### Browser compatibility
-We currently do not have a pre-release process to test different or old browser. Nevertheless you should test layout changes in at least all modern browsers (Chrome, Firefox, Safari). Bigger layout changes should also be tested in older browsers. Have a look at our [public browser compatibility list](https://docs.graylog.org/docs/web-interface#browser-compatibility).
+We currently do not have a pre-release process to test different or old browser. Nevertheless, you should test layout changes in at least all modern browsers (Chrome, Firefox, Safari). Bigger layout changes should also be tested in older browsers. Have a look at our [public browser compatibility list](https://docs.graylog.org/docs/web-interface#browser-compatibility).
 
 ### Plugin System
 - Graylog's plugin system allows users to extend the graylog core product without changing its source code. There are multiple points in the application which can be extended, like the navigation.
@@ -202,5 +202,5 @@ We currently do not have a pre-release process to test different or old browser.
 
 ### Modals
 - Users should be able to close a modal with the keyboard, i.e. typing ESC.
-- Modal forms should not close when clicking outside of the modal, since it is easy to lose some data.
+- Modal forms should not close when clicking outside the modal, since it is easy to lose some data.
 - Modal forms should focus on the first input (you can use autofocus for that).

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -55,7 +55,7 @@ We mainly develop using IntelliJ or WebStorm. If you also decide to use them to 
     * Commit any changes in both `package.json` and `yarn.lock` files
     * Do any changes required to adapt the code to the upgraded modules
 
-1. Update many dependencies
+2. Update many dependencies
 
     * It may be dangerous updating many dependencies at the same time, so be sure you checked the upgrade notes of all modules before getting started. Once you are ready to upgrade the modules, Yarn provides a few options to do it:
         * You can pass all packages you want to upgrade to Yarn: `yarn upgrade <package1> <package2>...`

--- a/graylog2-web-interface/docs/ux-patterns.md
+++ b/graylog2-web-interface/docs/ux-patterns.md
@@ -14,6 +14,6 @@
 ### `EmptyEntity` & `NoEntitiesExist` & `NoSearchResults` components
 
 - These three components are closely related and maybe confusing to decide which one to use for which situation.
-  - `EmptyEntity` should be used to display a message for an entity that does not have any entries in the database yet. This components supports displaying a message explaining what the entity is and can also support including a button link to create one via the children props
+  - `EmptyEntity` should be used to display a message for an entity that does not have any entries in the database yet. This component supports displaying a message explaining what the entity is and can also support including a button link to create one via the children props
   - `NoEntitiesExist` is similar to `EmptyEntity` except it is a more generic message without including the option to create a new one
   - `NoSearchResults` should be used in the case when a search is performed with a query and the result is no matching entries. This component should inform the user that entities still exist, just that none match the current filter.

--- a/graylog2-web-interface/src/stores/content-packs/CatalogStore.js
+++ b/graylog2-web-interface/src/stores/content-packs/CatalogStore.js
@@ -52,7 +52,7 @@ export const CatalogStore = singletonStore(
 
     getSelectedEntities(requestedEntities) {
       const payload = Object.keys(requestedEntities).reduce((result, key) => result.concat(requestedEntities[key]
-        .filter((entitiy) => entitiy instanceof EntityIndex)
+        .filter((entity) => entity instanceof EntityIndex)
         .map((entity) => entity.toJSON())), []);
       const url = URLUtils.qualifyUrl(ApiRoutes.CatalogsController.queryEntities().url);
       const promise = fetch('POST', url, { entities: payload });


### PR DESCRIPTION
## Description
Small fixing of typos in variable names like `entitiy`.
Fixed markup in documentation for double `1.` instead of `2.`.
Small grammar and punctuation fixes in docs.


## Motivation and Context
Fixing typos and grammar makes the code and the documentation more clean.

## How Has This Been Tested?
I have checked how the documentation looks visually now in the changed branch.
I have successfully ran the tests (linter and unit tests).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

