### PR TITLE
Use nested router on `ConfigurationsPage` to deep-link section.

### DIFF
--- a/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
@@ -16,7 +16,8 @@
  */
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { Navigate, Routes, Route } from 'react-router-dom';
+import { Navigate, Routes, Route, useResolvedPath } from 'react-router-dom';
+import URI from 'urijs';
 
 import ConfigletContainer from 'pages/configurations/ConfigletContainer';
 import { useStore } from 'stores/connect';
@@ -28,6 +29,7 @@ import { PluginConfigurationType } from 'components/configurations/Configuration
 import { Col, Nav, NavItem } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
 import { LinkContainer } from 'components/common/router';
+import useLocation from 'routing/useLocation';
 
 const pluginDisplayNames = [
   {
@@ -55,6 +57,27 @@ const pluginDisplayNames = [
     displayName: 'Geo-Location Processor',
   },
 ];
+
+type PluginSectionLinkProps = {
+  configType: string,
+  displayName: string,
+}
+
+const PluginSectionLink = ({ configType, displayName }: PluginSectionLinkProps) => {
+  const absolutePath = useResolvedPath(configType);
+  const location = useLocation();
+
+  const isActive = URI(location.pathname).equals(absolutePath.pathname)
+    || location.pathname.startsWith(absolutePath.pathname);
+
+  return (
+    <LinkContainer key={`plugin-nav-${configType}`} to={configType}>
+      <NavItem title={displayName} active={isActive}>
+        {displayName}
+      </NavItem>
+    </LinkContainer>
+  );
+};
 
 const PluginsConfig = () => {
   const [activeSectionKey, setActiveSectionKey] = useState(1);
@@ -84,18 +107,11 @@ const PluginsConfig = () => {
              stacked
              activeKey={activeSectionKey}
              onSelect={setActiveSectionKey}>
-          {pluginSystemConfigs.map(({ configType }, index) => {
+          {pluginSystemConfigs.map(({ configType }) => {
             const obj = pluginDisplayNames.find((entry) => entry.configType === configType);
             const displayName = obj?.displayName ?? configType;
 
-            return (
-              <LinkContainer to={configType}>
-
-                <NavItem key={`plugin-nav-${configType}`} eventKey={index + 1} title={displayName}>
-                  {displayName}
-                </NavItem>
-              </LinkContainer>
-            );
+            return <PluginSectionLink configType={configType} displayName={displayName} />;
           })}
         </Nav>
       </Col>

--- a/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
@@ -117,7 +117,7 @@ const PluginsConfig = () => {
       </Col>
       <Col md={8} lg={5}>
         <Routes>
-          <Route path="/" element={<Navigate to={pluginSystemConfigs[0].configType} />} />
+          <Route path="/" element={<Navigate to={pluginSystemConfigs[0].configType} replace />} />
           {pluginSystemConfigs
             .map(({ component: SystemConfigComponent, configType }) => (
               <Route path={configType}

--- a/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PluginsConfig.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { useEffect, useState } from 'react';
+import { Navigate, Routes, Route } from 'react-router-dom';
 
 import ConfigletContainer from 'pages/configurations/ConfigletContainer';
 import { useStore } from 'stores/connect';
@@ -26,6 +27,34 @@ import { getConfig } from 'components/configurations/helpers';
 import { PluginConfigurationType } from 'components/configurations/ConfigurationTypes';
 import { Col, Nav, NavItem } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
+import { LinkContainer } from 'components/common/router';
+
+const pluginDisplayNames = [
+  {
+    configType: PluginConfigurationType.COLLECTORS_SYSTEM,
+    displayName: 'Collectors System',
+  },
+  {
+    configType: PluginConfigurationType.AWS,
+    displayName: 'AWS',
+  },
+  {
+    configType: PluginConfigurationType.THREAT_INTEL,
+    displayName: 'Threat Intelligence Lookup',
+  },
+  {
+    configType: PluginConfigurationType.FAILURE_PROCESSING,
+    displayName: 'Failure Processing',
+  },
+  {
+    configType: PluginConfigurationType.TRAFFIC_LIMIT_VIOLATION,
+    displayName: 'Traffic Limit Violation',
+  },
+  {
+    configType: PluginConfigurationType.GEO_LOCATION,
+    displayName: 'Geo-Location Processor',
+  },
+];
 
 const PluginsConfig = () => {
   const [activeSectionKey, setActiveSectionKey] = useState(1);
@@ -42,33 +71,6 @@ const PluginsConfig = () => {
     });
   }, [configuration, pluginSystemConfigs]);
 
-  const pluginDisplayNames = [
-    {
-      configType: PluginConfigurationType.COLLECTORS_SYSTEM,
-      displayName: 'Collectors System',
-    },
-    {
-      configType: PluginConfigurationType.AWS,
-      displayName: 'AWS',
-    },
-    {
-      configType: PluginConfigurationType.THREAT_INTEL,
-      displayName: 'Threat Intelligence Lookup',
-    },
-    {
-      configType: PluginConfigurationType.FAILURE_PROCESSING,
-      displayName: 'Failure Processing',
-    },
-    {
-      configType: PluginConfigurationType.TRAFFIC_LIMIT_VIOLATION,
-      displayName: 'Traffic Limit Violation',
-    },
-    {
-      configType: PluginConfigurationType.GEO_LOCATION,
-      displayName: 'Geo-Location Processor',
-    },
-  ];
-
   const onUpdate = (configType: string) => (config) => ConfigurationsActions.update(configType, config);
 
   if (!isLoaded || !pluginSystemConfigs) {
@@ -84,27 +86,35 @@ const PluginsConfig = () => {
              onSelect={setActiveSectionKey}>
           {pluginSystemConfigs.map(({ configType }, index) => {
             const obj = pluginDisplayNames.find((entry) => entry.configType === configType);
-            const displayName = obj ? obj.displayName : configType;
+            const displayName = obj?.displayName ?? configType;
 
             return (
-              <NavItem key={`plugin-nav-${configType}`} eventKey={index + 1} title={displayName}>
-                {displayName}
-              </NavItem>
+              <LinkContainer to={configType}>
+
+                <NavItem key={`plugin-nav-${configType}`} eventKey={index + 1} title={displayName}>
+                  {displayName}
+                </NavItem>
+              </LinkContainer>
             );
           })}
         </Nav>
       </Col>
       <Col md={8} lg={5}>
-        {pluginSystemConfigs
-          .map(({ component: SystemConfigComponent, configType }, index) => (
-            (index + 1 === activeSectionKey) && (
-              <ConfigletContainer title={configType} key={`plugin-section-${configType}`}>
-                <SystemConfigComponent key={`system-configuration-${configType}`}
-                                       config={getConfig(configType, configuration) ?? undefined}
-                                       updateConfig={onUpdate(configType)} />
-              </ConfigletContainer>
-            )
-          ))}
+        <Routes>
+          <Route path="/" element={<Navigate to={pluginSystemConfigs[0].configType} />} />
+          {pluginSystemConfigs
+            .map(({ component: SystemConfigComponent, configType }) => (
+              <Route path={configType}
+                     key={configType}
+                     element={(
+                       <ConfigletContainer title={configType} key={`plugin-section-${configType}`}>
+                         <SystemConfigComponent key={`system-configuration-${configType}`}
+                                                config={getConfig(configType, configuration) ?? undefined}
+                                                updateConfig={onUpdate(configType)} />
+                       </ConfigletContainer>
+              )} />
+            ))}
+        </Routes>
       </Col>
     </>
   );

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.test.tsx
@@ -44,7 +44,7 @@ describe('ConfigurationsPage', () => {
 
     render(<ConfigurationsPage />);
 
-    const sidecarNavItem = await screen.findByRole('button', {
+    const sidecarNavItem = await screen.findByRole('link', {
       name: /sidecar/i,
     });
 
@@ -60,7 +60,7 @@ describe('ConfigurationsPage', () => {
 
     render(<ConfigurationsPage />);
 
-    const sidecarNavItem = await screen.findByRole('button', {
+    const sidecarNavItem = await screen.findByRole('link', {
       name: /sidecar/i,
     });
 

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
@@ -197,7 +197,7 @@ const ConfigurationsPage = () => {
         </Col>
 
         <Routes>
-          <Route path="/" element={<Navigate to={configurationSections[0].name} />} />
+          <Route path="/" element={<Navigate to={configurationSections[0].name} replace />} />
           {configurationSections.flatMap(({ catchAll, name, props = {}, SectionComponent }) => (
             <Route path={catchAll ? `${name}/*` : name}
                    key={name}

--- a/graylog2-web-interface/src/routing/AppRouter.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.tsx
@@ -195,7 +195,7 @@ const AppRouter = () => {
             !isCloud && { path: RoutePaths.import_extractors(':nodeId', ':inputId'), element: <ImportExtractorsPage /> },
             !isCloud && { path: RoutePaths.export_extractors(':nodeId', ':inputId'), element: <ExportExtractorsPage /> },
 
-            { path: RoutePaths.SYSTEM.CONFIGURATIONS, element: <ConfigurationsPage /> },
+            { path: `${RoutePaths.SYSTEM.CONFIGURATIONS}/*`, element: <ConfigurationsPage /> },
 
             { path: RoutePaths.SYSTEM.CONTENTPACKS.LIST, element: <ContentPacksPage /> },
             { path: RoutePaths.SYSTEM.CONTENTPACKS.CREATE, element: <CreateContentPackPage /> },

--- a/graylog2-web-interface/webpack.vendor.ts
+++ b/graylog2-web-interface/webpack.vendor.ts
@@ -103,7 +103,9 @@ if (TARGET === 'start') {
       hot: false,
       liveReload: true,
       compress: true,
-      historyApiFallback: true,
+      historyApiFallback: {
+        disableDotRule: true,
+      },
       proxy: {
         '/api': {
           target: apiUrl,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, it was not possible to deep-link configuration sections, a user always had to go through the navigation.

This PR is now adding nested routers for the configuration/plugin sections, so individual sections can be deep-linked.

**Note:** A change to the `webpack-dev-server` config was required, because previously URLs with a dot did not work.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.