### PR TITLE
Update workflows to use new action versions (#16418)

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -14,14 +14,7 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Yarn cache
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-          path: ~/.cache/yarn
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install
       - name: Resetting lockfile

--- a/.github/workflows/reviewbot.yml
+++ b/.github/workflows/reviewbot.yml
@@ -14,11 +14,11 @@ jobs:
     name: Reviewbot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -14,14 +14,7 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Yarn cache
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-          path: ~/.cache/yarn
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install
       - name: Updating browserslist db

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -14,14 +14,7 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Yarn cache
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-yarn-${{ hashFiles('graylog2-web-interface/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-          path: ~/.cache/yarn
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: yarn install
       - name: Create/Update Pull Request


### PR DESCRIPTION
- Update actions/checkout to v4
- Update actions/setup-java to v3
- Remove yarn caching because restoring the cache is slower than downloading all dependencies

Refs #16411

Co-authored-by: Dennis Oelkers <dennis@graylog.com>
(cherry picked from commit b626e4a6ab0e0c8188690edfd0d8749da8205c07)

/nocl