### PR TITLE
Memorize state of time range tabs in time range picker.

### DIFF
--- a/changelog/unreleased/issue-11465.toml
+++ b/changelog/unreleased/issue-11465.toml
@@ -1,0 +1,6 @@
+type = "c"
+message = "Memorize state of time range tabs in time range picker while picker is open."
+
+issues = ["11465"]
+pulls = ["16107"]
+

--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -52,6 +52,8 @@ export const DEFAULT_RELATIVE_FROM = 300;
 export const DEFAULT_RELATIVE_TO = DEFAULT_RELATIVE_FROM - 60;
 export const DEFAULT_TIMERANGE: RelativeTimeRangeWithEnd = { type: DEFAULT_RANGE_TYPE, from: DEFAULT_RELATIVE_FROM };
 
+export const NO_TIMERANGE_OVERRIDE = {};
+
 export const DEFAULT_HIGHLIGHT_COLOR = StaticColor.create('#ffec3d');
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red'])
   .mode('lch')

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
@@ -26,6 +26,7 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import TimeRangeFilterSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import type { SupportedTimeRangeType } from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker';
 import TimeRangePicker from 'views/components/searchbar/time-range-filter/time-range-picker/index';
+import { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
 
 import TimeRangeFilterButtons from './TimeRangeFilterButtons';
 import TimeRangeDisplay from './TimeRangeDisplay';
@@ -46,7 +47,7 @@ type Props = {
   hasErrorOnMount?: boolean,
   limitDuration: number,
   noOverride?: boolean,
-  onChange: (nextTimeRange: TimeRange | NoTimeRangeOverride) => void,
+  onChange: (timeRange: TimeRange | NoTimeRangeOverride) => void,
   position?: 'bottom' | 'right',
   showPresetDropdown?: boolean,
   validTypes?: Array<SupportedTimeRangeType>,
@@ -57,7 +58,7 @@ const TimeRangeFilter = ({
   disabled,
   hasErrorOnMount,
   noOverride,
-  value = {},
+  value = NO_TIMERANGE_OVERRIDE,
   onChange,
   validTypes,
   position,

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
@@ -29,7 +29,7 @@ type Props = {
   disabled?: boolean,
   hasErrorOnMount?: boolean,
   onPresetSelectOpen: () => void,
-  setCurrentTimeRange: (nextTimeRange: TimeRange | NoTimeRangeOverride) => void,
+  setCurrentTimeRange: (timeRange: TimeRange | NoTimeRangeOverride) => void,
   toggleShow: () => void,
   showPresetDropdown?: boolean,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteCalendar.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteCalendar.test.tsx
@@ -22,7 +22,7 @@ import AbsoluteCalendar from './AbsoluteCalendar';
 
 const defaultProps = {
   disabled: false,
-  nextTimeRange: {
+  timeRange: {
     type: 'absolute',
     from: '1955-05-11 06:15:00',
     to: '1985-10-25 08:18:00',
@@ -30,7 +30,7 @@ const defaultProps = {
 } as const;
 
 const renderWithForm = (element) => render((
-  <Formik initialValues={{ nextTimeRange: defaultProps.nextTimeRange }}
+  <Formik initialValues={{ timeRangeTabs: { absolute: defaultProps.timeRange }, activeTab: 'absolute' }}
           onSubmit={() => {}}>
     <Form>
       {element}
@@ -57,7 +57,7 @@ describe('AbsoluteCalendar', () => {
   });
 
   it('renders `to` date', () => {
-    renderWithForm(<AbsoluteCalendar {...defaultProps} range="to" startDate={new Date(defaultProps.nextTimeRange.from)} />);
+    renderWithForm(<AbsoluteCalendar {...defaultProps} range="to" startDate={new Date(defaultProps.timeRange.from)} />);
 
     const monthYear = screen.getByText('October 1985');
     const inputHour = screen.getByRole('spinbutton', { name: /to hour/i });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteCalendar.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteCalendar.tsx
@@ -27,7 +27,7 @@ import AbsoluteTimeInput from './AbsoluteTimeInput';
 type Props = {
   startDate?: Date,
   range: 'to' | 'from',
-  nextTimeRange: AbsoluteTimeRange,
+  timeRange: AbsoluteTimeRange,
 };
 
 const ErrorMessage = styled.span(({ theme }) => css`
@@ -38,11 +38,11 @@ const ErrorMessage = styled.span(({ theme }) => css`
   height: 1.5em;
 `);
 
-const AbsoluteCalendar = ({ startDate, nextTimeRange, range }: Props) => (
-  <Field name={`nextTimeRange[${range}]`}>
+const AbsoluteCalendar = ({ startDate, timeRange, range }: Props) => (
+  <Field name={`timeRangeTabs.absolute.${range}`}>
     {({ field: { value, onChange, name }, meta: { error } }) => {
       const _onChange = (newValue) => onChange({ target: { name, value: newValue } });
-      const dateTime = error ? nextTimeRange[range] : value || nextTimeRange[range];
+      const dateTime = error ? timeRange[range] : value || timeRange[range];
 
       return (
         <>
@@ -62,7 +62,7 @@ const AbsoluteCalendar = ({ startDate, nextTimeRange, range }: Props) => (
 );
 
 AbsoluteCalendar.propTypes = {
-  nextTimeRange: PropTypes.shape({ from: PropTypes.string, to: PropTypes.string }).isRequired,
+  timeRange: PropTypes.shape({ from: PropTypes.string, to: PropTypes.string }).isRequired,
   startDate: PropTypes.instanceOf(Date),
   range: PropTypes.oneOf(['to', 'from']).isRequired,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteTimestamp.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteTimestamp.tsx
@@ -26,7 +26,7 @@ import AbsoluteDateInput from './AbsoluteDateInput';
 type Props = {
   disabled: boolean,
   range: 'to' | 'from',
-  nextTimeRange: AbsoluteTimeRange,
+  timeRange: AbsoluteTimeRange,
 };
 
 const ErrorMessage = styled.span(({ theme }) => css`
@@ -37,11 +37,11 @@ const ErrorMessage = styled.span(({ theme }) => css`
   height: 1.5em;
 `);
 
-const AbsoluteTimestamp = ({ disabled, nextTimeRange, range }: Props) => (
-  <Field name={`nextTimeRange[${range}]`}>
+const AbsoluteTimestamp = ({ disabled, timeRange, range }: Props) => (
+  <Field name={`timeRangeTabs.absolute.${range}`}>
     {({ field: { value, onChange, name }, meta: { error } }) => {
       const _onChange = (newValue) => onChange({ target: { name, value: newValue } });
-      const dateTime = error ? nextTimeRange[range] : value || nextTimeRange[range];
+      const dateTime = error ? timeRange[range] : value || timeRange[range];
 
       return (
         <>
@@ -59,7 +59,7 @@ const AbsoluteTimestamp = ({ disabled, nextTimeRange, range }: Props) => (
 
 AbsoluteTimestamp.propTypes = {
   disabled: PropTypes.bool,
-  nextTimeRange: PropTypes.shape({ from: PropTypes.string, to: PropTypes.string }).isRequired,
+  timeRange: PropTypes.shape({ from: PropTypes.string, to: PropTypes.string }).isRequired,
   range: PropTypes.oneOf(['to', 'from']).isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/RelativeRangeSelect.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/RelativeRangeSelect.tsx
@@ -159,9 +159,9 @@ const RelativeRangeSelectInner = ({
 
   const _onUnsetRange = (event) => {
     const isUnsetting = event.target.checked;
-    const hasInitialRelativeRange = isTypeRelativeClassified(initialValues.nextTimeRange);
-    const _defaultRange = (hasInitialRelativeRange && !initialValues.nextTimeRange[fieldName].isAllTime)
-      ? initialValues.nextTimeRange[fieldName]
+    const hasInitialRelativeRange = isTypeRelativeClassified(initialValues.timeRangeTabs.relative);
+    const _defaultRange = (hasInitialRelativeRange && !initialValues.timeRangeTabs.relative?.[fieldName].isAllTime)
+      ? initialValues.timeRangeTabs.relative[fieldName]
       : defaultRange;
 
     if (isUnsetting && !!onUnsetRange) {
@@ -223,7 +223,7 @@ const RelativeRangeSelect = ({
   title,
   unsetRangeLabel,
 }: Props) => (
-  <Field name={`nextTimeRange.${fieldName}`}>
+  <Field name={`timeRangeTabs.relative.${fieldName}`}>
     {({ field: { value, onChange, name }, meta: { error } }) => (
       <RelativeRangeSelectInner classifiedRange={value}
                                 defaultRange={defaultRange}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.test.tsx
@@ -22,7 +22,7 @@ import TabAbsoluteTimeRange from './TabAbsoluteTimeRange';
 
 const defaultProps = {
   disabled: false,
-  nextTimeRange: {
+  timeRange: {
     type: 'absolute',
     from: '1955-05-11 06:15:00.000',
     to: '1985-10-25 08:18:00.000',
@@ -30,7 +30,7 @@ const defaultProps = {
 } as const;
 
 const renderWithForm = (element) => render((
-  <Formik initialValues={{ nextTimeRange: defaultProps.nextTimeRange }}
+  <Formik initialValues={{ timeRangeTabs: { absolute: defaultProps.timeRange }, activeTab: 'absolute' }}
           onSubmit={() => {}}>
     <Form>
       {element}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabAbsoluteTimeRange.tsx
@@ -22,7 +22,6 @@ import moment from 'moment';
 import { useFormikContext } from 'formik';
 
 import { Icon, Accordion, AccordionItem } from 'components/common';
-import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
 
 import AbsoluteCalendar from './AbsoluteCalendar';
@@ -76,10 +75,12 @@ const FlexWrap = styled.div`
 `;
 
 const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
-  const { values: { nextTimeRange } } = useFormikContext<TimeRangePickerFormValues & { nextTimeRange: AbsoluteTimeRange }>();
+  const { values: { timeRangeTabs } } = useFormikContext<TimeRangePickerFormValues>();
+  const activeTabTimeRange = timeRangeTabs.absolute;
+
   const { toUserTimezone } = useUserDateTime();
   const [activeAccordion, setActiveAccordion] = useState<'Timestamp' | 'Calendar' | undefined>();
-  const toStartDate = moment(nextTimeRange.from).toDate();
+  const toStartDate = moment(activeTabTimeRange.from).toDate();
   const fromStartDate = limitDuration ? toUserTimezone(new Date()).seconds(-limitDuration).toDate() : undefined;
 
   const handleSelect = (nextKey: 'Timestamp' | 'Calendar' | undefined) => {
@@ -97,7 +98,7 @@ const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
         <AccordionItem name="Calendar">
           <RangeWrapper>
             <AbsoluteCalendar startDate={fromStartDate}
-                              nextTimeRange={nextTimeRange}
+                              timeRange={activeTabTimeRange}
                               range="from" />
 
           </RangeWrapper>
@@ -108,7 +109,7 @@ const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
 
           <RangeWrapper>
             <AbsoluteCalendar startDate={toStartDate}
-                              nextTimeRange={nextTimeRange}
+                              timeRange={activeTabTimeRange}
                               range="to" />
           </RangeWrapper>
         </AccordionItem>
@@ -119,7 +120,7 @@ const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
             <FlexWrap>
               <RangeWrapper>
                 <AbsoluteTimestamp disabled={disabled}
-                                   nextTimeRange={nextTimeRange}
+                                   timeRange={activeTabTimeRange}
                                    range="from" />
               </RangeWrapper>
 
@@ -129,7 +130,7 @@ const TabAbsoluteTimeRange = ({ disabled, limitDuration }: Props) => {
 
               <RangeWrapper>
                 <AbsoluteTimestamp disabled={disabled}
-                                   nextTimeRange={nextTimeRange}
+                                   timeRange={activeTabTimeRange}
                                    range="to" />
               </RangeWrapper>
             </FlexWrap>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
@@ -29,7 +29,7 @@ jest.mock('stores/tools/ToolsStore', () => ({
 }));
 
 const TabKeywordTimeRange = ({ defaultValue, ...props }: { defaultValue: string } & React.ComponentProps<typeof TabKeywordTimeRange>) => (
-  <Formik initialValues={{ nextTimeRange: { type: 'keyword', keyword: defaultValue } }}
+  <Formik initialValues={{ timeRangeTabs: { keyword: { type: 'keyword', keyword: defaultValue } }, activeTab: 'keyword' }}
           onSubmit={() => {}}
           validateOnMount>
     <Form>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -68,7 +68,6 @@ type Props = {
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
   const [nextRangeProps, , nextRangeHelpers] = useField('timeRangeTabs.keyword');
-  console.log(nextRangeProps);
   const mounted = useRef(true);
   const keywordRef = useRef<string>();
   const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '', timezone: '' });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -67,12 +67,13 @@ type Props = {
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
-  const [nextRangeProps, , nextRangeHelpers] = useField('nextTimeRange');
+  const [nextRangeProps, , nextRangeHelpers] = useField('timeRangeTabs.keyword');
+  console.log(nextRangeProps);
   const mounted = useRef(true);
   const keywordRef = useRef<string>();
   const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '', timezone: '' });
 
-  const _setSuccessfullPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
+  const _setSuccessfulPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
     setValidatingKeyword(false);
 
     return setKeywordPreview(_parseKeywordPreview(response, formatTime));
@@ -99,13 +100,13 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
         ? Promise.resolve('Keyword must not be empty!')
         : ToolsStore.testNaturalDate(keyword, userTimezone)
           .then((response) => {
-            if (mounted.current) _setSuccessfullPreview(response);
+            if (mounted.current) _setSuccessfulPreview(response);
           })
           .catch(_setFailedPreview);
     }
 
     return undefined;
-  }, [_setFailedPreview, _setSuccessfullPreview, setValidatingKeyword, userTimezone]);
+  }, [_setFailedPreview, _setSuccessfulPreview, setValidatingKeyword, userTimezone]);
 
   useEffect(() => () => {
     mounted.current = false;
@@ -134,7 +135,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
     <Row className="no-bm">
       <Col sm={5}>
         <Headline>Time range:</Headline>
-        <Field name="nextTimeRange.keyword" validate={_validateKeyword}>
+        <Field name="timeRangeTabs.keyword.keyword" validate={_validateKeyword}>
           {({ field: { name, value, onChange }, meta: { error } }) => (
             <FormGroup controlId="form-inline-keyword"
                        style={{ marginRight: 5, width: '100%', marginBottom: 0 }}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.test.tsx
@@ -37,15 +37,18 @@ const defaultProps = {
 };
 
 const initialValues = {
-  nextTimeRange: {
-    type: 'relative',
-    from: {
-      value: 1,
-      unit: 'hours',
-      isAllTime: false,
+  timeRangeTabs: {
+    relative: {
+      type: 'relative',
+      from: {
+        value: 1,
+        unit: 'hours',
+        isAllTime: false,
+      },
+      to: RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
     },
-    to: RELATIVE_CLASSIFIED_ALL_TIME_RANGE,
   },
+  activeTab: 'relative',
 };
 
 const renderSUT = (allProps = defaultProps, initialFormValues = initialValues) => render(
@@ -89,21 +92,24 @@ describe('TabRelativeTimeRange', () => {
 
   it('renders initial time range with from and to value', async () => {
     const initialFormValues = {
-      ...initialValues,
-      nextTimeRange: {
-        ...initialValues.nextTimeRange,
-        from: {
-          value: 5,
-          unit: 'minutes',
-          isAllTime: false,
-        },
-        to: {
-          value: 4,
-          unit: 'minutes' as const,
-          isAllTime: false,
+      activeTab: 'relative',
+      timeRangeTabs: {
+        relative: {
+          type: 'relative',
+          from: {
+            value: 5,
+            unit: 'minutes',
+            isAllTime: false,
+          },
+          to: {
+            value: 4,
+            unit: 'minutes' as const,
+            isAllTime: false,
+          },
         },
       },
     };
+
     renderSUT(undefined, initialFormValues);
 
     expect((await screen.findByRole('spinbutton', { name: /Set the from value/i }) as HTMLInputElement).value).toBe('5');

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabRelativeTimeRange.tsx
@@ -48,8 +48,9 @@ const StyledIcon = styled(Icon)`
 `;
 
 const TabRelativeTimeRange = ({ disabled, limitDuration }: Props) => {
-  const { values: { nextTimeRange }, setFieldValue } = useFormikContext<TimeRangePickerFormValues>();
-  const disableUntil = disabled || (isTypeRelativeWithEnd(nextTimeRange) && nextTimeRange.from === RELATIVE_ALL_TIME);
+  const { values: { timeRangeTabs }, setFieldValue } = useFormikContext<TimeRangePickerFormValues>();
+  const activeTabTimeRange = timeRangeTabs.relative;
+  const disableUntil = disabled || (isTypeRelativeWithEnd(activeTabTimeRange) && activeTabTimeRange.from === RELATIVE_ALL_TIME);
 
   return (
     <div>
@@ -60,7 +61,7 @@ const TabRelativeTimeRange = ({ disabled, limitDuration }: Props) => {
                                disabled={disabled}
                                fieldName="from"
                                limitDuration={limitDuration}
-                               onUnsetRange={() => { setFieldValue('nextTimeRange.to', RELATIVE_CLASSIFIED_ALL_TIME_RANGE); }}
+                               onUnsetRange={() => { setFieldValue('timeRangeTabs.relative.to', RELATIVE_CLASSIFIED_ALL_TIME_RANGE); }}
                                title="From:"
                                unsetRangeLabel="All Time" />
           <StyledIcon name="arrow-right" />

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.test.tsx
@@ -51,7 +51,7 @@ jest.mock('stores/configurations/ConfigurationsStore', () => {
 
 describe('TimeRangeAddToQuickListButton', () => {
   const SUT = ({ timeRange }: { timeRange: TimeRange }) => (
-    <Formik initialValues={{ nextTimeRange: timeRange }} onSubmit={() => {}}>
+    <Formik initialValues={{ timeRangeTabs: { [timeRange.type]: timeRange }, activeTab: timeRange.type }} onSubmit={() => {}}>
       <Form>
         <TimeRangeAddToQuickListButton />
       </Form>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -71,9 +71,11 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target } : Pro
 
   const equalTimerange = useMemo(() => (config
     ?.quick_access_timerange_presets
-    ?.find((existingTimerange) => isTimerangeEqual(
-      existingTimerange.timerange,
-      normalizeFromSearchBarForBackend((activeTabTimeRange ?? {}) as TimeRange, userTimezone),
+    ?.find((existingPreset) => isTimerangeEqual(
+      existingPreset.timerange,
+      normalizeFromSearchBarForBackend((
+        normalizeFromPickerForSearchBar(activeTabTimeRange)
+      ) as TimeRange, userTimezone),
     ))), [config, activeTabTimeRange, userTimezone]);
 
   const onAddTimerange = useCallback(() => addTimerange(description), [addTimerange, description]);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton.tsx
@@ -31,7 +31,6 @@ import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
-import type { TimeRangePreset } from 'components/configurations/TimeRangePresetForm';
 import generateId from 'logic/generateId';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import type {
@@ -41,6 +40,7 @@ import {
   normalizeFromPickerForSearchBar,
   normalizeFromSearchBarForBackend,
 } from 'views/logic/queries/NormalizeTimeRange';
+import { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
 
 const StyledModalSubmit = styled(ModalSubmit)`
   margin-top: 15px;
@@ -50,7 +50,6 @@ type Props = {
   addTimerange: (title: string) => void,
   toggleModal: () => void,
   target: Button | undefined | null,
-  equalTimerange: TimeRangePreset
 };
 
 const isTimerangeEqual = (firstTimerange: TimeRange, secondTimerange: TimeRange) => {
@@ -60,9 +59,22 @@ const isTimerangeEqual = (firstTimerange: TimeRange, secondTimerange: TimeRange)
   return isEqual(firstTimerange, secondTimerange);
 };
 
-const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target, equalTimerange } : Props) => {
+const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target } : Props) => {
+  const { userTimezone } = useUserDateTime();
+  const { config } = useSearchConfiguration();
+  const { values: { timeRangeTabs, activeTab } } = useFormikContext<TimeRangePickerFormValues>();
+
   const [description, setDescription] = useState('');
   const debounceHandleOnChangeDescription = debounce((value: string) => setDescription(value), 300);
+
+  const activeTabTimeRange = timeRangeTabs[activeTab];
+
+  const equalTimerange = useMemo(() => (config
+    ?.quick_access_timerange_presets
+    ?.find((existingTimerange) => isTimerangeEqual(
+      existingTimerange.timerange,
+      normalizeFromSearchBarForBackend((activeTabTimeRange ?? {}) as TimeRange, userTimezone),
+    ))), [config, activeTabTimeRange, userTimezone]);
 
   const onAddTimerange = useCallback(() => addTimerange(description), [addTimerange, description]);
 
@@ -107,14 +119,15 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target, equalT
 
 const TimeRangeAddToQuickListButton = () => {
   const { userTimezone } = useUserDateTime();
-  const { values, errors } = useFormikContext<TimeRangePickerFormValues>();
+  const { values: { timeRangeTabs, activeTab }, errors } = useFormikContext<TimeRangePickerFormValues>();
   const formTarget = useRef();
+  const activeTabTimeRange = timeRangeTabs[activeTab];
 
   const { config, refresh } = useSearchConfiguration();
   const [showForm, setShowForm] = useState(false);
   const sendTelemetry = useSendTelemetry();
 
-  const isValidTimeRange = !errors.nextTimeRange;
+  const isValidTimeRange = !errors.timeRangeTabs?.[activeTab];
 
   const toggleModal = useCallback(() => {
     setShowForm((cur) => !cur);
@@ -123,7 +136,7 @@ const TimeRangeAddToQuickListButton = () => {
   const addTimerange = useCallback((description: string) => {
     const timeRangePreset = {
       description,
-      timerange: normalizeFromSearchBarForBackend(normalizeFromPickerForSearchBar(values.nextTimeRange) as TimeRange, userTimezone),
+      timerange: activeTabTimeRange ? normalizeFromSearchBarForBackend(normalizeFromPickerForSearchBar(activeTabTimeRange) as TimeRange, userTimezone) : NO_TIMERANGE_OVERRIDE,
       id: generateId(),
     };
 
@@ -149,14 +162,7 @@ const TimeRangeAddToQuickListButton = () => {
         },
       });
     }
-  }, [config, refresh, sendTelemetry, values.nextTimeRange, toggleModal, userTimezone]);
-
-  const equalTimerange = useMemo(() => config
-    ?.quick_access_timerange_presets
-    ?.find((existingTimerange) => isTimerangeEqual(
-      existingTimerange.timerange,
-      normalizeFromSearchBarForBackend(values.nextTimeRange as TimeRange, userTimezone),
-    )), [config, values.nextTimeRange, userTimezone]);
+  }, [config, refresh, sendTelemetry, activeTabTimeRange, toggleModal, userTimezone]);
 
   return (
     <>
@@ -170,8 +176,7 @@ const TimeRangeAddToQuickListButton = () => {
       {showForm && (
         <TimeRangeAddToQuickListForm addTimerange={addTimerange}
                                      toggleModal={toggleModal}
-                                     target={formTarget.current}
-                                     equalTimerange={equalTimerange} />
+                                     target={formTarget.current} />
       )}
     </>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
@@ -25,7 +25,6 @@ import { Tab, Tabs } from 'components/bootstrap';
 import type {
   AbsoluteTimeRange,
   KeywordTimeRange,
-  TimeRange,
   RelativeTimeRange,
 } from 'views/logic/queries/Query';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -114,6 +113,30 @@ type Props = {
   setValidatingKeyword: (validating: boolean) => void,
 };
 
+const newTabTimeRange = ({
+  activeTab,
+  nextTab,
+  timeRangeTabs,
+  formatTime,
+  defaultRanges,
+} : {
+  activeTab: TimeRangePickerFormValues['activeTab'],
+  nextTab: TimeRangePickerFormValues['activeTab'],
+  timeRangeTabs: TimeRangePickerFormValues['timeRangeTabs'],
+  formatTime: (time: DateTime, format: DateTimeFormats) => string,
+  defaultRanges: ReturnType<typeof createDefaultRanges>,
+}) => {
+  if (timeRangeTabs[nextTab]) {
+    return timeRangeTabs[nextTab];
+  }
+
+  if (isTimeRange(timeRangeTabs[activeTab])) {
+    return migrateTimeRangeToNewType(timeRangeTabs[activeTab], nextTab, formatTime);
+  }
+
+  return defaultRanges[nextTab];
+};
+
 const TimeRangeTabs = ({
   limitDuration,
   validTypes,
@@ -121,16 +144,23 @@ const TimeRangeTabs = ({
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const { formatTime } = useUserDateTime();
-  const { setFieldValue, values: { nextTimeRange } } = useFormikContext<TimeRangePickerFormValues>();
+  const { setValues, values: { activeTab, timeRangeTabs } } = useFormikContext<TimeRangePickerFormValues>();
   const defaultRanges = useMemo(() => createDefaultRanges(formatTime), [formatTime]);
-  const activeTab = isTimeRange(nextTimeRange) ? nextTimeRange.type : undefined;
 
   const onSelect = useCallback((nextTab: AbsoluteTimeRange['type'] | RelativeTimeRange['type'] | KeywordTimeRange['type']) => {
-    if ('type' in nextTimeRange) {
-      setFieldValue('nextTimeRange', migrateTimeRangeToNewType(nextTimeRange as TimeRange, nextTab, formatTime));
-    } else {
-      setFieldValue('nextTimeRange', defaultRanges[nextTab]);
-    }
+    setValues({
+      timeRangeTabs: {
+        ...timeRangeTabs,
+        [nextTab]: newTabTimeRange({
+          activeTab,
+          nextTab,
+          timeRangeTabs,
+          formatTime,
+          defaultRanges,
+        }),
+      },
+      activeTab: nextTab,
+    });
 
     sendTelemetry('click', {
       app_pathname: 'search',
@@ -140,7 +170,7 @@ const TimeRangeTabs = ({
         tab: nextTab,
       },
     });
-  }, [defaultRanges, formatTime, nextTimeRange, sendTelemetry, setFieldValue]);
+  }, [activeTab, defaultRanges, formatTime, sendTelemetry, setValues, timeRangeTabs]);
 
   const tabs = useMemo(() => timeRangeTypeTabs({
     activeTab,

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
@@ -16,7 +16,7 @@
  */
 
 import * as React from 'react';
-import { useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import { useFormikContext } from 'formik';
 import styled from 'styled-components';
 
@@ -51,15 +51,23 @@ const normalizePresetTimeRange = (timeRange: TimeRange) => {
 const TimeRangePresetRow = () => {
   const { showAddToQuickListButton } = useContext(TimeRangeInputSettingsContext);
   const { showPresetsButton } = useContext(TimeRangeInputSettingsContext);
-  const { setFieldValue, values } = useFormikContext<TimeRangePickerFormValues>();
+  const { values, setValues } = useFormikContext<TimeRangePickerFormValues>();
+  const { activeTab, timeRangeTabs } = values;
 
-  const onSetPreset = (newTimeRange: TimeRange) => {
-    setFieldValue('nextTimeRange', normalizePresetTimeRange(newTimeRange));
-  };
+  const onSetPreset = useCallback((newTimeRange: TimeRange) => {
+    setValues({
+      ...values,
+      timeRangeTabs: {
+        ...values.timeRangeTabs,
+        [newTimeRange.type]: normalizePresetTimeRange(newTimeRange),
+      },
+      activeTab: newTimeRange.type,
+    });
+  }, [setValues, values]);
 
   return (
     <Container>
-      {showAddToQuickListButton && isTimeRange(values.nextTimeRange) && (
+      {showAddToQuickListButton && isTimeRange(timeRangeTabs[activeTab]) && (
         <IfPermitted permissions="clusterconfigentry:edit">
           <TimeRangeAddToQuickListButton />
         </IfPermitted>

--- a/graylog2-web-interface/src/views/logic/queries/NormalizeTimeRange.ts
+++ b/graylog2-web-interface/src/views/logic/queries/NormalizeTimeRange.ts
@@ -16,16 +16,17 @@
  */
 
 import isAllMessagesRange from 'views/logic/queries/IsAllMessagesRange';
-import { RELATIVE_ALL_TIME } from 'views/Constants';
+import { NO_TIMERANGE_OVERRIDE, RELATIVE_ALL_TIME } from 'views/Constants';
 import {
   normalizeIfClassifiedRelativeTimeRange,
 } from 'views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper';
 import { isTypeKeyword, isTypeRelativeWithEnd, isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
 import { adjustFormat, toUTCFromTz } from 'util/DateTime';
+import type { TimeRangePickerTimeRange } from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker';
 
 import type { TimeRange, NoTimeRangeOverride } from './Query';
 
-export const normalizeIfAllMessagesRange = (timeRange: TimeRange | NoTimeRangeOverride) => {
+export const normalizeIfAllMessagesRange = (timeRange: TimeRange | NoTimeRangeOverride | undefined) => {
   if ('type' in timeRange && isAllMessagesRange(timeRange)) {
     return {
       type: timeRange.type,
@@ -36,7 +37,11 @@ export const normalizeIfAllMessagesRange = (timeRange: TimeRange | NoTimeRangeOv
   return timeRange;
 };
 
-export const normalizeFromPickerForSearchBar = (timeRange: TimeRange | NoTimeRangeOverride) => {
+export const normalizeFromPickerForSearchBar = (timeRange: TimeRangePickerTimeRange | undefined) => {
+  if (!timeRange) {
+    return NO_TIMERANGE_OVERRIDE;
+  }
+
   const normalizeIfKeywordTimeRange = (tr: TimeRange | NoTimeRangeOverride) => {
     if (isTypeKeyword(tr)) {
       return {

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -19,6 +19,7 @@ import * as Immutable from 'immutable';
 import isDeepEqual from 'stores/isDeepEqual';
 import generateId from 'logic/generateId';
 import type { FiltersType } from 'views/types';
+import type { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
 
 import type { SearchType } from './SearchType';
 
@@ -121,7 +122,7 @@ export type KeywordTimeRange = {
 
 export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
 
-export type NoTimeRangeOverride = {};
+export type NoTimeRangeOverride = typeof NO_TIMERANGE_OVERRIDE;
 
 const isNullish = (o: any) => (o === null || o === undefined);
 

--- a/graylog2-web-interface/src/views/typeGuards/timeRange.ts
+++ b/graylog2-web-interface/src/views/typeGuards/timeRange.ts
@@ -38,4 +38,4 @@ export const isTypeKeyword = (timeRange: TimeRange | NoTimeRangeOverride): timeR
 
 export const isNoTimeRangeOverride = (timeRange: TimeRange | NoTimeRangeOverride): timeRange is NoTimeRangeOverride => timeRange !== undefined && isEqual(timeRange, {});
 
-export const isTimeRange = (timeRange: TimeRange | NoTimeRangeOverride): timeRange is TimeRange => !isNoTimeRangeOverride(timeRange);
+export const isTimeRange = (timeRange: TimeRange | NoTimeRangeOverride): timeRange is TimeRange => timeRange && 'type' in timeRange;


### PR DESCRIPTION
**Please note:** This PR is based on https://github.com/Graylog2/graylog2-server/pull/16063 which needs to be merged first.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change we are memorising the state of time range tabs. As described in #11465 the current behaviour can be problematic in some scenarios. For example when you have a search with an absolute time range, you open the time range picker, switch to the relative tab and go back to the absolute tab. In this case the previous state of the absolute tab has not been memorised.

With this PR the state will be memorised, until you close the time range picker. 

Fixes: #11465