### PR TITLE
Use `useTheme` from `styled-components` where possible.

### DIFF
--- a/graylog2-web-interface/src/preflight/components/common/Alert.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Alert.tsx
@@ -15,9 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { css, ThemeContext } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import { Alert as MantineAlert } from '@mantine/core';
-import { useContext } from 'react';
 
 import type { ColorVariants } from '../../theme/types';
 
@@ -31,7 +30,7 @@ type Props = {
 };
 
 const Alert = ({ children, type }: Props) => {
-  const theme = useContext(ThemeContext);
+  const theme = useTheme();
 
   const alertStyles = () => ({
     root: {

--- a/graylog2-web-interface/src/preflight/components/common/Menu.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Menu.tsx
@@ -14,13 +14,13 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Menu as MantineMenu, type MenuProps } from '@mantine/core';
-import { ThemeContext } from 'styled-components';
+import { useTheme } from 'styled-components';
 
 const Menu = ({ children, ...otherProps }: MenuProps) => {
-  const theme = useContext(ThemeContext);
+  const theme = useTheme();
 
   const menuStyles = () => ({
     dropdown: {

--- a/graylog2-web-interface/src/preflight/components/common/Select.tsx
+++ b/graylog2-web-interface/src/preflight/components/common/Select.tsx
@@ -15,13 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext } from 'react';
 import type { SelectProps } from '@mantine/core';
 import { Select as MantineSelect } from '@mantine/core';
-import { ThemeContext } from 'styled-components';
+import { useTheme } from 'styled-components';
 
 const Select = ({ children, ...otherProps }: SelectProps) => {
-  const theme = useContext(ThemeContext);
+  const theme = useTheme();
   const SelectStyles = () => ({
     input: {
       color: theme.colors.input.color,

--- a/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
+++ b/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
@@ -35,6 +35,7 @@ const PreflightThemeProvider = ({ children }: Props) => {
   };
 
   const theme = new Sawmill(GraylogSawmill[mode], mode, handleModeChange);
+  console.log({ theme });
 
   return (
     <ThemeProvider theme={theme}>

--- a/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
+++ b/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
@@ -35,7 +35,6 @@ const PreflightThemeProvider = ({ children }: Props) => {
   };
 
   const theme = new Sawmill(GraylogSawmill[mode], mode, handleModeChange);
-  console.log({ theme });
 
   return (
     <ThemeProvider theme={theme}>

--- a/graylog2-web-interface/src/preflight/theme/ThemeWrapper.tsx
+++ b/graylog2-web-interface/src/preflight/theme/ThemeWrapper.tsx
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useContext } from 'react';
-import { ThemeContext } from 'styled-components';
+import React from 'react';
+import { useTheme } from 'styled-components';
 import type { MantineThemeOverride } from '@mantine/core';
 import { Global, MantineProvider } from '@mantine/core';
 
@@ -24,7 +24,7 @@ type Props = {
 };
 
 const ThemeWrapper = ({ children }: Props) => {
-  const theme = useContext(ThemeContext);
+  const theme = useTheme();
 
   const mantineTheme: MantineThemeOverride = {
     colorScheme: theme.mode === 'teint' ? 'light' : 'dark',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR contains a small refactoring to use `useTheme` from `styled-components` instead of `useContext(ThemeContext)`.

/nocl