### PR TITLE
Replace `react-bootstrap` alert with `mantine` alert.

### DIFF
--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -29,7 +29,7 @@
     "extends": "graylog"
   },
   "dependencies": {
-    "@graylog/sawmill": "2.0.4",
+    "@graylog/sawmill": "2.0.5",
     "@tanstack/react-query": "4.35.3",
     "@types/create-react-class": "15.6.4",
     "@types/jquery": "3.5.18",

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -29,10 +29,8 @@
     "extends": "graylog"
   },
   "dependencies": {
-<<<<<<< HEAD
-    "@graylog/sawmill": "^2.0.2",
+    "@graylog/sawmill": "2.0.4",
     "@tanstack/react-query": "4.35.3",
-
     "@types/create-react-class": "15.6.4",
     "@types/jquery": "3.5.18",
     "@types/react": "18.2.20",

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -29,8 +29,10 @@
     "extends": "graylog"
   },
   "dependencies": {
+<<<<<<< HEAD
     "@graylog/sawmill": "^2.0.2",
     "@tanstack/react-query": "4.35.3",
+
     "@types/create-react-class": "15.6.4",
     "@types/jquery": "3.5.18",
     "@types/react": "18.2.20",

--- a/graylog2-web-interface/src/components/authentication/AuthenticatorsEdit/HTTPHeaderAuthConfigSection.tsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticatorsEdit/HTTPHeaderAuthConfigSection.tsx
@@ -22,7 +22,7 @@ import Routes from 'routing/Routes';
 import type HTTPHeaderAuthConfig from 'logic/authentication/HTTPHeaderAuthConfig';
 import HTTPHeaderAuthConfigDomain from 'domainActions/authentication/HTTPHeaderAuthConfigDomain';
 import { Input, Button, Col, Row, Alert } from 'components/bootstrap';
-import { FormikFormGroup, ErrorAlert, Spinner, Icon } from 'components/common';
+import { FormikFormGroup, ErrorAlert, Spinner } from 'components/common';
 import SectionComponent from 'components/common/Section/SectionComponent';
 import useHistory from 'routing/useHistory';
 import type { HTTPHeaderAuthConfigJSON } from 'logic/authentication/HTTPHeaderAuthConfig';
@@ -88,7 +88,7 @@ const HTTPHeaderAuthConfigSection = () => {
             <Row>
               <Col mdOffset={3} md={9}>
                 <Alert bsStyle="info">
-                  <Icon name="info-circle" /> Please configure the <code>trusted_proxies</code> setting in the Graylog
+                  Please configure the <code>trusted_proxies</code> setting in the Graylog
                   server configuration file.
                 </Alert>
               </Col>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.tsx
@@ -55,8 +55,7 @@ const FORMS_VALIDATION = {
 const SubmitAllError = ({ error, backendId }: { error: FetchError, backendId: string | null | undefined }) => (
   <Row>
     <Col xs={9} xsOffset={3}>
-      <Alert bsStyle="danger" style={{ wordBreak: 'break-word' }}>
-        <b>Failed to {backendId ? 'edit' : 'create'} authentication service</b><br />
+      <Alert bsStyle="danger" style={{ wordBreak: 'break-word' }} title={`Failed to ${backendId ? 'edit' : 'create'} authentication service`}>
         {error?.message && <>{error.message}<br /><br /></>}
         {error?.additional?.res?.text}
       </Alert>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ConnectionErrors.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/ConnectionErrors.tsx
@@ -42,8 +42,7 @@ type Props = {
 };
 
 const ConnectionErrors = ({ errors, message }: Props) => (
-  <NotificationContainer bsStyle="danger">
-    <Title>{message}</Title>
+  <NotificationContainer bsStyle="danger" title={message}>
     <ErrorsList>
       {errors.map((error) => <li key={String(error)}>{String(error)}</li>)}
     </ErrorsList>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 
 import type Role from 'logic/roles/Role';
 import { validateField, formHasErrors } from 'util/FormsUtils';
-import { Icon, FormikFormGroup, Select, InputList } from 'components/common';
+import { FormikFormGroup, Select, InputList } from 'components/common';
 import { Alert, Button, ButtonToolbar, Row, Col, Panel, Input } from 'components/bootstrap';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 
@@ -190,7 +190,6 @@ const UserSyncStep = ({
           <Row>
             <Col sm={9} smOffset={3}>
               <Alert bsStyle="info">
-                <Icon name="info-circle" />{' '}
                 We recommend you test your user login in the sidebar panel to verify your settings.
               </Alert>
             </Col>

--- a/graylog2-web-interface/src/components/bootstrap/Alert.md
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.md
@@ -1,23 +1,40 @@
-### Default
+#### Default
 
-```js
+```tsx
 <Alert>
-  <i className="fa fa-exclamation-triangle fa-fw fa-lg" />{' '}
-  <strong>Default</strong> Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Default - Lorem ipsum dolor sit amet consectetur adipisicing elit.
 </Alert>
 ```
 
-### Variants
+#### Variants
 
-```js
+```tsx
 const styles = ['Danger', 'Info', 'Success', 'Warning'];
 
 styles.map((style, i) => {
   return (
     <Alert bsStyle={style.toLowerCase()} key={`button-${style}-${i}`}>
-      <i className="fa fa-exclamation-triangle fa-fw fa-lg" />{' '}
-      <strong>{style}</strong> Lorem ipsum dolor sit amet consectetur <a href="#">adipisicing elit</a>.
+      {style} - Lorem ipsum dolor sit amet consectetur adipisicing elit.
     </Alert>
   )
 })
+```
+
+
+#### With Title
+
+```tsx
+<Alert title="The Title">
+  Lorem ipsum dolor sit amet consectetur adipisicing elit.
+</Alert>
+```
+
+#### With Close Button
+
+```tsx
+import Icon from 'components/common/Icon';
+
+<Alert onClose={() => window.alert('You clicked on the alert close icon.')}>
+  Lorem ipsum dolor sit amet consectetur adipisicing elit.
+</Alert>
 ```

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
-import { Alert as BootstrapAlert } from 'react-bootstrap';
 import type { ColorVariant } from '@graylog/sawmill';
+import { Alert as MantineAlert } from '@mantine/core';
 
 interface Props {
   bsStyle: ColorVariant,
@@ -26,7 +26,7 @@ interface Props {
   onDismiss?: () => void,
 }
 
-const StyledAlert = styled(BootstrapAlert)<{ bsStyle: ColorVariant }>(({ bsStyle = 'info', theme }) => {
+const StyledAlert = styled(MantineAlert)<{ bsStyle: ColorVariant }>(({ bsStyle = 'info', theme }) => {
   const borderColor = theme.colors.variant.lighter[bsStyle];
   const backgroundColor = theme.colors.variant.lightest[bsStyle];
 

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import type { ColorVariant } from '@graylog/sawmill';
-import { Alert as MantineAlert } from '@mantine/core';
+import { Alert as MantineAlert, useMantineTheme } from '@mantine/core';
 
 interface Props {
   bsStyle: ColorVariant,
@@ -30,7 +30,19 @@ const StyledAlert = styled(MantineAlert)(({ theme }) => css`
   margin: ${theme.mantine.spacing.md} 0;
 `);
 
-const Alert = ({ bsStyle, ...rest }: Props) => <StyledAlert color={bsStyle} {...rest} />;
+const Alert = ({ bsStyle, ...rest }: Props) => {
+  const theme = useMantineTheme();
+  const alertStyles = () => ({
+    message: {
+      fontSize: theme.fontSizes.md,
+    },
+    title: {
+      fontSize: theme.fontSizes.md,
+    },
+  });
+
+  return <StyledAlert styles={alertStyles} color={bsStyle} {...rest} />;
+};
 
 Alert.defaultProps = {
   onDismiss: undefined,

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -20,6 +20,8 @@ import type { CSSProperties } from 'react';
 import type { ColorVariant } from '@graylog/sawmill';
 import { Alert as MantineAlert, useMantineTheme } from '@mantine/core';
 
+import Icon from 'components/common/Icon';
+
 type Props = {
   bsStyle: ColorVariant,
   children: React.ReactNode,
@@ -33,6 +35,18 @@ const StyledAlert = styled(MantineAlert)(({ theme }) => css`
   margin: ${theme.mantine.spacing.md} 0;
 `);
 
+const iconNameForType = (bsStyle: ColorVariant) => {
+  switch (bsStyle) {
+    case 'warning':
+    case 'danger':
+      return 'exclamation-triangle';
+    case 'success':
+      return 'circle-check';
+    default:
+      return 'info-circle';
+  }
+};
+
 const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props) => {
   const theme = useMantineTheme();
   const alertStyles = () => ({
@@ -43,6 +57,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
       fontSize: theme.fontSizes.md,
     },
   });
+  const iconName = iconNameForType(bsStyle);
 
   return (
     <StyledAlert className={className}
@@ -51,6 +66,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
                  styles={alertStyles}
                  onClose={onDismiss}
                  title={title}
+                 icon={<Icon name={iconName} />}
                  withCloseButton={typeof onDismiss === 'function'}>
       {children}
     </StyledAlert>

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -26,41 +26,11 @@ interface Props {
   onDismiss?: () => void,
 }
 
-const StyledAlert = styled(MantineAlert)<{ bsStyle: ColorVariant }>(({ bsStyle = 'info', theme }) => {
-  const borderColor = theme.colors.variant.lighter[bsStyle];
-  const backgroundColor = theme.colors.variant.lightest[bsStyle];
+const StyledAlert = styled(MantineAlert)(({ theme }) => css`
+  margin: ${theme.mantine.spacing.md} 0;
+`);
 
-  return css`
-    background-color: ${backgroundColor};
-    border-color: ${borderColor};
-    color: ${theme.utils.contrastingColor(backgroundColor)};
-
-    a:not(.btn) {
-      color: ${theme.utils.contrastingColor(backgroundColor, 'AA')};
-      font-weight: bold;
-      text-decoration: underline;
-
-      &:hover,
-      &:focus,
-      &:active {
-        color: ${theme.utils.contrastingColor(backgroundColor)};
-      }
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
-      }
-    }
-
-    &.alert-dismissible {
-      .close {
-        top: -9px;
-      }
-    }
-`;
-});
-
-const Alert = ({ bsStyle, ...rest }: Props) => <StyledAlert bsStyle={bsStyle} {...rest} />;
+const Alert = ({ bsStyle, ...rest }: Props) => <StyledAlert color={bsStyle} {...rest} />;
 
 Alert.defaultProps = {
   onDismiss: undefined,

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -26,13 +26,14 @@ type Props = {
   className?: string,
   onDismiss?: () => void,
   style?: CSSProperties,
+  title?: React.ReactNode,
 }
 
 const StyledAlert = styled(MantineAlert)(({ theme }) => css`
   margin: ${theme.mantine.spacing.md} 0;
 `);
 
-const Alert = ({ children, bsStyle, style, className, onDismiss }: Props) => {
+const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props) => {
   const theme = useMantineTheme();
   const alertStyles = () => ({
     message: {
@@ -49,6 +50,7 @@ const Alert = ({ children, bsStyle, style, className, onDismiss }: Props) => {
                  style={style}
                  styles={alertStyles}
                  onClose={onDismiss}
+                 title={title}
                  withCloseButton={typeof onDismiss === 'function'}>
       {children}
     </StyledAlert>

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -49,6 +49,9 @@ const iconNameForType = (bsStyle: ColorVariant) => {
 
 const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props) => {
   const theme = useMantineTheme();
+  const displayCloseButton = typeof onDismiss === 'function';
+  const iconName = iconNameForType(bsStyle);
+
   const alertStyles = () => ({
     message: {
       fontSize: theme.fontSizes.md,
@@ -57,7 +60,6 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
       fontSize: theme.fontSizes.md,
     },
   });
-  const iconName = iconNameForType(bsStyle);
 
   return (
     <StyledAlert className={className}
@@ -67,7 +69,8 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
                  onClose={onDismiss}
                  title={title}
                  icon={<Icon name={iconName} />}
-                 withCloseButton={typeof onDismiss === 'function'}>
+                 closeButtonLabel={displayCloseButton && 'Close alert'}
+                 withCloseButton={displayCloseButton}>
       {children}
     </StyledAlert>
   );

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -16,21 +16,23 @@
  */
 import * as React from 'react';
 import styled, { css } from 'styled-components';
-// eslint-disable-next-line no-restricted-imports
+import type { CSSProperties } from 'react';
 import type { ColorVariant } from '@graylog/sawmill';
 import { Alert as MantineAlert, useMantineTheme } from '@mantine/core';
 
-interface Props {
+type Props = {
   bsStyle: ColorVariant,
   children: React.ReactNode,
+  className?: string,
   onDismiss?: () => void,
+  style?: CSSProperties,
 }
 
 const StyledAlert = styled(MantineAlert)(({ theme }) => css`
   margin: ${theme.mantine.spacing.md} 0;
 `);
 
-const Alert = ({ bsStyle, ...rest }: Props) => {
+const Alert = ({ children, bsStyle, style, className, onDismiss }: Props) => {
   const theme = useMantineTheme();
   const alertStyles = () => ({
     message: {
@@ -41,11 +43,23 @@ const Alert = ({ bsStyle, ...rest }: Props) => {
     },
   });
 
-  return <StyledAlert styles={alertStyles} color={bsStyle} {...rest} />;
+  return (
+    <StyledAlert className={className}
+                 color={bsStyle}
+                 style={style}
+                 styles={alertStyles}
+                 onClose={onDismiss}
+                 withCloseButton={typeof onDismiss === 'function'}>
+      {children}
+    </StyledAlert>
+  );
 };
 
 Alert.defaultProps = {
+  className: undefined,
   onDismiss: undefined,
+  style: undefined,
+  title: undefined,
 };
 
 export default Alert;

--- a/graylog2-web-interface/src/components/common/EntityList.tsx
+++ b/graylog2-web-interface/src/components/common/EntityList.tsx
@@ -20,8 +20,6 @@ import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
 
-import Icon from './Icon';
-
 const StyledList = styled.ul`
   padding: 0;
   margin: 0;
@@ -42,7 +40,6 @@ const EntityList = ({ bsNoItemsStyle, items, noItemsText }: Props) => {
   if (items.length === 0) {
     return (
       <Alert bsStyle={bsNoItemsStyle}>
-        <Icon name="info-circle" />&nbsp;
         {noItemsText}
       </Alert>
     );

--- a/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
+++ b/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
@@ -16,14 +16,8 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import Icon from 'components/common/Icon';
-
-const StyledIcon = styled(Icon)`
-  margin-right: 5px;
-`;
 
 type Props = {
   children: React.ReactNode,
@@ -35,7 +29,7 @@ type Props = {
  * explain what that entity is and a link to create a new one please use <EmptyEntity>
 */
 const NoEntitiesExist = ({ children, className }: Props) => (
-  <Alert className={`${className ?? ''} no-bm`}><StyledIcon name="info-circle" />{children}</Alert>
+  <Alert className={`${className ?? ''} no-bm`}>{children}</Alert>
 );
 
 NoEntitiesExist.propTypes = {

--- a/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
+++ b/graylog2-web-interface/src/components/common/NoEntitiesExist.tsx
@@ -21,25 +21,22 @@ import { Alert } from 'components/bootstrap';
 
 type Props = {
   children: React.ReactNode,
-  className?: string,
 };
 
 /**
  * Component used to display a simple alert message for an empty entity in Graylog. For more complex messages that
  * explain what that entity is and a link to create a new one please use <EmptyEntity>
 */
-const NoEntitiesExist = ({ children, className }: Props) => (
-  <Alert className={`${className ?? ''} no-bm`}>{children}</Alert>
+const NoEntitiesExist = ({ children }: Props) => (
+  <Alert className="no-bm">{children}</Alert>
 );
 
 NoEntitiesExist.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node]),
-  className: PropTypes.string,
 };
 
 NoEntitiesExist.defaultProps = {
   children: 'No entities exist.',
-  className: undefined,
 };
 
 export default NoEntitiesExist;

--- a/graylog2-web-interface/src/components/common/NoSearchResult.tsx
+++ b/graylog2-web-interface/src/components/common/NoSearchResult.tsx
@@ -15,14 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import Icon from 'components/common/Icon';
-
-const StyledIcon = styled(Icon)`
-  margin-right: 5px;
-`;
 
 type Props = {
   children: React.ReactNode,
@@ -35,7 +29,6 @@ type Props = {
 */
 const NoSearchResult = ({ children, className }: Props) => (
   <Alert className={`${className ?? ''} no-bm`}>
-    <StyledIcon name="info-circle" />
     {children || 'No data available.'}
   </Alert>
 );

--- a/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import { fireEvent, render, screen, within } from 'wrappedTestingLibrary';
 import type { PluginExports } from 'graylog-web-plugin/plugin';
 
 import type { Notifications } from 'theme/types';
@@ -37,7 +37,7 @@ const mockedNotifications = {
     isDismissible: false,
   },
   '6075a2999f4efa083977b75b': {
-    title: 'Danger Alert 🔥',
+    title: 'Danger Alert',
     shortMessage: 'xcvbxcvb',
     longMessage: 'xcvbxcvbxcvbxcvbxcvbxcvb',
     atLogin: true,
@@ -116,9 +116,11 @@ describe('PublicNotifications', () => {
 
   it('should dismiss notification', () => {
     render(<PublicNotifications />);
-
     const dismissedId = Object.keys(mockedNotifications)[1];
-    const dismissBtn = screen.getByRole('button', {
+
+    const alert = screen.getByRole('alert', { name: /Danger Alert/i });
+
+    const dismissBtn = within(alert).getByRole('button', {
       name: /close alert/i,
     });
 

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -94,8 +94,7 @@ const PublicNotifications = ({ readFromConfig }: Props) => {
     const _dismiss = () => onDismissPublicNotification(notificationId);
 
     return (
-      <StyledAlert bsStyle={variant} onDismiss={isDismissible ? _dismiss : undefined} key={title}>
-        {!hiddenTitle && (<h3>{title}</h3>)}
+      <StyledAlert bsStyle={variant} onDismiss={isDismissible ? _dismiss : undefined} key={title} title={!hiddenTitle && title}>
         <FlexWrap>
           <ShortContent>{shortMessage}</ShortContent>
           {longMessage && <Button bsStyle="link" onClick={toggleReadMore}>Read {showReadMore === notificationId ? 'Less' : 'More'}</Button>}

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -48,10 +48,6 @@ const LongContent = styled.div<{ $visible: boolean}>(({ $visible }) => css`
 const StyledAlert = styled(Alert)`
   margin-bottom: 6px;
   padding-right: 9px;
-  
-  &.alert-dismissable .close {
-    right: 12px;
-  }
 `;
 
 const Wrapper = styled.div`

--- a/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.tsx
@@ -172,8 +172,8 @@ const MessageProcessorsConfig = () => {
             </tbody>
           </Table>
           {hasNoActiveProcessor() && (
-          <Alert bsStyle="danger">
-            <strong>ERROR:</strong> No active message processor!
+          <Alert bsStyle="danger" title="Error">
+            No active message processor!
           </Alert>
           )}
         </>

--- a/graylog2-web-interface/src/components/content-stream/ContentStreamNews.tsx
+++ b/graylog2-web-interface/src/components/content-stream/ContentStreamNews.tsx
@@ -23,8 +23,6 @@ import { Spinner, ExternalLink } from 'components/common';
 import ContentStreamNewsItem from 'components/content-stream/news/ContentStreamNewsItem';
 import { Alert } from 'components/bootstrap';
 
-import Icon from '../common/Icon';
-
 const ContentStreamNews = () => {
   const { feedList, isLoadingFeed, error } = useContentStream();
 
@@ -36,7 +34,7 @@ const ContentStreamNews = () => {
     return (
       <Alert bsStyle="info">
         <p>
-          <Icon name="exclamation-triangle" /> Unable to load RSS feed at the moment ! You can read more
+          Unable to load RSS feed at the moment ! You can read more
           on {' '}
           <ExternalLink href="https://www.graylog.org/blog/">
             Graylog

--- a/graylog2-web-interface/src/components/content-stream/ContentStreamReleasesSection.tsx
+++ b/graylog2-web-interface/src/components/content-stream/ContentStreamReleasesSection.tsx
@@ -24,8 +24,6 @@ import { ListGroup, ListGroupItem, Label, Alert } from 'components/bootstrap';
 import { RelativeTime, Spinner, ExternalLink } from 'components/common';
 import useContentStream from 'components/content-stream/hook/useContentStream';
 
-import Icon from '../common/Icon';
-
 const StyledListGroupItem = styled(ListGroupItem)(({ theme }: { theme: DefaultTheme }) => css`
   display: flex;
   gap: ${theme.spacings.md};
@@ -54,7 +52,7 @@ const ContentStreamReleasesSection = () => {
     return (
       <Alert bsStyle="info">
         <p>
-          <Icon name="exclamation-triangle" /> Unable to load RSS feed at the moment ! You can read more
+          Unable to load RSS feed at the moment ! You can read more
           on {' '}
           <ExternalLink href="https://www.graylog.org/post/tag/release-info">
             Graylog.org

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.tsx
@@ -39,8 +39,7 @@ const EventDefinitionValidationSummary = ({ validation }: Props) => {
   return (
     <Row>
       <Col md={12}>
-        <Alert bsStyle="danger" className={commonStyles.validationSummary}>
-          <h4>We found some errors!</h4>
+        <Alert bsStyle="danger" className={commonStyles.validationSummary} title="We found some errors!">
           <p>Please correct the following errors before saving this Event Definition:</p>
           <ul>
             {fieldsWithErrors.map((field) => validation.errors[field].map((error) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.tsx
@@ -123,8 +123,7 @@ const FieldsForm = ({ currentUser, eventDefinition, validation, onChange }: Prop
             </p>
 
             {errors.length > 0 && (
-              <Alert bsStyle="danger" className={commonStyles.validationSummary}>
-                <h4>Fields with errors</h4>
+              <Alert bsStyle="danger" className={commonStyles.validationSummary} title="Fields with errors">
                 <p>Please correct the following errors before saving this Event Definition:</p>
                 <ul>
                   {errors.map((error) => <li key={error}>{error}</li>)}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -113,8 +113,7 @@ class AggregationConditionsForm extends React.Component {
       <>
         <h3 className={commonStyles.title}>Create Events for Definition</h3>
         {validation.errors.conditions && (
-          <StyledAlert bsStyle="danger">
-            <h4><Icon name="exclamation-triangle" />&nbsp;Errors found</h4>
+          <StyledAlert bsStyle="danger" title={<><Icon name="exclamation-triangle" /> Errors found</>}>
             <p>{get(validation, 'errors.conditions[0]')}</p>
           </StyledAlert>
         )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -20,7 +20,6 @@ import styled from 'styled-components';
 import get from 'lodash/get';
 
 import { Alert, Row } from 'components/bootstrap';
-import { Icon } from 'components/common';
 import { emptyComparisonExpressionConfig } from 'logic/alerts/AggregationExpressionConfig';
 import validateExpression from 'logic/alerts/AggregationExpressionValidation';
 
@@ -113,7 +112,7 @@ class AggregationConditionsForm extends React.Component {
       <>
         <h3 className={commonStyles.title}>Create Events for Definition</h3>
         {validation.errors.conditions && (
-          <StyledAlert bsStyle="danger" title={<><Icon name="exclamation-triangle" /> Errors found</>}>
+          <StyledAlert bsStyle="danger" title="Errors found">
             <p>{get(validation, 'errors.conditions[0]')}</p>
           </StyledAlert>
         )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -158,7 +158,8 @@ class FilterAggregationSummary extends React.Component {
               {validationResults.isValid
                 ? <AggregationConditionSummary series={series} conditions={conditions} />
                 : (
-                  <Alert bsSize="small" bsStyle="danger"><Icon name="exclamation-triangle" />&nbsp;
+                  <Alert bsSize="small" bsStyle="danger">
+                    <Icon name="exclamation-triangle" />&nbsp;
                     Condition is not valid: {validationResults.errors.join(', ')}
                   </Alert>
                 )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -21,7 +21,6 @@ import upperFirst from 'lodash/upperFirst';
 
 import { Link } from 'components/common/router';
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { isPermitted } from 'util/PermissionsMixin';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
@@ -64,7 +63,7 @@ const renderQueryParameters = (queryParameters) => {
 
     return (
       <Alert bsStyle="danger">
-        <Icon name="exclamation-triangle" />&nbsp;There are undeclared query parameters: {undeclaredParameters}
+        There are undeclared query parameters: {undeclaredParameters}
       </Alert>
     );
   }
@@ -159,7 +158,6 @@ class FilterAggregationSummary extends React.Component {
                 ? <AggregationConditionSummary series={series} conditions={conditions} />
                 : (
                   <Alert bsSize="small" bsStyle="danger">
-                    <Icon name="exclamation-triangle" />&nbsp;
                     Condition is not valid: {validationResults.errors.join(', ')}
                   </Alert>
                 )}

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -193,8 +193,7 @@ class EventNotificationForm extends React.Component {
                   </Button>
                 </FormControl.Static>
                 {testResult.message && (
-                  <Alert bsStyle={testResult.error ? 'danger' : 'success'}>
-                    <b>{testResult.error ? 'Error: ' : 'Success: '}</b>
+                  <Alert bsStyle={testResult.error ? 'danger' : 'success'} title={testResult.error ? 'Error: ' : 'Success: '}>
                     {testResult.message}
                   </Alert>
                 )}

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthError.tsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthError.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 import type FetchError from 'logic/errors/FetchError';
 
 const ESClusterError = styled(Alert)`
@@ -28,7 +27,6 @@ const ESClusterError = styled(Alert)`
 
 const IndexerClusterHealthError = ({ error }: { error: FetchError }) => (
   <ESClusterError bsStyle="danger">
-    <Icon name="exclamation-triangle" /> &nbsp;
     Could not retrieve Elasticsearch cluster health. Fetching Elasticsearch cluster health failed: {error.message}
   </ESClusterError>
 );

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.tsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.tsx
@@ -19,7 +19,6 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 import { DocumentationLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
 
@@ -64,18 +63,9 @@ const IndexerClusterHealthSummary = ({ health, name }: {
     }
   }, [formattedHealthStatus, name]);
 
-  const iconNameForHealth = () => {
-    switch (formattedHealthStatus) {
-      case 'green': return 'check-circle';
-      case 'yellow': return 'exclamation-triangle';
-      case 'red': return 'ambulance';
-      default: return 'check-circle';
-    }
-  };
-
   return (
     <ESClusterStatus bsStyle={alertClassForHealth()}>
-      <Icon name={iconNameForHealth()} /> &nbsp;{formattedTextForHealth}{' '}
+      {formattedTextForHealth}{' '}
       Shards:{' '}
       {health.shards.active} active,{' '}
       {health.shards.initializing} initializing,{' '}

--- a/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
@@ -21,7 +21,7 @@ import styled from 'styled-components';
 
 import { LinkContainer } from 'components/common/router';
 import { Alert, Col, Row, Button } from 'components/bootstrap';
-import { Icon, Spinner } from 'components/common';
+import { Spinner } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 import { DocumentationLink } from 'components/support';
@@ -38,14 +38,6 @@ const formatTextForFailureCount = (count) => {
   }
 
   return <strong>There were {numeral(count).format('0,0')} failed indexing attempts in the last 24 hours.</strong>;
-};
-
-const iconForFailureCount = (count) => {
-  if (count === 0) {
-    return 'check-circle';
-  }
-
-  return 'ambulance';
 };
 
 class IndexerFailuresComponent extends React.Component {
@@ -65,7 +57,7 @@ class IndexerFailuresComponent extends React.Component {
 
   _formatFailuresSummary = () => (
     <Alert bsStyle={this.state.total === 0 ? 'success' : 'danger'}>
-      <Icon name={iconForFailureCount(this.state.total)} /> {formatTextForFailureCount(this.state.total)}
+      {formatTextForFailureCount(this.state.total)}
 
       <LinkContainer to={Routes.SYSTEM.INDICES.FAILURES}>
         <Button bsStyle="info" bsSize="xs" className="pull-right">

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -17,7 +17,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Icon } from 'components/common';
 import { Alert, Button } from 'components/bootstrap';
 import { IndexRangeSummary } from 'components/indices';
 import { IndicesActions } from 'stores/indices/IndicesStore';
@@ -45,7 +44,7 @@ class ClosedIndexDetails extends React.Component {
       <div className="index-info">
         <IndexRangeSummary indexRange={indexRange} />
         <Alert bsStyle="info">
-          <Icon name="info-circle" /> This index is closed. Index information is not available{' '}
+          This index is closed. Index information is not available{' '}
           at the moment, please reopen the index and try again.
         </Alert>
 

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -44,7 +44,8 @@ class ClosedIndexDetails extends React.Component {
     return (
       <div className="index-info">
         <IndexRangeSummary indexRange={indexRange} />
-        <Alert bsStyle="info"><Icon name="info-circle" /> This index is closed. Index information is not available{' '}
+        <Alert bsStyle="info">
+          <Icon name="info-circle" /> This index is closed. Index information is not available{' '}
           at the moment, please reopen the index and try again.
         </Alert>
 

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -30,7 +30,7 @@ import {
   TIME_BASED_SIZE_OPTIMIZING_ROTATION_STRATEGY_TYPE,
 } from 'stores/indices/IndicesStore';
 import { Alert, Col, Input, Row } from 'components/bootstrap';
-import { Icon, Select } from 'components/common';
+import { Select } from 'components/common';
 
 const StyledH3 = styled.h3`
   margin-bottom: 10px;
@@ -194,24 +194,24 @@ const IndexMaintenanceStrategiesConfiguration = ({
       <StyledH3>{title}</StyledH3>
       {description && (
         <StyledAlert>
-          <Icon name="info-circle" />{' '} {description}
+          {description}
         </StyledAlert>
       )}
       {helpText && (
         <StyledAlert>
-          <Icon name="info-circle" />{' '} {helpText}
+          {helpText}
         </StyledAlert>
       )}
       {shouldShowMaxRetentionWarning && (
         <StyledAlert bsStyle="warning">
-          <Icon name="exclamation-triangle" />{' '} The effective retention period value calculated from the
+          The effective retention period value calculated from the
           <b>Rotation period</b> and the <b>max number of indices</b> should not be greater than the
           <b>Max retention period </b> of <b>{maxRetentionPeriod}</b> set by the Administrator.
         </StyledAlert>
       )}
       {shouldShowInvalidRetentionWarning() && (
         <StyledAlert bsStyle="danger">
-          <Icon name="exclamation-triangle" />{' '} {getDisplayName()} strategy was deactivated.
+          {getDisplayName()} strategy was deactivated.
           Please configure a valid retention strategy.
         </StyledAlert>
       )}

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.tsx
@@ -40,8 +40,7 @@ const CSVFileAdapterDocumentation = () => {
       <p>The CSV data adapter can read key value pairs from a CSV file.</p>
       <p>Please make sure your CSV file is formatted according to your configuration settings.</p>
 
-      <Alert style={{ marginBottom: 10 }} bsStyle="info">
-        <h4 style={{ marginBottom: 10 }}>CSV file requirements:</h4>
+      <Alert style={{ marginBottom: 10 }} bsStyle="info" title="CSV file requirements">
         <ul className="no-padding">
           <li>The first line in the CSV file needs to be a list of field/column names</li>
           <li>The file uses <strong>utf-8</strong> encoding</li>

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterDocumentation.jsx
@@ -32,8 +32,7 @@ const DSVHTTPAdapterDocumentation = () => {
       <p>The DSV data adapter can read key value pairs (or check for the presence of a key) from a DSV file.</p>
       <p>Please make sure your DSV file is formatted according to your configuration settings.</p>
 
-      <Alert style={{ marginBottom: 10 }} bsStyle="info">
-        <h4 style={{ marginBottom: 10 }}>CSV file requirements:</h4>
+      <Alert style={{ marginBottom: 10 }} bsStyle="info" title="CSV file requirements">
         <ul className="no-padding">
           <li>The file uses <strong>utf-8</strong> encoding</li>
           <li>The file is accessible using the same URL by <strong>every</strong> Graylog server node</li>

--- a/graylog2-web-interface/src/components/lookup-tables/caches/CaffeineCacheDocumentation.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/CaffeineCacheDocumentation.tsx
@@ -24,8 +24,7 @@ const CaffeineCacheDocumentation = () => (
     <p>The in-memory cache maintains recently used values from data adapters.</p>
     <p>Please make sure your Graylog servers have enough heap to accomodate the cached entries and monitor the cache efficiency.</p>
 
-    <Alert style={{ marginBottom: 10 }} bsStyle="info">
-      <h4 style={{ marginBottom: 10 }}>Implementation details</h4>
+    <Alert style={{ marginBottom: 10 }} bsStyle="info" title="Implementation details">
       <p>The cache is local to each Graylog server, they do not share the entries.</p>
       <p>For example, if you have two servers, they will maintain a completely independent cache from each other.</p>
     </Alert>

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
@@ -60,8 +60,7 @@ class MaxmindAdapterDocumentation extends React.Component {
       <div>
         <p>The GeoIP data adapter supports reading MaxMind's GeoIP2 databases.</p>
 
-        <Alert style={{ marginBottom: 10 }} bsStyle="info">
-          <h4 style={{ marginBottom: 10 }}>Limitations</h4>
+        <Alert style={{ marginBottom: 10 }} bsStyle="info" title="Limitations">
           <p>Currently the ASN, city and country databases are supported.</p>
           <p>For support of additional database types, please visit our support channels.</p>
         </Alert>

--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -67,7 +67,6 @@ class MetricsComponent extends React.Component {
         <Row className="content">
           <Col md={12}>
             <Alert bsStyle="danger">
-              <Icon name="exclamation-triangle" />&nbsp;
               {error ? (
                 <span>
                   Could not fetch metrics from node: server returned <em>{error.responseMessage || ''}</em>{' '}

--- a/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Alert } from 'components/bootstrap';
-import { DataTable, ExternalLink, Spinner, Icon } from 'components/common';
+import { DataTable, ExternalLink, Spinner } from 'components/common';
 
 class InputTypesDataTable extends React.Component {
   static propTypes = {
@@ -46,7 +46,7 @@ class InputTypesDataTable extends React.Component {
     if (Object.keys(this.props.inputDescriptions).length === 0) {
       return (
         <Alert bsStyle="warning">
-          <Icon name="exclamation-triangle" />&nbsp; Input types are unavailable.
+          Input types are unavailable.
         </Alert>
       );
     }

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 
 import { Link } from 'components/common/router';
 import { Row, Col, Alert } from 'components/bootstrap';
-import { Spinner, RelativeTime, Icon } from 'components/common';
+import { Spinner, RelativeTime } from 'components/common';
 import ProgressBar, { Bar } from 'components/common/ProgressBar';
 import MetricsExtractor from 'logic/metrics/MetricsExtractor';
 import NumberUtils from 'util/NumberUtils';
@@ -112,7 +112,7 @@ const JournalDetails = createReactClass({
     if (!journalInformation.enabled) {
       return (
         <Alert bsStyle="warning">
-          <Icon name="exclamation-triangle" />&nbsp; The disk journal is disabled on this node.
+          The disk journal is disabled on this node.
         </Alert>
       );
     }
@@ -122,7 +122,7 @@ const JournalDetails = createReactClass({
     if (Object.keys(metrics).length === 0) {
       return (
         <Alert bsStyle="warning">
-          <Icon name="exclamation-triangle" />&nbsp; Journal metrics unavailable.
+          Journal metrics unavailable.
         </Alert>
       );
     }

--- a/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
@@ -17,7 +17,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { DataTable, ExternalLink, Spinner, Icon } from 'components/common';
+import { DataTable, ExternalLink, Spinner } from 'components/common';
 import { Alert } from 'components/bootstrap';
 
 class PluginsDataTable extends React.Component {
@@ -46,7 +46,7 @@ class PluginsDataTable extends React.Component {
     }
 
     if (this.props.plugins.length === 0) {
-      return <Alert bsStyle="info"><Icon name="info-circle" />&nbsp; This node has not any installed plugins.</Alert>;
+      return <Alert bsStyle="info">This node has not any installed plugins.</Alert>;
     }
 
     const headers = ['Name', 'Version', 'Author', 'Description'];

--- a/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
@@ -65,14 +65,12 @@ class SystemOverviewDetails extends React.Component {
         <Col md={4}>
           <Alert bsStyle="info">
             <span className="pull-right"> <DocumentationLink page={DocsHelper.PAGES.LOAD_BALANCERS} text="What does this mean?" /></span>
-            <Icon name="exchange-alt" />&nbsp;
             Lifecycle state: <strong>{StringUtils.capitalizeFirstLetter(this.props.information.lifecycle)}</strong>
           </Alert>
         </Col>
         <Col md={4}>
           <Alert bsStyle={lbStatus === 'ALIVE' ? 'success' : 'danger'}>
             <span className="pull-right"> <DocumentationLink page={DocsHelper.PAGES.LOAD_BALANCERS} text="What does this mean?" /></span>
-            <Icon name="heart" />&nbsp;
             Marked as <strong>{lbStatus}</strong> for load balancers
           </Alert>
         </Col>

--- a/graylog2-web-interface/src/components/notifications/Notification.test.tsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.test.tsx
@@ -50,10 +50,6 @@ jest.mock('stores/notifications/NotificationsStore', () => ({
 ));
 
 describe('<Notification>', () => {
-  beforeEach(() => {
-
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
@@ -82,10 +78,10 @@ describe('<Notification>', () => {
       jest.advanceTimersByTime(100);
     });
 
-    const title = screen.getByRole('heading', {
+    const alert = screen.getByRole('alert', {
       name: /there is a node without any running inputs/i,
     });
 
-    await waitFor(() => expect(title).toBeInTheDocument());
+    await waitFor(() => expect(alert).toBeInTheDocument());
   });
 });

--- a/graylog2-web-interface/src/components/notifications/Notification.tsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.tsx
@@ -19,8 +19,8 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import DOMPurify from 'dompurify';
 
-import { Alert, Button } from 'components/bootstrap';
-import { RelativeTime, Icon, Spinner } from 'components/common';
+import { Alert } from 'components/bootstrap';
+import { RelativeTime, Spinner } from 'components/common';
 import type { NotificationType } from 'stores/notifications/NotificationsStore';
 import { NotificationsActions } from 'stores/notifications/NotificationsStore';
 import useNotificationMessage from 'hooks/useNotificationMessage';
@@ -28,10 +28,6 @@ import useNotificationMessage from 'hooks/useNotificationMessage';
 type Props = {
   notification: NotificationType,
 };
-
-const StyledButton = styled(Button)`
-  float: right;
-`;
 
 const StyledAlert = styled(Alert)(({ theme }) => css`
   margin-top: 10px;
@@ -44,10 +40,6 @@ const StyledAlert = styled(Alert)(({ theme }) => css`
     margin-bottom: 0;
   }
 `);
-
-const NotificationHead = styled.h3`
-  margin-bottom: 5px;
-`;
 
 const NotificationTimestamp = styled.span(({ theme }) => css`
   margin-left: 3px;
@@ -81,12 +73,8 @@ const Notification = ({ notification }: Props) => {
                        (triggered <RelativeTime dateTime={notification.timestamp} />)
                      </NotificationTimestamp>
                    </>
-                 )}>
-      <StyledButton className="delete-notification" bsStyle="link" onClick={_onClose}>
-        <Icon name="times" />
-      </StyledButton>
-
-      <NotificationHead />
+                 )}
+                 onDismiss={_onClose}>
       <div dangerouslySetInnerHTML={{ __html: _sanitizeDescription(message?.description) }}
            className="notification-description" />
     </StyledAlert>

--- a/graylog2-web-interface/src/components/notifications/Notification.tsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.tsx
@@ -72,20 +72,21 @@ const Notification = ({ notification }: Props) => {
 
   /* eslint-disable react/no-danger */
   return (
-    <StyledAlert bsStyle="danger">
+    <StyledAlert bsStyle="danger"
+                 title={(
+                   <>
+                     {message.title}{' '}
+
+                     <NotificationTimestamp>
+                       (triggered <RelativeTime dateTime={notification.timestamp} />)
+                     </NotificationTimestamp>
+                   </>
+                 )}>
       <StyledButton className="delete-notification" bsStyle="link" onClick={_onClose}>
         <Icon name="times" />
       </StyledButton>
 
-      <NotificationHead>
-        <Icon name="bolt" />{' '}
-        <span />
-        {message.title}{' '}
-
-        <NotificationTimestamp>
-          (triggered <RelativeTime dateTime={notification.timestamp} />)
-        </NotificationTimestamp>
-      </NotificationHead>
+      <NotificationHead />
       <div dangerouslySetInnerHTML={{ __html: _sanitizeDescription(message?.description) }}
            className="notification-description" />
     </StyledAlert>

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Alert, Row, Col } from 'components/bootstrap';
-import { Icon, Spinner } from 'components/common';
+import { Spinner } from 'components/common';
 import Notification from 'components/notifications/Notification';
 import type { NotificationType } from 'stores/notifications/NotificationsStore';
 import { NotificationsStore } from 'stores/notifications/NotificationsStore';
@@ -35,8 +35,7 @@ const getTitle = (count) => (count === 0 ? 'No notifications' : `There ${_format
 
 const getContent = (count: number, notificationsList: Array<NotificationType>) => (count === 0 ? (
   <Alert bsStyle="success" className="notifications-none">
-    <Icon name="check-circle" />{' '}
-      &nbsp;No notifications
+    No notifications
   </Alert>
 ) : (
   notificationsList?.map((notification) => <Notification key={`${notification.type}-${notification?.key}-${notification.timestamp}`} notification={notification} />)

--- a/graylog2-web-interface/src/components/permissions/DependenciesWarning.tsx
+++ b/graylog2-web-interface/src/components/permissions/DependenciesWarning.tsx
@@ -32,11 +32,6 @@ const Container = styled(Alert)`
   overflow: auto;
 `;
 
-const Headline = styled.div`
-  font-weight: bold;
-  margin-bottom: 10px;
-`;
-
 const List = styled.ul`
   list-style: initial;
   padding-left: 20px;
@@ -49,9 +44,7 @@ const List = styled.ul`
 const _cap = StringUtils.capitalizeFirstLetter;
 
 const DependenciesWarning = ({ missingDependencies, availableGrantees }: Props) => (
-  <Container bsStyle="danger">
-    <Headline>There are missing dependencies for the current set of collaborators</Headline>
-
+  <Container bsStyle="danger" title="There are missing dependencies for the current set of collaborators">
     <List>
       {missingDependencies.entrySeq().map(([granteeGRN, dependencyList]) => {
         const grantee = availableGrantees.find((selectedGrantee) => selectedGrantee.id === granteeGRN);

--- a/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
+++ b/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
@@ -197,7 +197,8 @@ const Scratchpad = () => {
         {!isSecurityWarningConfirmed && (
           <StyledAlert bsStyle="warning" bsSize="sm">
             <Icon name="exclamation-triangle" size="lg" />
-            <AlertNote>We recommend you do <strong>not</strong> store any sensitive information, such as passwords, in
+            <AlertNote>
+              We recommend you do <strong>not</strong> store any sensitive information, such as passwords, in
               this area.
             </AlertNote>
             <Button bsStyle="link" bsSize="sm" onClick={handleGotIt}>Got It!</Button>

--- a/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
+++ b/graylog2-web-interface/src/components/scratchpad/Scratchpad.tsx
@@ -196,7 +196,6 @@ const Scratchpad = () => {
       <ContentArea>
         {!isSecurityWarningConfirmed && (
           <StyledAlert bsStyle="warning" bsSize="sm">
-            <Icon name="exclamation-triangle" size="lg" />
             <AlertNote>
               We recommend you do <strong>not</strong> store any sensitive information, such as passwords, in
               this area.

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ImportsViewModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ImportsViewModal.jsx
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Button, Alert, Modal, Tooltip } from 'components/bootstrap';
-import { OverlayTrigger, PaginatedList, Spinner, Timestamp, Icon } from 'components/common';
+import { OverlayTrigger, PaginatedList, Spinner, Timestamp } from 'components/common';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import UserNotification from 'util/UserNotification';
 import { CollectorConfigurationsActions } from 'stores/sidecars/CollectorConfigurationsStore';
@@ -110,7 +110,6 @@ class ImportsViewModal extends React.Component {
     if (totalUploads === 0) {
       return (
         <Alert bsStyle="info">
-          <Icon name="info-circle" />&nbsp;
           There are no configuration uploads available. Please go to
           <strong>System -&gt; Collectors (legacy)
             -&gt; Details -&gt; Import Configuration

--- a/graylog2-web-interface/src/components/simulator/SimulationPreview.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationPreview.jsx
@@ -25,8 +25,7 @@ const SimulationPreview = ({ simulationResults, streams }) => {
 
   if (messages.length === 0) {
     return (
-      <Alert bsStyle="info">
-        <p><strong>Message would be dropped</strong></p>
+      <Alert bsStyle="info" title="Message would be dropped">
         <p>
           The pipeline processor would drop such a message. That means that the message
           <strong>would not be stored</strong>, and would not be available for searches, alerts, outputs, or dashboards.

--- a/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
@@ -121,8 +121,7 @@ class SimulationResults extends React.Component {
 
     const errorMessage = error
       ? (
-        <Alert bsStyle="danger">
-          <p><strong>Error simulating message processing</strong></p>
+        <Alert bsStyle="danger" title="Error simulating message processing">
           <p>
             Could not simulate processing of message <em>{originalMessage.id}</em> in stream{' '}
             <em>{stream.title}</em>.

--- a/graylog2-web-interface/src/components/systemjobs/SystemJobsList.tsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJobsList.tsx
@@ -20,7 +20,6 @@ import styled, { css } from 'styled-components';
 
 import { SystemJob } from 'components/systemjobs';
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 
 const SystemJobWrap = styled.div(({ theme }) => css`
   margin-top: 10px;
@@ -58,8 +57,7 @@ const SystemJobsList = ({ jobs }): React.ReactElement => {
     (formattedJobs.length === 0)
       ? (
         <StyledAlert bsStyle="info">
-          <Icon name="info-circle" />{' '}
-          &nbsp;No active system jobs.
+          No active system jobs.
         </StyledAlert>
       )
       : (

--- a/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.tsx
+++ b/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.tsx
@@ -24,7 +24,7 @@ import { Icon } from 'components/common';
 const PermissionsUpdateInfo = () => (
   <Row className="content">
     <Col xs={12}>
-      <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}Granting Permissions</>}>
+      <Alert bsStyle="info" title="Granting Permissions">
         With Graylog 4.0, we&apos;ve updated the permissions system. Granting permissions for an entity like streams and dashboards is no longer part of the user edit page.
         It can now be configured using the <b><Icon name="user-plus" /> Share</b> button of an entity. You can find the button e.g. on the entities overview page. Learn more in the <DocumentationLink page={DocsHelper.PAGES.PERMISSIONS} text="documentation" />.
       </Alert>

--- a/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.tsx
+++ b/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.tsx
@@ -24,8 +24,7 @@ import { Icon } from 'components/common';
 const PermissionsUpdateInfo = () => (
   <Row className="content">
     <Col xs={12}>
-      <Alert bsStyle="info">
-        <Icon name="info-circle" />{' '}<b>Granting Permissions</b><br />
+      <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}Granting Permissions</>}>
         With Graylog 4.0, we&apos;ve updated the permissions system. Granting permissions for an entity like streams and dashboards is no longer part of the user edit page.
         It can now be configured using the <b><Icon name="user-plus" /> Share</b> button of an entity. You can find the button e.g. on the entities overview page. Learn more in the <DocumentationLink page={DocsHelper.PAGES.PERMISSIONS} text="documentation" />.
       </Alert>

--- a/graylog2-web-interface/src/components/users/TimeoutInput.tsx
+++ b/graylog2-web-interface/src/components/users/TimeoutInput.tsx
@@ -20,7 +20,6 @@ import PropTypes from 'prop-types';
 
 import { Row, Col, HelpBlock, Input, Alert } from 'components/bootstrap';
 import TimeoutUnitSelect from 'components/users/TimeoutUnitSelect';
-import { Icon } from 'components/common';
 
 import { MS_DAY, MS_HOUR, MS_MINUTE, MS_SECOND } from './timeoutConstants';
 
@@ -85,7 +84,7 @@ const TimeoutInput = ({ value: propsValue, onChange }: Props) => {
            label="Sessions Timeout">
       <Row className="no-bm">
         <Col xs={12}>
-          <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b>Changing the session timeout</b><br /></>}>
+          <Alert bsStyle="info" title="Changing the session timeout">
             Changing the timeout setting for sessions will log the user out of Graylog and will invalidate all their
             current sessions. If you are changing the setting for your own user, you will be logged out at the moment
             of saving the setting. In that case, make sure to save any pending changes before changing the timeout.

--- a/graylog2-web-interface/src/components/users/TimeoutInput.tsx
+++ b/graylog2-web-interface/src/components/users/TimeoutInput.tsx
@@ -85,8 +85,7 @@ const TimeoutInput = ({ value: propsValue, onChange }: Props) => {
            label="Sessions Timeout">
       <Row className="no-bm">
         <Col xs={12}>
-          <Alert bsStyle="info">
-            <Icon name="info-circle" />{' '}<b>Changing the session timeout</b><br />
+          <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b>Changing the session timeout</b><br /></>}>
             Changing the timeout setting for sessions will log the user out of Graylog and will invalidate all their
             current sessions. If you are changing the setting for your own user, you will be logged out at the moment
             of saving the setting. In that case, make sure to save any pending changes before changing the timeout.

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.tsx
@@ -259,7 +259,8 @@ const UserCreate = () => {
                                      key={role.id} />
                     ))}
                     {!hasValidRole && (
-                      <Alert bsStyle="danger">You need to select at least one of
+                      <Alert bsStyle="danger">
+                        You need to select at least one of
                         the <em>Reader</em> or <em>Admin</em> roles.
                       </Alert>
                     )}
@@ -273,8 +274,7 @@ const UserCreate = () => {
               {submitError && (
                 <Row>
                   <Col xs={9} xsOffset={3}>
-                    <Alert bsStyle="danger">
-                      <b>Failed to create user</b><br />
+                    <Alert bsStyle="danger" title="Failed to create user">
                       {showSubmitError(submitError)}
                     </Alert>
                   </Col>

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileUpdateInfo.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileUpdateInfo.tsx
@@ -20,8 +20,7 @@ import { Alert } from 'components/bootstrap';
 import { Icon } from 'components/common';
 
 const ProfileUpdateInfo = () => (
-  <Alert bsStyle="info">
-    <Icon name="info-circle" />{' '}<b> First and Last Name</b><br />
+  <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b> First and Last Name</b></>}>
     With Graylog 4.1, we&apos;ve added distinct first and last name fields. These must be provided before the user’s profile can be saved.
   </Alert>
 );

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileUpdateInfo.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileUpdateInfo.tsx
@@ -17,10 +17,9 @@
 import * as React from 'react';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 
 const ProfileUpdateInfo = () => (
-  <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b> First and Last Name</b></>}>
+  <Alert bsStyle="info" title="First and Last Name">
     With Graylog 4.1, we&apos;ve added distinct first and last name fields. These must be provided before the user’s profile can be saved.
   </Alert>
 );

--- a/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.tsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.tsx
@@ -18,7 +18,6 @@ import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { Alert } from 'components/bootstrap';
-import { Icon } from 'components/common';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 
 type Props = {
@@ -32,7 +31,7 @@ const WidgetVisualizationNotFound = ({ widgetClassName }: Props) => {
 
   return (
     <Alert bsStyle="danger">
-      <Icon name="exclamation-circle" /> Widget Visualization (<i>{widgetClassName}</i>) not found.
+      Widget Visualization (<i>{widgetClassName}</i>) not found.
       It looks like the plugin supplying this widget is not loaded.
     </Alert>
   );

--- a/graylog2-web-interface/src/integrations/dataadapters/GreyNoiseAdapterSummary.jsx
+++ b/graylog2-web-interface/src/integrations/dataadapters/GreyNoiseAdapterSummary.jsx
@@ -39,8 +39,7 @@ class GreyNoiseAdapterSummary extends React.Component {
           <dt>API Token</dt>
           <dd>******</dd>
         </dl>
-        <Alert style={{ marginBottom: 10 }} bsStyle="danger">
-          <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+        <Alert style={{ marginBottom: 10 }} bsStyle="danger" title="Deprecation Warning">
           <p>The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should not be used.</p>
         </Alert>
       </div>

--- a/graylog2-web-interface/src/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapterDocumentation.jsx
@@ -23,8 +23,7 @@ class GreyNoiseCommunityIpLookupAdapterDocumentation extends React.Component {
   render() {
     return (
       <div>
-        <Alert style={{ marginBottom: 10 }} bsStyle="warning">
-          <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+        <Alert style={{ marginBottom: 10 }} bsStyle="warning" title="Deprecation Warning">
           <p>The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should not be used.</p>
         </Alert>
       </div>

--- a/graylog2-web-interface/src/logic/telemetry/TelemetryInfoText.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryInfoText.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 
-import { Icon, ExternalLink } from 'components/common';
+import { ExternalLink } from 'components/common';
 import { Alert } from 'components/bootstrap';
 
 type Props = {
@@ -25,7 +25,7 @@ type Props = {
 
 const TelemetryInfoText = ({ showProfile }: Props) => (
   <Alert bsStyle="info">
-    <Icon name="info-circle" /> We would like to collect anonymous usage data to help us prioritize improvements
+    We would like to collect anonymous usage data to help us prioritize improvements
     and make Graylog better in the future.
     <br />
     We do not collect personal data, sensitive information, or content such as logs in your

--- a/graylog2-web-interface/src/pages/AuthenticationOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationOverviewPage.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import { AuthenticationActions } from 'stores/authentication/AuthenticationStore';
 import 'components/authentication/bindings'; // Bind all authentication plugins
 import { Alert, Row, Col } from 'components/bootstrap';
-import { DocumentTitle, PageHeader, Icon } from 'components/common';
+import { DocumentTitle, PageHeader } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import BackendsOverview from 'components/authentication/BackendsOverview';
 import AuthenticationPageNavigation from 'components/authentication/AuthenticationPageNavigation';
@@ -47,7 +47,7 @@ const AuthenticationOverviewPage = () => {
         <Row className="content">
           <Col xs={12}>
             <Alert bsStyle="warning">
-              <Icon name="exclamation-circle" /> None of the configured authentication services is currently active.
+              None of the configured authentication services is currently active.
             </Alert>
           </Col>
         </Row>

--- a/graylog2-web-interface/src/pages/IndexSetPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.tsx
@@ -186,7 +186,7 @@ class IndexSetPage extends React.Component<Props, State> {
       indicesInfo = (
         <span>
           <Alert bsStyle="success" style={{ marginTop: '10' }}>
-            <Icon name="th" /> &nbsp;{this._totalIndexCount()} indices with a total of{' '}
+            {this._totalIndexCount()} indices with a total of{' '}
             {numeral(indexerOverview.counts.events).format('0,0')} messages under management,
             current write-active index is <i>{deflectorInfo.current_target}</i>.
           </Alert>

--- a/graylog2-web-interface/src/pages/LoginPage.tsx
+++ b/graylog2-web-interface/src/pages/LoginPage.tsx
@@ -141,8 +141,8 @@ const LoginPage = () => {
     if (lastError) {
       return (
         <div className="form-group">
-          <Alert bsStyle="danger">
-            <button type="button" className="close" onClick={resetLastError}>&times;</button>{lastError}
+          <Alert bsStyle="danger" onDismiss={resetLastError}>
+            {lastError}
           </Alert>
         </div>
       );

--- a/graylog2-web-interface/src/pages/RolesOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/RolesOverviewPage.tsx
@@ -42,8 +42,7 @@ const RolesOverviewPage = () => (
 
     <Row className="content">
       <Col xs={12}>
-        <Alert bsStyle="info">
-          <Icon name="info-circle" />{' '}<b>Granting Permissions</b><br />
+        <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b>Granting Permissions</b></>}>
           With Graylog 4.0, we&apos;ve updated the permissions system and changed the purpose of roles.
           The built-in roles still allow granting capabilities to users, like creating dashboards or viewing the archive catalog.
           But they no longer grant permissions for a specific dashboard or stream. It is also not possible to create an own role.

--- a/graylog2-web-interface/src/pages/RolesOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/RolesOverviewPage.tsx
@@ -42,7 +42,7 @@ const RolesOverviewPage = () => (
 
     <Row className="content">
       <Col xs={12}>
-        <Alert bsStyle="info" title={<><Icon name="info-circle" />{' '}<b>Granting Permissions</b></>}>
+        <Alert bsStyle="info" title={<>Granting Permissions</>}>
           With Graylog 4.0, we&apos;ve updated the permissions system and changed the purpose of roles.
           The built-in roles still allow granting capabilities to users, like creating dashboards or viewing the archive catalog.
           But they no longer grant permissions for a specific dashboard or stream. It is also not possible to create an own role.

--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.tsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 
-import { DocumentTitle, Icon } from 'components/common';
+import { DocumentTitle } from 'components/common';
 import { Alert, Row, Col } from 'components/bootstrap';
 import PageHeader from 'components/common/PageHeader';
 import PageContentLayout from 'components/layout/PageContentLayout';
@@ -28,7 +28,7 @@ const UserHasNoStreamAccess = () => (
       <Row className="content">
         <Col md={12}>
           <Alert bsStyle="warning">
-            <Icon name="info-circle" />&nbsp;We cannot start a search right now, because you are not allowed to access any stream.
+            We cannot start a search right now, because you are not allowed to access any stream.
             If you feel this is an error, please contact your administrator.
           </Alert>
         </Col>

--- a/graylog2-web-interface/src/threatintel/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/threatintel/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
@@ -20,8 +20,7 @@ import { Alert } from 'components/bootstrap';
 
 const AbuseChRansomAdapterDocumentation = () => (
   <div>
-    <Alert style={{ marginBottom: 10 }} bsStyle="warning">
-      <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+    <Alert style={{ marginBottom: 10 }} bsStyle="warning" title="Deprecation Warning">
       <p>The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should not be used.</p>
     </Alert>
   </div>

--- a/graylog2-web-interface/src/threatintel/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
+++ b/graylog2-web-interface/src/threatintel/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
@@ -41,8 +41,7 @@ class AbuseChRansomAdapterSummary extends React.Component {
           <dt>Update interval</dt>
           <dd><TimeUnit value={config.refresh_interval} unit={config.refresh_interval_unit} /></dd>
         </dl>
-        <Alert style={{ marginBottom: 10 }} bsStyle="warning">
-          <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+        <Alert style={{ marginBottom: 10 }} bsStyle="warning" title="Deprecation Warning">
           <p>The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should not be used.</p>
         </Alert>
       </div>

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -226,8 +226,7 @@ const MigrateFieldCharts = () => {
   return (
     <Row>
       <Col>
-        <Alert bsStyle="warning">
-          <h2>Migrate existing search page charts</h2>
+        <Alert bsStyle="warning" title="Migrate existing search page charts">
           {/* Should we inform the user here about the backend migrations? */}
           <br />
           We found {chartAmount} chart(s), created for an older version of the search.

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
-import { Icon, SortableList } from 'components/common';
+import { SortableList } from 'components/common';
 
 import DecoratorStyles from './decoratorStyles.css';
 
@@ -65,7 +65,7 @@ class DecoratorList extends React.Component<Props> {
       return (
         <AlertContainer>
           <Alert bsStyle="info" className={DecoratorStyles.noDecoratorsAlert}>
-            <Icon name="info-circle" />&nbsp;No decorators configured.
+            No decorators configured.
           </Alert>
         </AlertContainer>
       );

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2474,10 +2474,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@graylog/sawmill@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.2.tgz#0620cd879be2ebe924580ddbfc49106194cc0644"
-  integrity sha512-K0Bm1gvHDDjg9fB7tpNQv8xcJMiCKpJo8FKzYAbBr5Bj/b+0ZZw1y4rFtwklXI5V8E0ykAYdJj1n4QpQcmc6vg==
+"@graylog/sawmill@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.3.tgz#c81c3fd5f9fb9a0448f4bdedd9a69fe9504548fd"
+  integrity sha512-6A8pk2qCqP3sqpGN21LSMzwoos1jNUOwsTNzUtmajBHjLo6kA94Hoqpzt//bLbffJ0T1uW8bwxpaf9cvki1+2g==
   dependencies:
     "@openfonts/dm-sans_latin" "^1.0.2"
     "@openfonts/source-sans-pro_latin" "^1.44.2"
@@ -8902,7 +8902,7 @@ graphemer@^1.4.0:
 "graylog-web-plugin@file:packages/graylog-web-plugin":
   version "5.2.0-SNAPSHOT"
   dependencies:
-    "@graylog/sawmill" "^2.0.2"
+    "@graylog/sawmill" "^2.0.3"
     "@tanstack/react-query" "4.35.3"
     "@types/create-react-class" "15.6.4"
     "@types/jquery" "3.5.18"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2474,10 +2474,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@graylog/sawmill@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.3.tgz#c81c3fd5f9fb9a0448f4bdedd9a69fe9504548fd"
-  integrity sha512-6A8pk2qCqP3sqpGN21LSMzwoos1jNUOwsTNzUtmajBHjLo6kA94Hoqpzt//bLbffJ0T1uW8bwxpaf9cvki1+2g==
+"@graylog/sawmill@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.4.tgz#fa0239f7823c02e9e88ce6b14b2467137ca62cfb"
+  integrity sha512-Cp95qglK1yS3iqHNJH1z1npmn1MObu1eGBWH2HkBAyaINGTeSIwy3OJGaR3YPHGzwRnJedB53SHhFNWy92CUGQ==
   dependencies:
     "@openfonts/dm-sans_latin" "^1.0.2"
     "@openfonts/source-sans-pro_latin" "^1.44.2"
@@ -8902,7 +8902,7 @@ graphemer@^1.4.0:
 "graylog-web-plugin@file:packages/graylog-web-plugin":
   version "5.2.0-SNAPSHOT"
   dependencies:
-    "@graylog/sawmill" "^2.0.3"
+    "@graylog/sawmill" "2.0.4"
     "@tanstack/react-query" "4.35.3"
     "@types/create-react-class" "15.6.4"
     "@types/jquery" "3.5.18"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2474,10 +2474,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@graylog/sawmill@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.4.tgz#fa0239f7823c02e9e88ce6b14b2467137ca62cfb"
-  integrity sha512-Cp95qglK1yS3iqHNJH1z1npmn1MObu1eGBWH2HkBAyaINGTeSIwy3OJGaR3YPHGzwRnJedB53SHhFNWy92CUGQ==
+"@graylog/sawmill@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.5.tgz#c198f46ba799a62b800281446da89b99f6e05c4c"
+  integrity sha512-KomTIkzfn1X7Dg8FJti7cyY+1zBbtrfZfYoqFsyH3l6LgqWcVsa7lUBgbzeZ4dibZ8mZQ9lUEyr7PCB5A3rn6w==
   dependencies:
     "@openfonts/dm-sans_latin" "^1.0.2"
     "@openfonts/source-sans-pro_latin" "^1.44.2"
@@ -8902,7 +8902,7 @@ graphemer@^1.4.0:
 "graylog-web-plugin@file:packages/graylog-web-plugin":
   version "5.2.0-SNAPSHOT"
   dependencies:
-    "@graylog/sawmill" "2.0.4"
+    "@graylog/sawmill" "2.0.5"
     "@tanstack/react-query" "4.35.3"
     "@types/create-react-class" "15.6.4"
     "@types/jquery" "3.5.18"


### PR DESCRIPTION
**Please note:** This PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/5789

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR migrates the first `react-bootstrap` component (the `Alert` component) to `mantine`. It is a follow-up for https://github.com/Graylog2/graylog2-server/pull/16406.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5789
/nocl