### PR TITLE
Avoid 500 error for cluster logger level API requests

### DIFF
--- a/changelog/unreleased/pr-16092.toml
+++ b/changelog/unreleased/pr-16092.toml
@@ -1,0 +1,13 @@
+type = "fixed"
+message = "Fix internal server error for cluster logger level API requests."
+
+issues = ["11408", "14256"]
+pulls = ["16092"]
+
+details.user = """
+Requests to the cluster logger-level endpoint `/cluster/system/loggers/{loggerName}/level/{level}` previously responded
+with a `500` error status (but still execute successfully) unless the request includes the `Accept: application/json`
+header.
+
+This API endpoint has been fixed to respond with a `200` success code even when the `Accept` header is not supplied.
+"""

--- a/changelog/unreleased/pr-16092.toml
+++ b/changelog/unreleased/pr-16092.toml
@@ -6,7 +6,7 @@ pulls = ["16092"]
 
 details.user = """
 Requests to the cluster logger-level endpoint `/cluster/system/loggers/{loggerName}/level/{level}` previously responded
-with a `500` error status (but still execute successfully) unless the request includes the `Accept: application/json`
+with a `500` error status (but still executed successfully) unless the request included the `Accept: application/json`
 header.
 
 This API endpoint has been fixed to respond with a `200` success code even when the `Accept` header is not supplied.

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
@@ -111,6 +111,7 @@ public class ClusterLoggersResource extends ProxiedResource {
     @ApiOperation(value = "Set the loglevel of a single logger",
             notes = "Provided level is falling back to DEBUG if it does not exist")
     @NoAuditEvent("proxy resource, audit event will be emitted on target nodes")
+    @Produces(MediaType.APPLICATION_JSON)
     public Map<String, CallResult<Void>> setClusterSingleLoggerLevel(
             @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") @NotEmpty String loggerName,
             @ApiParam(name = "level", required = true) @PathParam("level") @NotEmpty String level) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Requests to the cluster logger-level endpoint `/cluster/system/loggers/{loggerName}/level/{level}` report a 500 error status (but still execute successfully) unless the request includes the `Accept: application/json` header to clarify to Jersey which content type should be used for the response. 

In the server log, the following error is logged when the `500` is logged.

> ERROR [WriterInterceptorExecutor] MessageBodyWriter not found for media type=text/plain, type=class java.util.HashMap, genericType=java.util.Map<java.lang.String, org.graylog2.shared.rest.resources.ProxiedResource$CallResult<java.lang.Void>>

This PR adds the `@Produces` annotation to provide some advice to Jersey on which content type is being returned.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Graylog2/graylog2-server/issues/14256 https://github.com/Graylog2/graylog2-server/issues/11408

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing with cURL. For example, this request to enable debug logging for the CrowdStrike input, and verifying that the error no longer occurs.
```
curl -X PUT http://user:pass@localhost:9000/api/cluster/system/loggers/org.graylog.enterprise.integrations.crowdstrike/level/debug \
-H 'X-Requested-By: graylog-api-user'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

