### PR TITLE
Allow uppercase characters for lookup table test lookup

### DIFF
--- a/changelog/unreleased/issue-14373.toml
+++ b/changelog/unreleased/issue-14373.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix test lookup not accepting uppercase characters"
+
+issues = ["14373"]
+pulls = ["16909"]

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
@@ -50,7 +50,7 @@ const LookupTableView = ({ table, cache, dataAdapter }: Props) => {
     newValue.valid = event.target.value
                   && event.target.value.replace(/\s/g, '').length > 0;
 
-    newValue.value = event.target.value.toLowerCase();
+    newValue.value = event.target.value;
 
     switch (event.target.name) {
       case 'purgekey':


### PR DESCRIPTION
Fixes: https://github.com/Graylog2/graylog2-server/issues/14373

## Description

The test look up for look up tables would manually override uppercase characters to lowercase.
This has be removed in this PR in order to allow looking up keys with uppercase characters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

