### PR TITLE
Reordering CA creation/upload tabs in preflight UI.

### DIFF
--- a/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAConfiguration.tsx
+++ b/graylog2-web-interface/src/preflight/components/ConfigurationWizard/CAConfiguration.tsx
@@ -36,10 +36,10 @@ const CAConfiguration = () => (
       Using it we can provision your data nodes with certificates easily.
     </p>
     <Space h="md" />
-    <StyledTabs defaultValue="upload">
+    <StyledTabs defaultValue="create">
       <Tabs.List>
-        <Tabs.Tab value="upload">Upload CA</Tabs.Tab>
         <Tabs.Tab value="create">Create new CA</Tabs.Tab>
+        <Tabs.Tab value="upload">Upload CA</Tabs.Tab>
       </Tabs.List>
 
       <Tabs.Panel value="upload" pt="xs">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is reordering the CA creation/upload tabs in the preflight UI and sets the CA creation tab as default when opening it.

This promotes the least complex option for new users to get up and running as quick as possible.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.