### PR TITLE
Replace `styled-components` `withTheme` with `useTheme` where possible.

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.tsx
@@ -17,12 +17,10 @@
 import * as React from 'react';
 import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import type { DefaultTheme } from 'styled-components';
-import styled, { css, withTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import type { ItemCallback } from 'react-grid-layout';
 
-import { themePropTypes } from 'theme';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
@@ -146,7 +144,6 @@ type Props = {
   onSyncLayout?: (newPositions: Array<WidgetPositionJSON>) => void,
   positions: { [widgetId: string]: WidgetPosition },
   rowHeight?: number,
-  theme: DefaultTheme,
   width?: number,
 }
 
@@ -194,9 +191,9 @@ const ReactGridContainer = ({
   onSyncLayout: _onSyncLayout,
   positions,
   rowHeight,
-  theme,
   width,
 }: Props) => {
+  const theme = useTheme();
   const cellMargin = theme.spacings.px.xs;
   const onLayoutChange = useCallback<ItemCallback>((layout) => _onLayoutChange(layout, onPositionsChange), [onPositionsChange]);
   const onSyncLayout = useCallback((layout: Layout) => _onLayoutChange(layout, _onSyncLayout), [_onSyncLayout]);
@@ -320,7 +317,6 @@ ReactGridContainer.propTypes = {
    */
   measureBeforeMount: PropTypes.bool,
   width: PropTypes.number,
-  theme: themePropTypes.isRequired,
 };
 
 ReactGridContainer.defaultProps = {
@@ -335,4 +331,4 @@ ReactGridContainer.defaultProps = {
   onSyncLayout: undefined,
 };
 
-export default withTheme(ReactGridContainer);
+export default ReactGridContainer;

--- a/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
+++ b/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
@@ -16,20 +16,14 @@
  */
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import type { DefaultTheme } from 'styled-components';
-import styled, { css, withTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import defer from 'lodash/defer';
 
 import { Icon } from 'components/common';
-import { themePropTypes } from 'theme';
 import {
   THEME_MODE_LIGHT,
   THEME_MODE_DARK,
 } from 'theme/constants';
-
-type Props = {
-  theme: DefaultTheme,
-};
 
 const ThemeModeToggleWrap = styled.div`
   display: flex;
@@ -104,7 +98,8 @@ const Toggle = styled.label(({ theme }) => css`
   }
 `);
 
-const ThemeModeToggle = ({ theme }: Props) => {
+const ThemeModeToggle = () => {
+  const theme = useTheme();
   const currentMode = theme.mode;
   const [loadingTheme, setLoadingTheme] = useState(false);
 
@@ -146,8 +141,4 @@ const ThemeModeToggle = ({ theme }: Props) => {
   );
 };
 
-ThemeModeToggle.propTypes = {
-  theme: themePropTypes.isRequired,
-};
-
-export default withTheme(ThemeModeToggle);
+export default ThemeModeToggle;

--- a/graylog2-web-interface/src/components/sidecars/common/ColorLabel.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/ColorLabel.tsx
@@ -16,20 +16,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import type { DefaultTheme } from 'styled-components';
-import styled, { css, withTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
-import { themePropTypes } from 'theme';
 import { Label } from 'components/bootstrap';
 
 type Size = 'normal' | 'small' | 'xsmall';
-
-interface ColorLabelProps {
-  color: string,
-  size?: Size,
-  text?: string | React.ReactNode,
-  theme: DefaultTheme,
-}
 
 const ColorLabelWrap = styled.span<{ $size: Size }>(({ $size, theme }) => {
   const { body, small, tiny } = theme.fonts.size;
@@ -41,7 +32,14 @@ const ColorLabelWrap = styled.span<{ $size: Size }>(({ $size, theme }) => {
 `;
 });
 
-const ColorLabel = ({ color, size, text, theme }: ColorLabelProps) => {
+type Props = {
+  color: string,
+  size?: Size,
+  text?: string | React.ReactNode,
+}
+
+const ColorLabel = ({ color, size, text }: Props) => {
+  const theme = useTheme();
   const borderColor = theme.utils.colorLevel(color, 5);
   const textColor = theme.utils.contrastingColor(color);
 
@@ -67,7 +65,6 @@ ColorLabel.propTypes = {
   color: PropTypes.string.isRequired,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   size: PropTypes.oneOf(['normal', 'small', 'xsmall']),
-  theme: themePropTypes.isRequired,
 };
 
 ColorLabel.defaultProps = {
@@ -75,4 +72,4 @@ ColorLabel.defaultProps = {
   size: 'normal',
 };
 
-export default withTheme(ColorLabel);
+export default ColorLabel;

--- a/graylog2-web-interface/src/preflight/navigation/NavigationBrand.tsx
+++ b/graylog2-web-interface/src/preflight/navigation/NavigationBrand.tsx
@@ -15,16 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { GraylogTheme } from '@graylog/sawmill';
-import { withTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
 
-import ThemePropTypes from 'preflight/theme/types';
-
-type Props = {
-  theme: GraylogTheme
-}
-
-const NavigationBrand = ({ theme }: Props) => {
+const NavigationBrand = () => {
+  const theme = useTheme();
   const logoSecondColor = theme.mode === 'teint' ? theme.colors.brand.concrete : 'white';
 
   return (
@@ -41,8 +35,4 @@ const NavigationBrand = ({ theme }: Props) => {
   );
 };
 
-NavigationBrand.propTypes = {
-  theme: ThemePropTypes.isRequired,
-};
-
-export default withTheme(NavigationBrand);
+export default NavigationBrand;

--- a/graylog2-web-interface/src/preflight/navigation/ThemeModeToggle.tsx
+++ b/graylog2-web-interface/src/preflight/navigation/ThemeModeToggle.tsx
@@ -17,20 +17,14 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import type { SyntheticEvent } from 'react';
-import type { DefaultTheme } from 'styled-components';
-import styled, { css, withTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import defer from 'lodash/defer';
 
-import ThemePropTypes from 'preflight/theme/types';
 import { Icon } from 'preflight/components/common';
 import {
   THEME_MODE_LIGHT,
   THEME_MODE_DARK,
 } from 'theme/constants';
-
-type Props = {
-  theme: DefaultTheme,
-};
 
 const ThemeModeToggleWrap = styled.div`
   display: flex;
@@ -105,7 +99,8 @@ const Toggle = styled.label(({ theme }) => css`
   }
 `);
 
-const ThemeModeToggle = ({ theme }: Props) => {
+const ThemeModeToggle = () => {
+  const theme = useTheme();
   const currentMode = theme.mode;
   const [loadingTheme, setLoadingTheme] = useState(false);
 
@@ -146,8 +141,4 @@ const ThemeModeToggle = ({ theme }: Props) => {
   );
 };
 
-ThemeModeToggle.propTypes = {
-  theme: ThemePropTypes.isRequired,
-};
-
-export default withTheme(ThemeModeToggle);
+export default ThemeModeToggle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this small refactoring we are replacing `withTheme` with `useTheme` where possible. Using the `useTheme` hook simplifies the code and we do not have to rely on `styled-components` type definitions regarding the component props.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/nocl
