### PR TITLE
DataNode: Delay resume for non leader nodes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -209,6 +209,16 @@ public abstract class ServerBootstrap extends CmdLineTool {
         } finally {
             serviceManager.stopAsync().awaitStopped();
         }
+        try {
+            // give the leader node a headstart on resume so it can take care of mongo-collections etc.
+            // and we prevent problems that occured if all nodes started exactly at the same time
+            if (!configuration.isLeader())
+            {
+                Thread.sleep(5000);
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("Tried to wait for a bit before resuming but got interrupted. Resuming anyway now. Error was: {}", e.getMessage());
+        }
     }
 
     private void runMongoPreflightCheck() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Problems occurred in a multi-node cluster when all the GL nodes resumed the preflight at the same moment. All nodes tried to create collections at the same time which resulted in Exceptions that were not caught but could be ignored in the future. As this would be a larger refactoring, we opt for delaying all nodes that are not the leader node, so that the leader takes care of creating the collections first.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

