### PR TITLE
(Backport 5.2) - Add Alert Notification ID to System Notification for Missing Email Recipients

### DIFF
--- a/changelog/unreleased/issue-16988.toml
+++ b/changelog/unreleased/issue-16988.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added the Email Notification ID to the System Notification for Missing Email Recipients."
+
+issues = ["16988"]
+pulls = ["17061"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -49,6 +49,7 @@ import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
+import static org.graylog2.shared.utilities.StringUtils.f;
 
 public class EmailSender {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
@@ -178,7 +179,7 @@ public class EmailSender {
                     .addNode(nodeId.getNodeId())
                     .addType(Notification.Type.GENERIC)
                     .addSeverity(Notification.Severity.NORMAL)
-                    .addDetail("title", "No recipients have been defined!")
+                    .addDetail("title", f("No recipients have been defined for notification with ID [%s]!", ctx.notificationId()))
                     .addDetail("description", "To fix this, go to the notification configuration and add at least one alert recipient.");
             notificationService.publishIfFirst(notification);
         }


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/17061 to the 5.2 branch.