### PR TITLE
Fix tests for OpenSearch and blocked index/cluster after watermark hit

### DIFF
--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -24,6 +24,8 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.Streams;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
@@ -248,6 +250,13 @@ public class ClientES7 implements Client {
                 .toArray(String[]::new);
     }
 
+    public String getSetting(String setting) {
+        final ClusterGetSettingsRequest req = new ClusterGetSettingsRequest();
+        final ClusterGetSettingsResponse response = client.execute((c, requestOptions) -> c.cluster().getSettings(req, requestOptions),
+                "Unable to read OS cluster setting: " + setting);
+        return response.getSetting(setting);
+    }
+
     @Override
     public void putSetting(String setting, String value) {
         final ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
@@ -272,6 +281,11 @@ public class ClientES7 implements Client {
 
         client.execute((c, requestOptions) -> c.indices().putSettings(request, requestOptions),
                 "Unable to reset index block for " + index);
+    }
+
+    @Override
+    public void resetClusterBlock() {
+        // noop for ES7, needed for OS 2.x
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MessagesOS2IT.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MessagesOS2IT.java
@@ -16,17 +16,12 @@
  */
 package org.graylog.storage.opensearch2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.refresh.RefreshRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.index.IndexRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.index.IndexResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.client.core.CountRequest;
-import org.graylog.shaded.opensearch2.org.opensearch.client.core.CountResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.rest.RestStatus;
 import org.graylog.storage.opensearch2.testing.OpenSearchInstance;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
 import org.graylog2.indexer.messages.MessagesIT;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Rule;
 
 import java.util.Map;

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/ClientOS2.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/ClientOS2.java
@@ -24,6 +24,8 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.Streams;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
@@ -221,6 +223,7 @@ public class ClientOS2 implements Client {
         deleteIndices(existingIndices());
         deleteTemplates(existingTemplates());
         refreshNode();
+        resetClusterBlock();
     }
 
     private String[] existingTemplates() {
@@ -252,7 +255,31 @@ public class ClientOS2 implements Client {
     public void putSetting(String setting, String value) {
         final ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
 
-        request.persistentSettings(Settings.builder().put(setting, value));
+        if(value == null) {
+            request.transientSettings(Settings.builder().putNull(setting));
+        } else {
+            request.transientSettings(Settings.builder().put(setting, value));
+        }
+
+        client.execute((c, requestOptions) -> c.cluster().putSettings(request, requestOptions),
+                "Unable to update OS cluster setting: " + setting + "=" + value);
+    }
+
+    public String getSetting(String setting) {
+        final ClusterGetSettingsRequest req = new ClusterGetSettingsRequest();
+        final ClusterGetSettingsResponse response = client.execute((c, requestOptions) -> c.cluster().getSettings(req, requestOptions),
+                "Unable to read OS cluster setting: " + setting);
+        return response.getSetting(setting);
+    }
+
+    public void putPersistentSetting(String setting, String value) {
+        final ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+
+        if(value == null) {
+            request.persistentSettings(Settings.builder().putNull(setting));
+        } else {
+            request.persistentSettings(Settings.builder().put(setting, value));
+        }
 
         client.execute((c, requestOptions) -> c.cluster().putSettings(request, requestOptions),
                 "Unable to update OS cluster setting: " + setting + "=" + value);
@@ -272,6 +299,17 @@ public class ClientOS2 implements Client {
 
         client.execute((c, requestOptions) -> c.indices().putSettings(request, requestOptions),
                 "Unable to reset index block for " + index);
+    }
+
+    @Override
+    public void resetClusterBlock() {
+        final String block = getSetting("cluster.blocks.create_index");
+        if(Boolean.parseBoolean(block)) {
+            // high memory usage in previous tests may cause a cluster block. If that happens, we should reset this block before the next test.
+            LOG.info("Indexer cluster is blocked after heavy memory/disk usage, resetting the block");
+            // reset create_index block for OpenSearch 2.x see https://github.com/opensearch-project/OpenSearch/pull/5852
+            putPersistentSetting("cluster.blocks.create_index", null);
+        }
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -46,7 +46,7 @@ import static java.util.Objects.isNull;
 public class OpenSearchInstance extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchInstance.class);
 
-    public static final String DEFAULT_HEAP_SIZE = "2g";
+    public static final String DEFAULT_HEAP_SIZE = "3g";
     public static final SearchServer OPENSEARCH_VERSION = SearchServer.DEFAULT_OPENSEARCH_VERSION;
 
     private final OpenSearchClient openSearchClient;

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -46,7 +46,7 @@ import static java.util.Objects.isNull;
 public class OpenSearchInstance extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchInstance.class);
 
-    public static final String DEFAULT_HEAP_SIZE = "3g";
+    public static final String DEFAULT_HEAP_SIZE = "4g";
     public static final SearchServer OPENSEARCH_VERSION = SearchServer.DEFAULT_OPENSEARCH_VERSION;
 
     private final OpenSearchClient openSearchClient;

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -143,6 +143,7 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
                 .withEnv("plugins.security.disabled", "true")
                 .withEnv("action.auto_create_index", "false")
                 .withEnv("cluster.info.update.interval", "10s")
+                .withEnv("<cluster.routing.allocation.disk.reroute_interval>", "5s")
                 .withNetwork(network)
                 .withNetworkAliases(NETWORK_ALIAS)
                 .waitingFor(Wait.forHttp("/").forPort(OPENSEARCH_PORT));

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -46,7 +46,7 @@ import static java.util.Objects.isNull;
 public class OpenSearchInstance extends TestableSearchServerInstance {
     private static final Logger LOG = LoggerFactory.getLogger(OpenSearchInstance.class);
 
-    public static final String DEFAULT_HEAP_SIZE = "4g";
+    public static final String DEFAULT_HEAP_SIZE = "5g";
     public static final SearchServer OPENSEARCH_VERSION = SearchServer.DEFAULT_OPENSEARCH_VERSION;
 
     private final OpenSearchClient openSearchClient;

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.1"),
     OS2(OPENSEARCH, "2.0.1"),
-    OS2_LATEST(OPENSEARCH, "2.7.0"),
+    OS2_LATEST(OPENSEARCH, "2.6.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 
     public static final SearchServer DEFAULT_VERSION = DATANODE_DEV;

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.1"),
     OS2(OPENSEARCH, "2.0.1"),
-    OS2_LATEST(OPENSEARCH, "2.7.0"),
+    OS2_LATEST(OPENSEARCH, "2.8.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 
     public static final SearchServer DEFAULT_VERSION = DATANODE_DEV;

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.1"),
     OS2(OPENSEARCH, "2.0.1"),
-    OS2_LATEST(OPENSEARCH, "2.6.0"),
+    OS2_LATEST(OPENSEARCH, "2.7.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 
     public static final SearchServer DEFAULT_VERSION = DATANODE_DEV;

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.1"),
     OS2(OPENSEARCH, "2.0.1"),
-    OS2_LATEST(OPENSEARCH, "2.4.0"),
+    OS2_LATEST(OPENSEARCH, "2.6.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 
     public static final SearchServer DEFAULT_VERSION = DATANODE_DEV;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -61,12 +61,15 @@ public interface Client {
     String fieldType(String testIndexName, String source);
 
     void putSetting(String setting, String value);
+    String getSetting(String setting);
 
     void waitForIndexBlock(String index);
 
     void resetIndexBlock(String index);
 
     void setIndexBlock(String index);
+
+    void resetClusterBlock();
 
     void updateMapping(String index, Map<String, Object> mapping);
     Map<String, Object> getMapping(String index);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -69,6 +69,7 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
 
     @Before
     public void setUp() throws Exception {
+        client().resetClusterBlock(); // the index may be blocked with delay from a previous test, if yes then reset it.
         client().deleteIndices(INDEX_NAME);
         client().createIndex(INDEX_NAME);
         client().waitForGreenStatus(INDEX_NAME);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
OpenSearch 2.6 has a change that after a watermark for the full cluster fails, only resetting the index block is not enough.
cluster.blocks.create_index needs also to get reset.

/nocl

alternative version to #15420
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

