### PR TITLE
Fixing extraction order of auth infos in proxied resources.

### DIFF
--- a/changelog/unreleased/pr-16999.toml
+++ b/changelog/unreleased/pr-16999.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Aligning order of precedence of auth info in proxied resources with general authentication logic."
+
+issues = ["16985"]
+pulls = ["16999"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -109,17 +109,17 @@ public abstract class ProxiedResource extends RestResource {
     }
 
     public static String authenticationToken(HttpHeaders httpHeaders) {
-        final List<String> authorizationHeader = httpHeaders.getRequestHeader("Authorization");
-        if (authorizationHeader != null && !authorizationHeader.isEmpty()) {
-            return authorizationHeader.get(0);
-        }
-
         final Cookie authenticationCookie = httpHeaders.getCookies().get("authentication");
         if (authenticationCookie != null) {
             final String sessionId = authenticationCookie.getValue();
             final String credentials = sessionId + ":session";
             final String base64Credentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
             return "Basic " + base64Credentials;
+        }
+
+        final List<String> authorizationHeader = httpHeaders.getRequestHeader("Authorization");
+        if (authorizationHeader != null && !authorizationHeader.isEmpty()) {
+            return authorizationHeader.get(0);
         }
 
         return null;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `ProxiedResource` superclass used by REST resources which forward requests to other Graylog nodes in the cluster is providing logic to extract the authentication info of the current user in order to add it to the request sent to another Graylog node.

Prior to this PR, the extraction logic is operating in this order, returning early when the first one succeeds:

  - Extracting the `Authorization` header if present
  - Extracting a session cookie if present

For our general authentication logic, this order is reversed. This is a problem when a request has both, the `Authorization`-header as well as a session cookie.

This PR is now aligning the logic of the `ProxiedResource` with the general authentication logic, assigning precedence to the session cookie over the `Authorization` header.

Fixes #16985.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.