### PR TITLE
Persist currently selected perspective in user preferences.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -30,7 +30,7 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import Routes, { ENTERPRISE_ROUTE_DESCRIPTION, SECURITY_ROUTE_DESCRIPTION } from 'routing/Routes';
 import { Icon } from 'components/common';
-import PerspectiveSwitcher from 'components/perspectives/PerspectivesSwitcher';
+import PerspectivesSwitcher from 'components/perspectives/PerspectivesSwitcher';
 
 import UserMenu from './UserMenu';
 import HelpMenu from './HelpMenu';
@@ -140,7 +140,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
     <StyledNavbar fluid fixedTop collapseOnSelect>
       <Navbar.Header>
         <Navbar.Brand>
-          <PerspectiveSwitcher />
+          <PerspectivesSwitcher />
         </Navbar.Brand>
         <Navbar.Toggle />
         <DevelopmentHeaderBadge smallScreen />

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -90,7 +90,7 @@ const Switcher = () => {
   );
 };
 
-const PerspectiveSwitcher = () => {
+const PerspectivesSwitcher = () => {
   const perspectives = usePerspectives();
   const hasPerspectivesFeature = useFeature('frontend_perspectives');
 
@@ -103,4 +103,4 @@ const PerspectiveSwitcher = () => {
   return <Switcher />;
 };
 
-export default PerspectiveSwitcher;
+export default PerspectivesSwitcher;

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
@@ -67,7 +67,7 @@ const PerspectivesProvider = ({ children }: PropsWithChildren) => {
     activePerspective,
     availablePerspectives,
     setActivePerspective: setActivePerspectiveWithPersistence,
-  }), [activePerspective, availablePerspectives]);
+  }), [activePerspective, availablePerspectives, setActivePerspectiveWithPersistence]);
 
   return (
     <PerspectivesContext.Provider value={contextValue}>

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
@@ -16,14 +16,49 @@
  */
 import * as React from 'react';
 import type { PropsWithChildren } from 'react';
-import { useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 
 import usePluginEntities from 'hooks/usePluginEntities';
+import { useStore } from 'stores/connect';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
+import UserPreferencesContext from 'contexts/UserPreferencesContext';
+import { PreferencesStore } from 'stores/users/PreferencesStore';
+import Store from 'logic/local-storage/Store';
 
 import PerspectivesContext from './PerspectivesContext';
 
+const usePersistedSetting = (settingKey: string) => {
+  const { userIsReadOnly, username } = useStore(CurrentUserStore, (userStore) => ({
+    username: userStore.currentUser?.username,
+    userIsReadOnly: userStore.currentUser?.read_only ?? true,
+  }));
+
+  const userPreferences = useContext(UserPreferencesContext);
+  const setting = userIsReadOnly ? Store.get(settingKey) : userPreferences[settingKey];
+
+  const setSetting = useCallback((newSetting: string) => {
+    if (userIsReadOnly) {
+      Store.set(settingKey, newSetting);
+
+      return Promise.resolve();
+    }
+
+    const nextPreferences = { ...userPreferences, [settingKey]: newSetting };
+
+    return PreferencesStore.saveUserPreferences(username, nextPreferences);
+  }, [settingKey, userIsReadOnly, userPreferences, username]);
+
+  return useMemo(() => [setting, setSetting], [setSetting, setting]);
+};
+
 const PerspectivesProvider = ({ children }: PropsWithChildren) => {
-  const [activePerspective, setActivePerspective] = useState('default');
+  const [persistedPerspective, setPersistedPerspective] = usePersistedSetting('perspective');
+  const [activePerspective, setActivePerspective] = useState(persistedPerspective ?? 'default');
+  const setActivePerspectiveWithPersistence = useCallback((newPerspective: string) => {
+    setActivePerspective(newPerspective);
+
+    return setPersistedPerspective(newPerspective);
+  }, [setPersistedPerspective]);
   const allPerspectives = usePluginEntities('perspectives');
   const availablePerspectives = allPerspectives
     .filter((perspective) => (perspective.useCondition ? !!perspective.useCondition() : true));
@@ -31,7 +66,7 @@ const PerspectivesProvider = ({ children }: PropsWithChildren) => {
   const contextValue = useMemo(() => ({
     activePerspective,
     availablePerspectives,
-    setActivePerspective,
+    setActivePerspective: setActivePerspectiveWithPersistence,
   }), [activePerspective, availablePerspectives]);
 
   return (

--- a/graylog2-web-interface/src/contexts/ThemeAndUserProvider.tsx
+++ b/graylog2-web-interface/src/contexts/ThemeAndUserProvider.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
@@ -24,7 +24,7 @@ import CurrentUserPreferencesProvider from './CurrentUserPreferencesProvider';
 import CurrentUserProvider from './CurrentUserProvider';
 import UserDateTimeProvider from './UserDateTimeProvider';
 
-const ThemeAndUserProvider = ({ children }) => (
+const ThemeAndUserProvider = ({ children }: React.PropsWithChildren<{}>) => (
   <CurrentUserProvider>
     <UserDateTimeProvider>
       <CurrentUserPreferencesProvider>

--- a/graylog2-web-interface/src/stores/users/PreferencesStore.ts
+++ b/graylog2-web-interface/src/stores/users/PreferencesStore.ts
@@ -24,7 +24,6 @@ import UserNotification from 'util/UserNotification';
 import { singletonStore, singletonActions } from 'logic/singleton';
 
 type PreferencesActionsType = {
-  loadUserPreferences: (userName: string, callback?: (preferences: PreferencesMap) => void) => Promise<unknown>,
   saveUserPreferences: (userName: string, preferences: PreferencesUpdateMap, callback?: (preferences: PreferencesUpdateMap) => void, displaySuccessNotification?: boolean) => Promise<unknown>,
 }
 export const PreferencesActions = singletonActions(
@@ -34,11 +33,6 @@ export const PreferencesActions = singletonActions(
     saveUserPreferences: { asyncResult: true },
   }),
 );
-
-export type Preference = {
-  name: string,
-  value: boolean | string,
-};
 
 type BooleanString = 'true' | 'false'
 
@@ -56,10 +50,6 @@ export type PreferencesMap = {
   dashboardSidebarIsPinned?: boolean,
   searchSidebarIsPinned?: boolean,
   [PREFERENCES_THEME_MODE]: ColorScheme,
-};
-
-type PreferencesResponse = {
-  preferences: PreferencesMap,
 };
 
 const convertPreferences = (preferences: PreferencesUpdateMap): PreferencesMap => {
@@ -101,22 +91,6 @@ export const PreferencesStore = singletonStore(
         });
 
       PreferencesActions.saveUserPreferences.promise(promise);
-
-      return promise;
-    },
-    loadUserPreferences(userName: string, callback: (preferences: PreferencesMap) => void = () => {}) {
-      const url = this.URL + encodeURIComponent(userName);
-
-      const failCallback = (errorThrown) => {
-        UserNotification.error(
-          `Loading of user preferences for "${userName}" failed with status: ${errorThrown}. Try reloading the page`,
-          'Could not retrieve user preferences from server',
-        );
-      };
-
-      const promise = fetch('GET', url).then((data: PreferencesResponse) => callback(data?.preferences), failCallback);
-
-      PreferencesActions.loadUserPreferences.promise(promise);
 
       return promise;
     },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding functionality to persist the current perspective, when it is changed. The way it works is the same as for the current theme:

  - when the current user is read-only, the setting is persisted in local storage
  - when the current user is read-writable, the setting is persisted in the user preferences

As this is very similar to theming, an abstract `usePersistedSetting` hook is introduced, but inside the `PerspectiveProvider` module. A follow-up PR is already prepared which extracts and reuses it from within `usePreferredColorScheme`.

Fixes Graylog2/graylog-plugin-enterprise#6103.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.