### PR TITLE
add datanode IT to verify cluster add/remove

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.NoHttpResponseException;
 import org.graylog.datanode.configuration.variants.KeystoreInformation;
 import org.graylog.datanode.testinfra.DatanodeContainerizedBackend;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
+import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.file.Path;

--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
@@ -27,13 +27,15 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.NoHttpResponseException;
 import org.graylog.datanode.configuration.variants.KeystoreInformation;
 import org.graylog.datanode.testinfra.DatanodeContainerizedBackend;
-import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -57,94 +59,50 @@ public class DatanodeClusterIT {
     private KeyStore trustStore;
     private String usernameNodeA;
     private String passwordNodeA;
+    private KeystoreInformation ca;
 
     @BeforeEach
     void setUp() throws GeneralSecurityException, IOException {
 
         // first generate a self-signed CA
-        final KeystoreInformation ca = DatanodeSecurityTestUtils.generateCa(tempDir);
+        ca = DatanodeSecurityTestUtils.generateCa(tempDir);
 
         trustStore = DatanodeSecurityTestUtils.buildTruststore(ca);
-
-        usernameNodeA = RandomStringUtils.randomAlphabetic(10);
-        passwordNodeA = RandomStringUtils.randomAlphabetic(10);
-
-        final String usernameNodeB = RandomStringUtils.randomAlphabetic(10);
-        final String passwordNodeB = RandomStringUtils.randomAlphabetic(10);
 
         hostnameNodeA = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
         final KeystoreInformation transportNodeA = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeA");
         final KeystoreInformation httpNodeA = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeA");
+        usernameNodeA = RandomStringUtils.randomAlphabetic(10);
+        passwordNodeA = RandomStringUtils.randomAlphabetic(10);
+
+        final Network network = Network.newNetwork();
+        final GenericContainer<?> mongodb = DatanodeContainerizedBackend.createMongodbContainer(network);
+        nodeA = createDatanodeContainer(
+                network,
+                mongodb,
+                hostnameNodeA,
+                transportNodeA,
+                httpNodeA,
+                usernameNodeA,
+                passwordNodeA
+        ).start();
+
 
         final String hostnameNodeB = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
         final KeystoreInformation transportNodeB = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeB");
         final KeystoreInformation httpNodeB = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeB");
+        final String usernameNodeB = RandomStringUtils.randomAlphabetic(10);
+        final String passwordNodeB = RandomStringUtils.randomAlphabetic(10);
 
-        nodeA = new DatanodeContainerizedBackend(hostnameNodeA, datanodeContainer -> {
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_CLUSTER_INITIAL_MANAGER_NODES", hostnameNodeA);
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS", hostnameNodeA + ":9300");
-
-            datanodeContainer.withFileSystemBind(transportNodeA.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-transport-certificates.p12");
-            datanodeContainer.withFileSystemBind(httpNodeA.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-https-certificates.p12");
-
-            // configure transport security
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE", "datanode-transport-certificates.p12");
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE_PASSWORD", transportNodeA.passwordAsString());
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_INSECURE_STARTUP", "false");
-
-            // configure http security
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE", "datanode-https-certificates.p12");
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE_PASSWORD", httpNodeA.passwordAsString());
-
-            // configure initial admin username and password for Opensearch REST
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_USERNAME", usernameNodeA);
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_PASSWORD", passwordNodeA);
-
-            // this is the interface that we bind opensearch to. It must be 0.0.0.0 if we want
-            // to be able to reach opensearch from outside the container and docker network (true?)
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_BIND_ADDRESS", "0.0.0.0");
-
-            // HOSTNAME is used to generate the SSL certificates and to communicate inside the
-            // container and docker network, where we do the hostname validation.
-            datanodeContainer.withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(hostnameNodeA));
-            datanodeContainer.withEnv("GRAYLOG_DATANODE_HOSTNAME", hostnameNodeA);
-        }).start();
-
-        nodeB = new DatanodeContainerizedBackend(
-                nodeA.getNetwork(),
-                nodeA.getMongodbContainer(),
+        nodeB = createDatanodeContainer(
+                network,
+                mongodb,
                 hostnameNodeB,
-                datanodeContainer -> {
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_CLUSTER_INITIAL_MANAGER_NODES", hostnameNodeA);
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS", hostnameNodeA + ":9300");
-
-                    datanodeContainer.withFileSystemBind(transportNodeB.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-transport-certificates.p12");
-                    datanodeContainer.withFileSystemBind(httpNodeB.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-https-certificates.p12");
-
-                    // configure transport security
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE", "datanode-transport-certificates.p12");
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE_PASSWORD", transportNodeB.passwordAsString());
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_INSECURE_STARTUP", "false");
-
-                    // configure http security
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE", "datanode-https-certificates.p12");
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE_PASSWORD", httpNodeB.passwordAsString());
-
-                    // configure initial admin username and password for Opensearch REST
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_USERNAME", usernameNodeB);
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_PASSWORD", passwordNodeB);
-
-                    // this is the interface that we bind opensearch to. It must be 0.0.0.0 if we want
-                    // to be able to reach opensearch from outside the container and docker network (true?)
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_BIND_ADDRESS", "0.0.0.0");
-
-                    // HOSTNAME is used to generate the SSL certificates and to communicate inside the
-                    // container and docker network, where we do the hostname validation.
-                    datanodeContainer.withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(hostnameNodeB));
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HOSTNAME", hostnameNodeB);
-                }
-        );
-        nodeB.start();
+                transportNodeB,
+                httpNodeB,
+                usernameNodeB,
+                passwordNodeB
+        ).start();
     }
 
     @AfterEach
@@ -155,35 +113,92 @@ public class DatanodeClusterIT {
 
     @Test
     void testClusterFormation() throws ExecutionException, RetryException {
+        waitForNodesCount(2);
+    }
 
+    @Test
+    void testAddingNodeToExistingCluster() throws ExecutionException, RetryException {
+
+        final String hostnameNodeC = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
+        final KeystoreInformation transportNodeC = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeB");
+        final KeystoreInformation httpNodeC = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeB");
+        final String usernameNodeC = RandomStringUtils.randomAlphabetic(10);
+        final String passwordNodeC = RandomStringUtils.randomAlphabetic(10);
+
+        final DatanodeContainerizedBackend nodeC = createDatanodeContainer(
+                nodeA.getNetwork(), nodeA.getMongodbContainer(),
+                hostnameNodeC,
+                transportNodeC,
+                httpNodeC,
+                usernameNodeC,
+                passwordNodeC
+        );
+
+        nodeC.start();
+        waitForNodesCount(3);
+        nodeC.stop();
+        waitForNodesCount(2);
+    }
+
+    @NotNull
+    private DatanodeContainerizedBackend createDatanodeContainer(Network network, GenericContainer<?> mongodb, String hostname, KeystoreInformation transportKeystore, KeystoreInformation httpKeystore, String restUsername, String restPassword) {
+        return new DatanodeContainerizedBackend(
+                network,
+                mongodb,
+                hostname,
+                datanodeContainer -> {
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_CLUSTER_INITIAL_MANAGER_NODES", hostnameNodeA);
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS", hostnameNodeA + ":9300");
+
+                    datanodeContainer.withFileSystemBind(transportKeystore.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-transport-certificates.p12");
+                    datanodeContainer.withFileSystemBind(httpKeystore.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/bin/config/datanode-https-certificates.p12");
+
+                    // configure transport security
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE", "datanode-transport-certificates.p12");
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_TRANSPORT_CERTIFICATE_PASSWORD", transportKeystore.passwordAsString());
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_INSECURE_STARTUP", "false");
+
+                    // configure http security
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE", "datanode-https-certificates.p12");
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_CERTIFICATE_PASSWORD", httpKeystore.passwordAsString());
+
+                    // configure initial admin username and password for Opensearch REST
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_USERNAME", restUsername);
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_REST_API_PASSWORD", restPassword);
+
+                    // this is the interface that we bind opensearch to. It must be 0.0.0.0 if we want
+                    // to be able to reach opensearch from outside the container and docker network (true?)
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HTTP_BIND_ADDRESS", "0.0.0.0");
+
+                    // HOSTNAME is used to generate the SSL certificates and to communicate inside the
+                    // container and docker network, where we do the hostname validation.
+                    datanodeContainer.withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName(hostname));
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_HOSTNAME", hostname);
+                });
+    }
+
+    private void waitForNodesCount(int countOfNodes) throws ExecutionException, RetryException {
         try {
             final Retryer<ValidatableResponse> retryer = RetryerBuilder.<ValidatableResponse>newBuilder()
                     .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                     .withStopStrategy(StopStrategies.stopAfterAttempt(120))
                     .retryIfException(input -> input instanceof NoHttpResponseException)
                     .retryIfException(input -> input instanceof SocketException)
-                    .retryIfResult(input -> !input.extract().body().path("number_of_nodes").equals(2))
+                    .retryIfResult(input -> !input.extract().body().path("number_of_nodes").equals(countOfNodes))
                     .retryIfResult(input -> !input.extract().body().path("status").equals("green"))
+                    .retryIfResult(input -> !input.extract().body().path("discovered_cluster_manager").equals(true))
                     .build();
-
-            final Integer opensearchPort = nodeA.getOpensearchRestPort();
-
-            retryer.call(() -> this.getStatus(opensearchPort))
-                    .assertThat()
-                    .body("status", Matchers.equalTo("green"))
-                    .body("number_of_nodes", Matchers.equalTo(2))
-                    .body("discovered_cluster_manager", Matchers.equalTo(true));
-        } catch (RetryException retryException) {
+            retryer.call(() -> {
+                Integer mappedPort = nodeA.getOpensearchRestPort();
+                return RestAssured.given()
+                        .trustStore(trustStore)
+                        .auth().basic(usernameNodeA, passwordNodeA)
+                        .get("https://localhost:" + mappedPort + "/_cluster/health")
+                        .then();
+            });
+        } catch (Exception retryException) {
             LOG.error("DataNode Container logs follow:\n" + nodeA.getLogs());
             throw retryException;
         }
-    }
-
-    private ValidatableResponse getStatus(Integer mappedPort) {
-        return RestAssured.given()
-                .trustStore(trustStore)
-                .auth().basic(usernameNodeA, passwordNodeA)
-                .get("https://localhost:" + mappedPort + "/_cluster/health")
-                .then();
     }
 }

--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
@@ -50,7 +50,7 @@ public class DatanodeContainerizedBackend {
 
     public DatanodeContainerizedBackend(final String nodeName, DatanodeDockerHooks hooks) {
         this.network = Network.newNetwork();
-        this.mongodbContainer = createMongodbContainer();
+        this.mongodbContainer = createMongodbContainer(this.network);
         this.datanodeContainer = createDatanodeContainer(
                 nodeName,
                 hooks, createDockerImageFile(getOpensearchVersion()),
@@ -137,7 +137,7 @@ public class DatanodeContainerizedBackend {
                                 .build());
     }
 
-    private GenericContainer<?> createMongodbContainer() {
+    public static GenericContainer<?> createMongodbContainer(Network network) {
         return new GenericContainer<>("mongo:5.0")
                 .withNetwork(network)
                 .withNetworkAliases("mongodb")


### PR DESCRIPTION
/nocl

This PR adds a datanode integration tests that adds and removes a datanode to the cluster. The test verifies that the opensearch cluster is green before, during and after, with expected count of connected nodes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

