### PR TITLE
Modified return statement in _formatInputValue

### DIFF
--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -510,7 +510,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       .map((v) => {
         const availableOption = options.find((option) => option[valueKey || ''] === v);
 
-        return availableOption ?? { [displayKey]: String(value), [valueKey]: value };
+        return availableOption;
       });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed the return value of _formatInputValue from the Select component. Previously, in _formatInputValue function, if the availableOption returns empty or undefined, the method is returning the comma separated string of selected values as a key value pair, which is getting selected in the dropdown, which is not an expected behaviour.
To fix this issue, I have removed the { [displayKey]: String(value), [valueKey]: value } from the return statement.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/Graylog2/graylog2-server/assets/80875563/da1942de-6eed-4cf4-90aa-bd5d6a7d4690)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

