### PR TITLE
Make time range preset form in time picker an actual form

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.test.tsx
@@ -26,7 +26,7 @@ import mockSearchClusterConfig from 'fixtures/searchClusterConfig';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import type { TimeRange } from 'views/logic/queries/Query';
 
-import TimeRangeAddToQuickListButton from './TimeRangeAddToQuickListButton';
+import SaveTimeRangeAsPresetButton from './SaveTimeRangeAsPresetButton';
 
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
 jest.mock('lodash/debounce', () => jest.fn());
@@ -49,11 +49,11 @@ jest.mock('stores/configurations/ConfigurationsStore', () => {
   });
 });
 
-describe('TimeRangeAddToQuickListButton', () => {
+describe('SaveTimeRangeAsPresetButton', () => {
   const SUT = ({ timeRange }: { timeRange: TimeRange }) => (
     <Formik initialValues={{ timeRangeTabs: { [timeRange.type]: timeRange }, activeTab: timeRange.type }} onSubmit={() => {}}>
       <Form>
-        <TimeRangeAddToQuickListButton />
+        <SaveTimeRangeAsPresetButton />
       </Form>
     </Formik>
   );
@@ -67,7 +67,7 @@ describe('TimeRangeAddToQuickListButton', () => {
     asMock(debounce as DebouncedFunc<(...args: any) => any>).mockImplementation((fn) => fn);
   });
 
-  const getOpenButton = () => screen.getByRole('button', {
+  const findOpenButton = () => screen.findByRole('button', {
     name: /save current time range as preset/i,
   });
 
@@ -78,7 +78,7 @@ describe('TimeRangeAddToQuickListButton', () => {
         from: 300,
       }} />);
 
-    const buttonIcon = await getOpenButton();
+    const buttonIcon = await findOpenButton();
 
     fireEvent.click(buttonIcon);
 
@@ -94,7 +94,7 @@ describe('TimeRangeAddToQuickListButton', () => {
         from: 50,
       }} />);
 
-    const buttonIcon = await getOpenButton();
+    const buttonIcon = await findOpenButton();
 
     fireEvent.click(buttonIcon);
 
@@ -108,7 +108,7 @@ describe('TimeRangeAddToQuickListButton', () => {
         from: 300,
       }} />);
 
-    const buttonIcon = await getOpenButton();
+    const buttonIcon = await findOpenButton();
 
     fireEvent.click(buttonIcon);
 
@@ -122,7 +122,7 @@ describe('TimeRangeAddToQuickListButton', () => {
         from: 500,
       }} />);
 
-    const buttonIcon = await getOpenButton();
+    const buttonIcon = await findOpenButton();
 
     fireEvent.click(buttonIcon);
 
@@ -163,11 +163,11 @@ describe('TimeRangeAddToQuickListButton', () => {
         from: 500,
       }} />);
 
-    const buttonIcon = await getOpenButton();
+    fireEvent.click(await findOpenButton());
 
-    fireEvent.click(buttonIcon);
-
-    const descriptionInput = await screen.findByLabelText('Time range description');
+    const descriptionInput = await screen.findByRole('textbox', {
+      name: /time range description/i,
+    });
     descriptionInput.focus();
 
     fireEvent.change(descriptionInput, { target: { value: '' } });
@@ -176,6 +176,8 @@ describe('TimeRangeAddToQuickListButton', () => {
       name: /save preset/i,
     });
 
-    await expect(submitButton).toHaveAttribute('disabled');
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(submitButton).toHaveAttribute('disabled'));
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.tsx
@@ -128,7 +128,7 @@ const TimeRangeAddToQuickListForm = ({ addTimerange, toggleModal, target }: Prop
   );
 };
 
-const TimeRangeAddToQuickListButton = () => {
+const SaveTimeRangeAsPresetButton = () => {
   const { userTimezone } = useUserDateTime();
   const { values: { timeRangeTabs, activeTab }, errors } = useFormikContext<TimeRangePickerFormValues>();
   const formTarget = useRef();
@@ -193,4 +193,4 @@ const TimeRangeAddToQuickListButton = () => {
   );
 };
 
-export default TimeRangeAddToQuickListButton;
+export default SaveTimeRangeAsPresetButton;

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
@@ -23,8 +23,8 @@ import styled from 'styled-components';
 import TimeRangePresetDropdown from 'views/components/searchbar/time-range-filter/TimeRangePresetDropdown';
 import { isTimeRange, isTypeRelative } from 'views/typeGuards/timeRange';
 import { IfPermitted } from 'components/common';
-import TimeRangeAddToQuickListButton
-  from 'views/components/searchbar/time-range-filter/time-range-picker/TimeRangeAddToQuickListButton';
+import SaveTimeRangeAsPresetButton
+  from 'views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton';
 import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type {
@@ -69,7 +69,7 @@ const TimeRangePresetRow = () => {
     <Container>
       {showAddToQuickListButton && isTimeRange(timeRangeTabs[activeTab]) && (
         <IfPermitted permissions="clusterconfigentry:edit">
-          <TimeRangeAddToQuickListButton />
+          <SaveTimeRangeAsPresetButton />
         </IfPermitted>
       )}
       {showPresetsButton && <TimeRangePresetDropdown onChange={onSetPreset} />}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are making the time range preset form in the time range picker an actual `form`, mainly to be able to submit the form by pressing the return key.

/nocl
