### PR TITLE
Bump actions/checkout and actions/cache to fix cache restore issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
@@ -22,7 +22,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Set up Yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
           restore-keys: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: Build the repository
 on: 
   pull_request:
 
+# Cancel running build when new ref gets pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest-4-cores-public

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,6 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
           cache: maven
-      - name: Set up Yarn cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-          path: ~/.cache/yarn
       - name: License check
         run: mvn -B --fail-fast license:check
       - name: Build with Maven


### PR DESCRIPTION
Should fix the following issue on GitHub Actions:

```
The value of "length" is out of range. It must be >= 0 && <= 2147483647.
```
Relevant item from the actions/cache changelog:

> Fixed download issue for files > 2GB during restore.

/nocl