### PR TITLE
Add Alert Notification ID to System Notification for Missing Email Recipients

### DIFF
--- a/changelog/unreleased/issue-16988.toml
+++ b/changelog/unreleased/issue-16988.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added the Email Notification ID to the System Notification for Missing Email Recipients."
+
+issues = ["16988"]
+pulls = ["17061"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -49,6 +49,7 @@ import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
+import static org.graylog2.shared.utilities.StringUtils.f;
 
 public class EmailSender {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
@@ -178,7 +179,7 @@ public class EmailSender {
                     .addNode(nodeId.getNodeId())
                     .addType(Notification.Type.GENERIC)
                     .addSeverity(Notification.Severity.NORMAL)
-                    .addDetail("title", "No recipients have been defined!")
+                    .addDetail("title", f("No recipients have been defined for notification with ID [%s]!", ctx.notificationId()))
                     .addDetail("description", "To fix this, go to the notification configuration and add at least one alert recipient.");
             notificationService.publishIfFirst(notification);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A system notification is created when an Email Notification is fired without any recipients. This change adds the Alert Notification ID to the system notification so that users will know what config needs to be updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #16988

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in dev environment.

One way to reproduce:
1. Create a user 
2. Delete created users email address (I did this manually in MongoDB)
3. Create an email Notification and add the above user as the sole recipient
4. Attach above notification to an Alert
5. Cause the above alert to trigger

## Screenshots (if appropriate):
![image](https://github.com/Graylog2/graylog2-server/assets/103449971/87347b88-53be-4bd0-b60d-d2b73f5becc7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

