### PR TITLE
Add ability to clean field names for set_field and set_fields pipeline functions (5.1)

### DIFF
--- a/changelog/unreleased/pr-16514.toml
+++ b/changelog/unreleased/pr-16514.toml
@@ -1,0 +1,13 @@
+type = "a"
+message = "Added ability to clean field names for set_field and set_fields pipeline functions"
+
+issues = ["7137", "graylog-plugin-enterprise#5794"]
+pulls = ["16514"]
+
+details.user = """
+Add optional parameters to the following pipeline functions that can be used to replace invalid field name characters
+with underscores. Both default to `false`.
+
+* `set_field` pipeline function: New parameter: `clean_field`
+* `set_fields` pipeline function: New parameter: `clean_fields`
+"""

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetField.java
@@ -27,6 +27,7 @@ import org.graylog2.plugin.Message;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.bool;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
@@ -41,6 +42,7 @@ public class SetField extends AbstractFunction<Void> {
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
     private final ParameterDescriptor<Object, Object> defaultParam;
+    private final ParameterDescriptor<Boolean, Boolean> cleanField;
 
     public SetField() {
         fieldParam = string("field").description("The new field name").build();
@@ -49,6 +51,7 @@ public class SetField extends AbstractFunction<Void> {
         suffixParam = string("suffix").optional().description("The suffix for the field name").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
         defaultParam = object("default").optional().description("Used when value not available").build();
+        cleanField = bool("clean_field").optional().description("Substitute invalid field name characters with underscores").build();
     }
 
     @Override
@@ -80,6 +83,9 @@ public class SetField extends AbstractFunction<Void> {
             if (suffix.isPresent()) {
                 field = field + suffix.get();
             }
+            if (cleanField.optional(args, context).orElse(false)) {
+                field = Message.cleanKey(field);
+            }
             message.addField(field, value);
         }
         return null;
@@ -95,7 +101,8 @@ public class SetField extends AbstractFunction<Void> {
                         prefixParam,
                         suffixParam,
                         messageParam,
-                        defaultParam))
+                        defaultParam,
+                        cleanField))
                         .description("Sets a new field in a message")
                         .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/SetFields.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.bool;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
 
@@ -38,12 +39,14 @@ public class SetFields extends AbstractFunction<Void> {
     private final ParameterDescriptor<String, String> prefixParam;
     private final ParameterDescriptor<String, String> suffixParam;
     private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<Boolean, Boolean> cleanFields;
 
     public SetFields() {
         fieldsParam = type("fields", Map.class).description("The map of new fields to set").build();
         prefixParam = string("prefix").optional().description("The prefix for the field names").build();
         suffixParam = string("suffix").optional().description("The suffix for the field names").build();
         messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'").build();
+        cleanFields = bool("clean_fields").optional().description("Substitute invalid characters in field names with underscores").build();
     }
 
     @Override
@@ -62,6 +65,9 @@ public class SetFields extends AbstractFunction<Void> {
                 if (suffix.isPresent()) {
                     field = field + suffix.get();
                 }
+                if (cleanFields.optional(args, context).orElse(false)) {
+                    field = Message.cleanKey(field);
+                }
                 message.addField(field, value);
             });
         }
