### PR TITLE
Unify auto-refresh behaviour by disabling auto-refresh on search bar form changes

### DIFF
--- a/changelog/unreleased/issue-16893.toml
+++ b/changelog/unreleased/issue-16893.toml
@@ -1,0 +1,10 @@
+type = "c"
+message = "Unify auto-refresh behaviour in case there are form changes."
+
+issues = ["Graylog2/graylog-plugin-enterprise#5896"]
+pulls = ["16893"]
+
+details.user = """
+We are now submiting the search, when starting the auto-refresh and there are not submitted changes.
+We also unified the behaviour by stoping the auto-refresh, when there are changes, while the auto-refresh is active.
+"""

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
@@ -15,14 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { fireEvent, render, screen } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import 'helpers/mocking/react-dom_mock';
+import { Form, Formik, useFormikContext } from 'formik';
+import userEvent from '@testing-library/user-event';
 
 import { RefreshActions } from 'views/stores/RefreshStore';
 import { asMock } from 'helpers/mocking';
 import useRefreshConfig from 'views/components/searchbar/useRefreshConfig';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import type { SearchesConfig } from 'components/search/SearchConfig';
+import Button from 'preflight/components/common/Button';
 
 import RefreshControls from './RefreshControls';
 
@@ -49,6 +52,20 @@ const autoRefreshOptions = {
 };
 
 describe('RefreshControls', () => {
+  const SUT = ({ onSubmit, children }: { onSubmit?: () => void, children?: React.ReactNode }) => (
+    <Formik initialValues={{}} onSubmit={onSubmit}>
+      <Form>
+        <RefreshControls />
+        {children}
+      </Form>
+    </Formik>
+  );
+
+  SUT.defaultProps = {
+    onSubmit: () => {},
+    children: undefined,
+  };
+
   beforeEach(() => {
     asMock(useSearchConfiguration).mockReturnValue({
       config: {
@@ -73,7 +90,7 @@ describe('RefreshControls', () => {
     ${false}     | ${1000}
   `('renders refresh controls with enabled: $enabled and interval: $interval', async ({ enabled, interval }) => {
       asMock(useRefreshConfig).mockReturnValue({ enabled, interval });
-      render(<RefreshControls />);
+      render(<SUT />);
 
       await screen.findByLabelText(/refresh search controls/i);
     });
@@ -81,19 +98,45 @@ describe('RefreshControls', () => {
 
   it('should start the interval', async () => {
     asMock(useRefreshConfig).mockReturnValue({ enabled: false, interval: 1000 });
-    render(<RefreshControls />);
+    render(<SUT />);
 
-    fireEvent.click(await screen.findByTitle(/start refresh/i));
+    userEvent.click(await screen.findByTitle(/start refresh/i));
 
     expect(RefreshActions.enable).toHaveBeenCalled();
   });
 
   it('should stop the interval', async () => {
     asMock(useRefreshConfig).mockReturnValue({ enabled: true, interval: 1000 });
-    render(<RefreshControls />);
+    render(<SUT />);
 
-    fireEvent.click(await screen.findByTitle(/pause refresh/i));
+    userEvent.click(await screen.findByTitle(/pause refresh/i));
 
     expect(RefreshActions.disable).toHaveBeenCalled();
+  });
+
+  it('should submit the form when there are changes when starting the interval', async () => {
+    asMock(useRefreshConfig).mockReturnValue({ enabled: false, interval: 5000 });
+    const onSubmitMock = jest.fn();
+
+    const TriggerFormChangeButton = () => {
+      const { setFieldValue } = useFormikContext();
+
+      return (
+        <Button onClick={() => setFieldValue('example-field', 'example-value')}>
+          Change form field value
+        </Button>
+      );
+    };
+
+    render(
+      <SUT onSubmit={onSubmitMock}>
+        <TriggerFormChangeButton />
+      </SUT>,
+    );
+
+    userEvent.click(await screen.findByRole('button', { name: /change form field value/i }));
+    userEvent.click(await screen.findByTitle(/start refresh/i));
+
+    await waitFor(() => expect(onSubmitMock).toHaveBeenCalled());
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.test.tsx
@@ -66,6 +66,16 @@ describe('RefreshControls', () => {
     children: undefined,
   };
 
+  const TriggerFormChangeButton = () => {
+    const { setFieldValue } = useFormikContext();
+
+    return (
+      <Button onClick={() => setFieldValue('example-field', 'example-value')}>
+        Change form field value
+      </Button>
+    );
+  };
+
   beforeEach(() => {
     asMock(useSearchConfiguration).mockReturnValue({
       config: {
@@ -118,16 +128,6 @@ describe('RefreshControls', () => {
     asMock(useRefreshConfig).mockReturnValue({ enabled: false, interval: 5000 });
     const onSubmitMock = jest.fn();
 
-    const TriggerFormChangeButton = () => {
-      const { setFieldValue } = useFormikContext();
-
-      return (
-        <Button onClick={() => setFieldValue('example-field', 'example-value')}>
-          Change form field value
-        </Button>
-      );
-    };
-
     render(
       <SUT onSubmit={onSubmitMock}>
         <TriggerFormChangeButton />
@@ -138,5 +138,19 @@ describe('RefreshControls', () => {
     userEvent.click(await screen.findByTitle(/start refresh/i));
 
     await waitFor(() => expect(onSubmitMock).toHaveBeenCalled());
+  });
+
+  it('should stop the interval when there are form changes while the interval is active', async () => {
+    asMock(useRefreshConfig).mockReturnValue({ enabled: true, interval: 5000 });
+
+    render(
+      <SUT>
+        <TriggerFormChangeButton />
+      </SUT>,
+    );
+
+    userEvent.click(await screen.findByRole('button', { name: /change form field value/i }));
+
+    await waitFor(() => expect(RefreshActions.disable).toHaveBeenCalled());
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
@@ -51,6 +51,17 @@ const ButtonLabel = ({ refreshConfigEnabled, naturalInterval }: {
   return <>{buttonText}</>;
 };
 
+const useDisableOnFormChange = () => {
+  const refreshConfig = useRefreshConfig();
+  const { dirty, isSubmitting } = useFormikContext();
+
+  useEffect(() => {
+    if (refreshConfig.enabled && !isSubmitting && dirty) {
+      RefreshActions.disable();
+    }
+  }, [dirty, isSubmitting, refreshConfig.enabled]);
+};
+
 const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();
 
 const RefreshControls = () => {
@@ -69,9 +80,14 @@ const RefreshControls = () => {
     });
 
     RefreshActions.setInterval(interval);
+
+    if (dirty) {
+      submitForm();
+    }
   };
 
   useEffect(() => () => RefreshActions.disable(), []);
+  useDisableOnFormChange();
 
   const _toggleEnable = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_REFRESH_CONTROL_TOGGLED, {

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useCallback, useEffect } from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
+import { useFormikContext } from 'formik';
 
 import { MenuItem, ButtonGroup, DropdownButton, Button } from 'components/bootstrap';
 import { Icon, Pluralize } from 'components/common';
@@ -53,6 +54,7 @@ const ButtonLabel = ({ refreshConfigEnabled, naturalInterval }: {
 const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();
 
 const RefreshControls = () => {
+  const { dirty, submitForm } = useFormikContext();
   const refreshConfig = useRefreshConfig();
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
@@ -82,9 +84,13 @@ const RefreshControls = () => {
     if (refreshConfig.enabled) {
       RefreshActions.disable();
     } else {
+      if (dirty) {
+        submitForm();
+      }
+
       RefreshActions.enable();
     }
-  }, [refreshConfig?.enabled, sendTelemetry]);
+  }, [dirty, refreshConfig.enabled, sendTelemetry, submitForm]);
 
   const intervalOptions = Object.entries(autoRefreshTimerangeOptions).map(([interval, label]) => (
     <MenuItem key={`RefreshControls-${label}`} onClick={() => _onChange(durationToMS(interval))}>{label}</MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog-plugin-enterprise/issues/5896 the behaviour of the search auto-refresh can be confusing.
1. When you make a change, do not submit the form and start the auto-refresh, the search does not contain the latest change.
2. When you make a change while the auto-refresh is active, the search does not contain the latest change

With this PR we are now:
- In case 1 submitting the change when starting the auto-refresh
- in case 2 stoping the auto-refresh, when making changes while it is active. This way the behaviour is unified with similar cases. We also tested submitting the changes in this case, but always ran into issues with this approach.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/5896
