### PR TITLE
Remove not needed search sidebar toggle.

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
@@ -37,7 +37,7 @@ type ContainerProps = {
   $disabled: boolean,
 };
 
-const Container = styled.div<ContainerProps>(({ theme: { colors, fonts }, $isSelected, $sidebarIsPinned, $disabled }) => css`
+const Container = styled.button<ContainerProps>(({ theme: { colors, fonts }, $isSelected, $sidebarIsPinned, $disabled }) => css`
   position: relative;
   z-index: 4; /* to render over SidebarNav::before */
   width: 100%;
@@ -47,6 +47,8 @@ const Container = styled.div<ContainerProps>(({ theme: { colors, fonts }, $isSel
   font-size: ${fonts.size.h3};
   color: ${colors.variant.darkest.default};
   background: ${$isSelected ? colors.gray[90] : colors.global.contentBackground};
+  border: 0;
+  padding: 0;
 
   &:hover {
     color: ${$isSelected ? colors.variant.darkest.default : colors.variant.darker.default};

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -72,6 +72,8 @@ describe('<Sidebar />', () => {
   const searchTypes = {};
   const queryResult = new QueryResult({ execution_stats: executionStats, query, errors, search_types: searchTypes });
 
+  const openDescriptionSection = async () => fireEvent.click(await screen.findByRole('button', { name: /description/i }));
+
   const TestComponent = () => <div id="martian">Marc Watney</div>;
 
   const renderSidebar = () => render(
@@ -92,20 +94,10 @@ describe('<Sidebar />', () => {
     asMock(useGlobalOverride).mockReturnValue(GlobalOverride.empty());
   });
 
-  it('should render and open when clicking on header', async () => {
-    asMock(useViewTitle).mockReturnValue(viewMetaData.title);
-
-    renderSidebar();
-
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
-
-    await screen.findByText(viewMetaData.title);
-  });
-
   it('should render with a description about the query results', async () => {
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findAllByText((_content, node) => (node.textContent === 'Query executed in 64ms at 2018-08-28 16:39:27'));
   });
@@ -115,7 +107,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText(viewMetaData.summary);
     await screen.findByText(viewMetaData.description);
@@ -127,7 +119,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText(/This dashboard has no description/);
     await screen.findByText(/This dashboard has no summary/);
@@ -139,7 +131,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText(/This search has no description/);
     await screen.findByText(/This search has no summary/);
@@ -150,7 +142,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText(viewMetaData.summary);
     await screen.findByText(viewMetaData.description);
@@ -161,7 +153,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText('Save the search or export it to a dashboard to add a custom summary and description.');
 
@@ -173,7 +165,7 @@ describe('<Sidebar />', () => {
     asMock(useViewType).mockReturnValue(View.Type.Search);
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    await openDescriptionSection();
 
     await screen.findByText('2018-08-28 16:34:26.192');
     await screen.findByText('2018-08-28 16:39:26.192');
@@ -183,7 +175,7 @@ describe('<Sidebar />', () => {
     asMock(useViewType).mockReturnValue(View.Type.Dashboard);
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    fireEvent.click(await screen.findByRole('button', { name: /description/i }));
 
     await screen.findByText('Varies per widget');
   });
@@ -200,7 +192,7 @@ describe('<Sidebar />', () => {
 
     renderSidebar();
 
-    fireEvent.click(await screen.findByTitle(/open sidebar/i));
+    fireEvent.click(await screen.findByRole('button', { name: /description/i }));
 
     await screen.findByText('2018-08-28 16:34:26.192');
     await screen.findByText('2018-08-28 16:39:26.192');

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
@@ -104,7 +104,6 @@ const Sidebar = ({ searchPageLayout, results, children, sections, actions }: Pro
     <Container>
       <SidebarNavigation activeSection={activeSection}
                          selectSidebarSection={selectSidebarSection}
-                         toggleSidebar={toggleSidebar}
                          sections={sections}
                          sidebarIsPinned={sidebarIsPinned}
                          actions={actions} />

--- a/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
@@ -28,7 +28,6 @@ type Props = {
   actions: Array<SidebarAction>,
   selectSidebarSection: (sectionKey: string) => void,
   sidebarIsPinned: boolean,
-  toggleSidebar: () => void,
 };
 
 const Container = styled.div<{ $isOpen: boolean, $sidebarIsPinned: boolean }>(({ $isOpen, $sidebarIsPinned, theme }) => css`
@@ -73,18 +72,11 @@ const HorizontalRuleWrapper = styled.div`
   }
 `;
 
-const SidebarNavigation = ({ sections, activeSection, selectSidebarSection, sidebarIsPinned, toggleSidebar, actions }: Props) => {
-  const toggleIcon = activeSection ? 'chevron-left' : 'chevron-right';
+const SidebarNavigation = ({ sections, activeSection, selectSidebarSection, sidebarIsPinned, actions }: Props) => {
   const activeSectionKey = activeSection?.key;
 
   return (
     <Container $sidebarIsPinned={sidebarIsPinned} $isOpen={!!activeSection}>
-      <NavItem icon={toggleIcon}
-               onClick={toggleSidebar}
-               showTitleOnHover={false}
-               title={`${activeSection ? 'Close' : 'Open'} sidebar`}
-               sidebarIsPinned={sidebarIsPinned} />
-      <HorizontalRuleWrapper><hr /></HorizontalRuleWrapper>
       <SectionList>
         {sections.map(({ key, icon, title }) => (
           <NavItem isSelected={activeSectionKey === key}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are removing the search sidebar toggle, since there are many other ways to close the sidebar, like clicking on the section icon, the search title or (when not pinned) the transparent overlay.

Before:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/91723fc1-8032-4b85-a38e-00e7a53afafe)

After:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/444b5bf3-5a27-408e-a72a-1b2bec906556)

/nocl