### PR TITLE
Only show selected revision's installation modal

### DIFF
--- a/changelog/unreleased/issue-16913.toml
+++ b/changelog/unreleased/issue-16913.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed error where only most recent revision of a content pack could be installed."
+
+issues = ["16913"]
+pulls = ["16943"]

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -48,6 +48,7 @@ class ContentPackVersions extends React.Component {
     const { contentPackRevisions } = this.props;
 
     this.state = {
+      modalRev: 0,
       showModal: false,
       selectedVersion: contentPackRevisions.latestRevision,
     };
@@ -132,11 +133,11 @@ class ContentPackVersions extends React.Component {
     const { onInstall: onInstallProp } = this.props;
 
     const closeModal = () => {
-      this.setState({ showModal: false });
+      this.setState({ showModal: false, modalRev: 0 });
     };
 
     const open = () => {
-      this.setState({ showModal: true });
+      this.setState({ showModal: true, modalRev: item.rev });
     };
 
     const onInstall = () => {
@@ -145,7 +146,7 @@ class ContentPackVersions extends React.Component {
     };
 
     const modal = (
-      <BootstrapModalWrapper showModal={this.state.showModal}
+      <BootstrapModalWrapper showModal={this.state.showModal && this.state.modalRev === item.rev}
                              onHide={closeModal}
                              bsSize="large">
         <Modal.Header closeButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes error where only the most recent revision of a content pack could be installed.
## Description
<!--- Describe your changes in detail -->
All revision modals were being displayed with the latest revision modal on top. This introduces an extra state variable to track which single revision modal should be visible and used to install the appropriate revision.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #16913 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dev env
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

