### PR TITLE
Remove no longer needed CSS prefixes.

### DIFF
--- a/graylog2-server/src/main/resources/swagger/css/screen.css
+++ b/graylog2-server/src/main/resources/swagger/css/screen.css
@@ -113,9 +113,6 @@ h3 {
     display: block;
     clear: none;
     float: left;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    -ms-box-sizing: border-box;
     box-sizing: border-box;
     width: 60%;
 }
@@ -124,9 +121,6 @@ h3 {
     display: block;
     clear: none;
     float: right;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    -ms-box-sizing: border-box;
     box-sizing: border-box;
     margin-top: 10px;
 }
@@ -472,11 +466,6 @@ body #header form#api_selector .input a#explore {
     font-size: 0.9em;
     color: white;
     background-color: #547f00;
-    -moz-border-radius: 4px;
-    -webkit-border-radius: 4px;
-    -o-border-radius: 4px;
-    -ms-border-radius: 4px;
-    -khtml-border-radius: 4px;
     border-radius: 4px;
 }
 
@@ -633,11 +622,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px 0;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -700,17 +684,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border: 1px solid #c3d9ec;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px;
 }
@@ -808,11 +782,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px 0;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -875,17 +844,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border: 1px solid #c3e8d1;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px;
 }
@@ -983,11 +942,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -1050,17 +1004,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border: 1px solid #f0e0ca;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px;
 }
@@ -1158,11 +1102,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px 0;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -1225,17 +1164,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border: 1px solid #f0cecb;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px;
 }
@@ -1334,11 +1263,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px 0;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -1405,17 +1329,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border-color: #ffd20f;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px 0;
 }
@@ -1520,11 +1434,6 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     font-size: 0.7em;
     text-align: center;
     padding: 7px 0 4px 0;
-    -moz-border-radius: 2px;
-    -webkit-border-radius: 2px;
-    -o-border-radius: 2px;
-    -ms-border-radius: 2px;
-    -khtml-border-radius: 2px;
     border-radius: 2px;
 }
 
@@ -1587,17 +1496,7 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     border: 1px solid #e8c6c7;
     border-top: none;
     padding: 10px;
-    -moz-border-radius-bottomleft: 6px;
-    -webkit-border-bottom-left-radius: 6px;
-    -o-border-bottom-left-radius: 6px;
-    -ms-border-bottom-left-radius: 6px;
-    -khtml-border-bottom-left-radius: 6px;
     border-bottom-left-radius: 6px;
-    -moz-border-radius-bottomright: 6px;
-    -webkit-border-bottom-right-radius: 6px;
-    -o-border-bottom-right-radius: 6px;
-    -ms-border-bottom-right-radius: 6px;
-    -khtml-border-bottom-right-radius: 6px;
     border-bottom-right-radius: 6px;
     margin: 0 0 20px 0;
 }

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/FullSizeContainer.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/FullSizeContainer.tsx
@@ -26,8 +26,6 @@ const Wrapper = styled.div`
   overflow: hidden;
   grid-row: 2;
   grid-column: 1;
-  -ms-grid-row: 2;
-  -ms-grid-column: 1;
 `;
 
 type Dimensions = { height: number; width: number; };

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.css
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.css
@@ -3,23 +3,18 @@
     /* The grid prop is a workaround to fix
      * horizontal scrolling for safari */
     display: grid;
-    display: -ms-grid;
     grid-template-rows: 1fr;
-    -ms-grid-rows: 1fr;
     grid-template-columns: 1fr;
-    -ms-grid-columns: 1fr;
 }
 
 :local(.scrollContainer) {
     overflow: auto;
     grid-row: 1;
-    -ms-grid-row: 1;
     grid-column: 1;
-    -ms-grid-column: 1;
 }
 
 :local(.leftAligned) {
-    left: 0px;
+    left: 0;
 }
 
 @media print {

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -59,11 +59,8 @@ export const Container = styled.div<{ $sidebarIsPinned: boolean }>(({ theme, $si
 
 const ContentGrid = styled.div(({ theme }) => css`
   display: grid;
-  display: -ms-grid;
   grid-template-columns: 1fr;
   grid-template-rows: auto minmax(1px, 1fr);
-  -ms-grid-columns: 1fr;
-  -ms-grid-rows: auto 1fr;
   height: 100%;
   overflow-y: auto;
 
@@ -74,26 +71,20 @@ const ContentGrid = styled.div(({ theme }) => css`
 
 const Header = styled.div`
   grid-column: 1;
-  -ms-grid-column: 1;
   grid-row: 1;
-  -ms-grid-row: 1;
 `;
 
 const SearchTitle = styled.div`
   height: 35px;
   display: grid;
-  display: -ms-grid;
   grid-template-columns: 1fr auto;
-  -ms-grid-columns: 1fr auto;
 
   > *:nth-child(1) {
     grid-column: 1;
-    -ms-grid-column: 1;
   }
 
   > *:nth-child(2) {
     grid-column: 2;
-    -ms-grid-column: 2;
   }
 `;
 
@@ -122,15 +113,12 @@ const SectionTitle = styled.h2`
 
 const CenterVertical = styled.div`
   display: inline-grid;
-  display: -ms-inline-grid;
   align-content: center;
 `;
 
 const SectionContent = styled.div`
   grid-column: 1;
-  -ms-grid-column: 1;
   grid-row: 2;
-  -ms-grid-row: 2;
 
   /* Fixes padding problem with padding-bottom from container */
   > *:last-child {

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.tsx
@@ -36,24 +36,17 @@ const Container = styled.div`
   white-space: break-spaces;
   height: 100%;
   display: grid;
-  display: -ms-grid;
   grid-template-columns: 1fr;
   grid-template-rows: max-content 1fr;
-  -ms-grid-columns: 1fr;
-  -ms-grid-rows: max-content 1fr;
 
   > *:nth-child(1) {
     grid-column: 1;
-    -ms-grid-column: 1;
     grid-row: 1;
-    -ms-grid-row: 1;
   }
 
   > *:nth-child(2) {
     grid-column: 1;
-    -ms-grid-column: 1;
     grid-row: 2;
-    -ms-grid-row: 2;
   }
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are removing no longer needed CSS prefixes. We can remove these because all related styles are well supported, by the browsers we support.

https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix

/nocl