### PR TITLE
Security Views can be added to favourites

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -80,8 +80,10 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         final var favorites = this.findForUser(searchUser);
         if(favorites.isPresent()) {
             var fi = favorites.get();
-            fi.items().add(0, grn);
-            this.save(fi);
+            if (fi.items() != null && fi.items().stream().noneMatch(g -> g.toString().equalsIgnoreCase(in))) {
+                fi.items().add(0, grn);
+                this.save(fi);
+            }
         } else {
             var items = new FavoritesForUserDTO(searchUser.getUser().getId(), List.of(grn));
             this.create(items, searchUser);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -66,7 +66,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
                 .items()
                 .stream().filter(i -> type.isEmpty() || i.type().equals(type.get()))
                 .map(i -> startPageItemTitleRetriever
-                        .retrieveTitle(i)
+                        .retrieveTitle(i, searchUser)
                         .map(title -> new Favorite(i, title))
                 )
                 .flatMap(Optional::stream)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -204,6 +204,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
             if (viewResolver != null) {
                 ViewDTO view = viewResolver.get(decoder.getViewId()).orElseThrow(() -> new NotFoundException("Failed to resolve view:" + id));
                 if (searchUser.canReadView(view)) {
+                    startPageService.addLastOpenedFor(view, searchUser);
                     return view;
                 } else {
                     throw viewNotFoundException(id);
@@ -214,7 +215,6 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         } else {
             ViewDTO view =  loadViewIncludingFavorite(searchUser, id);
             if (searchUser.canReadView(view)) {
-                // Only register normal views in LastOpened, for ViewResolvers, a more global solution has to be found because of the catalog
                 startPageService.addLastOpenedFor(view, searchUser);
                 return view;
             } else {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolverDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewResolverDecoder.java
@@ -20,12 +20,12 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Provides support for decoding resolver view IDs (in the format resolver-name:viewId).
+ * Provides support for decoding resolver view IDs (in the format resolver-name__viewId).
  * See {@link ViewResolver} for more information.
  */
 public class ViewResolverDecoder {
 
-    public static final String SEPARATOR = ":";
+    public static final String SEPARATOR = "__";
     private final String viewId;
 
     public ViewResolverDecoder(String viewId) throws IllegalArgumentException {
@@ -41,7 +41,7 @@ public class ViewResolverDecoder {
     }
 
     /**
-     * @return The resolver name (provided before the ':' separator).
+     * @return The resolver name (provided before the '__' separator).
      */
     public String getResolverName() {
         final String[] split = viewId.split(SEPARATOR);
@@ -50,7 +50,7 @@ public class ViewResolverDecoder {
     }
 
     /**
-     * @return The view id (provided after the ':' separator).
+     * @return The view id (provided after the '__' separator).
      */
     public String getViewId() {
         final String[] split = viewId.split(SEPARATOR);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/StartPageService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/StartPageService.java
@@ -69,7 +69,7 @@ public class StartPageService {
                 .stream()
                 .skip((long) (page - 1) * perPage)
                 .map(i -> startPageItemTitleRetriever
-                        .retrieveTitle(i.grn())
+                        .retrieveTitle(i.grn(), searchUser)
                         .map(title -> new LastOpened(i.grn(), title, i.timestamp()))
                 )
                 .flatMap(Optional::stream)
@@ -83,7 +83,7 @@ public class StartPageService {
         final var items = recentActivityService.findRecentActivitiesFor(searchUser, page, perPage);
         final var mapped = items.stream()
                 .map(i -> startPageItemTitleRetriever
-                        .retrieveTitle(i.itemGrn())
+                        .retrieveTitle(i.itemGrn(), searchUser)
                         .map(title -> new RecentActivity(i.id(),
                                 i.activityType(),
                                 i.itemGrn(),

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/permissions/SearchUserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/permissions/SearchUserTest.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.views.search.rest.ViewsRestPermissions;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewLike;
 import org.graylog.plugins.views.search.views.ViewResolver;
+import org.graylog.plugins.views.search.views.ViewResolverDecoder;
 import org.graylog2.plugin.database.users.User;
 import org.junit.jupiter.api.Test;
 
@@ -118,19 +119,19 @@ class SearchUserTest {
     void testResolvedViewReadAccess() {
         // Test that the resolver permission check allows and disallows appropriately.
         assertThat(searchUserResolvedRequiringPermission("missing-permission")
-                .canReadView(new TestView("resolver:resolved-id"))).isFalse();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isFalse();
         assertThat(searchUserResolvedRequiringPermission("allowed-permission")
-                .canReadView(new TestView("resolver:resolved-id"))).isTrue();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isTrue();
 
         // Test that the resolver permission and entity id check allows and disallows appropriately.
         assertThat(searchUserResolvedRequiringPermissionEntity("bad-permission", "resolved-id")
-                .canReadView(new TestView("resolver:resolved-id"))).isFalse();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isFalse();
         assertThat(searchUserResolvedRequiringPermissionEntity("allowed-permission", "bad-id")
-                .canReadView(new TestView("resolver:resolved-id"))).isFalse();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isFalse();
         assertThat(searchUserResolvedRequiringPermissionEntity("missing-permission", "bad-id")
-                .canReadView(new TestView("resolver:resolved-id"))).isFalse();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isFalse();
         assertThat(searchUserResolvedRequiringPermissionEntity("allowed-permission", "resolved-id")
-                .canReadView(new TestView("resolver:resolved-id"))).isTrue();
+                .canReadView(new TestView("resolver" + ViewResolverDecoder.SEPARATOR + "resolved-id"))).isTrue();
     }
 
     private SearchUser searchUserResolvedRequiringPermission(String expectedPermission) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -34,6 +34,7 @@ import org.graylog.plugins.views.search.views.Position;
 import org.graylog.plugins.views.search.views.UnknownWidgetConfigDTO;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewResolver;
+import org.graylog.plugins.views.search.views.ViewResolverDecoder;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewStateDTO;
 import org.graylog.plugins.views.search.views.WidgetDTO;
@@ -422,17 +423,17 @@ public class ViewsResourceTest {
         );
 
         // Verify that view for valid id is found.
-        Assertions.assertThat(testResource.get(resolverName + ":" + VIEW_ID, SEARCH_USER).id()).isEqualTo(VIEW_ID);
+        Assertions.assertThat(testResource.get(resolverName + ViewResolverDecoder.SEPARATOR + VIEW_ID, SEARCH_USER).id()).isEqualTo(VIEW_ID);
 
 
         // Verify error paths for invalid resolver names and view ids.
-        Assertions.assertThatThrownBy(() -> testResource.get("invalid-resolver-name:" + VIEW_ID, SEARCH_USER))
+        Assertions.assertThatThrownBy(() -> testResource.get("invalid-resolver-name" + ViewResolverDecoder.SEPARATOR + VIEW_ID, SEARCH_USER))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("Failed to find view resolver: invalid-resolver-name");
 
-        Assertions.assertThatThrownBy(() -> testResource.get(resolverName + ":invalid-view-id", SEARCH_USER))
+        Assertions.assertThatThrownBy(() -> testResource.get(resolverName + ViewResolverDecoder.SEPARATOR + "invalid-view-id", SEARCH_USER))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("Failed to resolve view:test-resolver:invalid-view-id");
+                .hasMessageContaining("Failed to resolve view:test-resolver__invalid-view-id");
     }
 
     private ViewsResource createViewsResource(final ViewService viewService, final StartPageService startPageService, final RecentActivityService recentActivityService, final ClusterEventBus clusterEventBus, ReferencedSearchFiltersHelper referencedSearchFiltersHelper, SearchFilterVisibilityChecker searchFilterVisibilityChecker, final Map<String, ViewResolver> viewResolvers, Search... existingSearches) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewResolverDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewResolverDecoderTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 public class ViewResolverDecoderTest {
     @Test
     public void testValidResolver() {
-        final ViewResolverDecoder decoder = new ViewResolverDecoder("resolver:id");
+        final ViewResolverDecoder decoder = new ViewResolverDecoder("resolver" + ViewResolverDecoder.SEPARATOR + "id");
         assertTrue(decoder.isResolverViewId());
         assertEquals("resolver", decoder.getResolverName());
         assertEquals("id", decoder.getViewId());

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/StartPageServiceTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -103,7 +104,7 @@ public class StartPageServiceTest {
         var recentActivityService = new RecentActivityService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, eventbus, grnRegistry, permissionAndRoleResolver);
         catalog = mock(Catalog.class);
         doReturn(Optional.of(new Catalog.Entry("", ""))).when(catalog).getEntry(any());
-        startPageService = new StartPageService(grnRegistry, lastOpenedService, recentActivityService, eventbus, new StartPageItemTitleRetriever(catalog));
+        startPageService = new StartPageService(grnRegistry, lastOpenedService, recentActivityService, eventbus, new StartPageItemTitleRetriever(catalog, Map.of()));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/title/StartPageItemTitleRetrieverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/title/StartPageItemTitleRetrieverTest.java
@@ -17,6 +17,8 @@
 package org.graylog.plugins.views.startpage.title;
 
 import org.graylog.grn.GRN;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog2.lookup.Catalog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,28 +43,34 @@ class StartPageItemTitleRetrieverTest {
     @Mock
     private GRN grn;
 
+    @Mock
+    private SearchUser searchUser;
+
+    private Map<String, ViewResolver> viewResolvers;
+
     private StartPageItemTitleRetriever toTest;
 
     @BeforeEach
     void setUp() {
-        toTest = new StartPageItemTitleRetriever(catalog);
+        viewResolvers = Map.of();
+        toTest = new StartPageItemTitleRetriever(catalog, viewResolvers);
     }
 
     @Test
     void testReturnsEmptyOptionalOnEmptyEntryInCatalog() throws Exception {
         doReturn(Optional.empty()).when(catalog).getEntry(any());
-        assertTrue(toTest.retrieveTitle(grn).isEmpty());
+        assertTrue(toTest.retrieveTitle(grn, searchUser).isEmpty());
     }
 
     @Test
     void testReturnsIdIfTitleIsMissing() throws Exception {
         doReturn(Optional.of(new Catalog.Entry("id", null))).when(catalog).getEntry(any());
-        assertEquals(Optional.of("id"), toTest.retrieveTitle(grn));
+        assertEquals(Optional.of("id"), toTest.retrieveTitle(grn, searchUser));
     }
 
     @Test
     void testReturnsTitleIfPresent() throws Exception {
         doReturn(Optional.of(new Catalog.Entry("id", "title"))).when(catalog).getEntry(any());
-        assertEquals(Optional.of("title"), toTest.retrieveTitle(grn));
+        assertEquals(Optional.of("title"), toTest.retrieveTitle(grn, searchUser));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Separator for "resolvable"/"special" view IDs has been changed, so that it does not break GRN rules.
Security Views are registered in Favorite and Last Opened lists.
Their titles are obtained in a direct way, bypassing Catalog, where they are not registered.
Links from Favorite and Last Opened lists point to Security Views.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#5527
/nocl

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/5145

## How Has This Been Tested?
Manually. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

