### PR TITLE
Move pull request string extraction to gpi and add autodetection for pr-deps comment change

### DIFF
--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -13,21 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build pull requests string
-        id: pr_string
-        shell: bash
-        env:
-          PR_BODY: "${{ github.event.pull_request.body }}"
-        run: |
-          # Add the PR that triggered this workflow
-          pulls=("${{ github.repository }}#${{ github.event.number }}")
-
-          # Add any PR dependencies to the list of pulls
-          pulls+=($(grep -P '^/(jenkins-pr-deps|jpd|prd)' <<< "$PR_BODY" | \
-            grep -ioP '(Graylog2/\S+?#|https?://github.com/Graylog2/\S+?/pull/)[0-9]+' || true))
-
-          echo "pr_string=$(tr ' ' ',' <<< "${pulls[@]}")" >> $GITHUB_OUTPUT
-
       - name: dispatch job to graylog-project-internal
         run: >
           gh workflow run -R Graylog2/graylog-project-internal pr-build.yml --ref master
@@ -36,7 +21,6 @@ jobs:
           -f caller_base_branch=${{ github.base_ref || github.ref_name }}
           -f caller_head_branch=${{ github.head_ref }}
           -f head_sha=${{ github.event.pull_request.head.sha }}
-          -f pull_requests="${{ steps.pr_string.outputs.pr_string }}"
           -f initial_actor="${{ github.actor }}/${{ github.triggering_actor }}"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_GRAYLOG_PROJECT_INTERNAL_WORKFLOW_RW }}

--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -1,7 +1,8 @@
 name: Request dispatched PR Build
 
 on:
-  - pull_request
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +14,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: dispatch job to graylog-project-internal
+      - name: Check if PR edit changed deps string
+        if: ${{ github.event.action == edited }}
+        id: pr-string-changed
+        continue-on-error: true
+        run: |
+          old_pr_string=$(grep -P '^/(jenkins-pr-deps|jpd|prd)' <<< "$OLD_PR_BODY" | \
+            grep -ioP '(Graylog2/\S+?#|https?://github.com/Graylog2/\S+?/pull/)[0-9]+' || true)
+          new_pr_string=$(grep -P '^/(jenkins-pr-deps|jpd|prd)' <<< "$NEW_PR_BODY" | \
+            grep -ioP '(Graylog2/\S+?#|https?://github.com/Graylog2/\S+?/pull/)[0-9]+' || true)
+          if [ "$old_pr_string" != "$new_pr_string" ]; then
+            echo "PR deps string change detected: \"$old_pr_string\" -> \"$new_pr_string\""
+            echo "Re-triggering PR build..."
+            exit 0
+          fi
+          exit 1
+        env:
+          OLD_PR_BODY: "${{ github.event.changes.body }}"
+          NEW_PR_BODY: "${{ github.event.pull_request.body }}"
+
+      - name: Dispatch job to graylog-project-internal
+        if: ${{ github.event.action != 'edited' || steps.pr-string-changed.outcome == 'success' }}
         run: >
           gh workflow run -R Graylog2/graylog-project-internal pr-build.yml --ref master
           -f caller_repo=${{ github.repository }}

--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -30,7 +30,7 @@ jobs:
           fi
           exit 1
         env:
-          OLD_PR_BODY: "${{ github.event.changes.body }}"
+          OLD_PR_BODY: "${{ github.event.changes.body.from }}"
           NEW_PR_BODY: "${{ github.event.pull_request.body }}"
 
       - name: Dispatch job to graylog-project-internal

--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check if PR edit changed deps string
-        if: ${{ github.event.action == edited }}
+        if: ${{ github.event.action == 'edited' }}
         id: pr-string-changed
         continue-on-error: true
         run: |

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -68,6 +68,9 @@ cloud_inputs=on
 # Preflight web for cluster bootstrapping
 preflight_web=on
 
+# Instant archiving is disabled by default
+instant_archiving=off
+
 # Composable Index Templates
 composable_index_templates=off
 

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -68,9 +68,6 @@ cloud_inputs=on
 # Preflight web for cluster bootstrapping
 preflight_web=on
 
-# Instant archiving is disabled by default
-instant_archiving=off
-
 # Composable Index Templates
 composable_index_templates=off
 


### PR DESCRIPTION
/nocl

The edit event can detect whether the pr-deps comment has changed and will retrigger the build automatically:

<img width="712" alt="image" src="https://github.com/Graylog2/graylog2-server/assets/3034831/bd0e1761-3a2d-4de6-a6ef-24ea455c8e09">

