### PR TITLE
Delaying start of `IndexerClusterCheckerThread` to avoid deadlock.

### DIFF
--- a/changelog/unreleased/pr-16481.toml
+++ b/changelog/unreleased/pr-16481.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Indexer cluster checker thread start is delayed by 5s to avoid potential deadlock."
+
+pulls = ["16481"]

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -57,7 +57,7 @@ public class IndexerClusterCheckerThread extends Periodical {
 
     @Override
     public void doRun() {
-        if (!cluster.health().isPresent()) {
+        if (cluster.health().isEmpty()) {
             LOG.info("Indexer not fully initialized yet. Skipping periodic cluster check.");
             return;
         }
@@ -231,7 +231,7 @@ public class IndexerClusterCheckerThread extends Periodical {
 
     @Override
     public int getInitialDelaySeconds() {
-        return 0;
+        return 5;
     }
 
     @Override


### PR DESCRIPTION
**Note:** This needs a backport to `5.1` and `5.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, we were seeing issues in containerized integration tests where the Graylog container did not come up properly and container startup timed out. In its logs, we were always seeing something like this:

```
2023-09-14 08:26:13,464 INFO : org.graylog2.indexer.MongoIndexSet - Did not find a deflector alias. Setting one up now.
2023-09-14 08:26:13,474 INFO : org.graylog2.periodical.IndexRetentionThread - Skipping index retention checks because the Elasticsearch cluster is unhealthy: Green, Index Registry is up: false
2023-09-14 08:26:13,482 INFO : org.graylog2.indexer.MongoIndexSet - There is no index target to point to. Creating one now.
2023-09-14 08:26:13,490 INFO : org.graylog2.indexer.MongoIndexSet - Cycling from <none> to <graylog_0>.
2023-09-14 08:26:13,490 INFO : org.graylog2.indexer.MongoIndexSet - Creating target index <graylog_0>.
[...]
2023-09-14 08:26:21,344 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Graylog System Events" (6502c3a4b5a7db566ec93b62) doesn't exist yet
2023-09-14 08:26:21,344 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Graylog Events" (6502c3a4b5a7db566ec93b5f) doesn't exist yet
2023-09-14 08:26:21,344 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Default index set" (6502c3a2b5a7db566ec93aa1) doesn't exist yet
2023-09-14 08:26:27,347 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Graylog System Events" (6502c3a4b5a7db566ec93b62) doesn't exist yet
2023-09-14 08:26:27,349 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Graylog Events" (6502c3a4b5a7db566ec93b5f) doesn't exist yet
2023-09-14 08:26:27,349 WARN : org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical - Active write index for index set "Default index set" (6502c3a2b5a7db566ec93aa1) doesn't exist yet
2023-09-14 08:26:28,356 INFO : org.graylog2.periodical.IndexRangesCleanupPeriodical - Skipping index range cleanup because the Elasticsearch cluster is unhealthy: Green, Index Registry is up: false
```

A couple of things are sticking out here:

  - The `IndexFieldTypePollerPeriodical` is complaining about initial indices never being created
  - The `MongoIndexSet` class correctly determines that there are no deflectors yet
  - When creating the target index `graylog_0`, the `IndexRotationThread` seems to get stuck
  - The `IndexRotationThread` should be run every 10 seconds, but is never started again after the first time

After reproducing the issue locally, `jstack` was showing this picture of a deadlock:

```
"scheduled-daemon-4" #103 daemon prio=5 os_prio=0 cpu=45.98ms elapsed=115.82s tid=0x00007f18d471ac70 nid=0xcd in Object.wait()  [0x00007f18254ef000]
   java.lang.Thread.State: RUNNABLE
        at org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings$Builder.build(Settings.java:1244)
        - waiting on the Class initialization monitor for org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings
        at org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings$Builder.<clinit>(Settings.java:755)
        at org.graylog.shaded.opensearch2.org.opensearch.client.indices.PutIndexTemplateRequest.<init>(PutIndexTemplateRequest.java:97)
        at org.graylog.storage.opensearch2.LegacyIndexTemplateAdapter.ensureIndexTemplate(LegacyIndexTemplateAdapter.java:44)
        at org.graylog.storage.opensearch2.IndicesAdapterOS2.ensureIndexTemplate(IndicesAdapterOS2.java:208)
        at org.graylog2.indexer.indices.Indices.ensureIndexTemplate(Indices.java:171)
        at org.graylog2.indexer.indices.Indices.create(Indices.java:207)
        at org.graylog2.indexer.MongoIndexSet.cycle(MongoIndexSet.java:292)
        at org.graylog2.indexer.MongoIndexSet.setUp(MongoIndexSet.java:260)
        at org.graylog2.periodical.IndexRotationThread.checkAndRepair(IndexRotationThread.java:152)
        at org.graylog2.periodical.IndexRotationThread.lambda$doRun$0(IndexRotationThread.java:90)
        at org.graylog2.periodical.IndexRotationThread$$Lambda$1190/0x00000008019770c0.accept(Unknown Source)
        at java.lang.Iterable.forEach(java.base@17.0.4.1/Unknown Source)
        at org.graylog2.periodical.IndexRotationThread.doRun(IndexRotationThread.java:87)
        at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:99)
        at java.util.concurrent.Executors$RunnableAdapter.call(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.FutureTask.runAndReset(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.4.1/Unknown Source)

[...]

"scheduled-daemon-22" #125 daemon prio=5 os_prio=0 cpu=50.60ms elapsed=115.42s tid=0x00007f17a80488b0 nid=0xe3 in Object.wait()  [0x00007f1826114000]
   java.lang.Thread.State: RUNNABLE
        at org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings.<clinit>(Settings.java:100)
        - waiting on the Class initialization monitor for org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings$Builder
        at org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse.lambda$static$1(ClusterGetSettingsResponse.java:78)
        at org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse$$Lambda$1218/0x0000000801992908.parse(Unknown Source)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.AbstractObjectParser.lambda$declareObject$1(AbstractObjectParser.java:202)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.AbstractObjectParser$$Lambda$1219/0x00000008019930d8.parse(Unknown Source)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ObjectParser.lambda$declareField$9(ObjectParser.java:421)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ObjectParser$$Lambda$1172/0x00000008019634f0.parse(Unknown Source)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ObjectParser.parseValue(ObjectParser.java:589)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ObjectParser.parseSub(ObjectParser.java:604)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ObjectParser.parse(ObjectParser.java:354)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:188)
        at org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:180)
        at org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse.fromXContent(ClusterGetSettingsResponse.java:159)
        at org.graylog.shaded.opensearch2.org.opensearch.client.ClusterClient$$Lambda$1210/0x000000080198eb38.apply(Unknown Source)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:2235)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient.lambda$performRequestAndParseEntity$12(RestHighLevelClient.java:1852)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient$$Lambda$1126/0x000000080191ead0.apply(Unknown Source)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1935)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1884)
        at org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1852)
        at org.graylog.shaded.opensearch2.org.opensearch.client.ClusterClient.getSettings(ClusterClient.java:119)
        at org.graylog.storage.opensearch2.ClusterAdapterOS2.lambda$clusterAllocationDiskSettings$5(ClusterAdapterOS2.java:135)
        at org.graylog.storage.opensearch2.ClusterAdapterOS2$$Lambda$1208/0x000000080198e6f0.apply(Unknown Source)
        at org.graylog.storage.opensearch2.OpenSearchClient.execute(OpenSearchClient.java:113)
        at org.graylog.storage.opensearch2.OpenSearchClient.execute(OpenSearchClient.java:107)
        at org.graylog.storage.opensearch2.ClusterAdapterOS2.clusterAllocationDiskSettings(ClusterAdapterOS2.java:135)
        at org.graylog2.indexer.cluster.Cluster.getClusterAllocationDiskSettings(Cluster.java:98)
        at org.graylog2.periodical.IndexerClusterCheckerThread.checkDiskUsage(IndexerClusterCheckerThread.java:112)
        at org.graylog2.periodical.IndexerClusterCheckerThread.doRun(IndexerClusterCheckerThread.java:65)
        at org.graylog2.plugin.periodical.Periodical.run(Periodical.java:99)
        at java.util.concurrent.Executors$RunnableAdapter.call(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.FutureTask.runAndReset(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.4.1/Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.4.1/Unknown Source)
        at java.lang.Thread.run(java.base@17.0.4.1/Unknown Source)
```

This exact same constellation was seen for every successful attempt to reproduce the scenario. This implies that the `IndexerClusterCheckerThread` and the `IndexRotationThread` are deadlocked, because they are competing for the static initializations of a class structure with circular references (`org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings` and its static `Builder` class). 

Due to the fact that we cannot change the structure of the `Settings` class easily (because it is part of the OpenSearch client that we are shading), a pragmatic fix to prevent this in production is to delay the `IndexerClusterCheckerThread` by 5 seconds during startup. At this point the `Settings` class should be initialized completely, so any further attemps to use it from different threads should succeed.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As this is a deadlock related to specific timing, it is hard/impossible to prove its absence. I ran a high number of attempts (30+) starting a clean cluster and never saw the issue happening again, while previously I was able to reproduce it every 4-5 attempts.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.