### PR TITLE
Update opensearch to 2.8, adapt to cluster block settings

### DIFF
--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -24,6 +24,8 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.Streams;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
@@ -331,5 +333,12 @@ public class ClientES7 implements Client {
                 .path("blocks")
                 .fields()
                 .hasNext();
+    }
+
+    public String getClusterSetting(String setting) {
+        final ClusterGetSettingsRequest req = new ClusterGetSettingsRequest();
+        final ClusterGetSettingsResponse response = client.execute((c, requestOptions) -> c.cluster().getSettings(req, requestOptions),
+                "Unable to read ES cluster setting: " + setting);
+        return response.getSetting(setting);
     }
 }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/ClientOS2.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/ClientOS2.java
@@ -24,6 +24,8 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.Streams;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
@@ -331,5 +333,13 @@ public class ClientOS2 implements Client {
                 .path("blocks")
                 .fields()
                 .hasNext();
+    }
+
+
+    public String getClusterSetting(String setting) {
+        final ClusterGetSettingsRequest req = new ClusterGetSettingsRequest();
+        final ClusterGetSettingsResponse response = client.execute((c, requestOptions) -> c.cluster().getSettings(req, requestOptions),
+                "Unable to read OS cluster setting: " + setting);
+        return response.getSetting(setting);
     }
 }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -143,6 +143,7 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
                 .withEnv("plugins.security.disabled", "true")
                 .withEnv("action.auto_create_index", "false")
                 .withEnv("cluster.info.update.interval", "10s")
+                .withEnv("cluster.routing.allocation.disk.reroute_interval", "5s")
                 .withNetwork(network)
                 .withNetworkAliases(NETWORK_ALIAS)
                 .waitingFor(Wait.forHttp("/").forPort(OPENSEARCH_PORT));

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.1"),
     OS2(OPENSEARCH, "2.0.1"),
-    OS2_LATEST(OPENSEARCH, "2.4.0"),
+     OS2_LATEST(OPENSEARCH, "2.8.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 
     public static final SearchServer DEFAULT_VERSION = DATANODE_DEV;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -70,4 +70,6 @@ public interface Client {
 
     void updateMapping(String index, Map<String, Object> mapping);
     Map<String, Object> getMapping(String index);
+
+    String getClusterSetting(String setting);
 }


### PR DESCRIPTION
In order to successfully release the cluster index create block, we need to decrease `cluster.routing.allocation.disk.reroute_interval` for Opensearch 2.6+. 

With this minimal change, we are now able to run all the integration tests with OS 2.6 and 2.8. 

Opensearch 2.8. becomes our default OS version for integration tests.

  
/nocl

## How Has This Been Tested?
Existing set of ITs.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

