### PR TITLE
Correctly highlight selected day in date picker. (`5.0`)

### DIFF
--- a/changelog/unreleased/issue-16096.toml
+++ b/changelog/unreleased/issue-16096.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix timezone issue with date picker, which resulted in highlighting the wrong selected day."
+
+issues = ["16096"]
+pulls = ["16973"]

--- a/graylog2-web-interface/src/components/common/DatePicker.test.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { alice } from 'fixtures/users';
+
+import DatePicker from './DatePicker';
+
+const mockCurrentUser = alice.toBuilder()
+  .timezone('Europe/Berlin')
+  .build();
+
+jest.mock('hooks/useCurrentUser', () => () => mockCurrentUser);
+
+describe('DatePicker', () => {
+  describe('should consider user time zone when displaying selected date', () => {
+    it('for beginning of day (date with user tz)', async () => {
+      render(<DatePicker date="2023-10-19T00:00:00.000+02:00" onChange={() => {}} />);
+
+      expect(await screen.findByText('19')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('for end of day (date with user tz)', async () => {
+      render(<DatePicker date="2023-10-19T00:00:00.000+02:00" onChange={() => {}} />);
+
+      expect(await screen.findByText('19')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('for end of day (date with UTC tz)', async () => {
+      render(<DatePicker date="2023-10-19T23:59:00.000+00:00" onChange={() => {}} />);
+
+      expect(await screen.findByText('20')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+});

--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -65,7 +65,7 @@ const getFormatStringsForDateTimeFormats = (dateTimeFormats: Array<DateTimeForma
 
 export const toDateObject = (dateTime: DateTime, acceptedFormats?: Array<DateTimeFormats>, tz = DEFAULT_OUTPUT_TZ) => {
   const acceptedFormatStrings = getFormatStringsForDateTimeFormats(acceptedFormats);
-  const dateObject = moment(dateTime, acceptedFormatStrings, true).tz(tz);
+  const dateObject = moment.utc(dateTime, acceptedFormatStrings, true).tz(tz);
   const validationInfo = acceptedFormats?.length ? `Expected formats: ${acceptedFormatStrings.join(', ')}.` : undefined;
 
   return validateDateTime(dateObject, dateTime, validationInfo);

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -63,12 +63,6 @@ jest.mock('stores/connect', () => {
   };
 });
 
-jest.mock('moment', () => {
-  const mockMoment = jest.requireActual('moment');
-
-  return Object.assign(() => mockMoment('2019-10-10T12:26:31.146Z'), mockMoment);
-});
-
 jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
 jest.mock('views/components/searchbar/queryinput/BasicQueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
 jest.mock('views/components/searchbar/queryinput/QueryInput', () => ({ value = '' }: { value: string }) => <span>{value}</span>);
@@ -132,7 +126,7 @@ describe('WidgetQueryControls', () => {
   describe('displays if global override is set', () => {
     const resetTimeRangeButtonTitle = /reset global override/i;
     const resetQueryButtonTitle = /reset global filter/i;
-    const timeRangeOverrideInfo = '2019-10-10 14:26:31.146 - 2019-10-10 14:26:31.146';
+    const timeRangeOverrideInfo = '2020-01-01 11:00:00.850 - 2020-01-02 11:00:00.000';
     const queryOverrideInfo = globalOverrideWithQuery.query.query_string;
 
     it('shows preview of global override time range', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDatePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/date-time-picker/AbsoluteDatePicker.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { DateUtils } from 'react-day-picker';
-import moment from 'moment';
 
 import { DatePicker } from 'components/common';
-import { DATE_TIME_FORMATS } from 'util/DateTime';
+import { toUTCFromTz, toDateObject } from 'util/DateTime';
+import useUserDateTime from 'hooks/useUserDateTime';
 
 type Props = {
   dateTime: string,
@@ -29,25 +29,26 @@ type Props = {
 }
 
 const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
-  const initialDateTime = moment(dateTime).toObject();
+  const { userTimezone, formatTime } = useUserDateTime();
+  const initialDateTime = toUTCFromTz(dateTime, userTimezone);
 
-  const _onDatePicked = (date) => {
-    if (!!startDate && DateUtils.isDayBefore(date, startDate)) {
+  const _onDatePicked = (selectedDate: Date) => {
+    if (!!startDate && DateUtils.isDayBefore(selectedDate, startDate)) {
       return false;
     }
 
-    const newDate = moment(date).toObject();
+    const selectedDateObject = toDateObject(selectedDate);
+    const newDate = initialDateTime.set({
+      year: selectedDateObject.year(),
+      month: selectedDateObject.month(),
+      date: selectedDateObject.date(),
+    });
 
-    return onChange(moment({
-      ...initialDateTime,
-      years: newDate.years,
-      months: newDate.months,
-      date: newDate.date,
-    }).format(DATE_TIME_FORMATS.default));
+    return onChange(formatTime(newDate, 'default'));
   };
 
   return (
-    <DatePicker date={dateTime}
+    <DatePicker date={initialDateTime}
                 onChange={_onDatePicked}
                 fromDate={startDate} />
   );


### PR DESCRIPTION
**Please note**, this PR is a backport of #16973 for `5.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/16096 the highlight for the selected date in the date picker can be wrong for a date time like `2023-10-17 00:00:00`. In this case it displayed the previous day as active.

The reason is that the date time does not contain a time zone information and `moment()` still uses the estimated user time zone internally. For example when your browser timezone is `Europe/Paris` the UTC time for `2023-10-17 00:00:00` is `2023-10-16 22:00:00`.

We are now:
- using `moment.utc()` instead of `moment()` to make it's behaviour predictable for date times without a time zone.
This only effects few cases, because usually timestamps in the frontend have a timezone.
- considering the user time zone when handling dates in the date picker.

There are more improvements we can make regarding the date time utils, but I will do them in a follow-up PR, so this PR will be easy to backport.

Fixes: https://github.com/Graylog2/graylog2-server/issues/16096
Fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/5998