### PR TITLE
Fix heatmap colorbar font color for dark mode. (5.1)

### DIFF
--- a/changelog/unreleased/issue-15035.toml
+++ b/changelog/unreleased/issue-15035.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix heatmap colorbar font color for dark mode."
+
+issues = ["15035"]
+pulls = ["16129"]

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -43,6 +43,7 @@ export type ChartDefinition = {
   },
   customdata?: any,
   colorscale?: [number, string][],
+  colorbar?: { tickfont: { color: string } },
   reversescale?: boolean,
   zmin?: boolean,
   zmax?: boolean,

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useContext, useState, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Overlay, RootCloseWrapper } from 'react-overlays';
 import chunk from 'lodash/chunk';
 
@@ -32,7 +32,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type Series from 'views/logic/aggregationbuilder/Series';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 
-const ColorHint = styled.div(({ color }) => `
+const ColorHint = styled.div(({ color }) => css`
   cursor: pointer;
   background-color: ${color} !important; /* Needed for report generation */
   -webkit-print-color-adjust: exact !important; /* Needed for report generation */

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -20,6 +20,7 @@ import merge from 'lodash/merge';
 import fill from 'lodash/fill';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
+import { useTheme } from 'styled-components';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -43,7 +44,7 @@ const _generateSeriesTitles = (config, x, y) => {
   return y.map(() => columnSeriesTitles);
 };
 
-const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visualizationConfig): ChartDefinition => {
+const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visualizationConfig, theme): ChartDefinition => {
   const xAxisTitle = config.rowPivots[idx].fields?.join(', ');
   const yAxisTitle = config.columnPivots[idx].fields?.join(', ');
   const zSeriesTitles = _generateSeriesTitles(config, y, x);
@@ -63,10 +64,13 @@ const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visual
     reversescale: reverseScale,
     zmin: zMin,
     zmax: zMax,
+    colorbar: {
+      tickfont: { color: theme.colors.global.textDefault },
+    },
   };
 };
 
-const _generateSeries = (visualizationConfig) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, visualizationConfig);
+const _generateSeries = (visualizationConfig, theme) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, visualizationConfig, theme);
 
 const _fillUpMatrix = (z: Array<Array<any>>, xLabels: Array<any>, defaultValue = 'None') => {
   return z.map((series) => {
@@ -142,12 +146,13 @@ const _chartLayout = (heatmapData) => {
 const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !== 'row-leaf';
 
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+  const theme = useTheme();
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
   const heatmapData = useChartData(rows, {
     widgetConfig: config,
     chartType: 'heatmap',
-    generator: _generateSeries(visualizationConfig),
+    generator: _generateSeries(visualizationConfig, theme),
     seriesFormatter: _formatSeries(visualizationConfig),
     leafValueMatcher: _leafSourceMatcher,
   });

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -55,6 +55,7 @@ describe('HeatmapVisualization', () => {
         hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
         colorscale: 'Viridis',
         reversescale: false,
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 
@@ -100,6 +101,7 @@ describe('HeatmapVisualization', () => {
         hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
         colorscale: 'Viridis',
         reversescale: false,
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 


### PR DESCRIPTION
**Please note**: This is a backport of #16129 for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the heatmap colorbar font color for dark mode. Please have a look at https://github.com/Graylog2/graylog2-server/issues/15035 for more information.

Fixes https://github.com/Graylog2/graylog2-server/issues/15035