### PR TITLE
Allow skipping streams when retrieving type mappings.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/field_types/FieldTypeMappingsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/field_types/FieldTypeMappingsResource.java
@@ -78,8 +78,7 @@ public class FieldTypeMappingsResource extends RestResource {
     @NoAuditEvent("No audit for field type changes")
     public Response changeFieldType(@ApiParam(name = "request")
                                     @Valid
-                                    @NotNull(message = "Request body is mandatory") final FieldTypeChangeRequest request
-    ) {
+                                    @NotNull(message = "Request body is mandatory") final FieldTypeChangeRequest request) {
         checkPermissionsForCreation(request.indexSetsIds());
 
         //TODO: more complex validation of request

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/FieldTypeSummaryRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/FieldTypeSummaryRequest.java
@@ -18,11 +18,12 @@ package org.graylog2.rest.resources.system.indexer.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Set;
 
-public record FieldTypeSummaryRequest(@NotNull @NotEmpty
+public record FieldTypeSummaryRequest(@Nullable
                                       @JsonProperty("streams")
                                       Set<String> streamsIds,
                                       @NotNull @NotEmpty


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `streams` field of the request when retrieving field mappings for index sets was mandatory. With this PR it can be skipped (or set to an empty set), so all streams available to the user will be used.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.