### PR TITLE
Exclude non-message streams from search in aggregation events

### DIFF
--- a/changelog/unreleased/pr-17087.toml
+++ b/changelog/unreleased/pr-17087.toml
@@ -2,4 +2,4 @@ type = "c"
 message = "Exclude non-message streams from aggregation event searches."
 
 issues = ["Graylog2/graylog-plugin-enterprise/issues/6042"]
-pulls = ["99999"]
+pulls = ["17087"]

--- a/changelog/unreleased/pr-17087.toml
+++ b/changelog/unreleased/pr-17087.toml
@@ -1,5 +1,5 @@
-type = "c"
+type = "f"
 message = "Exclude non-message streams from aggregation event searches."
 
-issues = ["Graylog2/graylog-plugin-enterprise/issues/6042"]
+issues = ["Graylog2/graylog-plugin-enterprise#6042"]
 pulls = ["17087"]

--- a/changelog/unreleased/pr-99999.toml
+++ b/changelog/unreleased/pr-99999.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Exclude non-message streams from aggregation event searches."
+
+issues = ["Graylog2/graylog-plugin-enterprise/issues/6042"]
+pulls = ["99999"]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventStreamService.java
@@ -41,11 +41,11 @@ public class EventStreamService {
             // This can happen if the user didn't select any stream in the event definition and an event should be
             // created based on the absence of a search result. (e.g. count() < 1)
             // When the source streams field of an event is empty, every user can see it. That's why we need to add
-            // streams to the field. We decided to use all currently existing streams (minus the default event streams)
+            // streams to the field. We decided to use all currently existing streams (minus the non-message streams)
             // to make sure only users that have access to all message streams can see the event.
             sourceStreams = streamService.loadAll().stream()
                     .map(Persisted::getId)
-                    .filter(streamId -> !Stream.DEFAULT_EVENT_STREAM_IDS.contains(streamId))
+                    .filter(streamId -> !Stream.NON_MESSAGE_STREAM_IDS.contains(streamId))
                     .collect(Collectors.toSet());
         } else if (searchStreams.isEmpty()) {
             // If the search streams is empty, we search in all streams and so we include all source streams from the result.

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -43,6 +43,7 @@ import org.graylog.events.search.MoreSearch;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.errors.ParameterExpansionError;
 import org.graylog.plugins.views.search.errors.SearchException;
+import org.graylog.plugins.views.search.rest.PermittedStreams;
 import org.graylog.plugins.views.search.searchtypes.pivot.HasField;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.HasOptionalField;
@@ -61,8 +62,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -93,6 +94,7 @@ public class AggregationEventProcessor implements EventProcessor {
     private final EventStreamService eventStreamService;
     private final Messages messages;
     private final NotificationService notificationService;
+    private final PermittedStreams permittedStreams;
 
     @Inject
     public AggregationEventProcessor(@Assisted EventDefinition eventDefinition,
@@ -101,7 +103,8 @@ public class AggregationEventProcessor implements EventProcessor {
                                      DBEventProcessorStateService stateService,
                                      MoreSearch moreSearch,
                                      EventStreamService eventStreamService,
-                                     Messages messages, NotificationService notificationService) {
+                                     Messages messages, NotificationService notificationService,
+                                     PermittedStreams permittedStreams) {
         this.eventDefinition = eventDefinition;
         this.config = (AggregationEventProcessorConfig) eventDefinition.config();
         this.aggregationSearchFactory = aggregationSearchFactory;
@@ -111,6 +114,7 @@ public class AggregationEventProcessor implements EventProcessor {
         this.eventStreamService = eventStreamService;
         this.messages = messages;
         this.notificationService = notificationService;
+        this.permittedStreams = permittedStreams;
     }
 
     @Override
@@ -220,7 +224,10 @@ public class AggregationEventProcessor implements EventProcessor {
 
     private void filterSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,
                               EventConsumer<List<EventWithContext>> eventsConsumer) throws EventProcessorException {
-        final Set<String> streams = eventStreamService.buildEventSourceStreams(getStreams(parameters), Collections.emptySet());
+        Set<String> streams = getStreams(parameters);
+        if (streams.isEmpty()) {
+            streams = new HashSet<>(permittedStreams.load(streamId -> true));
+        }
 
         final AtomicInteger messageCount = new AtomicInteger(0);
         final MoreSearch.ScrollCallback callback = (messages, continueScrolling) -> {

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -219,7 +220,7 @@ public class AggregationEventProcessor implements EventProcessor {
 
     private void filterSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,
                               EventConsumer<List<EventWithContext>> eventsConsumer) throws EventProcessorException {
-        final Set<String> streams = getStreams(parameters);
+        final Set<String> streams = eventStreamService.buildEventSourceStreams(getStreams(parameters), Collections.emptySet());
 
         final AtomicInteger messageCount = new AtomicInteger(0);
         final MoreSearch.ScrollCallback callback = (messages, continueScrolling) -> {

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -65,7 +65,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -93,20 +92,14 @@ public class AggregationEventProcessorTest {
     private Consumer<List<MessageSummary>> messageConsumer;
     @Mock
     private NotificationService notificationService;
+    @Mock
+    private StreamService streamService;
+
     private EventStreamService eventStreamService;
 
     @Before
     public void setUp() throws Exception {
-        final StreamService streamService = mock(StreamService.class);
         eventStreamService = new EventStreamService(streamService);
-        when(streamService.loadAll()).thenReturn(ImmutableList.of(
-                new StreamMock(Collections.singletonMap("_id", "stream-1"), Collections.emptyList()),
-                new StreamMock(Collections.singletonMap("_id", "stream-2"), Collections.emptyList()),
-                new StreamMock(Collections.singletonMap("_id", "stream-3"), Collections.emptyList()),
-                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_STREAM_ID), Collections.emptyList()),
-                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_EVENTS_STREAM_ID), Collections.emptyList()),
-                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_SYSTEM_EVENTS_STREAM_ID), Collections.emptyList())
-        ));
     }
 
     @Test
@@ -447,6 +440,16 @@ public class AggregationEventProcessorTest {
 
     @Test
     public void testEventsFromAggregationResultWithEmptyResultAndNoConfiguredStreamsUsesAllStreamsAsSourceStreams() throws EventProcessorException {
+        when(streamService.loadAll()).thenReturn(ImmutableList.of(
+                new StreamMock(Collections.singletonMap("_id", "stream-1"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", "stream-2"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", "stream-3"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_STREAM_ID), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_EVENTS_STREAM_ID), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_SYSTEM_EVENTS_STREAM_ID), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.FAILURES_STREAM_ID), Collections.emptyList())
+        ));
+
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.minusHours(1).plusMillis(SEARCH_WINDOW_MS));
 


### PR DESCRIPTION
Relates to Graylog2/graylog-plugin-enterprise#6042
<!--- Provide a general summary of your changes in the Title above -->
When no source stream is given for an event definition we use all streams in the ES/OS search query. We now exclude all non-message streams. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users cannot select non-message streams as a source stream in the event definition. But these were still being included in the search when no source stream had been explicitly defined. This is unnecessary, inconsistent, and hurts performance. It may also push the search URI over the length limit, when there is a large number of streams.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

