### PR TITLE
Fixed variable naming in methods - it's a request, not a response

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
@@ -140,13 +140,13 @@ public class GraylogApis implements GraylogRestApi {
     }
 
     public ValidatableResponse post(final String url, final Users.User user, final String body, final int expectedResult) {
-        var response = prefix(user);
+        var request = prefix(user);
 
         if(body != null) {
-            response = response.body(body);
+            request = request.body(body);
         }
 
-        return response
+        return request
                 .post(url)
                 .then()
                 .log().ifStatusCodeMatches(not(expectedResult))
@@ -158,13 +158,13 @@ public class GraylogApis implements GraylogRestApi {
     }
 
     public ValidatableResponse put(final String url, final Users.User user, final String body, final int expectedResult) {
-        var response = prefix(user);
+        var request = prefix(user);
 
         if(body != null) {
-            response = response.body(body);
+            request = request.body(body);
         }
 
-        return response
+        return request
                 .put(url)
                 .then()
                 .log().ifStatusCodeMatches(not(expectedResult))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The variable was named `response` - but it's a request at that point.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

