### PR TITLE
Fix opensearch configuration sync permissions

### DIFF
--- a/changelog/unreleased/pr-17059.toml
+++ b/changelog/unreleased/pr-17059.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed opensearch configuration sync permissions"
+
+pulls = ["17059"]

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
@@ -42,7 +42,7 @@ public class OpensearchCommandLineProcess implements Closeable {
     private final CommandLineProcess commandLineProcess;
     private final CommandLineProcessListener resultHandler;
     private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    private static final String CONFIG = "opensearch.yml";
+    private static final Path CONFIG = Path.of("opensearch.yml");
 
     /**
      * as long as OpenSearch is not supported on macOS, we have to fix the jdk path if we want to
@@ -79,8 +79,7 @@ public class OpensearchCommandLineProcess implements Closeable {
 
     private void writeOpenSearchConfig(final OpensearchConfiguration config) {
         try {
-            final var configFile = config.datanodeDirectories().getOpensearchProcessConfigurationDir().resolve(CONFIG);
-            Files.deleteIfExists(configFile);
+            final Path configFile = config.datanodeDirectories().createOpensearchProcessConfigurationFile(CONFIG);
             mapper.writeValue(configFile.toFile(), getOpensearchConfigurationArguments(config));
         } catch (IOException e) {
             throw new RuntimeException("Could not generate OpenSearch config: " + e.getMessage(), e);

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -22,7 +22,6 @@ import org.apache.commons.exec.ExecuteException;
 import org.apache.http.client.utils.URIBuilder;
 import org.graylog.datanode.Configuration;
 import org.graylog.datanode.configuration.DatanodeConfiguration;
-import org.graylog.datanode.configuration.DatanodeConfigurationProvider;
 import org.graylog.datanode.process.OpensearchConfiguration;
 import org.graylog.datanode.process.OpensearchInfo;
 import org.graylog.datanode.process.ProcessEvent;
@@ -53,6 +52,7 @@ import java.util.stream.Collectors;
 class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpensearchProcessImpl.class);
+    public static final Path UNICAST_HOSTS_FILE = Path.of("unicast_hosts.txt");
     private final StateMachineTracerAggregator tracerAggregator;
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -70,7 +70,6 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
     private final Queue<String> stdout;
     private final Queue<String> stderr;
     private final CustomCAX509TrustManager trustManager;
-    private final Path hostsfile;
     private final NodeService nodeService;
     private final Configuration configuration;
 
@@ -85,7 +84,6 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
         this.trustManager = trustManager;
         this.nodeService = nodeService;
         this.configuration = configuration;
-        this.hostsfile = datanodeConfiguration.datanodeDirectories().getOpensearchProcessConfigurationDir().resolve("unicast_hosts.txt");
     }
 
     private RestHighLevelClient createRestClient(OpensearchConfiguration configuration) {
@@ -157,10 +155,11 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
 
     private void writeSeedHostsList() {
         try {
+            final Path hostsfile = datanodeConfiguration.datanodeDirectories().createOpensearchProcessConfigurationFile(UNICAST_HOSTS_FILE);
             final Set<String> current = nodeService.allActive(Node.Type.DATANODE).values().stream().map(Node::getClusterAddress).filter(Objects::nonNull).collect(Collectors.toSet());
             Files.write(hostsfile, current, Charset.defaultCharset(), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
         } catch (IOException iox) {
-            LOG.error("Could not write to file: {} - {}", hostsfile, iox.getMessage());
+            LOG.error("Could not write to file: {} - {}", UNICAST_HOSTS_FILE, iox.getMessage());
         }
 
     }

--- a/data-node/src/test/java/org/graylog/datanode/bootstrap/preflight/FullDirSyncTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/bootstrap/preflight/FullDirSyncTest.java
@@ -27,8 +27,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,6 +103,22 @@ class FullDirSyncTest {
                 .extracting(Path::toString)
                 .hasSize(4)
                 .contains("a.txt", "b.txt", "subdir", "subdir/c.txt");
+
+        Assertions.assertThat(afterSyncState)
+                .filteredOn(Files::isDirectory)
+                .allSatisfy(p -> {
+                    final Set<PosixFilePermission> permission = Files.getPosixFilePermissions(p);
+                    Assertions.assertThat(permission).containsExactlyInAnyOrderElementsOf(FullDirSync.DIRECTORY_PERMISSIONS);
+                });
+
+        Assertions.assertThat(afterSyncState)
+                .filteredOn(Files::isRegularFile)
+                .allSatisfy(p -> {
+                    final Set<PosixFilePermission> permission = Files.getPosixFilePermissions(p);
+                    Assertions.assertThat(permission).containsExactlyInAnyOrderElementsOf(FullDirSync.FILE_PERMISSIONS);
+                });
+
+
 
     }
 }


### PR DESCRIPTION

This PR adapts permissions of opensearch configuration files that we sync(=copy and generate) during each datanode startup.

**needs a backport to 5.2**

## Motivation and Context
We should fix not just key material permissions as requested in https://github.com/Graylog2/graylog2-server/issues/17009 but all config files used by the embedded OS.

## How Has This Been Tested?
Added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

