### PR TITLE
Add filtering to index field types page

### DIFF
--- a/changelog/unreleased/issue-17285.toml
+++ b/changelog/unreleased/issue-17285.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Add filtering to index field types page"
+
+issues = ["17285"]
+pulls = ["17326"]

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypesList.test.tsx
@@ -16,6 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent, within } from 'wrappedTestingLibrary';
+import { useQueryParam, QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import asMock from 'helpers/mocking/AsMock';
 import useIndexSetFieldTypes from 'hooks/useIndexSetFieldType';
@@ -70,15 +72,22 @@ const getData = (list = [{
   }
 );
 const renderIndexSetFieldTypesList = () => render(
-  <TestStoreProvider>
-    <IndexSetFieldTypesList />
-  </TestStoreProvider>,
+  <QueryParamProvider adapter={ReactRouter6Adapter}>
+    <TestStoreProvider>
+      <IndexSetFieldTypesList />
+    </TestStoreProvider>,
+  </QueryParamProvider>,
 );
 
 jest.mock('views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypes', () => jest.fn());
 jest.mock('hooks/useIndexSetFieldType', () => jest.fn());
 
 jest.mock('components/common/EntityDataTable/hooks/useUserLayoutPreferences');
+
+jest.mock('use-query-params', () => ({
+  ...jest.requireActual('use-query-params'),
+  useQueryParam: jest.fn(),
+}));
 
 describe('IndexSetFieldTypesList', () => {
   beforeAll(loadViewsPlugin);
@@ -107,6 +116,8 @@ describe('IndexSetFieldTypesList', () => {
       },
       isLoading: false,
     });
+
+    asMock(useQueryParam).mockImplementation(() => ([undefined, () => {}]));
   });
 
   describe('Shows list of set field types with correct data', () => {

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypesList.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypesList.tsx
@@ -15,6 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback, useMemo, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { useQueryParam, StringParam } from 'use-query-params';
 
 import type { IndexSetFieldType } from 'hooks/useIndexSetFieldType';
 import { Button } from 'components/bootstrap';
@@ -34,9 +36,9 @@ import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/ho
 import ChangeFieldTypeModal from 'views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal';
 import useFiledTypes from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypes';
 import EntityFilters from 'components/common/EntityFilters';
-import FilterValueRenderers from 'components/streams/StreamsOverview/FilterValueRenderers';
 import useUrlQueryFilters from 'components/common/EntityFilters/hooks/useUrlQueryFilters';
 import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
+import usePaginationQueryParameter from 'hooks/usePaginationQueryParameter';
 
 export const ENTITY_TABLE_ID = 'index-set-field-types';
 export const DEFAULT_LAYOUT = {
@@ -44,6 +46,26 @@ export const DEFAULT_LAYOUT = {
   sort: { attributeId: 'field_name', direction: 'asc' } as Sort,
   displayedColumns: ['field_name', 'type', 'is_custom', 'is_reserved'],
   columnsOrder: ['field_name', 'type', 'is_custom', 'is_reserved'],
+};
+
+const StyledIcon = styled(Icon)<{ $value: 'true' | 'false' }>(({ theme, $value }) => css`
+  color: ${$value === 'true' ? theme.colors.variant.success : theme.colors.variant.danger};
+  margin-right: 5px;
+`);
+
+const FilterValueRenderers = {
+  is_custom: (value: 'true' | 'false', title: string) => (
+    <>
+      <StyledIcon name={value === 'true' ? 'circle-check' : 'circle-xmark'} $value={value} />
+      {title}
+    </>
+  ),
+  is_reserved: (value: 'true' | 'false', title: string) => (
+    <>
+      <StyledIcon name={value === 'true' ? 'circle-check' : 'circle-xmark'} $value={value} />
+      {title}
+    </>
+  ),
 };
 
 const IndexSetFieldTypesList = () => {
@@ -60,8 +82,7 @@ const IndexSetFieldTypesList = () => {
 
   const initialSelection = useMemo(() => [indexSetId], [indexSetId]);
   const [urlQueryFilters, setUrlQueryFilters] = useUrlQueryFilters();
-  const [query, setQuery] = useState('');
-  const [activePage, setActivePage] = useState(1);
+  const [query, setQuery] = useQueryParam('query', StringParam);
   const { data: { fieldTypes }, isLoading: isOptionsLoading } = useFiledTypes();
   const { layoutConfig, isInitialLoading: isLoadingLayoutPreferences } = useTableLayout({
     entityTableId: ENTITY_TABLE_ID,
@@ -69,35 +90,25 @@ const IndexSetFieldTypesList = () => {
     defaultDisplayedAttributes: DEFAULT_LAYOUT.displayedColumns,
     defaultSort: DEFAULT_LAYOUT.sort,
   });
+  const paginationQueryParameter = usePaginationQueryParameter(undefined, layoutConfig.pageSize, false);
   const searchParams = useMemo(() => ({
     query,
-    page: activePage,
+    page: paginationQueryParameter.page,
     pageSize: layoutConfig.pageSize,
     sort: layoutConfig.sort,
     filters: urlQueryFilters,
-  }), [activePage, layoutConfig.pageSize, layoutConfig.sort, query, urlQueryFilters]);
+  }), [paginationQueryParameter.page, layoutConfig.pageSize, layoutConfig.sort, query, urlQueryFilters]);
   const { mutate: updateTableLayout } = useUpdateUserLayoutPreferences(ENTITY_TABLE_ID);
-  const onPageChange = useCallback(
-    (newPage: number, newPageSize: number) => {
-      if (newPage) {
-        setActivePage(newPage);
-      }
-
-      if (newPageSize) {
-        updateTableLayout({ perPage: newPageSize });
-      }
-    }, [updateTableLayout],
-  );
 
   const onPageSizeChange = useCallback((newPageSize: number) => {
-    setActivePage(1);
+    paginationQueryParameter.resetPage();
     updateTableLayout({ perPage: newPageSize });
-  }, [updateTableLayout]);
+  }, [paginationQueryParameter, updateTableLayout]);
 
   const onSortChange = useCallback((newSort: Sort) => {
-    setActivePage(1);
+    paginationQueryParameter.resetPage();
     updateTableLayout({ sort: newSort });
-  }, [updateTableLayout]);
+  }, [paginationQueryParameter, updateTableLayout]);
 
   const onColumnsChange = useCallback((displayedAttributes: Array<string>) => {
     updateTableLayout({ displayedAttributes });
@@ -141,12 +152,15 @@ const IndexSetFieldTypesList = () => {
     </Button>
   ), [openEditModal]);
 
-  const onSearch = useCallback((val: string) => setQuery(val), []);
-  const onSearchReset = useCallback(() => setQuery(''), []);
+  const onSearch = useCallback((val: string) => {
+    paginationQueryParameter.resetPage();
+    setQuery(val);
+  }, [paginationQueryParameter, setQuery]);
+  const onSearchReset = useCallback(() => setQuery(''), [setQuery]);
   const onChangeFilters = useCallback((newUrlQueryFilters: UrlQueryFilters) => {
-    setActivePage(1);
+    paginationQueryParameter.resetPage();
     setUrlQueryFilters(newUrlQueryFilters);
-  }, [setUrlQueryFilters]);
+  }, [paginationQueryParameter, setUrlQueryFilters]);
 
   if (isLoadingLayoutPreferences || isLoading) {
     return <Spinner />;
@@ -154,25 +168,23 @@ const IndexSetFieldTypesList = () => {
 
   return (
     <>
-      <PaginatedList onChange={onPageChange}
-                     totalItems={pagination?.total}
+      <PaginatedList totalItems={pagination?.total}
                      pageSize={layoutConfig.pageSize}
-                     activePage={activePage}
-                     showPageSizeSelect={false}
-                     useQueryParameter={false}>
+                     showPageSizeSelect={false}>
         <div style={{ marginBottom: 5 }}>
           <SearchForm onSearch={onSearch}
                       onReset={onSearchReset}
-                      query={query}>
+                      query={query}
+                      placeholder="Enter search query for the filed name...">
             <EntityFilters attributes={attributes}
                            urlQueryFilters={urlQueryFilters}
                            setUrlQueryFilters={onChangeFilters}
                            filterValueRenderers={FilterValueRenderers} />
           </SearchForm>
         </div>
-        {pagination?.total === 0 && !searchParams.query && (
+        {pagination?.total === 0 && (
           <NoEntitiesExist>
-            No fields have been created yet.
+            No fields have been found.
           </NoEntitiesExist>
         )}
         {!!list?.length && (

--- a/graylog2-web-interface/src/hooks/useIndexSetFieldType.ts
+++ b/graylog2-web-interface/src/hooks/useIndexSetFieldType.ts
@@ -21,6 +21,7 @@ import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import type { Attribute, SearchParams } from 'stores/PaginationTypes';
 import PaginationURL from 'util/PaginationURL';
+import FiltersForQueryParams from 'components/common/EntityFilters/FiltersForQueryParams';
 
 const INITIAL_DATA = {
   pagination: { total: 0 },
@@ -49,7 +50,7 @@ const fetchIndexSetFieldTypes = async (indexSetId: string, searchParams: SearchP
     searchParams.page,
     searchParams.pageSize,
     searchParams.query,
-    { sort: searchParams.sort.attributeId, order: searchParams.sort.direction });
+    { filters: FiltersForQueryParams(searchParams.filters), sort: searchParams.sort.attributeId, order: searchParams.sort.direction });
 
   return fetch('GET', url).then(
     ({ elements, total, attributes }) => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds an option to filtrate field types by field name, type, is custom, or is reserved
for proper work of  is custom and is reserved filtration [PR-17340](https://github.com/Graylog2/graylog2-server/pull/17340) has to be merged 
## Motivation and Context
fix: #17285 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

