### PR TITLE
Security update to Netty 4.1.100

### DIFF
--- a/changelog/unreleased/pr-16902.toml
+++ b/changelog/unreleased/pr-16902.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Netty to 4.1.100 to fix the [HTTP/2 Rapid Reset attack](https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/). [GHSA-xpw8-rcwv-8f8p](https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p) The security vulnerability affects all Graylog users that run the Graylog Forwarder input on their servers."
+
+pulls = ["16902"]

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <mongojack.version>2.10.1.3</mongojack.version>
         <mongojack4.version>4.8.0-1</mongojack4.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.99.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.61.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.11.0</okhttp.version>
         <okio.version>3.5.0</okio.version>


### PR DESCRIPTION
Fixes the recently revealed HTTP/2 Rapid Reset Attack.

- https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p
- https://www.cve.org/CVERecord?id=CVE-2023-44487
- https://netty.io/news/2023/10/10/4-1-100-Final.html

