### PR TITLE
Stop throwing errors on blank log messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -255,19 +255,21 @@ public class GelfCodec extends AbstractCodec {
 
         final JsonNode shortMessageNode = jsonNode.path("short_message");
         final JsonNode messageNode = jsonNode.path("message");
+        String message = shortMessageNode.asText();
         if (!shortMessageNode.isMissingNode()) {
             if (!shortMessageNode.isTextual()) {
                 throw new IllegalArgumentException(prefix + "has invalid \"short_message\": " + shortMessageNode.asText());
             }
-            if (StringUtils.isBlank(shortMessageNode.asText()) && StringUtils.isBlank(messageNode.asText())) {
-                throw new IllegalArgumentException(prefix + "has empty mandatory \"short_message\" field.");
+            String shortMessage = shortMessageNode.asText();
+            if (shortMessage == null && message == null) {
+                throw new IllegalArgumentException(prefix + "mandatory \"short_message\" field is null.");
             }
         } else if (!messageNode.isMissingNode()) {
             if (!messageNode.isTextual()) {
                 throw new IllegalArgumentException(prefix + "has invalid \"message\": " + messageNode.asText());
             }
-            if (StringUtils.isBlank(messageNode.asText())) {
-                throw new IllegalArgumentException(prefix + "has empty mandatory \"message\" field.");
+            if (message == null) {
+                throw new IllegalArgumentException(prefix + "mandatory \"message\" field is null.");
             }
         } else {
             throw new IllegalArgumentException(prefix + "is missing mandatory \"short_message\" or \"message\" field.");


### PR DESCRIPTION
## Description
Blank log messages should not generating errors. When a client sends a blank log message it should be processed like all other messages.

## Motivation and Context
Fixes https://github.com/Graylog2/graylog2-server/issues/5793
Related to https://github.com/docker/for-linux/issues/354 and https://github.com/fluent/fluentd-kubernetes-daemonset/issues/243