### PR TITLE
Disable `historyApiFallback` in preflight UI webpack dev config.

### DIFF
--- a/graylog2-web-interface/webpack.preflight.ts
+++ b/graylog2-web-interface/webpack.preflight.ts
@@ -74,7 +74,6 @@ if (mode === 'development') {
       hot: false,
       liveReload: true,
       compress: true,
-      historyApiFallback: true,
       proxy: {
         '/api': {
           target: apiUrl,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change you could open a route like `/test` and the preflight UI rendered, but it did not worked correctly, because the UI does not expect a route other than `/`.

With this change we are adjusting the webpack config. When you open a route like `/test` you will see an error.

/nocl