### PR TITLE
Move time range preset select to header of time range picker.

### DIFF
--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -28,7 +28,7 @@ type Props = {
   disabled?: boolean
   dropdownMinWidth?: number
   dropdownZIndex?: number,
-  onToggle?: () => void,
+  onToggle?: (isOpen: boolean) => void,
   title: React.ReactNode,
 };
 
@@ -50,7 +50,7 @@ const OverlayDropdownButton = ({
 
   const _onToggle = () => {
     if (typeof onToggleProp === 'function') {
-      onToggleProp();
+      onToggleProp(!show);
     }
 
     setShowDropdown((cur) => !cur);

--- a/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.test.tsx
@@ -80,7 +80,7 @@ describe('QuickAccessTimeRangeForm', () => {
 
   it('add action trigger onUpdate', async () => {
     renderForm();
-    const addItemButton = await screen.findByLabelText('Add quick access timerange');
+    const addItemButton = await screen.findByLabelText('Add new search time range preset');
 
     fireEvent.click(addItemButton);
 

--- a/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.test.tsx
@@ -104,16 +104,15 @@ describe('QuickAccessTimeRangeForm', () => {
     ]));
   });
 
-  it('edit timerange action trigger onUpdate', async () => {
+  it('edit time range action trigger onUpdate', async () => {
     renderForm();
     const timerangeItem = await screen.findByTestId('time-range-preset-tr-id-1');
     const timerangeFilter = await within(timerangeItem).findByText('5 minutes ago');
-    await fireEvent.click(timerangeFilter);
-    await screen.findByText(/search time range/i);
+    fireEvent.click(timerangeFilter);
     const fromInput = await screen.findByTitle('Set the from value');
-    await fireEvent.change(fromInput, { target: { value: 15 } });
+    fireEvent.change(fromInput, { target: { value: 15 } });
     const submit = await screen.findByTitle('Update time range');
-    await fireEvent.click(submit);
+    fireEvent.click(submit);
 
     await waitFor(() => expect(mockOnUpdate).toHaveBeenCalledWith(Immutable.List([
       { description: 'TimeRange1', id: 'tr-id-1', timerange: { from: 900, type: 'relative' } },

--- a/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.tsx
@@ -150,9 +150,9 @@ const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
 
   return (
     <div className="form-group">
-      <strong>Quick Access Time Range Options</strong>
+      <strong>Search Time Range Presets</strong>
       <span className="help-block">
-        <span>Configure the available options for the <strong>quick access</strong> time range selector</span>
+        <span>Configure the available search time range presets.</span>
       </span>
       <div className="wrapper">
         <TimeRangeInputSettingsContext.Provider value={contextSettings}>
@@ -163,7 +163,7 @@ const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
                         customContentRender={customContentRender} />
         </TimeRangeInputSettingsContext.Provider>
       </div>
-      <Button bsSize="xs" onClick={addTimeRange} title="Add quick access timerange" aria-label="Add quick access timerange">
+      <Button bsSize="xs" onClick={addTimeRange} title="Add new search time range preset" aria-label="Add new search time range preset">
         Add option
       </Button>
     </div>

--- a/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/QuickAccessTimeRangeForm.tsx
@@ -68,9 +68,7 @@ type ItemProps = {
 
 const contextSettings = {
   showDropdownButton: false,
-  showRelativePresetsButton: false,
-  showAbsolutePresetsButton: false,
-  showKeywordPresetsButton: false,
+  showPresetsButton: false,
   showAddToQuickListButton: false,
   ignoreLimitDurationInTimeRangeDropdown: true,
 };

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
@@ -248,7 +248,7 @@ const SearchesConfig = () => {
 
       <Row>
         <Col md={4}>
-          <strong>Quick access time range options</strong>
+          <strong>Search Time Range Presets</strong>
           <QuickAccessTimeRangeOptionsSummary options={quickAccessTimeRangePresetsFromBE.toArray()} />
           <strong>Surrounding time range options</strong>
           <TimeRangeOptionsSummary options={viewConfig.surrounding_timerange_options} />

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
@@ -31,10 +31,10 @@ import type { SearchConfig } from 'components/search';
 import Select from 'components/common/Select/Select';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import 'moment-duration-format';
-import type { QuickAccessTimeRange } from 'components/configurations/QuickAccessTimeRangeForm';
-import QuickAccessTimeRangeForm from 'components/configurations/QuickAccessTimeRangeForm';
+import type { TimeRangePreset } from 'components/configurations/TimeRangePresetForm';
+import TimeRangePresetForm from 'components/configurations/TimeRangePresetForm';
 import generateId from 'logic/generateId';
-import QuickAccessTimeRangeOptionsSummary from 'components/configurations/QuickAccessTimeRangeOptionsSummary';
+import TimeRangePresetOptionsSummary from 'components/configurations/TimeRangePresetOptionSummary';
 import { onInitializingTimerange } from 'views/components/TimerangeForForm';
 import useUserDateTime from 'hooks/useUserDateTime';
 import type { DateTime, DateTimeFormats } from 'util/DateTime';
@@ -57,7 +57,7 @@ const buildTimeRangeOptions = (options: { [x: string]: string; }) => Object.keys
 
 type Option = { period: string, description: string };
 
-const mapQuickAccessBEData = (items: Array<QuickAccessTimeRange>, formatTime: (time: DateTime, format?: DateTimeFormats) => string): Immutable.List<QuickAccessTimeRange> => Immutable.List(items.map(({ timerange, description, id }) => {
+const mapQuickAccessBEData = (items: Array<TimeRangePreset>, formatTime: (time: DateTime, format?: DateTimeFormats) => string): Immutable.List<TimeRangePreset> => Immutable.List(items.map(({ timerange, description, id }) => {
   const presetId = id ?? generateId();
 
   return { description, id: presetId, timerange: onInitializingTimerange(timerange, formatTime) };
@@ -76,7 +76,7 @@ const SearchesConfig = () => {
   const [surroundingFilterFieldsUpdate, setSurroundingFilterFieldsUpdate] = useState<string | undefined>(undefined);
   const [analysisDisabledFieldsUpdate, setAnalysisDisabledFieldsUpdate] = useState<string | undefined>(undefined);
   const [defaultAutoRefreshOptionUpdate, setDefaultAutoRefreshOptionUpdate] = useState<string | undefined>(undefined);
-  const [quickAccessTimeRangePresetsUpdated, setQuickAccessTimeRangePresetsUpdated] = useState<Immutable.List<QuickAccessTimeRange>>(undefined);
+  const [timeRangePresetsUpdated, setTimeRangePresetsUpdated] = useState<Immutable.List<TimeRangePreset>>(undefined);
   const sendTelemetry = useSendTelemetry();
 
   useEffect(() => {
@@ -91,8 +91,8 @@ const SearchesConfig = () => {
     setFormConfig({ ...formConfig, [field]: newOptions });
   };
 
-  const onQuickAccessTimeRangePresetsUpdate = (data: Immutable.List<QuickAccessTimeRange>) => {
-    setQuickAccessTimeRangePresetsUpdated(data);
+  const onTimeRangePresetsUpdate = (data: Immutable.List<TimeRangePreset>) => {
+    setTimeRangePresetsUpdated(data);
   };
 
   const onSurroundingTimeRangeOptionsUpdate = (data: Array<Option>) => {
@@ -140,7 +140,7 @@ const SearchesConfig = () => {
     setAnalysisDisabledFieldsUpdate(undefined);
     setAutoRefreshTimeRangeOptionsUpdate(undefined);
     setDefaultAutoRefreshOptionUpdate(undefined);
-    setQuickAccessTimeRangePresetsUpdated(undefined);
+    setTimeRangePresetsUpdated(undefined);
   };
 
   const handleModalCancel = () => {
@@ -168,12 +168,12 @@ const SearchesConfig = () => {
       setRelativeTimeRangeOptionsUpdate(undefined);
     }
 
-    if (quickAccessTimeRangePresetsUpdated) {
-      update.quick_access_timerange_presets = quickAccessTimeRangePresetsUpdated.toArray().map(({ description, timerange, id }) => ({
+    if (timeRangePresetsUpdated) {
+      update.quick_access_timerange_presets = timeRangePresetsUpdated.toArray().map(({ description, timerange, id }) => ({
         description, timerange: normalizeFromSearchBarForBackend(timerange, userTimezone), id,
       }));
 
-      setQuickAccessTimeRangePresetsUpdated(undefined);
+      setTimeRangePresetsUpdated(undefined);
     }
 
     if (surroundingTimeRangeOptionsUpdate) {
@@ -218,8 +218,8 @@ const SearchesConfig = () => {
     });
   };
 
-  const quickAccessTimeRangePresetsFromBE = useMemo(() => mapQuickAccessBEData(formConfig?.quick_access_timerange_presets ?? [], formatTime), [formConfig?.quick_access_timerange_presets, formatTime]);
-  const quickAccessTimeRangePresets = useMemo(() => quickAccessTimeRangePresetsUpdated ?? quickAccessTimeRangePresetsFromBE, [quickAccessTimeRangePresetsFromBE, quickAccessTimeRangePresetsUpdated]);
+  const timeRangePresetsFromBE = useMemo(() => mapQuickAccessBEData(formConfig?.quick_access_timerange_presets ?? [], formatTime), [formConfig?.quick_access_timerange_presets, formatTime]);
+  const timeRangePresets = useMemo(() => timeRangePresetsUpdated ?? timeRangePresetsFromBE, [timeRangePresetsFromBE, timeRangePresetsUpdated]);
 
   if (!viewConfig) {
     return <Spinner />;
@@ -249,7 +249,7 @@ const SearchesConfig = () => {
       <Row>
         <Col md={4}>
           <strong>Search Time Range Presets</strong>
-          <QuickAccessTimeRangeOptionsSummary options={quickAccessTimeRangePresetsFromBE.toArray()} />
+          <TimeRangePresetOptionsSummary options={timeRangePresetsFromBE.toArray()} />
           <strong>Surrounding time range options</strong>
           <TimeRangeOptionsSummary options={viewConfig.surrounding_timerange_options} />
         </Col>
@@ -313,7 +313,7 @@ const SearchesConfig = () => {
                                 validator={queryTimeRangeLimitValidator}
                                 required />
             )}
-            <QuickAccessTimeRangeForm options={quickAccessTimeRangePresets} onUpdate={onQuickAccessTimeRangePresetsUpdate} />
+            <TimeRangePresetForm options={timeRangePresets} onUpdate={onTimeRangePresetsUpdate} />
             <TimeRangeOptionsForm options={surroundingTimeRangeOptionsUpdate || buildTimeRangeOptions(formConfig.surrounding_timerange_options)}
                                   update={onSurroundingTimeRangeOptionsUpdate}
                                   validator={surroundingTimeRangeValidator}

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.tsx
@@ -35,9 +35,10 @@ import type { QuickAccessTimeRange } from 'components/configurations/QuickAccess
 import QuickAccessTimeRangeForm from 'components/configurations/QuickAccessTimeRangeForm';
 import generateId from 'logic/generateId';
 import QuickAccessTimeRangeOptionsSummary from 'components/configurations/QuickAccessTimeRangeOptionsSummary';
-import { onInitializingTimerange, onSubmittingTimerange } from 'views/components/TimerangeForForm';
+import { onInitializingTimerange } from 'views/components/TimerangeForForm';
 import useUserDateTime from 'hooks/useUserDateTime';
 import type { DateTime, DateTimeFormats } from 'util/DateTime';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 
 import TimeRangeOptionsForm from './TimeRangeOptionsForm';
 import TimeRangeOptionsSummary from './TimeRangeOptionsSummary';
@@ -169,7 +170,7 @@ const SearchesConfig = () => {
 
     if (quickAccessTimeRangePresetsUpdated) {
       update.quick_access_timerange_presets = quickAccessTimeRangePresetsUpdated.toArray().map(({ description, timerange, id }) => ({
-        description, timerange: onSubmittingTimerange(timerange, userTimezone), id,
+        description, timerange: normalizeFromSearchBarForBackend(timerange, userTimezone), id,
       }));
 
       setQuickAccessTimeRangePresetsUpdated(undefined);

--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.test.tsx
@@ -26,7 +26,7 @@ import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
 
-import QuickAccessTimeRangeForm from './QuickAccessTimeRangeForm';
+import TimeRangePresetForm from './TimeRangePresetForm';
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigStore: MockStore(['getInitialState', () => ({ searchesClusterConfig: mockSearchesClusterConfig })]),
@@ -43,14 +43,14 @@ const mockOnUpdate = jest.fn();
 
 const renderForm = () => render(
   <Formik initialValues={{ selectedFields: [] }} onSubmit={() => {}}>
-    <QuickAccessTimeRangeForm options={Immutable.List([
+    <TimeRangePresetForm options={Immutable.List([
       { description: 'TimeRange1', id: 'tr-id-1', timerange: { from: 300, type: 'relative' } },
       { description: 'TimeRange2', id: 'tr-id-2', timerange: { from: 600, type: 'relative' } },
     ])}
-                              onUpdate={mockOnUpdate} />
+                         onUpdate={mockOnUpdate} />
   </Formik>);
 
-describe('QuickAccessTimeRangeForm', () => {
+describe('TimeRangePresetForm', () => {
   beforeEach(() => {
     asMock(useSearchConfiguration).mockReturnValue({
       config: mockSearchesClusterConfig,

--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
@@ -30,7 +30,7 @@ import TimeRangeFilter from 'views/components/searchbar/time-range-filter';
 import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import generateId from 'logic/generateId';
 
-export type QuickAccessTimeRange = {
+export type TimeRangePreset = {
   timerange: TimeRange,
   description: string,
   id: string,
@@ -61,7 +61,7 @@ type ItemProps = {
   id: string,
   timerange: TimeRange,
   description: string,
-  onChange: (timerange: QuickAccessTimeRange, idx: number) => void,
+  onChange: (timerange: TimeRangePreset, idx: number) => void,
   onRemove: (idx: number) => void,
   limitDuration: number,
 }
@@ -73,7 +73,7 @@ const contextSettings = {
   ignoreLimitDurationInTimeRangeDropdown: true,
 };
 
-const QuickAccessTimeRangeFormItem = ({ idx, id, timerange, description, onChange, onRemove, limitDuration }: ItemProps) => {
+const TimeRangePresetFormItem = ({ idx, id, timerange, description, onChange, onRemove, limitDuration }: ItemProps) => {
   const handleOnChangeRange = useCallback((newTimerange: TimeRange) => {
     onChange({ timerange: newTimerange, description, id }, idx);
   }, [description, id, idx, onChange]);
@@ -109,11 +109,11 @@ const QuickAccessTimeRangeFormItem = ({ idx, id, timerange, description, onChang
   );
 };
 
-const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
-  options: Immutable.List<QuickAccessTimeRange>,
-  onUpdate: Dispatch<Immutable.List<QuickAccessTimeRange>>
+const TimeRangePresetForm = ({ options, onUpdate }: {
+  options: Immutable.List<TimeRangePreset>,
+  onUpdate: Dispatch<Immutable.List<TimeRangePreset>>
 }) => {
-  const onChange = useCallback((newPreset: QuickAccessTimeRange, idx: number) => {
+  const onChange = useCallback((newPreset: TimeRangePreset, idx: number) => {
     const newState = options.set(idx, newPreset);
     onUpdate(newState);
   }, [onUpdate, options]);
@@ -126,7 +126,7 @@ const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
     onUpdate(newState);
   }, [onUpdate, options]);
 
-  const onMoveItem = useCallback((items: Array<QuickAccessTimeRange>) => {
+  const onMoveItem = useCallback((items: Array<TimeRangePreset>) => {
     onUpdate(Immutable.List(items));
   }, [onUpdate]);
 
@@ -139,13 +139,13 @@ const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
   }, [onUpdate, options]);
 
   const customContentRender = useCallback(({ item: { id, description, timerange }, index }) => (
-    <QuickAccessTimeRangeFormItem id={id}
-                                  onRemove={onRemove}
-                                  idx={index}
-                                  onChange={onChange}
-                                  timerange={timerange}
-                                  description={description}
-                                  limitDuration={limitDuration} />
+    <TimeRangePresetFormItem id={id}
+                             onRemove={onRemove}
+                             idx={index}
+                             onChange={onChange}
+                             timerange={timerange}
+                             description={description}
+                             limitDuration={limitDuration} />
   ), [limitDuration, onChange, onRemove]);
 
   return (
@@ -170,4 +170,4 @@ const QuickAccessTimeRangeForm = ({ options, onUpdate }: {
   );
 };
 
-export default QuickAccessTimeRangeForm;
+export default TimeRangePresetForm;

--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetOptionSummary.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetOptionSummary.tsx
@@ -19,14 +19,14 @@ import React from 'react';
 import styled from 'styled-components';
 
 import assertUnreachable from 'logic/assertUnreachable';
-import type { QuickAccessTimeRange } from 'components/configurations/QuickAccessTimeRangeForm';
+import type { TimeRangePreset } from 'components/configurations/TimeRangePresetForm';
 import type {
   KeywordTimeRange,
   TimeRange,
 } from 'views/logic/queries/Query';
 import { range } from 'views/components/searchbar/time-range-filter/TimeRangeDisplay';
 
-type Props = { options : Array<QuickAccessTimeRange>};
+type Props = { options : Array<TimeRangePreset>};
 
 const StyledDL = styled.dl`
   && {
@@ -60,7 +60,7 @@ export const getTimeRangeValueSummary = (timerange: TimeRange) => {
   }
 };
 
-const QuickAccessTimeRangeOptionsSummary = ({ options }: Props) => (
+const TimeRangePresetOptionSummary = ({ options }: Props) => (
   <StyledDL className="deflist">
     {options.map(({ timerange, id, description }) => (
       <span key={`timerange-options-summary-${id}`}>
@@ -71,8 +71,8 @@ const QuickAccessTimeRangeOptionsSummary = ({ options }: Props) => (
   </StyledDL>
 );
 
-QuickAccessTimeRangeOptionsSummary.propTypes = {
+TimeRangePresetOptionSummary.propTypes = {
   options: PropTypes.object.isRequired,
 };
 
-export default QuickAccessTimeRangeOptionsSummary;
+export default TimeRangePresetOptionSummary;

--- a/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
@@ -29,8 +29,9 @@ import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import usePluginEntities from 'hooks/usePluginEntities';
 import useUserDateTime from 'hooks/useUserDateTime';
 import useHandlerContext from 'views/components/useHandlerContext';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 
-import { onInitializingTimerange, onSubmittingTimerange } from './TimerangeForForm';
+import { onInitializingTimerange } from './TimerangeForForm';
 
 export type DashboardFormValues = {
   timerange: TimeRange | undefined | null | NoTimeRangeOverride,
@@ -57,7 +58,7 @@ const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQ
     setEnableReinitialize(false);
 
     return onSubmit({
-      timerange: isNoTimeRangeOverride(timerange) ? undefined : onSubmittingTimerange(timerange, userTimezone),
+      timerange: isNoTimeRangeOverride(timerange) ? undefined : normalizeFromSearchBarForBackend(timerange, userTimezone),
       ...rest,
     }).then(() => setEnableReinitialize(true));
   }, [onSubmit, userTimezone]);

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -19,47 +19,6 @@ import type { TimeRange } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
 import { isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import type { DateTimeFormats } from 'util/DateTime';
-import { adjustFormat, toUTCFromTz } from 'util/DateTime';
-
-export const onSubmittingTimerange = (timerange: TimeRange, userTz: string): TimeRange => {
-  const { type } = timerange;
-
-  switch (timerange.type) {
-    case 'absolute':
-      return {
-        type: timerange.type,
-        from: adjustFormat(toUTCFromTz(timerange.from, userTz), 'internal'),
-        to: adjustFormat(toUTCFromTz(timerange.to, userTz), 'internal'),
-      };
-    case 'relative':
-      if (isTypeRelativeWithStartOnly(timerange)) {
-        return {
-          type: timerange.type,
-          range: timerange.range,
-        };
-      }
-
-      if (isTypeRelativeWithEnd(timerange)) {
-        if ('to' in timerange) {
-          return {
-            type: timerange.type,
-            from: timerange.from,
-            to: timerange.to,
-          };
-        }
-
-        return {
-          type: timerange.type,
-          from: timerange.from,
-        };
-      }
-
-      throw new Error('Invalid relative time range');
-    case 'keyword':
-      return timerange;
-    default: throw new Error(`Invalid time range type: ${type}`);
-  }
-};
 
 export const onInitializingTimerange = (timerange: TimeRange, formatTime: (dateTime: string, format: DateTimeFormats) => string): SearchBarFormValues['timerange'] => {
   const { type } = timerange;

--- a/graylog2-web-interface/src/views/components/TimerangeForForm.ts
+++ b/graylog2-web-interface/src/views/components/TimerangeForForm.ts
@@ -20,6 +20,7 @@ import type { SearchBarFormValues } from 'views/Constants';
 import { isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import type { DateTimeFormats } from 'util/DateTime';
 
+// eslint-disable-next-line import/prefer-default-export
 export const onInitializingTimerange = (timerange: TimeRange, formatTime: (dateTime: string, format: DateTimeFormats) => string): SearchBarFormValues['timerange'] => {
   const { type } = timerange;
 

--- a/graylog2-web-interface/src/views/components/contexts/TimeRangeInputSettingsContext.ts
+++ b/graylog2-web-interface/src/views/components/contexts/TimeRangeInputSettingsContext.ts
@@ -20,18 +20,14 @@ import { singleton } from 'logic/singleton';
 
 type TimeRangeInputSettings = {
   showDropdownButton: boolean,
-  showRelativePresetsButton: boolean,
-  showAbsolutePresetsButton: boolean,
-  showKeywordPresetsButton: boolean,
+  showPresetsButton: boolean,
   showAddToQuickListButton: boolean,
   ignoreLimitDurationInTimeRangeDropdown: boolean
 }
 
 const defaultValue = {
   showDropdownButton: true,
-  showRelativePresetsButton: true,
-  showAbsolutePresetsButton: true,
-  showKeywordPresetsButton: true,
+  showPresetsButton: true,
   showAddToQuickListButton: true,
   ignoreLimitDurationInTimeRangeDropdown: false,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -21,7 +21,8 @@ import type { FormikProps } from 'formik';
 import { Form, Formik } from 'formik';
 import isFunction from 'lodash/isFunction';
 
-import { onInitializingTimerange, onSubmittingTimerange } from 'views/components/TimerangeForForm';
+import { onInitializingTimerange } from 'views/components/TimerangeForForm';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 import type { SearchBarFormValues } from 'views/Constants';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
@@ -43,7 +44,7 @@ type Props = {
 
 const _isFunction = (children: Props['children']): children is FormRenderer => isFunction(children);
 
-export const normalizeSearchBarFormValues = ({ timerange, ...rest }: SearchBarFormValues, userTimezone: string) => ({ timerange: onSubmittingTimerange(timerange, userTimezone), ...rest });
+export const normalizeSearchBarFormValues = ({ timerange, ...rest }: SearchBarFormValues, userTimezone: string) => ({ timerange: normalizeFromSearchBarForBackend(timerange, userTimezone), ...rest });
 
 const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount, formRef, validateQueryString }: Props) => {
   const [enableReinitialize, setEnableReinitialize] = useState(true);

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -19,7 +19,7 @@ import isEqual from 'lodash/isEqual';
 import { SearchSuggestions } from '@graylog/server-api';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import { escape } from 'views/logic/queries/QueryHelper';
 
@@ -166,7 +166,7 @@ class FieldValueCompletion implements Completer {
       }
     }
 
-    const normalizedTimeRange = (!timeRange || isNoTimeRangeOverride(timeRange)) ? undefined : onSubmittingTimerange(timeRange, userTimezone);
+    const normalizedTimeRange = (!timeRange || isNoTimeRangeOverride(timeRange)) ? undefined : normalizeFromSearchBarForBackend(timeRange, userTimezone);
 
     return SearchSuggestions.suggestFieldValue({
       field: fieldName,

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -19,8 +19,8 @@ import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
-import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
 import generateId from 'logic/generateId';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 
 export type ValidationQuery = {
   queryString: ElasticsearchQueryString | string,
@@ -48,7 +48,7 @@ export const validateQuery = (
 
   const payload = {
     query: queryString,
-    timerange: timeRange ? onSubmittingTimerange(timeRange, userTimezone) : undefined,
+    timerange: timeRange ? normalizeFromSearchBarForBackend(timeRange, userTimezone) : undefined,
     streams,
     filter,
     ...rest,

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -154,12 +154,4 @@ describe('TimeRangeFilter', () => {
 
     expect(screen.queryByTitle('Add time range to quick access time range list')).not.toBeInTheDocument();
   });
-
-  it('has button add time renge to quick access for admin users', async () => {
-    asMock(useCurrentUser).mockReturnValue(adminUser);
-
-    render(<SUTTimeRangeFilter onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
-    await fireEvent.click(await screen.findByText(/5 minutes ago/));
-    await screen.findByTitle('Add time range to quick access time range list');
-  });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -145,13 +145,13 @@ describe('TimeRangeFilter', () => {
     expect(screen.queryByRole('button', { name: /open time range preset select/i })).not.toBeInTheDocument();
   });
 
-  it('has no button add time renge to quick access for non admin users', async () => {
+  it('has no button for non admin users to save current time range as preset', async () => {
     asMock(useCurrentUser).mockReturnValue(alice);
     render(<SUTTimeRangeFilter onChange={() => {}} value={defaultTimeRange} validTypes={['relative']} />);
     fireEvent.click(await screen.findByText(/5 minutes ago/));
 
     await screen.findByText(/search time range/i);
 
-    expect(screen.queryByTitle('Add time range to quick access time range list')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Save current time range as preset')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -24,7 +24,7 @@ import MockAction from 'helpers/mocking/MockAction';
 import TimeRangeFilter from 'views/components/searchbar/time-range-filter';
 import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
-import { adminUser, alice } from 'fixtures/users';
+import { alice } from 'fixtures/users';
 
 jest.mock('stores/configurations/ConfigurationsStore', () => ({
   ConfigurationsStore: MockStore(),

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 import * as React from 'react';
 
@@ -33,15 +34,19 @@ jest.mock('views/stores/SearchConfigStore', () => ({
   },
   SearchConfigStore: {
     listen: () => jest.fn(),
-    getInitialState: () => ({ searchesClusterConfig: mockSearchClusterConfig }),
+    getInitialState: () => ({ searchesClusterConfig: { ...mockSearchClusterConfig, query_time_range_limit: undefined } }),
   },
 }));
 
 const selectRangePreset = async (optionLabel: string) => {
-  const timeRangePresetButton = screen.getByLabelText('Open time range preset select');
-  fireEvent.click(timeRangePresetButton);
-  const rangePresetOption = await screen.findByText(optionLabel);
-  fireEvent.click(rangePresetOption);
+  const timeRangePresetButton = screen.getByRole('button', {
+    name: /open time range preset select/i,
+  });
+  userEvent.click(timeRangePresetButton);
+  const rangePresetOption = await screen.findByRole('menuitem', {
+    name: new RegExp(optionLabel, 'i'),
+  });
+  userEvent.click(rangePresetOption);
 };
 
 describe('TimeRangeFilterButtons', () => {
@@ -61,7 +66,7 @@ describe('TimeRangeFilterButtons', () => {
 
     const timeRangePickerButton = screen.getByLabelText('Open Time Range Selector');
 
-    fireEvent.click(timeRangePickerButton);
+    userEvent.click(timeRangePickerButton);
 
     expect(toggleShow).toHaveBeenCalled();
   });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
@@ -21,7 +21,6 @@ import { useFormikContext } from 'formik';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import { ButtonGroup } from 'components/bootstrap';
 import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
-import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
 import RangePresetDropdown from './TimeRangePresetDropdown';
 import TimeRangePickerButton from './time-range-picker/TimeRangePickerButton';
@@ -53,8 +52,6 @@ const TimeRangeFilterButtons = ({
   toggleShow,
 }: Props) => {
   const { submitForm, isValid } = useFormikContext();
-  const { config } = useSearchConfiguration();
-  const availableOptions = config?.quick_access_timerange_presets;
 
   const _onClick = (e) => {
     e.currentTarget.blur();
@@ -86,8 +83,7 @@ const TimeRangeFilterButtons = ({
                                    onChange={selectRelativeTimeRangePreset}
                                    onToggle={_onPresetSelectToggle}
                                    header="Select time range"
-                                   bsSize={null}
-                                   availableOptions={availableOptions} />
+                                   bsSize={null} />
       )}
     </StyledButtonGroup>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
@@ -33,7 +33,7 @@ describe('RangePresetDropdown', () => {
     });
 
     const onSelectOption = jest.fn();
-    render(<RangePresetDropdown onChange={onSelectOption} availableOptions={[]} />);
+    render(<RangePresetDropdown onChange={onSelectOption} />);
 
     const timeRangePresetButton = screen.getByLabelText('Open time range preset select');
     fireEvent.click(timeRangePresetButton);
@@ -48,32 +48,32 @@ describe('RangePresetDropdown', () => {
       config: {
         ...mockSearchClusterConfig,
         query_time_range_limit: 'PT6M',
+        quick_access_timerange_presets: [
+          {
+            id: '639843f5-049a-4532-8a54-102da850b7f1',
+            timerange: {
+              from: 300,
+              type: 'relative',
+            },
+            description: '5 minutes',
+          },
+          {
+            id: '8dda08e9-cd23-44ff-b4eb-edeb7a704cf4',
+            timerange: {
+              keyword: 'Last ten minutes',
+              timezone: 'Europe/Berlin',
+              type: 'keyword',
+            },
+            description: 'Keyword ten min',
+          },
+        ],
       },
       refresh: jest.fn(),
     });
 
     const onSelectOption = jest.fn();
 
-    render(<RangePresetDropdown onChange={onSelectOption}
-                                availableOptions={[
-                                  {
-                                    id: '639843f5-049a-4532-8a54-102da850b7f1',
-                                    timerange: {
-                                      from: 300,
-                                      type: 'relative',
-                                    },
-                                    description: '5 minutes',
-                                  },
-                                  {
-                                    id: '8dda08e9-cd23-44ff-b4eb-edeb7a704cf4',
-                                    timerange: {
-                                      keyword: 'Last ten minutes',
-                                      timezone: 'Europe/Berlin',
-                                      type: 'keyword',
-                                    },
-                                    description: 'Keyword ten min',
-                                  },
-                                ]} />);
+    render(<RangePresetDropdown onChange={onSelectOption} />);
 
     const timeRangePresetButton = screen.getByLabelText('Open time range preset select');
     fireEvent.click(timeRangePresetButton);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
@@ -15,17 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
 
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import asMock from 'helpers/mocking/AsMock';
 
-import RangePresetDropdown from './TimeRangePresetDropdown';
+import TimeRangePresetDropdown from './TimeRangePresetDropdown';
 
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
 
-describe('RangePresetDropdown', () => {
+describe('TimeRangePresetDropdown', () => {
   it('should not call onChange prop when selecting "Configure Ranges" option.', async () => {
     asMock(useSearchConfiguration).mockReturnValue({
       config: mockSearchClusterConfig,
@@ -33,12 +34,18 @@ describe('RangePresetDropdown', () => {
     });
 
     const onSelectOption = jest.fn();
-    render(<RangePresetDropdown onChange={onSelectOption} />);
+    render(<TimeRangePresetDropdown onChange={onSelectOption} />);
 
-    const timeRangePresetButton = screen.getByLabelText('Open time range preset select');
-    fireEvent.click(timeRangePresetButton);
-    const rangePresetOption = await screen.findByText('Configure Ranges');
-    fireEvent.click(rangePresetOption);
+    const timeRangePresetButton = screen.getByRole('button', {
+      name: /open time range preset select/i,
+    });
+    userEvent.click(timeRangePresetButton);
+    await screen.findByRole('menuitem', { name: /15 minutes/i });
+
+    const rangePresetOption = screen.getByRole('menuitem', {
+      name: /configure presets/i,
+    });
+    userEvent.click(rangePresetOption);
 
     expect(onSelectOption).not.toHaveBeenCalled();
   });
@@ -73,14 +80,15 @@ describe('RangePresetDropdown', () => {
 
     const onSelectOption = jest.fn();
 
-    render(<RangePresetDropdown onChange={onSelectOption} />);
+    render(<TimeRangePresetDropdown onChange={onSelectOption} />);
 
-    const timeRangePresetButton = screen.getByLabelText('Open time range preset select');
-    fireEvent.click(timeRangePresetButton);
+    const timeRangePresetButton = await screen.findByRole('button', {
+      name: /open time range preset select/i,
+    });
+    userEvent.click(timeRangePresetButton);
 
-    const tenMinTR = screen.queryByText('Keyword ten min');
-    await screen.findByText('5 minutes');
+    await screen.findByRole('menuitem', { name: /5 minutes/i });
 
-    expect(tenMinTR).not.toBeInTheDocument();
+    expect(screen.queryByText('Keyword ten min')).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
@@ -84,7 +84,7 @@ const preparePresetOptions = async (presets: SearchesConfig['quick_access_timera
       eventKey: timerange,
       key: `timerange-option-${id}`,
       disabled,
-      label: description.replace(/Search\sin(\sthe\slast)?\s/, ''),
+      label: description,
     }));
   }
 
@@ -151,7 +151,7 @@ const TimeRangePresetDropdown = ({ disabled, onChange, onToggle: onToggleProp, c
     if (!options) {
       await setDropdownOptions();
     }
-  }, [setDropdownOptions]);
+  }, [options, setDropdownOptions]);
 
   return (
     <DropdownButton title={displayTitle && 'Load Preset'}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
@@ -100,7 +100,7 @@ const usePresetOptions = (disabled: boolean) => {
   const [presetOptions, setPresetOptions] = useState<Array<PresetOption> | undefined>();
   const timeRangeLimit = useMemo(() => moment.duration(config?.query_time_range_limit).asSeconds(), [config?.query_time_range_limit]);
 
-  const onSetOptions = async () => {
+  const onSetOptions = useCallback(async () => {
     setPresetOptions(
       await preparePresetOptions(
         config?.quick_access_timerange_presets,
@@ -108,7 +108,7 @@ const usePresetOptions = (disabled: boolean) => {
         disabled,
       ),
     );
-  };
+  }, [config?.quick_access_timerange_presets, disabled, timeRangeLimit]);
 
   return ({ options: presetOptions, setOptions: onSetOptions });
 };
@@ -148,10 +148,8 @@ const TimeRangePresetDropdown = ({ disabled, onChange, onToggle: onToggleProp, c
   }, [onToggleProp]);
 
   const onMouseDown = useCallback(async () => {
-    if (!options) {
-      await setDropdownOptions();
-    }
-  }, [options, setDropdownOptions]);
+    await setDropdownOptions();
+  }, [setDropdownOptions]);
 
   return (
     <DropdownButton title={displayTitle && 'Load Preset'}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import styled, { css } from 'styled-components';
@@ -177,7 +177,7 @@ const TimeRangePresetDropdown = ({ disabled, onChange, onToggle: onToggleProp, c
       <IfPermitted permissions="clusterconfigentry:edit">
         <MenuItem divider />
         <AdminMenuItem href="/system/configurations" target="_blank">
-          Configure Ranges <ExternalIcon name="external-link-alt" />
+          Configure presets <ExternalIcon name="external-link-alt" />
         </AdminMenuItem>
       </IfPermitted>
     </DropdownButton>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
@@ -54,7 +54,7 @@ const relativeStartTimeForTimeRange = (timeRange: TimeRange) => {
 
       return timeRange.range;
     case 'absolute':
-      return moment().diff((timeRange.from, 'seconds'));
+      return moment().diff(timeRange.from, 'seconds');
     case 'keyword':
       return ToolsStore.testNaturalDate(timeRange.keyword, timeRange.timezone).then(
         ({ from }) => moment().diff(from, 'seconds'),
@@ -66,7 +66,11 @@ const relativeStartTimeForTimeRange = (timeRange: TimeRange) => {
 
 const filterOptionsByLimit = async (presets: SearchesConfig['quick_access_timerange_presets'], timeRangeLimit: number) => {
   const filteredOptions = await Promise.all(presets?.map(
-    (preset) => (relativeStartTimeForTimeRange(preset.timerange) <= timeRangeLimit ? preset : null),
+    async (preset) => {
+      const relativeStartTime = await relativeStartTimeForTimeRange(preset.timerange);
+
+      return ((relativeStartTime && relativeStartTime <= timeRangeLimit) ? preset : null);
+    },
   ));
 
   return filteredOptions.filter((opt) => !!opt);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import moment from 'moment';
@@ -24,10 +24,7 @@ import { useFormikContext } from 'formik';
 import { Icon, Accordion, AccordionItem } from 'components/common';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
-import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
-import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
-import TimeRangePresetRow from './TimeRangePresetRow';
 import AbsoluteCalendar from './AbsoluteCalendar';
 import AbsoluteTimestamp from './AbsoluteTimestamp';
 import type { TimeRangePickerFormValues } from './TimeRangePicker';
@@ -79,80 +76,67 @@ const FlexWrap = styled.div`
 `;
 
 const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
-  const { values: { nextTimeRange }, setFieldValue } = useFormikContext<TimeRangePickerFormValues & { nextTimeRange: AbsoluteTimeRange }>();
+  const { values: { nextTimeRange } } = useFormikContext<TimeRangePickerFormValues & { nextTimeRange: AbsoluteTimeRange }>();
   const { toUserTimezone } = useUserDateTime();
   const [activeAccordion, setActiveAccordion] = useState<'Timestamp' | 'Calendar' | undefined>();
   const toStartDate = moment(nextTimeRange.from).toDate();
   const fromStartDate = limitDuration ? toUserTimezone(new Date()).seconds(-limitDuration).toDate() : undefined;
-  const { config } = useSearchConfiguration();
-  const { showAbsolutePresetsButton } = useContext(TimeRangeInputSettingsContext);
-  const absoluteOptions = useMemo(() => config?.quick_access_timerange_presets?.filter((option) => option?.timerange?.type === 'absolute'), [config?.quick_access_timerange_presets]);
-  const onSetPreset = useCallback((range: AbsoluteTimeRange) => {
-    setFieldValue('nextTimeRange', range);
-  }, [setFieldValue]);
 
   const handleSelect = (nextKey: 'Timestamp' | 'Calendar' | undefined) => {
     setActiveAccordion(nextKey ?? activeAccordion);
   };
 
   return (
-    <>
-      <AbsoluteWrapper>
-        <StyledAccordion defaultActiveKey="calendar"
-                         onSelect={handleSelect}
-                         id="absolute-time-ranges"
-                         data-testid="absolute-time-ranges"
-                         activeKey={activeAccordion}>
+    <AbsoluteWrapper>
+      <StyledAccordion defaultActiveKey="calendar"
+                       onSelect={handleSelect}
+                       id="absolute-time-ranges"
+                       data-testid="absolute-time-ranges"
+                       activeKey={activeAccordion}>
 
-          <AccordionItem name="Calendar">
-            <RangeWrapper>
-              <AbsoluteCalendar startDate={fromStartDate}
-                                nextTimeRange={nextTimeRange}
-                                range="from" />
+        <AccordionItem name="Calendar">
+          <RangeWrapper>
+            <AbsoluteCalendar startDate={fromStartDate}
+                              nextTimeRange={nextTimeRange}
+                              range="from" />
 
-            </RangeWrapper>
+          </RangeWrapper>
 
-            <IconWrap>
-              <Icon name="arrow-right" />
-            </IconWrap>
+          <IconWrap>
+            <Icon name="arrow-right" />
+          </IconWrap>
 
-            <RangeWrapper>
-              <AbsoluteCalendar startDate={toStartDate}
-                                nextTimeRange={nextTimeRange}
-                                range="to" />
-            </RangeWrapper>
-          </AccordionItem>
+          <RangeWrapper>
+            <AbsoluteCalendar startDate={toStartDate}
+                              nextTimeRange={nextTimeRange}
+                              range="to" />
+          </RangeWrapper>
+        </AccordionItem>
 
-          <AccordionItem name="Timestamp">
-            <TimestampContent>
-              <p>Date should be formatted as <code>YYYY-MM-DD [HH:mm:ss[.SSS]]</code>.</p>
-              <FlexWrap>
-                <RangeWrapper>
-                  <AbsoluteTimestamp disabled={disabled}
-                                     nextTimeRange={nextTimeRange}
-                                     range="from" />
-                </RangeWrapper>
+        <AccordionItem name="Timestamp">
+          <TimestampContent>
+            <p>Date should be formatted as <code>YYYY-MM-DD [HH:mm:ss[.SSS]]</code>.</p>
+            <FlexWrap>
+              <RangeWrapper>
+                <AbsoluteTimestamp disabled={disabled}
+                                   nextTimeRange={nextTimeRange}
+                                   range="from" />
+              </RangeWrapper>
 
-                <IconWrap>
-                  <Icon name="arrow-right" />
-                </IconWrap>
+              <IconWrap>
+                <Icon name="arrow-right" />
+              </IconWrap>
 
-                <RangeWrapper>
-                  <AbsoluteTimestamp disabled={disabled}
-                                     nextTimeRange={nextTimeRange}
-                                     range="to" />
-                </RangeWrapper>
-              </FlexWrap>
-            </TimestampContent>
-          </AccordionItem>
-        </StyledAccordion>
-      </AbsoluteWrapper>
-      {showAbsolutePresetsButton && (
-        <TimeRangePresetRow disabled={disabled}
-                            onSetPreset={onSetPreset}
-                            availableOptions={absoluteOptions} />
-      )}
-    </>
+              <RangeWrapper>
+                <AbsoluteTimestamp disabled={disabled}
+                                   nextTimeRange={nextTimeRange}
+                                   range="to" />
+              </RangeWrapper>
+            </FlexWrap>
+          </TimestampContent>
+        </AccordionItem>
+      </StyledAccordion>
+    </AbsoluteWrapper>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -15,25 +15,20 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import trim from 'lodash/trim';
 import isEqual from 'lodash/isEqual';
-import { Field, useField, useFormikContext } from 'formik';
+import { Field, useField } from 'formik';
 
 import { Col, FormControl, FormGroup, Panel, Row } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import ToolsStore from 'stores/tools/ToolsStore';
-import type { KeywordTimeRange, AbsoluteTimeRange } from 'views/logic/queries/Query';
+import type { KeywordTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
-import useSearchConfiguration from 'hooks/useSearchConfiguration';
-import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import { InputDescription } from 'components/common';
-
-import type { TimeRangePickerFormValues } from './TimeRangePicker';
-import TimeRangePresetRow from './TimeRangePresetRow';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
 
@@ -71,7 +66,6 @@ type Props = {
 };
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
-  const { setFieldValue } = useFormikContext<TimeRangePickerFormValues & { nextTimeRange: AbsoluteTimeRange }>();
   const { formatTime, userTimezone } = useUserDateTime();
   const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
   const mounted = useRef(true);
@@ -136,13 +130,6 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     }
   }, [nextRangeProps.value, keywordPreview, nextRangeHelpers]);
 
-  const { config } = useSearchConfiguration();
-  const { showKeywordPresetsButton } = useContext(TimeRangeInputSettingsContext);
-  const keywordOptions = useMemo(() => config?.quick_access_timerange_presets?.filter((option) => option?.timerange?.type === 'keyword'), [config?.quick_access_timerange_presets]);
-  const onSetPreset = useCallback((range) => {
-    setFieldValue('nextTimeRange', range);
-  }, [setFieldValue]);
-
   return (
     <Row className="no-bm">
       <Col sm={5}>
@@ -181,12 +168,6 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
             </tr>
           </tbody>
         </EffectiveTimeRangeTable>
-
-        {showKeywordPresetsButton && (
-          <TimeRangePresetRow disabled={disabled}
-                              onSetPreset={onSetPreset}
-                              availableOptions={keywordOptions} />
-        )}
       </Col>
 
       <Col sm={7}>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.tsx
@@ -18,21 +18,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useFormikContext } from 'formik';
-import { useContext, useMemo } from 'react';
 
 import { isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import { RELATIVE_ALL_TIME, DEFAULT_RELATIVE_FROM, DEFAULT_RELATIVE_TO } from 'views/Constants';
 import { Icon } from 'components/common';
-import useSearchConfiguration from 'hooks/useSearchConfiguration';
-import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
-import type { RelativeTimeRange } from 'views/logic/queries/Query';
 
-import TimeRangePresetRow from './TimeRangePresetRow';
 import {
   classifyToRange,
   classifyFromRange,
   RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
-  classifyRelativeTimeRange,
 } from './RelativeTimeRangeClassifiedHelper';
 import type { TimeRangePickerFormValues } from './TimeRangePicker';
 import RelativeRangeSelect from './RelativeRangeSelect';
@@ -56,13 +50,6 @@ const StyledIcon = styled(Icon)`
 const TabRelativeTimeRange = ({ disabled, limitDuration }: Props) => {
   const { values: { nextTimeRange }, setFieldValue } = useFormikContext<TimeRangePickerFormValues>();
   const disableUntil = disabled || (isTypeRelativeWithEnd(nextTimeRange) && nextTimeRange.from === RELATIVE_ALL_TIME);
-  const { config } = useSearchConfiguration();
-  const { showRelativePresetsButton } = useContext(TimeRangeInputSettingsContext);
-  const relativeOptions = useMemo(() => config?.quick_access_timerange_presets?.filter((option) => option?.timerange?.type === 'relative'), [config?.quick_access_timerange_presets]);
-
-  const onSetPreset = (range: RelativeTimeRange) => {
-    setFieldValue('nextTimeRange', classifyRelativeTimeRange(range));
-  };
 
   return (
     <div>
@@ -87,11 +74,6 @@ const TabRelativeTimeRange = ({ disabled, limitDuration }: Props) => {
                                unsetRangeLabel="Now" />
         </>
       </RelativeWrapper>
-      {showRelativePresetsButton && (
-        <TimeRangePresetRow disabled={disabled}
-                            onSetPreset={onSetPreset}
-                            availableOptions={relativeOptions} />
-      )}
     </div>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
@@ -68,7 +68,7 @@ describe('TimeRangeAddToQuickListButton', () => {
     asMock(debounce as DebouncedFunc<(...args: any) => any>).mockImplementation((fn) => fn);
   });
 
-  const getOpenButton = () => screen.findByTitle('Add time range to quick access time range list');
+  const getOpenButton = () => screen.findByTitle('Save current time range as preset');
 
   it('shows popover on click', async () => {
     render(
@@ -81,7 +81,7 @@ describe('TimeRangeAddToQuickListButton', () => {
 
     fireEvent.click(buttonIcon);
 
-    await screen.findByText('Add to quick access list');
+    await screen.findByText('Save as preset');
   });
 
   it('dont shows alert about duplication when there is no similar time range', async () => {
@@ -129,7 +129,7 @@ describe('TimeRangeAddToQuickListButton', () => {
     await suppressConsole(async () => {
       await fireEvent.change(descriptionInput, { target: { value: 'My new time range' } });
 
-      const submitButton = await screen.findByTitle('Add time range');
+      const submitButton = await screen.findByTitle('Save preset');
       await fireEvent.click(submitButton);
     });
 
@@ -171,7 +171,7 @@ describe('TimeRangeAddToQuickListButton', () => {
       await fireEvent.change(descriptionInput, { target: { value: '' } });
     });
 
-    const submitButton = await screen.findByTitle('Add time range');
+    const submitButton = await screen.findByTitle('Save preset');
 
     await expect(submitButton).toHaveAttribute('disabled');
   });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import debounce from 'lodash/debounce';
 // eslint-disable-next-line no-restricted-imports
 import type { DebouncedFunc } from 'lodash';
@@ -24,7 +24,6 @@ import { Form, Formik } from 'formik';
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
-import suppressConsole from 'helpers/suppressConsole';
 import type { TimeRange } from 'views/logic/queries/Query';
 
 import TimeRangeAddToQuickListButton from './TimeRangeAddToQuickListButton';
@@ -68,7 +67,9 @@ describe('TimeRangeAddToQuickListButton', () => {
     asMock(debounce as DebouncedFunc<(...args: any) => any>).mockImplementation((fn) => fn);
   });
 
-  const getOpenButton = () => screen.findByTitle('Save current time range as preset');
+  const getOpenButton = () => screen.getByRole('button', {
+    name: /save current time range as preset/i,
+  });
 
   it('shows popover on click', async () => {
     render(
@@ -81,7 +82,9 @@ describe('TimeRangeAddToQuickListButton', () => {
 
     fireEvent.click(buttonIcon);
 
-    await screen.findByText('Save as preset');
+    await screen.findByRole('heading', {
+      name: /save as preset/i,
+    });
   });
 
   it('dont shows alert about duplication when there is no similar time range', async () => {
@@ -126,14 +129,15 @@ describe('TimeRangeAddToQuickListButton', () => {
     const descriptionInput = await screen.findByLabelText('Time range description');
     descriptionInput.focus();
 
-    await suppressConsole(async () => {
-      await fireEvent.change(descriptionInput, { target: { value: 'My new time range' } });
+    fireEvent.change(descriptionInput, { target: { value: 'My new time range' } });
 
-      const submitButton = await screen.findByTitle('Save preset');
-      await fireEvent.click(submitButton);
+    const submitButton = await screen.findByRole('button', {
+      name: /save preset/i,
     });
 
-    await expect(mockUpdate)
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockUpdate)
       .toHaveBeenCalledWith('org.graylog2.indexer.searches.SearchesClusterConfig',
         {
           ...mockSearchClusterConfig,
@@ -149,7 +153,7 @@ describe('TimeRangeAddToQuickListButton', () => {
             },
           ],
         },
-      );
+      ));
   });
 
   it('not runs action to update config on submitting form when description is empty', async () => {
@@ -166,12 +170,11 @@ describe('TimeRangeAddToQuickListButton', () => {
     const descriptionInput = await screen.findByLabelText('Time range description');
     descriptionInput.focus();
 
-    await suppressConsole(async () => {
-      await fireEvent.change(descriptionInput, { target: { value: 'Some description' } });
-      await fireEvent.change(descriptionInput, { target: { value: '' } });
-    });
+    fireEvent.change(descriptionInput, { target: { value: '' } });
 
-    const submitButton = await screen.findByTitle('Save preset');
+    const submitButton = await screen.findByRole('button', {
+      name: /save preset/i,
+    });
 
     await expect(submitButton).toHaveAttribute('disabled');
   });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -70,7 +70,7 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target, equalT
     <Portal>
       <Position placement="left"
                 target={target}>
-        <Popover title="Add to quick access list"
+        <Popover title="Save as preset"
                  id="add-to-quick-list-popover"
                  data-app-section="add-to-quick-list-popover_form"
                  data-event-element="Add to quick list"
@@ -93,7 +93,7 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target, equalT
             </p>
           )}
           <StyledModalSubmit disabledSubmit={!description}
-                             submitButtonText="Add time range"
+                             submitButtonText="Save preset"
                              isAsyncSubmit={false}
                              displayCancel
                              onCancel={toggleModal}
@@ -161,7 +161,7 @@ const TimeRangeAddToQuickListButton = () => {
   return (
     <>
       <Button disabled={!isValidTimeRange}
-              title="Add time range to quick access time range list"
+              title="Save current time range as preset"
               ref={formTarget}
               bsSize="small"
               onClick={toggleModal}>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -28,7 +28,6 @@ import type { TimeRange, KeywordTimeRange } from 'views/logic/queries/Query';
 import { ConfigurationsActions } from 'stores/configurations/ConfigurationsStore';
 import { ConfigurationType } from 'components/configurations/ConfigurationTypes';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
-import { onSubmittingTimerange } from 'views/components/TimerangeForForm';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
@@ -38,6 +37,10 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import type {
   TimeRangePickerFormValues,
 } from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker';
+import {
+  normalizeFromPickerForSearchBar,
+  normalizeFromSearchBarForBackend,
+} from 'views/logic/queries/NormalizeTimeRange';
 
 const StyledModalSubmit = styled(ModalSubmit)`
   margin-top: 15px;
@@ -83,8 +86,7 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target, equalT
           {!!equalTimerange && (
             <p>
               <Icon name="exclamation-triangle" />
-              You already have similar time range in
-                {' '}
+              You already have similar time range in{' '}
               <Link to={Routes.SYSTEM.CONFIGURATIONS} target="_blank">Range configuration</Link>
               <br />
               <i>f.e. ({equalTimerange.description})</i>
@@ -121,7 +123,7 @@ const TimeRangeAddToQuickListButton = () => {
   const addTimerange = useCallback((description: string) => {
     const quickAccessTimerangePreset = {
       description,
-      timerange: onSubmittingTimerange(values.nextTimeRange as TimeRange, userTimezone),
+      timerange: normalizeFromSearchBarForBackend(normalizeFromPickerForSearchBar(values.nextTimeRange) as TimeRange, userTimezone),
       id: generateId(),
     };
 
@@ -153,7 +155,7 @@ const TimeRangeAddToQuickListButton = () => {
     ?.quick_access_timerange_presets
     ?.find((existingTimerange) => isTimerangeEqual(
       existingTimerange.timerange,
-      onSubmittingTimerange(values.nextTimeRange as TimeRange, userTimezone),
+      normalizeFromSearchBarForBackend(values.nextTimeRange as TimeRange, userTimezone),
     )), [config, values.nextTimeRange, userTimezone]);
 
   return (

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -31,7 +31,7 @@ import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
-import type { QuickAccessTimeRange } from 'components/configurations/QuickAccessTimeRangeForm';
+import type { TimeRangePreset } from 'components/configurations/TimeRangePresetForm';
 import generateId from 'logic/generateId';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import type {
@@ -50,7 +50,7 @@ type Props = {
   addTimerange: (title: string) => void,
   toggleModal: () => void,
   target: Button | undefined | null,
-  equalTimerange: QuickAccessTimeRange
+  equalTimerange: TimeRangePreset
 };
 
 const isTimerangeEqual = (firstTimerange: TimeRange, secondTimerange: TimeRange) => {
@@ -121,7 +121,7 @@ const TimeRangeAddToQuickListButton = () => {
   }, []);
 
   const addTimerange = useCallback((description: string) => {
-    const quickAccessTimerangePreset = {
+    const timeRangePreset = {
       description,
       timerange: normalizeFromSearchBarForBackend(normalizeFromPickerForSearchBar(values.nextTimeRange) as TimeRange, userTimezone),
       id: generateId(),
@@ -132,20 +132,20 @@ const TimeRangeAddToQuickListButton = () => {
         ...config,
         quick_access_timerange_presets: [
           ...config.quick_access_timerange_presets,
-          quickAccessTimerangePreset],
+          timeRangePreset],
       }).then(() => {
       refresh();
       toggleModal();
     });
 
-    if (quickAccessTimerangePreset) {
+    if (timeRangePreset) {
       sendTelemetry('form_submit', {
         app_pathname: 'search',
         app_section: 'search-bar',
         app_action_value: 'add_to_quick_access_timerange_presets',
         event_details: {
-          timerange: quickAccessTimerangePreset.timerange,
-          id: quickAccessTimerangePreset.id,
+          timerange: timeRangePreset.timerange,
+          id: timeRangePreset.id,
         },
       });
     }

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -43,16 +43,6 @@ const StyledModalSubmit = styled(ModalSubmit)`
   margin-top: 15px;
 `;
 
-const Container = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  float: right;
-  transform: translateY(-3px);
-  gap: 5px;
-  margin-top: 6px;
-`;
-
 type Props = {
   addTimerange: (title: string) => void,
   toggleModal: () => void,
@@ -167,12 +157,13 @@ const TimeRangeAddToQuickListButton = () => {
     )), [config, values.nextTimeRange, userTimezone]);
 
   return (
-    <Container>
+    <>
       <Button disabled={!isValidTimeRange}
               title="Add time range to quick access time range list"
               ref={formTarget}
+              bsSize="small"
               onClick={toggleModal}>
-        <Icon name="floppy-disk" type="regular" />
+        Save as preset
       </Button>
       {showForm && (
         <TimeRangeAddToQuickListForm addTimerange={addTimerange}
@@ -180,7 +171,7 @@ const TimeRangeAddToQuickListButton = () => {
                                      target={formTarget.current}
                                      equalTimerange={equalTimerange} />
       )}
-    </Container>
+    </>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -18,12 +18,17 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from 'wrappedTestingLibrary';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 import userEvent from '@testing-library/user-event';
+import { defaultUser } from 'defaultMockValues';
 
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 import ToolsStore from 'stores/tools/ToolsStore';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { adminUser } from 'fixtures/users';
 
 import TimeRangePicker from './TimeRangePicker';
+
+jest.mock('hooks/useCurrentUser');
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigActions: {
@@ -59,6 +64,8 @@ describe('TimeRangePicker', () => {
       to: '2018-11-14 13:57:38',
       timezone: 'Asia/Tokyo',
     }));
+
+    asMock(useCurrentUser).mockReturnValue(defaultUser);
   });
 
   it('renders initial time range value', async () => {
@@ -145,5 +152,13 @@ describe('TimeRangePicker', () => {
     await waitFor(() => expect(setCurrentTimeRange).toHaveBeenCalledTimes(1));
 
     expect(setCurrentTimeRange).toHaveBeenCalledWith({ type: 'keyword', keyword: 'yesterday', timezone: 'Asia/Tokyo' });
+  });
+
+  it('has button add time range to quick access for admin users', async () => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+
+    render(<TimeRangePicker {...defaultProps} />);
+
+    await screen.findByTitle('Add time range to quick access time range list');
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -154,11 +154,11 @@ describe('TimeRangePicker', () => {
     expect(setCurrentTimeRange).toHaveBeenCalledWith({ type: 'keyword', keyword: 'yesterday', timezone: 'Asia/Tokyo' });
   });
 
-  it('has button add time range to quick access for admin users', async () => {
+  it('Displays button for admin users to save time range as preset', async () => {
     asMock(useCurrentUser).mockReturnValue(adminUser);
 
     render(<TimeRangePicker {...defaultProps} />);
 
-    await screen.findByTitle('Add time range to quick access time range list');
+    await screen.findByTitle('Save current time range as preset');
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -26,11 +26,12 @@ import type {
   AbsoluteTimeRange,
   KeywordTimeRange,
   NoTimeRangeOverride,
-  TimeRange,
 } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
-import { isTypeKeyword, isTypeRelative } from 'views/typeGuards/timeRange';
-import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
+import { isTypeRelative } from 'views/typeGuards/timeRange';
+import {
+  normalizeFromPickerForSearchBar,
+} from 'views/logic/queries/NormalizeTimeRange';
 import validateTimeRange from 'views/components/TimeRangeValidation';
 import type { DateTime } from 'util/DateTime';
 import useUserDateTime from 'hooks/useUserDateTime';
@@ -110,18 +111,6 @@ const onInitializingNextTimeRange = (currentTimeRange: SearchBarFormValues['time
   return currentTimeRange;
 };
 
-const normalizeIfKeywordTimeRange = (timeRange: TimeRange | NoTimeRangeOverride) => {
-  if (isTypeKeyword(timeRange)) {
-    return {
-      type: timeRange.type,
-      timezone: timeRange.timezone,
-      keyword: timeRange.keyword,
-    };
-  }
-
-  return timeRange;
-};
-
 type Props = {
   currentTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride,
   limitDuration: number,
@@ -166,11 +155,7 @@ const TimeRangePicker = ({
   const handleSubmit = useCallback(({ nextTimeRange }: {
     nextTimeRange: TimeRangePickerFormValues['nextTimeRange']
   }) => {
-    const normalizedTimeRange = normalizeIfKeywordTimeRange(
-      normalizeIfAllMessagesRange(
-        normalizeIfClassifiedRelativeTimeRange(nextTimeRange),
-      ),
-    );
+    const normalizedTimeRange = normalizeFromPickerForSearchBar(nextTimeRange);
 
     setCurrentTimeRange(normalizedTimeRange);
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -21,34 +21,29 @@ import styled, { css } from 'styled-components';
 import moment from 'moment';
 
 import { Button, Col, Row, Popover } from 'components/bootstrap';
-import { Icon, IfPermitted, KeyCapture, ModalSubmit } from 'components/common';
+import { Icon, KeyCapture, ModalSubmit } from 'components/common';
 import type {
   AbsoluteTimeRange,
   KeywordTimeRange,
   NoTimeRangeOverride,
   TimeRange,
-  RelativeTimeRange,
 } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
-import { isTypeKeyword, isTimeRange, isTypeRelative } from 'views/typeGuards/timeRange';
+import { isTypeKeyword, isTypeRelative } from 'views/typeGuards/timeRange';
 import { normalizeIfAllMessagesRange } from 'views/logic/queries/NormalizeTimeRange';
 import validateTimeRange from 'views/components/TimeRangeValidation';
-import type { DateTimeFormats, DateTime } from 'util/DateTime';
-import { toDateObject } from 'util/DateTime';
+import type { DateTime } from 'util/DateTime';
 import useUserDateTime from 'hooks/useUserDateTime';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
-import TimeRangeAddToQuickListButton
-  from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton';
 
 import type { RelativeTimeRangeClassified } from './types';
-import migrateTimeRangeToNewType from './migrateTimeRangeToNewType';
 import {
   classifyRelativeTimeRange,
   normalizeIfClassifiedRelativeTimeRange,
-  RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
 } from './RelativeTimeRangeClassifiedHelper';
 import TimeRangeTabs, { timeRangePickerTabs } from './TimeRangePickerTabs';
+import TimeRangePresetRow from './TimeRangePresetRow';
 
 export type TimeRangePickerFormValues = {
   nextTimeRange: RelativeTimeRangeClassified | AbsoluteTimeRange | KeywordTimeRange | NoTimeRangeOverride,
@@ -57,28 +52,6 @@ export type TimeRangePickerFormValues = {
 export type SupportedTimeRangeType = keyof typeof timeRangePickerTabs;
 
 export const allTimeRangeTypes = Object.keys(timeRangePickerTabs) as Array<SupportedTimeRangeType>;
-
-const createDefaultRanges = (formatTime: (time: DateTime, format: DateTimeFormats) => string) => ({
-  absolute: {
-    type: 'absolute',
-    from: formatTime(toDateObject(new Date()).subtract(300, 'seconds'), 'complete'),
-    to: formatTime(toDateObject(new Date()), 'complete'),
-  },
-  relative: {
-    type: 'relative',
-    from: {
-      value: 5,
-      unit: 'minutes',
-      isAllTime: false,
-    },
-    to: RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
-  },
-  keyword: {
-    type: 'keyword',
-    keyword: 'Last five minutes',
-  },
-  disabled: undefined,
-});
 
 const StyledPopover = styled(Popover)(({ theme }) => css`
   min-width: 750px;
@@ -137,6 +110,18 @@ const onInitializingNextTimeRange = (currentTimeRange: SearchBarFormValues['time
   return currentTimeRange;
 };
 
+const normalizeIfKeywordTimeRange = (timeRange: TimeRange | NoTimeRangeOverride) => {
+  if (isTypeKeyword(timeRange)) {
+    return {
+      type: timeRange.type,
+      timezone: timeRange.timezone,
+      keyword: timeRange.keyword,
+    };
+  }
+
+  return timeRange;
+};
+
 type Props = {
   currentTimeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride,
   limitDuration: number,
@@ -162,8 +147,6 @@ const TimeRangePicker = ({
   const [validatingKeyword, setValidatingKeyword] = useState(false);
   const sendTelemetry = useSendTelemetry();
   const positionIsBottom = position === 'bottom';
-  const defaultRanges = useMemo(() => createDefaultRanges(formatTime), [formatTime]);
-  const { showAddToQuickListButton } = useContext(TimeRangeInputSettingsContext);
 
   const handleNoOverride = useCallback(() => {
     setCurrentTimeRange({});
@@ -180,22 +163,10 @@ const TimeRangePicker = ({
     });
   }, [sendTelemetry, toggleDropdownShow]);
 
-  const normalizeIfKeywordTimerange = (timeRange: TimeRange | NoTimeRangeOverride) => {
-    if (isTypeKeyword(timeRange)) {
-      return {
-        type: timeRange.type,
-        timezone: timeRange.timezone,
-        keyword: timeRange.keyword,
-      };
-    }
-
-    return timeRange;
-  };
-
   const handleSubmit = useCallback(({ nextTimeRange }: {
     nextTimeRange: TimeRangePickerFormValues['nextTimeRange']
   }) => {
-    const normalizedTimeRange = normalizeIfKeywordTimerange(
+    const normalizedTimeRange = normalizeIfKeywordTimeRange(
       normalizeIfAllMessagesRange(
         normalizeIfClassifiedRelativeTimeRange(nextTimeRange),
       ),
@@ -240,48 +211,32 @@ const TimeRangePicker = ({
                                          validate={_validateTimeRange}
                                          onSubmit={handleSubmit}
                                          validateOnMount>
-        {(({ values: { nextTimeRange }, isValid, setFieldValue, submitForm }) => {
-          const handleActiveTab = (nextTab: AbsoluteTimeRange['type'] | RelativeTimeRange['type'] | KeywordTimeRange['type']) => {
-            if ('type' in nextTimeRange) {
-              setFieldValue('nextTimeRange', migrateTimeRangeToNewType(nextTimeRange as TimeRange, nextTab, formatTime));
-            } else {
-              setFieldValue('nextTimeRange', defaultRanges[nextTab]);
-            }
-          };
+        {(({ isValid, submitForm }) => (
+          <KeyCapture shortcuts={{ enter: submitForm, esc: handleCancel }}>
+            <Form>
+              <Row>
+                <Col md={12}>
+                  <TimeRangePresetRow />
+                  <TimeRangeTabs limitDuration={limitDuration}
+                                 validTypes={validTypes}
+                                 setValidatingKeyword={setValidatingKeyword} />
+                </Col>
+              </Row>
 
-          return (
-            <KeyCapture shortcuts={{ enter: submitForm, esc: handleCancel }}>
-              <Form>
-                <Row>
-                  <Col md={12}>
-                    {showAddToQuickListButton && isTimeRange(nextTimeRange) && (
-                      <IfPermitted permissions="clusterconfigentry:edit">
-                        <TimeRangeAddToQuickListButton />
-                      </IfPermitted>
-                    )}
-                    <TimeRangeTabs currentTimeRange={currentTimeRange}
-                                   handleActiveTab={handleActiveTab}
-                                   limitDuration={limitDuration}
-                                   validTypes={validTypes}
-                                   setValidatingKeyword={setValidatingKeyword} />
-                  </Col>
-                </Row>
-
-                <Row className="row-sm">
-                  <Col md={6}>
-                    <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
-                  </Col>
-                  <Col md={6}>
-                    <ModalSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
-                                 onCancel={handleCancel}
-                                 disabledSubmit={!isValid || validatingKeyword}
-                                 submitButtonText="Update time range" />
-                  </Col>
-                </Row>
-              </Form>
-            </KeyCapture>
-          );
-        })}
+              <Row className="row-sm">
+                <Col md={6}>
+                  <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
+                </Col>
+                <Col md={6}>
+                  <ModalSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
+                               onCancel={handleCancel}
+                               disabledSubmit={!isValid || validatingKeyword}
+                               submitButtonText="Update time range" />
+                </Col>
+              </Row>
+            </Form>
+          </KeyCapture>
+        ))}
       </Formik>
     </StyledPopover>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
@@ -16,25 +16,34 @@
  */
 
 import * as React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
+import { useFormikContext } from 'formik';
 
 import { availableTimeRangeTypes } from 'views/Constants';
 import { Tab, Tabs } from 'components/bootstrap';
 import type {
   AbsoluteTimeRange,
   KeywordTimeRange,
-  NoTimeRangeOverride,
   TimeRange,
   RelativeTimeRange,
 } from 'views/logic/queries/Query';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { isTimeRange } from 'views/typeGuards/timeRange';
+import migrateTimeRangeToNewType
+  from 'views/components/searchbar/time-range-filter/time-range-picker/migrateTimeRangeToNewType';
+import useUserDateTime from 'hooks/useUserDateTime';
+import type { DateTime, DateTimeFormats } from 'util/DateTime';
+import { toDateObject } from 'util/DateTime';
+import {
+  RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
+} from 'views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper';
 
 import TabAbsoluteTimeRange from './TabAbsoluteTimeRange';
 import TabKeywordTimeRange from './TabKeywordTimeRange';
 import TabRelativeTimeRange from './TabRelativeTimeRange';
 import TabDisabledTimeRange from './TabDisabledTimeRange';
-import type { SupportedTimeRangeType } from './TimeRangePicker';
+import type { SupportedTimeRangeType, TimeRangePickerFormValues } from './TimeRangePicker';
 
 export const timeRangePickerTabs = {
   absolute: TabAbsoluteTimeRange,
@@ -77,27 +86,51 @@ const timeRangeTypeTabs = ({
     );
   });
 
+const createDefaultRanges = (formatTime: (time: DateTime, format: DateTimeFormats) => string) => ({
+  absolute: {
+    type: 'absolute',
+    from: formatTime(toDateObject(new Date()).subtract(300, 'seconds'), 'complete'),
+    to: formatTime(toDateObject(new Date()), 'complete'),
+  },
+  relative: {
+    type: 'relative',
+    from: {
+      value: 5,
+      unit: 'minutes',
+      isAllTime: false,
+    },
+    to: RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
+  },
+  keyword: {
+    type: 'keyword',
+    keyword: 'Last five minutes',
+  },
+  disabled: undefined,
+});
+
 type Props = {
-  handleActiveTab: (nextTab: AbsoluteTimeRange['type'] | RelativeTimeRange['type'] | KeywordTimeRange['type']) => void,
-  currentTimeRange: NoTimeRangeOverride | TimeRange,
   limitDuration: number,
   validTypes: Array<'absolute' | 'relative' | 'keyword'>,
   setValidatingKeyword: (validating: boolean) => void,
 };
 
 const TimeRangeTabs = ({
-  handleActiveTab,
-  currentTimeRange,
   limitDuration,
   validTypes,
   setValidatingKeyword,
 }: Props) => {
-  const [activeTab, setActiveTab] = useState('type' in currentTimeRange ? currentTimeRange.type : undefined);
   const sendTelemetry = useSendTelemetry();
+  const { formatTime } = useUserDateTime();
+  const { setFieldValue, values: { nextTimeRange } } = useFormikContext<TimeRangePickerFormValues>();
+  const defaultRanges = useMemo(() => createDefaultRanges(formatTime), [formatTime]);
+  const activeTab = isTimeRange(nextTimeRange) ? nextTimeRange.type : undefined;
 
   const onSelect = useCallback((nextTab: AbsoluteTimeRange['type'] | RelativeTimeRange['type'] | KeywordTimeRange['type']) => {
-    handleActiveTab(nextTab);
-    setActiveTab(nextTab);
+    if ('type' in nextTimeRange) {
+      setFieldValue('nextTimeRange', migrateTimeRangeToNewType(nextTimeRange as TimeRange, nextTab, formatTime));
+    } else {
+      setFieldValue('nextTimeRange', defaultRanges[nextTab]);
+    }
 
     sendTelemetry('click', {
       app_pathname: 'search',
@@ -107,7 +140,7 @@ const TimeRangeTabs = ({
         tab: nextTab,
       },
     });
-  }, [handleActiveTab, sendTelemetry]);
+  }, [defaultRanges, formatTime, nextTimeRange, sendTelemetry, setFieldValue]);
 
   const tabs = useMemo(() => timeRangeTypeTabs({
     activeTab,

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
@@ -14,34 +14,59 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+
+import * as React from 'react';
+import { useContext } from 'react';
+import { useFormikContext } from 'formik';
 import styled from 'styled-components';
 
-import { ButtonGroup } from 'components/bootstrap';
 import TimeRangePresetDropdown from 'views/components/searchbar/time-range-filter/TimeRangePresetDropdown';
+import { isTimeRange, isTypeRelative } from 'views/typeGuards/timeRange';
+import { IfPermitted } from 'components/common';
+import TimeRangeAddToQuickListButton
+  from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton';
+import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import type { TimeRange } from 'views/logic/queries/Query';
-import type { QuickAccessTimeRange } from 'components/configurations/QuickAccessTimeRangeForm';
+import type {
+  TimeRangePickerFormValues,
+} from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker';
+import {
+  classifyRelativeTimeRange,
+} from 'views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper';
+import { ButtonToolbar } from 'components/bootstrap';
 
-const ConfiguredWrapper = styled.div`
-  display: flex;
-  margin: 3px 0;
-  justify-content: end;
+const Container = styled(ButtonToolbar)`
+  float: right;
+  margin-top: 6px;
 `;
 
-type Props = {
-  disabled: boolean,
-  onSetPreset: (timerange: TimeRange) => void,
-  availableOptions: Array<QuickAccessTimeRange>,
+const normalizePresetTimeRange = (timeRange: TimeRange) => {
+  if (isTypeRelative(timeRange)) {
+    return classifyRelativeTimeRange(timeRange);
+  }
+
+  return timeRange;
 };
 
-const TimeRangePresetRow = ({ onSetPreset, availableOptions, disabled }: Props) => (
-  <ConfiguredWrapper>
-    <ButtonGroup>
-      <TimeRangePresetDropdown disabled={disabled}
-                               onChange={onSetPreset}
-                               availableOptions={availableOptions} />
-    </ButtonGroup>
-  </ConfiguredWrapper>
-);
+const TimeRangePresetRow = () => {
+  const { showAddToQuickListButton } = useContext(TimeRangeInputSettingsContext);
+  const { showPresetsButton } = useContext(TimeRangeInputSettingsContext);
+  const { setFieldValue, values } = useFormikContext<TimeRangePickerFormValues>();
+
+  const onSetPreset = (newTimeRange: TimeRange) => {
+    setFieldValue('nextTimeRange', normalizePresetTimeRange(newTimeRange));
+  };
+
+  return (
+    <Container>
+      {showAddToQuickListButton && isTimeRange(values.nextTimeRange) && (
+        <IfPermitted permissions="clusterconfigentry:edit">
+          <TimeRangeAddToQuickListButton />
+        </IfPermitted>
+      )}
+      {showPresetsButton && <TimeRangePresetDropdown onChange={onSetPreset} />}
+    </Container>
+  );
+};
 
 export default TimeRangePresetRow;

--- a/graylog2-web-interface/src/views/logic/queries/NormalizeTimeRange.ts
+++ b/graylog2-web-interface/src/views/logic/queries/NormalizeTimeRange.ts
@@ -17,10 +17,14 @@
 
 import isAllMessagesRange from 'views/logic/queries/IsAllMessagesRange';
 import { RELATIVE_ALL_TIME } from 'views/Constants';
+import {
+  normalizeIfClassifiedRelativeTimeRange,
+} from 'views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper';
+import { isTypeKeyword, isTypeRelativeWithEnd, isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
+import { adjustFormat, toUTCFromTz } from 'util/DateTime';
 
 import type { TimeRange, NoTimeRangeOverride } from './Query';
 
-/* eslint-disable import/prefer-default-export */
 export const normalizeIfAllMessagesRange = (timeRange: TimeRange | NoTimeRangeOverride) => {
   if ('type' in timeRange && isAllMessagesRange(timeRange)) {
     return {
@@ -30,4 +34,64 @@ export const normalizeIfAllMessagesRange = (timeRange: TimeRange | NoTimeRangeOv
   }
 
   return timeRange;
+};
+
+export const normalizeFromPickerForSearchBar = (timeRange: TimeRange | NoTimeRangeOverride) => {
+  const normalizeIfKeywordTimeRange = (tr: TimeRange | NoTimeRangeOverride) => {
+    if (isTypeKeyword(tr)) {
+      return {
+        type: tr.type,
+        timezone: tr.timezone,
+        keyword: tr.keyword,
+      };
+    }
+
+    return tr;
+  };
+
+  return normalizeIfKeywordTimeRange(
+    normalizeIfAllMessagesRange(
+      normalizeIfClassifiedRelativeTimeRange(timeRange),
+    ),
+  );
+};
+
+export const normalizeFromSearchBarForBackend = (timerange: TimeRange, userTz: string): TimeRange => {
+  const { type } = timerange;
+
+  switch (timerange.type) {
+    case 'absolute':
+      return {
+        type: timerange.type,
+        from: adjustFormat(toUTCFromTz(timerange.from, userTz), 'internal'),
+        to: adjustFormat(toUTCFromTz(timerange.to, userTz), 'internal'),
+      };
+    case 'relative':
+      if (isTypeRelativeWithStartOnly(timerange)) {
+        return {
+          type: timerange.type,
+          range: timerange.range,
+        };
+      }
+
+      if (isTypeRelativeWithEnd(timerange)) {
+        if ('to' in timerange) {
+          return {
+            type: timerange.type,
+            from: timerange.from,
+            to: timerange.to,
+          };
+        }
+
+        return {
+          type: timerange.type,
+          from: timerange.from,
+        };
+      }
+
+      throw new Error('Invalid relative time range');
+    case 'keyword':
+      return timerange;
+    default: throw new Error(`Invalid time range type: ${type}`);
+  }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are moving the time range preset dropdown button in the time range picker next to the save preset button.

We are also:
- Using a name for the save preset button instead of just an icon
- Improving the data fetching logic. We are doing a request to check if a keyword time range is in the query time range limit. Before this PR we were doing the requests every time you open the search page. Now we are doing these requests only when opening the dropdown.
- Fixing a problem with saving `relative` time ranges.
- No longer displaying the `All times` preset, when a query time range limit is defined
- Unifying the naming of time range presets

Fixes https://github.com/Graylog2/graylog2-server/issues/16000

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5554

/nocl