### PR TITLE
add pipeline and stage to log output on exception

### DIFF
--- a/changelog/unreleased/pr-16161.toml
+++ b/changelog/unreleased/pr-16161.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add pipeline name and stage to log output when an exception occurs during pipeline processing."
+
+issues = ["8627"]
+pulls = ["16161"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -285,11 +285,11 @@ public class PipelineInterpreter implements MessageProcessor {
     }
 
     public void evaluateStage(Stage stage,
-                               Message message,
-                               String msgId,
-                               List<Message> result,
-                               Set<Pipeline> pipelinesToSkip,
-                               InterpreterListener interpreterListener) {
+                              Message message,
+                              String msgId,
+                              List<Message> result,
+                              Set<Pipeline> pipelinesToSkip,
+                              InterpreterListener interpreterListener) {
         final Pipeline pipeline = stage.getPipeline();
         if (pipelinesToSkip.contains(pipeline)) {
             log.debug("[{}] previous stage result prevents further processing of pipeline `{}`",
@@ -319,22 +319,22 @@ public class PipelineInterpreter implements MessageProcessor {
                 allRulesMatched &= ruleCondition;
 
                 if (context.hasEvaluationErrors()) {
-                    log.warn("Error evaluating condition for rule <{}/{}> with message: {} (Error: {})",
-                            rule.name(), rule.id(), message, context.lastEvaluationError());
+                    log.warn("Error evaluating condition for rule <{}/{}> in pipeline <{}/stage {}> with message: {} (Error: {})",
+                            rule.name(), rule.id(), pipeline.name(), stage.stage(), message, context.lastEvaluationError());
                     break;
                 }
 
             } catch (Exception e) {
-                log.warn("Error evaluating condition for rule <{}/{}> with message: {} (Error: {})",
-                        rule.name(), rule.id(), message, e.getMessage());
+                log.warn("Error evaluating condition for rule <{}/{}> in pipeline <{}/stage {}> with message: {} (Error: {})",
+                        rule.name(), rule.id(), pipeline.name(), stage.stage(), message, e.getMessage());
                 throw e;
             }
         }
 
         for (Rule rule : rulesToRun) {
             if (!executeRuleActions(rule, message, msgId, pipeline, context, interpreterListener)) {
-                log.warn("Error evaluating action for rule <{}/{}> with message: {} (Error: {})",
-                        rule.name(), rule.id(), message, context.lastEvaluationError());
+                log.warn("Error evaluating action for rule <{}/{}> in pipeline <{}/stage {}> with message: {} (Error: {})",
+                        rule.name(), rule.id(), pipeline.name(), stage.stage(), message, context.lastEvaluationError());
                 // if any of the rules raise an error, skip the rest of the rules
                 break;
             }


### PR DESCRIPTION
## Description
includes pipeline name and stage to log message when an exception occurs in the pipeline interpreter

## Motivation and Context
resolves #8627

## How Has This Been Tested?
- create a rule action throwing an exception (i.e. parse_date with invalid pattern)
- check that log warning contains pipeline name and stage
- do the same for a rule condition throwing an exception

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


