### PR TITLE
Revert "Bump org.codehaus.mojo:rpm-maven-plugin from 2.2.0 to 2.3.0"

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -44,7 +44,7 @@
 
         <!-- Plugin versions -->
         <jdeb.version>1.10</jdeb.version>
-        <rpm-maven.version>2.3.0</rpm-maven.version>
+        <rpm-maven.version>2.2.0</rpm-maven.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Breaks IntelliJ.

This reverts commit 8ab78cbc4bd8e4d1f8d1919d88d7177a3466cb10.