### PR TITLE
Use random port for test container in ModelIdParamConverterTest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/jersey/ModelIdParamConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/jersey/ModelIdParamConverterTest.java
@@ -18,6 +18,7 @@ package org.graylog2.contentpacks.jersey;
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
@@ -47,6 +48,7 @@ public class ModelIdParamConverterTest extends JerseyTest {
 
     @Override
     protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
         return new ResourceConfig(Resource.class, ModelIdParamConverter.Provider.class);
     }
 


### PR DESCRIPTION
Copied from here:
https://github.com/Graylog2/graylog2-server/blob/f35df42e165ac570b8b27de3f8eeac85e74ed610/graylog2-server/src/test/java/org/graylog2/rest/GenericErrorCsvWriterTest.java#L46

/nocl
