### PR TITLE
Adjust keybindings for query input autocompletion.

### DIFF
--- a/changelog/unreleased/issue-14793.toml
+++ b/changelog/unreleased/issue-14793.toml
@@ -1,0 +1,14 @@
+type = "fixed"
+message = "Adjust keybindings for query input autocompletion (disable `Return` key)."
+
+issues = ["14793"]
+pulls = ["16162"]
+
+details.user = """
+With #6909 we received the feedback that it would be useful to only press tab once to insert the first autocomplete suggestion (instead of pressing it twice).
+As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case.
+When you search for a custom value like `ssh login` the autocomplete suggested field names for login and pressing `Return`
+did not execute the search but inserted the first suggestion.
+
+We are now disabling the `Return` and `Shift-Return` keybindings for the query input autocompletion. Only the `Tab` key inserts a suggestion.
+"""

--- a/changelog/unreleased/issue-14793.toml
+++ b/changelog/unreleased/issue-14793.toml
@@ -1,14 +1,11 @@
 type = "fixed"
-message = "Adjust keybindings for query input autocompletion (disable `Return` key)."
+message = "Adjust keybindings for query input autocompletion."
 
 issues = ["14793"]
 pulls = ["16162"]
 
 details.user = """
-With #6909 we received the feedback that it would be useful to only press tab once to insert the first autocomplete suggestion (instead of pressing it twice).
-As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case.
-When you search for a custom value like `ssh login` the autocomplete suggested field names for login and pressing `Return`
-did not execute the search but inserted the first suggestion.
-
-We are now disabling the `Return` and `Shift-Return` keybindings for the query input autocompletion. Only the `Tab` key inserts a suggestion.
+With #6909 we received the feedback that it would be useful to only press `Tab` once to insert the first autocomplete suggestion (instead of pressing it twice). As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case. When you search for a custom value like ssh login the autocomplete suggested field names for login and pressing Return did not execute the search but inserted the first suggestion.
+We are now no longer focusing the first suggestion and adjusting the behaviour for Tab key. When pressing Tab while no suggestion is focused we select and insert the first entry.
+This way it is possible to press Return when searching for a custom value and it still requires only one press to insert the first suggestion.
 """

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -652,6 +652,14 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     color: ${theme.colors.input.color};
   }
 
+  .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
+    background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.7)};
+    color: ${theme.colors.input.colorDisabled};
+  }
+  .ace_editor.ace_autocomplete .ace_text-layer .ace_completion-highlight {
+    color: ${theme.colors.variant.info};
+  }
+
   code {
     color: ${theme.colors.variant.darker.danger};
     background-color: ${theme.colors.variant.lightest.danger};

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -645,20 +645,29 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
   }
 
   /* additional styles for 'StyledAceEditor' */
-  .ace_editor.ace_autocomplete.ace-queryinput {
+  .ace_editor.ace_autocomplete {
     width: 600px !important;
     margin-top: 6px;
     background-color: ${theme.colors.input.background};
     color: ${theme.colors.input.color};
-  }
 
-  .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line {
-    background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.7)};
-    color: ${theme.colors.input.colorDisabled};
-  }
+    .ace_marker-layer .ace_active-line {
+      background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.7)};
+      color: ${theme.colors.input.colorDisabled};
 
