### PR TITLE
Replace Map.Entry a simple MessageWithIndex record

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessageWithIndex.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessageWithIndex.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.messages;
+
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.plugin.Message;
+
+public record MessageWithIndex(Message message, IndexSet indexSet) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -28,11 +28,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.graylog.failure.FailureSubmissionService;
-import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.InvalidWriteTargetException;
 import org.graylog2.indexer.MasterNotDiscoveredException;
 import org.graylog2.indexer.results.ResultMessage;
-import org.graylog2.plugin.Message;
 import org.graylog2.shared.utilities.ExceptionUtils;
 import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.slf4j.Logger;
@@ -45,7 +43,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -115,25 +112,25 @@ public class Messages {
         return messagesAdapter.analyze(toAnalyze, index, analyzer);
     }
 
-    public Set<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList) {
+    public Set<String> bulkIndex(final List<MessageWithIndex> messageList) {
         return bulkIndex(messageList, false, null);
     }
 
-    public Set<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, IndexingListener indexingListener) {
+    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, IndexingListener indexingListener) {
         return bulkIndex(messageList, false, indexingListener);
     }
 
-    public Set<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, boolean isSystemTraffic) {
+    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic) {
         return bulkIndex(messageList, isSystemTraffic, null);
     }
 
-    public Set<String> bulkIndex(final List<Map.Entry<IndexSet, Message>> messageList, boolean isSystemTraffic, IndexingListener indexingListener) {
+    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic, IndexingListener indexingListener) {
         if (messageList.isEmpty()) {
             return Set.of();
         }
 
         final List<IndexingRequest> indexingRequestList = messageList.stream()
-                .map(entry -> IndexingRequest.create(entry.getKey(), entry.getValue()))
+                .map(entry -> IndexingRequest.create(entry.indexSet(), entry.message()))
                 .collect(Collectors.toList());
 
         return bulkIndexRequests(indexingRequestList, isSystemTraffic, indexingListener);

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -20,10 +20,10 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.messages.MessageWithIndex;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.shared.journal.Journal;
@@ -35,7 +35,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -64,7 +63,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     private final int shutdownTimeoutMs;
     private final ScheduledExecutorService daemonScheduler;
 
-    private volatile List<Map.Entry<IndexSet, Message>> buffer;
+    private volatile List<MessageWithIndex> buffer;
 
     private static final AtomicInteger activeFlushThreads = new AtomicInteger(0);
     private final AtomicLong lastFlushTime = new AtomicLong();
@@ -97,12 +96,12 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     @Override
     public void write(Message message) throws Exception {
         for (IndexSet indexSet : message.getIndexSets()) {
-            writeMessageEntry(Maps.immutableEntry(indexSet, message));
+            writeMessageEntry(new MessageWithIndex(message, indexSet));
         }
     }
 
-    public void writeMessageEntry(Map.Entry<IndexSet, Message> entry) throws Exception {
-        List<Map.Entry<IndexSet, Message>> flushBatch = null;
+    public void writeMessageEntry(MessageWithIndex entry) throws Exception {
+        List<MessageWithIndex> flushBatch = null;
         synchronized (this) {
             buffer.add(entry);
 
@@ -119,7 +118,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         }
     }
 
-    private void flush(List<Map.Entry<IndexSet, Message>> messages) {
+    private void flush(List<MessageWithIndex> messages) {
         // never try to flush an empty buffer
         if (messages.isEmpty()) {
             return;
@@ -135,7 +134,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         try {
             indexMessageBatch(messages);
             // This does not exclude failedMessageIds, because we don't know if ES is ever gonna accept these messages.
-            acknowledger.acknowledge(messages.stream().map(Map.Entry::getValue).collect(Collectors.toList()));
+            acknowledger.acknowledge(messages.stream().map(MessageWithIndex::message).collect(Collectors.toList()));
         } catch (Exception e) {
             log.error("Unable to flush message buffer", e);
             bufferFlushFailures.mark();
@@ -144,7 +143,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         log.debug("Flushing {} messages completed", messages.size());
     }
 
-    protected Set<String> indexMessageBatch(List<Map.Entry<IndexSet, Message>> messages) throws Exception {
+    protected Set<String> indexMessageBatch(List<MessageWithIndex> messages) throws Exception {
         try (Timer.Context ignored = processTime.time()) {
             lastFlushTime.set(System.nanoTime());
             final Set<String> failedMessageIds = writeMessageEntries(messages);
@@ -166,7 +165,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
 
     private void forceFlush() {
         // flip buffer quickly and initiate flush
-        final List<Map.Entry<IndexSet, Message>> flushBatch;
+        final List<MessageWithIndex> flushBatch;
         synchronized (this) {
             flushBatch = buffer;
             buffer = new ArrayList<>(maxBufferSize);

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.messages.MessageWithIndex;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
@@ -88,10 +89,10 @@ public class ElasticSearchOutput implements MessageOutput {
         throw new UnsupportedOperationException("Method not supported!");
     }
 
-    public Set<String> writeMessageEntries(List<Map.Entry<IndexSet, Message>> messageList) throws Exception {
+    public Set<String> writeMessageEntries(List<MessageWithIndex> messageList) throws Exception {
         if (LOG.isTraceEnabled()) {
             final String sortedIds = messageList.stream()
-                    .map(Map.Entry::getValue)
+                    .map(MessageWithIndex::message)
                     .map(Message::getId)
                     .sorted(Comparator.naturalOrder())
                     .collect(Collectors.joining(", "));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
@@ -17,7 +17,6 @@
 package org.graylog2.indexer.messages;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSet;
@@ -33,7 +32,6 @@ import org.mockito.Mock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,7 +70,7 @@ public abstract class MessagesBatchIT extends ElasticsearchBaseTest {
         // This will trigger the circuit breaker when we are trying to index large batches
         final int MESSAGECOUNT = 50;
         // Each Message is about 1 MB
-        final List<Map.Entry<IndexSet, Message>> largeMessageBatch = createMessageBatch(1024 * 1024, MESSAGECOUNT);
+        final List<MessageWithIndex> largeMessageBatch = createMessageBatch(1024 * 1024, MESSAGECOUNT);
         final Set<String> failedItems = this.messages.bulkIndex(largeMessageBatch);
 
         client().refreshNode(); // wait for ES to finish indexing
@@ -89,12 +87,12 @@ public abstract class MessagesBatchIT extends ElasticsearchBaseTest {
         return DateTime.now(DateTimeZone.UTC);
     }
 
-    private ArrayList<Map.Entry<IndexSet, Message>> createMessageBatch(int size, int count) {
-        final ArrayList<Map.Entry<IndexSet, Message>> messageList = new ArrayList<>();
+    private ArrayList<MessageWithIndex> createMessageBatch(int size, int count) {
+        final ArrayList<MessageWithIndex> messageList = new ArrayList<>();
 
         final String message = Strings.repeat("A", size);
         for (int i = 0; i < count; i++) {
-            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", now())));
+            messageList.add(new MessageWithIndex(new Message(i + message, "source", now()), indexSet));
         }
         return messageList;
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
@@ -28,11 +28,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -85,7 +83,7 @@ class MessagesBulkIndexRetryingTest {
         when(mockedMessage.getId()).thenReturn(messageId);
         when(mockedMessage.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
 
-        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(mockedMessage);
+        final List<MessageWithIndex> messageList = messageListWith(mockedMessage);
 
         final Set<String> result = messages.bulkIndex(messageList);
 
@@ -100,7 +98,7 @@ class MessagesBulkIndexRetryingTest {
                 .thenThrow(new IOException("Boom!"))
                 .thenReturn(Collections.emptyList());
 
-        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(mock(Message.class));
+        final List<MessageWithIndex> messageList = messageListWith(mock(Message.class));
 
         final Set<String> result = messages.bulkIndex(messageList);
 
@@ -164,10 +162,10 @@ class MessagesBulkIndexRetryingTest {
         assertThat(result).containsOnly("other-error-id");
     }
 
-    private List<Map.Entry<IndexSet, Message>> messagesWithIds(String... ids) {
+    private List<MessageWithIndex> messagesWithIds(String... ids) {
         return Arrays.stream(ids)
                 .map(this::messageWithId)
-                .map(m -> new AbstractMap.SimpleEntry<>(mock(IndexSet.class), m))
+                .map(m -> new MessageWithIndex(m, mock(IndexSet.class)))
                 .collect(Collectors.toList());
     }
 
@@ -178,10 +176,8 @@ class MessagesBulkIndexRetryingTest {
         return mockedMessage;
     }
 
-    private List<Map.Entry<IndexSet, Message>> messageListWith(Message mockedMessage) {
-        return ImmutableList.of(
-                new AbstractMap.SimpleEntry<>(mock(IndexSet.class), mockedMessage)
-        );
+    private List<MessageWithIndex> messageListWith(Message mockedMessage) {
+        return List.of(new MessageWithIndex(mockedMessage, mock(IndexSet.class)));
     }
 
     private Messages.IndexingError errorResultItem(String messageId, Messages.IndexingError.ErrorType errorType, String errorReason) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
@@ -33,12 +33,10 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -89,10 +87,10 @@ public class MessagesTest {
     public void bulkIndexingShouldAccountMessageSizes() throws IOException {
         when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
         final IndexSet indexSet = mock(IndexSet.class);
-        final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(
-                createMessageListEntry(indexSet, messageWithSize(17)),
-                createMessageListEntry(indexSet, messageWithSize(23)),
-                createMessageListEntry(indexSet, messageWithSize(42))
+        final List<MessageWithIndex> messageList = List.of(
+                new MessageWithIndex(messageWithSize(17), indexSet),
+                new MessageWithIndex(messageWithSize(23), indexSet),
+                new MessageWithIndex(messageWithSize(42), indexSet)
         );
 
         messages.bulkIndex(messageList);
@@ -105,10 +103,10 @@ public class MessagesTest {
     public void bulkIndexingShouldAccountMessageSizesForSystemTrafficSeparately() throws IOException {
         when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
         final IndexSet indexSet = mock(IndexSet.class);
-        final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(
-                createMessageListEntry(indexSet, messageWithSize(17)),
-                createMessageListEntry(indexSet, messageWithSize(23)),
-                createMessageListEntry(indexSet, messageWithSize(42))
+        final List<MessageWithIndex> messageList = List.of(
+                new MessageWithIndex(messageWithSize(17), indexSet),
+                new MessageWithIndex(messageWithSize(23), indexSet),
+                new MessageWithIndex(messageWithSize(42), indexSet)
         );
 
         messages.bulkIndex(messageList, true);
@@ -195,10 +193,6 @@ public class MessagesTest {
         when(mock.getMessageId()).thenReturn(msgId);
         when(mock.getTimestamp()).thenReturn(ts);
         return mock;
-    }
-
-    private Map.Entry<IndexSet, Message> createMessageListEntry(IndexSet indexSet, Message message) {
-        return new AbstractMap.SimpleEntry<>(indexSet, message);
     }
 
     private Message messageWithSize(long size) {

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
@@ -18,10 +18,10 @@ package org.graylog2.outputs;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import org.graylog2.Configuration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.messages.MessageWithIndex;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
@@ -37,7 +37,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
@@ -93,14 +92,14 @@ public class BlockingBatchedESOutputTest {
 
     @Test
     public void write() throws Exception {
-        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize());
+        final List<MessageWithIndex> messageList = sendMessages(output, config.getOutputBatchSize());
 
         verify(messages, times(1)).bulkIndex(eq(messageList));
     }
 
     @Test
     public void forceFlushIfTimedOut() throws Exception {
-        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+        final List<MessageWithIndex> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
 
         // Should flush the buffer even though the batch size is not reached yet
         output.forceFlushIfTimedout();
@@ -110,7 +109,7 @@ public class BlockingBatchedESOutputTest {
 
     @Test
     public void flushWithService() throws Exception {
-        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+        final List<MessageWithIndex> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
 
         Thread.sleep(config.getOutputFlushInterval() * 1000L + 100); // let the flushservice run
 
@@ -122,7 +121,7 @@ public class BlockingBatchedESOutputTest {
         when(cluster.isConnected()).thenReturn(true);
         when(cluster.isDeflectorHealthy()).thenReturn(true);
 
-        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+        final List<MessageWithIndex> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
 
         output.stop();
 
@@ -155,7 +154,7 @@ public class BlockingBatchedESOutputTest {
             return null;
         });
 
-        final List<Map.Entry<IndexSet, Message>> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
+        final List<MessageWithIndex> messageList = sendMessages(output, config.getOutputBatchSize() - 1);
 
         // shutdown timeout is < test timeout
         output.stop();
@@ -163,19 +162,19 @@ public class BlockingBatchedESOutputTest {
         verify(messages, times(1)).bulkIndex(eq(messageList));
     }
 
-    private List<Map.Entry<IndexSet, Message>> buildMessages(final int count) {
-        final ImmutableList.Builder<Map.Entry<IndexSet, Message>> builder = ImmutableList.builder();
+    private List<MessageWithIndex> buildMessages(final int count) {
+        final ImmutableList.Builder<MessageWithIndex> builder = ImmutableList.builder();
         for (int i = 0; i < count; i++) {
-            builder.add(Maps.immutableEntry(mock(IndexSet.class), new Message("message" + i, "test", Tools.nowUTC())));
+            builder.add(new MessageWithIndex(new Message("message" + i, "test", Tools.nowUTC()), mock(IndexSet.class)));
         }
 
         return builder.build();
     }
 
-    private List<Map.Entry<IndexSet, Message>> sendMessages(BlockingBatchedESOutput output, int count) throws Exception {
-        final List<Map.Entry<IndexSet, Message>> messageList = buildMessages(count);
+    private List<MessageWithIndex> sendMessages(BlockingBatchedESOutput output, int count) throws Exception {
+        final List<MessageWithIndex> messageList = buildMessages(count);
 
-        for (Map.Entry<IndexSet, Message> entry : messageList) {
+        for (MessageWithIndex entry : messageList) {
             output.writeMessageEntry(entry);
         }
 


### PR DESCRIPTION
This simplifies tons code using
 `List<Map.Entry<IndexSet, Message>> messages`
to
 `List<MessageWithIndex> messages`

/nocl
/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5679
