### PR TITLE
add content stream to csp default headers

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/FiltersIT.java
@@ -31,7 +31,7 @@ import static io.restassured.RestAssured.given;
 
 @ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, withMailServerEnabled = true)
 public class FiltersIT {
-    private static final String DEFAULT_CONNECT_SRC = "connect-src 'self' https://telemetry.graylog.cloud;";
+    private static final String DEFAULT_CONNECT_SRC = "connect-src 'self' https://graylog.org/post/tag/ https://telemetry.graylog.cloud;";
     private final GraylogApis api;
     private final CSPResources cspResources;
     private final Pattern defaultCSPPattern;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.net.URI;
 import java.util.stream.Collectors;
 
 public class CSPServiceImpl implements CSPService {
@@ -38,7 +39,7 @@ public class CSPServiceImpl implements CSPService {
         this.telemetryApiHost = telemetryConfiguration.getTelemetryApiHost();
         this.dbService = dbService;
         this.cspResources = new CSPResources();
-        this.contentStreamRssApiHost = contentStreamConfiguration.getContentStreamRssUri().toString() + "/";
+        this.contentStreamRssApiHost = getContentStreamHost(contentStreamConfiguration.getContentStreamRssUri());
         updateConnectSrc();
     }
 
@@ -57,5 +58,14 @@ public class CSPServiceImpl implements CSPService {
     @Override
     public String cspString(String group) {
         return cspResources.cspString(group);
+    }
+
+    private String getContentStreamHost(URI contentStreamRssApiHost) {
+        String slash = "/";
+        if (contentStreamRssApiHost.getPath().endsWith(slash)) {
+            return contentStreamRssApiHost.toString();
+        } else {
+            return contentStreamRssApiHost.toString() + slash;
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
@@ -17,6 +17,7 @@
 package org.graylog2.shared.rest.resources.csp;
 
 import org.graylog.security.authservice.DBAuthServiceBackendService;
+import org.graylog2.configuration.ContentStreamConfiguration;
 import org.graylog2.configuration.TelemetryConfiguration;
 import org.graylog2.rest.PaginationParameters;
 import org.slf4j.Logger;
@@ -28,14 +29,16 @@ import java.util.stream.Collectors;
 public class CSPServiceImpl implements CSPService {
     private static final Logger LOG = LoggerFactory.getLogger(CSPServiceImpl.class);
     private final String telemetryApiHost;
+    private final String contentStreamRssApiHost;
     private final DBAuthServiceBackendService dbService;
     private final CSPResources cspResources;
 
     @Inject
-    protected CSPServiceImpl(TelemetryConfiguration telemetryConfiguration, DBAuthServiceBackendService dbService) {
+    protected CSPServiceImpl(TelemetryConfiguration telemetryConfiguration, ContentStreamConfiguration contentStreamConfiguration, DBAuthServiceBackendService dbService) {
         this.telemetryApiHost = telemetryConfiguration.getTelemetryApiHost();
         this.dbService = dbService;
         this.cspResources = new CSPResources();
+        this.contentStreamRssApiHost = contentStreamConfiguration.getContentStreamRssUri().toString() + "/";
         updateConnectSrc();
     }
 
@@ -46,7 +49,7 @@ public class CSPServiceImpl implements CSPService {
                 .filter(java.util.Optional::isPresent)
                 .map(optList -> String.join(" ", optList.get()))
                 .collect(Collectors.joining(" "));
-        String connectSrcValue = "'self' " + telemetryApiHost + " " + hostList;
+        String connectSrcValue = "'self' " + telemetryApiHost + " " + contentStreamRssApiHost + " " + hostList;
         cspResources.updateAll("connect-src", connectSrcValue);
         LOG.debug("Updated CSP: {}", connectSrcValue);
     }


### PR DESCRIPTION
/nocl
Add Graylog content stream endpoint to CSP-Header

```
Path parts in the CSP that end in / match any path they are a prefix of. 
For example, example.com/api/ will match URLs like example.com/api/users/new.
```
See section Hosts values https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy 