### PR TITLE
Fix changelog entry pr-15088.toml

### DIFF
--- a/changelog/unreleased/pr-15088.toml
+++ b/changelog/unreleased/pr-15088.toml
@@ -1,4 +1,4 @@
 type = "a"
-message = "run matrix tests with a given indexer version"
+message = "Run matrix tests with a given indexer version."
 
-pull = ["15088"]
+pulls = ["15088"]


### PR DESCRIPTION
Fixes the following linter error:

```
$ graylog-project cl lint changelog/unreleased/
Linted 110 snippet file(s) - ok=109 error=1
linter error in file changelog/unreleased/pr-15088.toml: at least one issue or pull request number needs to be present
detected errors in 1 file(s)
```

The broken entry got added before we ran the linter for every PR.