### PR TITLE
allow colon in field values

### DIFF
--- a/graylog2-web-interface/src/components/rules/rule-builder/helpers.ts
+++ b/graylog2-web-interface/src/components/rules/rule-builder/helpers.ts
@@ -36,7 +36,7 @@ const jsonifyText = (text: string): string => {
           .split('\n')
           .map((line) => line.trim().split(':').map((keyValue) => keyValue.trim()))
           .filter((keyValue) => keyValue[0] && keyValue[1])
-          .map((keyValue) => keyValue.join('":"'))
+          .map((keyValue) => `${keyValue[0]}":"${keyValue.slice(1).join(':')}`)
           .join('","')
       }"}`;
 


### PR DESCRIPTION
if the value part of a field in the map syntax contains a colon, the fields are now set correctly.

fixes #16983

/nocl
