### PR TITLE
Mark required fields in RoleResponse

### DIFF
--- a/changelog/unreleased/pr-16019.toml
+++ b/changelog/unreleased/pr-16019.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Mark required fields in body of API call `PUT roles/{rolename}`"
+
+issues = ["16019"]
+pull = ["16046"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/roles/responses/RoleResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/roles/responses/RoleResponse.java
@@ -47,9 +47,9 @@ public abstract class RoleResponse {
     public abstract boolean readOnly();
 
     @JsonCreator
-    public static RoleResponse create(@JsonProperty("name") @NotBlank String name,
+    public static RoleResponse create(@JsonProperty(value = "name", required = true) @NotBlank String name,
                                       @JsonProperty("description") Optional<String> description,
-                                      @JsonProperty("permissions") @NotNull Set<String> permissions,
+                                      @JsonProperty(value = "permissions", required = true) @NotNull Set<String> permissions,
                                       @JsonProperty("read_only") boolean readOnly) {
         return new AutoValue_RoleResponse(name, description, permissions, readOnly);
     }


### PR DESCRIPTION
Resolves #16019 

Mark required fields in `JsonCreator` of class `RoleResponse`. Otherwise they show up as optional in Swagger, which is confusing and wrong.