### PR TITLE
Introduce IndexingResults class

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -35,7 +35,11 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.rest.RestStatus;
 import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.DocumentNotFoundException;
 import org.graylog2.indexer.messages.Indexable;
+import org.graylog2.indexer.messages.IndexingError;
 import org.graylog2.indexer.messages.IndexingRequest;
+import org.graylog2.indexer.messages.IndexingResult;
+import org.graylog2.indexer.messages.IndexingResults;
+import org.graylog2.indexer.messages.IndexingSuccess;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.results.ResultMessage;
@@ -44,9 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -104,47 +106,37 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     }
 
     @Override
-    public List<Messages.IndexingError> bulkIndex(List<IndexingRequest> messageList) throws IOException {
+    public IndexingResults bulkIndex(List<IndexingRequest> messageList) throws IOException {
         return chunkedBulkIndexer.index(messageList, this::bulkIndexChunked);
     }
 
-    private List<Messages.IndexingError> bulkIndexChunked(ChunkedBulkIndexer.Chunk command) throws ChunkedBulkIndexer.EntityTooLargeException {
+    private IndexingResults bulkIndexChunked(ChunkedBulkIndexer.Chunk command) throws ChunkedBulkIndexer.EntityTooLargeException {
         final List<IndexingRequest> messageList = command.requests;
         final int offset = command.offset;
         final int chunkSize = command.size;
 
+        final IndexingResults.Builder accumulatedResults = IndexingResults.Builder.create();
         if (messageList.isEmpty()) {
-            return Collections.emptyList();
+            return accumulatedResults.build();
         }
 
         final Iterable<List<IndexingRequest>> chunks = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);
         int chunkCount = 1;
         int indexedSuccessfully = 0;
-        final List<Messages.IndexingError> indexFailures = new ArrayList<>();
         for (List<IndexingRequest> chunk : chunks) {
 
-            final BulkResponse result = runBulkRequest(indexedSuccessfully, chunk);
-
+            final BulkResponse response = runBulkRequest(indexedSuccessfully, accumulatedResults.build(), chunk);
             indexedSuccessfully += chunk.size();
+            final IndexingResults results = indexingResultsFrom(response, messageList);
+            accumulatedResults.addResults(results);
 
-            final List<BulkItemResponse> failures = extractFailures(result);
-
-            indexFailures.addAll(indexingErrorsFrom(failures, messageList));
-
-            logDebugInfo(messageList, offset, chunkSize, chunkCount, result, failures);
-
-            logFailures(result, failures.size());
+            logDebugInfo(messageList, offset, chunkSize, chunkCount, response, results.errors());
+            logFailures(response, results.errors().size());
 
             chunkCount++;
         }
 
-        return indexFailures;
-    }
-
-    private List<BulkItemResponse> extractFailures(BulkResponse result) {
-        return Arrays.stream(result.getItems())
-                        .filter(BulkItemResponse::isFailed)
-                        .collect(Collectors.toList());
+        return accumulatedResults.build();
     }
 
     private void logFailures(BulkResponse result, int failureCount) {
@@ -154,7 +146,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         }
     }
 
-    private void logDebugInfo(List<IndexingRequest> messageList, int offset, int chunkSize, int chunkCount, BulkResponse result, List<BulkItemResponse> failures) {
+    private void logDebugInfo(List<IndexingRequest> messageList, int offset, int chunkSize, int chunkCount, BulkResponse result, List<IndexingError> failures) {
         if (LOG.isDebugEnabled()) {
             String chunkInfo = "";
             if (chunkSize != messageList.size()) {
@@ -166,7 +158,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         }
     }
 
-    private BulkResponse runBulkRequest(int indexedSuccessfully, List<IndexingRequest> chunk) throws ChunkedBulkIndexer.EntityTooLargeException {
+    private BulkResponse runBulkRequest(int indexedSuccessfully, IndexingResults previousResults, List<IndexingRequest> chunk) throws ChunkedBulkIndexer.EntityTooLargeException {
         final BulkRequest bulkRequest = createBulkRequest(chunk);
 
         final BulkResponse result;
@@ -175,10 +167,10 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         } catch (ElasticsearchException e) {
             for (ElasticsearchException cause : e.guessRootCauses()) {
                 if (cause.status().equals(RestStatus.REQUEST_ENTITY_TOO_LARGE)) {
-                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully);
+                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully, previousResults);
                 }
                 if (cause.status().equals(RestStatus.TOO_MANY_REQUESTS)) {
-                    throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully);
+                    throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully, previousResults);
                 }
             }
             throw new org.graylog2.indexer.ElasticsearchException(e);
@@ -194,53 +186,61 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         return bulkRequest;
     }
 
