### PR TITLE
Properly select new active dashboard tab when tab is removed.

### DIFF
--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -16,7 +16,7 @@
  */
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import type * as Immutable from 'immutable';
+import * as Immutable from 'immutable';
 
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type { ViewState, RootState, GetState } from 'views/types';
@@ -217,7 +217,7 @@ export const removeQuery = (queryId: string) => async (dispatch: AppDispatch, ge
     .build();
 
   const indexedQueryIds = search.queries.map((query) => query.id).toList();
-  const newActiveQuery = FindNewActiveQueryId(indexedQueryIds, activeQuery);
+  const newActiveQuery = FindNewActiveQueryId(indexedQueryIds, activeQuery, Immutable.List([queryId]));
 
   await dispatch(selectQuery(newActiveQuery));
   await dispatch(updateView(newView, true));

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.test.ts
@@ -18,9 +18,11 @@ import * as Immutable from 'immutable';
 
 import FindNewActiveQuery from 'views/logic/views/FindNewActiveQuery';
 
+const emptyList = Immutable.List<string>();
+
 describe('FindNewActiveQuery', () => {
   it('does not break when there are no queries left', () => {
-    expect(FindNewActiveQuery(Immutable.List(), 'deadbeef')).toBeUndefined();
+    expect(FindNewActiveQuery(emptyList, 'deadbeef', emptyList)).toBeUndefined();
     expect(FindNewActiveQuery(Immutable.List(['foo']), 'deadbeef', Immutable.List(['foo']))).toBeUndefined();
   });
 

--- a/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
+++ b/graylog2-web-interface/src/views/logic/views/FindNewActiveQuery.ts
@@ -16,9 +16,9 @@
  */
 
 // Returns a new query ID, in case the active query gets deleted.
-import { List } from 'immutable';
+import type { List } from 'immutable';
 
-const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string> = List()) => {
+const FindNewActiveQueryId = (queryIds: List<string>, activeQueryId: string, removedQueryIds: List<string>) => {
   const currentQueryIdIndex = queryIds.indexOf(activeQueryId);
   const priorQueryIds = queryIds.slice(0, currentQueryIdIndex).toList();
   const listToPickNewIdFrom = priorQueryIds.isEmpty()


### PR DESCRIPTION
**Note:** This needs to be backported to `5.2`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the `FindNewActiveQueryId` function is not passed the list of removed tabs when a user removes a dashboard tab. This leads to an error when the first dashboard tab is active and removed.

Fixes #16964.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.