### PR TITLE
Fixing error which could occur after selecting all time range.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/RelativeTimeRangeClassifiedHelper.ts
@@ -82,7 +82,15 @@ export const classifyRelativeTimeRange = (timeRange: RelativeTimeRange): Relativ
   };
 };
 
-export const isTypeRelativeClassified = (timeRange): timeRange is RelativeTimeRangeClassified => (timeRange.type === 'relative' && typeof timeRange.from === 'object' && typeof timeRange.to === 'object');
+export const isTypeRelativeClassified = (timeRange: TimeRange | NoTimeRangeOverride | undefined): timeRange is RelativeTimeRangeClassified => (
+  timeRange
+  && 'type' in timeRange
+  && timeRange.type === 'relative'
+  && 'from' in timeRange
+  && typeof timeRange?.from === 'object'
+  && 'to' in timeRange
+  && typeof timeRange.to === 'object'
+);
 
 export const normalizeClassifiedRange = ({ value, unit, isAllTime }: RangeClassified) => {
   if (isAllTime) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is fixing a runtime error which occurred in the following scenario:
1. configure a keyword time range for a search
2. open the time range picker
3. select the relative tab
4. select "All time" for "From"

/nocl