### PR TITLE
Referenced search filters are inlined when fetched from Content Packs

### DIFF
--- a/changelog/unreleased/issue-15841.toml
+++ b/changelog/unreleased/issue-15841.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fixes problems with editing Search Filters of entities installed via Content Packs. Search Filters of those types of entities are not inlined during Content Pack installation and can be edited."
+
+issues = ["15841"]
+pulls = ["16085","Graylog2/graylog-plugin-enterprise/5560"]

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/NativeEntityConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/NativeEntityConverter.java
@@ -17,19 +17,41 @@
 package org.graylog2.contentpacks;
 
 import com.google.common.graph.MutableGraph;
+import org.graylog.plugins.views.search.searchfilters.model.ReferencedSearchFilter;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public interface NativeEntityConverter<T> {
     T toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities);
+
     default void resolveForInstallation(EntityV1 entity,
                                         Map<String, ValueReference> parameters,
                                         Map<EntityDescriptor, Entity> entities,
                                         MutableGraph<Entity> graph) {
+
+    }
+
+    default List<UsedSearchFilter> convertSearchFilters(final List<UsedSearchFilter> contentPackSavedFilters) {
+        if (contentPackSavedFilters == null) {
+            return List.of();
+        }
+        return contentPackSavedFilters.stream()
+                .map(filter -> {
+                    if (filter instanceof ReferencedSearchFilter referenced) {
+                        return referenced.toInlineRepresentation();
+                    } else {
+                        return filter;
+                    }
+                })
+                .collect(Collectors.toList());
+
 
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
@@ -117,7 +117,7 @@ public abstract class EventListEntity implements SearchTypeEntity {
                 .streams(mappedStreams(nativeEntities))
                 .id(id())
                 .filter(filter())
-                .filters(filters())
+                .filters(convertSearchFilters(filters()))
                 .query(query().orElse(null))
                 .timerange(timerange().orElse(null))
                 .name(name().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
@@ -177,7 +177,7 @@ public abstract class MessageListEntity implements SearchTypeEntity {
                 .decorators(decorators())
                 .timerange(timerange().orElse(null))
                 .filter(filter())
-                .filters(filters())
+                .filters(convertSearchFilters(filters()))
                 .name(name().orElse(null))
                 .type(type())
                 .query(query().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -198,7 +198,7 @@ public abstract class PivotEntity implements SearchTypeEntity {
                 .rollup(rollup())
                 .query(query().orElse(null))
                 .filter(filter())
-                .filters(filters())
+                .filters(convertSearchFilters(filters()))
                 .type(type())
                 .id(id())
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
@@ -172,7 +172,7 @@ public abstract class QueryEntity implements NativeEntityConverter<Query> {
                         .collect(Collectors.toSet()))
                 .query(query())
                 .filter(shallowMappedFilter(nativeEntities))
-                .filters(filters())
+                .filters(convertSearchFilters(filters()))
                 .timerange(timerange())
                 .globalOverride(globalOverride().orElse(null))
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetEntity.java
@@ -152,7 +152,7 @@ public abstract class WidgetEntity implements NativeEntityConverter<WidgetDTO> {
         final WidgetDTO.Builder widgetBuilder = WidgetDTO.builder()
                 .config(this.config())
                 .filter(this.filter())
-                .filters(this.filters())
+                .filters(convertSearchFilters(this.filters()))
                 .id(this.id())
                 .streams(this.streams().stream()
                         .map(id -> EntityDescriptor.create(id, ModelTypes.STREAM_V1))

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/NativeEntityConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/NativeEntityConverterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.contentpacks;
+
+import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
+import org.graylog.plugins.views.search.searchfilters.model.ReferencedQueryStringSearchFilter;
+import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+
+class NativeEntityConverterTest {
+
+    private NativeEntityConverter<?> toTest;
+
+    @BeforeEach
+    void setUp() {
+        //only default methods will be tested, implementation of others does not matter
+        toTest = (parameters, nativeEntities) -> null;
+    }
+
+    @Test
+    void testSearchFilterConversionReturnsEmptyListOnNullInput() {
+        assertThat(toTest.convertSearchFilters(null)).isEmpty();
+    }
+
+    @Test
+    void testSearchFilterConversionReturnsEmptyListOnEmptyInput() {
+        assertThat(toTest.convertSearchFilters(List.of())).isEmpty();
+    }
+
+    @Test
+    void testSearchFilterConversionKeepsOriginalFiltersAndInlinesReferencedOnes() {
+        final ReferencedQueryStringSearchFilter shouldBeInlined = ReferencedQueryStringSearchFilter.builder()
+                .id("Referenced")
+                .queryString("smth:nice")
+                .description("Will be inlined")
+                .build();
+        final InlineQueryStringSearchFilter shouldStayUnchanged = InlineQueryStringSearchFilter.builder()
+                .queryString("smth:normal")
+                .description("Will stay unchanged")
+                .build();
+
+        final List<UsedSearchFilter> convertedSearchFilters = toTest.convertSearchFilters(List.of(
+                shouldBeInlined,
+                shouldStayUnchanged
+        ));
+
+        assertThat(convertedSearchFilters)
+                .isNotNull()
+                .hasSize(2)
+                .containsExactly(
+                        InlineQueryStringSearchFilter.builder()
+                                .queryString("smth:nice")
+                                .description("Will be inlined")
+                                .build(),
+                        shouldStayUnchanged
+                );
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/QueryEntityTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/QueryEntityTest.java
@@ -49,7 +49,12 @@ class QueryEntityTest {
 
         final ImmutableList<UsedSearchFilter> originalSearchFilters = ImmutableList.of(
                 InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").disabled(true).build(),
-                ReferencedQueryStringSearchFilter.create("42")
+                ReferencedQueryStringSearchFilter.create("42").withQueryString("method:GET")
+        );
+
+        final ImmutableList<UsedSearchFilter> expectedSearchFilters = ImmutableList.of(
+                InlineQueryStringSearchFilter.builder().title("title").description("descr").queryString("*").disabled(true).build(),
+                InlineQueryStringSearchFilter.builder().queryString("method:GET").build()
         );
         QueryEntity queryWithFilters = QueryEntity.Builder
                 .createWithDefaults()
@@ -60,6 +65,6 @@ class QueryEntityTest {
                 .build();
         assertThat(queryWithFilters.toNativeEntity(Collections.emptyMap(), Collections.emptyMap()).filters())
                 .isNotNull()
-                .isEqualTo(originalSearchFilters);
+                .isEqualTo(expectedSearchFilters);
     }
 }


### PR DESCRIPTION
## Description
Fixes #15841.
When creating a new `Content Pack` with an entity that references a `Search Filter` and later on installing this `Content Pack` on a new machine, we will find out that referenced `Search Filter` is missing on a new machine.
It may lead to problems later on, i.e. during `Search Filter` edit attempts, as described in #15841.

While long-term solution is possible, making `Search Filters` part of the `Content Pack`, it may require complex implementation and still lead to many problems (`Search Filters` are hidden under license, permissions considerations etc.).

The simpler solution of the problem is to inline `Search Filters`, so that they are no longer referenced and can be safely edited locally.

The decision was made to keep existing representation of `Search Filters` in the `Content Packs`, with referencing.
`Search Filters` are inlined when `Content Packs` are installed.

The main advantages of that solution:
- The problem can be solved with all the `Content Packs` created so far. They do not have to be re-created, it should be enough to re-install them.
- Proper, original form of the data is kept in `Content Packs`.
- The solution can be changed to more complex one without bigger problems, as we still keep information about original, referenced `Search Filter`.

Alternative would be to inline `Search Filters` when creating `Content Packs`, missing all the advantages described above.

**It is very likely it should be backported to 5.0 and 5.1.**


## Motivation and Context
Problem is described in detail in #15841.

## How Has This Been Tested?
Manually and with new unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

