### PR TITLE
Toggle preflight feature flag.

### DIFF
--- a/changelog/unreleased/pr-16722.toml
+++ b/changelog/unreleased/pr-16722.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Enabling pre-flight UI for general availability."
+
+pulls = ["16722"]

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -65,8 +65,8 @@ field_types_management=off
 # Enabling inputs in cloud environment
 cloud_inputs=on
 
-# Preflight web is currently disabled by default
-preflight_web=off
+# Preflight web for cluster bootstrapping
+preflight_web=on
 
 # Instant archiving is disabled by default
 instant_archiving=off


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is toggling the preflight UI feature flag to be turned on by default, enabling it for general usage.

### What is the Pre-Flight UI?

The pre-flight UI is a special mode of the Graylog server which is activated at the first start on fresh installs. It is supposed to help with setting up new clusters. In this first version, it helps with setting up Data Nodes (a drop-in replacement for OpenSearch) as well as CA certificate management and provisioning of Data Nodes with matching certificates.

After the initial setup/provisioning, regular operation of Graylog server continues.

Fixes #16602.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.