@@ -73,7 +79,7 @@ public class SetFields extends AbstractFunction<Void> {
         return FunctionDescriptor.<Void>builder()
                 .name(NAME)
                 .returnType(Void.class)
-                .params(of(fieldsParam, prefixParam, suffixParam, messageParam))
+                .params(of(fieldsParam, prefixParam, suffixParam, messageParam, cleanFields))
                 .description("Sets new fields in a message")
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -192,7 +192,11 @@ public class Message implements Messages, Indexable {
     @Deprecated
     public static final String FIELD_GL2_SOURCE_RADIO_INPUT = "gl2_source_radio_input";
 
+    // Matches whole field names containing a-z, A-Z, 0-9, period char, -, or @.
     private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\.\\-@]*$");
+    // Same as above, but matches only the invalid (non-indicated) characters.
+    // [^ ... ] around the pattern inverts the match.
+    private static final Pattern INVALID_KEY_CHARS = Pattern.compile("[^\\w\\.\\-@]");
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
@@ -625,6 +629,10 @@ public class Message implements Messages, Indexable {
 
     public static boolean validKey(final String key) {
         return VALID_KEY_CHARS.matcher(key).matches();
+    }
+
+    public static String cleanKey(final String key) {
+        return INVALID_KEY_CHARS.matcher(key).replaceAll(String.valueOf(KEY_REPLACEMENT_CHAR));
     }
 
     public void addFields(final Map<String, Object> fields) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -357,13 +357,13 @@ public class MessageTest {
         final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
 
         message.addField(Message.FIELD_TIMESTAMP,
-                         dateTime.toDate());
+                dateTime.toDate());
 
         final Map<String, Object> elasticSearchObject = message.toElasticSearchObject(objectMapper, invalidTimestampMeter);
         final Object esTimestampFormatted = elasticSearchObject.get(Message.FIELD_TIMESTAMP);
 
         assertEquals("Setting message timestamp as java.util.Date results in correct format for elasticsearch",
-                     Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
+                Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
     }
 
     @Test
@@ -390,6 +390,26 @@ public class MessageTest {
         assertFalse(Message.validKey("foo+bar"));
         assertFalse(Message.validKey("foo$bar"));
         assertFalse(Message.validKey(" "));
+    }
+
+    @Test
+    public void testCleanKey() throws Exception {
+        // Valid keys
+        assertEquals("foo123", Message.cleanKey("foo123"));
+        assertEquals("foo-bar123", Message.cleanKey("foo-bar123"));
+        assertEquals("foo_bar123", Message.cleanKey("foo_bar123"));
+        assertEquals("foo.bar123", Message.cleanKey("foo.bar123"));
+        assertEquals("foo@bar", Message.cleanKey("foo@bar"));
+        assertEquals("123", Message.cleanKey("123"));
+        assertEquals("", Message.cleanKey(""));
+
+        assertEquals("foo_bar", Message.cleanKey("foo bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo+bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo$bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo{bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo,bar"));
+        assertEquals("foo_bar", Message.cleanKey("foo?bar"));
+        assertEquals("_", Message.cleanKey(" "));
     }
 
     @Test
@@ -604,9 +624,9 @@ public class MessageTest {
     @Test
     public void fieldTest() {
         assertThat(Message.sizeForField("", true)).isEqualTo(4);
-        assertThat(Message.sizeForField("", (byte)1)).isEqualTo(1);
-        assertThat(Message.sizeForField("", (char)1)).isEqualTo(2);
-        assertThat(Message.sizeForField("", (short)1)).isEqualTo(2);
+        assertThat(Message.sizeForField("", (byte) 1)).isEqualTo(1);
+        assertThat(Message.sizeForField("", (char) 1)).isEqualTo(2);
+        assertThat(Message.sizeForField("", (short) 1)).isEqualTo(2);
         assertThat(Message.sizeForField("", 1)).isEqualTo(4);
         assertThat(Message.sizeForField("", 1L)).isEqualTo(8);
         assertThat(Message.sizeForField("", 1.0f)).isEqualTo(4);

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setField.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setField.txt
@@ -1,0 +1,8 @@
+rule "set_field"
+when true
+then
+  set_field(field: "f1", value: "v1");
+  set_field(field: "f_2", value: "v_2");
+  set_field(field: "f 3", value: "will be skipped");
+  set_field(field: "f 4", value: "will be added with clean field param", clean_field: true);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFields.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFields.txt
@@ -1,0 +1,9 @@
+rule "set_fields"
+when true
+then
+  let newValue = to_map(parse_json(to_string($message.json_field_map)));
+  set_fields(fields: newValue);
+
+  let cleanFieldValue = to_map(parse_json(to_string($message.json_clean_field_map)));
+  set_fields(fields: cleanFieldValue, clean_fields: true);
+end


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/16514 to the `5.1` branch.