### PR TITLE
Only trigger query input autocompletion popover when it is hidden. (`5.0`)

### DIFF
--- a/changelog/unreleased/issue-15718.toml
+++ b/changelog/unreleased/issue-15718.toml
@@ -1,0 +1,5 @@
+type = "f" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fixing problem with focus loss in query input autocompletion."
+
+issues = ["15718"]
+pulls = ["15933"]

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -98,7 +98,7 @@ const _onLoadEditor = (editor, isInitialTokenizerUpdate: React.MutableRefObject<
     editor.commands.removeCommands(['find', 'indent', 'outdent']);
 
     editor.session.on('tokenizerUpdate', (_input, { bgTokenizer: { currentLine, lines } }) => {
-      if (editor.isFocused() && !isInitialTokenizerUpdate.current) {
+      if (editor.isFocused() && !editor.completer?.activated && !isInitialTokenizerUpdate.current) {
         editor.completers.forEach((completer) => {
           if (completer?.shouldShowCompletions(currentLine, lines)) {
             editor.execCommand('startAutocomplete');

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -52,7 +52,8 @@ export type Popup = {
 
 export type Completer = {
   autoSelect: boolean,
-  popup: Popup,
+  popup?: Popup,
+  activated: boolean,
 };
 
 export type Editor = {


### PR DESCRIPTION
**Please note:** This is a backport of #15933 for `5.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #15718 it is possible that the focus for an option in the query input autocompletion gets lost.
This problem occurs because we triggered `editor.execCommand('startAutocomplete');`, even when the autocompletion popover is already visible. Related to https://github.com/Graylog2/graylog2-server/pull/14233.

Fixes #15718

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

