### PR TITLE
Bump com.github.eirslett:frontend-maven-plugin from 1.14.0 to 1.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.14.0</version>
+                    <version>1.14.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>


### PR DESCRIPTION
We backport this update to fix build errors due to corrupted downloads that happen from time to time.

Bumps [com.github.eirslett:frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) from 1.14.0 to 1.14.2.
- [Changelog](https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md)
- [Commits](https://github.com/eirslett/frontend-maven-plugin/compare/frontend-plugins-1.14.0...frontend-plugins-1.14.2)

---
updated-dependencies:
- dependency-name: com.github.eirslett:frontend-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

(cherry picked from commit b800f2237c5480cad8d612a5090fa4c2b5b4fd52)

/nocl