### PR TITLE
Remove check for write block for TSO rotation strategy

### DIFF
--- a/changelog/unreleased/pr-16503.toml
+++ b/changelog/unreleased/pr-16503.toml
@@ -1,5 +1,5 @@
 type = "f"
 message = "Fixes failure to delete indices with time/size optimizing strategy, when write block is not present."
 
-issues = ["5722"]
+issues = ["Graylog2/graylog-plugin-enterprise#5722"]
 pulls = ["16481"]

--- a/changelog/unreleased/pr-16503.toml
+++ b/changelog/unreleased/pr-16503.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixes failure to delete indices with time/size optimizing strategy, when write block is not present."
+
+issues = ["5722"]
+pulls = ["16481"]

--- a/changelog/unreleased/pr-16503.toml
+++ b/changelog/unreleased/pr-16503.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Fixes failure to delete indices with time/size optimizing strategy, when write block is not present."
 
 issues = ["Graylog2/graylog-plugin-enterprise#5722"]
-pulls = ["16481"]
+pulls = ["16503"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -19,7 +19,6 @@ package org.graylog2.indexer.retention.strategies;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.graylog2.periodical.IndexRetentionThread;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
@@ -72,14 +71,12 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
     private void retainTimeBased(IndexSet indexSet, TimeBasedSizeOptimizingStrategyConfig timeBasedConfig) {
         final Map<String, Set<String>> deflectorIndices = indexSet.getAllIndexAliases();
 
-        final IndicesBlockStatus indicesBlocksStatus = indices.getIndicesBlocksStatus(deflectorIndices.keySet().stream().toList());
         // Account for DST and time zones in determining age
         final DateTime now = clock.nowUTC();
         final long cutoffSoft = now.minus(timeBasedConfig.indexLifetimeMin()).getMillis();
         final long cutoffHard = now.minus(timeBasedConfig.indexLifetimeMax()).getMillis();
         final int removeCount = (int)deflectorIndices.keySet()
                 .stream()
-                .filter(indexName -> indexIsReadOnly(indicesBlocksStatus, indexName))
                 .filter(indexName -> !indices.isReopened(indexName))
                 .filter(indexName -> !hasCurrentWriteAlias(indexSet, deflectorIndices, indexName))
                 .filter(indexName -> exceedsAgeLimit(indexName, cutoffSoft, cutoffHard))
@@ -92,10 +89,6 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
 
             runRetention(indexSet, deflectorIndices, removeCount);
         }
-    }
-
-    private boolean indexIsReadOnly(IndicesBlockStatus blockStatus, String index) {
-        return Optional.ofNullable(blockStatus.getIndexBlocks(index)).map(b -> b.contains("index.blocks.write")).orElse(false);
     }
 
     private boolean exceedsAgeLimit(String indexName, long cutoffSoft, long cutoffHard) {


### PR DESCRIPTION
Resolves #5722

Time/size optimizing Rotation strategy (TSO) was filtering for indices that had the write block set when running retention. If it was not present (i.e. setting the write block had failed), then those indices were not being retained. There are legitimate scenarios where we want to delete archives anyway, e.g. if we are in a high watermark situation and indices have `read_only_allow_delete` block set.

None of the other rotation strategies performs this test, so it is consistent to do the same for TSO. This also avoids lots of downstream issues when indices are unexpectedly not being retained and piling up.