### PR TITLE
Remove query from view state when removing a page in the pages configuration modal.

### DIFF
--- a/changelog/unreleased/issue-16634.toml
+++ b/changelog/unreleased/issue-16634.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing error which occurred when saving a dashboard after deleting a page in the pages configuration modal."
+
+issues = ["16634"]
+pulls = ["16674"]

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -370,7 +370,7 @@ const AdaptableQueryTabs = ({
       {showConfigurationModal && (
         <AdaptableQueryTabsConfiguration show={showConfigurationModal}
                                          setShow={setShowConfigurationModal}
-                                         onRemove={onRemove}
+                                         dashboardId={dashboardId}
                                          queriesList={currentTabs.queriesList}
                                          activeQueryId={activeQueryId} />
       )}

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -269,7 +269,7 @@ const AdaptableQueryTabs = ({
       const tabTitle = (
         <QueryTitle active={id === activeQueryId}
                     id={id}
-                    onClose={() => onRemove(id)}
+                    onRemove={() => onRemove(id)}
                     openEditModal={openTitleEditModal}
                     openCopyToDashboardModal={toggleCopyToDashboardModal}
                     allowsClosing={queries.size > 1}
@@ -370,9 +370,9 @@ const AdaptableQueryTabs = ({
       {showConfigurationModal && (
         <AdaptableQueryTabsConfiguration show={showConfigurationModal}
                                          setShow={setShowConfigurationModal}
+                                         onRemove={onRemove}
                                          queriesList={currentTabs.queriesList}
-                                         activeQueryId={activeQueryId}
-                                         dashboardId={dashboardId} />
+                                         activeQueryId={activeQueryId} />
       )}
       {showCopyToDashboardModal && (
         <CopyToDashboardForm onSubmit={(selectedDashboardId) => onCopyToDashboard(selectedDashboardId)}

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -53,7 +53,7 @@ describe('AdaptableQueryTabsConfiguration', () => {
       <AdaptableQueryTabsConfiguration show
                                        setShow={() => {}}
                                        activeQueryId="queryId-1"
-                                       dashboardId="dashboard-id"
+                                       onRemove={() => Promise.resolve()}
                                        queriesList={OrderedSet(
                                          [
                                            { id: 'queryId-1', title: 'Query Title 1' },

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -53,7 +53,7 @@ describe('AdaptableQueryTabsConfiguration', () => {
       <AdaptableQueryTabsConfiguration show
                                        setShow={() => {}}
                                        activeQueryId="queryId-1"
-                                       onRemove={() => Promise.resolve()}
+                                       dashboardId="dashboard-id"
                                        queriesList={OrderedSet(
                                          [
                                            { id: 'queryId-1', title: 'Query Title 1' },

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -82,12 +82,12 @@ type Props = {
 const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQueryId, dashboardId }: Props) => {
   const { setDashboardPage } = useContext(DashboardPageContext);
   const widgetIds = useWidgetIds();
-  const [orderedQueriesList, setOrderedQueriesList] = useState<Immutable.OrderedSet<PageListItem>>(queriesList);
-  const disablePageDelete = orderedQueriesList.size <= 1;
+  const [nextQueriesList, setNextQueriesList] = useState<Immutable.OrderedSet<PageListItem>>(queriesList);
+  const disablePageDelete = nextQueriesList.size <= 1;
   const dispatch = useAppDispatch();
   const sendTelemetry = useSendTelemetry();
   const onConfirmPagesConfiguration = useCallback(() => {
-    const isActiveQueryDeleted = !orderedQueriesList.find(({ id }) => id === activeQueryId);
+    const isActiveQueryDeleted = !nextQueriesList.find(({ id }) => id === activeQueryId);
 
     sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_PAGE_CONFIGURATION_UPDATED, {
       app_pathname: 'dashboard',
@@ -96,14 +96,15 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
     });
 
     if (isActiveQueryDeleted) {
-      const indexedQueryIds = queriesList.map(({ id }) => id).toIndexedSeq();
-      const newActiveQueryId = FindNewActiveQueryId(Immutable.List(indexedQueryIds), activeQueryId);
+      const indexedQueryIds = queriesList.map(({ id }) => id).toList();
+      const removedQueryIds = indexedQueryIds.filter((queryId) => !nextQueriesList.find((query) => queryId === query.id)).toList();
+      const newActiveQueryId = FindNewActiveQueryId(indexedQueryIds, activeQueryId, removedQueryIds);
       setDashboardPage(newActiveQueryId);
     }
 
-    dispatch(setQueriesOrder(orderedQueriesList.map(({ id }) => id).toOrderedSet()))
+    dispatch(setQueriesOrder(nextQueriesList.map(({ id }) => id).toOrderedSet()))
       .then(() => {
-        const newTitles = orderedQueriesList.map(({ id, title }) => {
+        const newTitles = nextQueriesList.map(({ id, title }) => {
           const titleMap = Immutable.Map<string, string>({ title });
           const titlesMap = Immutable.Map<TitleType, Immutable.Map<string, string>>({ [TitleTypes.Tab]: titleMap }) as TitlesMap;
 
@@ -113,7 +114,8 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
         dispatch(mergeQueryTitles(newTitles));
         setShow(false);
       });
-  }, [orderedQueriesList, sendTelemetry, dispatch, activeQueryId, queriesList, setDashboardPage, setShow]);
+  }, [nextQueriesList, sendTelemetry, dispatch, activeQueryId, queriesList, setDashboardPage, setShow]);
+
   const onPagesConfigurationModalClose = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_PAGE_CONFIGURATION_CANCELED, {
       app_pathname: 'dashboard',
@@ -130,11 +132,11 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
       app_action_value: 'dashboard-page-configuration-sorting',
     });
 
-    setOrderedQueriesList(Immutable.OrderedSet(order));
-  }, [sendTelemetry, setOrderedQueriesList]);
+    setNextQueriesList(Immutable.OrderedSet(order));
+  }, [sendTelemetry, setNextQueriesList]);
 
   const onUpdateTitle = useCallback((id: string, title: string) => {
-    setOrderedQueriesList((currentQueries) => currentQueries
+    setNextQueriesList((currentQueries) => currentQueries
       .map((query) => (query.id === id ? { id, title } : query))
       .toOrderedSet());
   }, []);
@@ -151,7 +153,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
         app_action_value: 'dashboard-page-configuration-remove-page',
       });
 
-      setOrderedQueriesList((currentQueries) => currentQueries
+      setNextQueriesList((currentQueries) => currentQueries
         .filter((query) => query.id !== queryId).toOrderedSet());
     }
 
@@ -178,7 +180,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
           Use drag and drop to change the order of the dashboard pages.
           Double-click on a dashboard title to change it.
         </p>
-        <SortableList<PageListItem> items={orderedQueriesList.toArray()}
+        <SortableList<PageListItem> items={nextQueriesList.toArray()}
                                     onMoveItem={updatePageSorting}
                                     displayOverlayInPortal
                                     alignItemContent="center"

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -97,7 +97,8 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
 
     if (isActiveQueryDeleted) {
       const indexedQueryIds = queriesList.map(({ id }) => id).toList();
-      const removedQueryIds = indexedQueryIds.filter((queryId) => !nextQueriesList.find((query) => queryId === query.id)).toList();
+      const nextQueryIds = nextQueriesList.map(({ id }) => id).toArray();
+      const removedQueryIds = indexedQueryIds.filter((queryId) => !nextQueryIds.includes(queryId)).toList();
       const newActiveQueryId = FindNewActiveQueryId(indexedQueryIds, activeQueryId, removedQueryIds);
       setDashboardPage(newActiveQueryId);
     }

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -62,8 +62,14 @@ const QueryBar = () => {
     }
   }, [dispatch, setDashboardPage]);
 
-  const onRemove = useCallback((queryId: string) => onCloseTab(dashboardId, queryId, activeQueryId, queries, widgetIds, dispatch),
-    [dashboardId, activeQueryId, queries, widgetIds, dispatch]);
+  const onRemove = useCallback((queryId: string) => onCloseTab(
+    dashboardId,
+    queryId,
+    activeQueryId,
+    queries,
+    widgetIds,
+    dispatch),
+  [dashboardId, activeQueryId, queries, widgetIds, dispatch]);
 
   const _onTitleChange = useCallback((queryId: string, newTitle: string) => dispatch(setTitle(queryId, 'tab', 'title', newTitle)), [dispatch]);
 

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -31,7 +31,7 @@ import { setTitle } from 'views/logic/slices/titlesActions';
 
 import QueryTabs from './QueryTabs';
 
-const onCloseTab = async (dashboardId: string, queryId: string, activeQueryId: string, queries: Immutable.OrderedSet<string>, widgetIds: Immutable.Map<string, Immutable.List<string>>, dispatch: AppDispatch) => {
+const onRemovePage = async (dashboardId: string, queryId: string, activeQueryId: string, queries: Immutable.OrderedSet<string>, widgetIds: Immutable.Map<string, Immutable.List<string>>, dispatch: AppDispatch) => {
   if (queries.size === 1) {
     return Promise.resolve();
   }
@@ -62,14 +62,17 @@ const QueryBar = () => {
     }
   }, [dispatch, setDashboardPage]);
 
-  const onRemove = useCallback((queryId: string) => onCloseTab(
-    dashboardId,
-    queryId,
-    activeQueryId,
-    queries,
-    widgetIds,
-    dispatch),
-  [dashboardId, activeQueryId, queries, widgetIds, dispatch]);
+  const removePage = useCallback(
+    (queryId: string) => onRemovePage(
+      dashboardId,
+      queryId,
+      activeQueryId,
+      queries,
+      widgetIds,
+      dispatch,
+    ),
+    [dashboardId, activeQueryId, queries, widgetIds, dispatch],
+  );
 
   const _onTitleChange = useCallback((queryId: string, newTitle: string) => dispatch(setTitle(queryId, 'tab', 'title', newTitle)), [dispatch]);
 
@@ -80,7 +83,7 @@ const QueryBar = () => {
                dashboardId={dashboardId}
                onSelect={onSelectPage}
                onTitleChange={_onTitleChange}
-               onRemove={onRemove} />
+               onRemove={removePage} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -55,7 +55,7 @@ const QueryBar = () => {
 
   const onSelectPage = useCallback((pageId: string) => {
     if (pageId === 'new') {
-      dispatch(createQuery());
+      dispatch(createQuery()).then((newPageId) => setDashboardPage(newPageId));
     } else {
       setDashboardPage(pageId);
       dispatch(selectQuery(pageId));

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
@@ -62,7 +62,7 @@ describe('QueryTitle', () => {
       <QueryTitle active
                   id="query-id-1"
                   openEditModal={() => {}}
-                  onClose={() => Promise.resolve()}
+                  onRemove={() => Promise.resolve()}
                   title="Foo"
                   openCopyToDashboardModal={() => {}}
                   {...props} />

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -36,13 +36,13 @@ type Props = {
   active: boolean,
   allowsClosing?: boolean,
   id: QueryId,
-  onClose: () => Promise<void | ViewState>,
+  onRemove: () => Promise<void | ViewState>,
   openEditModal: (title: string) => void,
   openCopyToDashboardModal: (isOpen: boolean) => void,
   title: string,
 };
 
-const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCopyToDashboardModal, title }: Props) => {
+const QueryTitle = ({ active, allowsClosing, id, onRemove, openEditModal, openCopyToDashboardModal, title }: Props) => {
   const [titleValue, setTitleValue] = useState(title);
   const { setDashboardPage } = useContext(DashboardPageContext);
   const dispatch = useAppDispatch();
@@ -68,7 +68,7 @@ const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCop
             Copy to Dashboard
           </MenuItem>
           <MenuItem divider />
-          <MenuItem onSelect={onClose} disabled={!allowsClosing}>Delete</MenuItem>
+          <MenuItem onSelect={onRemove} disabled={!allowsClosing}>Delete</MenuItem>
         </QueryActionDropdown>
       )}
     </>
@@ -77,7 +77,7 @@ const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCop
 
 QueryTitle.propTypes = {
   allowsClosing: PropTypes.bool,
-  onClose: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   openEditModal: PropTypes.func.isRequired,
 };

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -181,7 +181,7 @@ export const addQuery = (query: Query, viewState: ViewStateType) => async (dispa
     .state(newViewStates)
     .build();
 
-  return dispatch(updateView(newView, true)).then(() => dispatch(selectQuery(query.id)));
+  return dispatch(updateView(newView, true)).then(() => dispatch(selectQuery(query.id))).then(() => query.id);
 };
 
 export const updateQuery = (queryId: QueryId, query: Query) => async (dispatch: AppDispatch, getState: () => RootState) => {

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -161,8 +161,13 @@ export const updateQueries = (newQueries: Immutable.OrderedSet<Query>) => async 
     .build();
 
   const searchAfterSave = await createSearch(newSearch);
+  const newViewState = view.state.filter((_state, queryId) => (
+    !!newQueries.find((query) => query.id === queryId)),
+  ).toMap();
+
   const newView = view.toBuilder()
     .search(searchAfterSave)
+    .state(newViewState)
     .build();
 
   return dispatch(updateView(newView));

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
@@ -32,5 +32,7 @@ describe('FindNewActiveQuery', () => {
   it('returns next query when current query is removed', () => {
     expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'bar', Immutable.List(['bar']))).toEqual('foo');
     expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['foo', 'baz']))).toEqual('bar');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'baz', Immutable.List(['baz']))).toEqual('bar');
+    expect(FindNewActiveQuery(Immutable.List(['bar', 'baz']), 'foo', Immutable.List(['foo']))).toEqual('bar');
   });
 });

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
@@ -1,0 +1,20 @@
+import * as Immutable from 'immutable';
+
+import FindNewActiveQuery from 'views/logic/views/FindNewActiveQuery';
+
+describe('FindNewActiveQuery', () => {
+  it('does not break when there are no queries left', () => {
+    expect(FindNewActiveQuery(Immutable.List(), 'deadbeef')).toBeUndefined();
+    expect(FindNewActiveQuery(Immutable.List(['foo']), 'deadbeef', Immutable.List(['foo']))).toBeUndefined();
+  });
+
+  it('returns current query when it is still present', () => {
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['bar']))).toEqual('foo');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['bar', 'baz']))).toEqual('foo');
+  });
+
+  it('returns next query when current query is removed', () => {
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'bar', Immutable.List(['bar']))).toEqual('foo');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['foo', 'baz']))).toEqual('bar');
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as Immutable from 'immutable';
 
 import FindNewActiveQuery from 'views/logic/views/FindNewActiveQuery';

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -21,8 +21,7 @@ import { List } from 'immutable';
 const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string> = List()) => {
   const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
   const priorQueryIds = queryIds.slice(0, currentQueryIdIndex).toList();
-
-  const listToPickNewIdFrom = priorQueryIds.isEmpty
+  const listToPickNewIdFrom = priorQueryIds.isEmpty()
     ? queryIds
     : priorQueryIds.reverse();
 

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -16,14 +16,13 @@
  */
 
 // Returns a new query ID, in case the active query gets deleted.
-import type { List } from 'immutable';
+import { List } from 'immutable';
 
-const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string) => {
+const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string> = List()) => {
   const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
-  const newQueryIdIndex = Math.min(0, currentQueryIdIndex - 1);
+  const priorQueryIds = queryIds.slice(0, currentQueryIdIndex);
 
-  return queryIds.filter((queryId) => (queryId !== activeQueryId))
-    .get(newQueryIdIndex);
+  return priorQueryIds.reverse().find((queryId) => !removedQueryIds.includes(queryId));
 };
 
 export default FindNewActiveQueryId;

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -20,9 +20,13 @@ import { List } from 'immutable';
 
 const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string> = List()) => {
   const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
-  const priorQueryIds = queryIds.slice(0, currentQueryIdIndex);
+  const priorQueryIds = queryIds.slice(0, currentQueryIdIndex).toList();
 
-  return priorQueryIds.reverse().find((queryId) => !removedQueryIds.includes(queryId));
+  const listToPickNewIdFrom = priorQueryIds.isEmpty
+    ? queryIds
+    : priorQueryIds.reverse();
+
+  return listToPickNewIdFrom.find((queryId) => !removedQueryIds.includes(queryId));
 };
 
 export default FindNewActiveQueryId;


### PR DESCRIPTION
**Please note:** this PR needs a backport for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the bug described in https://github.com/Graylog2/graylog2-server/issues/16634. Before this change a dashboard could not be saved after deleting a dashboard page in the pages configuration modal.

Fixes #16634