### PR TITLE
Removing `localhost`/loopback-addresses from SAN of data node certs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrSigner.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/CsrSigner.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.security.certutil.csr;
 
-import com.google.common.collect.Sets;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
@@ -44,7 +43,6 @@ import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -54,12 +52,6 @@ import static org.bouncycastle.asn1.x509.GeneralName.rfc822Name;
 import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
 
 public class CsrSigner {
-    private static final Set<GeneralName> localhostAttributes = Set.of(
-            new GeneralName(dNSName, "localhost"),
-            new GeneralName(iPAddress, "127.0.0.1"),
-            new GeneralName(iPAddress, "0:0:0:0:0:0:0:1")
-    );
-
     private final Clock clock;
 
     public CsrSigner() {
@@ -136,7 +128,7 @@ public class CsrSigner {
                 .collect(Collectors.toSet());
         if (!altNames.isEmpty()) {
             builder.addExtension(Extension.subjectAlternativeName, false,
-                    new GeneralNames(Sets.union(localhostAttributes, altNames).toArray(new GeneralName[0])));
+                    new GeneralNames(altNames.toArray(new GeneralName[0])));
         }
 
         ContentSigner signer = new JcaContentSignerBuilder(SIGNING_ALGORITHM).build(caPrivateKey);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is removing `localhost`/loopback-addresses from the SAN of generated data node certs, as it seems like they are not required for operation.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.