### PR TITLE
Allow duplicating event definitions with a limit of 0

### DIFF
--- a/changelog/unreleased/pr-16251.toml
+++ b/changelog/unreleased/pr-16251.toml
@@ -1,0 +1,6 @@
+type = "a"
+message = "Add API endpoint for event definition duplication."
+
+issues = [""]
+pulls = ["16251"]
+

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -25,6 +25,7 @@ import org.graylog.scheduler.DBJobTriggerService;
 import org.graylog.scheduler.JobDefinitionDto;
 import org.graylog.scheduler.JobTriggerDto;
 import org.graylog.scheduler.clock.JobSchedulerClock;
+import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.plugin.database.users.User;
 import org.joda.time.DateTime;
 import org.mongojack.DBQuery;
@@ -88,6 +89,25 @@ public class EventDefinitionHandler {
         }
 
         return eventDefinition;
+    }
+
+    /**
+     * Duplicates an existing event definition.
+     * The new copy will be disabled by default and will have the {@link DefaultEntityScope}.
+     * Also the title will be prefixed with the string "COPY-".
+     * @param eventDefinition the event definition to copy
+     * @param user the user who copied this eventDefinition. If empty, no ownership will be registered.
+     * @return the newly created event definition
+     */
+    public EventDefinitionDto duplicate(EventDefinitionDto eventDefinition, Optional<User> user) {
+        var copy = eventDefinition.toBuilder()
+                .id(null)
+                .title("COPY-" + eventDefinition.title())
+                .scope(DefaultEntityScope.NAME)
+                .state(EventDefinition.State.DISABLED)
+                .build();
+
+        return createWithoutSchedule(copy, user);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -47,7 +47,6 @@ import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
-import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.rest.ValidationFailureException;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -443,15 +442,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                 new BadRequestException(f("Unable to find event definition '%s' to duplicate", definitionId)));
         checkEventDefinitionPermissions(eventDefinitionDto, "create");
 
-        var copy = eventDefinitionDto.toBuilder()
-                .id(null)
-                .title("COPY-" + eventDefinitionDto.title())
-                .scope(DefaultEntityScope.NAME)
-                .state(EventDefinition.State.DISABLED)
-                .build();
-
-        final EventDefinitionDto saved = eventDefinitionHandler.createWithoutSchedule(copy, Optional.of(userContext.getUser()));
-
+        final EventDefinitionDto saved = eventDefinitionHandler.duplicate(eventDefinitionDto, Optional.of(userContext.getUser()));
         return Response.ok().entity(saved).build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -47,6 +47,7 @@ import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.rest.ValidationFailureException;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -97,6 +98,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+import static org.graylog2.shared.utilities.StringUtils.f;
 
 @Api(value = "Events/Definitions", description = "Event definition management", tags = {CLOUD_VISIBLE})
 @Path("/events/definitions")
@@ -260,7 +262,9 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         if (result.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(result).build();
         }
-        final EventDefinitionDto entity = schedule ? eventDefinitionHandler.create(dto, Optional.of(userContext.getUser())) : eventDefinitionHandler.createWithoutSchedule(dto, Optional.of(userContext.getUser()));
+        final EventDefinitionDto entity = schedule ?
+                eventDefinitionHandler.create(dto, Optional.of(userContext.getUser())) :
+                eventDefinitionHandler.createWithoutSchedule(dto.toBuilder().state(EventDefinition.State.DISABLED).build(), Optional.of(userContext.getUser()));
         recentActivityService.create(entity.id(), GRNTypes.EVENT_DEFINITION, userContext.getUser());
         return Response.ok().entity(entity).build();
     }
@@ -347,7 +351,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                                        @Context UserContext userContext) {
         checkPermission(RestPermissions.EVENT_DEFINITIONS_EDIT, definitionId);
         final EventDefinitionDto eventDefinitionDto = dbService.get(definitionId).orElseThrow(() ->
-                new BadRequestException(org.graylog2.shared.utilities.StringUtils.f("Unable to find event definition '%s' to enable", definitionId)));
+                new BadRequestException(f("Unable to find event definition '%s' to enable", definitionId)));
         eventDefinitionHandler.schedule(definitionId);
         return eventDefinitionDto.toBuilder().state(EventDefinition.State.ENABLED).build();
     }
@@ -378,7 +382,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                                          @Context UserContext userContext) {
         checkPermission(RestPermissions.EVENT_DEFINITIONS_EDIT, definitionId);
         final EventDefinitionDto eventDefinitionDto = dbService.get(definitionId).orElseThrow(() ->
-                new BadRequestException(org.graylog2.shared.utilities.StringUtils.f("Unable to find event definition '%s' to disable", definitionId)));
+                new BadRequestException(f("Unable to find event definition '%s' to disable", definitionId)));
         eventDefinitionHandler.unschedule(definitionId);
         return eventDefinitionDto.toBuilder().state(EventDefinition.State.DISABLED).build();
     }
@@ -426,6 +430,29 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         } catch (EventProcessorException e) {
             throw new InternalServerErrorException(e.getMessage(), e);
         }
