### PR TITLE
Make sure default for matching_type is applied for paginated streams endpoint too. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-16474.toml
+++ b/changelog/unreleased/issue-16474.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing broken streams page if streams without `matching_type` exist."
+
+issues = ["16474"]
+pulls = ["16522"]

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
@@ -54,6 +54,7 @@ public abstract class StreamDTO {
     public static final String FIELD_INDEX_SET_ID = "index_set_id";
     public static final String EMBEDDED_ALERT_CONDITIONS = "alert_conditions";
     public static final String FIELD_IS_EDITABLE = "is_editable";
+    public static final Stream.MatchingType DEFAULT_MATCHING_TYPE = Stream.MatchingType.AND;
 
     @JsonProperty("id")
     public abstract String id();
@@ -124,7 +125,7 @@ public abstract class StreamDTO {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_StreamDTO.Builder()
-                    .matchingType(Stream.MatchingType.AND.toString())
+                    .matchingType(DEFAULT_MATCHING_TYPE.toString())
                     .isDefault(false)
                     .isEditable(false)
                     .removeMatchesFromDefaultStream(false);
@@ -195,7 +196,7 @@ public abstract class StreamDTO {
                 .id(document.getObjectId(FIELD_ID).toHexString())
                 .title(document.getString(FIELD_TITLE))
                 .description(document.getString(FIELD_DESCRIPTION))
-                .matchingType(document.getString(FIELD_MATCHING_TYPE))
+                .matchingType(document.get(FIELD_MATCHING_TYPE, DEFAULT_MATCHING_TYPE.toString()))
                 .createdAt(document.getDate(FIELD_CREATED_AT))
                 .contentPack(document.getString(FIELD_CONTENT_PACK))
                 .isEditable(document.getBoolean(FIELD_IS_EDITABLE, true))


### PR DESCRIPTION
**Note:** This PR is a backport of #16522 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue which was introduced in #14085. A slightly different code path is introduced for the paginated streams endpoint, which led to streams missing the `matching_type` field to fail deserializing, because the default for `matching_type` is not applied and a `null` value is passed instead to the builder method. 

Fixes #16474.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.