### PR TITLE
Add an optional flag to invert remove_field condition

### DIFF
--- a/changelog/unreleased/issue-8128.toml
+++ b/changelog/unreleased/issue-8128.toml
@@ -2,4 +2,4 @@ type = "a"
 message = "Optional flag to invert condition of `remove_field` function."
 
 issues = ["8128"]
-pulls = [""]
+pulls = ["16182"]

--- a/changelog/unreleased/issue-8128.toml
+++ b/changelog/unreleased/issue-8128.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Optional flag to invert condition of `remove_field` function."
+
+issues = ["8128"]
+pulls = [""]

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1364,4 +1364,17 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(utcHour).isEqualTo(10);
         assertThat(manilaHour).isEqualTo(18);
     }
+
+    @Test
+    public void removeField() {
+        Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = new Message("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("f1")).isNull();
+        assertThat(message.getField("i1")).isNull();
+        assertThat(message.getField("i2")).isNull();
+        assertThat(message.getField("f2")).isEqualTo("f2");
+        assertThat(message.getField("f3")).isEqualTo("f3");
+    }
 }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeField.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeField.txt
@@ -1,0 +1,12 @@
+rule "remove_field"
+when true
+then
+  set_field(field: "f1", value: "f1");
+  set_field(field: "f2", value: "f2");
+  set_field(field: "f3", value: "f3");
+  set_field(field: "i1", value: "i1");
+  set_field(field: "i2", value: "i2");
+
+  remove_field(field:"f1");
+  remove_field(field:"f.", invert:true);
+end


### PR DESCRIPTION
Resolves #8128 

Introduce an optional flag `invert` to `remove_field` function. When `true`, remove all fields except those those that match the given name / regex.