-  .ace_editor.ace_autocomplete .ace_text-layer .ace_completion-highlight {
-    color: ${theme.colors.variant.info};
+      &::after {
+        content: "⇥";
+        right: 3px;
+        position: absolute;
+        display: inline-block;
+        font-size: 20px;
+        font-family: ${theme.fonts.family.body};
+      }
+    }
+
+    .ace_text-layer .ace_completion-highlight {
+      color: ${theme.colors.variant.info};
+    }
   }
 
   code {

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -650,23 +650,6 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     margin-top: 6px;
     background-color: ${theme.colors.input.background};
     color: ${theme.colors.input.color};
-
-    .ace_marker-layer .ace_active-line {
-      background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.7)};
-      color: ${theme.colors.input.colorDisabled};
-
-      &::after {
-        content: "⇥";
-        right: 3px;
-        position: absolute;
-        font-size: 1.3rem;
-        font-family: ${theme.fonts.family.body};
-      }
-    }
-
-    .ace_text-layer .ace_completion-highlight {
-      color: ${theme.colors.variant.info};
-    }
   }
 
   code {

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -659,8 +659,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
         content: "⇥";
         right: 3px;
         position: absolute;
-        display: inline-block;
-        font-size: 20px;
+        font-size: 1.3rem;
         font-family: ${theme.fonts.family.body};
       }
     }

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -131,7 +131,7 @@ const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCo
 
       const completerCommandKeyBinding = editor.completer?.keyboardHandler?.commandKeyBinding;
 
-      if (completerCommandKeyBinding?.tab && completerCommandKeyBinding?.tab?.name !== 'improved-tab') {
+      if (completerCommandKeyBinding?.tab && completerCommandKeyBinding.tab.name !== 'improved-tab') {
         editor.completer.keyboardHandler.addCommand({
           name: 'improved-tab',
           bindKey: { win: 'Tab', mac: 'Tab' },

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -124,8 +124,15 @@ const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCo
   const editor = node && node.editor;
 
   if (editor) {
-    commands.forEach((command) => editor.commands.addCommand(command));
+    editor.commands.on('afterExec', () => {
+      const completerCommandKeyBinding = editor.completer?.keyboardHandler?.commandKeyBinding;
 
+      if (completerCommandKeyBinding?.return || completerCommandKeyBinding?.['Shift-Return']) {
+        editor.completer.keyboardHandler.removeCommands(['Return', 'Shift-Return']);
+      }
+    });
+
+    commands.forEach((command) => editor.commands.addCommand(command));
     editor.completers = [completer];
   }
 };

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -68,12 +68,14 @@ export type Completer = {
   autoSelect: boolean,
   popup?: Popup,
   activated: boolean,
+  insertMatch: () => boolean,
+  detach: () => void,
+  goTo: (direction: string) => void,
   keyboardHandler: {
     commandKeyBinding: {
-      return: unknown,
-      'Shift-Return': unknown
+      tab: Command,
     },
-    removeCommands: (commands: Array<string>) => void
+    addCommand: (command: Command) => void
   }
 };
 
@@ -86,6 +88,7 @@ export type Editor = {
   renderer: Renderer,
   setFontSize: (newFontSize: number) => void,
   getValue: () => string,
+  tabstopManager: unknown,
   setValue: (newValue: string) => void,
   isFocused: () => boolean,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -57,6 +57,7 @@ export type Command = {
 export type Commands = {
   addCommand: (command: Command) => void,
   removeCommands: (commands: Array<string>) => void,
+  on: (commandName: string, callback: () => void) => void
 };
 
 export type Popup = {
@@ -67,6 +68,13 @@ export type Completer = {
   autoSelect: boolean,
   popup?: Popup,
   activated: boolean,
+  keyboardHandler: {
+    commandKeyBinding: {
+      return: unknown,
+      'Shift-Return': unknown
+    },
+    removeCommands: (commands: Array<string>) => void
+  }
 };
 
 export type Editor = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


With #6909 we received the feedback that it would be useful to only press `Tab` once to insert the first autocomplete suggestion (instead of pressing it twice). As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case. When you search for a custom value like `ssh login` the autocomplete suggested field names for `login` and pressing `Return` did not execute the search but inserted the first suggestion.

We are now no longer focusing the first suggestion and adjusting the behaviour for `Tab` key. When pressing `Tab` while no suggestion is focused we select and insert the first entry.

This way it is possible to press `Return` when searching for a custom value and it still requires only one press to insert the first suggestion.

Fixes https://github.com/Graylog2/graylog2-server/issues/14793