-    private List<Messages.IndexingError> indexingErrorsFrom(List<IndexingRequest> messageList) {
-        return messageList.stream()
-                .map(this::indexingErrorFrom)
-                .collect(Collectors.toList());
-    }
+    private IndexingResults indexingResultsFrom(BulkResponse response, List<IndexingRequest> request) {
+        final Map<Boolean, List<BulkItemResponse>> partitionedResults = Arrays.stream(response.getItems()).collect(Collectors.partitioningBy(BulkItemResponse::isFailed));
+        final List<BulkItemResponse> failures = partitionedResults.get(true);
+        final List<BulkItemResponse> successes = partitionedResults.get(false);
 
-    private Messages.IndexingError indexingErrorFrom(IndexingRequest indexingRequest) {
-        return Messages.IndexingError.create(indexingRequest.message(), indexingRequest.indexSet().getWriteIndexAlias());
-    }
-
-    private List<Messages.IndexingError> indexingErrorsFrom(List<BulkItemResponse> failedItems, List<IndexingRequest> messageList) {
-        if (failedItems.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        final Map<String, Indexable> messageMap = messageList.stream()
+        final Map<String, Indexable> messageMap = request.stream()
                 .map(IndexingRequest::message)
                 .distinct()
                 .collect(Collectors.toMap(Indexable::getId, Function.identity()));
 
-        return failedItems.stream()
+        return IndexingResults.create(indexingSuccessFrom(successes, messageMap), indexingErrorsFrom(failures, messageMap));
+    }
+
+    private List<IndexingError> indexingErrorsFrom(List<BulkItemResponse> failedItems, Map<String, Indexable> messageMap) {
+        return indexingResultsFrom(failedItems, messageMap)
+                .stream().filter(IndexingError.class::isInstance).map(IndexingError.class::cast).toList();
+    }
+
+    private List<IndexingSuccess> indexingSuccessFrom(List<BulkItemResponse> failedItems, Map<String, Indexable> messageMap) {
+        return indexingResultsFrom(failedItems, messageMap)
+                .stream().filter(IndexingSuccess.class::isInstance).map(IndexingSuccess.class::cast).toList();
+    }
+
+    private List<IndexingResult> indexingResultsFrom(List<BulkItemResponse> responses, Map<String, Indexable> messageMap) {
+        return responses.stream()
                 .map(item -> {
                     final Indexable message = messageMap.get(item.getId());
-
-                    return indexingErrorFromResponse(item, message);
+                    return indexingResultFromResponse(item, message);
                 })
                 .collect(Collectors.toList());
     }
 
-    private Messages.IndexingError indexingErrorFromResponse(BulkItemResponse item, Indexable message) {
-        return Messages.IndexingError.create(message, item.getIndex(), errorTypeFromResponse(item), item.getFailureMessage());
+    private IndexingResult indexingResultFromResponse(BulkItemResponse response, Indexable message) {
+        if (response.isFailed()) {
+            return IndexingError.create(message, response.getIndex(), errorTypeFromResponse(response), response.getFailureMessage());
+        }
+        return IndexingSuccess.create(message, response.getIndex());
     }
 
-    private Messages.IndexingError.ErrorType errorTypeFromResponse(BulkItemResponse item) {
+    private IndexingError.Type errorTypeFromResponse(BulkItemResponse item) {
         final ParsedElasticsearchException exception = ParsedElasticsearchException.from(item.getFailureMessage());
         switch (exception.type()) {
-            case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
+            case MAPPER_PARSING_EXCEPTION:
+                return IndexingError.Type.MappingError;
             case INDEX_BLOCK_ERROR:
                 if (exception.reason().contains(INDEX_BLOCK_REASON) || exception.reason().contains(FLOOD_STAGE_WATERMARK))
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
+                    return IndexingError.Type.IndexBlocked;
             case UNAVAILABLE_SHARDS_EXCEPTION:
                 if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON))
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
+                    return IndexingError.Type.IndexBlocked;
             case ILLEGAL_ARGUMENT_EXCEPTION:
                 if (exception.reason().contains(NO_WRITE_INDEX_DEFINED_FOR_ALIAS))
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
-            default: return Messages.IndexingError.ErrorType.Unknown;
+                    return IndexingError.Type.IndexBlocked;
+            default:
+                return IndexingError.Type.Unknown;
         }
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MessagesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MessagesAdapterOS2.java
@@ -21,13 +21,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
-import org.graylog2.indexer.messages.ChunkedBulkIndexer;
-import org.graylog2.indexer.messages.DocumentNotFoundException;
-import org.graylog2.indexer.messages.Indexable;
-import org.graylog2.indexer.messages.IndexingRequest;
-import org.graylog2.indexer.messages.Messages;
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.indexer.results.ResultMessage;
 import org.graylog.shaded.opensearch2.org.opensearch.OpenSearchException;
 import org.graylog.shaded.opensearch2.org.opensearch.action.bulk.BulkItemResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.bulk.BulkRequest;
@@ -39,14 +32,23 @@ import org.graylog.shaded.opensearch2.org.opensearch.client.indices.AnalyzeReque
 import org.graylog.shaded.opensearch2.org.opensearch.client.indices.AnalyzeResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.common.xcontent.XContentType;
 import org.graylog.shaded.opensearch2.org.opensearch.rest.RestStatus;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
+import org.graylog2.indexer.messages.DocumentNotFoundException;
+import org.graylog2.indexer.messages.Indexable;
+import org.graylog2.indexer.messages.IndexingError;
+import org.graylog2.indexer.messages.IndexingRequest;
+import org.graylog2.indexer.messages.IndexingResult;
+import org.graylog2.indexer.messages.IndexingResults;
+import org.graylog2.indexer.messages.IndexingSuccess;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.results.ResultMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -104,47 +106,37 @@ public class MessagesAdapterOS2 implements MessagesAdapter {
     }
 
     @Override
-    public List<Messages.IndexingError> bulkIndex(List<IndexingRequest> messageList) throws IOException {
+    public IndexingResults bulkIndex(List<IndexingRequest> messageList) throws IOException {
         return chunkedBulkIndexer.index(messageList, this::bulkIndexChunked);
     }
 
-    private List<Messages.IndexingError> bulkIndexChunked(ChunkedBulkIndexer.Chunk command) throws ChunkedBulkIndexer.EntityTooLargeException {
+    private IndexingResults bulkIndexChunked(ChunkedBulkIndexer.Chunk command) throws ChunkedBulkIndexer.EntityTooLargeException {
         final List<IndexingRequest> messageList = command.requests;
         final int offset = command.offset;
         final int chunkSize = command.size;
 
+        final IndexingResults.Builder accumulatedResults = IndexingResults.Builder.create();
         if (messageList.isEmpty()) {
-            return Collections.emptyList();
+            return accumulatedResults.build();
         }
 
         final Iterable<List<IndexingRequest>> chunks = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);
         int chunkCount = 1;
         int indexedSuccessfully = 0;
-        final List<Messages.IndexingError> indexFailures = new ArrayList<>();
         for (List<IndexingRequest> chunk : chunks) {
 
-            final BulkResponse result = runBulkRequest(indexedSuccessfully, chunk);
-
+            final BulkResponse response = runBulkRequest(indexedSuccessfully, accumulatedResults.build(), chunk);
             indexedSuccessfully += chunk.size();
+            final IndexingResults results = indexingResultsFrom(response, messageList);
+            accumulatedResults.addResults(results);
 
-            final List<BulkItemResponse> failures = extractFailures(result);
-
-            indexFailures.addAll(indexingErrorsFrom(failures, messageList));
-
-            logDebugInfo(messageList, offset, chunkSize, chunkCount, result, failures);
-
-            logFailures(result, failures.size());
+            logDebugInfo(messageList, offset, chunkSize, chunkCount, response, results.errors());
+            logFailures(response, results.errors().size());
 
             chunkCount++;
         }
 
-        return indexFailures;
-    }
-
-    private List<BulkItemResponse> extractFailures(BulkResponse result) {
-        return Arrays.stream(result.getItems())
-                        .filter(BulkItemResponse::isFailed)
-                        .collect(Collectors.toList());
+        return accumulatedResults.build();
     }
 
     private void logFailures(BulkResponse result, int failureCount) {
@@ -154,7 +146,7 @@ public class MessagesAdapterOS2 implements MessagesAdapter {
         }
     }
 
-    private void logDebugInfo(List<IndexingRequest> messageList, int offset, int chunkSize, int chunkCount, BulkResponse result, List<BulkItemResponse> failures) {
+    private void logDebugInfo(List<IndexingRequest> messageList, int offset, int chunkSize, int chunkCount, BulkResponse result, List<IndexingError> failures) {
         if (LOG.isDebugEnabled()) {
             String chunkInfo = "";
             if (chunkSize != messageList.size()) {
@@ -166,7 +158,7 @@ public class MessagesAdapterOS2 implements MessagesAdapter {
         }
     }
 
-    private BulkResponse runBulkRequest(int indexedSuccessfully, List<IndexingRequest> chunk) throws ChunkedBulkIndexer.EntityTooLargeException {
+    private BulkResponse runBulkRequest(int indexedSuccessfully, IndexingResults previousResults, List<IndexingRequest> chunk) throws ChunkedBulkIndexer.EntityTooLargeException {
         final BulkRequest bulkRequest = createBulkRequest(chunk);
 
         final BulkResponse result;
@@ -175,9 +167,9 @@ public class MessagesAdapterOS2 implements MessagesAdapter {
         } catch (OpenSearchException e) {
             for (OpenSearchException cause : e.guessRootCauses()) {
                 if (cause.status().equals(RestStatus.REQUEST_ENTITY_TOO_LARGE)) {
-                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully);
+                    throw new ChunkedBulkIndexer.EntityTooLargeException(indexedSuccessfully, previousResults);
                 } else if (cause.status().equals(RestStatus.TOO_MANY_REQUESTS)) {
-                    throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully);
+                    throw new ChunkedBulkIndexer.TooManyRequestsException(indexedSuccessfully, previousResults);
                 }
             }
             throw new org.graylog2.indexer.ElasticsearchException(e);
@@ -193,56 +185,64 @@ public class MessagesAdapterOS2 implements MessagesAdapter {
         return bulkRequest;
     }
 
-    private List<Messages.IndexingError> indexingErrorsFrom(List<IndexingRequest> messageList) {
-        return messageList.stream()
-                .map(this::indexingErrorFrom)
-                .collect(Collectors.toList());
-    }
+    private IndexingResults indexingResultsFrom(BulkResponse response, List<IndexingRequest> request) {
+        final Map<Boolean, List<BulkItemResponse>> partitionedResults = Arrays.stream(response.getItems()).collect(Collectors.partitioningBy(BulkItemResponse::isFailed));
+        final List<BulkItemResponse> failures = partitionedResults.get(true);
+        final List<BulkItemResponse> successes = partitionedResults.get(false);
 
-    private Messages.IndexingError indexingErrorFrom(IndexingRequest indexingRequest) {
-        return Messages.IndexingError.create(indexingRequest.message(), indexingRequest.indexSet().getWriteIndexAlias());
-    }
-
-    private List<Messages.IndexingError> indexingErrorsFrom(List<BulkItemResponse> failedItems, List<IndexingRequest> messageList) {
-        if (failedItems.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        final Map<String, Indexable> messageMap = messageList.stream()
+        final Map<String, Indexable> messageMap = request.stream()
                 .map(IndexingRequest::message)
                 .distinct()
                 .collect(Collectors.toMap(Indexable::getId, Function.identity()));
 
-        return failedItems.stream()
+        return IndexingResults.create(indexingSuccessFrom(successes, messageMap), indexingErrorsFrom(failures, messageMap));
+    }
+
+    private List<IndexingError> indexingErrorsFrom(List<BulkItemResponse> failedItems, Map<String, Indexable> messageMap) {
+        return indexingResultsFrom(failedItems, messageMap)
+                .stream().filter(IndexingError.class::isInstance).map(IndexingError.class::cast).toList();
+    }
+
+    private List<IndexingSuccess> indexingSuccessFrom(List<BulkItemResponse> failedItems, Map<String, Indexable> messageMap) {
+        return indexingResultsFrom(failedItems, messageMap)
+                .stream().filter(IndexingSuccess.class::isInstance).map(IndexingSuccess.class::cast).toList();
+    }
+
+    private List<IndexingResult> indexingResultsFrom(List<BulkItemResponse> responses, Map<String, Indexable> messageMap) {
+        return responses.stream()
                 .map(item -> {
                     final Indexable message = messageMap.get(item.getId());
-
-                    return indexingErrorFromResponse(item, message);
+                    return indexingResultFromResponse(item, message);
                 })
                 .collect(Collectors.toList());
     }
 
-    private Messages.IndexingError indexingErrorFromResponse(BulkItemResponse item, Indexable message) {
-        return Messages.IndexingError.create(message, item.getIndex(), errorTypeFromResponse(item), item.getFailureMessage());
+    private IndexingResult indexingResultFromResponse(BulkItemResponse response, Indexable message) {
+        if (response.isFailed()) {
+            return IndexingError.create(message, response.getIndex(), errorTypeFromResponse(response), response.getFailureMessage());
+        }
+        return IndexingSuccess.create(message, response.getIndex());
     }
 
-    private Messages.IndexingError.ErrorType errorTypeFromResponse(BulkItemResponse item) {
+    private IndexingError.Type errorTypeFromResponse(BulkItemResponse item) {
         final ParsedOpenSearchException exception = ParsedOpenSearchException.from(item.getFailureMessage());
         switch (exception.type()) {
-            case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
+            case MAPPER_PARSING_EXCEPTION:
+                return IndexingError.Type.MappingError;
             case INDEX_BLOCK_ERROR:
                 if (exception.reason().contains(INDEX_BLOCK_REASON) || exception.reason().contains(FLOOD_STAGE_WATERMARK)) {
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
+                    return IndexingError.Type.IndexBlocked;
                 }
             case UNAVAILABLE_SHARDS_EXCEPTION:
                 if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON)) {
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
+                    return IndexingError.Type.IndexBlocked;
                 }
             case ILLEGAL_ARGUMENT_EXCEPTION:
                 if (exception.reason().contains(NO_WRITE_INDEX_DEFINED_FOR_ALIAS)) {
-                    return Messages.IndexingError.ErrorType.IndexBlocked;
+                    return IndexingError.Type.IndexBlocked;
                 }
-            default: return Messages.IndexingError.ErrorType.Unknown;
+            default:
+                return IndexingError.Type.Unknown;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingError.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingError.java
@@ -16,15 +16,17 @@
  */
 package org.graylog2.indexer.messages;
 
-import org.graylog2.indexer.results.ResultMessage;
+public record IndexingError(Indexable message, String index, Error error) implements IndexingResult {
+    public enum Type {
+        IndexBlocked,
+        MappingError,
+        Unknown;
+    }
 
-import java.io.IOException;
-import java.util.List;
+    public static IndexingError create(Indexable message, String index, Type errorType, String errorMessage) {
+        return new IndexingError(message, index, new Error(errorType, errorMessage));
+    }
 
-public interface MessagesAdapter {
-    ResultMessage get(String messageId, String index) throws IOException, DocumentNotFoundException;
-
-    List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
-
-    IndexingResults bulkIndex(final List<IndexingRequest> messageList) throws IOException;
+    public record Error(Type type, String errorMessage) {
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResult.java
@@ -16,15 +16,8 @@
  */
 package org.graylog2.indexer.messages;
 
-import org.graylog2.indexer.results.ResultMessage;
+public interface IndexingResult {
+    public Indexable message();
 
-import java.io.IOException;
-import java.util.List;
-
-public interface MessagesAdapter {
-    ResultMessage get(String messageId, String index) throws IOException, DocumentNotFoundException;
-
-    List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
-
-    IndexingResults bulkIndex(final List<IndexingRequest> messageList) throws IOException;
+    public String index();
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResults.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResults.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@AutoValue
+public abstract class IndexingResults {
+    public abstract ImmutableList<IndexingSuccess> successes();
+
+    public abstract ImmutableList<IndexingError> errors();
+
+    public static IndexingResults create(List<IndexingSuccess> successful, List<IndexingError> errors) {
+        return Builder.create().addSuccesses(successful).addErrors(errors).build();
+    }
+
+    public static IndexingResults empty() {
+        return Builder.create().build();
+    }
+
+    public IndexingResults mergeWith(List<IndexingSuccess> successes, List<IndexingError> errors) {
+        var mergedSuccesses = Stream.concat(successes().stream(), successes.stream()).distinct().toList();
+        var mergedErrors = Stream.concat(errors().stream(), errors.stream()).distinct().toList();
+        return create(mergedSuccesses, mergedErrors);
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        abstract ImmutableList.Builder<IndexingSuccess> successesBuilder();
+
+        abstract ImmutableList.Builder<IndexingError> errorsBuilder();
+
+        public static Builder create() {
+            return new AutoValue_IndexingResults.Builder();
+        }
+
+        public final Builder addSuccesses(List<IndexingSuccess> successes) {
+            successesBuilder().addAll(successes);
+            return this;
+        }
+
+        public final Builder addErrors(List<IndexingError> errors) {
+            errorsBuilder().addAll(errors);
+            return this;
+        }
+
+        public final Builder addResults(IndexingResults results) {
+            successesBuilder().addAll(results.successes());
+            errorsBuilder().addAll(results.errors());
+            return this;
+        }
+
+        public abstract IndexingResults build();
+    }
+
+    public List<? extends IndexingResult> allResults() {
+        return Stream.concat(successes().stream(), errors().stream()).toList();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingSuccess.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingSuccess.java
@@ -16,15 +16,8 @@
  */
 package org.graylog2.indexer.messages;
 
-import org.graylog2.indexer.results.ResultMessage;
-
-import java.io.IOException;
-import java.util.List;
-
-public interface MessagesAdapter {
-    ResultMessage get(String messageId, String index) throws IOException, DocumentNotFoundException;
-
-    List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
-
-    IndexingResults bulkIndex(final List<IndexingRequest> messageList) throws IOException;
+public record IndexingSuccess(Indexable message, String index) implements IndexingResult {
+    public static IndexingSuccess create(Indexable message, String index) {
+        return new IndexingSuccess(message, index);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -24,7 +24,6 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.WaitStrategies;
 import com.github.rholder.retry.WaitStrategy;
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.graylog.failure.FailureSubmissionService;
@@ -40,7 +39,6 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,6 +49,7 @@ import java.util.stream.Collectors;
 public class Messages {
     public interface IndexingListener {
         void onRetry(long attemptNumber);
+
         void onSuccess(long delaySinceFirstAttempt);
     }
 
@@ -70,8 +69,8 @@ public class Messages {
     static final WaitStrategy exponentialWaitMilliseconds = WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit());
 
     @SuppressWarnings("UnstableApiUsage")
-    private RetryerBuilder<List<IndexingError>> createBulkRequestRetryerBuilder() {
-        return RetryerBuilder.<List<IndexingError>>newBuilder()
+    private RetryerBuilder<IndexingResults> createBulkRequestRetryerBuilder() {
+        return RetryerBuilder.<IndexingResults>newBuilder()
                 .retryIfException(t -> ExceptionUtils.hasCauseOf(t, IOException.class)
                         || t instanceof InvalidWriteTargetException
                         || t instanceof MasterNotDiscoveredException)
@@ -112,21 +111,21 @@ public class Messages {
         return messagesAdapter.analyze(toAnalyze, index, analyzer);
     }
 
-    public Set<String> bulkIndex(final List<MessageWithIndex> messageList) {
+    public IndexingResults bulkIndex(final List<MessageWithIndex> messageList) {
         return bulkIndex(messageList, false, null);
     }
 
-    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, IndexingListener indexingListener) {
+    public IndexingResults bulkIndex(final List<MessageWithIndex> messageList, IndexingListener indexingListener) {
         return bulkIndex(messageList, false, indexingListener);
     }
 
-    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic) {
+    public IndexingResults bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic) {
         return bulkIndex(messageList, isSystemTraffic, null);
     }
 
-    public Set<String> bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic, IndexingListener indexingListener) {
+    public IndexingResults bulkIndex(final List<MessageWithIndex> messageList, boolean isSystemTraffic, IndexingListener indexingListener) {
         if (messageList.isEmpty()) {
-            return Set.of();
+            return IndexingResults.empty();
         }
 
         final List<IndexingRequest> indexingRequestList = messageList.stream()
@@ -136,29 +135,28 @@ public class Messages {
         return bulkIndexRequests(indexingRequestList, isSystemTraffic, indexingListener);
     }
 
-    public Set<String> bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic) {
+    public IndexingResults bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic) {
         return bulkIndexRequests(indexingRequestList, isSystemTraffic, null);
     }
 
-    public Set<String> bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic, IndexingListener indexingListener) {
-        final List<IndexingError> indexingErrors = runBulkRequest(indexingRequestList, indexingRequestList.size(), indexingListener);
+    public IndexingResults bulkIndexRequests(List<IndexingRequest> indexingRequestList, boolean isSystemTraffic, IndexingListener indexingListener) {
+        final IndexingResults indexingResults = runBulkRequest(indexingRequestList, indexingRequestList.size(), indexingListener);
 
-        final Set<IndexingError> remainingErrors = retryOnlyIndexBlockItemsForever(indexingRequestList, indexingErrors, indexingListener);
+        final IndexingResults retryBlockResults = retryOnlyIndexBlockItemsForever(indexingRequestList, indexingResults.errors(), indexingListener);
 
-        final Set<String> failedIds = remainingErrors.stream()
-                .map(indexingError -> indexingError.message().getId())
-                .collect(Collectors.toSet());
-        final List<IndexingRequest> successfulRequests = indexingRequestList.stream()
-                .filter(indexingRequest -> !failedIds.contains(indexingRequest.message().getId()))
-                .collect(Collectors.toList());
+        final IndexingResults finalResults = retryBlockResults.mergeWith(indexingResults.successes(), List.of());
 
-        recordTimestamp(successfulRequests);
-        accountTotalMessageSizes(indexingRequestList, isSystemTraffic);
+        recordTimestamp(finalResults.successes());
+        accountTotalMessageSizes(finalResults.successes(), isSystemTraffic);
 
-        return propagateFailure(remainingErrors);
+        if (!finalResults.errors().isEmpty()) {
+            failureSubmissionService.submitIndexingErrors(finalResults.errors());
+        }
+
+        return finalResults;
     }
 
-    private Set<IndexingError> retryOnlyIndexBlockItemsForever(List<IndexingRequest> messages, List<IndexingError> allFailedItems, IndexingListener indexingListener) {
+    private IndexingResults retryOnlyIndexBlockItemsForever(List<IndexingRequest> messages, List<IndexingError> allFailedItems, IndexingListener indexingListener) {
         Set<IndexingError> indexBlocks = indexBlocksFrom(allFailedItems);
         final Set<IndexingError> otherFailures = new HashSet<>(Sets.difference(new HashSet<>(allFailedItems), indexBlocks));
         List<IndexingRequest> blockedMessages = messagesForResultItems(messages, indexBlocks);
@@ -169,11 +167,14 @@ public class Messages {
 
         long attempt = 1;
 
+        final IndexingResults.Builder builder = IndexingResults.Builder.create();
         while (!indexBlocks.isEmpty()) {
             waitBeforeRetrying(attempt++);
 
-            final List<Messages.IndexingError> failedItems = runBulkRequest(blockedMessages, messages.size(), indexingListener);
+            final IndexingResults indexingResults = runBulkRequest(blockedMessages, messages.size(), indexingListener);
 
+            builder.addSuccesses(indexingResults.successes());
+            final var failedItems = indexingResults.errors();
             indexBlocks = indexBlocksFrom(failedItems);
             blockedMessages = messagesForResultItems(blockedMessages, indexBlocks);
 
@@ -185,7 +186,8 @@ public class Messages {
             }
         }
 
-        return otherFailures;
+        builder.addErrors(otherFailures.stream().toList());
+        return builder.build();
     }
 
     private List<IndexingRequest> messagesForResultItems(List<IndexingRequest> chunk, Set<IndexingError> indexBlocks) {
@@ -199,7 +201,7 @@ public class Messages {
     }
 
     private boolean hasFailedDueToBlockedIndex(IndexingError indexingError) {
-        return indexingError.errorType().equals(IndexingError.ErrorType.IndexBlocked);
+        return indexingError.error().type().equals(IndexingError.Type.IndexBlocked);
     }
 
     private void waitBeforeRetrying(long attempt) {
@@ -212,8 +214,8 @@ public class Messages {
     }
 
     @SuppressWarnings("UnstableApiUsage")
-    private List<IndexingError> runBulkRequest(List<IndexingRequest> indexingRequestList, int count, @Nullable IndexingListener indexingListener) {
-        final Retryer<List<IndexingError>> bulkRequestRetryer = indexingListener == null
+    private IndexingResults runBulkRequest(List<IndexingRequest> indexingRequestList, int count, @Nullable IndexingListener indexingListener) {
+        final Retryer<IndexingResults> bulkRequestRetryer = indexingListener == null
                 ? createBulkRequestRetryerBuilder().build()
                 : createBulkRequestRetryerBuilder().withRetryListener(retryListenerFor(indexingListener)).build();
 
@@ -243,9 +245,9 @@ public class Messages {
         };
     }
 
-    private void accountTotalMessageSizes(List<IndexingRequest> requests, boolean isSystemTraffic) {
+    private void accountTotalMessageSizes(List<IndexingSuccess> requests, boolean isSystemTraffic) {
         final long totalSizeOfIndexedMessages = requests.stream()
-                .map(IndexingRequest::message)
+                .map(IndexingSuccess::message)
                 .mapToLong(Indexable::getSize)
                 .sum();
 
@@ -256,44 +258,11 @@ public class Messages {
         }
     }
 
-    private void recordTimestamp(List<IndexingRequest> messageList) {
-        for (final IndexingRequest entry : messageList) {
+    private void recordTimestamp(List<IndexingSuccess> messageList) {
+        for (final IndexingSuccess entry : messageList) {
             final Indexable message = entry.message();
 
             processingStatusRecorder.updatePostIndexingReceiveTime(message.getReceiveTime());
-        }
-    }
-
-    private Set<String> propagateFailure(Collection<IndexingError> indexingErrors) {
-        if (indexingErrors.isEmpty()) {
-            return Set.of();
-        }
-
-        failureSubmissionService.submitIndexingErrors(indexingErrors);
-
-        return indexingErrors.stream()
-                .map(IndexingError::message).map(Indexable::getId)
-                .collect(Collectors.toSet());
-    }
-
-    @AutoValue
-    public abstract static class IndexingError {
-        public enum ErrorType {
-            IndexBlocked,
-            MappingError,
-            Unknown;
-        }
-        public abstract Indexable message();
-        public abstract String index();
-        public abstract ErrorType errorType();
-        public abstract String errorMessage();
-
-        public static IndexingError create(Indexable message, String index, ErrorType errorType, String errorMessage) {
-            return new AutoValue_Messages_IndexingError(message, index, errorType, errorMessage);
-        }
-
-        public static IndexingError create(Indexable message, String index) {
-            return create(message, index, ErrorType.Unknown, "");
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.messages.IndexingResults;
 import org.graylog2.indexer.messages.MessageWithIndex;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
@@ -35,7 +36,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -143,13 +143,13 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         log.debug("Flushing {} messages completed", messages.size());
     }
 
-    protected Set<String> indexMessageBatch(List<MessageWithIndex> messages) throws Exception {
+    protected IndexingResults indexMessageBatch(List<MessageWithIndex> messages) throws Exception {
         try (Timer.Context ignored = processTime.time()) {
             lastFlushTime.set(System.nanoTime());
-            final Set<String> failedMessageIds = writeMessageEntries(messages);
+            final IndexingResults indexingResults = writeMessageEntries(messages);
             batchSize.update(messages.size());
             bufferFlushes.mark();
-            return failedMessageIds;
+            return indexingResults;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -19,7 +19,7 @@ package org.graylog2.outputs;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.messages.IndexingResults;
 import org.graylog2.indexer.messages.MessageWithIndex;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
@@ -36,8 +36,6 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -89,7 +87,7 @@ public class ElasticSearchOutput implements MessageOutput {
         throw new UnsupportedOperationException("Method not supported!");
     }
 
-    public Set<String> writeMessageEntries(List<MessageWithIndex> messageList) throws Exception {
+    public IndexingResults writeMessageEntries(List<MessageWithIndex> messageList) {
         if (LOG.isTraceEnabled()) {
             final String sortedIds = messageList.stream()
                     .map(MessageWithIndex::message)
@@ -100,13 +98,13 @@ public class ElasticSearchOutput implements MessageOutput {
         }
 
         writes.mark(messageList.size());
-        final Set<String> failedMessageIds;
+        final IndexingResults indexingResults;
         try (final Timer.Context ignored = processTime.time()) {
-            failedMessageIds = messages.bulkIndex(messageList);
+            indexingResults = messages.bulkIndex(messageList);
         }
-        failures.mark(failedMessageIds.size());
+        failures.mark(indexingResults.errors().size());
 
-        return failedMessageIds;
+        return indexingResults;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/failure/FailureSubmissionServiceTest.java
@@ -16,7 +16,7 @@
  */
 package org.graylog.failure;
 
-import org.graylog2.indexer.messages.Messages;
+import org.graylog2.indexer.messages.IndexingError;
 import org.graylog2.plugin.Message;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +26,8 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.indexer.messages.IndexingError.Type.MappingError;
+import static org.graylog2.indexer.messages.IndexingError.Type.Unknown;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -49,9 +51,9 @@ public class FailureSubmissionServiceTest {
         when(msg2.getMessageId()).thenReturn("msg-2");
         when(msg2.supportsFailureHandling()).thenReturn(true);
 
-        final List<Messages.IndexingError> indexingErrors = List.of(
-                Messages.IndexingError.create(msg1, "index-1", Messages.IndexingError.ErrorType.MappingError, "Error"),
-                Messages.IndexingError.create(msg2, "index-2", Messages.IndexingError.ErrorType.Unknown, "Error2")
+        final List<IndexingError> indexingErrors = List.of(
+                IndexingError.create(msg1, "index-1", MappingError, "Error"),
+                IndexingError.create(msg2, "index-2", Unknown, "Error2")
         );
 
         // when
@@ -98,9 +100,9 @@ public class FailureSubmissionServiceTest {
         when(msg2.getMessageId()).thenReturn("msg-2");
         when(msg2.supportsFailureHandling()).thenReturn(false);
 
-        final List<Messages.IndexingError> indexingErrors = List.of(
-                Messages.IndexingError.create(msg1, "index-1", Messages.IndexingError.ErrorType.MappingError, "Error"),
-                Messages.IndexingError.create(msg2, "index-2", Messages.IndexingError.ErrorType.Unknown, "Error2")
+        final List<IndexingError> indexingErrors = List.of(
+                IndexingError.create(msg1, "index-1", MappingError, "Error"),
+                IndexingError.create(msg2, "index-2", Unknown, "Error2")
         );
 
         // when

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBatchIT.java
@@ -32,7 +32,6 @@ import org.mockito.Mock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -71,11 +70,11 @@ public abstract class MessagesBatchIT extends ElasticsearchBaseTest {
         final int MESSAGECOUNT = 50;
         // Each Message is about 1 MB
         final List<MessageWithIndex> largeMessageBatch = createMessageBatch(1024 * 1024, MESSAGECOUNT);
-        final Set<String> failedItems = this.messages.bulkIndex(largeMessageBatch);
+        var results = this.messages.bulkIndex(largeMessageBatch);
 
         client().refreshNode(); // wait for ES to finish indexing
 
-        assertThat(failedItems).isEmpty();
+        assertThat(results.errors()).isEmpty();
         assertThat(messageCount(INDEX_NAME)).isEqualTo(MESSAGECOUNT);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
@@ -37,10 +37,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.indexer.messages.IndexingError.Type.IndexBlocked;
+import static org.graylog2.indexer.messages.IndexingError.Type.MappingError;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -64,7 +65,7 @@ public class MessagesTest {
     private FailureSubmissionService failureSubmissionService;
 
     @Captor
-    private ArgumentCaptor<Collection<Messages.IndexingError>> indexingErrorsArgumentCaptor;
+    private ArgumentCaptor<Collection<IndexingError>> indexingErrorsArgumentCaptor;
 
     private Messages messages;
 
@@ -75,23 +76,24 @@ public class MessagesTest {
 
     @Test
     public void bulkIndexingShouldNotDoAnythingForEmptyList() throws Exception {
-        final Set<String> result = messages.bulkIndex(Collections.emptyList());
+        final IndexingResults indexingResults = messages.bulkIndex(Collections.emptyList());
 
-        assertThat(result).isNotNull()
-                .isEmpty();
+        assertThat(indexingResults).isNotNull();
+        assertThat(indexingResults.allResults()).isEmpty();
 
         verify(messagesAdapter, never()).bulkIndex(any());
     }
 
     @Test
     public void bulkIndexingShouldAccountMessageSizes() throws IOException {
-        when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
+        when(messagesAdapter.bulkIndex(any())).thenReturn(IndexingResults.empty());
         final IndexSet indexSet = mock(IndexSet.class);
         final List<MessageWithIndex> messageList = List.of(
                 new MessageWithIndex(messageWithSize(17), indexSet),
                 new MessageWithIndex(messageWithSize(23), indexSet),
                 new MessageWithIndex(messageWithSize(42), indexSet)
         );
+        when(messagesAdapter.bulkIndex(any())).thenReturn(IndexingResults.create(createSuccessFromMessages(messageList), List.of()));
 
         messages.bulkIndex(messageList);
 
@@ -101,13 +103,13 @@ public class MessagesTest {
 
     @Test
     public void bulkIndexingShouldAccountMessageSizesForSystemTrafficSeparately() throws IOException {
-        when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
         final IndexSet indexSet = mock(IndexSet.class);
         final List<MessageWithIndex> messageList = List.of(
                 new MessageWithIndex(messageWithSize(17), indexSet),
                 new MessageWithIndex(messageWithSize(23), indexSet),
                 new MessageWithIndex(messageWithSize(42), indexSet)
         );
+        when(messagesAdapter.bulkIndex(any())).thenReturn(IndexingResults.create(createSuccessFromMessages(messageList), List.of()));
 
         messages.bulkIndex(messageList, true);
 
@@ -131,18 +133,23 @@ public class MessagesTest {
                 IndexingRequest.create(indexSet, message3));
 
         when(messagesAdapter.bulkIndex(indexingRequest)).thenReturn(
-                ImmutableList.of(
-                        Messages.IndexingError.create(message2, "msg-index", Messages.IndexingError.ErrorType.MappingError, "Some error message"),
-                        Messages.IndexingError.create(message3, "msg-index", Messages.IndexingError.ErrorType.MappingError, "Some error message"),
-                        Messages.IndexingError.create(message4, "msg-index", Messages.IndexingError.ErrorType.IndexBlocked, "Index blocked error message")
+                IndexingResults.create(List.of(),
+                        List.of(
+                                IndexingError.create(message2, "msg-index", MappingError, "Some error message"),
+                                IndexingError.create(message3, "msg-index", MappingError, "Some error message"),
+                                IndexingError.create(message4, "msg-index", IndexBlocked, "Index blocked error message")
+                        )
                 )
         );
+        when(messagesAdapter.bulkIndex(List.of())).thenReturn(IndexingResults.empty());
 
         // when
-        final Set<String> failureIds = messages.bulkIndexRequests(indexingRequest, false);
+        final IndexingResults indexingResults = messages.bulkIndexRequests(indexingRequest, false);
 
         // then
-        assertThat(failureIds).hasSize(2)
+        assertThat(indexingResults.errors()).hasSize(2)
+                .map(IndexingResult::message)
+                .map(Indexable::getId)
                 .containsExactlyInAnyOrder("msg-2", "msg-3");
 
         verify(failureSubmissionService, times(1)).submitIndexingErrors(indexingErrorsArgumentCaptor.capture());
@@ -153,12 +160,12 @@ public class MessagesTest {
                 .collect(Collectors.toList())
         ).satisfies(indexingErrors -> {
             assertThat(indexingErrors.get(0)).satisfies(indexingError -> {
-                assertThat(indexingError.errorType()).isEqualTo(Messages.IndexingError.ErrorType.MappingError);
+                assertThat(indexingError.error().type()).isEqualTo(MappingError);
                 assertThat(indexingError.message()).isEqualTo(message2);
             });
 
             assertThat(indexingErrors.get(1)).satisfies(indexingError -> {
-                assertThat(indexingError.errorType()).isEqualTo(Messages.IndexingError.ErrorType.MappingError);
+                assertThat(indexingError.error().type()).isEqualTo(MappingError);
                 assertThat(indexingError.message()).isEqualTo(message3);
             });
         });
@@ -176,15 +183,19 @@ public class MessagesTest {
                 IndexingRequest.create(indexSet, message1),
                 IndexingRequest.create(indexSet, message2));
 
-        when(messagesAdapter.bulkIndex(indexingRequest)).thenReturn(ImmutableList.of());
+        when(messagesAdapter.bulkIndex(indexingRequest)).thenReturn(IndexingResults.empty());
 
         // when
-        final Set<String> failureIds = messages.bulkIndexRequests(indexingRequest, false);
+        final IndexingResults indexingResults = messages.bulkIndexRequests(indexingRequest, false);
 
         // then
-        assertThat(failureIds).isEmpty();
+        assertThat(indexingResults.errors()).isEmpty();
 
         verifyNoInteractions(failureSubmissionService);
+    }
+
+    private List<IndexingSuccess> createSuccessFromMessages(List<MessageWithIndex> messageList) {
+        return messageList.stream().map(m -> new IndexingSuccess(m.message(), "index_2")).collect(Collectors.toList());
     }
 
     private Message message(String msgId, DateTime ts) {


### PR DESCRIPTION
Bulk index requests were only returning errors so far.

Introduce a new value class: `IndexingResults` which
contains bulk indexing `errors()` and `successes()`

This allows bulk index callers to see into which
actual index a message has been ingested.

/nocl

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5700