### PR TITLE
Allow disabling allowlist for data node proxy API.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -35,7 +35,6 @@ import org.graylog2.cluster.leader.LeaderElectionService;
 import org.graylog2.cluster.lock.MongoLockService;
 import org.graylog2.configuration.converters.JavaDurationConverter;
 import org.graylog2.notifications.Notification;
-import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.security.realm.RootAccountRealm;
 import org.graylog2.utilities.IPSubnetConverter;
 import org.graylog2.utilities.IpSubnet;
@@ -215,6 +214,9 @@ public class Configuration extends CaConfiguration {
 
     @Parameter(value = "system_event_excluded_types", converter = TrimmedStringSetConverter.class)
     private Set<String> systemEventExcludedTypes = Sets.newHashSet(Notification.Type.SIDECAR_STATUS_UNKNOWN.name());
+
+    @Parameter(value = "datanode_proxy_api_allowlist")
+    private boolean datanodeProxyAPIAllowlist = true;
 
     public boolean maintainsStreamAwareFieldTypes() {
         return streamAwareFieldTypes;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
@@ -27,6 +27,7 @@ import org.graylog2.indexer.datanode.ProxyRequestAdapter;
 import org.graylog2.shared.rest.resources.RestResource;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -58,10 +59,13 @@ public class DataNodeApiProxyResource extends RestResource {
     );
 
     private final ProxyRequestAdapter proxyRequestAdapter;
+    private final boolean enableAllowlist;
 
     @Inject
-    public DataNodeApiProxyResource(ProxyRequestAdapter proxyRequestAdapter) {
+    public DataNodeApiProxyResource(ProxyRequestAdapter proxyRequestAdapter,
+                                    @Named("datanode_proxy_api_allowlist") boolean enableAllowlist) {
         this.proxyRequestAdapter = proxyRequestAdapter;
+        this.enableAllowlist = enableAllowlist;
     }
 
     @GET
@@ -102,7 +106,7 @@ public class DataNodeApiProxyResource extends RestResource {
 
     private Response request(String method, String path, InputStream entityStream) throws IOException {
         final var request = new ProxyRequestAdapter.ProxyRequest(method, path, entityStream);
-        if (allowList.stream().noneMatch(condition -> condition.test(request))) {
+        if (enableAllowlist && allowList.stream().noneMatch(condition -> condition.test(request))) {
             return Response.status(Response.Status.BAD_REQUEST).entity("This request is not allowed.").build();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareProvider.java
@@ -25,8 +25,8 @@ public class VersionAwareProvider<T> implements Provider<T> {
     private final Map<SearchVersion, Provider<T>> pluginBindings;
 
     @Inject
-    public VersionAwareProvider(@DetectedSearchVersion SearchVersion elasticsearchVersion, Map<SearchVersion, Provider<T>> pluginBindings) {
-        this.elasticsearchMajorVersion = majorVersionFrom(elasticsearchVersion);
+    public VersionAwareProvider(@DetectedSearchVersion SearchVersion indexerVersion, Map<SearchVersion, Provider<T>> pluginBindings) {
+        this.elasticsearchMajorVersion = majorVersionFrom(indexerVersion);
         this.pluginBindings = pluginBindings;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ProxyRequestAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ProxyRequestAdapterProvider.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class ProxyRequestAdapterProvider extends VersionAwareProvider<ProxyRequestAdapter> {
     @Inject
-    public ProxyRequestAdapterProvider(@DetectedSearchVersion SearchVersion elasticsearchVersion, Map<SearchVersion, Provider<ProxyRequestAdapter>> pluginBindings) {
-        super(elasticsearchVersion, pluginBindings);
+    public ProxyRequestAdapterProvider(@DetectedSearchVersion SearchVersion indexerVersion, Map<SearchVersion, Provider<ProxyRequestAdapter>> pluginBindings) {
+        super(indexerVersion, pluginBindings);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding a `datanode_proxy_api_allowlist` config setting (`true` by default), which allows adventurous users to disable the allow list for the data node proxy API endpoint. It should not be used under normal circumstances, but only for debugging purposes during e.g. an incident. Instead, any endpoints which serve useful and are safe to use should be added to the allow list. As this is not possible without a new release and a redeployment, the config setting was introduced as a temporary measure.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.