### PR TITLE
Adjust keybindings for query input autocompletion. (5.1)

### DIFF
--- a/changelog/unreleased/issue-14793.toml
+++ b/changelog/unreleased/issue-14793.toml
@@ -1,0 +1,11 @@
+type = "fixed"
+message = "Adjust keybindings for query input autocompletion."
+
+issues = ["14793"]
+pulls = ["16162"]
+
+details.user = """
+With #6909 we received the feedback that it would be useful to only press `Tab` once to insert the first autocomplete suggestion (instead of pressing it twice). As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case. When you search for a custom value like ssh login the autocomplete suggested field names for login and pressing Return did not execute the search but inserted the first suggestion.
+We are now no longer focusing the first suggestion and adjusting the behaviour for Tab key. When pressing Tab while no suggestion is focused we select and insert the first entry.
+This way it is possible to press Return when searching for a custom value and it still requires only one press to insert the first suggestion.
+"""

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.js
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.js
@@ -645,7 +645,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
   }
 
   /* additional styles for 'StyledAceEditor' */
-  .ace_editor.ace_autocomplete.ace-queryinput {
+  .ace_editor.ace_autocomplete {
     width: 600px !important;
     margin-top: 6px;
     background-color: ${theme.colors.input.background};
@@ -656,7 +656,6 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     background-color: ${theme.utils.opacify(theme.colors.variant.info, 0.7)};
     color: ${theme.colors.input.colorDisabled};
   }
-
   .ace_editor.ace_autocomplete .ace_text-layer .ace_completion-highlight {
     color: ${theme.colors.variant.info};
   }

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -64,7 +64,7 @@ const handleExecution = ({
 }) => {
   const execute = () => {
     if (editor?.completer && editor.completer.popup) {
-      editor.completer.popup.hide();
+      editor.completer.detach();
     }
 
     onExecute(value);
@@ -124,8 +124,33 @@ const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCo
   const editor = node && node.editor;
 
   if (editor) {
-    commands.forEach((command) => editor.commands.addCommand(command));
+    editor.commands.on('afterExec', () => {
+      if (editor.completer?.autoSelect) {
+        editor.completer.autoSelect = false;
+      }
 
+      const completerCommandKeyBinding = editor.completer?.keyboardHandler?.commandKeyBinding;
+
+      if (completerCommandKeyBinding?.tab && completerCommandKeyBinding.tab.name !== 'improved-tab') {
+        editor.completer.keyboardHandler.addCommand({
+          name: 'improved-tab',
+          bindKey: { win: 'Tab', mac: 'Tab' },
+          exec: (currentEditor: Editor) => {
+            const result = currentEditor.completer.insertMatch();
+
+            if (!result && !currentEditor.tabstopManager) {
+              currentEditor.completer.goTo('down');
+
+              return currentEditor.completer.insertMatch();
+            }
+
+            return result;
+          },
+        });
+      }
+    });
+
+    commands.forEach((command) => editor.commands.addCommand(command));
     editor.completers = [completer];
   }
 };

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-types.ts
@@ -57,6 +57,7 @@ export type Command = {
 export type Commands = {
   addCommand: (command: Command) => void,
   removeCommands: (commands: Array<string>) => void,
+  on: (commandName: string, callback: () => void) => void
 };
 
 export type Popup = {
@@ -67,6 +68,15 @@ export type Completer = {
   autoSelect: boolean,
   popup?: Popup,
   activated: boolean,
+  insertMatch: () => boolean,
+  detach: () => void,
+  goTo: (direction: string) => void,
+  keyboardHandler: {
+    commandKeyBinding: {
+      tab: Command,
+    },
+    addCommand: (command: Command) => void
+  }
 };
 
 export type Editor = {
@@ -78,6 +88,7 @@ export type Editor = {
   renderer: Renderer,
   setFontSize: (newFontSize: number) => void,
   getValue: () => string,
+  tabstopManager: unknown,
   setValue: (newValue: string) => void,
   isFocused: () => boolean,
 };


### PR DESCRIPTION
**Please note:** This is a backport of https://github.com/Graylog2/graylog2-server/pull/16162 for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


With #6909 we received the feedback that it would be useful to only press `Tab` once to insert the first autocomplete suggestion (instead of pressing it twice). As result we implemented a change to automatically focus the first suggestion. This led to a problem in a different use case. When you search for a custom value like `ssh login` the autocomplete suggested field names for `login` and pressing `Return` did not execute the search but inserted the first suggestion.

We are now no longer focusing the first suggestion and adjusting the behaviour for `Tab` key. When pressing `Tab` while no suggestion is focused we select and insert the first entry.

This way it is possible to press `Return` when searching for a custom value and it still requires only one press to insert the first suggestion.

Fixes https://github.com/Graylog2/graylog2-server/issues/14793

