### PR TITLE
Better auto interval handling

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
@@ -20,16 +20,21 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Interval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Time;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.BucketOrder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotBucketSpecHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.PivotBucket;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -38,6 +43,8 @@ import java.util.stream.Stream;
 public class ESTimeHandler extends ESPivotBucketSpecHandler<Time> {
     private static final String AGG_NAME = "agg";
     private static final BucketOrder defaultOrder = BucketOrder.key(true);
+    private static final int BASE_NUM_BUCKETS = 25;
+    public static final String DATE_TIME_FORMAT = "date_time";
 
     @Nonnull
     @Override
@@ -45,26 +52,51 @@ public class ESTimeHandler extends ESPivotBucketSpecHandler<Time> {
         AggregationBuilder root = null;
         AggregationBuilder leaf = null;
 
-        for (String timeField : timeSpec.fields()) {
-            final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(timeSpec.interval().toDateInterval(query.effectiveTimeRange(pivot)).toString());
-            final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
-            final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
-                    .field(timeField)
-                    .order(ordering)
-                    .format("date_time");
+        final Interval interval = timeSpec.interval();
+        final TimeRange timerange = query.timerange();
+        if (interval instanceof AutoInterval autoInterval
+                && isAllMessages(timerange)) {
+            for (String timeField : timeSpec.fields()) {
+                final AutoDateHistogramAggregationBuilder builder = new AutoDateHistogramAggregationBuilder(name)
+                        .field(timeField)
+                        .setNumBuckets((int) (BASE_NUM_BUCKETS / autoInterval.scaling()))
+                        .format(DATE_TIME_FORMAT);
 
-            setInterval(builder, dateHistogramInterval);
-
-            if (root == null && leaf == null) {
-                root = builder;
-                leaf = builder;
-            } else {
-                leaf.subAggregation(builder);
-                leaf = builder;
+                if (root == null && leaf == null) {
+                    root = builder;
+                    leaf = builder;
+                } else {
+                    leaf.subAggregation(builder);
+                    leaf = builder;
+                }
             }
-    }
+        } else {
+            for (String timeField : timeSpec.fields()) {
+                final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(interval.toDateInterval(query.effectiveTimeRange(pivot)).toString());
+                final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+                final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
+                        .field(timeField)
+                        .order(ordering)
+                        .format(DATE_TIME_FORMAT);
+
+                setInterval(builder, dateHistogramInterval);
+
+                if (root == null && leaf == null) {
+                    root = builder;
+                    leaf = builder;
+                } else {
+                    leaf.subAggregation(builder);
+                    leaf = builder;
+                }
+            }
+        }
 
         return CreatedAggregations.create(root, leaf);
+    }
+
+    private boolean isAllMessages(final TimeRange timerange) {
+        return timerange instanceof RelativeRange
+                && ((RelativeRange) timerange).isAllMessages();
     }
 
     private void setInterval(DateHistogramAggregationBuilder builder, DateHistogramInterval interval) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSTimeHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSTimeHandler.java
@@ -20,16 +20,21 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Interval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Time;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.BucketOrder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotBucketSpecHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.PivotBucket;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -38,33 +43,59 @@ import java.util.stream.Stream;
 public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
     private static final String AGG_NAME = "agg";
     private static final BucketOrder defaultOrder = BucketOrder.key(true);
+    private static final int BASE_NUM_BUCKETS = 25;
+    public static final String DATE_TIME_FORMAT = "date_time";
 
     @Nonnull
     @Override
     public CreatedAggregations<AggregationBuilder> doCreateAggregation(Direction direction, String name, Pivot pivot, Time timeSpec, OSGeneratedQueryContext queryContext, Query query) {
         AggregationBuilder root = null;
         AggregationBuilder leaf = null;
-        final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+        final Interval interval = timeSpec.interval();
+        final TimeRange timerange = query.timerange();
+        if (interval instanceof AutoInterval autoInterval
+                && isAllMessages(timerange)) {
+            for (String timeField : timeSpec.fields()) {
+                final AutoDateHistogramAggregationBuilder builder = new AutoDateHistogramAggregationBuilder(name)
+                        .field(timeField)
+                        .setNumBuckets((int) (BASE_NUM_BUCKETS / autoInterval.scaling()))
+                        .format(DATE_TIME_FORMAT);
 
-        for (String field : timeSpec.fields()) {
-            final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(timeSpec.interval().toDateInterval(query.effectiveTimeRange(pivot)).toString());
-            final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
-                    .field(field)
-                    .order(ordering)
-                    .format("date_time");
+                if (root == null && leaf == null) {
+                    root = builder;
+                    leaf = builder;
+                } else {
+                    leaf.subAggregation(builder);
+                    leaf = builder;
+                }
+            }
+        } else {
+            for (String timeField : timeSpec.fields()) {
+                final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(interval.toDateInterval(query.effectiveTimeRange(pivot)).toString());
+                final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+                final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
+                        .field(timeField)
+                        .order(ordering)
+                        .format(DATE_TIME_FORMAT);
 
-            setInterval(builder, dateHistogramInterval);
+                setInterval(builder, dateHistogramInterval);
 
-            if (root == null && leaf == null) {
-                root = builder;
-                leaf = builder;
-            } else {
-                leaf.subAggregation(builder);
-                leaf = builder;
+                if (root == null && leaf == null) {
+                    root = builder;
+                    leaf = builder;
+                } else {
+                    leaf.subAggregation(builder);
+                    leaf = builder;
+                }
             }
         }
 
         return CreatedAggregations.create(root, leaf);
+    }
+
+    private boolean isAllMessages(final TimeRange timerange) {
+        return timerange instanceof RelativeRange
+                && ((RelativeRange) timerange).isAllMessages();
     }
 
     private void setInterval(DateHistogramAggregationBuilder builder, DateHistogramInterval interval) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #14906.
Current approach did not work well with auto interval and long time ranges (like "All time"), especially for relatively fresh systems.
The biggest interval was 1 month, while "All time" means around 50 years in GL... So all data used to land in 1 bucket.
The implementation has been changed, so that AutoDateHistogramAggregationBuilder is used. We allow ES/OS to select interval, do not do it ourselves for auto interval, just providing some clue for number of expected buckets, using `scaling` field.
/nocl

## Motivation and Context
See #14906.

## How Has This Been Tested?
Manually and with new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

