### PR TITLE
Move org.apache.directory.api:api-all into test scope

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -99,6 +99,7 @@
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-all</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -34,7 +34,6 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTreeProperty;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.mina.util.IdentityHashSet;
 import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.Stage;
@@ -93,6 +92,7 @@ import org.joda.time.Period;
 import javax.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -893,7 +893,7 @@ public class PipelineRuleParser {
         private ParseTreeProperty<List<Expression>> argsLists = new ParseTreeProperty<>();
         private Set<ParseError> errors = Sets.newHashSet();
         // inner nodes in the parse tree will be ignored during type checker printing, they only transport type information
-        private Set<RuleContext> innerNodes = new IdentityHashSet<>();
+        private Map<RuleContext, Boolean> innerNodes = new IdentityHashMap<>();
         public List<Statement> statements = Lists.newArrayList();
         public List<Rule> rules = Lists.newArrayList();
         private Map<String, Expression> varDecls = Maps.newHashMap();
@@ -936,11 +936,11 @@ public class PipelineRuleParser {
         }
 
         public void addInnerNode(RuleContext node) {
-            innerNodes.add(node);
+            innerNodes.put(node, Boolean.TRUE);
         }
 
         public boolean isInnerNode(RuleContext node) {
-            return innerNodes.contains(node);
+            return innerNodes.containsKey(node);
         }
 
         /**


### PR DESCRIPTION
Adjust `PipelineRuleParser` and `IndexFieldTypePollerPeriodical` to use an `IdentityHashMap` and `ConcurrentHashMap` instead of classes from mina-core.

Moving the `api-all` dependency to the "test" scope removes `mina-core` from the "compile" scope. The `IdentityHashSet` and `ConcurrentHashSet` classes from `mina-core` are basically small wrappers around `IdentityHashMap` and `ConcurrentHashMap`. It's not worth including the `mina-core` dependency just for those.

/nocl