### PR TITLE
Remove placeholder for Java API changes from upgrade notes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,14 +82,6 @@ Removed fields:
 Note that additional Microsoft Defender for Endpoint message parsing is expected to be released in a future release of
 Graylog Illuminate.
 
-## Java API Changes
-The following Java Code API changes have been made.
-
-| File/method                   | Description                                                     |
-|-------------------------------|-----------------------------------------------------------------|
-| `ExampleClass#exampleFuntion` | TODO placeholder comment             |
-
-
 ## REST API Endpoint Changes
 The following REST API changes have been made.
 


### PR DESCRIPTION
Removes the `Java API Changes` section from the `5.2` upgrade notes because it only contains a placeholder.

/nocl
