### PR TITLE
DataNode: Remove CA from MongoDB on startover

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
@@ -126,7 +126,7 @@ public class CaServiceImpl implements CaService {
 
     @Override
     public void startOver() {
-
+        keystoreStorage.removeKeyStore(mongoDbCaLocation);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
@@ -29,6 +29,7 @@ import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLoca
 import org.graylog2.Configuration;
 import org.graylog2.bootstrap.preflight.web.resources.model.CA;
 import org.graylog2.bootstrap.preflight.web.resources.model.CAType;
+import org.graylog2.cluster.certificates.CertificatesService;
 import org.graylog2.plugin.system.NodeId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +61,7 @@ public class CaServiceImpl implements CaService {
     private final CACreator caCreator;
     private final PemCaReader pemCaReader;
     private final CaConfiguration configuration;
+    private final CertificatesService certificatesService;
     private final String passwordSecret;
 
     @Inject
@@ -68,12 +70,14 @@ public class CaServiceImpl implements CaService {
                      final NodeId nodeId,
                      final CACreator caCreator,
                      final PemCaReader pemCaReader,
+                     final CertificatesService certificatesService,
                      final @Named("password_secret") String passwordSecret) {
         this.keystoreStorage = keystoreStorage;
         this.nodeId = nodeId;
         this.caCreator = caCreator;
         this.pemCaReader = pemCaReader;
         this.configuration = configuration;
+        this.certificatesService = certificatesService;
         this.passwordSecret = configuration.getCaPassword() != null ? configuration.getCaPassword() : passwordSecret;
         this.mongoDbCaLocation = new KeystoreMongoLocation(nodeId.getNodeId(), KeystoreMongoCollections.GRAYLOG_CA_KEYSTORE_COLLECTION);
         this.manuallyProvidedCALocation = new KeystoreFileLocation(configuration.getCaKeystoreFile());
@@ -126,7 +130,7 @@ public class CaServiceImpl implements CaService {
 
     @Override
     public void startOver() {
-        keystoreStorage.removeKeyStore(mongoDbCaLocation);
+        certificatesService.removeCert(mongoDbCaLocation);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
@@ -19,7 +19,6 @@ package org.graylog.security.certutil.keystore.storage;
 import org.graylog.security.certutil.CertConstants;
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
-import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 
 import javax.inject.Inject;
 import java.io.FileOutputStream;

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
@@ -66,10 +66,4 @@ public final class KeystoreFileStorage implements KeystoreStorage<KeystoreFileLo
             throw new KeyStoreStorageException("Could not read keystore: " + ex.getMessage(), ex);
         }
     }
-
-    @Override
-    public void removeKeyStore(final KeystoreFileLocation location) {
-        // noop, we don't remove files from the filesystem
-    }
-
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreFileStorage.java
@@ -19,6 +19,7 @@ package org.graylog.security.certutil.keystore.storage;
 import org.graylog.security.certutil.CertConstants;
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreFileLocation;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 
 import javax.inject.Inject;
 import java.io.FileOutputStream;
@@ -65,6 +66,11 @@ public final class KeystoreFileStorage implements KeystoreStorage<KeystoreFileLo
         } catch (IOException | GeneralSecurityException ex) {
             throw new KeyStoreStorageException("Could not read keystore: " + ex.getMessage(), ex);
         }
+    }
+
+    @Override
+    public void removeKeyStore(final KeystoreFileLocation location) {
+        // noop, we don't remove files from the filesystem
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -17,6 +17,7 @@
 package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog2.cluster.certificates.CertificatesService;
 
@@ -73,6 +74,11 @@ public final class KeystoreMongoStorage implements KeystoreStorage<KeystoreMongo
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public void removeKeyStore(final KeystoreMongoLocation location) {
+        certificatesService.removeCert(location);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -74,10 +74,4 @@ public final class KeystoreMongoStorage implements KeystoreStorage<KeystoreMongo
         }
         return Optional.empty();
     }
-
-    @Override
-    public void removeKeyStore(final KeystoreMongoLocation location) {
-        certificatesService.removeCert(location);
-    }
-
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreMongoStorage.java
@@ -17,7 +17,6 @@
 package org.graylog.security.certutil.keystore.storage;
 
 import org.graylog.security.certutil.ca.exceptions.KeyStoreStorageException;
-import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
 import org.graylog2.cluster.certificates.CertificatesService;
 

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
@@ -32,4 +32,5 @@ public sealed interface KeystoreStorage<T extends KeystoreLocation> permits Keys
 
     Optional<KeyStore> readKeyStore(final T location, char[] password) throws KeyStoreStorageException;
 
+    void removeKeyStore(final T location);
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/KeystoreStorage.java
@@ -31,6 +31,4 @@ public sealed interface KeystoreStorage<T extends KeystoreLocation> permits Keys
     ) throws KeyStoreStorageException;
 
     Optional<KeyStore> readKeyStore(final T location, char[] password) throws KeyStoreStorageException;
-
-    void removeKeyStore(final T location);
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
@@ -61,11 +61,4 @@ public final class SmartKeystoreStorage implements KeystoreStorage<KeystoreLocat
             return Optional.empty();
         }
     }
