### PR TITLE
Send custom oupt_out telemetry event 

### DIFF
--- a/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
@@ -54,6 +54,7 @@ const TelemetrySettingsConfig = () => {
 
   const updateTelemetryOpt = (data: UserTelemetrySettings) => {
     if (posthog && isTelemetryEnabled && !data.telemetry_enabled) {
+      posthog.capture('$opt_out');
       posthog.opt_out_capturing();
     }
   };


### PR DESCRIPTION
With these changes, we send a custom `opt_out` event when opting out users. This is necessary because Posthog sends only `opt_in` events. 

fix Graylog2/graylog-plugin-enterprise#5545
/nocl
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

