### PR TITLE
Change GenerateNextPosition implementation

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.ts
@@ -16,11 +16,12 @@
  */
 import { List, Map } from 'immutable';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import * as Immutable from 'immutable';
 
 import type Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
 import type Query from 'views/logic/queries/Query';
-import GenerateNextPosition from 'views/logic/views/GenerateNextPosition';
+import { ConcatPositions } from 'views/logic/views/GenerateNextPosition';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TitleTypes from 'views/stores/TitleTypes';
 
@@ -29,13 +30,12 @@ import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 
 type QueryId = string;
 
-const _newPositionsMap = (oldPosition, widgetPositions, widget, widgets) => {
-  const widgetPositionsMap = oldPosition ? {
-    ...widgetPositions,
-    [widget.id]: oldPosition.toBuilder().row(0).col(0).build(),
-  } : widgetPositions;
+const _newPositionsMap = (oldPosition, widgetPositions, widget): Immutable.Map<string, WidgetPosition> => {
+  const newWidgetPositions: Immutable.Map<string, WidgetPosition> = oldPosition
+    ? ConcatPositions(Immutable.Map({ [widget.id]: oldPosition.toBuilder().row(1).col(1).build() }), Immutable.Map(widgetPositions))
+    : Immutable.Map(widgetPositions);
 
-  return GenerateNextPosition(Map(widgetPositionsMap), widgets.toArray());
+  return newWidgetPositions;
 };
 
 const _newTitlesMap = (titlesMap, widget, title) => {
@@ -55,7 +55,7 @@ const _addWidgetToDashboard = (widget: Widget, dashboard: View, oldPosition: Wid
   const widgets = viewState.widgets.push(widget);
 
   const { widgetPositions } = viewState;
-  const newWidgetPositions = _newPositionsMap(oldPosition, widgetPositions, widget, widgets);
+  const newWidgetPositions: Map<string, WidgetPosition> = _newPositionsMap(oldPosition, widgetPositions, widget);
 
   const titlesMap = viewState.titles;
   const newTitlesMap = _newTitlesMap(titlesMap, widget, title);

--- a/graylog2-web-interface/src/views/logic/views/GenerateNextPosition.ts
+++ b/graylog2-web-interface/src/views/logic/views/GenerateNextPosition.ts
@@ -21,14 +21,48 @@ import GetPositionForNewWidget from 'views/logic/views/GetPositionForNewWidget';
 
 import type Widget from '../widgets/Widget';
 
-const incrementRow = (position: WidgetPosition) => position.row + 1;
+export const ConcatPositions = (
+  newPositions: Immutable.Map<string, WidgetPosition>,
+  curPositions: Immutable.Map<string, WidgetPosition>,
+) => {
+  let rowIncrement = 0;
+
+  const newUpdatedPositions: Immutable.Map<string, WidgetPosition> = newPositions.map((initialPosition) => {
+    const defaultHeight = initialPosition.height;
+    const row: number = rowIncrement + initialPosition.row;
+    const widgetPosition = initialPosition.toBuilder().row(row).build();
+    rowIncrement += defaultHeight;
+
+    return widgetPosition;
+  });
+
+  const curUpdatedPositions: Immutable.Map<string, WidgetPosition> = curPositions.map((initialPosition) => {
+    const row: number = rowIncrement + initialPosition.row;
+    const widgetPosition = initialPosition.toBuilder().row(row).build();
+
+    return widgetPosition;
+  });
+
+  return newUpdatedPositions.merge(curUpdatedPositions);
+};
 
 export default (
   widgetPositions: Immutable.Map<string, WidgetPosition>,
   widgets: Array<Widget>,
-): Immutable.Map<string, WidgetPosition> => Immutable.Map(
-  widgets
-    .map((widget) => [widget.id, widgetPositions.has(widget.id)
-      ? widgetPositions.get(widget.id).toBuilder().row(incrementRow(widgetPositions.get(widget.id))).build()
-      : GetPositionForNewWidget(widget)]),
-);
+): Immutable.Map<string, WidgetPosition> => {
+  const widgetsWithPosition = widgets
+    .filter((widget) => widgetPositions.has(widget.id));
+
+  const widgetsWithoutPosition = widgets
+    .filter((widget) => !widgetPositions.has(widget.id));
+
+  const newPositions: Immutable.Map<string, WidgetPosition> = Immutable.Map(widgetsWithoutPosition.map((widget) => [widget.id, GetPositionForNewWidget(widget)]));
+
+  const updatedPositions: Immutable.Map<string, WidgetPosition> = Immutable.Map(widgetsWithPosition.map((widget) => {
+    const widgetPosition = widgetPositions.get(widget.id);
+
+    return [widget.id, widgetPosition];
+  }));
+
+  return ConcatPositions(newPositions, updatedPositions);
+};

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.ts
@@ -24,7 +24,7 @@ import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import View from './View';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
-import GenerateNextPosition from './GenerateNextPosition';
+import { ConcatPositions } from './GenerateNextPosition';
 
 import type Widget from '../widgets/Widget';
 
@@ -77,11 +77,9 @@ const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View
   const newWidget = widget?.id ? widget : widget.toBuilder().newId().build();
   const newWidgets = viewState.widgets.push(newWidget);
   const { widgetPositions } = viewState;
-  const widgetPositionsMap = oldPosition ? {
-    ...widgetPositions,
-    [newWidget.id]: oldPosition.toBuilder().row(0).col(0).build(),
-  } : widgetPositions;
-  const newWidgetPositions = GenerateNextPosition(Immutable.Map(widgetPositionsMap), newWidgets.toArray());
+  const newWidgetPositions = oldPosition
+    ? ConcatPositions(Immutable.Map({ [newWidget.id]: oldPosition.toBuilder().row(1).col(1).build() }), Immutable.Map(widgetPositions))
+    : Immutable.Map(widgetPositions);
   const newTitleMap = _setWidgetTitle(viewState.titles, newWidget.id, widgetTitle);
   const newViewState = viewState.toBuilder()
     .widgets(newWidgets)

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.ts.snap
@@ -14,17 +14,35 @@ exports[`copyWidgetToDashboard should copy a widget to a dashboard 1`] = `
         "highlighting": [],
       },
       "positions": Immutable.Map {
-        "a8058a41-34ea-4846-83d0-1acc2fbc1d7f": {
-          "col": 1,
-          "height": 4,
-          "row": 2,
-          "width": "Infinity",
-        },
         "dead-beef": {
-          "col": 0,
+          "col": 1,
           "height": 4,
           "row": 1,
           "width": 4,
+        },
+        "546b13fe-eae7-4fb8-abb9-e0e3a907c3e6": {
+          "col": 1,
+          "height": 3,
+          "row": 9,
+          "width": "Infinity",
+        },
+        "32889f0b-fe5a-4f18-baa0-773869d49af3": {
+          "col": 1,
+          "height": 6,
+          "row": 14,
+          "width": "Infinity",
+        },
+        "8532ff94-2881-42b4-b26d-080d09305e95": {
+          "col": 1,
+          "height": 2,
+          "row": 12,
+          "width": "Infinity",
+        },
+        "a8058a41-34ea-4846-83d0-1acc2fbc1d7f": {
+          "col": 1,
+          "height": 4,
+          "row": 5,
+          "width": "Infinity",
         },
       },
       "selected_fields": [

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/GenerateNextPosition.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/GenerateNextPosition.test.ts.snap
@@ -22,7 +22,7 @@ Immutable.Map {
   "foo": {
     "col": 1,
     "height": 8,
-    "row": 2,
+    "row": 6,
     "width": 3,
   },
 }

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.ts.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.ts.snap
@@ -66,7 +66,7 @@ exports[`MoveWidgetToTab should copy a Widget to a dashboard 1`] = `
       },
       "positions": Immutable.Map {
         "dead-beef": {
-          "col": 0,
+          "col": 1,
           "height": 4,
           "row": 1,
           "width": 4,
@@ -145,7 +145,7 @@ exports[`MoveWidgetToTab should move a Widget to a dashboard 1`] = `
       },
       "positions": Immutable.Map {
         "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": {
-          "col": 0,
+          "col": 1,
           "height": 4,
           "row": 1,
           "width": 4,
@@ -222,14 +222,7 @@ exports[`MoveWidgetToTab should provide a default position in case the widgets p
       "formatting": {
         "highlighting": [],
       },
-      "positions": Immutable.Map {
-        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": {
-          "col": 1,
-          "height": 4,
-          "row": 1,
-          "width": 4,
-        },
-      },
+      "positions": Immutable.Map {},
       "selected_fields": undefined,
       "titles": Immutable.Map {
         "widget": Immutable.Map {
@@ -301,7 +294,7 @@ exports[`MoveWidgetToTab should work when titles are empty 1`] = `
       },
       "positions": Immutable.Map {
         "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": {
-          "col": 0,
+          "col": 1,
           "height": 4,
           "row": 1,
           "width": 4,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR changes GenerateNextPosition implementation. Now for widgets that don't have defined positions, we create positions starting from row === 1, for the next  + the sum of the height of all prev new widgets. For existing widgets, we change the row by adding the sum of all new widgets' height 

## Motivation and Context
The reason why [#16039](https://github.com/Graylog2/graylog2-server/issues/16039) happens is that during adding a new widget we create it with default positions and for the rest of the widget we just increase the row by 1. This causes situations where the row of the widget may be smaller than the sum of the row and height of the previous widget. In turn, this triggers the `react-grid-layout` functionality that recalculates all the heights and rows for each element. As a result, we run `updateViewState` twice, on creating a new widget and on recalculation. That is why we have 2 revisions in or undo redu buffer after one action and why we need to press undo twice to remove the widget.


fix: [#16039](https://github.com/Graylog2/graylog2-server/issues/16039)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

