### PR TITLE
Security update to Netty 4.1.100 (#16902)

### DIFF
--- a/changelog/unreleased/pr-16902.toml
+++ b/changelog/unreleased/pr-16902.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Netty to 4.1.100 to fix the [HTTP/2 Rapid Reset attack](https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/). [GHSA-xpw8-rcwv-8f8p](https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p) The security vulnerability affects all Graylog users that run the Graylog Forwarder input on their servers."
+
+pulls = ["16902"]

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <mongodb-driver.version>4.7.1</mongodb-driver.version>
         <mongojack.version>2.10.1.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.91.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.59.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <okta-sdk.version>8.2.1</okta-sdk.version>


### PR DESCRIPTION
Fixes the recently revealed HTTP/2 Rapid Reset Attack.

- https://github.com/netty/netty/security/advisories/GHSA-xpw8-rcwv-8f8p
- https://www.cve.org/CVERecord?id=CVE-2023-44487
- https://netty.io/news/2023/10/10/4-1-100-Final.html

* Add changelog

(cherry picked from commit bfb002b24816cd19146923740799da07228105b5)
