### PR TITLE
Expose generic plugin UI settings

### DIFF
--- a/graylog2-web-interface/src/util/AppConfig.ts
+++ b/graylog2-web-interface/src/util/AppConfig.ts
@@ -93,6 +93,10 @@ const AppConfig = {
     return appConfig()?.pluginUISettings?.['org.graylog.plugins.customization.notifications'] ?? {};
   },
 
+  pluginUISettings(key: string) : any {
+    return appConfig()?.pluginUISettings?.[key] ?? {};
+  },
+
 };
 
 export default AppConfig;


### PR DESCRIPTION
This way, a plugin can access their specific UI settings without the need to add a plugin-specific accessor method to AppConfig every time.

I'm making use of it [here](https://github.com/Graylog2/graylog-plugin-enterprise/pull/5636/files#diff-1e06d2ba6e00c8269ad66e51b3cb7923afdc02de27d9fd6bba3b722096de3cbd).

/nocl