### PR TITLE
Change log level for some migration messages from ERROR to DEBUG

### DIFF
--- a/changelog/unreleased/pr-16184.toml
+++ b/changelog/unreleased/pr-16184.toml
@@ -1,0 +1,4 @@
+type = "r"
+message = "Remove ERROR level logs that happened during user/role creation."
+
+pulls = ["16184"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -341,7 +341,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
             collector = collectorService.findByNameAndOs(collectorName, nodeOperatingSystem);
             if (collector == null) {
                 final String msg = "Couldn't find collector '{} on {}' fixing it.";
-                LOG.error(msg, collectorName, nodeOperatingSystem);
+                LOG.debug(msg, collectorName, nodeOperatingSystem);
                 throw new IllegalArgumentException();
             }
         } catch (IllegalArgumentException ignored) {

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationHelpers.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationHelpers.java
@@ -55,7 +55,7 @@ public class MigrationHelpers {
             previousRole = roleService.load(roleName);
             if (!previousRole.isReadOnly() || !expectedPermissions.equals(previousRole.getPermissions())) {
                 final String msg = "Invalid role '" + roleName + "', fixing it.";
-                LOG.error(msg);
+                LOG.debug(msg);
                 throw new IllegalArgumentException(msg); // jump to fix code
             }
         } catch (NotFoundException | IllegalArgumentException | NoSuchElementException ignored) {
@@ -130,7 +130,7 @@ public class MigrationHelpers {
                     || !previousUser.getRoleIds().containsAll(expectedRoles)
                     || !Objects.equals(isServiceAccount, previousUser.isServiceAccount())) {
                 final String msg = "Invalid user '" + userName + "', fixing it.";
-                LOG.error(msg);
+                LOG.debug(msg);
                 throw new IllegalArgumentException(msg);
             }
         } catch (IllegalArgumentException ignored) {


### PR DESCRIPTION
We shouldn't log messages with ERROR level in situations where we immediately fix the problem in the next step.

Fixes logs like the following on initial server startup:

```
2023-08-16 10:16:41,705 ERROR: org.graylog2.migrations.MigrationHelpers - Invalid user 'graylog-report', fixing it.
2023-08-16 10:16:41,705 INFO : org.graylog2.migrations.MigrationHelpers - graylog-report user is missing or invalid, re-adding it as a built-in user.
2023-08-16 10:16:41,770 ERROR: org.graylog.plugins.sidecar.migrations.V20180212165000_AddDefaultCollectors - Couldn't find collector 'filebeat on linux' fixing it.
2023-08-16 10:16:41,771 INFO : org.graylog.plugins.sidecar.migrations.V20180212165000_AddDefaultCollectors - filebeat collector on linux is missing, adding it.
```

With this PR applied we only log the following.

```
2023-08-16 10:16:41,705 INFO : org.graylog2.migrations.MigrationHelpers - graylog-report user is missing or invalid, re-adding it as a built-in user.
2023-08-16 10:16:41,771 INFO : org.graylog.plugins.sidecar.migrations.V20180212165000_AddDefaultCollectors - filebeat collector on linux is missing, adding it.
```