### PR TITLE
Update various backend dependencies

### DIFF
--- a/changelog/unreleased/pr-16476.toml
+++ b/changelog/unreleased/pr-16476.toml
@@ -1,0 +1,22 @@
+type = "security"
+message = "Update various third-party libraries to address vulnerabilites."
+
+pulls = ["16476"]
+
+details.user = """
+Updates third-party libraries to address the following vulnerabilities:
+
+  - [CVE-2022-36944](https://www.cve.org/CVERecord?id=CVE-2022-36944)
+  - [CVE-2023-34455](https://www.cve.org/CVERecord?id=CVE-2023-34455)
+  - [CVE-2021-22569](https://www.cve.org/CVERecord?id=CVE-2021-22569)
+  - [CVE-2019-10086](https://www.cve.org/CVERecord?id=CVE-2019-10086)
+  - [CVE-2021-28170](https://www.cve.org/CVERecord?id=CVE-2021-28170)
+  - [CVE-2021-29425](https://www.cve.org/CVERecord?id=CVE-2021-29425)
+  - [CVE-2023-3635](https://www.cve.org/CVERecord?id=CVE-2023-3635)
+  - [CVE-2022-25647](https://www.cve.org/CVERecord?id=CVE-2022-25647)
+  - [CVE-2023-34462](https://www.cve.org/CVERecord?id=CVE-2023-34462)
+  - [CVE-2023-33201](https://www.cve.org/CVERecord?id=CVE-2023-33201)
+  - [CVE-2020-10693](https://www.cve.org/CVERecord?id=CVE-2020-10693)
+  - [CVE-2021-37533](https://www.cve.org/CVERecord?id=CVE-2021-37533)
+  - [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976)
+"""

--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -138,12 +138,12 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>

--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -154,11 +154,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-scala_3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -819,7 +819,8 @@
                         <bundledSignature>jdk-reflection</bundledSignature>
                         <!-- disallow undocumented classes like sun.misc.Unsafe: -->
                         <bundledSignature>jdk-non-portable</bundledSignature>
