### PR TITLE
better error message with instructions for problems with opensearch distribution location

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/OpensearchDistributionTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/OpensearchDistributionTest.java
@@ -31,6 +31,9 @@ class OpensearchDistributionTest {
     private Path tempDir;
 
     @TempDir
+    private Path emptyTempDir;
+
+    @TempDir
     private Path tempDirWithoutArch;
 
     @BeforeEach
@@ -41,6 +44,16 @@ class OpensearchDistributionTest {
 
         Files.createDirectory(tempDirWithoutArch.resolve("opensearch-2.4.1"));
         Files.createDirectory(tempDir.resolve(".config")); // just to include something which is not OS dist
+    }
+
+    @Test
+    void testFailedDetectionInDirectory() {
+        Assertions.assertThatThrownBy(() -> OpensearchDistribution.detectInDirectory(emptyTempDir.resolve("nonexistent"), "amd64"))
+                .hasMessageStartingWith("Failed to list content of provided directory");
+
+
+        Assertions.assertThatThrownBy(() -> OpensearchDistribution.detectInDirectory(emptyTempDir, "amd64"))
+                .hasMessageStartingWith("Could not detect any opensearch distribution");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/Graylog2/graylog2-server/issues/16826

## Description
The new error message looks like this:

/nocl

```
java.lang.IllegalArgumentException: Failed to list content of provided directory. Directory used for Opensearch detection: /tmp/junit10789252857559246705/nonexistent. Please configure opensearch_location to a directory that contains an opensearch distribution for your architecture x64. You can download Opensearch from https://opensearch.org/downloads.html . Please extract the downloaded distribution and point opensearch_location configuration option to that directory.
```

## Motivation and Context
Let's make our error message as helpful as possible

## How Has This Been Tested?
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

