### PR TITLE
Add execution duration to jobs overview

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -30,6 +30,7 @@ import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.utilities.MongoQueryUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.mongojack.DBCursor;
 import org.mongojack.DBQuery;
 import org.mongojack.DBQuery.Query;
@@ -76,6 +77,7 @@ public class DBJobTriggerService {
     private static final String FIELD_UPDATED_AT = JobTriggerDto.FIELD_UPDATED_AT;
     private static final String FIELD_TRIGGERED_AT = JobTriggerDto.FIELD_TRIGGERED_AT;
     private static final String FIELD_CONSTRAINTS = JobTriggerDto.FIELD_CONSTRAINTS;
+    private static final String FIELD_LAST_EXECUTION_TIME = JobTriggerDto.FIELD_EXECUTION_DURATION;
 
     private static final String FIELD_JOB_DEFINITION_TYPE = JobTriggerDto.FIELD_JOB_DEFINITION_TYPE;
 
@@ -415,6 +417,11 @@ public class DBJobTriggerService {
         if (triggerUpdate.data().isPresent()) {
             update.set(FIELD_DATA, triggerUpdate.data());
         }
+        trigger.triggeredAt().ifPresent(triggeredAt -> {
+            var duration = new org.joda.time.Duration(triggeredAt, DateTime.now(DateTimeZone.UTC));
+            var executionDuration = java.time.Duration.ofMillis(duration.getMillis());
+            update.set(FIELD_LAST_EXECUTION_TIME, Optional.ofNullable(executionDuration));
+        });
 
         final int changedDocs = db.update(query, update).getN();
         if (changedDocs > 1) {
@@ -481,6 +488,7 @@ public class DBJobTriggerService {
 
     /**
      * Update the job progress on a trigger
+     *
      * @param trigger  the trigger to update
      * @param progress the job progress in percent (0-100)
      */
@@ -492,7 +500,8 @@ public class DBJobTriggerService {
 
     /**
      * Cancel a JobTrigger that matches a query
-     * @param query  the db query
+     *
+     * @param query the db query
      * @return an Optional of the trigger that was cancelled. Empty if no matching trigger was found.
      */
     public Optional<JobTriggerDto> cancelTriggerByQuery(Query query) {
@@ -503,7 +512,8 @@ public class DBJobTriggerService {
 
     /**
      * Find triggers by using the provided query. Use judiciously!
-     * @param query  The query
+     *
+     * @param query The query
      * @return All found JobTriggers
      */
     public List<JobTriggerDto> findByQuery(Query query) {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -420,7 +420,7 @@ public class DBJobTriggerService {
         trigger.triggeredAt().ifPresent(triggeredAt -> {
             var duration = new org.joda.time.Duration(triggeredAt, DateTime.now(DateTimeZone.UTC));
             var executionDuration = java.time.Duration.ofMillis(duration.getMillis());
-            update.set(FIELD_LAST_EXECUTION_TIME, Optional.ofNullable(executionDuration));
+            update.set(FIELD_LAST_EXECUTION_TIME, Optional.of(duration.getMillis()));
         });
 
         final int changedDocs = db.update(query, update).getN();

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -419,7 +419,6 @@ public class DBJobTriggerService {
         }
         trigger.triggeredAt().ifPresent(triggeredAt -> {
             var duration = new org.joda.time.Duration(triggeredAt, DateTime.now(DateTimeZone.UTC));
-            var executionDuration = java.time.Duration.ofMillis(duration.getMillis());
             update.set(FIELD_LAST_EXECUTION_TIME, Optional.of(duration.getMillis()));
         });
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
@@ -28,6 +28,7 @@ import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 
@@ -41,6 +42,7 @@ public abstract class JobTriggerDto {
     static final String FIELD_START_TIME = "start_time";
     static final String FIELD_END_TIME = "end_time";
     static final String FIELD_NEXT_TIME = "next_time";
+    static final String FIELD_EXECUTION_DURATION = "execution_duration";
     private static final String FIELD_CREATED_AT = "created_at";
     static final String FIELD_UPDATED_AT = "updated_at";
     static final String FIELD_TRIGGERED_AT = "triggered_at";
@@ -59,6 +61,7 @@ public abstract class JobTriggerDto {
 
     @JsonProperty(FIELD_JOB_DEFINITION_TYPE)
     public abstract String jobDefinitionType();
+
     @JsonProperty(FIELD_JOB_DEFINITION_ID)
     public abstract String jobDefinitionId();
 
@@ -80,6 +83,9 @@ public abstract class JobTriggerDto {
     @JsonProperty(FIELD_TRIGGERED_AT)
     public abstract Optional<DateTime> triggeredAt();
 
+    @JsonProperty(FIELD_EXECUTION_DURATION)
+    public abstract Optional<Duration> executionDuration();
+
     @JsonProperty(FIELD_STATUS)
     public abstract JobTriggerStatus status();
 
@@ -97,6 +103,7 @@ public abstract class JobTriggerDto {
 
     @JsonProperty(FIELD_IS_CANCELLED)
     public abstract boolean isCancelled();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -156,6 +163,9 @@ public abstract class JobTriggerDto {
 
         @JsonProperty(FIELD_TRIGGERED_AT)
         public abstract Builder triggeredAt(@Nullable DateTime triggeredAt);
+
+        @JsonProperty(FIELD_EXECUTION_DURATION)
+        public abstract Builder executionDuration(@Nullable Duration executionDuration);
 
         @JsonProperty(FIELD_STATUS)
         public abstract Builder status(JobTriggerStatus status);

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
@@ -17,6 +17,7 @@
 package org.graylog.scheduler;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -34,6 +35,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonDeserialize(builder = JobTriggerDto.Builder.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class JobTriggerDto {
     public static final String FIELD_ID = "id";
 
@@ -115,6 +117,7 @@ public abstract class JobTriggerDto {
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static abstract class Builder {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobTriggerDto.java
@@ -29,7 +29,6 @@ import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 
@@ -86,7 +85,7 @@ public abstract class JobTriggerDto {
     public abstract Optional<DateTime> triggeredAt();
 
     @JsonProperty(FIELD_EXECUTION_DURATION)
-    public abstract Optional<Duration> executionDuration();
+    public abstract Optional<Long> executionDurationMs();
 
     @JsonProperty(FIELD_STATUS)
     public abstract JobTriggerStatus status();
@@ -168,7 +167,7 @@ public abstract class JobTriggerDto {
         public abstract Builder triggeredAt(@Nullable DateTime triggeredAt);
 
         @JsonProperty(FIELD_EXECUTION_DURATION)
-        public abstract Builder executionDuration(@Nullable Duration executionDuration);
+        public abstract Builder executionDurationMs(@Nullable Long executionDurationMs);
 
         @JsonProperty(FIELD_STATUS)
         public abstract Builder status(JobTriggerStatus status);

--- a/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobResourceHandlerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobResourceHandlerService.java
@@ -21,6 +21,7 @@ import org.graylog.security.UserContext;
 import org.graylog2.rest.models.system.SystemJobSummary;
 
 import javax.inject.Inject;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class JobResourceHandlerService {
                 details.info(),
                 Objects.toString(trigger.lock().lastOwner(), ""),
                 trigger.triggeredAt().orElse(null),
-                trigger.executionDuration().orElse(null),
+                Duration.ofMillis(trigger.executionDurationMs().orElse(0L)),
                 trigger.lock().progress(),
                 details.isCancellable(),
                 true,

--- a/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobResourceHandlerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/rest/JobResourceHandlerService.java
@@ -98,6 +98,7 @@ public class JobResourceHandlerService {
                 details.info(),
                 Objects.toString(trigger.lock().lastOwner(), ""),
                 trigger.triggeredAt().orElse(null),
+                trigger.executionDuration().orElse(null),
                 trigger.lock().progress(),
                 details.isCancellable(),
                 true,

--- a/graylog2-web-interface/src/components/systemjobs/SystemJob.tsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJob.tsx
@@ -109,7 +109,9 @@ const SystemJob = ({ job }) => {
         <span data-toggle="tooltip" title={job.name}>{job.info}</span>{' '}
         - on <LinkToNode nodeId={job.node_id} />{' '}
         <RelativeTime dateTime={job.started_at} />{' '}
-        <StatusBadge status={mappedJobStatus}>{mappedJobStatus}</StatusBadge>
+        <span data-toggle="tooltip" title={`runtime: ${job.execution_duration}`}>
+          <StatusBadge status={mappedJobStatus}>{mappedJobStatus}</StatusBadge>
+        </span>
         {!jobIsOver && job.is_cancelable
           ? (<Button type="button" bsSize="xs" bsStyle="primary" className="pull-right" onClick={_onCancel()}>Cancel</Button>)
           : (<AcknowledgeButton type="button" bsStyle="link" onClick={_onAcknowledge()} bsSize="xs" className="pull-right" title="Acknowledge"><Icon name="x" /></AcknowledgeButton>)}
@@ -129,6 +131,7 @@ SystemJob.propTypes = {
     name: PropTypes.string,
     node_id: PropTypes.string,
     started_at: PropTypes.string,
+    execution_duration: PropTypes.string,
     job_status: PropTypes.oneOf(Object.values(JobStatus)),
   }).isRequired,
 };


### PR DESCRIPTION
The duration info will be displayed as a tool-tip on the status badge. Knowing how long it took a job (e.g. archive restore) to complete can be helpful.

Furthermore, this info is persisted with the trigger in the DB, so we could also build something like: show me the (current) slowest running event definition.

/nocl

