### PR TITLE
Implement option to change order of search highlighting rules.

### DIFF
--- a/changelog/unreleased/pr-16095.toml
+++ b/changelog/unreleased/pr-16095.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Implement option to change order of search highlighting rules."
+
+pulls = ["16095"]

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ColorPreview.tsx
@@ -23,8 +23,8 @@ import type HighlightingColor from 'views/logic/views/formatting/highlighting/Hi
 import scaleForGradient from 'views/components/sidebar/highlighting/Scale';
 
 const ColorPreviewBase = styled.div`
-  height: 2rem;
-  width: 2rem;
+  height: 25px;
+  width: 25px;
   margin-right: 0.4rem;
 
   border-radius: 4px;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { forwardRef, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
@@ -32,12 +32,16 @@ import { updateHighlightingRule, removeHighlightingRule } from 'views/logic/slic
 
 import ColorPreview from './ColorPreview';
 
-export const Container = styled.div`
+export const Container = styled.div<{ $displayBorder?: boolean }>(({ theme, $displayBorder = true }) => css`
   display: flex;
   padding-top: 5px;
   padding-bottom: 5px;
   word-break: break-word;
-`;
+  
+  &:not(:last-child) {
+    border-bottom: ${$displayBorder ? `1px solid ${theme.colors.global.background}` : 'none'};
+  }
+`);
 
 const RightCol = styled.div`
   flex: 1

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.tsx
@@ -15,13 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useState } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import Rule, { ConditionLabelMap } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import { ColorPickerPopover, IconButton } from 'components/common';
+import { ColorPickerPopover, Icon, IconButton } from 'components/common';
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
 import type HighlightingColor from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
@@ -31,41 +32,34 @@ import { updateHighlightingRule, removeHighlightingRule } from 'views/logic/slic
 
 import ColorPreview from './ColorPreview';
 
-export const HighlightingRuleGrid = styled.div`
-  display: grid;
-  display: -ms-grid;
-  grid-template-columns: max-content 1fr max-content;
-  -ms-grid-columns: max-content 1fr max-content;
-  margin-top: 10px;
+export const Container = styled.div`
+  display: flex;
+  padding-top: 5px;
+  padding-bottom: 5px;
   word-break: break-word;
+`;
 
-  > *:nth-child(1) {
-    grid-column: 1;
-    -ms-grid-column: 1;
-  }
-
-  > *:nth-child(2) {
-    grid-column: 2;
-    -ms-grid-column: 2;
-  }
-
-  > *:nth-child(3) {
-    grid-column: 3;
-    -ms-grid-column: 3;
-  }
+const RightCol = styled.div`
+  flex: 1
 `;
 
 const ButtonContainer = styled.div`
-  display: flex;
+  display: inline-flex;
+  float: right;
 `;
 
 export const RuleContainer = styled.div`
-  padding-top: 4px;
+  padding-top: 2px;
+  display: inline-block;
 `;
 
-type Props = {
-  rule: Rule,
-};
+const DragHandle = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 25px;
+  width: 25px;
+`;
 
 const updateColor = (rule: Rule, newColor: HighlightingColor, hidePopover: () => void) => async (dispatch: AppDispatch) => dispatch(updateHighlightingRule(rule, { color: newColor })).then(hidePopover);
 
@@ -104,7 +98,14 @@ const RuleColorPreview = ({ color, onChange }: RuleColorPreviewProps) => {
   throw new Error(`Invalid highlighting color: ${color}`);
 };
 
