### PR TITLE
Bump scala version to 2.13.12

### DIFF
--- a/changelog/unreleased/pr-16456.toml
+++ b/changelog/unreleased/pr-16456.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Scala to 2.13.12 to include fix of CVE-2022-36944."
+
+pulls = ["16456"]

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <protobuf.version>3.17.3</protobuf.version>
         <reflections.version>0.10.2</reflections.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <scala.version>2.13.4</scala.version>
+        <scala.version>2.13.12</scala.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
         <shiro.version>1.12.0</shiro.version>
         <oshi.version>5.3.7</oshi.version>


### PR DESCRIPTION
Fixes [CVE-2022-36944](https://nvd.nist.gov/vuln/detail/CVE-2022-36944)