### PR TITLE
Fix heatmap colorbar font color for dark mode.

### DIFF
--- a/changelog/unreleased/issue-15035.toml
+++ b/changelog/unreleased/issue-15035.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix heatmap colorbar font color for dark mode."
+
+issues = ["15035"]
+pulls = ["16129"]

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -18,6 +18,7 @@ import flatten from 'lodash/flatten';
 import flow from 'lodash/flow';
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
+import type { ColorBar } from 'plotly.js';
 
 import type { Key, Leaf, Row, Rows, Value } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -47,6 +48,7 @@ export type ChartDefinition = {
   },
   customdata?: any,
   colorscale?: string,
+  colorbar?: { tickfont: { color: string } },
   reversescale?: boolean,
   zmin?: number,
   zmax?: number,

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -18,7 +18,6 @@ import flatten from 'lodash/flatten';
 import flow from 'lodash/flow';
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
-import type { ColorBar } from 'plotly.js';
 
 import type { Key, Leaf, Row, Rows, Value } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useContext, useState, useCallback, useMemo } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Overlay, RootCloseWrapper } from 'react-overlays';
 import chunk from 'lodash/chunk';
 
@@ -35,7 +35,7 @@ import type { ChartDefinition } from 'views/components/visualizations/ChartData'
 import { keySeparator, humanSeparator } from 'views/Constants';
 import useMapKeys from 'views/components/visualizations/useMapKeys';
 
-const ColorHint = styled.div(({ color }) => `
+const ColorHint = styled.div(({ color }) => css`
   cursor: pointer;
   background-color: ${color} !important; /* Needed for report generation */
   -webkit-print-color-adjust: exact !important; /* Needed for report generation */

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -20,6 +20,8 @@ import merge from 'lodash/merge';
 import fill from 'lodash/fill';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
+import type { DefaultTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -45,7 +47,7 @@ const _generateSeriesTitles = (config, x, y) => {
   return y.map(() => columnSeriesTitles);
 };
 
-const _generateSeries = (visualizationConfig: HeatmapVisualizationConfig, mapKeys: KeyMapper): Generator => ({
+const _generateSeries = (visualizationConfig: HeatmapVisualizationConfig, mapKeys: KeyMapper, theme: DefaultTheme): Generator => ({
   type,
   name,
   labels,
@@ -77,6 +79,9 @@ const _generateSeries = (visualizationConfig: HeatmapVisualizationConfig, mapKey
     zmin: zMin,
     zmax: zMax,
     originalName: name,
+    colorbar: {
+      tickfont: { color: theme.colors.global.textDefault },
+    },
   };
 };
 
@@ -148,13 +153,14 @@ const _chartLayout = (heatmapData: ChartDefinition[]) => {
 const _leafSourceMatcher = ({ source }: { source: string }) => source.endsWith('leaf') && source !== 'row-leaf';
 
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+  const theme = useTheme();
   const visualizationConfig = (config.visualizationConfig ?? HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
   const mapKeys = useMapKeys();
   const heatmapData = useChartData(rows, {
     widgetConfig: config,
     chartType: 'heatmap',
-    generator: _generateSeries(visualizationConfig, mapKeys),
+    generator: _generateSeries(visualizationConfig, mapKeys, theme),
     seriesFormatter: _formatSeries(visualizationConfig),
     leafValueMatcher: _leafSourceMatcher,
   });

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -72,6 +72,7 @@ describe('HeatmapVisualization', () => {
         colorscale: 'Viridis',
         reversescale: false,
         originalName: 'Heatmap Chart',
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 
@@ -118,6 +119,7 @@ describe('HeatmapVisualization', () => {
         colorscale: 'Viridis',
         reversescale: false,
         originalName: 'Heatmap Chart',
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the heatmap colorbar font color for dark mode. Please have a look at https://github.com/Graylog2/graylog2-server/issues/15035 for more information.

Fixes https://github.com/Graylog2/graylog2-server/issues/15035