### PR TITLE
Timerange conversion fix for months/years - backport to 5.2

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
@@ -24,8 +24,22 @@ import java.util.function.Function;
 public class PeriodToRelativeRangeConverter implements Function<Period, RelativeRange> {
 
     @Override
-    public RelativeRange apply(final Period period) {
+    public RelativeRange apply(Period period) {
         if (period != null) {
+            // years are not supported in the toStandardSeconds conversion, so we convert it to days and assume 365 days a year
+            if(period.getYears() > 0) {
+                final int years = period.getYears();
+                period = period.minusYears(years);
+                period = period.plusDays(years * 365);
+            }
+
+            // months are not supported in the toStandardSeconds conversion, so we convert it to days and assume 30 days a month
+            if(period.getMonths() > 0) {
+                final int months = period.getMonths();
+                period = period.minusMonths(months);
+                period = period.plusDays(months * 30);
+            }
+
             return RelativeRange.Builder.builder()
                     .from(period.toStandardSeconds().getSeconds())
                     .build();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
@@ -27,13 +27,13 @@ public class PeriodToRelativeRangeConverter implements Function<Period, Relative
     public RelativeRange apply(Period period) {
         if (period != null) {
             // years are not supported in the toStandardSeconds conversion, so we convert it to days and assume 365 days a year
-            if(period.getYears() > 0) {
+            if (period.getYears() > 0) {
                 final int years = period.getYears();
                 period = period.minusYears(years).plusDays(years * 365);
             }
 
             // months are not supported in the toStandardSeconds conversion, so we convert it to days and assume 30 days a month
-            if(period.getMonths() > 0) {
+            if (period.getMonths() > 0) {
                 final int months = period.getMonths();
                 period = period.minusMonths(months).plusDays(months * 30);
             }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
@@ -24,22 +24,10 @@ import java.util.function.Function;
 public class PeriodToRelativeRangeConverter implements Function<Period, RelativeRange> {
 
     @Override
-    public RelativeRange apply(Period period) {
+    public RelativeRange apply(final Period period) {
         if (period != null) {
-            // years are not supported in the toStandardSeconds conversion, so we convert it to days and assume 365 days a year
-            if (period.getYears() > 0) {
-                final int years = period.getYears();
-                period = period.minusYears(years).plusDays(years * 365);
-            }
-
-            // months are not supported in the toStandardSeconds conversion, so we convert it to days and assume 30 days a month
-            if (period.getMonths() > 0) {
-                final int months = period.getMonths();
-                period = period.minusMonths(months).plusDays(months * 30);
-            }
-
             return RelativeRange.Builder.builder()
-                    .from(period.toStandardSeconds().getSeconds())
+                    .from(period.withYears(0).withMonths(0).plusDays(period.getYears() * 365).plusDays(period.getMonths() * 30).toStandardSeconds().getSeconds())
                     .build();
         } else {
             return null;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverter.java
@@ -29,15 +29,13 @@ public class PeriodToRelativeRangeConverter implements Function<Period, Relative
             // years are not supported in the toStandardSeconds conversion, so we convert it to days and assume 365 days a year
             if(period.getYears() > 0) {
                 final int years = period.getYears();
-                period = period.minusYears(years);
-                period = period.plusDays(years * 365);
+                period = period.minusYears(years).plusDays(years * 365);
             }
 
             // months are not supported in the toStandardSeconds conversion, so we convert it to days and assume 30 days a month
             if(period.getMonths() > 0) {
                 final int months = period.getMonths();
-                period = period.minusMonths(months);
-                period = period.plusDays(months * 30);
+                period = period.minusMonths(months).plusDays(months * 30);
             }
 
             return RelativeRange.Builder.builder()

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/timerangepresets/conversion/PeriodToRelativeRangeConverterTest.java
@@ -68,6 +68,30 @@ class PeriodToRelativeRangeConverterTest {
         verifyResult(result, 4207);
     }
 
+    @Test
+    void testMonthsPeriodConversion() {
+        final RelativeRange result = converter.apply(Period.months(2));
+        verifyResult(result, 2 * 30 * 24 * 60 * 60);
+    }
+
+    @Test
+    void testYearsPeriodConversion() {
+        final RelativeRange result = converter.apply(Period.years(3));
+        verifyResult(result, 3 * 365 * 24 * 60 * 60);
+    }
+
+    @Test
+    void testYearsMonthsPeriodConversion() {
+        final RelativeRange result = converter.apply(Period.years(5).plusMonths(1));
+        verifyResult(result, (5 * 365 + 1 * 30) * 24 * 60 * 60);
+    }
+
+    @Test
+    void testYearsMonthsMixedPeriodConversion() {
+        final RelativeRange result = converter.apply(Period.years(5).plusMonths(1).plusHours(1).plusMinutes(10).plusSeconds(7));
+        verifyResult(result, ((5 * 365 + 1 * 30) * 24 * 60 * 60) + (60 * 60) + (10 * 60) + 7);
+    }
+
     private void verifyResult(final RelativeRange result, final int expectedFromField) {
         assertThat(result)
                 .isNotNull()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The migration does not work for months/years, so we have to convert those values into days assuming a standard length of 30 days for a month/365 days for a year first.

**backport into 5.2 from #17054**

fixes #17045 

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

