### PR TITLE
Add suffix to docker datanode container name, for parallel runs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCert.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilCert.java
@@ -90,7 +90,6 @@ public class CertutilCert implements CliCommand {
 
             final CertRequest req = CertRequest.signed(Tools.getLocalCanonicalHostname(), intermediateCA)
                     .withSubjectAlternativeName("localhost")
-                    .withSubjectAlternativeName("graylog-datanode-host")
                     .withSubjectAlternativeName(Tools.getLocalHostname())
                     .withSubjectAlternativeName(String.valueOf(InetAddress.getLocalHost()))
                     .withSubjectAlternativeName("127.0.0.1")

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilHttp.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilHttp.java
@@ -128,7 +128,6 @@ public class CertutilHttp implements CliCommand {
                 CertRequest certificateRequest = CertRequest.signed(cnName, caKeyPair)
                         .withSubjectAlternativeName("localhost")
                         .withSubjectAlternativeName(Tools.getLocalHostname())
-                        .withSubjectAlternativeName("graylog-datanode-host")
                         .withSubjectAlternativeName(String.valueOf(InetAddress.getLocalHost()))
                         .withSubjectAlternativeName("127.0.0.1")
                         .withSubjectAlternativeName("ip6-localhost")


### PR DESCRIPTION
/nocl

Fixing following problem:

```
2023-07-21T13:17:01.916Z] 2023-07-21 15:17:00,549 ERROR: 🐳 [local/graylog-datanode:latest] - Could not start container

[2023-07-21T13:17:01.916Z] com.github.dockerjava.api.exception.ConflictException: Status 409: {"message":"Conflict. The container name \"/graylog-datanode-host\" is already in use by container \"e92dade34bbad3e1acb520f2cd17a7dec6a0f9db4eb9ccf235579f3b5ccfefcb\". You have to remove (or rename) that container to be able to reuse that name."}

[2023-07-21T13:17:01.916Z] 

[2023-07-21T13:17:01.916Z] 	at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:245) ~[testcontainers-1.17.6.jar:1.17.6]
```

## How Has This Been Tested?
Existing integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

