### PR TITLE
backport 5.2: set state to SKIPPED if "resume startup" is called with no data nodes…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/PreflightStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/web/resources/PreflightStatusResource.java
@@ -23,7 +23,6 @@ import org.graylog2.bootstrap.preflight.PreflightConfigResult;
 import org.graylog2.bootstrap.preflight.PreflightConfigService;
 import org.graylog2.bootstrap.preflight.PreflightConstants;
 import org.graylog2.plugin.Version;
-import org.graylog2.plugin.database.ValidationException;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -53,7 +52,14 @@ public class PreflightStatusResource {
     @NoAuditEvent("No audit event yet")
     @POST
     @Path("/finish-config")
-    public PreflightConfig finishConfig() throws ValidationException {
+    public PreflightConfig finishConfig() {
          return preflightConfigService.setConfigResult(PreflightConfigResult.FINISHED);
+    }
+
+    @NoAuditEvent("No audit event yet")
+    @POST
+    @Path("/skip-config")
+    public PreflightConfig skipConfig() {
+        return preflightConfigService.setConfigResult(PreflightConfigResult.SKIPPED);
     }
 }

--- a/graylog2-web-interface/src/preflight/App.test.tsx
+++ b/graylog2-web-interface/src/preflight/App.test.tsx
@@ -97,7 +97,7 @@ describe('App', () => {
 
     const resumeStartupButton = await startupButton();
     userEvent.click(resumeStartupButton);
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/finish-config'), undefined, false));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/skip-config'), undefined, false));
     await screen.findByText(/The Graylog server is currently starting./);
   });
 
@@ -114,8 +114,8 @@ describe('App', () => {
     const resumeStartupButton = await startupButton();
     userEvent.click(resumeStartupButton);
 
-    await waitFor(() => expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to resume startup without a running Graylog data node?'));
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/finish-config'), undefined, false));
+    await waitFor(() => expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to resume startup without a running Graylog data node? This will cause the configuration to fall back to using an Opensearch instance on localhost:9200.'));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/skip-config'), undefined, false));
   });
 
   it('should display error when resuming startup failed', async () => {
@@ -128,7 +128,7 @@ describe('App', () => {
       userEvent.click(resumeStartupButton);
     });
 
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/finish-config'), undefined, false));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('POST', expect.stringContaining('/api/status/skip-config'), undefined, false));
     await waitFor(() => expect(UserNotification.error).toHaveBeenCalledWith('Resuming startup failed with error: Error: Unexpected error!', 'Could not resume startup'));
   });
 });

--- a/graylog2-web-interface/src/preflight/components/ResumeStartupButton.tsx
+++ b/graylog2-web-interface/src/preflight/components/ResumeStartupButton.tsx
@@ -36,8 +36,10 @@ const ResumeStartupButton = ({ setIsWaitingForStartup, children, variant, compac
 
   const onResumeStartup = useCallback(() => {
     // eslint-disable-next-line no-alert
-    if (dataNodes?.length || window.confirm('Are you sure you want to resume startup without a running Graylog data node?')) {
-      fetch('POST', qualifyUrl('/api/status/finish-config'), undefined, false)
+    if (dataNodes?.length || window.confirm('Are you sure you want to resume startup without a running Graylog data node? This will cause the configuration to fall back to using an Opensearch instance on localhost:9200.')) {
+      const status = (dataNodes?.length) ? 'finish' : 'skip';
+
+      fetch('POST', qualifyUrl(`/api/status/${status}-config`), undefined, false)
         .then(() => {
           setIsWaitingForStartup(true);
         })


### PR DESCRIPTION
backport for #17136

fixes #17117 

* set state to SKIPPED if resume startup is called with no datanodes

(cherry picked from commit da7cf5feebcae17f22d4a23e9005d22e8211fc5e)

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

