### PR TITLE
allow overriding`PluginLoader`

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -79,6 +79,7 @@ import org.graylog2.storage.versionprobe.ElasticsearchProbeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
@@ -268,7 +269,7 @@ public abstract class CmdLineTool implements CliCommand {
         MetricRegistry metricRegistry = MetricRegistryFactory.create();
         featureFlags = getFeatureFlags(metricRegistry);
 
-        pluginLoader = new PluginLoader(getPluginPath(configFile).toFile(), chainingClassLoader);
+        pluginLoader = getPluginLoader(getPluginPath(configFile).toFile(), chainingClassLoader);
 
         installCommandConfig();
         installPluginBootstrapConfig(pluginLoader);
@@ -325,6 +326,10 @@ public abstract class CmdLineTool implements CliCommand {
         reporter.start();
 
         startCommand();
+    }
+
+    protected PluginLoader getPluginLoader(File pluginDir, ChainingClassLoader classLoader) {
+        return new PluginLoader(pluginDir, classLoader);
     }
 
     private void installPluginBootstrapConfig(PluginLoader pluginLoader) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
@@ -52,7 +52,7 @@ public class PluginLoader {
     private static final String[] PLUGIN_FILE_EXTENSIONS = {"jar", "JAR"};
 
     private final File pluginDir;
-    private final ChainingClassLoader classLoader;
+    protected final ChainingClassLoader classLoader;
 
     public PluginLoader(File pluginDir, ChainingClassLoader classLoader) {
         this.pluginDir = requireNonNull(pluginDir);
@@ -72,11 +72,11 @@ public class PluginLoader {
                 .build();
     }
 
-    private Iterable<Plugin> loadClassPathPlugins() {
+    protected Iterable<Plugin> loadClassPathPlugins() {
         return ServiceLoader.load(Plugin.class);
     }
 
-    private Iterable<Plugin> loadJarPlugins() {
+    protected Iterable<Plugin> loadJarPlugins() {
         return ImmutableSet.copyOf(ServiceLoader.load(Plugin.class, classLoader));
     }
 
@@ -204,7 +204,7 @@ public class PluginLoader {
         }
     }
 
-    private class PluginAdapterFunction implements Function<Plugin, Plugin> {
+    protected class PluginAdapterFunction implements Function<Plugin, Plugin> {
         private final Injector injector;
 
         public PluginAdapterFunction(Injector injector) {


### PR DESCRIPTION
## Description
allow setting a custom `PluginLoader` in `CmdLineTools` and make methods visible for overriding

## Motivation and Context
needed for skipping loading of plugins in forwarder after merging enterprise-integrations plugin into enterprise

/nocl
