### PR TITLE
fix timestamp of sidecar roles migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20230502164900_AddSidecarManagerAndReaderRole.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20230502164900_AddSidecarManagerAndReaderRole.java
@@ -35,7 +35,7 @@ public class V20230502164900_AddSidecarManagerAndReaderRole extends Migration {
 
     @Override
     public ZonedDateTime createdAt() {
-        return ZonedDateTime.parse("2018-03-23T15:00:00Z");
+        return ZonedDateTime.parse("2023-05-02T16:49:00Z");
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In #15380, the sidecar manager and reader role was introduced, but the duplicate timestamp in the migration sometimes causes the migration to be ignored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/nocl

