### PR TITLE
Handle promises correctly for form submits in preflight UI.

### DIFF
--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CACreateForm.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CACreateForm.tsx
@@ -38,7 +38,7 @@ const createCA = (caData: FormValues) => fetch(
 const CACreateForm = () => {
   const queryClient = useQueryClient();
 
-  const { mutate: onSubmit } = useMutation(createCA, {
+  const { mutateAsync: onCreateCA } = useMutation(createCA, {
     onSuccess: () => {
       UserNotification.success('CA created successfully');
       queryClient.invalidateQueries(DATA_NODES_CA_QUERY_KEY);
@@ -47,6 +47,8 @@ const CACreateForm = () => {
       UserNotification.error(`CA creation failed with error: ${error}`);
     },
   });
+
+  const onSubmit = (formValues: FormValues) => onCreateCA(formValues).catch(() => {});
 
   return (
     <div>

--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/RenewalPolicyConfiguration.tsx
@@ -80,7 +80,7 @@ const defaultFormValues = {
 const RenewalPolicyConfiguration = () => {
   const queryClient = useQueryClient();
 
-  const { mutate: onSubmit } = useMutation(createPolicy, {
+  const { mutateAsync: onCreateRenewalPolicy } = useMutation(createPolicy, {
     onSuccess: () => {
       UserNotification.success('Renewal policy created successfully');
       queryClient.invalidateQueries(RENEWAL_POLICY_QUERY_KEY);
@@ -89,6 +89,8 @@ const RenewalPolicyConfiguration = () => {
       UserNotification.error(`Renewal policy creation failed with error: ${error}`);
     },
   });
+
+  const onSubmit = (formValues: FormValues) => onCreateRenewalPolicy(formValues).catch(() => {});
 
   return (
     <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR contains an improvement for the preflight UI form submits. By using `mutateAsync` form `useMutation` we are actually returning a promise, which will be used by formik to update `isSubmitting`.

/nocl