### PR TITLE
Hide menu item for data node configuration page in cloud deployments.

### DIFF
--- a/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.tsx
@@ -165,6 +165,7 @@ const ConfigurationsPage = () => {
     },
     {
       name: 'Data Node',
+      hide: isCloud,
       SectionComponent: ConfigurationSection,
       props: {
         ConfigurationComponent: DataNodeConfiguration,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change we hide the menu item for data node configuration page (on System -> Configurations) in cloud deployments.

Fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/5982
/nocl

