### PR TITLE
Visual improvements for Field Type Change modal.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
@@ -51,7 +51,7 @@ public class IndexSetFieldTypeSummaryService {
             EntityAttribute.builder().id(INDEX_SET_ID).title("Index Set Id").hidden(true).sortable(true).build(),
             EntityAttribute.builder().id(INDEX_SET_TITLE).title("Index Set Title").sortable(true).build(),
             EntityAttribute.builder().id(STREAM_TITLES).title("Stream Titles").sortable(false).build(),
-            EntityAttribute.builder().id(FIELD_TYPE_HISTORY).title("Field Type History").sortable(false).build()
+            EntityAttribute.builder().id(FIELD_TYPE_HISTORY).title("Current Types").sortable(false).build()
     );
 
     private final IndexFieldTypesService indexFieldTypesService;

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useMemo, useCallback, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
+import { Badge, BootstrapModalForm, Alert, Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';
 import StreamLink from 'components/streams/StreamLink';
-import { BootstrapModalForm, Alert, Input } from 'components/bootstrap';
 import useFiledTypes from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypes';
 import IndexSetsTable from 'views/logic/fieldactions/ChangeFieldType/IndexSetsTable';
 import usePutFiledTypeMutation from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypeMutation';
@@ -32,6 +32,12 @@ const StyledSelect = styled(Select)`
   width: 400px;
   margin-bottom: 20px;
 `;
+
+const RedBadge = styled(Badge)(({ theme }) => css`
+  background-color: ${theme.colors.variant.light.danger};
+`);
+
+const BetaBadge = () => <RedBadge>Beta Feature</RedBadge>;
 
 const failureStreamId = '000000000000000000000004';
 
@@ -72,7 +78,7 @@ const ChangeFieldTypeModal = ({ show, onClose, field }: Props) => {
   }, []);
 
   return (
-    <BootstrapModalForm title={`Change ${field} field type`}
+    <BootstrapModalForm title={<span>Change {field} field type <BetaBadge /></span>}
                         submitButtonText="Change field type"
                         onSubmitForm={onSubmit}
                         onCancel={onClose}

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
@@ -91,7 +91,7 @@ const ChangeFieldTypeModal = ({ show, onClose, field }: Props) => {
           ingestion errors. It is recommended to enable <DocumentationLink page={DocsHelper.PAGES.INDEXER_FAILURES} displayIcon text="Failure Processing" /> and watch
           the {failureStreamLoading ? <Spinner /> : <StreamLink stream={failureStream} />} stream closely afterwards.
         </Alert>
-        <Input label="New Field Type:">
+        <Input label="New Field Type:" id="new-field-type">
           <StyledSelect inputId="field_type"
                         options={fieldTypeOptions}
                         value={newFieldType}

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
@@ -26,6 +26,7 @@ import usePutFiledTypeMutation from 'views/logic/fieldactions/ChangeFieldType/ho
 import useStream from 'components/streams/hooks/useStream';
 import { DocumentationLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
+import { defaultCompare } from 'logic/DefaultCompare';
 
 const StyledSelect = styled(Select)`
   width: 400px;
@@ -44,10 +45,12 @@ const ChangeFieldTypeModal = ({ show, onClose, field }: Props) => {
   const [rotated, setRotated] = useState(false);
   const [newFieldType, setNewFieldType] = useState(null);
   const { data: { fieldTypes }, isLoading: isOptionsLoading } = useFiledTypes();
-  const fieldTypeOptions = useMemo(() => Object.entries(fieldTypes).map(([value, label]) => ({
-    value,
-    label,
-  })), [fieldTypes]);
+  const fieldTypeOptions = useMemo(() => Object.entries(fieldTypes)
+    .sort(([, label1], [, label2]) => defaultCompare(label1, label2))
+    .map(([value, label]) => ({
+      value,
+      label,
+    })), [fieldTypes]);
   const { data: failureStream, isFetching: failureStreamLoading } = useStream(failureStreamId);
 
   const [indexSetSelection, setIndexSetSelection] = useState<Array<string>>();
@@ -82,14 +85,16 @@ const ChangeFieldTypeModal = ({ show, onClose, field }: Props) => {
           ingestion errors. It is recommended to enable <DocumentationLink page={DocsHelper.PAGES.INDEXER_FAILURES} displayIcon text="Failure Processing" /> and watch
           the {failureStreamLoading ? <Spinner /> : <StreamLink stream={failureStream} />} stream closely afterwards.
         </Alert>
-        <StyledSelect inputId="field_type"
-                      options={fieldTypeOptions}
-                      value={newFieldType}
-                      onChange={onChangeFieldType}
-                      placeholder="Select field type"
-                      disabled={isOptionsLoading}
-                      inputProps={{ 'aria-label': 'Select field type' }}
-                      required />
+        <Input label="New Field Type:">
+          <StyledSelect inputId="field_type"
+                        options={fieldTypeOptions}
+                        value={newFieldType}
+                        onChange={onChangeFieldType}
+                        placeholder="Select field type"
+                        disabled={isOptionsLoading}
+                        inputProps={{ 'aria-label': 'Select field type' }}
+                        required />
+        </Input>
         <Alert bsStyle="info">
           By default the type will be changed in all index sets of the current message/search. By expanding the next section, you can select for which index sets you would like to make the change.
         </Alert>

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/hooks/useColumnRenderers.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/hooks/useColumnRenderers.tsx
@@ -31,7 +31,7 @@ const RestTypesContainer = styled.i(({ theme }) => css`
 export const useColumnRenderers = (fieldTypes: FieldTypes) => {
   const customColumnRenderers: ColumnRenderers<FieldTypeUsage> = useMemo(() => ({
     attributes: {
-      streamTitles: {
+      stream_titles: {
         renderCell: (streams: Array<string>) => streams.join(', '),
       },
       types: {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding minor visual improvements for the Field Type Change modal:

  - The new field type select got a label
  - Field types are sorted lexicographically
  - The modal title got a beta label
  - The Field Type History column was renamed to `Current Types`
  - Stream titles are rendered so they are joined using `,` and shown
    completely

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://github.com/Graylog2/graylog2-server/assets/41929/e560ff5d-b9a9-4f6e-a7f1-838a31ce3be2)

![image](https://github.com/Graylog2/graylog2-server/assets/41929/dc30c101-2d0e-48d4-8340-22508a42861c)

After:

![image](https://github.com/Graylog2/graylog2-server/assets/41929/e43710e7-0f3f-43fb-99e1-24d4c8d0c17d)

![image](https://github.com/Graylog2/graylog2-server/assets/41929/51ba0b75-e853-4274-99fc-450866ecd79f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.