### PR TITLE
Improve error handling when uploading CA bundle in preflight UI.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightJerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/PreflightJerseyService.java
@@ -39,6 +39,7 @@ import org.graylog2.Configuration;
 import org.graylog2.bootstrap.preflight.web.BasicAuthFilter;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.JacksonPropertyExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JsonProcessingExceptionMapper;
 import org.jetbrains.annotations.NotNull;
@@ -180,7 +181,8 @@ public class PreflightJerseyService extends AbstractIdleService {
                         JacksonJaxbJsonProvider.class,
                         JsonProcessingExceptionMapper.class,
                         JsonMappingExceptionMapper.class,
-                        JacksonPropertyExceptionMapper.class
+                        JacksonPropertyExceptionMapper.class,
+                        AnyExceptionClassMapper.class
                 )
                 // Replacing this with a lambda leads to missing subtypes - https://github.com/Graylog2/graylog2-server/pull/10617#discussion_r630236360
                 .register(new ContextResolver<ObjectMapper>() {

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/PreflightResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/PreflightResource.java
@@ -31,6 +31,7 @@ import org.graylog2.cluster.preflight.DataNodeProvisioningConfig;
 import org.graylog2.cluster.preflight.DataNodeProvisioningService;
 import org.graylog2.plugin.certificates.RenewalPolicy;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.rest.ApiError;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -43,6 +44,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -110,9 +112,13 @@ public class PreflightResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Path("/ca/upload")
     @NoAuditEvent("No Audit Event needed")
-    public String uploadCA(@FormDataParam("password") String password, @FormDataParam("files") List<FormDataBodyPart> bodyParts) throws CACreationException {
-        caService.upload(password, bodyParts);
-        return "Ok";
+    public Response uploadCA(@FormDataParam("password") String password, @FormDataParam("files") List<FormDataBodyPart> bodyParts) {
+        try {
+            caService.upload(password, bodyParts);
+            return Response.ok().build();
+        } catch (CACreationException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(ApiError.create(e.getMessage())).build();
+        }
     }
 
     @DELETE

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.test.tsx
@@ -80,7 +80,7 @@ describe('CAUpload', () => {
   });
 
   it('should show error when CA upload fails', async () => {
-    asMock(fetchMultiPartFormData).mockImplementation(() => Promise.reject(new Error('Error')));
+    asMock(fetchMultiPartFormData).mockRejectedValue(new Error('Something bad happened'));
 
     renderPreflight(
       <DefaultQueryClientProvider options={{ logger }}>
@@ -99,6 +99,6 @@ describe('CAUpload', () => {
       false,
     ));
 
-    expect(UserNotification.error).toHaveBeenCalledWith('CA upload failed with error: Error: Error');
+    expect(UserNotification.error).toHaveBeenCalledWith('CA upload failed with error: Error: Something bad happened');
   });
 });

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.tsx
@@ -93,7 +93,7 @@ const CAUpload = () => {
     UserNotification.error('CA upload failed');
   }, []);
 
-  const { mutate: onProcessUpload, isLoading } = useMutation(submitUpload, {
+  const { mutateAsync: onProcessUpload, isLoading } = useMutation(submitUpload, {
     onSuccess: () => {
       UserNotification.success('CA uploaded successfully');
       queryClient.invalidateQueries(DATA_NODES_CA_QUERY_KEY);

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAUpload.tsx
@@ -77,7 +77,11 @@ const validate = (formValues: FormValues) => {
   let errors = {};
 
   if (!formValues.files?.length) {
-    errors = { ...errors, files: 'A CA file is required' };
+    errors = { ...errors, files: 'Please upload a file.' };
+  }
+
+  if (formValues.files?.length > 1) {
+    errors = { ...errors, files: 'Please upload only a single file.' };
   }
 
   return errors;
@@ -103,20 +107,10 @@ const CAUpload = () => {
     },
   });
 
-  const validateFiles = (files: Array<unknown>) => {
-    if (!files?.length) {
-      return 'Please upload a file.';
-    }
-
-    if (files?.length > 1) {
-      return 'Please upload only a single file.';
-    }
-
-    return null;
-  };
+  const onSubmit = useCallback((formValues: FormValues) => onProcessUpload(formValues).catch(() => {}), [onProcessUpload]);
 
   return (
-    <Formik<FormValues> initialValues={{}} onSubmit={(formValues: FormValues) => onProcessUpload(formValues)} validate={validate}>
+    <Formik<FormValues> initialValues={{}} onSubmit={onSubmit} validate={validate}>
       {({ isSubmitting, isValid }) => (
         <Form>
           <Explanation>
@@ -124,7 +118,7 @@ const CAUpload = () => {
             (encrypted or unencrypted), the CA certificate as well as any intermediate certificates. The file can be in PEM
             or in PKCS#12 format. If your private key is encrypted, you also need to supply its password.
           </Explanation>
-          <Field name="files" validate={validateFiles}>
+          <Field name="files">
             {({ field: { name, onChange, value }, meta: { error } }) => (
               <>
                 <Input.Label required htmlFor="ca-dropzone">Certificate Authority</Input.Label>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is improving error handling in the CA upload of the preflight UI by:

  - Returning structured error message when reading CA bundle failed
  - Adding general exception handler to preflight API
  - Use async mutation so "Upload CA" button does not stay disabled
    after error

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.