### PR TITLE
DataNode: Removing obsolete single-node setting

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -235,9 +235,6 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "root_email")
     private String rootEmail = "";
 
-    @Parameter(value = "single_node_only")
-    private boolean singleNodeOnly = false;
-
     public String getNodeIdFile() {
         return nodeIdFile;
     }
@@ -292,10 +289,6 @@ public class Configuration extends BaseConfiguration {
 
     public Optional<String> getOpensearchNetworkHostHost() {
         return Optional.ofNullable(opensearchNetworkHostHost);
-    }
-
-    public boolean isSingleNodeOnly() {
-        return singleNodeOnly;
     }
 
     public static class NodeIdFileValidator implements Validator<String> {

--- a/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
@@ -116,11 +116,7 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
                 networkHost -> config.put("network.host", networkHost));
         config.put("path.data", Path.of(localConfiguration.getOpensearchDataLocation()).resolve(localConfiguration.getDatanodeNodeName()).toAbsolutePath().toString());
         config.put("path.logs", Path.of(localConfiguration.getOpensearchLogsLocation()).resolve(localConfiguration.getDatanodeNodeName()).toAbsolutePath().toString());
-        if (localConfiguration.isSingleNodeOnly()) {
-            config.put("discovery.type", "single-node");
-        } else {
-            config.put("cluster.initial_master_nodes", localConfiguration.getInitialManagerNodes());
-        }
+        config.put("cluster.initial_master_nodes", localConfiguration.getInitialManagerNodes());
 
         // listen on all interfaces
         config.put("network.bind_host", "0.0.0.0");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As far as I understand the docs (and my own tests), the single-node setting is necessary for single-node installations that only bind to localhost so that inter-cluster communication for leader-election etc. is not possible.

In the context of the DataNode, this does not make sense, we bind to the real network interface, so this setting was removed.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

