### PR TITLE
Remove "<repositories>" from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,31 +207,6 @@
         <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
     </properties>
 
-    <repositories>
-        <!-- to make our snapshot releases work with Travis et al -->
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-releases</id>
-            <name>Sonatype Nexus Releases</name>
-            <url>https://oss.sonatype.org/content/repositories/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <!-- Ensure consistent versions across dependencies and transitive dependencies -->
     <dependencyManagement>


### PR DESCRIPTION
Since we haven't published SNAPSHOT releases of Graylog for a long time, we don't need the custom configuration anymore.

The configuration also breaks GitHub's dependabot checks due to a bug in the dependabot-core maven module:
https://github.com/dependabot/dependabot-core/issues/5947