### PR TITLE
Correctly normalize keyword time range for search bar form when selecting keyword time range.

### DIFF
--- a/changelog/unreleased/issue-15472.toml
+++ b/changelog/unreleased/issue-15472.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix problem with search bar submit button incorrectly indicating changes for keyword time range."
+
+issues = ["15472"]
+pulls = ["15938"]

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
+import userEvent from '@testing-library/user-event';
 
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
@@ -44,7 +45,7 @@ const defaultProps = {
     type: 'relative',
     from: 300,
   },
-  limitDuration: 259200,
+  limitDuration: 0,
   noOverride: false,
   setCurrentTimeRange: jest.fn(),
   toggleDropdownShow: jest.fn(),
@@ -83,7 +84,7 @@ describe('TimeRangePicker', () => {
   });
 
   it('Limit duration is shown when setup', async () => {
-    render(<TimeRangePicker {...defaultProps} />);
+    render(<TimeRangePicker {...defaultProps} limitDuration={259200} />);
 
     const limitDuration = await screen.findByText(/admin has limited searching to 3 days ago/i);
 
@@ -126,5 +127,23 @@ describe('TimeRangePicker', () => {
 
     expect(noOverrideButton).toBeInTheDocument();
     expect(noOverrideContent).toBeInTheDocument();
+  });
+
+  it('Should not change keyword time range after submitting without changes', async () => {
+    const setCurrentTimeRange = jest.fn();
+
+    render(<TimeRangePicker {...defaultProps}
+                            currentTimeRange={{ type: 'keyword', keyword: 'yesterday', timezone: 'Asia/Tokyo' }}
+                            setCurrentTimeRange={setCurrentTimeRange} />);
+
+    const submitButton = await screen.findByRole('button', {
+      name: /update time range/i,
+    });
+
+    userEvent.click(submitButton);
+
+    await waitFor(() => expect(setCurrentTimeRange).toHaveBeenCalledTimes(1));
+
+    expect(setCurrentTimeRange).toHaveBeenCalledWith({ type: 'keyword', keyword: 'yesterday', timezone: 'Asia/Tokyo' });
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -30,7 +30,7 @@ import type {
   RelativeTimeRange,
 } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
-import { isTypeRelative } from 'views/typeGuards/timeRange';
+import { isTypeKeyword, isTypeRelative } from 'views/typeGuards/timeRange';
 import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
 import validateTimeRange from 'views/components/TimeRangeValidation';
 import type { DateTimeFormats, DateTime } from 'util/DateTime';
@@ -179,10 +179,28 @@ const TimeRangePicker = ({
     });
   }, [sendTelemetry, toggleDropdownShow]);
 
+  const normalizeIfKeywordTimerange = (timeRange: TimeRange | NoTimeRangeOverride) => {
+    if (isTypeKeyword(timeRange)) {
+      return {
+        type: timeRange.type,
+        timezone: timeRange.timezone,
+        keyword: timeRange.keyword,
+      };
+    }
+
+    return timeRange;
+  };
+
   const handleSubmit = useCallback(({ nextTimeRange }: {
     nextTimeRange: TimeRangePickerFormValues['nextTimeRange']
   }) => {
-    setCurrentTimeRange(normalizeIfAllMessagesRange(normalizeIfClassifiedRelativeTimeRange(nextTimeRange)));
+    const normalizedTimeRange = normalizeIfKeywordTimerange(
+      normalizeIfAllMessagesRange(
+        normalizeIfClassifiedRelativeTimeRange(nextTimeRange),
+      ),
+    );
+
+    setCurrentTimeRange(normalizedTimeRange);
 
     toggleDropdownShow();
 


### PR DESCRIPTION
**Please note:** this PR requires a backport for `5.0` and `5.1`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change a keyword time range in the search bar form could have not needed `from` and `to` attributes. These attributes:
- change when you reopen and submit the time range dropdown
- are not expected in the search bar form and will be removed from the form state in some cases

As a result the search bar form button was incorrectly displayed as dirty, in some cases (see https://github.com/Graylog2/graylog2-server/issues/15472)

Fixes: https://github.com/Graylog2/graylog2-server/issues/15471
Fixes: https://github.com/Graylog2/graylog2-server/issues/15472
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
