### PR TITLE
Update download-maven-plugin to our fork

### DIFF
--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -498,7 +498,7 @@
 
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>org.graylog.repackaged</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <version>${download-maven-plugin.version}</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
 
         <!-- Plugin versions -->
         <license-maven.version>4.0.rc2</license-maven.version>
-        <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
+        <download-maven-plugin.version>1.6.8.1</download-maven-plugin.version>
     </properties>
 
 
@@ -878,7 +878,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>org.graylog.repackaged</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <version>${download-maven-plugin.version}</version>
                 <configuration>


### PR DESCRIPTION
The caching in the latest upstream version is completely broken since April 2023 and the maintainers are currently unresponsive.

Our fork is based on version 1.6.8 and fixes the excessive download progress logging which is a problem with the log size limit on GitHub Actions.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6131
/nocl