### PR TITLE
Include parameters when replaying search for dashboard widget.

### DIFF
--- a/changelog/unreleased/pr-16051.toml
+++ b/changelog/unreleased/pr-16051.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Include parameters when replaying search for dashboard widget."
+
+issues = ["graylog-plugin-enterprise#4576"]
+pulls = ["16051"]

--- a/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromLocalStorage.ts
+++ b/graylog2-web-interface/src/components/event-definitions/hooks/useEventDefinitionConfigFromLocalStorage.ts
@@ -47,9 +47,7 @@ type EventDefinitionConfigFromUrl = {
 }
 
 const useEventDefinitionConfigFromLocalStorage = (): { hasLocalStorageConfig: boolean; configFromLocalStorage: EventDefinitionConfigFromUrl } => {
-  const {
-    'session-id': sessionId,
-  } = useQuery();
+  const { 'session-id': sessionId } = useQuery();
 
   return useMemo(() => {
     const parsedLocalStorageConfig = Store.get(sessionId);

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -16,12 +16,19 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
+import { useCallback, useMemo } from 'react';
+import type * as Immutable from 'immutable';
+import URI from 'urijs';
 
 import IconButton from 'components/common/IconButton';
 import Icon from 'components/common/Icon';
 import SearchLink from 'views/logic/search/SearchLink';
+import Store from 'logic/local-storage/Store';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import generateId from 'logic/generateId';
+import type Parameter from 'views/logic/parameters/Parameter';
+import type { ParameterBindings } from 'views/logic/search/SearchExecutionState';
 
 const NeutralLink = styled.a`
   display: inline-flex;
@@ -39,46 +46,68 @@ const StyledIcon = styled(Icon)`
 `;
 
 const buildSearchLink = (
+  sessionId: string,
   timerange: TimeRange,
   queryString: string,
   streams: Array<string>,
-) => SearchLink.builder()
-  .query(createElasticsearchQueryString(queryString))
-  .timerange(timerange)
-  .streams(streams)
-  .build()
-  .toURL();
+  parameters?: Immutable.Set<Parameter>,
+) => {
+  let searchLink = SearchLink.builder()
+    .query(createElasticsearchQueryString(queryString))
+    .timerange(timerange)
+    .streams(streams)
+    .build()
+    .toURL();
 
-type Props = {
-  queryString?: string | undefined,
-  timerange?: TimeRange | undefined,
-  streams?: string[] | undefined,
-  children?: React.ReactNode,
+  if (parameters?.size) {
+    searchLink = new URI(searchLink).setSearch('session-id', sessionId).toString();
+  }
+
+  return searchLink;
 };
 
-export const ReplaySearchButtonComponent = ({ searchLink, children }: { children?: React.ReactNode, searchLink: string }) => (
-  <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search">
+export const ReplaySearchButtonComponent = ({ searchLink, children, onClick }: { children?: React.ReactNode, searchLink: string, onClick?: () => void }) => (
+  <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search" onClick={onClick}>
     {children
       ? <>{children} <StyledIcon name="play" /></>
       : <IconButton name="play" focusable={false} />}
   </NeutralLink>
 );
 
-const ReplaySearchButton = ({ queryString, timerange, streams, children }: Props) => {
-  const searchLink = buildSearchLink(timerange, queryString, streams);
+type Props = {
+  queryString?: string | undefined,
+  timerange?: TimeRange | undefined,
+  streams?: string[] | undefined,
+  parameters?: Immutable.Set<Parameter>,
+  children?: React.ReactNode,
+  parameterBindings?: ParameterBindings,
+};
 
-  return <ReplaySearchButtonComponent searchLink={searchLink}>{children}</ReplaySearchButtonComponent>;
+const ReplaySearchButton = ({ queryString, timerange, streams, parameters, children, parameterBindings }: Props) => {
+  const sessionId = useMemo(() => `replay-search-${generateId()}`, []);
+  const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, parameters);
+
+  const onReplaySearch = useCallback(() => {
+    if (parameters?.size) {
+      Store.set(sessionId, JSON.stringify({ parameters, parameterBindings }));
+    }
+  }, [sessionId, parameters, parameterBindings]);
+
+  return <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch}>{children}</ReplaySearchButtonComponent>;
 };
 
 ReplaySearchButton.defaultProps = {
   queryString: undefined,
   timerange: undefined,
   streams: undefined,
+  parameters: undefined,
+  parameterBindings: undefined,
   children: undefined,
 };
 
 ReplaySearchButtonComponent.defaultProps = {
   children: undefined,
+  onClick: undefined,
 };
 
 export default ReplaySearchButton;

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -47,6 +47,7 @@ import type { HistoryFunction } from 'routing/useHistory';
 import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
+import useParameters from 'views/hooks/useParameters';
 
 import ReplaySearchButton from './ReplaySearchButton';
 import ExtraWidgetActions from './ExtraWidgetActions';
@@ -156,6 +157,7 @@ const WidgetActionsMenu = ({
   const history = useHistory();
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
+  const { parameters, parameterBindings } = useParameters();
 
   const onDuplicate = useCallback(() => {
     sendTelemetry('click', {
@@ -209,7 +211,9 @@ const WidgetActionsMenu = ({
         <IfDashboard>
           <ReplaySearchButton queryString={query.query_string}
                               timerange={timerange}
-                              streams={streams} />
+                              streams={streams}
+                              parameterBindings={parameterBindings}
+                              parameters={parameters} />
         </IfDashboard>
         {isFocused && (
           <IconButton name="compress-arrows-alt"

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -97,7 +97,7 @@ const searchExecutionSlice = createSlice({
   },
 });
 
-export const { loading, finishedLoading, updateGlobalOverride, setWidgetsToSearch, setParameterValues } = searchExecutionSlice.actions;
+export const { loading, finishedLoading, updateGlobalOverride, setWidgetsToSearch, setParameterValues, setParameterBindings } = searchExecutionSlice.actions;
 
 export const searchExecutionSliceReducer = searchExecutionSlice.reducer;
 

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.tsx
@@ -21,6 +21,7 @@ import omit from 'lodash/omit';
 import isEmpty from 'lodash/isEmpty';
 import styled from 'styled-components';
 
+import Store from 'logic/local-storage/Store';
 import { Modal, Button } from 'components/bootstrap';
 import type {
   ItemKey,
@@ -54,6 +55,8 @@ const CreateEventDefinitionModal = ({ modalData, mappedData, show, onClose }: { 
   const [{ strategy, checked, showDetails }, dispatchWithData] = useModalReducer(modalData);
   const localStorageConfig = useLocalStorageConfigData({ mappedData, checked });
   const sessionId = useMemo(() => `cedfv-${generateId()}`, []);
+  const eventDefinitionCreationUrl = `${Routes.ALERTS.DEFINITIONS.CREATE}?step=condition&session-id=${sessionId}`;
+
   const onCheckboxChange = useCallback((updates) => {
     dispatchWithData({ type: 'UPDATE_CHECKED_ITEMS', payload: updates });
   }, [dispatchWithData]);
@@ -78,8 +81,6 @@ const CreateEventDefinitionModal = ({ modalData, mappedData, show, onClose }: { 
     <CheckboxLabel itemKey={key} value={value} />
   )), [modalData]);
 
-  const eventDefinitionCreationUrl = useMemo(() => `${Routes.ALERTS.DEFINITIONS.CREATE}?step=condition&session-id=${sessionId}`, [sessionId]);
-
   const strategyAvailabilities = useMemo<{[name in StrategyId]: boolean}>(() => ({
     ALL: true,
     ROW: !!mappedData?.rowValuePath?.length,
@@ -89,7 +90,7 @@ const CreateEventDefinitionModal = ({ modalData, mappedData, show, onClose }: { 
   }), [mappedData?.columnValuePath?.length, mappedData?.rowValuePath?.length]);
 
   const onContinueConfigurationClick = useCallback(() => {
-    localStorage.setItem(sessionId, JSON.stringify(localStorageConfig));
+    Store.set(sessionId, JSON.stringify(localStorageConfig));
     onClose();
   }, [sessionId, localStorageConfig, onClose]);
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
@@ -19,13 +19,20 @@ import { useMemo } from 'react';
 import View from 'views/logic/views/View';
 import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
 import ViewGenerator from 'views/logic/views/ViewGenerator';
+import type Parameter from 'views/logic/parameters/Parameter';
 
-const useCreateSavedSearch = (
+const useCreateSavedSearch = ({
+  streamId,
+  timeRange,
+  queryString,
+  parameters,
+}:{
   streamId?: string | string[],
   timeRange?: TimeRange,
   queryString?: ElasticsearchQueryString,
-) => useMemo(
-  () => ViewGenerator(View.Type.Search, streamId, timeRange, queryString),
+  parameters?: Array<Parameter>,
+}) => useMemo(
+  () => ViewGenerator({ type: View.Type.Search, streamId, timeRange, queryString, parameters }),
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [],
 );

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
@@ -16,6 +16,7 @@
  */
 import type { TimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
 import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';
+import type Parameter from 'views/logic/parameters/Parameter';
 
 import View from './View';
 import ViewStateGenerator from './ViewStateGenerator';
@@ -24,14 +25,23 @@ import type { ViewType } from './View';
 import Search from '../search/Search';
 import QueryGenerator from '../queries/QueryGenerator';
 
-export default async (
+export default async ({
+  type,
+  streamId,
+  timeRange,
+  queryString,
+  parameters,
+}: {
   type: ViewType,
-  streamId: string | string[] | undefined | null,
+  streamId?: string | string[],
   timeRange?: TimeRange,
   queryString?: ElasticsearchQueryString,
+  parameters?: Array<Parameter>,
+},
 ) => {
   const query = QueryGenerator(streamId, undefined, timeRange, queryString);
-  const search = Search.create().toBuilder().queries([query]).build();
+  const search = Search.create().toBuilder().queries([query]).parameters(parameters)
+    .build();
   const viewState = await ViewStateGenerator(type, streamId);
 
   const view = View.create()

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
@@ -37,7 +37,7 @@ const NewDashboardPage = () => {
 
   const viewPromise = useMemo(() => (searchView?.search
     ? Promise.resolve(viewTransformer(searchView))
-    : ViewGenerator(View.Type.Dashboard, undefined)),
+    : ViewGenerator({ type: View.Type.Dashboard })),
   // This should be run only once upon mount on purpose.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   []);

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -87,7 +87,12 @@ describe('NewSearchPage', () => {
       asMock(useQuery).mockReturnValue({});
       render(<SimpleNewSearchPage />);
 
-      await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith([], undefined, undefined));
+      await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith({
+        parameters: undefined,
+        queryString: undefined,
+        streamId: [],
+        timeRange: undefined,
+      }));
     });
 
     it('should process hooks with provided location query', async () => {

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
@@ -15,19 +15,52 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import Immutable from 'immutable';
+import { useMemo } from 'react';
 
 import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
 import { useSearchURLQueryParams } from 'views/logic/NormalizeSearchURLQueryParams';
 import useCreateSearch from 'views/hooks/useCreateSearch';
+import useQuery from 'routing/useQuery';
+import Store from 'logic/local-storage/Store';
+import Parameter from 'views/logic/parameters/Parameter';
+import type { ParameterBindingJsonRepresentation } from 'views/logic/parameters/ParameterBinding';
+import ParameterBinding from 'views/logic/parameters/ParameterBinding';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 
 import SearchPage from './SearchPage';
 
+const useParametersFromStore = () => {
+  const { 'session-id': sessionId } = useQuery();
+
+  return useMemo(() => {
+    if (sessionId) {
+      const searchDataFromStore = Store.get(sessionId);
+      Store.delete(sessionId);
+
+      const searchData = searchDataFromStore ? JSON.parse(searchDataFromStore) : undefined;
+
+      if (searchData?.parameters) {
+        return {
+          parameters: searchData.parameters.map((param) => Parameter.fromJSON(param)),
+          parameterBindings: Immutable.Map<string, ParameterBinding>(Object.entries<ParameterBindingJsonRepresentation>(searchData.parameterBindings ?? {}).map(
+            ([paramName, paramBinding]) => ([paramName, ParameterBinding.fromJSON(paramBinding)]),
+          )),
+        };
+      }
+    }
+
+    return { parameters: undefined, parameterBindings: undefined };
+  }, [sessionId]);
+};
+
 const NewSearchPage = () => {
+  const { parameters, parameterBindings } = useParametersFromStore();
   const { timeRange, queryString, streams } = useSearchURLQueryParams();
-  const viewPromise = useCreateSavedSearch(streams, timeRange, queryString);
+  const viewPromise = useCreateSavedSearch({ streamId: streams, timeRange, queryString, parameters });
   const view = useCreateSearch(viewPromise);
 
-  return <SearchPage view={view} isNew />;
+  return <SearchPage view={view} executionState={SearchExecutionState.create(parameterBindings)} isNew />;
 };
 
 export default NewSearchPage;

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -82,19 +82,32 @@ describe('StreamSearchPage', () => {
 
   it('should create view with streamId passed from props', async () => {
     render(<SimpleStreamSearchPage />);
-    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith(streamId, undefined, undefined));
+
+    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith({
+      queryString: undefined,
+      streamId: 'stream-id-1',
+      timeRange: undefined,
+    }));
   });
 
   it('should recreate view when streamId passed from props changes', async () => {
     const { rerender } = render(<SimpleStreamSearchPage />);
 
-    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith(streamId, undefined, undefined));
+    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith({
+      queryString: undefined,
+      streamId: 'stream-id-1',
+      timeRange: undefined,
+    }));
 
     asMock(useParams).mockReturnValue({ streamId: 'stream-id-2' });
 
     rerender(<SimpleStreamSearchPage />);
 
-    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenLastCalledWith('stream-id-2', undefined, undefined));
+    await waitFor(() => expect(useCreateSavedSearch).toHaveBeenLastCalledWith({
+      queryString: undefined,
+      streamId: 'stream-id-2',
+      timeRange: undefined,
+    }));
   });
 
   describe('loading another view', () => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
@@ -35,7 +35,7 @@ const StreamSearchPage = () => {
   }
 
   const { timeRange, queryString } = useSearchURLQueryParams();
-  const viewPromise = useCreateSavedSearch(streamId, timeRange, queryString);
+  const viewPromise = useCreateSavedSearch({ streamId, timeRange, queryString });
   const view = useCreateSearch(viewPromise);
 
   const _loadNewView = useCallback(() => loadNewViewForStream(history, streamId), [history, streamId]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we were not including parameters when replaying the search for a dashboard widget.

Fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/4576
