### PR TITLE
Remove okta-sdk.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
         <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.11.0</okhttp.version>
         <okio.version>3.5.0</okio.version>
-        <okta-sdk.version>8.2.1</okta-sdk.version>
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.30.0</opentelemetry.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
We only use it in the enterprise repository since we merged our plugins.

/nocl
/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/5878