### PR TITLE
DataNode: Fixed dependency for IT tests if we skip the datanode in cloud builds

### DIFF
--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -57,19 +57,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.graylog2</groupId>
-            <artifactId>data-node</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.graylog2</groupId>
-            <artifactId>data-node</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.graylog</groupId>
             <artifactId>graylog-storage-elasticsearch7</artifactId>
             <version>${project.version}</version>
@@ -222,4 +209,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>datanode</id>
+            <activation>
+                <property>
+                    <name>!skip.datanode</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.graylog2</groupId>
+                    <artifactId>data-node</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.graylog2</groupId>
+                    <artifactId>data-node</artifactId>
+                    <version>${project.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We skip the datanode build in the cloud plugin, so we can't have the dependencies in the integration tests in the cloud build. As we don't run the tests, only the artefacts are built. Which is fine because the dependencies are only needed at runtime.

/nocl
/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/5811

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

