### PR TITLE
Favorites sorting changed, newest favorites go first

### DIFF
--- a/changelog/unreleased/pr-16050.toml
+++ b/changelog/unreleased/pr-16050.toml
@@ -1,0 +1,5 @@
+type = "c" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "When entity was added to the favorites, it was added to the end of the list. It meant that top of the favorites' list contained entities that had been added first to the list. It seemed wrong. From now on, the newly added entity will be shown on the top of the favorites' list."
+
+issues = [""]
+pulls = ["16050"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -80,7 +80,7 @@ public class FavoritesService extends PaginatedDbService<FavoritesForUserDTO> {
         final var favorites = this.findForUser(searchUser);
         if(favorites.isPresent()) {
             var fi = favorites.get();
-            fi.items().add(grn);
+            fi.items().add(0, grn);
             this.save(fi);
         } else {
             var items = new FavoritesForUserDTO(searchUser.getUser().getId(), List.of(grn));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoritesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoritesServiceTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MongoJackExtension.class)
 @ExtendWith(GRNExtension.class)
 @ExtendWith(TestUserServiceExtension.class)
-public class FavoriteServiceTest {
+public class FavoritesServiceTest {
     FavoritesService favoritesService;
     TestUserService testUserService;
     GRNRegistry grnRegistry;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When entity was added to the favorites, it was added to the end of the list. It meant that top of the favorites' list contained entities that had been added first to the list. It seemed wrong. From now on, the newly added entity will be shown on the top of the favorites' list.


## Motivation and Context
As described in description section.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

