### PR TITLE
Revert rename rotation->retention to avoid incompatibility with Cloud

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -129,13 +129,13 @@ public class ElasticsearchConfiguration {
     private Size timeSizeOptimizingRotationMaxShardSize = Size.gigabytes(50);
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME)
-    private Period timeSizeOptimizingRetentionMinLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MIN;
+    private Period timeSizeOptimizingRotationMinLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MIN;
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_RETENTION_MAX_LIFETIME)
-    private Period timeSizeOptimizingRetentionMaxLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MAX;
+    private Period timeSizeOptimizingRotationMaxLifeTime = TimeBasedSizeOptimizingStrategyConfig.DEFAULT_LIFETIME_MAX;
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY)
-    private Period timeSizeOptimizingRetentionFixedLeeway;
+    private Period timeSizeOptimizingRotationFixedLeeway;
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -261,17 +261,17 @@ public class ElasticsearchConfiguration {
         return timeSizeOptimizingRotationMaxShardSize;
     }
 
-    public Period getTimeSizeOptimizingRetentionMinLifeTime() {
-        return timeSizeOptimizingRetentionMinLifeTime;
+    public Period getTimeSizeOptimizingRotationMinLifeTime() {
+        return timeSizeOptimizingRotationMinLifeTime;
     }
 
-    public Period getTimeSizeOptimizingRetentionMaxLifeTime() {
-        return timeSizeOptimizingRetentionMaxLifeTime;
+    public Period getTimeSizeOptimizingRotationMaxLifeTime() {
+        return timeSizeOptimizingRotationMaxLifeTime;
     }
 
     @Nullable
-    public Period getTimeSizeOptimizingRetentionFixedLeeway() {
-        return timeSizeOptimizingRetentionFixedLeeway;
+    public Period getTimeSizeOptimizingRotationFixedLeeway() {
+        return timeSizeOptimizingRotationFixedLeeway;
     }
 
     public boolean isDisableVersionCheck() {
@@ -307,22 +307,22 @@ public class ElasticsearchConfiguration {
                     TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE, getTimeSizeOptimizingRotationMaxShardSize())
             );
         }
-        Seconds timeSizeOptimizingRotationMaxLifeTimeSeconds = getTimeSizeOptimizingRetentionMaxLifeTime().toStandardSeconds();
-        Seconds timeSizeOptimizingRotationMinLifeTimeSeconds = getTimeSizeOptimizingRetentionMinLifeTime().toStandardSeconds();
+        Seconds timeSizeOptimizingRotationMaxLifeTimeSeconds = getTimeSizeOptimizingRotationMaxLifeTime().toStandardSeconds();
+        Seconds timeSizeOptimizingRotationMinLifeTimeSeconds = getTimeSizeOptimizingRotationMinLifeTime().toStandardSeconds();
         if (timeSizeOptimizingRotationMaxLifeTimeSeconds.compareTo(timeSizeOptimizingRotationMinLifeTimeSeconds) <= 0) {
             throw new ValidationException(f("\"%s=%s\" needs to be larger than \"%s=%s\"",
-                    TIME_SIZE_OPTIMIZING_RETENTION_MAX_LIFETIME, getTimeSizeOptimizingRetentionMaxLifeTime(),
-                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRetentionMinLifeTime())
+                    TIME_SIZE_OPTIMIZING_RETENTION_MAX_LIFETIME, getTimeSizeOptimizingRotationMaxLifeTime(),
+                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRotationMinLifeTime())
             );
         }
 
         Seconds calculatedLeeway = timeSizeOptimizingRotationMaxLifeTimeSeconds.minus(timeSizeOptimizingRotationMinLifeTimeSeconds);
-        if (getTimeSizeOptimizingRetentionFixedLeeway() != null &&
-                calculatedLeeway.isLessThan(getTimeSizeOptimizingRetentionFixedLeeway().toStandardSeconds())) {
+        if (getTimeSizeOptimizingRotationFixedLeeway() != null &&
+                calculatedLeeway.isLessThan(getTimeSizeOptimizingRotationFixedLeeway().toStandardSeconds())) {
             throw new ValidationException(f("\"%s=%s\" and \"%s=%s\" leeway cannot be less than \"%s=%s\"",
-                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRetentionMinLifeTime(),
-                    TIME_SIZE_OPTIMIZING_RETENTION_MAX_LIFETIME, getTimeSizeOptimizingRetentionMaxLifeTime(),
-                    TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY, getTimeSizeOptimizingRetentionFixedLeeway())
+                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRotationMinLifeTime(),
+                    TIME_SIZE_OPTIMIZING_RETENTION_MAX_LIFETIME, getTimeSizeOptimizingRotationMaxLifeTime(),
+                    TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY, getTimeSizeOptimizingRotationFixedLeeway())
             );
         }
 
@@ -332,7 +332,7 @@ public class ElasticsearchConfiguration {
                 getMaxIndexRetentionPeriod().toStandardSeconds().isLessThan(
                         timeSizeOptimizingRotationMinLifeTimeSeconds.plus(calculatedLeeway))) {
             throw new ValidationException(f("\"%s=%s\" plus leeway=%s cannot to be larger than \"%s=%s\"",
-                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRetentionMinLifeTime(),
+                    TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME, getTimeSizeOptimizingRotationMinLifeTime(),
                     new Period(calculatedLeeway),
                     MAX_INDEX_RETENTION_PERIOD + " + leeway", getMaxIndexRetentionPeriod().plus(calculatedLeeway))
             );

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -128,7 +128,7 @@ public class IndexSetValidator {
                         leeway, TIME_SIZE_OPTIMIZING_ROTATION_PERIOD, elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()));
             }
 
