### PR TITLE
Unify styling of buttons in event definition wizard.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.jsx
@@ -126,8 +126,8 @@ class AddNotificationForm extends React.Component {
     const { notifications } = this.props;
     const { displayNewNotificationForm, selectedNotification } = this.state;
     const doneButton = displayNewNotificationForm
-      ? <Button bsStyle="primary" type="submit" form="new-notification-form">Done</Button>
-      : <Button bsStyle="primary" onClick={this.handleSubmit}>Done</Button>;
+      ? <Button bsStyle="success" type="submit" form="new-notification-form">Add notification</Button>
+      : <Button bsStyle="success" onClick={this.handleSubmit}>Add notification</Button>;
 
     return (
       <Row>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -309,7 +309,7 @@ class FieldForm extends React.Component {
 
         <Col md={12}>
           <ButtonToolbar>
-            <Button bsStyle="primary" onClick={this.handleSubmit}>Done</Button>
+            <Button bsStyle="success" onClick={this.handleSubmit}>Add custom field</Button>
             <Button onClick={this.handleCancel}>Cancel</Button>
           </ButtonToolbar>
         </Col>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.jsx
@@ -119,7 +119,7 @@ class FieldsList extends React.Component {
     const fieldNames = Object.keys(fields).sort(naturalSort);
     const addCustomFieldButton = (
       <Button bsStyle="success" onClick={this.handleAddFieldClick}>
-        Add Custom Field
+        New custom field
       </Button>
     );
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.jsx
@@ -119,7 +119,7 @@ class FieldsList extends React.Component {
     const fieldNames = Object.keys(fields).sort(naturalSort);
     const addCustomFieldButton = (
       <Button bsStyle="success" onClick={this.handleAddFieldClick}>
-        New custom field
+        Add custom field
       </Button>
     );
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
@@ -50,8 +50,8 @@ class NotificationList extends React.Component {
         <tr>
           <td colSpan={2}>Could not find information for Notification <em>{notification.title}</em></td>
           <td className="actions">
-            <Button bsStyle="info" bsSize="xsmall" onClick={this.handleRemoveClick(notification.title)}>
-              Remove from Event
+            <Button bsStyle="danger" bsSize="xsmall" onClick={this.handleRemoveClick(notification.title)}>
+              Delete
             </Button>
           </td>
         </tr>
@@ -65,8 +65,8 @@ class NotificationList extends React.Component {
         <td>{notification.title}</td>
         <td>{plugin.displayName || notification.config.type}</td>
         <td className="actions">
-          <Button bsStyle="info" bsSize="xsmall" onClick={this.handleRemoveClick(notification.id)}>
-            Remove from Event
+          <Button bsStyle="danger" bsSize="xsmall" onClick={this.handleRemoveClick(notification.id)}>
+            Delete
           </Button>
         </td>
       </tr>
@@ -83,7 +83,7 @@ class NotificationList extends React.Component {
       });
     const addNotificationButton = (
       <Button bsStyle="success" onClick={onAddNotificationClick}>
-        Add Notification
+        New notification
       </Button>
     );
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
@@ -21,20 +21,20 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Button } from 'components/bootstrap';
 import { DataTable } from 'components/common';
 
+const getNotificationPlugin = (type) => {
+  if (type === undefined) {
+    return {};
+  }
+
+  return PluginStore.exports('eventNotificationTypes').find((n) => n.type === type) || {};
+};
+
 class NotificationList extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
     notifications: PropTypes.array.isRequired,
     onAddNotificationClick: PropTypes.func.isRequired,
     onRemoveNotificationClick: PropTypes.func.isRequired,
-  };
-
-  getNotificationPlugin = (type) => {
-    if (type === undefined) {
-      return {};
-    }
-
-    return PluginStore.exports('eventNotificationTypes').find((n) => n.type === type) || {};
   };
 
   handleRemoveClick = (notificationId) => () => {
@@ -58,7 +58,7 @@ class NotificationList extends React.Component {
       );
     }
 
-    const plugin = this.getNotificationPlugin(notification.config.type);
+    const plugin = getNotificationPlugin(notification.config.type);
 
     return (
       <tr key={notification.id}>
@@ -83,7 +83,7 @@ class NotificationList extends React.Component {
       });
     const addNotificationButton = (
       <Button bsStyle="success" onClick={onAddNotificationClick}>
-        New notification
+        Add notification
       </Button>
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR contains a small improvement to unify the styling and naming of buttons in the event definition wizard.
/nocl
