### PR TITLE
Further improvements for new alert styling

### DIFF
--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -29,7 +29,7 @@
     "extends": "graylog"
   },
   "dependencies": {
-    "@graylog/sawmill": "2.0.5",
+    "@graylog/sawmill": "2.0.6",
     "@tanstack/react-query": "4.35.3",
     "@types/create-react-class": "15.6.4",
     "@types/jquery": "3.5.19",

--- a/graylog2-web-interface/src/components/bootstrap/Alert.md
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.md
@@ -34,7 +34,7 @@ styles.map((style, i) => {
 ```tsx
 import Icon from 'components/common/Icon';
 
-<Alert onClose={() => window.alert('You clicked on the alert close icon.')}>
+<Alert onDismiss={() => window.alert('You clicked on the alert close icon.')}>
   Lorem ipsum dolor sit amet consectetur adipisicing elit.
 </Alert>
 ```

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -58,7 +58,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
     },
     title: {
       fontSize: theme.fontSizes.md,
-      color: theme.others.colors.global.textDefault,
+      color: theme.other.colors.global.textDefault,
     },
   });
 

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -23,7 +23,7 @@ import { Alert as MantineAlert, useMantineTheme } from '@mantine/core';
 import Icon from 'components/common/Icon';
 
 type Props = {
-  bsStyle: ColorVariant,
+  bsStyle?: ColorVariant,
   children: React.ReactNode,
   className?: string,
   onDismiss?: () => void,
@@ -58,6 +58,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
     },
     title: {
       fontSize: theme.fontSizes.md,
+      color: theme.others.colors.global.textDefault,
     },
   });
 
@@ -81,6 +82,7 @@ Alert.defaultProps = {
   onDismiss: undefined,
   style: undefined,
   title: undefined,
+  bsStyle: 'default',
 };
 
 export default Alert;

--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -53,11 +53,17 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
   const iconName = iconNameForType(bsStyle);
 
   const alertStyles = () => ({
+    root: {
+      border: `1px solid ${theme.other.shades.lighter(bsStyle)}`,
+    },
     message: {
       fontSize: theme.fontSizes.md,
     },
     title: {
       fontSize: theme.fontSizes.md,
+      color: theme.other.colors.global.textDefault,
+    },
+    closeButton: {
       color: theme.other.colors.global.textDefault,
     },
   });

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2493,10 +2493,10 @@
   dependencies:
     prop-types "^15.8.1"
 
-"@graylog/sawmill@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.5.tgz#c198f46ba799a62b800281446da89b99f6e05c4c"
-  integrity sha512-KomTIkzfn1X7Dg8FJti7cyY+1zBbtrfZfYoqFsyH3l6LgqWcVsa7lUBgbzeZ4dibZ8mZQ9lUEyr7PCB5A3rn6w==
+"@graylog/sawmill@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-2.0.6.tgz#c8a293cd7ecb3e76b1da7bb4c405b69cef8d36ce"
+  integrity sha512-9dnDvQK1Ivw/pdGb0451aCBn/hKSLN8AKcT9aFkwZa+8P1ZOqJzSaVhZG4EghQdVG884RUFuP9ouKHzMgLYp9A==
   dependencies:
     "@openfonts/dm-sans_latin" "^1.0.2"
     "@openfonts/source-sans-pro_latin" "^1.44.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are:
- Fixing the alert headline color
- change default alert background color to default
- Upgrading to sawmill 2.0.6
- Fixing color of alert close icon 
- Adding border for alert to fix contrast problem with "default" background-color in dark mode.

Fixes https://github.com/Graylog2/graylog2-server/issues/16521
/nocl