### PR TITLE
Improve the way we display fetch errors in the preflight UI.

### DIFF
--- a/graylog2-web-interface/src/preflight/App.test.tsx
+++ b/graylog2-web-interface/src/preflight/App.test.tsx
@@ -15,17 +15,18 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { screen, renderPreflight, waitFor } from 'wrappedTestingLibrary';
+import { screen, renderPreflight, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
 import fetch from 'logic/rest/FetchProvider';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import { asMock } from 'helpers/mocking';
 import UserNotification from 'preflight/util/UserNotification';
+import suppressConsole from 'helpers/suppressConsole';
 
 import App from './App';
 
-jest.mock('logic/rest/FetchProvider', () => jest.fn());
+jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve({})));
 
 jest.mock('util/AppConfig', () => ({
   gl2ServerUrl: () => 'https://example.org/',
@@ -58,6 +59,14 @@ describe('App', () => {
   let windowConfirm;
   let windowLocation;
 
+  const startupButton = async () => {
+    const welcomeSection = await screen.findByTestId('welcome-section');
+
+    return within(welcomeSection).getByRole('button', {
+      name: /resume startup/i,
+    });
+  };
+
   beforeAll(() => {
     windowConfirm = window.confirm;
     window.confirm = jest.fn(() => true);
@@ -86,12 +95,8 @@ describe('App', () => {
   it('should resume startup and display loading page', async () => {
     renderPreflight(<App />);
 
-    const resumeStartupButton = await screen.findByRole('button', {
-      name: /resume startup/i,
-    });
-
+    const resumeStartupButton = await startupButton();
     userEvent.click(resumeStartupButton);
-
     await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/finish-config'), undefined, false));
     await screen.findByText(/The Graylog server is currently starting./);
   });
@@ -106,10 +111,7 @@ describe('App', () => {
 
     renderPreflight(<App />);
 
-    const resumeStartupButton = screen.getByRole('button', {
-      name: /resume startup/i,
-    });
-
+    const resumeStartupButton = await startupButton();
     userEvent.click(resumeStartupButton);
 
     await waitFor(() => expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to resume startup without a running Graylog data node?'));
@@ -121,11 +123,10 @@ describe('App', () => {
 
     renderPreflight(<App />);
 
-    const resumeStartupButton = screen.getByRole('button', {
-      name: /resume startup/i,
+    suppressConsole(async () => {
+      const resumeStartupButton = await startupButton();
+      userEvent.click(resumeStartupButton);
     });
-
-    userEvent.click(resumeStartupButton);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/finish-config'), undefined, false));
     await waitFor(() => expect(UserNotification.error).toHaveBeenCalledWith('Resuming startup failed with error: Error: Unexpected error!', 'Could not resume startup'));

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.test.tsx
@@ -40,21 +40,21 @@ jest.mock('preflight/hooks/useDataNodesCA', () => jest.fn(() => ({
 
 describe('ConfigurationWizard', () => {
   it('should show CA configuration step', async () => {
-    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CA_CONFIGURATION.key, isLoading: false });
+    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CA_CONFIGURATION.key, isLoading: false, errors: null });
     renderPreflight(<ConfigurationWizard setIsWaitingForStartup={() => {}} />);
 
     await screen.findByText(/In this first step you can either upload or create a new certificate authority./);
   });
 
   it('should show CA provisioning step', async () => {
-    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key, isLoading: false });
+    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key, isLoading: false, errors: null });
     renderPreflight(<ConfigurationWizard setIsWaitingForStartup={() => {}} />);
 
     await screen.findByText(/Certificate authority has been configured successfully./);
   });
 
   it('should show success step', async () => {
-    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key, isLoading: false });
+    asMock(useConfigurationStep).mockReturnValue({ step: CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key, isLoading: false, errors: null });
     renderPreflight(<ConfigurationWizard setIsWaitingForStartup={() => {}} />);
 
     await screen.findByText(/The provisioning has been successful and all data nodes are secured and reachable./);

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/ConfigurationWizard.tsx
@@ -24,11 +24,12 @@ import { CONFIGURATION_STEPS, CONFIGURATION_STEPS_ORDER } from 'preflight/Consta
 import type { IconName } from 'components/common/Icon';
 import Icon from 'components/common/Icon';
 import Spinner from 'components/common/Spinner';
-import { List, Grid, Space } from 'preflight/components/common';
+import { List, Grid, Space, Alert } from 'preflight/components/common';
 import RenewalPolicyConfiguration from 'preflight/components/ConfigurationWizard/RenewalPolicyConfiguration';
 import type { ConfigurationStep } from 'preflight/types';
 import ResumeStartupButton from 'preflight/components/ResumeStartupButton';
 import RestartConfigurationButton from 'preflight/components/RestartConfigurationButton';
+import type FetchError from 'logic/errors/FetchError';
 
 import CertificateProvisioning from './CertificateProvisioning';
 import CAConfiguration from './CAConfiguration';
@@ -70,13 +71,27 @@ const stepIcon = (stepKey: ConfigurationStep, activeStepKey: ConfigurationStep, 
   };
 };
 
+type FetchErrorsOverviewProps = {
+  errors: Array<{ entityName: string, error: FetchError}> | null
+}
+
+const FetchErrorsOverview = ({ errors }: FetchErrorsOverviewProps) => (
+  <>
+    {errors.map(({ entityName, error }) => (
+      <Alert type="danger" key={entityName}>
+        There was an error fetching the {entityName}: {error.message}
+      </Alert>
+    ))}
+  </>
+);
+
 type Props = {
   setIsWaitingForStartup: React.Dispatch<React.SetStateAction<boolean>>,
 }
 
 const ConfigurationWizard = ({ setIsWaitingForStartup }: Props) => {
   const [isSkippingProvisioning, setIsSkippingProvisioning] = useState(false);
-  const { step: activeStepKey, isLoading: isLoadingConfigurationStep } = useConfigurationStep({ isSkippingProvisioning });
+  const { step: activeStepKey, isLoading: isLoadingConfigurationStep, errors } = useConfigurationStep({ isSkippingProvisioning });
   const theme = useTheme();
 
   const onSkipProvisioning = useCallback(() => {
@@ -85,6 +100,10 @@ const ConfigurationWizard = ({ setIsWaitingForStartup }: Props) => {
 
   if (isLoadingConfigurationStep) {
     return <Spinner />;
+  }
+
+  if (errors?.length) {
+    return <FetchErrorsOverview errors={errors} />;
   }
 
   return (
@@ -127,9 +146,9 @@ const ConfigurationWizard = ({ setIsWaitingForStartup }: Props) => {
         {activeStepKey === CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key && <RenewalPolicyConfiguration />}
         {activeStepKey === CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key && <CertificateProvisioning onSkipProvisioning={onSkipProvisioning} />}
         {activeStepKey === CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key && (
-        <ConfigurationFinished setIsWaitingForStartup={setIsWaitingForStartup}
-                               isSkippingProvisioning={isSkippingProvisioning}
-                               setIsSkippingProvisioning={setIsSkippingProvisioning} />
+          <ConfigurationFinished setIsWaitingForStartup={setIsWaitingForStartup}
+                                 isSkippingProvisioning={isSkippingProvisioning}
+                                 setIsSkippingProvisioning={setIsSkippingProvisioning} />
         )}
       </Grid.Col>
     </Grid>

--- a/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
@@ -20,7 +20,6 @@ import { renderPreflight, screen } from 'wrappedTestingLibrary';
 import DataNodesOverview from 'preflight/components/Setup/DataNodesOverview';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import { asMock } from 'helpers/mocking';
-import FetchError from 'logic/errors/FetchError';
 import { dataNodes } from 'fixtures/dataNodes';
 
 jest.mock('preflight/hooks/useDataNodes');
@@ -50,18 +49,5 @@ describe('DataNodesOverview', () => {
 
     await screen.findByText('node-id-3');
     await screen.findByText('http://localhost:9200');
-  });
-
-  it('should display error message when there was an error fetching data nodes', async () => {
-    asMock(useDataNodes).mockReturnValue({
-      data: [],
-      isFetching: false,
-      isInitialLoading: false,
-      error: new FetchError('The request error message', 500, { status: 500, body: { message: 'The request error message' } }),
-    });
-
-    renderPreflight(<DataNodesOverview />);
-    await screen.findByText(/There was an error fetching the data nodes:/);
-    await screen.findByText(/There was an error fetching a resource: The request error message. Additional information: Not available/);
   });
 });

--- a/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.tsx
+++ b/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.tsx
@@ -34,7 +34,6 @@ const DataNodesOverview = () => {
   const {
     data: dataNodes,
     isFetching: isFetchingDataNodes,
-    error: dataNodesFetchError,
     isInitialLoading: isInitialLoadingDataNodes,
   } = useDataNodes();
 
@@ -70,11 +69,6 @@ const DataNodesOverview = () => {
       {(!dataNodes.length && !isInitialLoadingDataNodes) && (
         <Alert type="info">
           No data nodes have been found.
-        </Alert>
-      )}
-      {dataNodesFetchError && (
-        <Alert type="danger">
-          There was an error fetching the data nodes: {dataNodesFetchError.message}
         </Alert>
       )}
       <Space h="md" />

--- a/graylog2-web-interface/src/preflight/components/Setup/Setup.tsx
+++ b/graylog2-web-interface/src/preflight/components/Setup/Setup.tsx
@@ -34,7 +34,7 @@ type Props = {
 
 const Setup = ({ setIsWaitingForStartup }: Props) => (
   <>
-    <Section title="Welcome!" titleOrder={1}>
+    <Section title="Welcome!" titleOrder={1} dataTestid="welcome-section">
       <P>
         It looks like you are starting Graylog for the first time and have not configured a data node.<br />
         Data nodes allow you to index and search through all the messages in your Graylog message database.

--- a/graylog2-web-interface/src/preflight/components/common/Section.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Section.tsx
@@ -49,6 +49,7 @@ type Props = {
   title: React.ReactNode,
   actions?: React.ReactNode,
   titleOrder?: TitleOrder
+  dataTestid?: string,
 };
 
 const SectionHeader = ({ title, actions, titleOrder }: Props) => (
@@ -79,8 +80,8 @@ Subsection.defaultProps = {
   titleOrder: undefined,
 };
 
-const Section = ({ title, children, actions, titleOrder }: React.PropsWithChildren<Props>) => (
-  <SectionContainer component="section">
+const Section = ({ title, children, actions, titleOrder, dataTestid }: React.PropsWithChildren<Props>) => (
+  <SectionContainer component="section" data-testid={dataTestid}>
     <SectionHeader title={title} actions={actions} titleOrder={titleOrder} />
     {children}
   </SectionContainer>

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.test.tsx
@@ -91,6 +91,7 @@ describe('useConfigurationStep', () => {
     await waitFor(() => expect(result.current).toEqual({
       step: CONFIGURATION_STEPS.CA_CONFIGURATION.key,
       isLoading: false,
+      errors: null,
     }));
   });
 
@@ -105,6 +106,7 @@ describe('useConfigurationStep', () => {
     await waitFor(() => expect(result.current).toEqual({
       step: CONFIGURATION_STEPS.RENEWAL_POLICY_CONFIGURATION.key,
       isLoading: false,
+      errors: null,
     }));
   });
 
@@ -143,6 +145,7 @@ describe('useConfigurationStep', () => {
     await waitFor(() => expect(result.current).toEqual({
       step: CONFIGURATION_STEPS.CERTIFICATE_PROVISIONING.key,
       isLoading: false,
+      errors: null,
     }));
   });
 
@@ -165,6 +168,7 @@ describe('useConfigurationStep', () => {
     await waitFor(() => expect(result.current).toEqual({
       step: CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key,
       isLoading: false,
+      errors: null,
     }));
   });
 
@@ -203,6 +207,7 @@ describe('useConfigurationStep', () => {
     await waitFor(() => expect(result.current).toEqual({
       step: CONFIGURATION_STEPS.CONFIGURATION_FINISHED.key,
       isLoading: false,
+      errors: null,
     }));
   });
 });

--- a/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
+++ b/graylog2-web-interface/src/preflight/hooks/useConfigurationStep.tsx
@@ -21,6 +21,7 @@ import { CONFIGURATION_STEPS, DATA_NODES_STATUS } from 'preflight/Constants';
 import type { DataNodes, ConfigurationStep, DataNodesCA, RenewalPolicy } from 'preflight/types';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import useRenewalPolicy from 'preflight/hooks/useRenewalPolicy';
+import type FetchError from 'logic/errors/FetchError';
 
 import useDataNodesCA from './useDataNodesCA';
 
@@ -51,23 +52,47 @@ type Props = {
   isSkippingProvisioning: boolean
 }
 
-const useConfigurationStep = ({ isSkippingProvisioning }: Props): { step: ConfigurationStep | undefined, isLoading: boolean } => {
-  const { data: dataNodes, isInitialLoading: isLoadingDataNodes } = useDataNodes();
-  const { data: dataNodesCA, isInitialLoading: isLoadingCAStatus } = useDataNodesCA();
-  const { data: renewalPolicy, isInitialLoading: isLoadingRenewalPolicy } = useRenewalPolicy();
+type Result = {
+  step: ConfigurationStep | null,
+  isLoading: boolean,
+  errors: Array<{ entityName: string, error: FetchError}> | null
+}
+
+const useConfigurationStep = ({ isSkippingProvisioning }: Props): Result => {
+  const { data: dataNodes, isInitialLoading: isLoadingDataNodes, error: dataNodesError } = useDataNodes();
+  const { data: dataNodesCA, isInitialLoading: isLoadingCAStatus, error: caError } = useDataNodesCA();
+  const { data: renewalPolicy, isInitialLoading: isLoadingRenewalPolicy, error: renewalPolicyError } = useRenewalPolicy();
   const step = configurationStep(dataNodes, dataNodesCA, renewalPolicy, isSkippingProvisioning);
 
   return useMemo(() => {
+    if (dataNodesError || caError || renewalPolicyError) {
+      const errors = [
+        { entityName: 'data nodes', error: dataNodesError },
+        { entityName: 'certificate authority', error: caError },
+        { entityName: 'renewal policy', error: renewalPolicyError },
+      ].filter(({ error }) => !!error);
+
+      return ({ isLoading: false, step: null, errors });
+    }
+
     if (isLoadingDataNodes || isLoadingCAStatus || isLoadingRenewalPolicy) {
-      return ({ isLoading: true, step: undefined });
+      return ({ isLoading: true, step: null, errors: null });
     }
 
     return ({
-
       isLoading: false,
       step,
+      errors: null,
     });
-  }, [isLoadingCAStatus, isLoadingDataNodes, isLoadingRenewalPolicy, step]);
+  }, [
+    caError,
+    dataNodesError,
+    isLoadingCAStatus,
+    isLoadingDataNodes,
+    isLoadingRenewalPolicy,
+    renewalPolicyError,
+    step,
+  ]);
 };
 
 export default useConfigurationStep;

--- a/graylog2-web-interface/src/preflight/hooks/useDataNodes.ts
+++ b/graylog2-web-interface/src/preflight/hooks/useDataNodes.ts
@@ -16,6 +16,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -34,20 +35,43 @@ const useDataNodes = (): {
   isInitialLoading: boolean,
   error: FetchError
 } => {
+  const [metaData, setMetaData] = useState<{
+    error: FetchError | null,
+    isInitialLoading: boolean,
+  }>({
+    error: null,
+    isInitialLoading: false,
+  });
   const {
     data,
     isFetching,
-    error,
-    isInitialLoading,
   } = useQuery<DataNodes, FetchError>(
-    DATA_NODES_OVERVIEW_QUERY_KEY,
-    fetchDataNodes,
     {
+      queryKey: DATA_NODES_OVERVIEW_QUERY_KEY,
+      queryFn: fetchDataNodes,
       refetchInterval: 3000,
       keepPreviousData: true,
+      onError: (newError) => {
+        setMetaData({
+          error: newError,
+          isInitialLoading: false,
+        });
+      },
+      onSuccess: () => {
+        setMetaData({
+          error: null,
+          isInitialLoading: false,
+        });
+      },
+      retry: false,
     });
 
-  return { data: data ?? DEFAULT_DATA, isFetching, isInitialLoading, error };
+  return {
+    data: data ?? DEFAULT_DATA,
+    isFetching,
+    isInitialLoading: metaData.isInitialLoading,
+    error: metaData.error,
+  };
 };
 
 export default useDataNodes;

--- a/graylog2-web-interface/src/preflight/hooks/useDataNodesCA.ts
+++ b/graylog2-web-interface/src/preflight/hooks/useDataNodesCA.ts
@@ -16,6 +16,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import type { DataNodesCA } from 'preflight/types';
 import type FetchError from 'logic/errors/FetchError';
@@ -33,19 +34,42 @@ const useDataNodesCA = (): {
   error: FetchError,
   isInitialLoading: boolean
 } => {
+  const [metaData, setMetaData] = useState<{
+    error: FetchError | null,
+    isInitialLoading: boolean,
+  }>({
+    error: null,
+    isInitialLoading: false,
+  });
   const {
     data,
     isFetching,
-    error,
-    isInitialLoading,
   } = useQuery<DataNodesCA, FetchError>({
     queryKey: QUERY_KEY,
     queryFn: fetchDataNodesCA,
     initialData: undefined,
-    retry: 3000,
+    refetchInterval: 3000,
+    retry: false,
+    onError: (newError) => {
+      setMetaData({
+        error: newError,
+        isInitialLoading: false,
+      });
+    },
+    onSuccess: () => {
+      setMetaData({
+        error: null,
+        isInitialLoading: false,
+      });
+    },
   });
 
-  return { data, isFetching, error, isInitialLoading };
+  return {
+    data,
+    isFetching,
+    isInitialLoading: metaData.isInitialLoading,
+    error: metaData.error,
+  };
 };
 
 export default useDataNodesCA;

--- a/graylog2-web-interface/src/preflight/hooks/useRenewalPolicy.ts
+++ b/graylog2-web-interface/src/preflight/hooks/useRenewalPolicy.ts
@@ -16,6 +16,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import type { RenewalPolicy } from 'preflight/types';
 import type FetchError from 'logic/errors/FetchError';
@@ -33,19 +34,42 @@ const useRenewalPolicy = (): {
   error: FetchError,
   isInitialLoading: boolean
 } => {
+  const [metaData, setMetaData] = useState<{
+    error: FetchError | null,
+    isInitialLoading: false,
+  }>({
+    error: null,
+    isInitialLoading: false,
+  });
   const {
     data,
     isFetching,
-    error,
-    isInitialLoading,
   } = useQuery<RenewalPolicy, FetchError>({
     queryKey: QUERY_KEY,
     queryFn: fetchRenewalPolicy,
     initialData: undefined,
-    retry: 3000,
+    refetchInterval: 3000,
+    retry: false,
+    onError: (newError) => {
+      setMetaData({
+        error: newError,
+        isInitialLoading: false,
+      });
+    },
+    onSuccess: () => {
+      setMetaData({
+        error: null,
+        isInitialLoading: false,
+      });
+    },
   });
 
-  return { data, isFetching, error, isInitialLoading };
+  return {
+    data,
+    isFetching,
+    isInitialLoading: metaData.isInitialLoading,
+    error: metaData.error,
+  };
 };
 
 export default useRenewalPolicy;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the preflight UI we need to perform multiple fetch requests. Before this change we are not showing related errors in the UI properly. In some cases we did not show any error, in other cases the error message flashed every few seconds.

/nocl