### PR TITLE
Show errors again when loading a saved search or dashboard which exceeds the query limit

### DIFF
--- a/changelog/unreleased/issue-15958.toml
+++ b/changelog/unreleased/issue-15958.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Show errors again when loading a saved search or dashboard which exceeds the query limit."
+
+issues = ["15958"]
+pulls = ["15998", "16033"]
+

--- a/graylog2-web-interface/src/views/components/useWidgetResults.ts
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.ts
@@ -26,7 +26,7 @@ import useAppSelector from 'stores/useAppSelector';
 import { selectSearchExecutionResult } from 'views/logic/slices/searchExecutionSelectors';
 import { selectActiveQuery, selectWidget } from 'views/logic/slices/viewSelectors';
 
-const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results: QueryResult, currentQueryErrors) => {
+const _getDataAndErrors = (widget: Widget, widgetMapping: WidgetMapping, results: QueryResult) => {
   const { searchTypes } = results;
   const widgetType = widgetDefinition(widget.type);
   const dataTransformer = widgetType.searchResultTransformer || ((x) => x);
@@ -58,13 +58,9 @@ type WidgetResults = {
 };
 
 const _getErrorsForQuery = (currentQueryId: string, currentQueryErrors: SearchError[] | undefined) => {
-  const queryError = currentQueryErrors?.find(({ query_id }) => query_id === currentQueryId);
+  const queryError = currentQueryErrors?.find((searchError) => searchError.queryId === currentQueryId);
 
-  if (queryError) {
-    return { widgetData: undefined, error: [queryError] };
-  }
-
-  return { widgetData: undefined, error: [] };
+  return { widgetData: undefined, error: queryError ? [queryError] : [] };
 };
 
 const selectWidgetResults = (widgetId: string) => createSelector(
@@ -77,7 +73,7 @@ const selectWidgetResults = (widgetId: string) => createSelector(
     const currentQueryErrors = result?.errors;
 
     return (currentQueryResults
-      ? _getDataAndErrors(widget, widgetMapping, currentQueryResults, currentQueryErrors)
+      ? _getDataAndErrors(widget, widgetMapping, currentQueryResults)
       : _getErrorsForQuery(currentQueryId, currentQueryErrors)) as WidgetResults;
   },
 );

--- a/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.tsx
@@ -17,13 +17,27 @@
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
 
+import SearchError from 'views/logic/SearchError';
+
 import ErrorWidget from './ErrorWidget';
 
 describe('<ErrorWidget />', () => {
   it('should display a list item for every provided error', () => {
     const errors = [
-      { description: 'The first error' },
-      { description: 'The second error' },
+      new SearchError({
+        description: 'The first error',
+        query_id: 'query-id-1',
+        search_type_id: 'search_type_id-1',
+        type: 'query',
+        backtrace: '',
+      }),
+      new SearchError({
+        description: 'The second error',
+        query_id: 'query-id-2',
+        search_type_id: 'search_type_id-2',
+        type: 'query',
+        backtrace: '',
+      }),
     ];
 
     const wrapper = mount(<ErrorWidget errors={errors} />);

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -24,7 +24,7 @@ import asMock from 'helpers/mocking/AsMock';
 import WidgetModel from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import useWidgetResults from 'views/components/useWidgetResults';
-import type SearchError from 'views/logic/SearchError';
+import SearchError from 'views/logic/SearchError';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { duplicateWidget, updateWidgetConfig, updateWidget } from 'views/logic/slices/widgetActions';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
@@ -139,7 +139,18 @@ describe('<Widget />', () => {
   });
 
   it('should render error widget for widget with one error', async () => {
-    asMock(useWidgetResults).mockReturnValue({ error: [{ description: 'The widget has failed: the dungeon collapsed, you die!' } as SearchError], widgetData: undefined });
+    asMock(useWidgetResults).mockReturnValue({
+      error: [
+        new SearchError({
+          description: 'The widget has failed: the dungeon collapsed, you die!',
+          query_id: 'query-id-2',
+          search_type_id: 'search_type_id-2',
+          type: 'query',
+          backtrace: '',
+        })],
+      widgetData: undefined,
+    });
+
     render(<DummyWidget />);
 
     await screen.findByText('The widget has failed: the dungeon collapsed, you die!');
@@ -148,8 +159,20 @@ describe('<Widget />', () => {
   it('should render error widget including all error messages for widget with multiple errors', async () => {
     asMock(useWidgetResults).mockReturnValue({
       error: [
-        { description: 'Something is wrong' } as SearchError,
-        { description: 'Very wrong' } as SearchError,
+        new SearchError({
+          description: 'Something is wrong',
+          query_id: 'query-id-1',
+          search_type_id: 'search_type_id-1',
+          type: 'query',
+          backtrace: '',
+        }),
+        new SearchError({
+          description: 'Very wrong',
+          query_id: 'query-id-2',
+          search_type_id: 'search_type_id-2',
+          type: 'query',
+          backtrace: '',
+        }),
       ],
       widgetData: undefined,
     });

--- a/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.tsx
@@ -44,7 +44,9 @@ export const WidgetData = PropTypes.oneOfType([
 export const WidgetDataMap = PropTypes.objectOf(WidgetData);
 
 export const WidgetError = PropTypes.exact({
-  description: PropTypes.string,
+  _state: PropTypes.shape({
+    description: PropTypes.string,
+  }),
 });
 export const WidgetErrorsList = PropTypes.arrayOf(WidgetError);
 export const WidgetErrorsMap = PropTypes.objectOf(WidgetErrorsList);

--- a/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.tsx
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import Widget from 'views/logic/widgets/Widget';
+import SearchError from 'views/logic/SearchError';
 
 import CustomPropTypes from '../CustomPropTypes';
 
@@ -43,10 +44,6 @@ export const WidgetData = PropTypes.oneOfType([
 
 export const WidgetDataMap = PropTypes.objectOf(WidgetData);
 
-export const WidgetError = PropTypes.exact({
-  _state: PropTypes.shape({
-    description: PropTypes.string,
-  }),
-});
+export const WidgetError = PropTypes.instanceOf(SearchError);
 export const WidgetErrorsList = PropTypes.arrayOf(WidgetError);
 export const WidgetErrorsMap = PropTypes.objectOf(WidgetErrorsList);

--- a/graylog2-web-interface/src/views/logic/SearchResult.ts
+++ b/graylog2-web-interface/src/views/logic/SearchResult.ts
@@ -60,7 +60,7 @@ class SearchResult {
 
     this._results = fromJS(mapValues(result.results, (queryResult) => new QueryResult(queryResult)));
 
-    this._errors = fromJS(result?.errors ?? [].map((error: SearchErrorResponse | ResultWindowLimitErrorResponse) => {
+    this._errors = fromJS((result?.errors ?? []).map((error: SearchErrorResponse | ResultWindowLimitErrorResponse) => {
       if (isResultWindowLimitErrorResponse(error)) {
         return new ResultWindowLimitError(error, this);
       }

--- a/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
+++ b/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
@@ -27,7 +27,7 @@ const delay = (ms: number) => new Promise((resolve) => {
 });
 
 const trackJobStatus = (job: SearchJobType): Promise<SearchJobType> => new Promise((resolve) => {
-  if (job?.execution?.done || job?.execution.completed_exceptionally) {
+  if (job?.execution?.done || job?.execution?.completed_exceptionally) {
     resolve(job);
   } else {
     resolve(delay(250)

--- a/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
+++ b/graylog2-web-interface/src/views/logic/slices/executeSearch.ts
@@ -27,7 +27,7 @@ const delay = (ms: number) => new Promise((resolve) => {
 });
 
 const trackJobStatus = (job: SearchJobType): Promise<SearchJobType> => new Promise((resolve) => {
-  if (job?.execution?.done) {
+  if (job?.execution?.done || job?.execution.completed_exceptionally) {
     resolve(job);
   } else {
     resolve(delay(250)


### PR DESCRIPTION
**Please note**: this PR needs a backport for `5.0` and `5.1`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #15958 we currently just show a loading spinner when loading a saved search or dashboard  which exceeds the query limit. With this PR we are showing the error message again.

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/f792296b-539b-41f6-85c3-10f73dafc0ba)


Fix #15958

