### PR TITLE
Data Node: Do not log state transition when src/dst are identical.

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/ServerBootstrap.java
@@ -73,10 +73,10 @@ public abstract class ServerBootstrap extends CmdLineTool {
     }
 
     @Option(name = {"-p", "--pidfile"}, description = "File containing the PID of Graylog DataNode")
-    private String pidFile = TMPDIR + FILE_SEPARATOR + "datanode.pid";
+    private final String pidFile = TMPDIR + FILE_SEPARATOR + "datanode.pid";
 
     @Option(name = {"-np", "--no-pid-file"}, description = "Do not write a PID file (overrides -p/--pidfile)")
-    private boolean noPidFile = false;
+    private final boolean noPidFile = false;
 
     protected abstract void startNodeRegistration(Injector injector);
 
@@ -219,8 +219,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
         Runtime.getRuntime().addShutdownHook(new Thread(injector.getInstance(shutdownHook())));
 
         // Start services.
-//        final ServiceManagerListener serviceManagerListener = injector.getInstance(ServiceManagerListener.class);
-//        serviceManager.addListener(serviceManagerListener, MoreExecutors.directExecutor());
         try {
             serviceManager.startAsync().awaitHealthy();
         } catch (Exception e) {
@@ -241,7 +239,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
         try {
             Thread.currentThread().join();
         } catch (InterruptedException e) {
-            return;
         }
     }
 
@@ -271,13 +268,9 @@ public abstract class ServerBootstrap extends CmdLineTool {
         final List<Module> result = super.getSharedBindingsModules();
         result.add(new FreshInstallDetectionModule(isFreshInstallation()));
         result.add(new GenericBindings(isMigrationCommand()));
-//        result.add(new SecurityBindings());
-//        result.add(new ValidatorModule());
-//        result.add(new SharedPeriodicalBindings());
         result.add(new SchedulerBindings());
         result.add(new GenericInitializerBindings());
         result.add(new DatanodeConfigurationBindings());
-//        result.add(new SystemStatsModule(configuration.isDisableNativeSystemStatsCollector()));
 
         return result;
     }

--- a/data-node/src/main/java/org/graylog/datanode/management/StateMachineTransitionLogger.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/StateMachineTransitionLogger.java
@@ -33,6 +33,8 @@ public class StateMachineTransitionLogger implements StateMachineTracer {
 
     @Override
     public void transition(ProcessEvent trigger, ProcessState source, ProcessState destination) {
-        LOG.debug("Triggered {}, source state: {}, destination: {}", trigger, source, destination);
+        if (!source.equals(destination)) {
+            LOG.debug("Triggered {}, source state: {}, destination: {}", trigger, source, destination);
+        }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This avoids constant logging of identical states every 10s:

```
2023-10-20 12:04:06,253 DEBUG: org.graylog.datanode.management.StateMachineTransitionLogger - Triggered HEALTH_CHECK_OK, source state: AVAILABLE, destination: AVAILABLE
2023-10-20 12:04:16,252 DEBUG: org.graylog.datanode.management.StateMachineTransitionLogger - Triggered HEALTH_CHECK_OK, source state: AVAILABLE, destination: AVAILABLE
[...]
```

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.