### PR TITLE
Add logic to change perPage in component ListWithOwnState states when new perPage prop arrives (5.2)

### DIFF
--- a/changelog/unreleased/issue-17261.toml
+++ b/changelog/unreleased/issue-17261.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixing problem with persisting selected page size for some paginated lists."
+issues = ["17261"]
+pulls = ["17278"]

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 import usePaginationQueryParameter, { DEFAULT_PAGE_SIZES } from 'hooks/usePaginationQueryParameter';
@@ -110,16 +110,23 @@ const ListWithOwnState = ({
   pageSize: propPageSize,
   ...props
 }: Required<Props> & { activePage: number, pageSize: number }) => {
-  const [{ page: currentPage, pageSize: currentPageSize }, setPagination] = React.useState({
-    page: Math.max(activePage, INITIAL_PAGE),
-    pageSize: propPageSize,
-  });
+  const [currentPage, setCurrentPage] = useState<number>(Math.max(activePage, INITIAL_PAGE));
+  const [currentPageSize, setCurrentPageSize] = useState<number>(propPageSize);
 
   useEffect(() => {
-    if (activePage > 0 && activePage !== currentPage) {
-      setPagination((cur) => ({ ...cur, page: activePage }));
+    if (activePage > 0) {
+      setCurrentPage(activePage);
     }
-  }, [activePage, currentPage]);
+  }, [activePage]);
+
+  useEffect(() => {
+    setCurrentPageSize(propPageSize);
+  }, [propPageSize]);
+
+  const setPagination = useCallback(({ page, pageSize }) => {
+    setCurrentPageSize(pageSize);
+    setCurrentPage(page);
+  }, []);
 
   return (
     <ListBase {...props}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Please note**: This PR is a backport of https://github.com/Graylog2/graylog2-server/pull/17278 for `5.2`


## Description
The bug happens because we update per page value only on the render stage. This PR adds useEffect which changes the inner state of the ListWithOwnState component. 

## Motivation and Context
fix: #17261

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl