### PR TITLE
DataNode: Always using the hostname from the configuration in the NodePingPeriodical

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/NodePingPeriodical.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.datanode.periodicals;
 
+import org.graylog.datanode.Configuration;
 import org.graylog.datanode.management.OpensearchProcess;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
@@ -26,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.net.URI;
 import java.util.function.Supplier;
 
@@ -38,16 +41,18 @@ public class NodePingPeriodical extends Periodical {
     private final Supplier<URI> opensearchBaseUri;
     private final Supplier<String> opensearchClusterUri;
     private final Supplier<Boolean> isLeader;
+    private final Configuration configuration;
 
 
     @Inject
-    public NodePingPeriodical(NodeService nodeService, NodeId nodeId, OpensearchProcess managedOpenSearch) {
-        this(nodeService, nodeId, managedOpenSearch::getOpensearchBaseUrl, managedOpenSearch::getOpensearchClusterUrl, managedOpenSearch::isLeaderNode);
+    public NodePingPeriodical(NodeService nodeService, NodeId nodeId, Configuration configuration, OpensearchProcess managedOpenSearch) {
+        this(nodeService, nodeId, configuration, managedOpenSearch::getOpensearchBaseUrl, managedOpenSearch::getOpensearchClusterUrl, managedOpenSearch::isLeaderNode);
     }
 
     NodePingPeriodical(
             NodeService nodeService,
             NodeId nodeId,
+            Configuration configuration,
             Supplier<URI> opensearchBaseUri,
             Supplier<String> opensearchClusterUri,
             Supplier<Boolean> isLeader
@@ -57,6 +62,7 @@ public class NodePingPeriodical extends Periodical {
         this.opensearchBaseUri = opensearchBaseUri;
         this.opensearchClusterUri = opensearchClusterUri;
         this.isLeader = isLeader;
+        this.configuration = configuration;
     }
 
     @Override
@@ -115,7 +121,7 @@ public class NodePingPeriodical extends Periodical {
                 isLeader.get(),
                 opensearchBaseUri.get(),
                 opensearchClusterUri.get(),
-                Tools.getLocalCanonicalHostname());
+                configuration.getHostname());
 
         if (!registrationSucceeded) {
             LOG.error("Failed to register node {} for heartbeats.", nodeId.getNodeId());

--- a/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.datanode.periodicals;
 
+import org.graylog.datanode.Configuration;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.plugin.system.SimpleNodeId;
@@ -34,9 +35,13 @@ class NodePingPeriodicalTest {
         final String cluster = "localhost:9300";
         final NodeService nodeService = Mockito.mock(NodeService.class);
 
+        Configuration configuration = Mockito.mock(Configuration.class);
+        Mockito.when(configuration.getHostname()).thenReturn("localhost");
+
         final NodePingPeriodical task = new NodePingPeriodical(
                 nodeService,
                 nodeID,
+                configuration,
                 () -> uri,
                 () -> cluster,
                 () -> true
@@ -63,9 +68,13 @@ class NodePingPeriodicalTest {
 
         Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster);
 
+        Configuration configuration = Mockito.mock(Configuration.class);
+        Mockito.when(configuration.getHostname()).thenReturn("localhost");
+
         final NodePingPeriodical task = new NodePingPeriodical(
                 nodeService,
                 nodeID,
+                configuration,
                 () -> uri,
                 () -> cluster,
                 () -> true
@@ -79,6 +88,40 @@ class NodePingPeriodicalTest {
                 Mockito.eq(uri),
                 Mockito.eq(cluster),
                 Mockito.any()
+        );
+    }
+
+    @Test
+    void doRunRegisterWithCustomHostname() throws NodeNotFoundException {
+
+        final SimpleNodeId nodeID = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
+        final URI uri = URI.create("http://otherhost:9200");
+        final String cluster = "otherhost:9300";
+
+        final NodeService nodeService = Mockito.mock(NodeService.class);
+
+        Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster);
+
+        Configuration configuration = Mockito.mock(Configuration.class);
+        Mockito.when(configuration.getHostname()).thenReturn("otherhost");
+
+        final NodePingPeriodical task = new NodePingPeriodical(
+                nodeService,
+                nodeID,
+                configuration,
+                () -> uri,
+                () -> cluster,
+                () -> true
+        );
+
+        task.doRun();
+
+        Mockito.verify(nodeService).registerServer(
+                Mockito.eq(nodeID.getNodeId()),
+                Mockito.eq(true),
+                Mockito.eq(uri),
+                Mockito.eq(cluster),
+                Mockito.eq("otherhost")
         );
     }
 }

--- a/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
@@ -69,7 +69,7 @@ class NodePingPeriodicalTest {
         Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster);
 
         Configuration configuration = Mockito.mock(Configuration.class);
-        Mockito.when(configuration.getHostname()).thenReturn("localhost");
+        Mockito.when(configuration.getHostname()).thenReturn("hostname.setting.from.config");
 
         final NodePingPeriodical task = new NodePingPeriodical(
                 nodeService,
@@ -87,41 +87,7 @@ class NodePingPeriodicalTest {
                 Mockito.eq(true),
                 Mockito.eq(uri),
                 Mockito.eq(cluster),
-                Mockito.any()
-        );
-    }
-
-    @Test
-    void doRunRegisterWithCustomHostname() throws NodeNotFoundException {
-
-        final SimpleNodeId nodeID = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
-        final URI uri = URI.create("http://otherhost:9200");
-        final String cluster = "otherhost:9300";
-
-        final NodeService nodeService = Mockito.mock(NodeService.class);
-
-        Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster);
-
-        Configuration configuration = Mockito.mock(Configuration.class);
-        Mockito.when(configuration.getHostname()).thenReturn("otherhost");
-
-        final NodePingPeriodical task = new NodePingPeriodical(
-                nodeService,
-                nodeID,
-                configuration,
-                () -> uri,
-                () -> cluster,
-                () -> true
-        );
-
-        task.doRun();
-
-        Mockito.verify(nodeService).registerServer(
-                Mockito.eq(nodeID.getNodeId()),
-                Mockito.eq(true),
-                Mockito.eq(uri),
-                Mockito.eq(cluster),
-                Mockito.eq("otherhost")
+                Mockito.eq("hostname.setting.from.config")
         );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

To ensure that we always use the hostname that a user has specified.


favoring this over #17004 

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

