### PR TITLE
Update guice to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <grpc.version>1.58.0</grpc.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>32.1.2-jre</guava.version>
-        <guice.version>5.0.1</guice.version>
+        <guice.version>6.0.0</guice.version>
         <HdrHistogram.version>2.1.12</HdrHistogram.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>


### PR DESCRIPTION
Guice 7.0.0 is already available, but we can't update to that version yet, because it doesn't support the old "java.inject.*" namespace anymore.

See: https://github.com/google/guice/wiki/Guice600#jee-jakarta-transition

We can update to 7.x when we do the Jakarta transition for all of our dependencies.

Changes:
- 5.1.0: https://github.com/google/guice/wiki/Guice510#changes-since-guice-501
- 6.0.0: https://github.com/google/guice/wiki/Guice600#changes-since-guice-510

/nocl