### PR TITLE
DataNode: Disabling unused auth methods

### DIFF
--- a/data-node/src/main/resources/opensearch/config/opensearch-security/config.yml
+++ b/data-node/src/main/resources/opensearch/config/opensearch-security/config.yml
@@ -98,8 +98,8 @@ config:
           type: noop
       basic_internal_auth_domain:
         description: "Authenticate via HTTP Basic against internal users database"
-        http_enabled: true
-        transport_enabled: true
+        http_enabled: false
+        transport_enabled: false
         order: 4
         http_authenticator:
           type: basic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disable the now unused internal user DB. This leaves JWT auth to be the only enabled auth method.

This PR should probably not get merged before we add an additional way to access OpenSearch from within GL.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

