### PR TITLE
Revert "Bump io.netty:netty-bom from 4.1.97.Final to 4.1.98.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <mongojack.version>2.10.1.3</mongojack.version>
         <mongojack4.version>4.8.0-1</mongojack4.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.98.Final</netty.version>
+        <netty.version>4.1.97.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.11.0</okhttp.version>
         <okio.version>3.5.0</okio.version>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Revert upgrade from `4.1.97.Final` to `4.1.98.Final` from https://github.com/Graylog2/graylog2-server/pull/16699.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This update appears to cause a runtime issue on Mac systems. On my M1 Mac, when starting Graylog, the following error occurs. The same issue affects the recent `5.2.0-alpha.1` build. 

> dyld[3001]: missing symbol called

![image](https://github.com/Graylog2/graylog2-server/assets/3423655/cac17632-9bf6-4f86-9d1c-e88ee6e8b6bb)

From testing reversion of various commits, I was able to narrow it down to this specific commit causing the issue (when reverted, the error does not occur).

An issue has been raised with Netty for the same error on Mac systems within the last week with several thumbs-ups:
https://github.com/netty/netty/issues/13632

I think we should wait until the issue is addressed by Netty in a subsequent version before updating the dependency. 

/nocl
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On an M1 Mac, start the `5.2.0-alpha.1` tar build, or run the latest master in Intellij. Verify that the error happens. 
Reverted the Netty upgrade, and confirmed the issue is resolved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

