### PR TITLE
Skip building assemblies in full backend tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/MavenPackager.java
@@ -33,7 +33,7 @@ import static org.graylog.testing.graylognode.ExecutableFileUtil.makeSureExecuta
 
 public class MavenPackager {
     private static final Logger LOG = LoggerFactory.getLogger(MavenPackager.class);
-    private static final String MVN_COMMAND = "mvn -V package -DskipTests -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true ";
+    private static final String MVN_COMMAND = "mvn -V package -DskipTests -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS ";
     private static final String EXCLUDE_FE = " -Dskip.web.build ";
 
     private static boolean jarHasBeenPackagedInThisRun = false;


### PR DESCRIPTION
Just a test if we can skip building the assemblies when running the full backend tests.
