### PR TITLE
Define highlights on view generation for event and event definition replay

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/replay-search/AggreagtionConditions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/AggreagtionConditions.tsx
@@ -22,7 +22,7 @@ import { StaticColor } from 'views/logic/views/formatting/highlighting/Highlight
 import { ColorPickerPopover, Icon } from 'components/common';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import type HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import { conditionToExprMapper, exprToConditionMapper } from 'hooks/useHighlightValuesForEventDefinition';
+import { conditionToExprMapper, exprToConditionMapper } from 'views/logic/ExpressionConditionMappers';
 import useAppSelector from 'stores/useAppSelector';
 import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData';

--- a/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/EventInfoBar.tsx
@@ -22,7 +22,6 @@ import styled from 'styled-components';
 import { Button } from 'components/bootstrap';
 import { FlatContentRow, Icon } from 'components/common';
 import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData';
-import useHighlightValuesForEventDefinition from 'hooks/useHighlightValuesForEventDefinition';
 import useAttributeComponents from 'components/event-definitions/replay-search/hooks/useAttributeComponents';
 import NoAttributeProvided from 'components/event-definitions/replay-search/NoAttributeProvided';
 
@@ -56,7 +55,6 @@ const Value = styled.div`
 `;
 
 const EventInfoBar = () => {
-  useHighlightValuesForEventDefinition();
   const { isEventDefinition, isEvent, isAlert } = useAlertAndEventDefinitionData();
   const [open, setOpen] = useState<boolean>(true);
 

--- a/graylog2-web-interface/src/views/logic/ExpressionConditionMappers.tsx
+++ b/graylog2-web-interface/src/views/logic/ExpressionConditionMappers.tsx
@@ -15,14 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import { useEffect } from 'react';
-
-import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData';
 import type { ValueExpr } from 'hooks/useEventDefinition';
-import { createHighlightingRules } from 'views/logic/slices/highlightActions';
-import useAppDispatch from 'stores/useAppDispatch';
 import type { Condition } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 
 export const exprToConditionMapper: {[name: string]: Condition} = {
   '<': 'less',
@@ -39,22 +33,3 @@ export const conditionToExprMapper: {[name: string]: ValueExpr} = {
   greater: '>',
   equal: '==',
 };
-
-const useHighlightValuesForEventDefinition = () => {
-  const dispatch = useAppDispatch();
-  const { aggregations } = useAlertAndEventDefinitionData();
-
-  return useEffect(() => {
-    if (aggregations?.length) {
-      const valuesToHighlight = aggregations.map(({ fnSeries, value, expr }) => ({
-        value,
-        field: fnSeries,
-        color: randomColor(),
-        condition: exprToConditionMapper[expr],
-      }));
-      if (valuesToHighlight.length) dispatch(createHighlightingRules(valuesToHighlight));
-    }
-  }, [aggregations, dispatch]);
-};
-
-export default useHighlightValuesForEventDefinition;

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
@@ -32,6 +32,7 @@ import { UseCreateViewForEvent } from 'views/logic/views/UseCreateViewForEvent';
 import generateId from 'logic/generateId';
 import asMock from 'helpers/mocking/AsMock';
 import type View from 'views/logic/views/View';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 const counter = () => {
   let index = 0;
@@ -100,6 +101,14 @@ jest.mock('graylog-web-plugin/plugin', () => ({
 jest.mock('logic/generateId', () => jest.fn());
 
 jest.mock('bson-objectid', () => jest.fn());
+
+const mock_color = StaticColor.create('#ffffff');
+
+jest.mock('views/logic/views/formatting/highlighting/HighlightingRule', () => ({
+  ...jest.requireActual('views/logic/views/formatting/highlighting/HighlightingRule'),
+  randomColor: jest.fn(() => mock_color),
+  __esModule: true,
+}));
 
 jest.mock('views/logic/Widgets', () => ({
   ...jest.requireActual('views/logic/Widgets'),

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -43,6 +43,9 @@ import Direction from 'views/logic/aggregationbuilder/Direction';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
 import Parameter from 'views/logic/parameters/Parameter';
 import { concatQueryStrings, escape } from 'views/logic/queries/QueryHelper';
+import HighlightingRule, { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import { exprToConditionMapper } from 'views/logic/ExpressionConditionMappers';
+import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
 
 const AGGREGATION_WIDGET_HEIGHT = 3;
 
@@ -159,11 +162,14 @@ export const WidgetsGenerator = async ({ streams, aggregations, groupBy }) => {
 export const ViewStateGenerator = async ({ streams, aggregations, groupBy }: {groupBy: Array<string>, streams: string | string[] | undefined, aggregations: Array<any>}) => {
   const { titles, widgets, positions } = await WidgetsGenerator({ streams, aggregations, groupBy });
 
+  const highlightRules = aggregations?.map(({ fnSeries, value, expr }) => HighlightingRule.create(fnSeries, value, exprToConditionMapper[expr] || 'equal', randomColor()));
+
   return ViewState.create()
     .toBuilder()
     .titles(titles)
     .widgets(Immutable.List(widgets))
     .widgetPositions(positions)
+    .formatting(FormattingSettings.create(highlightRules))
     .build();
 };
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.test.ts
@@ -26,6 +26,7 @@ import UseCreateViewForEventDefinition from 'views/logic/views/UseCreateViewForE
 import generateId from 'logic/generateId';
 import asMock from 'helpers/mocking/AsMock';
 import type View from 'views/logic/views/View';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 const counter = () => {
   let index = 0;
@@ -78,6 +79,13 @@ jest.mock('graylog-web-plugin/plugin', () => ({
 jest.mock('logic/generateId', () => jest.fn());
 
 jest.mock('bson-objectid', () => jest.fn());
+const mock_color = StaticColor.create('#ffffff');
+
+jest.mock('views/logic/views/formatting/highlighting/HighlightingRule', () => ({
+  ...jest.requireActual('views/logic/views/formatting/highlighting/HighlightingRule'),
+  randomColor: jest.fn(() => mock_color),
+  __esModule: true,
+}));
 
 jest.mock('views/logic/Widgets', () => ({
   ...jest.requireActual('views/logic/Widgets'),

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -31,7 +31,11 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import { allMessagesTable, resultHistogram } from 'views/logic/Widgets';
+import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
+import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 
+const mock_color = StaticColor.create('#ffffff');
 export const mockEventData = {
   event: {
     alert: true,
@@ -332,6 +336,10 @@ export const mockedViewWithTwoAggregations = View.create()
         'allm-widget-id': new WidgetPosition(1, 12, 6, Infinity),
         'summary-widget-id': new WidgetPosition(1, 1, 3, Infinity),
       })
+      .formatting(FormattingSettings.create([
+        HighlightingRule.create('count(field1)', 500, 'greater', mock_color),
+        HighlightingRule.create('count(field2)', 8000, 'less', mock_color),
+      ]))
       .build(),
   })
   .search(searchTwoAggregations)
@@ -366,6 +374,9 @@ export const mockedViewWithOneAggregation = View.create()
         'mc-widget-id': new WidgetPosition(1, 4, 2, Infinity),
         'allm-widget-id': new WidgetPosition(1, 6, 6, Infinity),
       })
+      .formatting(FormattingSettings.create([
+        HighlightingRule.create('count(field1)', 500, 'greater', mock_color),
+      ]))
       .build(),
   })
   .search(searchOneAggregation)
@@ -394,6 +405,9 @@ export const mockedViewWithOneAggregationNoField = View.create()
         'mc-widget-id': new WidgetPosition(1, 4, 2, Infinity),
         'allm-widget-id': new WidgetPosition(1, 6, 6, Infinity),
       })
+      .formatting(FormattingSettings.create([
+        HighlightingRule.create('count()', 500, 'greater', mock_color),
+      ]))
       .build(),
   })
   .search(searchOneAggregation)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This bug happens because we run at the same time 2 action functions to change the view state (normalize position and set highlights). This pr adds highlights on the stage when we generate a view for the View component 

## Motivation and Context
fix: #15715

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl