### PR TITLE
Improve keyboard shortcuts for dashboards.

### DIFF
--- a/graylog2-web-interface/src/contexts/HotkeysContext.tsx
+++ b/graylog2-web-interface/src/contexts/HotkeysContext.tsx
@@ -48,6 +48,7 @@ export type Options = {
   enableOnFormTags?: readonly FormTags[] | boolean // Enable hotkeys on a list of tags. (Default: false)
   enableOnContentEditable?: boolean // Enable hotkeys on tags with contentEditable props. (Default: false)
   preventDefault?: Trigger // Prevent default browser behavior? (Default: false)
+  displayInOverview?: boolean
 }
 export type ActiveHotkey = {
   options?: Options & { scope: ScopeName },

--- a/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
+++ b/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
@@ -55,6 +55,7 @@ export const hotKeysCollections: HotkeyCollections = {
     actions: {
       ...viewActions,
       save: { keys: 'mod+s', description: 'Save dashboard' },
+      'save-as': { keys: 'mod+shift+s', description: 'Save dashboard as' },
     },
   },
 };

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -138,7 +138,8 @@ const DashboardActionsMenu = () => {
                              openSaveAsModal={() => setSaveNewDashboardOpen(true)} />
       )}
       {showSaveNewButton && (
-        <SaveAsDashboardButton onClick={() => setSaveNewDashboardOpen(true)} />
+        <SaveAsDashboardButton onClick={() => setSaveNewDashboardOpen(true)}
+                               openSaveAsModal={() => setSaveNewDashboardOpen(true)} />
       )}
       {showShareButton && (
         <ShareButton entityType="dashboard"

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -16,9 +16,10 @@
  */
 import React, { useState, useCallback, useMemo, useRef } from 'react';
 
+import useHistory from 'routing/useHistory';
 import { isPermitted } from 'util/PermissionsMixin';
 import AppConfig from 'util/AppConfig';
-import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/bootstrap';
+import { DropdownButton, MenuItem, ButtonGroup } from 'components/bootstrap';
 import { Icon, ShareButton } from 'components/common';
 import ExportModal from 'views/components/export/ExportModal';
 import DebugOverlay from 'views/components/DebugOverlay';
@@ -35,16 +36,13 @@ import {
 import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useView from 'views/hooks/useView';
 import useIsNew from 'views/hooks/useIsNew';
-import useHasUndeclaredParameters from 'views/logic/parameters/useHasUndeclaredParameters';
 import useAppDispatch from 'stores/useAppDispatch';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { updateView } from 'views/logic/slices/viewSlice';
-import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
-import useHistory from 'routing/useHistory';
-import SaveViewButton from 'views/components/searchbar/SaveViewButton';
-import useHotkey from 'hooks/useHotkey';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import SaveDashboardButton from 'views/components/searchbar/SaveDashboardButton';
+import SaveAsDashboardButton from 'views/components/searchbar/SaveAsDashboardButton';
 
 import DashboardPropertiesModal from './dashboard/DashboardPropertiesModal';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
@@ -56,7 +54,7 @@ const DashboardActionsMenu = () => {
   const view = useView();
   const isNewView = useIsNew();
   const currentUser = useCurrentUser();
-  const hasUndeclaredParameters = useHasUndeclaredParameters();
+
   const {
     viewActions: {
       save: {
@@ -122,15 +120,7 @@ const DashboardActionsMenu = () => {
 
     return dispatch(onSaveNewDashboard(newDashboard, history));
   }, [currentUser.permissions, dispatch, history, pluggableSaveViewControls, sendTelemetry, view.id]);
-  const _onSaveView = useCallback(() => {
-    sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_SAVED, {
-      app_pathname: 'dashboard',
-      app_section: 'dashboard',
-      app_action_value: 'dashboard-save',
-    });
 
-    return dispatch(OnSaveViewAction(view));
-  }, [dispatch, sendTelemetry, view]);
   const _onUpdateView = useCallback((updatedView) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_UPDATED, {
       app_pathname: 'dashboard',
@@ -141,26 +131,14 @@ const DashboardActionsMenu = () => {
     return dispatch(updateView(updatedView));
   }, [dispatch, sendTelemetry]);
 
-  useHotkey({
-    actionKey: 'save',
-    callback: () => _onSaveView(),
-    scope: 'dashboard',
-    telemetryAppPathname: 'search',
-  });
-
   return (
     <ButtonGroup>
       {showSaveButton && (
-        <SaveViewButton title="Save dashboard"
-                        onClick={_onSaveView}
-                        disabled={isNewView || hasUndeclaredParameters || !allowedToEdit} />
+        <SaveDashboardButton userIsAllowedToEdit={allowedToEdit}
+                             openSaveAsModal={() => setSaveNewDashboardOpen(true)} />
       )}
       {showSaveNewButton && (
-        <Button onClick={() => setSaveNewDashboardOpen(true)}
-                disabled={hasUndeclaredParameters}
-                title="Save as new dashboard">
-          <Icon name="copy" /> Save as
-        </Button>
+        <SaveAsDashboardButton onClick={() => setSaveNewDashboardOpen(true)} />
       )}
       {showShareButton && (
         <ShareButton entityType="dashboard"

--- a/graylog2-web-interface/src/views/components/searchbar/SaveAsDashboardButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SaveAsDashboardButton.tsx
@@ -19,22 +19,32 @@ import React from 'react';
 
 import Button from 'components/bootstrap/Button';
 import { Icon } from 'components/common';
+import useHasUndeclaredParameters from 'views/logic/parameters/useHasUndeclaredParameters';
+import useHotkey from 'hooks/useHotkey';
 
 type Props = {
-  disabled?: boolean,
   onClick: () => void,
+  openSaveAsModal: () => void,
 }
 
-const SaveAsDashboardButton = ({ disabled, onClick }: Props) => (
-  <Button onClick={onClick}
-          disabled={disabled}
-          title="Save as new dashboard">
-    <Icon name="copy" /> Save as
-  </Button>
-);
+const SaveAsDashboardButton = ({ onClick, openSaveAsModal }: Props) => {
+  const hasUndeclaredParameters = useHasUndeclaredParameters();
 
-SaveAsDashboardButton.defaultProps = {
-  disabled: false,
+  useHotkey({
+    actionKey: 'save-as',
+    callback: () => openSaveAsModal(),
+    scope: 'dashboard',
+    telemetryAppPathname: 'search',
+    options: { enabled: !hasUndeclaredParameters },
+  });
+
+  return (
+    <Button onClick={onClick}
+            disabled={hasUndeclaredParameters}
+            title="Save as new dashboard">
+      <Icon name="copy" /> Save as
+    </Button>
+  );
 };
 
 export default SaveAsDashboardButton;

--- a/graylog2-web-interface/src/views/components/searchbar/SaveAsDashboardButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SaveAsDashboardButton.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import React from 'react';
+
+import Button from 'components/bootstrap/Button';
+import { Icon } from 'components/common';
+
+type Props = {
+  disabled?: boolean,
+  onClick: () => void,
+}
+
+const SaveAsDashboardButton = ({ disabled, onClick }: Props) => (
+  <Button onClick={onClick}
+          disabled={disabled}
+          title="Save as new dashboard">
+    <Icon name="copy" /> Save as
+  </Button>
+);
+
+SaveAsDashboardButton.defaultProps = {
+  disabled: false,
+};
+
+export default SaveAsDashboardButton;

--- a/graylog2-web-interface/src/views/components/searchbar/SaveDashboardButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SaveDashboardButton.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback } from 'react';
+
+import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import useAppDispatch from 'stores/useAppDispatch';
+import SaveViewButton from 'views/components/searchbar/SaveViewButton';
+import useHotkey from 'hooks/useHotkey';
+import useView from 'views/hooks/useView';
+import useIsNew from 'views/hooks/useIsNew';
+import useHasUndeclaredParameters from 'views/logic/parameters/useHasUndeclaredParameters';
+
+type Props = {
+  userIsAllowedToEdit: boolean,
+  openSaveAsModal: () => void,
+}
+
+const SaveDashboardButton = ({ userIsAllowedToEdit, openSaveAsModal }: Props) => {
+  const view = useView();
+  const isNewView = useIsNew();
+  const sendTelemetry = useSendTelemetry();
+  const dispatch = useAppDispatch();
+  const hasUndeclaredParameters = useHasUndeclaredParameters();
+  const _onSaveView = useCallback(() => {
+    sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_SAVED, {
+      app_pathname: 'dashboard',
+      app_section: 'dashboard',
+      app_action_value: 'dashboard-save',
+    });
+
+    return dispatch(OnSaveViewAction(view));
+  }, [dispatch, sendTelemetry, view]);
+
+  useHotkey({
+    actionKey: 'save',
+    callback: () => (isNewView ? openSaveAsModal() : _onSaveView()),
+    scope: 'dashboard',
+    telemetryAppPathname: 'search',
+    options: { enabled: !hasUndeclaredParameters && userIsAllowedToEdit },
+  });
+
+  return (
+    <SaveViewButton title="Save dashboard"
+                    onClick={_onSaveView}
+                    disabled={hasUndeclaredParameters || isNewView || !userIsAllowedToEdit} />
+  );
+};
+
+export default SaveDashboardButton;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is improving the hotkeys for dashboards by:
- fixing an error which occurred when pressing "ctrl + s" on `/dashboards/new`
- adding a hotkey for "save as new", similar to the search page
- making sure we open the "save as new" modal when pressing "ctrl + s" on `/dashboards/new`
- making sure we do not offer the "save" hotkey on security pages.

Fixes: https://github.com/Graylog2/graylog2-server/issues/16797

/nocl