### PR TITLE
make `creation_date` optional

### DIFF
--- a/changelog/unreleased/pr-16166.toml
+++ b/changelog/unreleased/pr-16166.toml
@@ -1,4 +1,4 @@
-type = "a"
+type = "c"
 message = "Make `creation_date` optional when creating index sets via api. If none is provided, the current server time will be used."
 
 issues = ["4709"]

--- a/changelog/unreleased/pr-16166.toml
+++ b/changelog/unreleased/pr-16166.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Make `creation_date` optional when creating index sets via api. If none is provided, the current server time will be used."
+
+issues = ["4709"]
+pulls = ["16166"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -33,6 +33,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.Optional;
 
 @AutoValue
@@ -124,12 +125,15 @@ public abstract class IndexSetSummary {
                                          @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                          @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
                                          @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
-                                         @JsonProperty("creation_date") @NotNull ZonedDateTime creationDate,
+                                         @JsonProperty("creation_date") @Nullable ZonedDateTime creationDate,
                                          @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
                                          @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
                                          @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled,
                                          @JsonProperty("field_type_refresh_interval") Duration fieldTypeRefreshInterval,
                                          @JsonProperty("index_template_type") @Nullable String templateType) {
+        if (Objects.isNull(creationDate)) {
+            creationDate = ZonedDateTime.now();
+        }
         return new AutoValue_IndexSetSummary(id, title, description, isDefault, canBeDefault,
                 isWritable, indexPrefix, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,


### PR DESCRIPTION
## Description
make `creation_date` optional when creating index sets using `/api/system/indices/index_sets`
if none is provided, the current server time will be used.

## Motivation and Context
resolves #4709

## How Has This Been Tested?
create index set using api without/with `creation_date`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


