### PR TITLE
Fix description for multiple matching highlighting rules.

### DIFF
--- a/changelog/unreleased/pr-16668.toml
+++ b/changelog/unreleased/pr-16668.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix description for the scenario that one term or value has multiple matching highlighting rules."
+
+pulls = ["16668"]

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -70,7 +70,7 @@ const HighlightingRules = () => {
       <SectionInfo>
         Search terms and field values can be highlighted. Highlighting your search query in the results can be enabled/disabled in the graylog server config.
         Any field value can be highlighted by clicking on the value and selecting &quot;Highlight this value&quot;.
-        If a term or a value has more than one rule, the last matching rule is used.
+        If a term or a value has more than one rule, the first matching rule is used.
       </SectionInfo>
       <SectionSubheadline>Active highlights <IconButton className="pull-right" name="plus" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
       {showForm && <HighlightForm onClose={() => setShowForm(false)} />}


### PR DESCRIPTION
**Please note**: this PR needs a backport for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing the description for the scenario that one term or value has multiple matching highlighting rules.
Before the description said: "If a term or a value has more than one rule, the last matching rule is used."
Now it says "...the first matching rule is used."

Here is an example:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/d36c83ff-d331-419f-8b8c-9fb6ed25e685)

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/41315b07-070c-4449-905a-1271a37c4fcd)