-            Period fixedLeeway = elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway();
+            Period fixedLeeway = elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway();
             if (Objects.nonNull(fixedLeeway) && leeway.toStandardSeconds().isLessThan(fixedLeeway.toStandardSeconds())) {
                 return Violation.create(f("The duration between %s and %s <%s> cannot be shorter than %s <%s>", INDEX_LIFETIME_MAX, INDEX_LIFETIME_MIN,
                         leeway, TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY, fixedLeeway));

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -69,8 +69,8 @@ public class TimeBasedSizeOptimizingStrategy extends AbstractRotationStrategy {
     @Override
     public RotationStrategyConfig defaultConfiguration() {
         return TimeBasedSizeOptimizingStrategyConfig.builder()
-                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMinLifeTime())
-                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMaxLifeTime())
+                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
+                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
                 .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
@@ -79,8 +79,8 @@ public class MaintenanceStrategiesHelper {
             case TimeBasedSizeOptimizingStrategy.NAME -> {
                 return ImmutablePair.of(TimeBasedSizeOptimizingStrategy.class.getCanonicalName(),
                         TimeBasedSizeOptimizingStrategyConfig.builder()
-                                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMinLifeTime())
-                                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRetentionMaxLifeTime())
+                                .indexLifetimeMin(elasticsearchConfiguration.getTimeSizeOptimizingRotationMinLifeTime())
+                                .indexLifetimeMax(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxLifeTime())
                                 .build());
             }
             default -> {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -83,7 +83,7 @@ public class RotationStrategyResource extends RestResource {
                 .collect(Collectors.toList());
 
         final RotationStrategies.Context context =
-                RotationStrategies.Context.create(elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway());
+                RotationStrategies.Context.create(elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway());
 
         return RotationStrategies.create(strategies, context);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -218,7 +218,7 @@ public class IndexSetValidatorTest {
     @Test
     public void timeBasedSizeOptimizingHonorsFixedLeeWay() {
         when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(Period.days(1));
-        when(elasticsearchConfiguration.getTimeSizeOptimizingRetentionFixedLeeway()).thenReturn(Period.days(10));
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationFixedLeeway()).thenReturn(Period.days(10));
 
         when(indexSetRegistry.iterator()).thenReturn(Collections.emptyIterator());
         final IndexSetConfig failingConfig = testIndexSetConfig().toBuilder()


### PR DESCRIPTION
/nocl no user-visible changes

#16448 included some renaming for better consistency; but the corresponding change in Cloud repo was missing. For simplicity, this PR reverts the rename in the 5.1 branch.