### PR TITLE
Remove opacity of search loading indicator.

### DIFF
--- a/graylog2-web-interface/src/components/common/LoadingIndicator.tsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.tsx
@@ -16,24 +16,29 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Alert } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
 
 import Delayed from './Delayed';
 
-const StyledAlert = styled(Alert)`
+const Container = styled.div(({ theme }) => css`
+  background-color: ${theme.colors.global.contentBackground};
   position: fixed;
-  height: 32px;
   min-width: 200px;
   top: 60px;
   left: 50%;
   transform: translateX(-50%);
-  padding: 5px 20px;
-  text-align: center;
   box-shadow: 0 2px 10px rgb(0 0 0 / 20%);
   z-index: 2000;
+`);
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+  height: 32px;
+  padding: 5px 20px;
+  text-align: center;
 `;
 
 type Props = {
@@ -49,9 +54,11 @@ type Props = {
  */
 const LoadingIndicator = ({ text }: Props) => (
   <Delayed delay={500}>
-    <StyledAlert bsStyle="info">
-      <Spinner delay={0} text={text} />
-    </StyledAlert>
+    <Container>
+      <StyledAlert bsStyle="info">
+        <Spinner delay={0} text={text} />
+      </StyledAlert>
+    </Container>
   </Delayed>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the opacity of the loading indicator for the dark mode.

Before:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/1c4f7765-c922-4e65-bf12-8387a4222a59)


After
<img width="324" alt="image" src="https://github.com/Graylog2/graylog2-server/assets/46300478/114ccf41-4404-4fc6-88e6-44515e2ed2a8">

I considered changing the background of the alert component, but adding a container for the loading indicator is the more pragmatic approach.

Fixes: https://github.com/Graylog2/graylog2-server/issues/16831
/nocl