### PR TITLE
don't save a CA per node, we want only a single one

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CaServiceImpl.java
@@ -55,10 +55,11 @@ import static org.graylog.security.certutil.CertConstants.PKCS12;
 @Singleton
 public class CaServiceImpl implements CaService {
     private static final Logger LOG = LoggerFactory.getLogger(CaServiceImpl.class);
+
+    public final String KEYSTORE_ID = "GRAYLOG CA";
     private final SmartKeystoreStorage keystoreStorage;
     private final KeystoreMongoLocation mongoDbCaLocation;
     private final KeystoreFileLocation manuallyProvidedCALocation;
-    private final NodeId nodeId;
     private final CACreator caCreator;
     private final PemCaReader pemCaReader;
     private final CaConfiguration configuration;
@@ -70,19 +71,17 @@ public class CaServiceImpl implements CaService {
     @Inject
     public CaServiceImpl(final Configuration configuration,
                          final SmartKeystoreStorage keystoreStorage,
-                         final NodeId nodeId,
                          final CACreator caCreator,
                          final PemCaReader pemCaReader,
                          final CertificatesService certificatesService,
                          final @Named("password_secret") String passwordSecret, ClusterEventBus eventBus) {
         this.keystoreStorage = keystoreStorage;
-        this.nodeId = nodeId;
         this.caCreator = caCreator;
         this.pemCaReader = pemCaReader;
         this.configuration = configuration;
         this.certificatesService = certificatesService;
         this.passwordSecret = configuration.getCaPassword() != null ? configuration.getCaPassword() : passwordSecret;
-        this.mongoDbCaLocation = new KeystoreMongoLocation(nodeId.getNodeId(), KeystoreMongoCollections.GRAYLOG_CA_KEYSTORE_COLLECTION);
+        this.mongoDbCaLocation = new KeystoreMongoLocation(KEYSTORE_ID, KeystoreMongoCollections.GRAYLOG_CA_KEYSTORE_COLLECTION);
         this.manuallyProvidedCALocation = new KeystoreFileLocation(configuration.getCaKeystoreFile());
         this.eventBus = eventBus;
     }
@@ -93,7 +92,7 @@ public class CaServiceImpl implements CaService {
             return new CA("local CA", CAType.LOCAL);
         } else {
             var keystore = keystoreStorage.readKeyStore(mongoDbCaLocation, passwordSecret.toCharArray());
-            return keystore.map(c -> new CA(nodeId.getNodeId(), CAType.GENERATED)).orElse(null);
+            return keystore.map(c -> new CA(KEYSTORE_ID, CAType.GENERATED)).orElse(null);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We saved the CA per node - which was not correct as we only want one CA per cluster. As all the cert services etc are also used in different contexts, I included a default CA name instead of refactoring all the services into two separate versions.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

