### PR TITLE
Backport 5.1: Account for leeway in validating retention period for time-size-optimizing retention

### DIFF
--- a/changelog/unreleased/issue-16392.toml
+++ b/changelog/unreleased/issue-16392.toml
@@ -1,0 +1,5 @@
+type = "f" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fixes validation of max index retention lifetime for time-size-optimizing indices."
+
+issues = ["Graylog2/graylog-plugin-enterprise#5685"]
+pulls = ["16392"]

--- a/changelog/unreleased/issue-16392.toml
+++ b/changelog/unreleased/issue-16392.toml
@@ -2,4 +2,4 @@ type = "f" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecu
 message = "Fixes validation of max index retention lifetime for time-size-optimizing indices."
 
 issues = ["Graylog2/graylog-plugin-enterprise#5685"]
-pulls = ["16392"]
+pulls = ["16448"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -128,7 +128,7 @@ public class IndexSetValidator {
                         leeway, TIME_SIZE_OPTIMIZING_ROTATION_PERIOD, elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()));
             }
 
-            Period fixedLeeway = elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway();
+            Period fixedLeeway = elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway();
             if (Objects.nonNull(fixedLeeway) && leeway.toStandardSeconds().isLessThan(fixedLeeway.toStandardSeconds())) {
                 return Violation.create(f("The duration between %s and %s <%s> cannot be shorter than %s <%s>", INDEX_LIFETIME_MAX, INDEX_LIFETIME_MIN,
                         leeway, TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY, fixedLeeway));

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -69,8 +69,8 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     @Override
     public RotationStrategyConfig defaultConfiguration() {
         return TimeBasedSizeOptimizingStrategyConfig.builder()
-                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
-                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
+                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMinLifeTime())
+                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMaxLifeTime())
                 .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
@@ -79,8 +79,8 @@ public class MaintenanceStrategiesHelper {
             case TimeBasedSizeOptimizingStrategy.NAME -> {
                 return ImmutablePair.of(TimeBasedSizeOptimizingStrategy.class.getCanonicalName(),
                         TimeBasedSizeOptimizingStrategyConfig.builder()
-                                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
-                                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
+                                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMinLifeTime())
+                                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMaxLifeTime())
                                 .build());
             }
             default -> {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -83,7 +83,7 @@ public class RotationStrategyResource extends RestResource {
                 .collect(Collectors.toList());
 
         final RotationStrategies.Context context =
-                RotationStrategies.Context.create(elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway());
+                RotationStrategies.Context.create(elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway());
 
         return RotationStrategies.create(strategies, context);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -218,7 +218,7 @@ public class IndexSetValidatorTest {
     @Test
     public void timeBasedSizeOptimizingHonorsFixedLeeWay() {
         when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(Period.days(1));
-        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway()).thenReturn(Period.days(10));
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway()).thenReturn(Period.days(10));
 
         when(indexSetRegistry.iterator()).thenReturn(Collections.emptyIterator());
         final IndexSetConfig failingConfig = testIndexSetConfig().toBuilder()

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -324,7 +324,7 @@ stream_aware_field_types=false
 # Multiple rotation strategies are supported, the default being "time-size-optimizing":
 #   - "time-size-optimizing" tries to rotate daily, while focussing on optimal sized shards.
 #      The global default values can be configured with
-#       "time_size_optimizing_rotation_min_lifetime" and "time_size_optimizing_rotation_max_lifetime".
+#       "time_size_optimizing_retention_min_lifetime" and "time_size_optimizing_retention_max_lifetime".
 #   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
 #   - "size" per index, use elasticsearch_max_size_per_index below to configure
 #   - "time" interval between index rotations, use elasticsearch_max_time_per_index to configure


### PR DESCRIPTION
Backporting #16392 

Refers to Graylog2/graylog-plugin-enterprise#5685
