### PR TITLE
Add forceSave method to bypass mutability checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/entities/ScopedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/ScopedDbService.java
@@ -118,4 +118,12 @@ public abstract class ScopedDbService<E extends ScopedEntity> extends PaginatedD
         // Intentionally omit ensure mutability check.
         return super.delete(id);
     }
+
+    /**
+     * Saves an entity without checking for mutability. Do not call this method for API requests for the user interface.
+     */
+    public final E forceSave(E entity) {
+        // Intentionally omit ensure mutability check.
+        return super.save(entity);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a `forceSave` option in the ScopedDbService to allow for migrations to modify otherwise immutable DB entities
/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Migrations for entities intended to be immutable through the UI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

