### PR TITLE
DataNode: Fix to start DataNode inside IntelliJ on macOS

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,7 +54,7 @@ public class OpensearchCommandLineProcess implements Closeable {
             builder.redirectErrorStream(true);
             try {
                 final Process process = builder.start();
-                final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), Charset.defaultCharset()));
                 var line = reader.readLine();
                 if(line != null && Files.exists(Path.of(line))) {
                     final var target = Path.of(line);

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
@@ -16,21 +16,63 @@
  */
 package org.graylog.datanode.management;
 
+import org.apache.commons.exec.OS;
 import org.graylog.datanode.process.OpensearchConfiguration;
 import org.graylog.datanode.process.ProcessInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
+import java.io.BufferedReader;
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 
 public class OpensearchCommandLineProcess implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(OpensearchCommandLineProcess.class);
 
     private final CommandLineProcess commandLineProcess;
 
+    /**
+     * as long as OpenSearch is not supported on macOS, we have to fix the jdk path if we want to
+     * start the DataNode inside IntelliJ.
+     * @param config
+     */
+    private void fixJdkOnMac(final OpensearchConfiguration config) {
+        final var isMacOS = OS.isFamilyMac();
+        final var jdk = config.opensearchDir().resolve("jdk.app");
+        final var jdkNotLinked = !Files.exists(jdk);
+        if (isMacOS && jdkNotLinked) {
+            // Link System jdk into startup folder, get path:
+            final ProcessBuilder builder = new ProcessBuilder("/usr/libexec/java_home");
+            builder.redirectErrorStream(true);
+            try {
+                final Process process = builder.start();
+                final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                var line = reader.readLine();
+                if(line != null && Files.exists(Path.of(line))) {
+                    final var target = Path.of(line);
+                    final var src = Files.createDirectories(jdk.resolve("Contents"));
+                    Files.createSymbolicLink(src.resolve("Home"), target);
+                } else {
+                    LOG.error("Output of '/usr/libexec/java_home' is not the jdk: {}", line);
+                }
+                // cleanup
+                process.destroy();
+                reader.close();
+            } catch (IOException e) {
+                LOG.error("Could not link jdk.app on macOS: {}", e.getMessage(), e);
+            }
+        }
+    }
+
     public OpensearchCommandLineProcess(OpensearchConfiguration config, ProcessListener listener) {
+        fixJdkOnMac(config);
         final Path executable = config.opensearchDir().resolve(Paths.get("bin", "opensearch"));
         final List<String> arguments = config.asMap().entrySet().stream()
                 .map(it -> String.format(Locale.ROOT, "-E%s=%s", it.getKey(), it.getValue())).toList();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If you want to start the DataNode/OpenSearch on macOS, you have to link the jdk.app into the OpenSearch folder so it can start. This modification takes care of it.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

