### PR TITLE
Display indicator when dashboard has unsaved changes. (5.1)

### DIFF
--- a/changelog/unreleased/issue-10682.toml
+++ b/changelog/unreleased/issue-10682.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Display indicator when dashboard has unsaved changes."
+
+issues = ["10682"]
+pulls = ["16122"]

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -40,6 +40,7 @@ import useAppDispatch from 'stores/useAppDispatch';
 import { updateView } from 'views/logic/slices/viewSlice';
 import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 import useHistory from 'routing/useHistory';
+import SaveViewButton from 'views/components/searchbar/SaveViewButton';
 
 import DashboardPropertiesModal from './dashboard/DashboardPropertiesModal';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
@@ -100,11 +101,9 @@ const DashboardActionsMenu = () => {
   return (
     <ButtonGroup>
       {showSaveButton && (
-        <Button onClick={_onSaveView}
-                disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}
-                title="Save dashboard">
-          <Icon name="save" /> Save
-        </Button>
+        <SaveViewButton title="Save dashboard"
+                        onClick={_onSaveView}
+                        disabled={isNewView || hasUndeclaredParameters || !allowedToEdit} />
       )}
       {showSaveNewButton && (
         <Button onClick={() => setSaveNewDashboardOpen(true)}

--- a/graylog2-web-interface/src/views/components/searchbar/SaveViewButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SaveViewButton.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { forwardRef } from 'react';
+import styled, { css } from 'styled-components';
+
+import { Icon } from 'components/common';
+import useIsDirty from 'views/hooks/useIsDirty';
+import { Button } from 'components/bootstrap';
+
+const StyledIcon = styled(Icon)<{ $isDirty: boolean }>(({ theme, $isDirty }) => css`
+  color: ${$isDirty ? theme.colors.variant.dark.warning : 'default'};
+`);
+
+type Props = {
+  title: string,
+  onClick: () => void,
+  disabled?: boolean,
+}
+
+const SaveViewButton = forwardRef<HTMLButtonElement, Props>(({ title, onClick, disabled }, ref) => {
+  const isDirty = useIsDirty();
+
+  return (
+    <Button title={title}
+            ref={ref}
+            onClick={onClick}
+            disabled={disabled}>
+      <StyledIcon name="floppy-disk" type={isDirty ? 'solid' : 'regular'} $isDirty={!disabled && isDirty} /> Save
+    </Button>
+  );
+});
+
+SaveViewButton.defaultProps = {
+  disabled: false,
+};
+
+export default SaveViewButton;

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { useCallback, useState, useContext, useRef, useMemo } from 'react';
 
 import { isPermitted } from 'util/PermissionsMixin';
@@ -47,6 +47,7 @@ import { loadView, updateView } from 'views/logic/slices/viewSlice';
 import type FetchError from 'logic/errors/FetchError';
 import useHistory from 'routing/useHistory';
 import usePluginEntities from 'hooks/usePluginEntities';
+import SaveViewButton from 'views/components/searchbar/SaveViewButton';
 
 import SavedSearchForm from './SavedSearchForm';
 import SavedSearchesModal from './SavedSearchesModal';
@@ -69,7 +70,6 @@ const _extractErrorMessage = (error: FetchError) => {
 };
 
 const SearchActionsMenu = () => {
-  const theme = useTheme();
   const dirty = useIsDirty();
   const view = useView();
   const isNew = useIsNew();
@@ -88,7 +88,6 @@ const SearchActionsMenu = () => {
   const onUpdateView = useCallback((newView: View) => dispatch(updateView(newView)), [dispatch]);
 
   const loaded = isNew === false;
-  const savedSearchColor = dirty ? theme.colors.variant.dark.warning : theme.colors.variant.info;
   const disableReset = !(dirty || loaded);
   const savedViewTitle = loaded ? 'Saved search' : 'Save search';
   const title = dirty ? 'Unsaved changes' : savedViewTitle;
@@ -164,9 +163,9 @@ const SearchActionsMenu = () => {
 
   return (
     <Container aria-label="Search Meta Buttons">
-      <Button title={title} ref={formTarget} onClick={toggleFormModal}>
-        <Icon style={{ color: loaded ? savedSearchColor : undefined }} name="floppy-disk" type={loaded ? 'solid' : 'regular'} /> Save
-      </Button>
+      <SaveViewButton title={title}
+                      ref={formTarget}
+                      onClick={toggleFormModal} />
       {showForm && (
         <SavedSearchForm target={formTarget.current}
                          saveSearch={saveSearch}


### PR DESCRIPTION
**Please note:** This is a backport of #16122 for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are unifying the behaviour of the "save" icon on the search and dashboard page. Before this change the dashboard save icon did not indicate unsaved changes.

Fixes #10682
