### PR TITLE
close networks and containers in tests

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeSecuritySetupIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeSecuritySetupIT.java
@@ -30,6 +30,7 @@ import org.graylog.datanode.testinfra.DatanodeContainerizedBackend;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.utilities.StringUtils;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -104,6 +105,11 @@ public class DatanodeSecuritySetupIT {
 
             datanodeContainer.withEnv("GRAYLOG_DATANODE_SINGLE_NODE_ONLY", "true");
         }).start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        backend.stop();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
@@ -72,4 +72,13 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
             return "could not get info from container!";
         }
     }
+
+    @Override
+    public void close() {
+        super.close();
+        final Network network = getNetwork();
+        if(network != null) {
+            network.close();
+        }
+    }
 }


### PR DESCRIPTION
/nocl

## Description
Opened networks and containers can exhaust docker resources even before testcontainers run the cleanup during the jvm shutdown. We should close everything that we create and don't need anymore as soon as possible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

