### PR TITLE
Enable/Disable EventDefinition status when clicking on status badge

### DIFF
--- a/changelog/unreleased/issue-15095.toml
+++ b/changelog/unreleased/issue-15095.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Enable/Disable EventDefinition status when clicking on status badge."
+
+issues = ["15095"]
+pulls = ["16203"]
+

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionsContainer.tsx
@@ -36,7 +36,7 @@ import type { EventDefinition } from '../event-definitions-types';
 import useEventDefinitions from '../hooks/useEventDefinitions';
 import { ENTITY_TABLE_ID, DEFAULT_LAYOUT, ADDITIONAL_ATTRIBUTES } from '../constants';
 
-const customColumnRenderers = (): ColumnRenderers<EventDefinition> => ({
+const customColumnRenderers = (refetchEventDefinitions: () => void): ColumnRenderers<EventDefinition> => ({
   attributes: {
     title: {
       renderCell: (title: string, eventDefinition) => (
@@ -50,7 +50,7 @@ const customColumnRenderers = (): ColumnRenderers<EventDefinition> => ({
     },
     status: {
       renderCell: (_status: string, eventDefinition) => (
-        <StatusCell status={eventDefinition?.state} />
+        <StatusCell eventDefinition={eventDefinition} refetchEventDefinitions={refetchEventDefinitions} />
       ),
       staticWidth: 100,
     },
@@ -76,7 +76,7 @@ const EventDefinitionsContainer = () => {
     pageSize: layoutConfig.pageSize,
     sort: layoutConfig.sort,
   });
-  const columnRenderers = customColumnRenderers();
+  const columnRenderers = customColumnRenderers(refetchEventDefinitions);
   const columnDefinitions = useMemo(
     () => ([...(paginatedEventDefinitions?.attributes ?? []), ...ADDITIONAL_ATTRIBUTES]),
     [paginatedEventDefinitions?.attributes],

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/StatusCell.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/StatusCell.tsx
@@ -15,9 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 
+import { EventDefinitionsActions } from 'stores/event-definitions/EventDefinitionsStore';
 import { Label } from 'components/bootstrap';
+import { Icon } from 'components/common';
+
+import type { EventDefinition } from '../event-definitions-types';
 
 const StatusLabel = styled(Label)`
   display: inline-flex;
@@ -25,16 +30,57 @@ const StatusLabel = styled(Label)`
   gap: 4px;
 `;
 
+const Spacer = styled.div`
+  border-left: 1px solid currentColor;
+  height: 1em;
+`;
+
+const _title = (disabled: boolean, disabledChange: boolean, description: string) => {
+  if (disabledChange) {
+    return description;
+  }
+
+  return disabled ? 'Enable' : 'Disable';
+};
+
 type Props ={
-  status: string
+  eventDefinition: EventDefinition,
+  refetchEventDefinitions: () => void,
 }
 
-const StatusCell = ({ status } : Props) => {
-  const isSuccess = status === 'ENABLED';
+const StatusCell = ({ eventDefinition, refetchEventDefinitions } : Props) => {
+  const isEnabled = eventDefinition?.state === 'ENABLED';
+  const disableChange = eventDefinition?.config?.type === 'system-notifications-v1';
+  const description = isEnabled ? 'enabled' : 'disabled';
+  const title = _title(!isEnabled, disableChange, description);
+
+  const toggleEventDefinitionStatus = useCallback(async () => {
+    // eslint-disable-next-line no-alert
+    if (isEnabled && window.confirm(`Do you really want to disable event definition '${eventDefinition.title}'?`)) {
+      await EventDefinitionsActions.disable(eventDefinition);
+      await refetchEventDefinitions();
+    }
+
+    if (!isEnabled) {
+      await EventDefinitionsActions.enable(eventDefinition);
+      await refetchEventDefinitions();
+    }
+  }, [isEnabled, eventDefinition, refetchEventDefinitions]);
 
   return (
-    <StatusLabel bsStyle={isSuccess ? 'success' : 'warning'}>
-      {isSuccess ? 'enabled' : 'disabled'}
+    <StatusLabel bsStyle={isEnabled ? 'success' : 'warning'}
+                 onClick={disableChange ? undefined : toggleEventDefinitionStatus}
+                 title={title}
+                 aria-label={title}
+                 role="button"
+                 $clickable={!disableChange}>
+      {description}
+      {!disableChange && (
+        <>
+          <Spacer />
+          <Icon name={isEnabled ? 'pause' : 'play'} />
+        </>
+      )}
     </StatusLabel>
   );
 };


### PR DESCRIPTION
Added capability to Enable/Disable EventDefinition status when clicking on status badge, similar to the streams overview.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog2-server/issues/15095

## Screenshots (if appropriate):
![Screenshot 2023-08-18 at 13 02 59](https://github.com/Graylog2/graylog2-server/assets/106236152/51fbb2c5-a441-4735-a528-d1ad61481eda)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

