### PR TITLE
Check permission before loading content stream tag

### DIFF
--- a/graylog2-web-interface/src/components/content-stream/hook/useContentStream.ts
+++ b/graylog2-web-interface/src/components/content-stream/hook/useContentStream.ts
@@ -20,6 +20,8 @@ import { XMLParser } from 'fast-xml-parser';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { DEFAULT_FEED } from 'components/content-stream/Constants';
 import AppConfig from 'util/AppConfig';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
 
 export type FeedMediaContent = {
   'media:title'?: {
@@ -97,9 +99,11 @@ export const fetchNewsFeed = (rssUrl: string) => rssUrl && window.fetch(rssUrl, 
 export const CONTENT_STREAM_CONTENT_KEY = ['content-stream', 'content'];
 
 const useContentStream = (path?: string): { isLoadingFeed: boolean, feedList: Array<FeedITem>, error: Error } => {
+  const { permissions } = useCurrentUser();
   const { rss_url } = AppConfig.contentStream() || {};
+
   const contentStreamPlugin = usePluginEntities('content-stream')[0];
-  const getPath = contentStreamPlugin?.hooks?.useContentStreamTag || getDefaultTag;
+  const getPath = (isPermitted(permissions, ['licenseinfos:read']) && contentStreamPlugin?.hooks?.useContentStreamTag) || getDefaultTag;
   const rssUrl = rss_url && `${rss_url}/${path || getPath()}/feed`;
 
   const {


### PR DESCRIPTION
This PR fixes the permission issue when loading content stream tag.

fixes Graylog2/graylog-plugin-enterprise#5683

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

