### PR TITLE
Remove changing the config when using static leader election

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/leader/StaticLeaderElectionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/leader/StaticLeaderElectionService.java
@@ -50,7 +50,5 @@ public class StaticLeaderElectionService extends AbstractIdleService implements 
 
     @Override
     protected void shutDown() throws Exception {
-        // This has likely no effect in the server shutdown phase
-        configuration.setIsLeader(false);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We start/stop the leader election service between preflight and regular mode. this led to a missing leader node when using static leader election. IMHO the service should not change the config at all.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

