### PR TITLE
fix initial uname/pwd for datanode cluster tests

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
@@ -57,8 +57,8 @@ public class DatanodeClusterIT {
     static Path tempDir;
     private String hostnameNodeA;
     private KeyStore trustStore;
-    private String usernameNodeA;
-    private String passwordNodeA;
+    private String initialAdminUsername;
+    private String initialAdminPassword;
     private KeystoreInformation ca;
 
     @BeforeEach
@@ -72,8 +72,9 @@ public class DatanodeClusterIT {
         hostnameNodeA = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
         final KeystoreInformation transportNodeA = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeA");
         final KeystoreInformation httpNodeA = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeA");
-        usernameNodeA = RandomStringUtils.randomAlphabetic(10);
-        passwordNodeA = RandomStringUtils.randomAlphabetic(10);
+
+        initialAdminUsername = RandomStringUtils.randomAlphabetic(10);
+        initialAdminPassword = RandomStringUtils.randomAlphabetic(10);
 
         final Network network = Network.newNetwork();
         final GenericContainer<?> mongodb = DatanodeContainerizedBackend.createMongodbContainer(network);
@@ -83,16 +84,14 @@ public class DatanodeClusterIT {
                 hostnameNodeA,
                 transportNodeA,
                 httpNodeA,
-                usernameNodeA,
-                passwordNodeA
+                initialAdminUsername,
+                initialAdminPassword
         ).start();
 
 
         final String hostnameNodeB = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
         final KeystoreInformation transportNodeB = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeB");
         final KeystoreInformation httpNodeB = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeB");
-        final String usernameNodeB = RandomStringUtils.randomAlphabetic(10);
-        final String passwordNodeB = RandomStringUtils.randomAlphabetic(10);
 
         nodeB = createDatanodeContainer(
                 network,
@@ -100,8 +99,8 @@ public class DatanodeClusterIT {
                 hostnameNodeB,
                 transportNodeB,
                 httpNodeB,
-                usernameNodeB,
-                passwordNodeB
+                initialAdminUsername,
+                initialAdminPassword
         ).start();
     }
 
@@ -122,16 +121,14 @@ public class DatanodeClusterIT {
         final String hostnameNodeC = "graylog-datanode-host-" + RandomStringUtils.random(8, "0123456789abcdef");
         final KeystoreInformation transportNodeC = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, "nodeB");
         final KeystoreInformation httpNodeC = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, "nodeB");
-        final String usernameNodeC = RandomStringUtils.randomAlphabetic(10);
-        final String passwordNodeC = RandomStringUtils.randomAlphabetic(10);
 
         final DatanodeContainerizedBackend nodeC = createDatanodeContainer(
                 nodeA.getNetwork(), nodeA.getMongodbContainer(),
                 hostnameNodeC,
                 transportNodeC,
                 httpNodeC,
-                usernameNodeC,
-                passwordNodeC
+                initialAdminUsername,
+                initialAdminPassword
         );
 
         nodeC.start();
@@ -192,7 +189,7 @@ public class DatanodeClusterIT {
                 Integer mappedPort = nodeA.getOpensearchRestPort();
                 return RestAssured.given()
                         .trustStore(trustStore)
-                        .auth().basic(usernameNodeA, passwordNodeA)
+                        .auth().basic(initialAdminUsername, initialAdminPassword)
                         .get("https://localhost:" + mappedPort + "/_cluster/health")
                         .then();
             });


### PR DESCRIPTION
/nocl

When opensearch nodes join a cluster, only users from the initial manager node will be available. So we need to make sure we use everywhere the same credentials, otherwise we won't be able to communicate with other nodes from the cluster directly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

