### PR TITLE
Add ability to clean field names for set_field and set_fields pipeline functions

### DIFF
--- a/changelog/unreleased/pr-16514.toml
+++ b/changelog/unreleased/pr-16514.toml
@@ -1,7 +1,7 @@
 type = "a"
 message = "Added ability to clean field names for set_field and set_fields pipeline functions"
 
-issues = ["7137", "graylog-plugin-enterprise/5794"]
+issues = ["7137", "graylog-plugin-enterprise#5794"]
 pulls = ["16514"]
 
 details.user = """

--- a/changelog/unreleased/pr-16514.toml
+++ b/changelog/unreleased/pr-16514.toml
@@ -1,0 +1,13 @@
+type = "a"
+message = "Added ability to clean field names for set_field and set_fields pipeline functions"
+
+issues = ["7137", "graylog-plugin-enterprise/5794"]
+pulls = ["16514"]
+
+details.user = """
+Add optional parameters to the following pipeline functions that can be used to replace invalid field name characters
+with underscores. Both default to `false`.
+
+* `set_field` pipeline function: New parameter: `clean_field`
+* `set_fields` pipeline function: New parameter: `clean_fields`
+"""

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.bool;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
 
@@ -39,12 +40,14 @@ public class SetFields extends AbstractFunction<Void> {
     private final ParameterDescriptor<String, String> prefixParam;
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<Boolean, Boolean> cleanFields;
 
     public SetFields() {
         fieldsParam = type("fields", Map.class).primary().description("The map of new fields to set").build();
         prefixParam = string("prefix").optional().description("The prefix for the field names").build();
         suffixParam = string("suffix").optional().description("The suffix for the field names").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
+        cleanFields = bool("clean_fields").optional().description("Substitute invalid characters in field names with underscores").build();
     }
 
     @Override
@@ -63,6 +66,9 @@ public class SetFields extends AbstractFunction<Void> {
                 if (suffix.isPresent()) {
                     field = field + suffix.get();
                 }
+                if (cleanFields.optional(args, context).orElse(false)) {
+                    field = Message.cleanKey(field);
+                }
                 message.addField(field, value);
             });
         }
@@ -74,7 +80,7 @@ public class SetFields extends AbstractFunction<Void> {
         return FunctionDescriptor.<Void>builder()
                 .name(NAME)
                 .returnType(Void.class)
-                .params(of(fieldsParam, prefixParam, suffixParam, messageParam))
+                .params(of(fieldsParam, prefixParam, suffixParam, messageParam, cleanFields))
                 .description("Sets new fields in a message. If no specific message is provided, it sets the fields in the currently processed message")
                 .ruleBuilderEnabled(false)
                 .ruleBuilderName("Set fields")

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -200,7 +200,11 @@ public class Message implements Messages, Indexable {
     @Deprecated
     public static final String FIELD_GL2_SOURCE_RADIO_INPUT = "gl2_source_radio_input";
 
+    // Matches whole field names containing a-z, A-Z, 0-9, period char, -, or @.
     private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\.\\-@]*$");
+    // Same as above, but matches only the invalid (non-indicated) characters.
+    // [^ ... ] around the pattern inverts the match.
+    private static final Pattern INVALID_KEY_CHARS = Pattern.compile("[^\\w\\.\\-@]");
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
@@ -636,6 +640,10 @@ public class Message implements Messages, Indexable {
 
     public static boolean validKey(final String key) {
         return VALID_KEY_CHARS.matcher(key).matches();
+    }
+
+    public static String cleanKey(final String key) {
+        return INVALID_KEY_CHARS.matcher(key).replaceAll(String.valueOf(KEY_REPLACEMENT_CHAR));
     }
 
     public void addFields(final Map<String, Object> fields) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1402,4 +1402,42 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("f2")).isEqualTo("f2");
         assertThat(message.getField("f3")).isEqualTo("f3");
     }
+
+    @Test
+    public void setField() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = new Message("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("f1")).isEqualTo("v1");
+        assertThat(message.getField("f_2")).isEqualTo("v_2");
+        assertThat(message.getField("f 3")).isNull();
+        assertThat(message.getField("f_3")).isNull();
+        assertThat(message.getField("f_4")).isEqualTo("will be added with clean field param");
+    }
+
+    @Test
+    public void setFields() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = new Message("test", "test", Tools.nowUTC());
+        message.addField("json_field_map", "{ " +
+                "  \"k1\": \"v1\", " +
+                "  \"k_2\": \"v_2\", " +
+                "  \"k 3\": \"will be skipped\" " +
+                "}");
+        message.addField("json_clean_field_map", "{ " +
+                "  \"k4\": \"v4\", " +
+                "  \"k_5\": \"v_5\", " +
+                "  \"k 6\": \"will be added with clean_fields param\" " +
+                "}");
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("k1")).isEqualTo("v1");
+        assertThat(message.getField("k_2")).isEqualTo("v_2");
+        assertThat(message.getField("k 3")).isNull();
+        assertThat(message.getField("k_3")).isNull();
+        assertThat(message.getField("k4")).isEqualTo("v4");
+        assertThat(message.getField("k_5")).isEqualTo("v_5");
+        assertThat(message.getField("k_6")).isEqualTo("will be added with clean_fields param");
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -368,8 +368,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         when(grokPatternService.loadByName("GREEDY")).thenReturn(Optional.of(greedyPattern));
         final EventBus clusterBus = new EventBus();
         final GrokPatternRegistry grokPatternRegistry = new GrokPatternRegistry(clusterBus,
-                                                                                grokPatternService,
-                                                                                Executors.newScheduledThreadPool(1));
+                grokPatternService,
+                Executors.newScheduledThreadPool(1));
         functions.put(GrokMatch.NAME, new GrokMatch(grokPatternRegistry));
         functions.put(GrokExists.NAME, new GrokExists(grokPatternRegistry));
 
@@ -390,7 +390,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void stringConcat(){
+    public void stringConcat() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule, new Message("Dummy Message", "test", Tools.nowUTC()));
 
@@ -1103,7 +1103,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message).isNotNull();
             assertThat(message.getField("interval"))
                     .isInstanceOf(Duration.class)
-                    .matches(o -> ((Duration)o).isEqual(Duration.standardDays(1)), "Exactly one day difference");
+                    .matches(o -> ((Duration) o).isEqual(Duration.standardDays(1)), "Exactly one day difference");
             assertThat(message.getField("years")).isEqualTo(Period.years(2));
             assertThat(message.getField("months")).isEqualTo(Period.months(2));
             assertThat(message.getField("weeks")).isEqualTo(Period.weeks(2));

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -393,6 +393,26 @@ public class MessageTest {
     }
 
     @Test
+    public void testCleanKey() throws Exception {
+        // Valid keys
+        assertEquals("foo123",Message.cleanKey("foo123"));
+        assertEquals("foo-bar123",Message.cleanKey("foo-bar123"));
+        assertEquals("foo_bar123",Message.cleanKey("foo_bar123"));
+        assertEquals("foo.bar123",Message.cleanKey("foo.bar123"));
+        assertEquals("foo@bar",Message.cleanKey("foo@bar"));
+        assertEquals("123",Message.cleanKey("123"));
+        assertEquals("",Message.cleanKey(""));
+
+        assertEquals("foo_bar",Message.cleanKey("foo bar"));
+        assertEquals("foo_bar",Message.cleanKey("foo+bar"));
+        assertEquals("foo_bar",Message.cleanKey("foo$bar"));
+        assertEquals("foo_bar",Message.cleanKey("foo{bar"));
+        assertEquals("foo_bar",Message.cleanKey("foo,bar"));
+        assertEquals("foo_bar",Message.cleanKey("foo?bar"));
+        assertEquals("_",Message.cleanKey(" "));
+    }
+
+    @Test
     public void testToElasticSearchObject() throws Exception {
         message.addField("field1", "wat");
         message.addField("field2", "that");

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -357,13 +357,13 @@ public class MessageTest {
         final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
 
         message.addField(Message.FIELD_TIMESTAMP,
-                         dateTime.toDate());
+                dateTime.toDate());
 
         final Map<String, Object> elasticSearchObject = message.toElasticSearchObject(objectMapper, invalidTimestampMeter);
         final Object esTimestampFormatted = elasticSearchObject.get(Message.FIELD_TIMESTAMP);
 
         assertEquals("Setting message timestamp as java.util.Date results in correct format for elasticsearch",
-                     Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
+                Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
     }
 
     @Test
@@ -395,21 +395,21 @@ public class MessageTest {
     @Test
     public void testCleanKey() throws Exception {
         // Valid keys
-        assertEquals("foo123",Message.cleanKey("foo123"));
-        assertEquals("foo-bar123",Message.cleanKey("foo-bar123"));
-        assertEquals("foo_bar123",Message.cleanKey("foo_bar123"));
-        assertEquals("foo.bar123",Message.cleanKey("foo.bar123"));
-        assertEquals("foo@bar",Message.cleanKey("foo@bar"));
-        assertEquals("123",Message.cleanKey("123"));
-        assertEquals("",Message.cleanKey(""));
+        assertEquals("foo123", Message.cleanKey("foo123"));
+        assertEquals("foo-bar123", Message.cleanKey("foo-bar123"));
+        assertEquals("foo_bar123", Message.cleanKey("foo_bar123"));
+        assertEquals("foo.bar123", Message.cleanKey("foo.bar123"));
+        assertEquals("foo@bar", Message.cleanKey("foo@bar"));
+        assertEquals("123", Message.cleanKey("123"));
+        assertEquals("", Message.cleanKey(""));
 
-        assertEquals("foo_bar",Message.cleanKey("foo bar"));
-        assertEquals("foo_bar",Message.cleanKey("foo+bar"));
-        assertEquals("foo_bar",Message.cleanKey("foo$bar"));
-        assertEquals("foo_bar",Message.cleanKey("foo{bar"));
-        assertEquals("foo_bar",Message.cleanKey("foo,bar"));
-        assertEquals("foo_bar",Message.cleanKey("foo?bar"));
-        assertEquals("_",Message.cleanKey(" "));
+        assertEquals("foo_bar", Message.cleanKey("foo bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo+bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo$bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo{bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo,bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo?bar"));
+        assertEquals("_", Message.cleanKey(" "));
     }
 
     @Test
@@ -624,9 +624,9 @@ public class MessageTest {
     @Test
     public void fieldTest() {
         assertThat(Message.sizeForField("", true)).isEqualTo(4);
-        assertThat(Message.sizeForField("", (byte)1)).isEqualTo(1);
-        assertThat(Message.sizeForField("", (char)1)).isEqualTo(2);
-        assertThat(Message.sizeForField("", (short)1)).isEqualTo(2);
+        assertThat(Message.sizeForField("", (byte) 1)).isEqualTo(1);
+        assertThat(Message.sizeForField("", (char) 1)).isEqualTo(2);
+        assertThat(Message.sizeForField("", (short) 1)).isEqualTo(2);
         assertThat(Message.sizeForField("", 1)).isEqualTo(4);
         assertThat(Message.sizeForField("", 1L)).isEqualTo(8);
         assertThat(Message.sizeForField("", 1.0f)).isEqualTo(4);

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setField.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setField.txt
@@ -1,0 +1,8 @@
+rule "set_field"
+when true
+then
+  set_field(field: "f1", value: "v1");
+  set_field(field: "f_2", value: "v_2");
+  set_field(field: "f 3", value: "will be skipped");
+  set_field(field: "f 4", value: "will be added with clean field param", clean_field: true);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFields.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFields.txt
@@ -1,0 +1,9 @@
+rule "set_fields"
+when true
+then
+  let newValue = to_map(parse_json(to_string($message.json_field_map)));
+  set_fields(fields: newValue);
+
+  let cleanFieldValue = to_map(parse_json(to_string($message.json_clean_field_map)));
+  set_fields(fields: cleanFieldValue, clean_fields: true);
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add optional parameters to the following pipeline functions that can be used to replace invalid field name characters with underscores. Both default to `false`.

* `set_field` pipeline function: New parameter: `clean_field`
* `set_fields` pipeline function: New parameter: `clean_fields`

**`set_field` example**

```
rule "set_field"
when true
then
  set_field(field: "has space chars", value: "value", clean_field: true);
end
```

In this example, the field `has_space_chars` will be added to the message with the value `value`.

**`set_fields` example**
Given a message with a `json_map` field containing the following value:

```
{
  "key_1": "value 1",
  "has space chars": "value"
}
```

And the following rule:
```
rule "set_fields"
when true
then
  let cleanFieldValue = to_map(parse_json(to_string($message.json_map)));
  set_fields(fields: cleanFieldValue, clean_fields: true);
end

```

In this example, the same field with a spaces in it will be successfully added to the message (along with the other field `key_1`: `value`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When attempting to use a JSON map to set fields on a message, any fields that contain invalid characters (spaces, for example) will not be added to the message. This new optional parameter provides a backwards-compatible and convenient  way to automatically clean up invalid field names and ensure that all fields in the map will be set on the message. 

Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/5794
Closes https://github.com/Graylog2/graylog2-server/issues/7137

## Screenshots
![image](https://github.com/Graylog2/graylog2-server/assets/3423655/2946db23-7818-4732-8e20-87189bad027c)
![image](https://github.com/Graylog2/graylog2-server/assets/3423655/fe37da4a-d6c1-4455-b0e6-1042a33373e8)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and manual tests.

You can send a message with a JSON map in using the above `set_fields` example using this GELF HTTP example:
```
curl -XPOST -v http://127.0.0.1:12201/gelf -p0 \
-d $'{"short_message":"Bulk message 1", "host":"example.org", "facility":"test", "_json_map":"{ \\"key_1\\": \\"value 1\\", \\"k 6\\": \\"value\\" }"}'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

