### PR TITLE
Remove query from view state when removing a page in the pages configuration modal (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-16634.toml
+++ b/changelog/unreleased/issue-16634.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing error which occurred when saving a dashboard after deleting a page in the pages configuration modal."
+
+issues = ["16634"]
+pulls = ["16674"]

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -253,7 +253,7 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, activeQueryId, onRemove
       const tabTitle = (
         <QueryTitle active={id === activeQueryId}
                     id={id}
-                    onClose={() => onRemove(id)}
+                    onRemove={() => onRemove(id)}
                     openEditModal={openTitleEditModal}
                     openCopyToDashboardModal={toggleCopyToDashboardModal}
                     allowsClosing={queries.size > 1}
@@ -336,9 +336,9 @@ const AdaptableQueryTabs = ({ maxWidth, queries, titles, activeQueryId, onRemove
       {showConfigurationModal && (
         <AdaptableQueryTabsConfiguration show={showConfigurationModal}
                                          setShow={setShowConfigurationModal}
+                                         dashboardId={dashboardId}
                                          queriesList={currentTabs.queriesList}
-                                         activeQueryId={activeQueryId}
-                                         dashboardId={dashboardId} />
+                                         activeQueryId={activeQueryId} />
       )}
       {showCopyToDashboardModal && (
         <CopyToDashboardForm onSubmit={(selectedDashboardId) => onCopyToDashboard(selectedDashboardId)}

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -31,7 +31,7 @@ import { setTitle } from 'views/logic/slices/titlesActions';
 
 import QueryTabs from './QueryTabs';
 
-const onCloseTab = async (dashboardId: string, queryId: string, activeQueryId: string, queries: Immutable.OrderedSet<string>, widgetIds: Immutable.Map<string, Immutable.List<string>>, dispatch: AppDispatch) => {
+const onRemovePage = async (dashboardId: string, queryId: string, activeQueryId: string, queries: Immutable.OrderedSet<string>, widgetIds: Immutable.Map<string, Immutable.List<string>>, dispatch: AppDispatch) => {
   if (queries.size === 1) {
     return Promise.resolve();
   }
@@ -55,15 +55,24 @@ const QueryBar = () => {
 
   const onSelectPage = useCallback((pageId: string) => {
     if (pageId === 'new') {
-      dispatch(createQuery());
+      dispatch(createQuery()).then((newPageId) => setDashboardPage(newPageId));
     } else {
       setDashboardPage(pageId);
       dispatch(selectQuery(pageId));
     }
   }, [dispatch, setDashboardPage]);
 
-  const onRemove = useCallback((queryId: string) => onCloseTab(dashboardId, queryId, activeQueryId, queries, widgetIds, dispatch),
-    [dashboardId, activeQueryId, queries, widgetIds, dispatch]);
+  const removePage = useCallback(
+    (queryId: string) => onRemovePage(
+      dashboardId,
+      queryId,
+      activeQueryId,
+      queries,
+      widgetIds,
+      dispatch,
+    ),
+    [dashboardId, activeQueryId, queries, widgetIds, dispatch],
+  );
 
   const _onTitleChange = useCallback((queryId: string, newTitle: string) => dispatch(setTitle(queryId, 'tab', 'title', newTitle)), [dispatch]);
 
@@ -74,7 +83,7 @@ const QueryBar = () => {
                dashboardId={dashboardId}
                onSelect={onSelectPage}
                onTitleChange={_onTitleChange}
-               onRemove={onRemove} />
+               onRemove={removePage} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
@@ -62,7 +62,7 @@ describe('QueryTitle', () => {
       <QueryTitle active
                   id="query-id-1"
                   openEditModal={() => {}}
-                  onClose={() => Promise.resolve()}
+                  onRemove={() => Promise.resolve()}
                   title="Foo"
                   openCopyToDashboardModal={() => {}}
                   {...props} />

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -36,13 +36,13 @@ type Props = {
   active: boolean,
   allowsClosing?: boolean,
   id: QueryId,
-  onClose: () => Promise<void | ViewState>,
+  onRemove: () => Promise<void | ViewState>,
   openEditModal: (title: string) => void,
   openCopyToDashboardModal: (isOpen: boolean) => void,
   title: string,
 };
 
-const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCopyToDashboardModal, title }: Props) => {
+const QueryTitle = ({ active, allowsClosing, id, onRemove, openEditModal, openCopyToDashboardModal, title }: Props) => {
   const [titleValue, setTitleValue] = useState(title);
   const { setDashboardPage } = useContext(DashboardPageContext);
   const dispatch = useAppDispatch();
@@ -68,7 +68,7 @@ const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCop
             Copy to Dashboard
           </MenuItem>
           <MenuItem divider />
-          <MenuItem onSelect={onClose} disabled={!allowsClosing}>Delete</MenuItem>
+          <MenuItem onSelect={onRemove} disabled={!allowsClosing}>Delete</MenuItem>
         </QueryActionDropdown>
       )}
     </>
@@ -77,7 +77,7 @@ const QueryTitle = ({ active, allowsClosing, id, onClose, openEditModal, openCop
 
 QueryTitle.propTypes = {
   allowsClosing: PropTypes.bool,
-  onClose: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   openEditModal: PropTypes.func.isRequired,
 };

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -144,8 +144,13 @@ export const updateQueries = (newQueries: Immutable.OrderedSet<Query>) => async 
     .build();
 
   const searchAfterSave = await createSearch(newSearch);
+  const newViewState = view.state.filter((_state, queryId) => (
+    !!newQueries.find((query) => query.id === queryId)),
+  ).toMap();
+
   const newView = view.toBuilder()
     .search(searchAfterSave)
+    .state(newViewState)
     .build();
 
   return dispatch(updateView(newView));
@@ -164,7 +169,7 @@ export const addQuery = (query: Query, viewState: ViewStateType) => async (dispa
     .state(newViewStates)
     .build();
 
-  return dispatch(updateView(newView, true)).then(() => dispatch(selectQuery(query.id)));
+  return dispatch(updateView(newView, true)).then(() => dispatch(selectQuery(query.id))).then(() => query.id);
 };
 
 export const updateQuery = (queryId: QueryId, query: Query) => async (dispatch: AppDispatch, getState: () => RootState) => {

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as Immutable from 'immutable';
+
+import FindNewActiveQuery from 'views/logic/views/FindNewActiveQuery';
+
+describe('FindNewActiveQuery', () => {
+  it('does not break when there are no queries left', () => {
+    expect(FindNewActiveQuery(Immutable.List(), 'deadbeef')).toBeUndefined();
+    expect(FindNewActiveQuery(Immutable.List(['foo']), 'deadbeef', Immutable.List(['foo']))).toBeUndefined();
+  });
+
+  it('returns current query when it is still present', () => {
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['bar']))).toEqual('foo');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['bar', 'baz']))).toEqual('foo');
+  });
+
+  it('returns next query when current query is removed', () => {
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'bar', Immutable.List(['bar']))).toEqual('foo');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'foo', Immutable.List(['foo', 'baz']))).toEqual('bar');
+    expect(FindNewActiveQuery(Immutable.List(['foo', 'bar', 'baz']), 'baz', Immutable.List(['baz']))).toEqual('bar');
+    expect(FindNewActiveQuery(Immutable.List(['bar', 'baz']), 'foo', Immutable.List(['foo']))).toEqual('bar');
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -16,14 +16,16 @@
  */
 
 // Returns a new query ID, in case the active query gets deleted.
-import type { List } from 'immutable';
+import { List } from 'immutable';
 
-const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string) => {
+const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string> = List()) => {
   const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
-  const newQueryIdIndex = Math.min(0, currentQueryIdIndex - 1);
+  const priorQueryIds = queryIds.slice(0, currentQueryIdIndex).toList();
+  const listToPickNewIdFrom = priorQueryIds.isEmpty()
+    ? queryIds
+    : priorQueryIds.reverse();
 
-  return queryIds.filter((queryId) => (queryId !== activeQueryId))
-    .get(newQueryIdIndex);
+  return listToPickNewIdFrom.find((queryId) => !removedQueryIds.includes(queryId));
 };
 
 export default FindNewActiveQueryId;


### PR DESCRIPTION
**Please note:** this is a backport of https://github.com/Graylog2/graylog2-server/pull/16674 for `5.1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the bug described in https://github.com/Graylog2/graylog2-server/issues/16634. Before this change a dashboard could not be saved after deleting a dashboard page in the pages configuration modal.

Fixes #16634