### PR TITLE
IndexFieldTypeService can provide a history of types for certain inde…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -51,6 +51,7 @@ import static com.mongodb.client.model.Projections.include;
 import static org.graylog2.indexer.fieldtypes.FieldTypeDTO.FIELD_NAME;
 import static org.graylog2.indexer.fieldtypes.FieldTypeDTO.FIELD_PHYSICAL_TYPE;
 import static org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO.FIELD_FIELDS;
+import static org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO.FIELD_INDEX_NAME;
 import static org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO.FIELD_INDEX_SET_ID;
 
 /**
@@ -75,10 +76,10 @@ public class IndexFieldTypesService {
                 objectMapperProvider.get());
 
         this.db.createIndex(new BasicDBObject(ImmutableMap.of(
-                IndexFieldTypesDTO.FIELD_INDEX_NAME, 1,
+                FIELD_INDEX_NAME, 1,
                 FIELD_INDEX_SET_ID, 1
         )), new BasicDBObject("unique", true));
-        this.db.createIndex(new BasicDBObject(IndexFieldTypesDTO.FIELD_INDEX_NAME, 1), new BasicDBObject("unique", true));
+        this.db.createIndex(new BasicDBObject(FIELD_INDEX_NAME, 1), new BasicDBObject("unique", true));
         this.db.createIndex(new BasicDBObject(FIELDS_FIELD_NAMES, 1));
         this.db.createIndex(new BasicDBObject(FIELD_INDEX_SET_ID, 1));
     }
@@ -123,7 +124,7 @@ public class IndexFieldTypesService {
             return Optional.ofNullable(db.findOneById(new ObjectId(idOrIndexName)));
         } catch (IllegalArgumentException e) {
             // Not an ObjectId, try again with index_name
-            return Optional.ofNullable(db.findOne(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_NAME, idOrIndexName)));
+            return Optional.ofNullable(db.findOne(DBQuery.is(FIELD_INDEX_NAME, idOrIndexName)));
         }
     }
 
@@ -135,7 +136,7 @@ public class IndexFieldTypesService {
     public Optional<IndexFieldTypesDTO> upsert(IndexFieldTypesDTO dto) {
         final WriteResult<IndexFieldTypesDTO, ObjectId> update = MongoDBUpsertRetryer.run(() -> db.update(
                 DBQuery.and(
-                        DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_NAME, dto.indexName()),
+                        DBQuery.is(FIELD_INDEX_NAME, dto.indexName()),
                         DBQuery.is(FIELD_INDEX_SET_ID, dto.indexSetId())
                 ),
                 dto,
@@ -157,7 +158,7 @@ public class IndexFieldTypesService {
             db.removeById(new ObjectId(idOrIndexName));
         } catch (IllegalArgumentException e) {
             // Not an ObjectId, try again with index_name
-            db.remove(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_NAME, idOrIndexName));
+            db.remove(DBQuery.is(FIELD_INDEX_NAME, idOrIndexName));
         }
     }
 
@@ -177,7 +178,7 @@ public class IndexFieldTypesService {
 
     public Collection<IndexFieldTypesDTO> findForFieldNamesAndIndices(Collection<String> fieldNames, Collection<String> indexNames) {
         final DBQuery.Query query = DBQuery.and(
-                DBQuery.in(IndexFieldTypesDTO.FIELD_INDEX_NAME, indexNames),
+                DBQuery.in(FIELD_INDEX_NAME, indexNames),
                 DBQuery.in(FIELDS_FIELD_NAMES, fieldNames)
         );
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -19,6 +19,11 @@ package org.graylog2.indexer.fieldtypes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.BasicDBObject;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
@@ -29,27 +34,41 @@ import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Projections.excludeId;
+import static com.mongodb.client.model.Projections.include;
+import static org.graylog2.indexer.fieldtypes.FieldTypeDTO.FIELD_NAME;
+import static org.graylog2.indexer.fieldtypes.FieldTypeDTO.FIELD_PHYSICAL_TYPE;
+import static org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO.FIELD_FIELDS;
+import static org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO.FIELD_INDEX_SET_ID;
+
 /**
  * Manages the "index_field_types" MongoDB collection.
  */
 public class IndexFieldTypesService {
-    private static final String FIELDS_FIELD_NAMES = String.format(Locale.US, "%s.%s", IndexFieldTypesDTO.FIELD_FIELDS, FieldTypeDTO.FIELD_NAME);
+    private static final String FIELDS_FIELD_NAMES = String.format(Locale.US, "%s.%s", FIELD_FIELDS, FIELD_NAME);
 
     private final JacksonDBCollection<IndexFieldTypesDTO, ObjectId> db;
     private final StreamService streamService;
+    private final MongoCollection<Document> mongoCollection;
 
     @Inject
     public IndexFieldTypesService(MongoConnection mongoConnection,
                                   StreamService streamService,
                                   MongoJackObjectMapperProvider objectMapperProvider) {
         this.streamService = streamService;
+        this.mongoCollection = mongoConnection.getMongoDatabase().getCollection("index_field_types");
         this.db = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection("index_field_types"),
                 IndexFieldTypesDTO.class,
                 ObjectId.class,
@@ -57,11 +76,46 @@ public class IndexFieldTypesService {
 
         this.db.createIndex(new BasicDBObject(ImmutableMap.of(
                 IndexFieldTypesDTO.FIELD_INDEX_NAME, 1,
-                IndexFieldTypesDTO.FIELD_INDEX_SET_ID, 1
+                FIELD_INDEX_SET_ID, 1
         )), new BasicDBObject("unique", true));
         this.db.createIndex(new BasicDBObject(IndexFieldTypesDTO.FIELD_INDEX_NAME, 1), new BasicDBObject("unique", true));
         this.db.createIndex(new BasicDBObject(FIELDS_FIELD_NAMES, 1));
-        this.db.createIndex(new BasicDBObject(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, 1));
+        this.db.createIndex(new BasicDBObject(FIELD_INDEX_SET_ID, 1));
+    }
+
+    public List<String> fieldTypeHistory(final String indexSetId,
+                                         final String fieldName,
+                                         final boolean skipEntriesWithUnchangedType) {
+        final AggregateIterable<Document> aggregateResult = this.mongoCollection.aggregate(List.of(
+                        Aggregates.unwind("$" + FIELD_FIELDS),
+                        Aggregates.match(and(
+                                eq(FIELD_INDEX_SET_ID, indexSetId),
+                                eq(FIELD_FIELDS + "." + FIELD_NAME, fieldName)
+                        )),
+                        Aggregates.project(Projections.fields(
+                                include(FIELD_FIELDS + "." + FIELD_PHYSICAL_TYPE),
+                                excludeId()
+                        ))
+                )
+        );
+
+        List<String> typeHistory = new ArrayList<>();
+
+        aggregateResult
+                .map(document -> ((Document) document.get(FIELD_FIELDS)).getString(FIELD_PHYSICAL_TYPE))
+                .forEach(typeHistory::add);
+
+        if (!skipEntriesWithUnchangedType) {
+            return typeHistory;
+        } else {
+            LinkedList<String> reducedTypeHistory = new LinkedList<>();
+            typeHistory.forEach(type -> {
+                if (reducedTypeHistory.isEmpty() || !type.equals(reducedTypeHistory.getLast())) {
+                    reducedTypeHistory.add(type);
+                }
+            });
+            return reducedTypeHistory;
+        }
     }
 
     public Optional<IndexFieldTypesDTO> get(String idOrIndexName) {
@@ -82,7 +136,7 @@ public class IndexFieldTypesService {
         final WriteResult<IndexFieldTypesDTO, ObjectId> update = MongoDBUpsertRetryer.run(() -> db.update(
                 DBQuery.and(
                         DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_NAME, dto.indexName()),
-                        DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, dto.indexSetId())
+                        DBQuery.is(FIELD_INDEX_SET_ID, dto.indexSetId())
                 ),
                 dto,
                 true,
@@ -108,12 +162,12 @@ public class IndexFieldTypesService {
     }
 
     public Collection<IndexFieldTypesDTO> findForIndexSet(String indexSetId) {
-        return findByQuery(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId));
+        return findByQuery(DBQuery.is(FIELD_INDEX_SET_ID, indexSetId));
     }
 
     public Collection<IndexFieldTypesDTO> findForIndexSets(Collection<String> indexSetIds) {
         return findByQuery(
-                DBQuery.in(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetIds)
+                DBQuery.in(FIELD_INDEX_SET_ID, indexSetIds)
         );
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
@@ -27,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.of;
@@ -68,6 +69,44 @@ public class IndexFieldTypesServiceTest {
 
     private IndexFieldTypesDTO createDto(String indexName, Set<FieldTypeDTO> fields) {
         return createDto(indexName, "abc123", fields);
+    }
+
+    @Test
+    public void testTypeHistoryForFieldChangingType() {
+        dbService.save(createDto("graylog_0", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "long"))));
+        dbService.save(createDto("graylog_1", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "text"))));
+        dbService.save(createDto("graylog_2", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "text"))));
+        dbService.save(createDto("graylog_3", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "double"))));
+        dbService.save(createDto("graylog_4", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "long"))));
+        dbService.save(createDto("graylog_5", "index_set_id", Set.of(FieldTypeDTO.create("field_changing_type", "long"))));
+
+        List<String> typeHistory = dbService.fieldTypeHistory("index_set_id", "field_changing_type", true);
+        assertThat(typeHistory).isEqualTo(List.of("long", "text", "double", "long"));
+        typeHistory = dbService.fieldTypeHistory("index_set_id", "field_changing_type", false);
+        assertThat(typeHistory).isEqualTo(List.of("long", "text", "text", "double", "long", "long"));
+
+    }
+
+    @Test
+    public void testTypeHistoryForFieldWithStableType() {
+        dbService.save(createDto("graylog_0", "index_set_id", Set.of()));
+        dbService.save(createDto("graylog_1", "index_set_id", Set.of()));
+
+        List<String> typeHistory = dbService.fieldTypeHistory("index_set_id", "message", true);
+        assertThat(typeHistory).isEqualTo(List.of("text"));
+        typeHistory = dbService.fieldTypeHistory("index_set_id", "message", false);
+        assertThat(typeHistory).isEqualTo(List.of("text", "text"));
+    }
+
+    @Test
+    public void testTypeHistoryForNonExistingField() {
+        dbService.save(createDto("graylog_0", "index_set_id", Set.of()));
+        dbService.save(createDto("graylog_1", "index_set_id", Set.of()));
+
+        List<String> typeHistory = dbService.fieldTypeHistory("index_set_id", "non_existing_field", true);
+        assertThat(typeHistory).isEqualTo(List.of());
+        typeHistory = dbService.fieldTypeHistory("index_set_id", "non_existing_field", false);
+        assertThat(typeHistory).isEqualTo(List.of());
     }
 
     @Test


### PR DESCRIPTION
…x_set and field
/nocl


## Description
IndexFieldTypeService can provide a history of types for certain index_set and field. 

## Motivation and Context
This feature will be needed for `Field Type Management` topic (please refer to Maksym's mocks for details).

## How Has This Been Tested?
With additional automatic tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

