### PR TITLE
Handle ignore_null on cache form

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/caches/CaffeineCacheFieldSet.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/CaffeineCacheFieldSet.tsx
@@ -17,8 +17,10 @@
 import * as React from 'react';
 import { useFormikContext } from 'formik';
 
+import { Input } from 'components/bootstrap';
 import { FormikFormGroup, TimeUnitInput } from 'components/common';
 import type { LookupTableCache, LookupTableCacheConfig } from 'logic/lookup-tables/types';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type Props = {
   config: LookupTableCacheConfig,
@@ -42,6 +44,14 @@ const CaffeineCacheFieldSet = ({ config }: Props, ref: any) => {
   React.useImperativeHandle(ref, () => ({
     validate: () => (validateConfig()),
   }));
+
+  const handleIgnoreNullChange = (event) => {
+    const ignoreValue = getValueFromInput(event.target);
+
+    const valConfig = { ...values.config, ignore_null: ignoreValue };
+    setStateConfig(valConfig);
+    setValues({ ...values, config: valConfig });
+  };
 
   const handleUpdate = (name: string) => (value: number, unit: string, enabled: boolean) => {
     const auxConfig = { ...stateConfig };
@@ -85,6 +95,14 @@ const CaffeineCacheFieldSet = ({ config }: Props, ref: any) => {
                      defaultEnabled={config.expire_after_write > 0}
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
+      <Input type="checkbox"
+             id="ignore_null"
+             name="ignore_null"
+             label="Ignore null"
+             checked={stateConfig.ignore_null}
+             onChange={handleIgnoreNullChange}
+             help="When enabled, null lookup result will be ignored and not cached."
+             wrapperClassName="col-md-offset-3 col-md-9" />
     </fieldset>
   );
 };

--- a/graylog2-web-interface/src/logic/lookup-tables/types.ts
+++ b/graylog2-web-interface/src/logic/lookup-tables/types.ts
@@ -30,6 +30,7 @@ export type LookupTableCacheConfig = {
   expire_after_access_unit?: 'NANOSECONDS' | 'MICROSECONDS' | 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS' | null,
   expire_after_write?: number,
   expire_after_write_unit?: 'NANOSECONDS' | 'MICROSECONDS' | 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS' | null,
+  ignore_null?: boolean,
 };
 
 export type LookupTableCache = GenericEntityType & {


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/16199, a new ignore_null configuration was introduced to the cache configuration to enable ignoring null lookup results in the cache. These changes handle the configuration of the UI part.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

