### PR TITLE
Save & reload updated dashboard after changing title. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-16440.toml
+++ b/changelog/unreleased/issue-16440.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Updating title of dashboard is now properly saved."
+
+issues = ["16440"]
+pulls = ["16441"]

--- a/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
@@ -129,11 +129,14 @@ const ViewHeader = () => {
 
   const { alertId, definitionId, definitionTitle, isAlert, isEventDefinition, isEvent } = useAlertAndEventDefinitionData();
   const dispatch = useAppDispatch();
-  const _onSaveView = useCallback(() => dispatch(onSaveView(view)), [dispatch, view]);
+  const _onSaveView = useCallback(async (updatedView: View) => {
+    await dispatch(onSaveView(updatedView));
+    await dispatch(updateView(updatedView));
+  }, [dispatch]);
 
   const typeText = view?.type?.toLocaleLowerCase();
   const title = useViewTitle();
-  const onChangeFavorite = useCallback((newValue) => dispatch(updateView(view.toBuilder().favorite(newValue).build())), [dispatch, view]);
+  const onChangeFavorite = useCallback((newValue: boolean) => dispatch(updateView(view.toBuilder().favorite(newValue).build())), [dispatch, view]);
 
   const breadCrumbs = useMemo(() => {
     if (isAlert || isEvent) return links.alert({ id: alertId });


### PR DESCRIPTION
**Note:** This PR is a backport of #16441 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue described in #16440, where changing the title of a dashboard was not properly saved. This is due to the save view action being called with the original dashboard and not the updated one.

Fixes #16440.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.