### PR TITLE
Extend mantine theme type to include custom data.

### DIFF
--- a/graylog2-web-interface/src/@types/mantine/index.d.ts
+++ b/graylog2-web-interface/src/@types/mantine/index.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { MantineTheme as CustomMantineTheme } from '@graylog/sawmill/mantine';
+
+declare module '@mantine/core' {
+  export interface MantineTheme extends CustomMantineTheme {}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change the mantine theme type includes the custom data we define for the theme, like `theme.others.colors.global`.

/nocl