### PR TITLE
Add debugging log for TSO retain strategy (5.1)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -89,16 +89,18 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
 
             runRetention(indexSet, deflectorIndices, removeCount);
         } else {
-            var debug = deflectorIndices.keySet().stream()
-                    .collect(Collectors.toMap(k -> k, k -> Map.of(
-                            "isReopened", indices.isReopened(k),
-                            "hasCurrentWriteAlias", hasCurrentWriteAlias(indexSet, deflectorIndices, k),
-                            "exceedsAgeLimit", exceedsAgeLimit(k, cutoffSoft, cutoffHard),
-                            "closingDate", indices.indexClosingDate(k),
-                            "creationDate", indices.indexCreationDate(k)
-                    )));
-            LOG.debug("Nothing to retain for indexSet <{}>: (min {}, max {}) details: <{}>",
-                    indexSet.getIndexPrefix(), timeBasedConfig.indexLifetimeMin(), timeBasedConfig.indexLifetimeMax(), debug);
+            if (LOG.isDebugEnabled()) {
+                var debug = deflectorIndices.keySet().stream()
+                        .collect(Collectors.toMap(k -> k, k -> Map.of(
+                                "isReopened", indices.isReopened(k),
+                                "hasCurrentWriteAlias", hasCurrentWriteAlias(indexSet, deflectorIndices, k),
+                                "exceedsAgeLimit", exceedsAgeLimit(k, cutoffSoft, cutoffHard),
+                                "closingDate", indices.indexClosingDate(k),
+                                "creationDate", indices.indexCreationDate(k)
+                        )));
+                LOG.debug("Nothing to retain for indexSet <{}>: (min {}, max {}) details: <{}>",
+                        indexSet.getIndexPrefix(), timeBasedConfig.indexLifetimeMin(), timeBasedConfig.indexLifetimeMax(), debug);
+            }
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexRetentionStrategy.java
@@ -88,6 +88,17 @@ public abstract class AbstractIndexRetentionStrategy implements RetentionStrateg
             activityWriter.write(new Activity(msg, IndexRetentionThread.class));
 
             runRetention(indexSet, deflectorIndices, removeCount);
+        } else {
+            var debug = deflectorIndices.keySet().stream()
+                    .collect(Collectors.toMap(k -> k, k -> Map.of(
+                            "isReopened", indices.isReopened(k),
+                            "hasCurrentWriteAlias", hasCurrentWriteAlias(indexSet, deflectorIndices, k),
+                            "exceedsAgeLimit", exceedsAgeLimit(k, cutoffSoft, cutoffHard),
+                            "closingDate", indices.indexClosingDate(k),
+                            "creationDate", indices.indexCreationDate(k)
+                    )));
+            LOG.debug("Nothing to retain for indexSet <{}>: (min {}, max {}) details: <{}>",
+                    indexSet.getIndexPrefix(), timeBasedConfig.indexLifetimeMin(), timeBasedConfig.indexLifetimeMax(), debug);
         }
     }
 


### PR DESCRIPTION
Log output example:
`
2023-10-05 14:43:07,188 DEBUG : org.graylog2.indexer.retention.strategies.AbstractIndexRetentionStrategy - Nothing to retain for indexSet <graylog>: (min P30D, max P40D) details: <{graylog_1={closingDate=Optional.empty, hasCurrentWriteAlias=true, creationDate=Optional[2023-10-05T13:27:28.099Z], isReopened=false, exceedsAgeLimit=false}, graylog_0={closingDate=Optional[2023-10-05T13:27:58.615Z], hasCurrentWriteAlias=false, creationDate=Optional[2023-08-08T08:34:57.906Z], isReopened=false, exceedsAgeLimit=false}}>
`

/nocl
