### PR TITLE
Field type list pagination with querying and filtering.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/Filter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/Filter.java
@@ -17,9 +17,14 @@
 package org.graylog2.database.filtering;
 
 import org.bson.conversions.Bson;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
 
-interface Filter {
+import java.util.function.Predicate;
+
+public interface Filter {
     String field();
 
     Bson toBson();
+
+    Predicate<InMemoryFilterable> toPredicate();
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
@@ -19,11 +19,13 @@ package org.graylog2.database.filtering;
 import com.mongodb.client.model.Filters;
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
-record RangeFilter(String field, Object from, Object to) implements Filter {
+public record RangeFilter(String field, Object from, Object to) implements Filter {
 
     @Override
     public Bson toBson() {
@@ -39,5 +41,11 @@ record RangeFilter(String field, Object from, Object to) implements Filter {
         } else {
             return new BsonDocument();
         }
+    }
+
+    @Override
+    public Predicate<InMemoryFilterable> toPredicate() {
+        //TODO: we do not have a use case for that, but maybe this one needs to be implemented for future use cases...
+        throw new UnsupportedOperationException("RangeFilters are only supported in MongoDB-based filtering, not in in-memory filtering.");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/RangeFilter.java
@@ -23,6 +23,7 @@ import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 public record RangeFilter(String field, Object from, Object to) implements Filter {
@@ -47,5 +48,18 @@ public record RangeFilter(String field, Object from, Object to) implements Filte
     public Predicate<InMemoryFilterable> toPredicate() {
         //TODO: we do not have a use case for that, but maybe this one needs to be implemented for future use cases...
         throw new UnsupportedOperationException("RangeFilters are only supported in MongoDB-based filtering, not in in-memory filtering.");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RangeFilter that = (RangeFilter) o;
+        return Objects.equals(field, that.field) && Objects.equals(from, that.from) && Objects.equals(to, that.to);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, from, to);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/SingleValueFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/SingleValueFilter.java
@@ -20,6 +20,7 @@ import com.mongodb.client.model.Filters;
 import org.bson.conversions.Bson;
 import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 
 public record SingleValueFilter(String field, Object value) implements Filter {
@@ -34,5 +35,18 @@ public record SingleValueFilter(String field, Object value) implements Filter {
         return o -> o.extractFieldValue(field)
                 .map(fieldValue -> fieldValue.equals(value))
                 .orElse(false);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final SingleValueFilter that = (SingleValueFilter) o;
+        return Objects.equals(field, that.field) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, value);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/InMemoryFilterExpressionParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/InMemoryFilterExpressionParser.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.database.filtering.inmemory;
 
-import org.bson.conversions.Bson;
+import com.google.common.base.Predicates;
 import org.graylog2.database.filtering.Filter;
 import org.graylog2.rest.resources.entities.EntityAttribute;
 
@@ -31,10 +31,10 @@ public class InMemoryFilterExpressionParser {
 
     private final SingleFilterParser singleFilterParser = new SingleFilterParser();
 
-    public Predicate<InMemoryFilterable> parsePredicate(final List<String> filterExpressions,
-                                                        final List<EntityAttribute> attributes) {
+    public Predicate<InMemoryFilterable> parse(final List<String> filterExpressions,
+                                               final List<EntityAttribute> attributes) {
         if (filterExpressions == null || filterExpressions.isEmpty()) {
-            return o -> true;
+            return Predicates.alwaysTrue();
         }
         final Map<String, List<Filter>> groupedByField = filterExpressions.stream()
                 .map(expr -> singleFilterParser.parseSingleExpression(expr, attributes))
@@ -44,12 +44,8 @@ public class InMemoryFilterExpressionParser {
                 .map(grouped -> grouped.stream()
                         .map(Filter::toPredicate)
                         .collect(Collectors.toList()))
-                .map(groupedPredicates -> groupedPredicates.stream().reduce(Predicate::or).orElse(o -> true))
-                .reduce(Predicate::and).orElse(o -> true);
+                .map(groupedPredicates -> groupedPredicates.stream().reduce(Predicate::or).orElse(Predicates.alwaysTrue()))
+                .reduce(Predicate::and).orElse(Predicates.alwaysTrue());
     }
 
-    public Bson parseSingleExpression(final String filterExpression, final List<EntityAttribute> attributes) {
-        final Filter filter = singleFilterParser.parseSingleExpression(filterExpression, attributes);
-        return filter.toBson();
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/InMemoryFilterable.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/InMemoryFilterable.java
@@ -14,25 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog2.database.filtering;
+package org.graylog2.database.filtering.inmemory;
 
-import com.mongodb.client.model.Filters;
-import org.bson.conversions.Bson;
-import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
+import java.util.Optional;
 
-import java.util.function.Predicate;
+public interface InMemoryFilterable {
 
-public record SingleValueFilter(String field, Object value) implements Filter {
-
-    @Override
-    public Bson toBson() {
-        return Filters.eq(field(), value());
-    }
-
-    @Override
-    public Predicate<InMemoryFilterable> toPredicate() {
-        return o -> o.extractFieldValue(field)
-                .map(fieldValue -> fieldValue.equals(value))
-                .orElse(false);
-    }
+    Optional<Object> extractFieldValue(final String fieldName);
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/SingleFilterParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/SingleFilterParser.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering.inmemory;
+
+import org.graylog2.database.filtering.Filter;
+import org.graylog2.database.filtering.RangeFilter;
+import org.graylog2.database.filtering.SingleValueFilter;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.search.SearchQueryField;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+public class SingleFilterParser {
+
+    public static final String FIELD_AND_VALUE_SEPARATOR = ":";
+    public static final String RANGE_VALUES_SEPARATOR = "><";
+    static final String WRONG_FILTER_EXPR_FORMAT_ERROR_MSG =
+            "Wrong filter expression, <field_name>" + FIELD_AND_VALUE_SEPARATOR + "<field_value> format should be used";
+
+    public Filter parseSingleExpression(final String filterExpression, final List<EntityAttribute> attributes) {
+        if (!filterExpression.contains(FIELD_AND_VALUE_SEPARATOR)) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+        final String[] split = filterExpression.split(FIELD_AND_VALUE_SEPARATOR, 2);
+
+        final String fieldPart = split[0];
+        if (fieldPart == null || fieldPart.isEmpty()) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+        final String valuePart = split[1];
+        if (valuePart == null || valuePart.isEmpty()) {
+            throw new IllegalArgumentException(WRONG_FILTER_EXPR_FORMAT_ERROR_MSG);
+        }
+
+        final EntityAttribute attributeMetaData = getAttributeMetaData(attributes, fieldPart);
+
+        final SearchQueryField.Type fieldType = attributeMetaData.type();
+        if (isRangeValueExpression(valuePart, fieldType)) {
+            if (valuePart.startsWith(RANGE_VALUES_SEPARATOR)) {
+                return new RangeFilter(attributeMetaData.id(),
+                        null,
+                        extractValue(fieldType, valuePart.substring(RANGE_VALUES_SEPARATOR.length()))
+                );
+            } else if (valuePart.endsWith(RANGE_VALUES_SEPARATOR)) {
+                return new RangeFilter(attributeMetaData.id(),
+                        extractValue(fieldType, valuePart.substring(0, valuePart.length() - RANGE_VALUES_SEPARATOR.length())),
+                        null
+                );
+            } else {
+                final String[] ranges = valuePart.split(RANGE_VALUES_SEPARATOR);
+                return new RangeFilter(attributeMetaData.id(),
+                        extractValue(fieldType, ranges[0]),
+                        extractValue(fieldType, ranges[1])
+                );
+            }
+        } else {
+            return new SingleValueFilter(attributeMetaData.id(), extractValue(fieldType, valuePart));
+        }
+
+    }
+
+    private Object extractValue(SearchQueryField.Type fieldType, String valuePart) {
+        final Object converted = fieldType.getMongoValueConverter().apply(valuePart);
+        if (converted instanceof DateTime && fieldType == SearchQueryField.Type.DATE) {
+            return ((DateTime) converted).toDate(); //MongoDB does not like Joda
+        } else {
+            return converted;
+        }
+
+    }
+
+    private EntityAttribute getAttributeMetaData(final List<EntityAttribute> attributes,
+                                                 final String attributeName) {
+        EntityAttribute matchingByTitle = null;
+
+        for (EntityAttribute attr : attributes) {
+            if (attributeName.equals(attr.id()) && isFilterable(attr)) {
+                return attr;
+            } else if (attributeName.equalsIgnoreCase(attr.title()) && isFilterable(attr)) {
+                matchingByTitle = attr;
+            }
+        }
+
+        if (matchingByTitle != null) {
+            return matchingByTitle;
+        } else {
+            throw new IllegalArgumentException(attributeName + " is not a field that can be used for filtering");
+        }
+
+    }
+
+    private boolean isRangeValueExpression(String valuePart, SearchQueryField.Type fieldType) {
+        return SearchQueryField.Type.NUMERIC_TYPES.contains(fieldType) && valuePart.contains(RANGE_VALUES_SEPARATOR);
+    }
+
+    private boolean isFilterable(final EntityAttribute attr) {
+        return Boolean.TRUE.equals(attr.filterable());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
@@ -100,7 +100,7 @@ public class IndexFieldTypesListService {
                         )
                 )
                 .filter(indexSetFieldType -> indexSetFieldType.fieldName().contains(fieldNameQuery))
-                .filter(indexSetFieldType -> inMemoryFilterExpressionParser.parsePredicate(filters, IndexSetFieldType.ATTRIBUTES).test(indexSetFieldType))
+                .filter(indexSetFieldType -> inMemoryFilterExpressionParser.parse(filters, IndexSetFieldType.ATTRIBUTES).test(indexSetFieldType))
                 .sorted(IndexSetFieldType.getComparator(sort, order))
                 .skip((long) Math.max(0, page - 1) * perPage)
                 .limit(perPage)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableSet;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterExpressionParser;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.fieldtypes.mapping.FieldTypeMappingsService;
@@ -45,21 +46,27 @@ public class IndexFieldTypesListService {
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory indexSetFactory;
 
+    private final InMemoryFilterExpressionParser inMemoryFilterExpressionParser;
+
     private FieldTypeDTOsMerger fieldTypeDTOsMerger;
 
     @Inject
     public IndexFieldTypesListService(final IndexFieldTypesService indexFieldTypesService,
                                       final IndexSetService indexSetService,
                                       final MongoIndexSet.Factory indexSetFactory,
-                                      final FieldTypeDTOsMerger fieldTypeDTOsMerger) {
+                                      final FieldTypeDTOsMerger fieldTypeDTOsMerger,
+                                      final InMemoryFilterExpressionParser inMemoryFilterExpressionParser) {
         this.indexFieldTypesService = indexFieldTypesService;
         this.indexSetService = indexSetService;
         this.indexSetFactory = indexSetFactory;
         this.fieldTypeDTOsMerger = fieldTypeDTOsMerger;
+        this.inMemoryFilterExpressionParser = inMemoryFilterExpressionParser;
     }
 
     public PageListResponse<IndexSetFieldType> getIndexSetFieldTypesList(
             final String indexSetId,
+            final String fieldNameQuery,
+            final List<String> filters,
             final int page,
             final int perPage,
             final String sort,
@@ -92,6 +99,8 @@ public class IndexFieldTypesListService {
                                 FieldTypeMappingsService.BLACKLISTED_FIELDS.contains(fieldTypeDTO.fieldName())
                         )
                 )
+                .filter(indexSetFieldType -> indexSetFieldType.fieldName().contains(fieldNameQuery))
+                .filter(indexSetFieldType -> inMemoryFilterExpressionParser.parsePredicate(filters, IndexSetFieldType.ATTRIBUTES).test(indexSetFieldType))
                 .sorted(IndexSetFieldType.getComparator(sort, order))
                 .skip((long) Math.max(0, page - 1) * perPage)
                 .limit(perPage)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -46,6 +46,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -76,6 +77,8 @@ public class IndexSetsMappingResource extends RestResource {
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Gets list of field_name-field_type pairs for given index set")
     public PageListResponse<IndexSetFieldType> indexSetFieldTypesList(@ApiParam(name = "index_set_id") @PathParam("index_set_id") String indexSetId,
+                                                                      @ApiParam(name = "fieldNameQuery") @QueryParam("query") @DefaultValue("") String fieldNameQuery,
+                                                                      @ApiParam(name = "filters") @QueryParam("filters") List<String> filters,
                                                                       @ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
                                                                       @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
                                                                       @ApiParam(name = "sort",
@@ -88,6 +91,8 @@ public class IndexSetsMappingResource extends RestResource {
                                                                       @Context SearchUser searchUser) {
         checkPermission(RestPermissions.INDEXSETS_READ, indexSetId);
         return indexFieldTypesListService.getIndexSetFieldTypesList(indexSetId,
+                fieldNameQuery,
+                filters,
                 page,
                 perPage,
                 sort,

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
@@ -29,7 +29,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.graylog2.database.filtering.DbFilterExpressionParser.FIELD_AND_VALUE_SEPARATOR;
+import static org.graylog2.database.filtering.inmemory.SingleFilterParser.FIELD_AND_VALUE_SEPARATOR;
+import static org.graylog2.database.filtering.inmemory.SingleFilterParser.RANGE_VALUES_SEPARATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -216,7 +217,7 @@ class DbFilterExpressionParserTest {
                                 new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate())
                 ),
 
-                toTest.parseSingleExpression("created_at:" + fromString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + toString,
+                toTest.parseSingleExpression("created_at:" + fromString + RANGE_VALUES_SEPARATOR + toString,
                         entityAttributes
                 ));
     }
@@ -237,7 +238,7 @@ class DbFilterExpressionParserTest {
                 Filters.and(
                         Filters.gte("created_at", dateObject.toDate())
                 ),
-                toTest.parseSingleExpression("created_at:" + dateString + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR,
+                toTest.parseSingleExpression("created_at:" + dateString + RANGE_VALUES_SEPARATOR,
                         entityAttributes
                 ));
 
@@ -245,7 +246,7 @@ class DbFilterExpressionParserTest {
                 Filters.and(
                         Filters.lte("created_at", dateObject.toDate())
                 ),
-                toTest.parseSingleExpression("created_at:" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + dateString,
+                toTest.parseSingleExpression("created_at:" + RANGE_VALUES_SEPARATOR + dateString,
                         entityAttributes
                 ));
     }
@@ -265,7 +266,7 @@ class DbFilterExpressionParserTest {
                         Filters.lte("number", 53)
                 ),
 
-                toTest.parseSingleExpression("number:42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53",
+                toTest.parseSingleExpression("number:42" + RANGE_VALUES_SEPARATOR + "53",
                         entityAttributes
                 ));
     }
@@ -280,9 +281,9 @@ class DbFilterExpressionParserTest {
                 .build());
 
         assertEquals(
-                Filters.eq("text", "42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53"),
+                Filters.eq("text", "42" + RANGE_VALUES_SEPARATOR + "53"),
 
-                toTest.parseSingleExpression("text:42" + DbFilterExpressionParser.RANGE_VALUES_SEPARATOR + "53",
+                toTest.parseSingleExpression("text:42" + RANGE_VALUES_SEPARATOR + "53",
                         entityAttributes
                 ));
     }

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/SingleValueFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/SingleValueFilterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.bson.conversions.Bson;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleValueFilterTest {
+
+    @Test
+    void testPredicateCreation() {
+        final SingleValueFilter toTest = new SingleValueFilter("field", "value");
+        final Predicate<InMemoryFilterable> predicate = toTest.toPredicate();
+
+        assertTrue(predicate.test(createMock(Map.of("field", "value"))));
+        assertFalse(predicate.test(createMock(Map.of())));
+        assertFalse(predicate.test(createMock(Map.of("field", "wrong_value"))));
+    }
+
+    @Test
+    void testBsonCreation() {
+        final SingleValueFilter toTest = new SingleValueFilter("field", "value");
+        final Bson bson = toTest.toBson();
+
+        assertEquals(Filters.eq("field", "value"), bson);
+    }
+
+    private InMemoryFilterable createMock(final Map<String, Object> fields) {
+        return fieldName -> Optional.ofNullable(fields.get(fieldName));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/InMemoryFilterExpressionParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/InMemoryFilterExpressionParserTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering.inmemory;
+
+import com.google.common.base.Predicates;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.database.filtering.inmemory.SingleFilterParser.FIELD_AND_VALUE_SEPARATOR;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InMemoryFilterExpressionParserTest {
+
+    private InMemoryFilterExpressionParser toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new InMemoryFilterExpressionParser();
+    }
+
+    @Test
+    void returnsAlwaysTruePredicateOnNullFilterList() {
+        assertThat(toTest.parse(null, List.of()))
+                .isEqualTo(Predicates.alwaysTrue());
+    }
+
+    @Test
+    void returnsAlwaysTruePredicateOnEmptyFilterList() {
+        assertThat(toTest.parse(List.of(), List.of()))
+                .isEqualTo(Predicates.alwaysTrue());
+    }
+
+    @Test
+    void throwsExceptionOnFieldThatDoesNotExistInAttributeList() {
+
+        assertThrows(IllegalArgumentException.class, () ->
+                toTest.parse(List.of("strange_field:blabla"),
+                        List.of(EntityAttribute.builder()
+                                .id("owner")
+                                .title("Owner")
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void throwsExceptionOnFieldThatIsNotFilterable() {
+
+        assertThrows(IllegalArgumentException.class, () ->
+                toTest.parse(List.of("owner:juan"),
+                        List.of(EntityAttribute.builder()
+                                .id("owner")
+                                .title("Owner")
+                                .filterable(false)
+                                .build())
+                ));
+    }
+
+    @Test
+    void throwsExceptionOnWrongFilterFormat() {
+        final List<EntityAttribute> attributes = List.of(
+                EntityAttribute.builder().id("good").title("Good").filterable(true).build(),
+                EntityAttribute.builder().id("another").title("Hidden and dangerous").filterable(true).build()
+        );
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of("No separator"), attributes));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of(FIELD_AND_VALUE_SEPARATOR + "no field name"), attributes));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(List.of("no field value" + FIELD_AND_VALUE_SEPARATOR), attributes));
+        assertThrows(IllegalArgumentException.class, () -> toTest.parse(
+                List.of("good" + FIELD_AND_VALUE_SEPARATOR + "one",
+                        "another" + FIELD_AND_VALUE_SEPARATOR + "good_one",
+                        "single wrong one is enough to throw exception"),
+                attributes)
+        );
+    }
+
+    //
+
+    @Test
+    void groupsMultipleFilterForTheSameFieldUsingOrLogic() {
+
+        final List<EntityAttribute> attributes = List.of(EntityAttribute.builder()
+                        .id("owner")
+                        .title("Owner")
+                        .filterable(true)
+                        .build(),
+                EntityAttribute.builder()
+                        .id("title")
+                        .title("Title")
+                        .filterable(true)
+                        .build());
+
+
+        final Predicate<InMemoryFilterable> predicate = toTest.parse(List.of("owner:baldwin", "owner:beomund", "title:crusade"), attributes);
+        assertTrue(predicate.test(createMock(Map.of("owner", "baldwin", "title", "crusade"))));
+        assertTrue(predicate.test(createMock(Map.of("owner", "beomund", "title", "crusade"))));
+        assertFalse(predicate.test(createMock(Map.of("owner", "casimir", "title", "crusade"))));
+        assertFalse(predicate.test(createMock(Map.of("owner", "beomund", "title", "whatever"))));
+    }
+
+    private InMemoryFilterable createMock(final Map<String, Object> fields) {
+        return fieldName -> Optional.ofNullable(fields.get(fieldName));
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/SingleFilterParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/SingleFilterParserTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering.inmemory;
+
+import org.bson.types.ObjectId;
+import org.graylog2.database.filtering.RangeFilter;
+import org.graylog2.database.filtering.SingleValueFilter;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.search.SearchQueryField;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.graylog2.database.filtering.inmemory.SingleFilterParser.RANGE_VALUES_SEPARATOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SingleFilterParserTest {
+
+    SingleFilterParser toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new SingleFilterParser();
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForStringType() {
+
+        assertEquals(new SingleValueFilter("owner", "baldwin"),
+                toTest.parseSingleExpression("owner:baldwin",
+                        List.of(EntityAttribute.builder()
+                                .id("owner")
+                                .title("Owner")
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForBoolType() {
+
+        assertEquals(new SingleValueFilter("away", true),
+                toTest.parseSingleExpression("away:true",
+                        List.of(EntityAttribute.builder()
+                                .id("away")
+                                .title("Away")
+                                .type(SearchQueryField.Type.BOOLEAN)
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForObjectIdType() {
+
+        assertEquals(new SingleValueFilter("id", new ObjectId("5f4dfb9c69be46153b9a9a7b")),
+                toTest.parseSingleExpression("id:5f4dfb9c69be46153b9a9a7b",
+                        List.of(EntityAttribute.builder()
+                                .id("id")
+                                .title("Id")
+                                .type(SearchQueryField.Type.OBJECT_ID)
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForDateType() {
+
+        assertEquals(new SingleValueFilter("created_at", new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate()),
+                toTest.parseSingleExpression("created_at:2012-12-12 12:12:12",
+                        List.of(EntityAttribute.builder()
+                                .id("created_at")
+                                .title("Creation Date")
+                                .type(SearchQueryField.Type.DATE)
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForIntType() {
+
+        assertEquals(new SingleValueFilter("num", 42),
+                toTest.parseSingleExpression("num:42",
+                        List.of(EntityAttribute.builder()
+                                .id("num")
+                                .title("Num")
+                                .type(SearchQueryField.Type.INT)
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForDateRanges() {
+        final String fromString = "2012-12-12 12:12:12";
+        final String toString = "2022-12-12 12:12:12";
+
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new RangeFilter("created_at",
+                        new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate(),
+                        new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate()
+                ),
+
+                toTest.parseSingleExpression("created_at:" + fromString + RANGE_VALUES_SEPARATOR + toString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForOpenDateRanges() {
+        final String dateString = "2012-12-12 12:12:12";
+        final DateTime dateObject = new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC);
+
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new RangeFilter("created_at", dateObject.toDate(), null),
+                toTest.parseSingleExpression("created_at:" + dateString + RANGE_VALUES_SEPARATOR,
+                        entityAttributes
+                ));
+
+        assertEquals(
+                new RangeFilter("created_at", null, dateObject.toDate()),
+                toTest.parseSingleExpression("created_at:" + RANGE_VALUES_SEPARATOR + dateString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForIntRanges() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("number")
+                .title("Number")
+                .type(SearchQueryField.Type.INT)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new RangeFilter("number", 42, 53),
+                toTest.parseSingleExpression("number:42" + RANGE_VALUES_SEPARATOR + "53",
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionForStringFieldsCorrectlyEvenIfValueContainsRangeSeparator() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("text")
+                .title("Text")
+                .type(SearchQueryField.Type.STRING)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new SingleValueFilter("text", "42" + RANGE_VALUES_SEPARATOR + "53"),
+
+                toTest.parseSingleExpression("text:42" + RANGE_VALUES_SEPARATOR + "53",
+                        entityAttributes
+                ));
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListServiceTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterExpressionParser;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.fieldtypes.utils.FieldTypeDTOsMerger;
 import org.graylog2.indexer.indexset.CustomFieldMapping;
@@ -56,14 +57,14 @@ class IndexFieldTypesListServiceTest {
 
     @BeforeEach
     void setUp() {
-        toTest = new IndexFieldTypesListService(indexFieldTypesService, indexSetService, indexSetFactory, new FieldTypeDTOsMerger());
+        toTest = new IndexFieldTypesListService(indexFieldTypesService, indexSetService, indexSetFactory, new FieldTypeDTOsMerger(), new InMemoryFilterExpressionParser());
     }
 
     @Test
     void testReturnsEmptyPageOnWrongIndexId() {
         doReturn(Optional.empty()).when(indexSetService).get("I_do_not_exist!");
 
-        final PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_do_not_exist!", 0, 10, "index_set_id", Sorting.Direction.ASC);
+        final PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_do_not_exist!", "", List.of(), 0, 10, "index_set_id", Sorting.Direction.ASC);
 
         assertEquals(0, response.total());
         assertTrue(response.elements().isEmpty());
@@ -80,7 +81,7 @@ class IndexFieldTypesListServiceTest {
         doReturn(null).when(indexSetFactory).create(indexSetConfig);
 
 
-        final PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_am_strangely_broken!", 0, 10, "index_set_id", Sorting.Direction.ASC);
+        final PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_am_strangely_broken!", "", List.of(), 0, 10, "index_set_id", Sorting.Direction.ASC);
 
         assertEquals(0, response.total());
         assertTrue(response.elements().isEmpty());
@@ -121,20 +122,54 @@ class IndexFieldTypesListServiceTest {
                 .findOneByIndexName("graylog_41");
 
 
-        PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_am_fine!", 0, 2, "field_name", Sorting.Direction.ASC);
+        PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_am_fine!", "", List.of(), 0, 2, "field_name", Sorting.Direction.ASC);
         assertThat(response.elements())
                 .containsExactly(
                         new IndexSetFieldType("field_1", "ip", true, false),
                         new IndexSetFieldType("field_2", "long", false, false)
                 );
 
-        response = toTest.getIndexSetFieldTypesList("I_am_fine!", 0, 2, "field_name", Sorting.Direction.DESC);
+        response = toTest.getIndexSetFieldTypesList("I_am_fine!", "", List.of(), 0, 2, "field_name", Sorting.Direction.DESC);
         assertThat(response.elements())
                 .containsExactly(
                         new IndexSetFieldType("field_5", "string_fts", false, false),
                         new IndexSetFieldType("field_4", "string", false, false)
                 );
 
+
+    }
+
+    @Test
+    void testFilteringAndQuerying() {
+        IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        doReturn(Optional.of(indexSetConfig)).when(indexSetService).get("I_am_fine!");
+        final CustomFieldMappings customFieldMappings = new CustomFieldMappings(
+                List.of(new CustomFieldMapping("field_custom", "long")) //expected to be filtered out by "is_custom:false" filter
+        );
+        doReturn(customFieldMappings).when(indexSetConfig).customFieldMappings();
+        MongoIndexSet indexSet = mock(MongoIndexSet.class);
+        doReturn("graylog_0").when(indexSet).getActiveWriteIndex();
+        doReturn(indexSet).when(indexSetFactory).create(indexSetConfig);
+
+        ImmutableSet<FieldTypeDTO> deflectorFields = ImmutableSet.of(
+                FieldTypeDTO.create("field_1", "long"), //expected in results
+                FieldTypeDTO.create("field_2", "long"), //expected in results
+                FieldTypeDTO.create("field_3", "ip"), //expected to be filtered out by "type:long" filter
+                FieldTypeDTO.create("aaaa", "long"), //expected to be filtered out by "field" fieldNameQuery
+                FieldTypeDTO.create("bbb", "long"), //expected to be filtered out by "field" fieldNameQuery
+                FieldTypeDTO.create("ccc", "ip") //expected to be filtered out by "field" fieldNameQuery
+        );
+        IndexFieldTypesDTO deflectorDTO = IndexFieldTypesDTO.create("nvmd", "graylog_0", deflectorFields);
+        doReturn(deflectorDTO)
+                .when(indexFieldTypesService)
+                .findOneByIndexName("graylog_0");
+
+        PageListResponse<IndexSetFieldType> response = toTest.getIndexSetFieldTypesList("I_am_fine!", "field", List.of("type:long", "is_custom:false"), 0, 50, "field_name", Sorting.Direction.ASC);
+        assertThat(response.elements())
+                .containsExactly(
+                        new IndexSetFieldType("field_1", "long", false, false),
+                        new IndexSetFieldType("field_2", "long", false, false)
+                );
 
     }
 }


### PR DESCRIPTION
## Description
Field type list pagination with querying and filtering.
Support for querying and filtering on Entity Table even if it is not used for Mongo-backed entity, but rather for in-memory object.

/nocl

## Motivation and Context
Required for Field Type Management page.

## How Has This Been Tested?
Manually and with new unit tests.

## Screenshots (if appropriate):
![image](https://github.com/Graylog2/graylog2-server/assets/100699120/a31bfeeb-7e1b-41fc-87ba-1cc3aeca474c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