-
-    @Override
-    public void removeKeyStore(final KeystoreLocation location) {
-        if (location instanceof final KeystoreMongoLocation mongoLocation) {
-            keystoreMongoStorage.removeKeyStore(mongoLocation);
-        }
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/keystore/storage/SmartKeystoreStorage.java
@@ -62,5 +62,10 @@ public final class SmartKeystoreStorage implements KeystoreStorage<KeystoreLocat
         }
     }
 
-
+    @Override
+    public void removeKeyStore(final KeystoreLocation location) {
+        if (location instanceof final KeystoreMongoLocation mongoLocation) {
+            keystoreMongoStorage.removeKeyStore(mongoLocation);
+        }
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
@@ -23,6 +23,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
+import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollection;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;
@@ -127,4 +128,14 @@ public class CertificatesService {
         return Optional.empty();
     }
 
+    public void removeCert(final KeystoreMongoLocation keystoreMongoLocation) {
+        final KeystoreMongoCollection collection = keystoreMongoLocation.collection();
+        MongoCollection<Document> dbCollection = mongoDatabase.getCollection(collection.collectionName());
+        dbCollection.deleteOne(
+                eq(
+                        collection.identifierField(),
+                        keystoreMongoLocation.nodeId()
+                )
+        );
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
@@ -23,7 +23,6 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
-import org.graylog.security.certutil.keystore.storage.location.KeystoreLocation;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollection;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoCollections;
 import org.graylog.security.certutil.keystore.storage.location.KeystoreMongoLocation;

--- a/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/certificates/CertificatesService.java
@@ -127,14 +127,15 @@ public class CertificatesService {
         return Optional.empty();
     }
 
-    public void removeCert(final KeystoreMongoLocation keystoreMongoLocation) {
+    public boolean removeCert(final KeystoreMongoLocation keystoreMongoLocation) {
         final KeystoreMongoCollection collection = keystoreMongoLocation.collection();
         MongoCollection<Document> dbCollection = mongoDatabase.getCollection(collection.collectionName());
-        dbCollection.deleteOne(
+        var result = dbCollection.deleteOne(
                 eq(
                         collection.identifierField(),
                         keystoreMongoLocation.nodeId()
                 )
         );
+        return result.getDeletedCount() > 0;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
@@ -104,7 +104,8 @@ public class CertificatesServiceTest {
                 new KeystoreMongoLocation("node_id_5", DATA_NODE_KEYSTORE_COLLECTION)
         ));
 
-        certificatesService.removeCert(new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION));
+        var result = certificatesService.removeCert(new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION));
+        assertTrue("Removal of an existing cert should result in 'true'", result);
 
         assertFalse(certificatesService.hasCert(
                 new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION)
@@ -113,6 +114,9 @@ public class CertificatesServiceTest {
         assertTrue(certificatesService.hasCert(
                 new KeystoreMongoLocation("node_id_5", DATA_NODE_KEYSTORE_COLLECTION)
         ));
+
+        result = certificatesService.removeCert(new KeystoreMongoLocation("node_id_6", DATA_NODE_KEYSTORE_COLLECTION));
+        assertFalse("Removal of non existing cert should result in 'true'", result);
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
@@ -91,5 +91,28 @@ public class CertificatesServiceTest {
         ));
     }
 
+    @Test
+    public void testCertRemoval() {
+        certificatesService.writeCert(new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION), "Certificate string representation 1");
+        certificatesService.writeCert(new KeystoreMongoLocation("node_id_5", DATA_NODE_KEYSTORE_COLLECTION), "Certificate string representation 2");
+
+        assertTrue(certificatesService.hasCert(
+                new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION)
+        ));
+
+        assertTrue(certificatesService.hasCert(
+                new KeystoreMongoLocation("node_id_5", DATA_NODE_KEYSTORE_COLLECTION)
+        ));
+
+        certificatesService.removeCert(new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION));
+
+        assertFalse(certificatesService.hasCert(
+                new KeystoreMongoLocation("node_id_4", DATA_NODE_KEYSTORE_COLLECTION)
+        ));
+
+        assertTrue(certificatesService.hasCert(
+                new KeystoreMongoLocation("node_id_5", DATA_NODE_KEYSTORE_COLLECTION)
+        ));
+    }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/certificates/CertificatesServiceTest.java
@@ -116,7 +116,7 @@ public class CertificatesServiceTest {
         ));
 
         result = certificatesService.removeCert(new KeystoreMongoLocation("node_id_6", DATA_NODE_KEYSTORE_COLLECTION));
-        assertFalse("Removal of non existing cert should result in 'true'", result);
+        assertFalse("Removal of non existing cert should result in 'false'", result);
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If we press the restart button in the UI, we want to remove the CA from MongoDB.
We do not remove a CA from the filesystem because that was configured manually by the user - so it should remain.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