+    }
+
+    @POST
+    @ApiOperation("Duplicate an event definition")
+    @Path("{definitionId}/duplicate")
+    @Consumes(MediaType.WILDCARD)
+    @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_CREATE)
+    @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
+    public Response duplicate(@ApiParam(name = "definitionId") @PathParam("definitionId") @NotBlank String definitionId, @Context UserContext userContext) {
+        final EventDefinitionDto eventDefinitionDto = dbService.get(definitionId).orElseThrow(() ->
+                new BadRequestException(f("Unable to find event definition '%s' to duplicate", definitionId)));
+        checkEventDefinitionPermissions(eventDefinitionDto, "create");
+
+        var copy = eventDefinitionDto.toBuilder()
+                .id(null)
+                .title("COPY-" + eventDefinitionDto.title())
+                .scope(DefaultEntityScope.NAME)
+                .state(EventDefinition.State.DISABLED)
+                .build();
+
+        final EventDefinitionDto saved = eventDefinitionHandler.createWithoutSchedule(copy, Optional.of(userContext.getUser()));
+
+        return Response.ok().entity(saved).build();
     }
 
     @POST

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
@@ -54,7 +54,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +68,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 
 public class EventDefinitionHandlerTest {
-    public static final Set<EntityScope> ENTITY_SCOPES = Collections.singleton(new DefaultEntityScope());
+    public final Set<EntityScope> ENTITY_SCOPES = Set.of(new DefaultEntityScope(), new TestEntityScope());
     @Rule
     public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
 
@@ -162,6 +161,36 @@ public class EventDefinitionHandlerTest {
             assertThat(schedule.interval()).isEqualTo(60001);
             assertThat(schedule.unit()).isEqualTo(TimeUnit.MILLISECONDS);
         });
+    }
+
+    @Test
+    public void duplicate() {
+        final EventDefinitionDto newDto = EventDefinitionDto.builder()
+                .title("Test")
+                .description("A test event definition")
+                .config(TestEventProcessorConfig.builder()
+                        .message("This is a test event processor")
+                        .searchWithinMs(300000)
+                        .executeEveryMs(60001)
+                        .build())
+                .priority(3)
+                .state(EventDefinition.State.ENABLED)
+                .scope(TestEntityScope.NAME)
+                .alert(false)
+                .notificationSettings(EventNotificationSettings.withGracePeriod(60000))
+                .keySpec(ImmutableList.of("a", "b"))
+                .notifications(ImmutableList.of())
+                .build();
+
+        final var existingEvent = eventDefinitionService.save(newDto);
+        final var duplicated = handler.duplicate(existingEvent, Optional.empty());
+        final var saved = eventDefinitionService.get(duplicated.id()).get();
+
+        assertThat(saved.title()).startsWith("COPY-");
+        assertThat(saved.scope()).isEqualTo(DefaultEntityScope.NAME);
+        assertThat(saved.state()).isEqualTo(EventDefinition.State.DISABLED);
+
+        assertThat(jobDefinitionService.getByConfigField("event_definition_id", saved.id())).isNotPresent();
     }
 
     @Test
@@ -499,5 +528,22 @@ public class EventDefinitionHandlerTest {
 
         assertThat(jobTriggerService.get("61fbcca5b2507945cc120001")).isNotPresent();
         assertThat(jobTriggerService.get("61fbcca5b2507945cc120002")).isPresent();
+    }
+
+    static class TestEntityScope extends EntityScope {
+        public static final String NAME = "TESTSCOPE";
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+        @Override
+        public boolean isMutable() {
+            return false;
+        }
+        @Override
+        public boolean isDeletable() {
+            return false;
+        }
     }
 }

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -237,23 +237,13 @@ export const EventDefinitionsStore = singletonStore(
       EventDefinitionsActions.create.promise(promise);
     },
 
-    copy(eventDefinitionToCopy) {
-      const { eventDefinition } = this.extractSchedulerInfo(eventDefinitionToCopy);
-      // Remove the id from the event definition to create a new copy
-      delete eventDefinition.id;
-      // Remove the scheduler from the event definition to create a new copy
-      delete eventDefinition.scheduler;
-      // Modify the title to indicate a copy
-      eventDefinition.title = `COPY-${eventDefinition.title}`;
-      // Set the scope to DEFAULT
-      eventDefinition._scope = 'DEFAULT';
-
-      const promise = fetch('POST', this.eventDefinitionsUrl({ query: { schedule: false } }), this.setAlertFlag(eventDefinition));
+    copy(eventDefinition) {
+      const promise = fetch('POST', this.eventDefinitionsUrl({ segments: [eventDefinition.id, 'duplicate'] }));
 
       promise.then(
         (response) => {
-          UserNotification.success('Event Definition copied successfully',
-            `Event Definition "${eventDefinition.title}" was created successfully.`);
+          UserNotification.success('Event Definition duplicated successfully',
+            `Event Definition "${response.title}" was created successfully.`);
 
           this.refresh();
 
@@ -261,8 +251,8 @@ export const EventDefinitionsStore = singletonStore(
         },
         (error) => {
           if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
-            UserNotification.error(`Creating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
-              'Could not save Event Definition');
+            UserNotification.error(`Duplicating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
+              'Could not duplicate Event Definition');
           }
         },
       );


### PR DESCRIPTION
With #16035 we try to enforce a new default event limit, without breaking backwards compatibility.

The validations are making an exemption if an existing event definition is being edited which doesn't have an event limit yet (limit of 0)

Duplicating event definitions was done in the frontend, followed by creating a new one.
This makes it impossible to differentiate between copy and create in the backend.

 - Create a new `/events/definitions/{definitionId}/duplicate` endpoint. Which creates a copy without performing a validation.

 - Also correctly set the state for unscheduled event defintions. This got missed with #15558

Refs #16035

