### PR TITLE
Create simple error boundary for preflight UI.

### DIFF
--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.tsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.tsx
@@ -29,7 +29,7 @@ import StreamPermissionErrorPage from 'pages/StreamPermissionErrorPage';
 
 const FallbackErrorPage = ({ reportedError }: { reportedError: ReportedError }) => (
   <ErrorPage title="Something went wrong"
-             description={<p>An unkown error has occured. Please have a look at the following message and the graylog server log for more information.</p>}>
+             description={<p>An unknown error has occurred. Please have a look at the following message and the graylog server log for more information.</p>}>
     <pre>
       {JSON.stringify(reportedError)}
     </pre>
@@ -82,6 +82,7 @@ const ReportedErrorBoundary = ({ children }: Props) => {
     return <ReportedErrorPage reportedError={reportedError} />;
   }
 
+  // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{children}</>;
 };
 

--- a/graylog2-web-interface/src/preflight/App.tsx
+++ b/graylog2-web-interface/src/preflight/App.tsx
@@ -21,14 +21,17 @@ import { useState } from 'react';
 import Navigation from 'preflight/navigation/Navigation';
 import Setup from 'preflight/components/Setup';
 import WaitingForStartup from 'preflight/components/WaitingForStartup';
+import ErrorBoundary from 'preflight/components/ErrorBoundary';
 
 const App = () => {
   const [isWaitingForStartup, setIsWaitingForStartup] = useState(false);
 
   return (
     <AppShell padding="md" header={<Navigation />}>
-      {!isWaitingForStartup && <Setup setIsWaitingForStartup={setIsWaitingForStartup} />}
-      {isWaitingForStartup && <WaitingForStartup />}
+      <ErrorBoundary>
+        {!isWaitingForStartup && <Setup setIsWaitingForStartup={setIsWaitingForStartup} />}
+        {isWaitingForStartup && <WaitingForStartup />}
+      </ErrorBoundary>
     </AppShell>
   );
 };

--- a/graylog2-web-interface/src/preflight/components/ErrorBoundary.tsx
+++ b/graylog2-web-interface/src/preflight/components/ErrorBoundary.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import React from 'react';
+
+import type { ReportedError } from 'logic/errors/ReportedErrors';
+import { createReactError } from 'logic/errors/ReportedErrors';
+import { Section } from 'preflight/components/common';
+
+type Props = {
+  children: React.ReactNode | Array<React.ReactNode>
+}
+
+type State = {
+  error: ReportedError | undefined,
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      error: undefined,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error, info: { componentStack: string }) {
+    return { error: createReactError(error, info) };
+  }
+
+  render() {
+    const { error } = this.state;
+    const { children } = this.props;
+
+    if (error) {
+      return (
+        <div>
+          <Section title="Something went wrong" titleOrder={1}>
+            <p>An unknown error has occurred. Please have a look at the following message and the graylog server log for more information.</p>
+            <pre className="content">
+              {error.error.message}
+              <br />
+              <br />
+              {error.error.stack}
+            </pre>
+          </Section>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are implementing a simple error boundary for JS runtime error in the preflight UI.

Fixes: https://github.com/Graylog2/graylog2-server/issues/15867

/nocl