### PR TITLE
Fix/5.2 17204 rules editor tooltip

### DIFF
--- a/changelog/unreleased/issue-17204.toml
+++ b/changelog/unreleased/issue-17204.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix tooltip colors on Rule Editor."
+
+issues = ["17204"]
+pulls = [""]

--- a/graylog2-web-interface/src/components/rules/RuleForm.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.tsx
@@ -32,13 +32,20 @@ type Props = {
 };
 
 const StyledContainer = styled.div`
-  & .react-resizable {
-    border: 1px solid #d4d5d7;
-    border-radius: 0 0 5px 5px;
+  & .source-code-editor div {
+    border-color: ${({ theme }) => theme.colors.input.border};
+    border-radius: 0;
+
+    & .ace_editor {
+      border-radius: 0;
+    }
   }
 
   & .ace_tooltip.ace-graylog {
-    background-color: #f5f5f5;
+    background-color: ${({ theme }) => theme.colors.global.background};
+    padding: 4px;
+    padding-left: 0;
+    line-height: 1.5;
   }
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaces hard-coded colors for values defined on the theme.

## Description
<!--- Describe your changes in detail -->
The tooltip shown when the rule has an error had white letters on white background. In this particular component these values where set without using the theme. This PR changes the hard-coded values for those on the theme to keep a more consistent UI across the application.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

