### PR TITLE
Fixing type casts for `SearchServerBuilder`.

### DIFF
--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MessagesBatchOS2IT.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MessagesBatchOS2IT.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 
 public class MessagesBatchOS2IT extends MessagesBatchIT {
     @Rule
-    public final OpenSearchInstance openSearchInstance = (OpenSearchInstance)OpenSearchInstanceBuilder.builder().heapSize("256m").build();
+    public final OpenSearchInstance openSearchInstance = OpenSearchInstanceBuilder.builder().heapSize("256m").build();
 
     @Override
     protected SearchServerInstance searchServer() {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/SearchServerBuilder.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/SearchServerBuilder.java
@@ -38,7 +38,7 @@ public abstract class SearchServerBuilder<T extends SearchServerInstance> {
         return version;
     }
 
-    public SearchServerBuilder network(final Network network){
+    public SearchServerBuilder<T> network(final Network network) {
         this.network = network;
         return this;
     }
@@ -47,7 +47,7 @@ public abstract class SearchServerBuilder<T extends SearchServerInstance> {
         return network;
     }
 
-    public SearchServerBuilder heapSize(final String heapSize) {
+    public SearchServerBuilder<T> heapSize(final String heapSize) {
         this.heapSize = heapSize;
         return this;
     }
@@ -56,7 +56,7 @@ public abstract class SearchServerBuilder<T extends SearchServerInstance> {
         return heapSize;
     }
 
-    public SearchServerBuilder featureFlags(final List<String> featureFlags) {
+    public SearchServerBuilder<T> featureFlags(final List<String> featureFlags) {
         this.featureFlags = new ArrayList<>(featureFlags);
         return this;
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a tiny refactoring removing the need for type-casts when using `OpenSearchInstanceBuilder` (or any subclass of `SearchServerBuilder`.

/nocl
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#5615

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.