### PR TITLE
Retrieval of single config property from exposed config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/retrieval/SingleConfigurationValueRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/retrieval/SingleConfigurationValueRetriever.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration.retrieval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+
+public class SingleConfigurationValueRetriever {
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public SingleConfigurationValueRetriever(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Optional<Object> retrieveSingleValue(final Object jsonObject, final String valueName) {
+        final Map<String, Object> map = objectMapper.convertValue(jsonObject, new TypeReference<>() {});
+        return Optional.ofNullable(map.get(valueName));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
@@ -17,18 +17,24 @@
 package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.Configuration;
 import org.graylog2.configuration.ExposedConfiguration;
 import org.graylog2.shared.rest.resources.RestResource;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
 
 @RequiresAuthentication
 @Api(value = "System/Configuration", description = "Read-only access to configuration settings")
@@ -38,7 +44,7 @@ public class ConfigurationResource extends RestResource {
     private final Configuration configuration;
 
     @Inject
-    public ConfigurationResource(Configuration configuration) {
+    public ConfigurationResource(final Configuration configuration) {
         this.configuration = configuration;
     }
 
@@ -47,5 +53,27 @@ public class ConfigurationResource extends RestResource {
     @ApiOperation(value = "Get relevant configuration settings and their values")
     public ExposedConfiguration getRelevant() {
         return ExposedConfiguration.create(configuration);
+    }
+
+    @GET
+    @Path("/{name}")
+    @Timed
+    @ApiOperation(value = "Get relevant configuration setting value")
+    public Response getRelevantByName(@ApiParam(name = "name", required = true)
+                                      @PathParam("name") @NotEmpty String configSettingName) {
+
+        final ExposedConfiguration conf = ExposedConfiguration.create(configuration);
+
+        return Arrays.stream(ExposedConfiguration.class.getMethods())
+                .filter(method -> method.isAnnotationPresent(JsonProperty.class))
+                .filter(method -> method.getAnnotation(JsonProperty.class).value().equals(configSettingName))
+                .findFirst()
+                .map(method -> {
+                    try {
+                        return Response.ok(method.invoke(conf)).build();
+                    } catch (Exception ex) {
+                        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getMessage()).build();
+                    }
+                }).orElse(Response.status(Response.Status.NOT_FOUND).build());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/retrieval/SingleConfigurationValueRetrieverTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/retrieval/SingleConfigurationValueRetrieverTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.configuration.retrieval;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleConfigurationValueRetrieverTest {
+
+    private SingleConfigurationValueRetriever toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new SingleConfigurationValueRetriever(new ObjectMapper());
+    }
+
+    @Test
+    void testRetrievesSingleValue() {
+        Optional<Object> value = toTest.retrieveSingleValue(new TestJson(42, "ho!"), "test_string");
+        assertEquals(Optional.of("ho!"), value);
+
+        value = toTest.retrieveSingleValue(new TestJson(42, "ho!"), "test_int");
+        assertEquals(Optional.of(42), value);
+    }
+
+    @Test
+    void testRetrievesEmptyOptionalOnWrongValueName() {
+        Optional<Object> value = toTest.retrieveSingleValue(new TestJson(42, "ho!"), "carramba!");
+        assertTrue(value.isEmpty());
+    }
+
+    private record TestJson(@JsonProperty("test_int") int testInt,
+                            @JsonProperty("test_string") String testString) {
+
+    }
+}


### PR DESCRIPTION
## Description
Retrieval of single config property from exposed config.
/nocl

## Motivation and Context
We do not want to provide all config properties to the FE if only one property is needed.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

