### PR TITLE
Fix heatmap colorbar font color for dark mode. (5.0)

### DIFF
--- a/changelog/unreleased/issue-15035.toml
+++ b/changelog/unreleased/issue-15035.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix heatmap colorbar font color for dark mode."
+
+issues = ["15035"]
+pulls = ["16129"]

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -40,6 +40,7 @@ export type ChartDefinition = {
   },
   customdata?: any,
   colorscale?: [number, string][],
+  colorbar?: { tickfont: { color: string } },
   reversescale?: boolean,
   zmin?: boolean,
   zmax?: boolean,

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useContext, useState, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Overlay, RootCloseWrapper } from 'react-overlays';
 import { chunk } from 'lodash';
 
@@ -33,7 +33,7 @@ import type Series from 'views/logic/aggregationbuilder/Series';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
 import useCurrentQueryId from 'views/logic/queries/useCurrentQueryId';
 
-const ColorHint = styled.div(({ color }) => `
+const ColorHint = styled.div(({ color }) => css`
   cursor: pointer;
   background-color: ${color} !important; /* Needed for report generation */
   -webkit-print-color-adjust: exact !important; /* Needed for report generation */

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { values, merge, fill, find, isEmpty } from 'lodash';
+import { useTheme } from 'styled-components';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -25,7 +26,6 @@ import useChartData from 'views/components/visualizations/useChartData';
 
 import type { ChartDefinition, ExtractedSeries, ValuesBySeries } from '../ChartData';
 import GenericPlot from '../GenericPlot';
-import { useTheme } from 'styled-components';
 
 const _generateSeriesTitles = (config, x, y) => {
   const seriesTitles = config.series.map((s) => s.function);

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -25,6 +25,7 @@ import useChartData from 'views/components/visualizations/useChartData';
 
 import type { ChartDefinition, ExtractedSeries, ValuesBySeries } from '../ChartData';
 import GenericPlot from '../GenericPlot';
+import { useTheme } from 'styled-components';
 
 const _generateSeriesTitles = (config, x, y) => {
   const seriesTitles = config.series.map((s) => s.function);
@@ -39,7 +40,7 @@ const _generateSeriesTitles = (config, x, y) => {
   return y.map(() => columnSeriesTitles);
 };
 
-const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visualizationConfig): ChartDefinition => {
+const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visualizationConfig, theme): ChartDefinition => {
   const xAxisTitle = config.rowPivots[idx].fields?.join(', ');
   const yAxisTitle = config.columnPivots[idx].fields?.join(', ');
   const zSeriesTitles = _generateSeriesTitles(config, y, x);
@@ -59,10 +60,13 @@ const _heatmapGenerateSeries = (type, name, x, y, z, idx, _total, config, visual
     reversescale: reverseScale,
     zmin: zMin,
     zmax: zMax,
+    colorbar: {
+      tickfont: { color: theme.colors.global.textDefault },
+    },
   };
 };
 
-const _generateSeries = (visualizationConfig) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, visualizationConfig);
+const _generateSeries = (visualizationConfig, theme) => (type, name, x, y, z, idx, total, config) => _heatmapGenerateSeries(type, name, x, y, z, idx, total, config, visualizationConfig, theme);
 
 const _fillUpMatrix = (z: Array<Array<any>>, xLabels: Array<any>, defaultValue = 'None') => {
   return z.map((series) => {
@@ -138,12 +142,13 @@ const _chartLayout = (heatmapData) => {
 const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !== 'row-leaf';
 
 const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+  const theme = useTheme();
   const visualizationConfig = (config.visualizationConfig || HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
   const heatmapData = useChartData(rows, {
     widgetConfig: config,
     chartType: 'heatmap',
-    generator: _generateSeries(visualizationConfig),
+    generator: _generateSeries(visualizationConfig, theme),
     seriesFormatter: _formatSeries(visualizationConfig),
     leafValueMatcher: _leafSourceMatcher,
   });

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -62,6 +62,7 @@ describe('HeatmapVisualization', () => {
         hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
         colorscale: 'Viridis',
         reversescale: false,
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 
@@ -107,6 +108,7 @@ describe('HeatmapVisualization', () => {
         hovertemplate: 'hour: %{y}<br>http_status: %{x}<br>%{text}: %{customdata}<extra></extra>',
         colorscale: 'Viridis',
         reversescale: false,
+        colorbar: { tickfont: { color: '#3e434c' } },
       },
     ];
 


### PR DESCRIPTION
**Please note**: This is a backport of #16129 for 5.0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the heatmap colorbar font color for dark mode. Please have a look at https://github.com/Graylog2/graylog2-server/issues/15035 for more information.

Fixes https://github.com/Graylog2/graylog2-server/issues/15035