### PR TITLE
converted dns_lookup_adapter_resolver_pool_size warning message to use dynamic value instead of hard-coded value (10)

### DIFF
--- a/changelog/unreleased/pr-16475.toml
+++ b/changelog/unreleased/pr-16475.toml
@@ -1,4 +1,4 @@
 type = "f"
-message = "server.log now accurately reflects configured `dns_lookup_adapter_resolver_pool_size` value."
+message = "DNS Resolver Pool warning log message now accurately reflects configured `dns_lookup_adapter_resolver_pool_size` value."
 
 pulls = ["16475"]

--- a/changelog/unreleased/pr-16475.toml
+++ b/changelog/unreleased/pr-16475.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "server.log now accurately reflects configured `dns_lookup_adapter_resolver_pool_size` value."
+
+pulls = ["16475"]

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsResolverPool.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsResolverPool.java
@@ -173,9 +173,9 @@ public class DnsResolverPool {
                         iterator.add(new ResolverLease(resolverFactory.create()));
                     } else {
                         LOG.warn("Lease for resolver [{}] is in-use. Skipping refresh. This will be attempted again in [{}] seconds. " +
-                                        "If this happens frequently for high message rates, consider increasing the [dns_lookup_adapter_resolver_pool_size = 10] " +
+                                        "If this happens frequently for high message rates, consider increasing the [dns_lookup_adapter_resolver_pool_size = {}] " +
                                         "server configuration property to allow more DNS resolvers.",
-                                lease.getId(), poolRefreshSeconds);
+                                lease.getId(), poolRefreshSeconds, resolverPool.size());
                     }
                 }
             }


### PR DESCRIPTION
## Description
The value of dns_lookup_adapter_resolver_pool_size in the warning message for when this value should be increased should be dynamic and based on the actual value configured in server.conf. Previously, it was hard-coded to the default of "10".

## Motivation and Context
Fixes inaccurate feedback to user who has modified the dns_lookup_adapter_resolver_pool_size value. Now the user will at least receive acknowledgement that their modified value is in use by Graylog.

## How Has This Been Tested?
Not tested unfortunately as I do not have the knowledge/ability to. However this being a very minor change, I felt it appropriate to submit this PR anyway and welcome someone to test it who has the ability to.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

