### PR TITLE
Remove management for unused httpasyncclient dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
         <amqp-client.version>5.8.0</amqp-client.version>
         <antlr.version>4.8-1</antlr.version>
         <apache-directory-version>1.0.3</apache-directory-version>
-        <apache-httpasyncclient.version>4.1.5</apache-httpasyncclient.version>
         <apache-httpclient.version>4.5.13</apache-httpclient.version>
         <apache-httpcore.version>4.4.16</apache-httpcore.version>
         <asm.version>9.5</asm.version>
@@ -247,11 +246,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${apache-httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpasyncclient</artifactId>
-                <version>${apache-httpasyncclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Remove management for unused `org.apache.httpcomponents:httpasyncclient` dependency

The dependency doesn't appear in the output of `mvn dependency:tree`.

/nocl
