### PR TITLE
Re-enable weak TLS ciphers for backwards compatibility (5.1 backport)

### DIFF
--- a/changelog/unreleased/issue-16076.toml
+++ b/changelog/unreleased/issue-16076.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fix TLS compatibility with older operating systems. (e.g. Win Server 2019)."
+
+issues = ["16076"]
+pulls = [""]
+

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -47,7 +47,6 @@ import com.google.inject.name.Names;
 import com.google.inject.spi.Message;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
-import joptsimple.internal.Strings;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -224,8 +223,8 @@ public abstract class CmdLineTool implements CliCommand {
         // Only restrict ciphers if insecure TLS protocols are explicitly enabled.
         // c.f. https://github.com/Graylog2/graylog2-server/issues/10944
         if (tlsProtocols == null || !(tlsProtocols.isEmpty() || tlsProtocols.contains("TLSv1") || tlsProtocols.contains("TLSv1.1"))) {
-            disabledAlgorithms.addAll(ImmutableSet.of("CBC", "3DES", "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384"));
-            Security.setProperty("jdk.tls.disabledAlgorithms", Strings.join(disabledAlgorithms, ", "));
+            disabledAlgorithms.addAll(ImmutableSet.of("CBC", "3DES"));
+            Security.setProperty("jdk.tls.disabledAlgorithms", String.join(", ", disabledAlgorithms));
         } else {
             // Remove explicitly enabled legacy TLS protocols from the disabledAlgorithms filter
             Set<String> reEnabledTLSProtocols;
@@ -238,7 +237,7 @@ public abstract class CmdLineTool implements CliCommand {
                     .filter(p -> !reEnabledTLSProtocols.contains(p))
                     .collect(Collectors.toList());
 
-            Security.setProperty("jdk.tls.disabledAlgorithms", Strings.join(updatedProperties, ", "));
+            Security.setProperty("jdk.tls.disabledAlgorithms", String.join(", ", updatedProperties));
         }
 
         // Explicitly register Bouncy Castle as security provider.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -381,8 +381,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
 
     private static Set<String> getSecureCipherSuites() {
         final Set<String> openSslCipherSuites = OpenSsl.availableOpenSslCipherSuites();
-        final String[] disabledAlgorithms = {".*CBC.*", "AES128-SHA", "AES256-SHA", "ECDHE-RSA-AES128-SHA",
-                "ECDHE-RSA-AES256-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384"};
+        final String[] disabledAlgorithms = {".*CBC.*", "AES128-SHA", "AES256-SHA", "ECDHE-RSA-AES128-SHA", "ECDHE-RSA-AES256-SHA"};
         return openSslCipherSuites.stream().filter(s -> Arrays.stream(disabledAlgorithms).noneMatch(s::matches)).collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
Revert
 https://github.com/Graylog2/graylog2-server/pull/14592

and allow
https://ciphersuite.info/cs/TLS_RSA_WITH_AES_128_GCM_SHA256/ https://ciphersuite.info/cs/TLS_RSA_WITH_AES_256_GCM_SHA384/

by default again.
This should fix comptibility issues with Windows Server 2019 and older OS.

(cherry picked from commit 03e93946c4cec8370bbdab140e434b156a43a38f)