-                        <bundledSignature>commons-io-unsafe-${commons-io.version}</bundledSignature>
+                        <!-- Workaround until signatures for ${commons-io.version} are released: -->
+                        <bundledSignature>commons-io-unsafe-2.11.0</bundledSignature>
                     </bundledSignatures>
                     <signaturesFiles>
                         <signaturesFile>${project.basedir}/../config/forbidden-apis/netty3.txt</signaturesFile>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -311,12 +311,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.lmax</groupId>
                 <artifactId>disruptor</artifactId>
                 <version>${disruptor.version}</version>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -462,11 +462,6 @@
                 <version>${swagger.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>${javax.el-api.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.squareup.retrofit2</groupId>
                 <artifactId>retrofit</artifactId>
                 <version>${retrofit.version}</version>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -692,12 +692,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.opensearch</groupId>
-                <artifactId>opensearch-testcontainers-bom</artifactId>
-                <version>${testcontainers.opensearch.version}</version>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jukito</groupId>
                 <artifactId>jukito</artifactId>
                 <version>${jukito.version}</version>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -161,16 +161,6 @@
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp-tls</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.graylog2</groupId>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -272,30 +272,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_2.13</artifactId>
+                <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun.jmx</groupId>
-                        <artifactId>jmxri</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jdmk</groupId>
-                        <artifactId>jmxtools</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.jms</groupId>
-                        <artifactId>jms</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -620,7 +620,6 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -585,7 +585,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.msk</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -509,11 +509,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
         </dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -651,7 +651,6 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>${commons-net.version}</version>
         </dependency>
 
         <!-- additional integrations dependencies -->

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -385,7 +385,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <aws-java-sdk-2.version>2.20.61</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.10</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>1.1.7</aws-msk-iam-auth.version>
-        <bouncycastle.version>1.69</bouncycastle.version>
+        <bouncycastle.version>1.76</bouncycastle.version>
         <caffeine.version>2.8.1</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <classgraph.version>4.8.157</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
         <shiro.version>1.12.0</shiro.version>
         <snakeyaml.version>2.2</snakeyaml.version>
+        <snappy-java.version>1.1.10.3</snappy-java.version>
         <oshi.version>5.3.7</oshi.version>
         <siv-mode.version>1.4.1</siv-mode.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -339,6 +340,11 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
                 <version>${jjwt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy-java.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <grok.version>0.1.9-graylog-2</grok.version>
         <grpc.version>1.58.0</grpc.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>32.1.2-jre</guava.version>
         <guice.version>5.0.1</guice.version>
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <guice.version>5.0.1</guice.version>
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
-        <hibernate-validator.version>6.1.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <hk2.version>2.6.1</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.15.2</jackson.version>
         <jadconfig.version>0.14.0</jadconfig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <commons-csv.version>1.7</commons-csv.version>
         <commons-email.version>1.5</commons-email.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
-        <commons-validator.version>1.6</commons-validator.version>
+        <commons-validator.version>1.7</commons-validator.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
         <freemarker.version>2.3.31</freemarker.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <commons-email.version>1.5</commons-email.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-validator.version>1.7</commons-validator.version>
-        <commons-io.version>2.6</commons-io.version>
+        <commons-io.version>2.13.0</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
         <freemarker.version>2.3.31</freemarker.version>
         <gelfclient.version>1.5.0</gelfclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,8 @@
         <natty.version>0.13</natty.version>
         <netty.version>4.1.91.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
-        <okhttp.version>3.14.6</okhttp.version>
+        <okhttp.version>4.11.0</okhttp.version>
+        <okio.version>3.5.0</okio.version>
         <okta-sdk.version>8.2.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.24.0</opentelemetry.version>
@@ -363,6 +364,22 @@
                 <groupId>com.cronutils</groupId>
                 <artifactId>cron-utils</artifactId>
                 <version>${cron-utils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-tls</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+            <!-- Explicitly manage okio to fix CVE-2023-3635. Can probably be removed with next okhttp update -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@
         <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
@@ -179,7 +178,7 @@
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <zstd.version>1.5.4-1</zstd.version>
-        <cron-utils.version>9.1.6</cron-utils.version>
+        <cron-utils.version>9.2.1</cron-utils.version>
         <asciitable.version>0.3.2</asciitable.version>
         <commons-net.version>3.6</commons-net.version>
         <jjwt.version>0.11.5</jjwt.version>
@@ -359,6 +358,11 @@
                 <version>${grpc.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.cronutils</groupId>
+                <artifactId>cron-utils</artifactId>
+                <version>${cron-utils.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
         <mongojack.version>2.10.1.3</mongojack.version>
         <mongojack4.version>4.8.0-1</mongojack4.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.91.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.97.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.11.0</okhttp.version>
         <okio.version>3.5.0</okio.version>
         <okta-sdk.version>8.2.1</okta-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <joda-time.version>2.10.6</joda-time.version>
         <jool.version>0.9.14</jool.version>
         <json-path.version>2.8.0</json-path.version>
-        <kafka.version>3.4.0</kafka.version>
+        <kafka.version>3.5.1</kafka.version>
         <kafka09.version>0.9.0.1-7</kafka09.version>
         <log4j.version>2.17.1</log4j.version>
         <lucene.version>9.1.0</lucene.version>
@@ -162,7 +162,6 @@
         <protobuf.version>3.17.3</protobuf.version>
         <reflections.version>0.10.2</reflections.version>
         <retrofit.version>2.9.0</retrofit.version>
-        <scala.version>2.13.12</scala.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
         <shiro.version>1.12.0</shiro.version>
         <snakeyaml.version>2.2</snakeyaml.version>
@@ -340,16 +339,6 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
                 <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
-                <artifactId>scala-reflect</artifactId>
-                <version>${scala.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <gelfclient.version>1.5.0</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
         <grok.version>0.1.9-graylog-2</grok.version>
-        <grpc.version>1.48.1</grpc.version>
+        <grpc.version>1.58.0</grpc.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>31.0.1-jre</guava.version>
         <guice.version>5.0.1</guice.version>
@@ -159,7 +159,7 @@
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.5</pkts.version>
         <prometheus-client.version>0.11.0</prometheus-client.version>
-        <protobuf.version>3.17.3</protobuf.version>
+        <protobuf.version>3.24.3</protobuf.version>
         <reflections.version>0.10.2</reflections.version>
         <retrofit.version>2.9.0</retrofit.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
@@ -345,6 +345,20 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>${snappy-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-bom</artifactId>
+                <version>${protobuf.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <commons-csv.version>1.7</commons-csv.version>
         <commons-email.version>1.5</commons-email.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-net.version>3.9.0</commons-net.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-io.version>2.13.0</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
@@ -181,7 +182,6 @@
         <zstd.version>1.5.4-1</zstd.version>
         <cron-utils.version>9.2.1</cron-utils.version>
         <asciitable.version>0.3.2</asciitable.version>
-        <commons-net.version>3.6</commons-net.version>
         <jjwt.version>0.11.5</jjwt.version>
 
         <!-- Test dependencies -->
@@ -380,6 +380,11 @@
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
                 <version>${okio.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+                <version>${commons-net.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Updates various backend dependencies:

- kafka `3.4.0` -> `3.5.1`
- scala-library (*removed*)
- snappy-java `1.1.8.3` -> `1.1.10.3`
- grpc `1.48.1` -> `1.58.0`
- protobuf `3.17.3` -> `3.24.3`
- commons-validator `1.6` -> `1.7`
- cron-utils `9.1.6` -> `9.2.1`
- commons-io `2.6` -> `2.13.0`
- okhttp `3.14.6` -> `4.11.0`
- netty `4.1.91` -> `4.1.97`
- bouncycastle `1.69` -> `1.76`
- hibernate-validator `6.1.2.Final` -> `6.2.5.Final`
- commons-net `3.6` -> `3.9.0`
- guava `31.0.1-jre` -> `32.1.2-jre`

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/4306

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5795