-const HighlightingRule = ({ rule }: Props) => {
+type Props = {
+  rule: Rule,
+  className?: string,
+  draggableProps?: DraggableProvidedDraggableProps;
+  dragHandleProps?: DraggableProvidedDragHandleProps;
+};
+
+const HighlightingRule = forwardRef<HTMLDivElement, Props>(({ rule, className, draggableProps, dragHandleProps }, ref) => {
   const { field, value, color, condition } = rule;
   const [showForm, setShowForm] = useState(false);
   const dispatch = useAppDispatch();
@@ -113,20 +114,31 @@ const HighlightingRule = ({ rule }: Props) => {
   const _onDelete = useCallback(() => dispatch(onDelete(rule)), [dispatch, rule]);
 
   return (
-    <>
-      <HighlightingRuleGrid>
-        <RuleColorPreview color={color} onChange={_onChange} />
+    <Container className={className} ref={ref} {...(draggableProps ?? {})}>
+      <RuleColorPreview color={color} onChange={_onChange} />
+      <RightCol>
         <RuleContainer data-testid="highlighting-rule">
           <strong>{field}</strong> {ConditionLabelMap[condition]} <i>&quot;{String(value)}&quot;</i>.
         </RuleContainer>
         <ButtonContainer>
           <IconButton title="Edit this Highlighting Rule" name="edit" onClick={() => setShowForm(true)} />
           <IconButton title="Remove this Highlighting Rule" name="trash-alt" onClick={_onDelete} />
+          {dragHandleProps && (
+          <DragHandle {...dragHandleProps}>
+            <Icon name="bars" />
+          </DragHandle>
+          )}
         </ButtonContainer>
-      </HighlightingRuleGrid>
+      </RightCol>
       {showForm && <HighlightForm onClose={() => setShowForm(false)} rule={rule} />}
-    </>
+    </Container>
   );
+});
+
+HighlightingRule.defaultProps = {
+  className: undefined,
+  draggableProps: undefined,
+  dragHandleProps: undefined,
 };
 
 HighlightingRule.propTypes = {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -15,22 +15,55 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
+import type { DraggableProvidedDraggableProps, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
 import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 import IconButton from 'components/common/IconButton';
+import { SortableList } from 'components/common';
+import { updateHighlightingRules } from 'views/logic/slices/highlightActions';
+import useAppDispatch from 'stores/useAppDispatch';
+import type HighlightingRuleType from 'views/logic/views/formatting/highlighting/HighlightingRule';
 
-import HighlightingRule, { HighlightingRuleGrid, RuleContainer } from './HighlightingRule';
+import HighlightingRule, { Container, RuleContainer } from './HighlightingRule';
 import ColorPreview from './ColorPreview';
 import HighlightForm from './HighlightForm';
 
 import SectionInfo from '../SectionInfo';
 import SectionSubheadline from '../SectionSubheadline';
 
+type SortableHighlightingRuleProps = {
+  item: { id: string, rule: HighlightingRuleType },
+  draggableProps: DraggableProvidedDraggableProps,
+  dragHandleProps: DraggableProvidedDragHandleProps,
+  className?: string,
+  ref: React.Ref<HTMLDivElement>
+}
+const SortableHighlightingRule = ({ item: { id, rule }, draggableProps, dragHandleProps, className, ref }: SortableHighlightingRuleProps) => (
+  <HighlightingRule key={id}
+                    rule={rule}
+                    dragHandleProps={dragHandleProps}
+                    draggableProps={draggableProps}
+                    className={className}
+                    ref={ref} />
+);
+
+SortableHighlightingRule.defaultProps = {
+  className: undefined,
+};
+
 const HighlightingRules = () => {
   const [showForm, setShowForm] = useState(false);
   const rules = useContext(HighlightingRulesContext) ?? [];
+  const rulesWithId = rules.map((rule) => ({ rule, id: `${rule.field}-${rule.value}-${rule.color}-${rule.condition}` }));
+  const dispatch = useAppDispatch();
+
+  const updateRules = useCallback((newRulesWithId: Array<{ id: string, rule: HighlightingRuleType }>) => {
+    const newRules = newRulesWithId.map(({ rule }) => rule);
+
+    return dispatch(updateHighlightingRules(newRules));
+  }, [dispatch]);
 
   return (
     <>
@@ -41,11 +74,13 @@ const HighlightingRules = () => {
       </SectionInfo>
       <SectionSubheadline>Active highlights <IconButton className="pull-right" name="plus" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
       {showForm && <HighlightForm onClose={() => setShowForm(false)} />}
-      <HighlightingRuleGrid>
+      <Container>
         <ColorPreview color={DEFAULT_HIGHLIGHT_COLOR} />
         <RuleContainer>Search terms</RuleContainer>
-      </HighlightingRuleGrid>
-      {rules.map((rule) => <HighlightingRule key={`${rule.field}-${rule.value}-${rule.color}-${rule.condition}`} rule={rule} />)}
+      </Container>
+      <SortableList items={rulesWithId}
+                    onMoveItem={updateRules}
+                    customListItemRender={SortableHighlightingRule} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -74,7 +74,7 @@ const HighlightingRules = () => {
       </SectionInfo>
       <SectionSubheadline>Active highlights <IconButton className="pull-right" name="plus" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
       {showForm && <HighlightForm onClose={() => setShowForm(false)} />}
-      <Container>
+      <Container $displayBorder={!!rulesWithId?.length}>
         <ColorPreview color={DEFAULT_HIGHLIGHT_COLOR} />
         <RuleContainer>Search terms</RuleContainer>
       </Container>

--- a/graylog2-web-interface/src/views/logic/slices/highlightActions.ts
+++ b/graylog2-web-interface/src/views/logic/slices/highlightActions.ts
@@ -24,59 +24,6 @@ import { updateViewState } from 'views/logic/slices/viewSlice';
 import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 import type { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
-export const addHighlightingRule = (rule: HighlightingRule) => async (dispatch: AppDispatch, getState: GetState) => {
-  const activeQuery = selectActiveQuery(getState());
-  const activeViewState = selectActiveViewState(getState());
-  const { formatting = FormattingSettings.empty() } = activeViewState;
-  const newFormatting = formatting.toBuilder()
-    .highlighting([...formatting.highlighting, rule])
-    .build();
-
-  const newViewState = activeViewState
-    .toBuilder()
-    .formatting(newFormatting)
-    .build();
-
-  return dispatch(updateViewState(activeQuery, newViewState));
-};
-
-export const addHighlightingRules = (rules: Array<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
-  const activeQuery = selectActiveQuery(getState());
-  const activeViewState = selectActiveViewState(getState());
-  const { formatting = FormattingSettings.empty() } = activeViewState;
-  const newFormatting = formatting.toBuilder()
-    .highlighting([...formatting.highlighting, ...rules])
-    .build();
-
-  const newViewState = activeViewState
-    .toBuilder()
-    .formatting(newFormatting)
-    .build();
-
-  return dispatch(updateViewState(activeQuery, newViewState));
-};
-
-export const createHighlightingRule = (field: string, value: any) => async (dispatch: AppDispatch) => {
-  const newRule = HighlightingRule.builder()
-    .field(field)
-    .value(value)
-    .color(randomColor())
-    .build();
-
-  return dispatch(addHighlightingRule(newRule));
-};
-
-export const createHighlightingRules = (rules: Array<{field: string, value: any, condition?: Condition, color?: StaticColor}>) => async (dispatch: AppDispatch) => {
-  const newRules = rules.map(({ field, value, color, condition }) => HighlightingRule.builder()
-    .field(field)
-    .value(value)
-    .condition(condition || 'equal')
-    .color(color || randomColor())
-    .build());
-
-  return dispatch(addHighlightingRules(newRules));
-};
-
 export const updateHighlightingRules = (rules: Array<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
   const activeQuery = selectActiveQuery(getState());
   const currentViewState = selectActiveViewState(getState());
@@ -102,6 +49,41 @@ export const updateHighlightingRule = (rule: HighlightingRule, payload: Partial<
   const newHighlightingRules = highlightingRules.map((currentRule) => (currentRule === rule ? newRule : currentRule));
 
   return dispatch(updateHighlightingRules(newHighlightingRules));
+};
+
+export const addHighlightingRule = (rule: HighlightingRule) => async (dispatch: AppDispatch, getState: GetState) => {
+  const activeViewState = selectActiveViewState(getState());
+  const { formatting = FormattingSettings.empty() } = activeViewState;
+
+  return dispatch(updateHighlightingRules([...formatting.highlighting, rule]));
+};
+
+export const addHighlightingRules = (rules: Array<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
+  const activeViewState = selectActiveViewState(getState());
+  const { formatting = FormattingSettings.empty() } = activeViewState;
+
+  return dispatch(updateHighlightingRules([...formatting.highlighting, ...rules]));
+};
+
+export const createHighlightingRule = (field: string, value: any) => async (dispatch: AppDispatch) => {
+  const newRule = HighlightingRule.builder()
+    .field(field)
+    .value(value)
+    .color(randomColor())
+    .build();
+
+  return dispatch(addHighlightingRule(newRule));
+};
+
+export const createHighlightingRules = (rules: Array<{field: string, value: any, condition?: Condition, color?: StaticColor}>) => async (dispatch: AppDispatch) => {
+  const newRules = rules.map(({ field, value, color, condition }) => HighlightingRule.builder()
+    .field(field)
+    .value(value)
+    .condition(condition || 'equal')
+    .color(color || randomColor())
+    .build());
+
+  return dispatch(addHighlightingRules(newRules));
 };
 
 export const removeHighlightingRule = (rule: HighlightingRule) => async (dispatch: AppDispatch, getState: GetState) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are implementing the option to sort highlighting rules. Sorting can be helpful when multiple rules relate to the same field, in this cases their order effects the resulting highlight.