### PR TITLE
Additional Logging of SearchServer logs if the GL container fails to start due to timeouts.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -64,12 +64,11 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
                         int[] extraPorts, List<URL> mongoDBFixtures,
                         PluginJarsProvider pluginJarsProvider, MavenProjectDirProvider mavenProjectDirProvider,
                         List<String> enabledFeatureFlags, boolean preImportLicense, boolean withMailServerEnabled) {
-
         final var network = Network.newNetwork();
         final var builder = SearchServerInstanceProvider.getBuilderFor(version).orElseThrow(() -> new UnsupportedOperationException("Search version " + version + " not supported."));
 
         MongoDBInstance mongoDB = MongoDBInstance.createStartedWithUniqueName(network, Lifecycle.CLASS, mongodbVersion);
-        if(withMailServerEnabled) {
+        if (withMailServerEnabled) {
             this.emailServerInstance = MailServerContainer.createStarted(network);
         }
         mongoDB.dropDatabase();
@@ -77,27 +76,32 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
 
         SearchServerInstance searchServer = builder.network(network).featureFlags(enabledFeatureFlags).build();
 
-        if(preImportLicense) {
+        if (preImportLicense) {
             createLicenses(mongoDB, "GRAYLOG_LICENSE_STRING", "GRAYLOG_SECURITY_LICENSE_STRING");
         }
 
-        NodeInstance node = NodeInstance.createStarted(
-                network,
-                MongoDBInstance.internalUri(),
-                searchServer.internalUri(),
-                searchServer.version(),
-                extraPorts,
-                pluginJarsProvider, mavenProjectDirProvider,
-                enabledFeatureFlags);
-        this.network = network;
-        this.searchServer = searchServer;
-        this.mongodb = mongoDB;
-        this.node = node;
+        try {
+            NodeInstance node = NodeInstance.createStarted(
+                    network,
+                    MongoDBInstance.internalUri(),
+                    searchServer.internalUri(),
+                    searchServer.version(),
+                    extraPorts,
+                    pluginJarsProvider, mavenProjectDirProvider,
+                    enabledFeatureFlags);
+            this.network = network;
+            this.searchServer = searchServer;
+            this.mongodb = mongoDB;
+            this.node = node;
 
-        // ensure that all containers and networks will be removed after all tests finish
-        // We can't close the resources in an afterAll callback, as the instances are cached and reused
-        // so we need a solution that will be triggered only once after all test classes
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+            // ensure that all containers and networks will be removed after all tests finish
+            // We can't close the resources in an afterAll callback, as the instances are cached and reused
+            // so we need a solution that will be triggered only once after all test classes
+            Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        } catch (Exception ex) {
+            // if the graylog Node is not coming up (because OpenSearch hangs?) it fails here. So in this case, we also log the search server logs
+            LOG.error("------------------------------ Search Server logs: --------------------------------------\n{}", searchServer.getLogs());
+        }
     }
 
     private void createLicenses(final MongoDBInstance mongoDBInstance, final String... licenseStrs) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
/nocl

Sometimes the Graylog Container for full backend tests is failing to start but the problem is probably in the Search Server container. So we log the logs of the other container additionally for now until we find the real problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

