### PR TITLE
DataNode: using the short node id as nodename if none was provided in the config

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -97,13 +97,13 @@ public class Configuration extends BaseConfiguration {
 
 
     @Parameter(value = "node_name")
-    private String datanodeNodeName = "node1";
+    private String datanodeNodeName;
 
     /**
      * Comma separated list of opensearch nodes that are eligible as manager nodes.
      */
     @Parameter(value = "cluster_initial_manager_nodes")
-    private String initialManagerNodes = "node1";
+    private String initialManagerNodes;
 
     @Parameter(value = "opensearch_http_port", converter = IntegerConverter.class)
     private int opensearchHttpPort = 9200;

--- a/data-node/src/main/java/org/graylog/datanode/bindings/ConfigurationModule.java
+++ b/data-node/src/main/java/org/graylog/datanode/bindings/ConfigurationModule.java
@@ -19,6 +19,8 @@ package org.graylog.datanode.bindings;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import org.graylog.datanode.Configuration;
+import org.graylog2.plugin.system.FilePersistedNodeIdProvider;
+import org.graylog2.plugin.system.NodeId;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,6 +33,7 @@ public class ConfigurationModule implements Module {
 
     @Override
     public void configure(Binder binder) {
+        binder.bind(NodeId.class).toProvider(FilePersistedNodeIdProvider.class).asEagerSingleton();
         binder.bind(Configuration.class).toInstance(configuration);
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
@@ -156,7 +156,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
                 new NamedConfigParametersModule(jadConfig.getConfigurationBeans()),
                 new ConfigurationModule(configuration),
                 new DatanodeConfigurationBindings()
-
         );
     }
 

--- a/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfigurationProvider.java
@@ -18,6 +18,7 @@ package org.graylog.datanode.configuration;
 
 import org.graylog.datanode.Configuration;
 import org.graylog.datanode.OpensearchDistribution;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.security.IndexerJwtAuthTokenProvider;
 
 import javax.inject.Inject;
@@ -32,14 +33,19 @@ public class DatanodeConfigurationProvider implements Provider<DatanodeConfigura
     private final DatanodeConfiguration datanodeConfiguration;
 
     @Inject
-    public DatanodeConfigurationProvider(final Configuration localConfiguration, IndexerJwtAuthTokenProvider jwtTokenProvider) throws IOException {
+    public DatanodeConfigurationProvider(final Configuration localConfiguration, IndexerJwtAuthTokenProvider jwtTokenProvider, final NodeId nodeId) throws IOException {
         final OpensearchDistribution opensearchDistribution = detectOpensearchDistribution(localConfiguration);
         datanodeConfiguration = new DatanodeConfiguration(
                 opensearchDistribution,
-                localConfiguration.getDatanodeNodeName(),
+                getNodesFromConfig(localConfiguration.getDatanodeNodeName(), nodeId),
                 localConfiguration.getProcessLogsBufferSize(),
                 jwtTokenProvider
         );
+    }
+
+    public static String getNodesFromConfig(final String configProperty, final NodeId nodeId) {
+        if(configProperty != null) return configProperty;
+        return nodeId.getShortNodeId();
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To be able to remove the `node1` default as the nodename and instead provide a unique name, we're using the short id from the node id if no names are set in the config.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

