### PR TITLE
Correctly normalize keyword time range for search bar form when selecting keyword (`5.0`)

### DIFF
--- a/changelog/unreleased/issue-15472.toml
+++ b/changelog/unreleased/issue-15472.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix problem with search bar submit button incorrectly indicating changes for keyword time range."
+
+issues = ["15472"]
+pulls = ["15938"]

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -215,6 +215,18 @@ const TimeRangeTabs = ({ handleActiveTab, currentTimeRange, limitDuration, valid
   );
 };
 
+const normalizeIfKeywordTimerange = (timeRange: TimeRange | NoTimeRangeOverride) => {
+  if (isTypeKeyword(timeRange)) {
+    return {
+      type: timeRange.type,
+      timezone: timeRange.timezone,
+      keyword: timeRange.keyword,
+    };
+  }
+
+  return timeRange;
+};
+
 const TimeRangeDropdown = ({
   noOverride,
   toggleDropdownShow,
@@ -238,18 +250,6 @@ const TimeRangeDropdown = ({
   const handleCancel = useCallback(() => {
     toggleDropdownShow();
   }, [toggleDropdownShow]);
-
-  const normalizeIfKeywordTimerange = (timeRange: TimeRange | NoTimeRangeOverride) => {
-    if (isTypeKeyword(timeRange)) {
-      return {
-        type: timeRange.type,
-        timezone: timeRange.timezone,
-        keyword: timeRange.keyword,
-      };
-    }
-
-    return timeRange;
-  };
 
   const handleSubmit = useCallback(({ nextTimeRange }: {
     nextTimeRange: TimeRangeDropDownFormValues['nextTimeRange']

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/TimeRangeDropdown.tsx
@@ -31,7 +31,7 @@ import type {
   RelativeTimeRange,
 } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
-import { isTypeRelative } from 'views/typeGuards/timeRange';
+import { isTypeKeyword, isTypeRelative } from 'views/typeGuards/timeRange';
 import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
 import type { RelativeTimeRangeClassified } from 'views/components/searchbar/date-time-picker/types';
 import validateTimeRange from 'views/components/TimeRangeValidation';
@@ -239,8 +239,28 @@ const TimeRangeDropdown = ({
     toggleDropdownShow();
   }, [toggleDropdownShow]);
 
-  const handleSubmit = useCallback(({ nextTimeRange }: { nextTimeRange: TimeRangeDropDownFormValues['nextTimeRange'] }) => {
-    setCurrentTimeRange(normalizeIfAllMessagesRange(normalizeIfClassifiedRelativeTimeRange(nextTimeRange)));
+  const normalizeIfKeywordTimerange = (timeRange: TimeRange | NoTimeRangeOverride) => {
+    if (isTypeKeyword(timeRange)) {
+      return {
+        type: timeRange.type,
+        timezone: timeRange.timezone,
+        keyword: timeRange.keyword,
+      };
+    }
+
+    return timeRange;
+  };
+
+  const handleSubmit = useCallback(({ nextTimeRange }: {
+    nextTimeRange: TimeRangeDropDownFormValues['nextTimeRange']
+  }) => {
+    const normalizedTimeRange = normalizeIfKeywordTimerange(
+      normalizeIfAllMessagesRange(
+        normalizeIfClassifiedRelativeTimeRange(nextTimeRange),
+      ),
+    );
+
+    setCurrentTimeRange(normalizedTimeRange);
 
     toggleDropdownShow();
   }, [setCurrentTimeRange, toggleDropdownShow]);


### PR DESCRIPTION
**Please note:** this is a backport of 15938 for `5.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change a keyword time range in the search bar form could have not needed `from` and `to` attributes. These attributes:
- change when you reopen and submit the time range dropdown
- are not expected in the search bar form and will be removed from the form state in some cases

As a result the search bar form button was incorrectly displayed as dirty, in some cases (see https://github.com/Graylog2/graylog2-server/issues/15472)

Fixes: https://github.com/Graylog2/graylog2-server/issues/15471
Fixes: https://github.com/Graylog2/graylog2-server/issues/15472
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
