### PR TITLE
Implementing navigation dropdown with Mantine.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -25,6 +25,7 @@ module.exports = {
     require.resolve('./lib/setup-files/mock-FetchProvider.js'),
     require.resolve('./lib/setup-files/mock-Version.js'),
     require.resolve('./lib/setup-files/mock-IntersectionObserver.js'),
+    require.resolve('./lib/setup-files/mock-ResizeObserver.js'),
     require.resolve('./lib/setup-files/mock-moment-timezone.js'),
     require.resolve('./lib/setup-files/console-warnings-fail-tests.js'),
     require.resolve('./lib/setup-files/mock-crypto-getrandomvalues.js'),

--- a/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-ResizeObserver.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-ResizeObserver.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+global.ResizeObserver = require('resize-observer-polyfill');

--- a/graylog2-web-interface/packages/jest-preset-graylog/package.json
+++ b/graylog2-web-interface/packages/jest-preset-graylog/package.json
@@ -28,6 +28,7 @@
     "jest-environment-jsdom": "29.6.2",
     "jest-enzyme": "^7.1.2",
     "jest-styled-components": "7.2.0",
-    "react-select-event": "^5.0.0"
+    "react-select-event": "^5.0.0",
+    "resize-observer-polyfill": "^1.5.1"
   }
 }

--- a/graylog2-web-interface/src/components/bootstrap/Menu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Menu.tsx
@@ -24,9 +24,10 @@ type Props = PropsWithChildren<{
   shadow?: MenuProps['shadow'],
   width?: number,
   withinPortal?: boolean,
+  opened?: boolean,
 }>
 
-const Menu = ({ children, shadow, width, withinPortal, position }: Props) => {
+const Menu = ({ children, shadow, width, withinPortal, position, opened }: Props) => {
   const theme = useTheme();
 
   const styles = () => ({
@@ -40,6 +41,7 @@ const Menu = ({ children, shadow, width, withinPortal, position }: Props) => {
 
   return (
     <MantineMenu shadow={shadow}
+                 opened={opened}
                  width={width}
                  position={position}
                  withinPortal={withinPortal}
@@ -76,6 +78,7 @@ Menu.defaultProps = {
   shadow: undefined,
   width: undefined,
   withinPortal: false,
+  opened: false,
 };
 
 export default Menu;

--- a/graylog2-web-interface/src/components/bootstrap/Menu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Menu.tsx
@@ -17,7 +17,7 @@
 import type { PropsWithChildren } from 'react';
 import React from 'react';
 import { Menu as MantineMenu, type MenuProps } from '@mantine/core';
-import { useTheme } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
 type Props = PropsWithChildren<{
   position?: MenuProps['position'],
@@ -33,6 +33,8 @@ const Menu = ({ children, shadow, width, withinPortal, position }: Props) => {
     dropdown: {
       backgroundColor: theme.colors.global.contentBackground,
       border: `1px solid ${theme.colors.variant.lighter.default}`,
+      fontFamily: theme.fonts.family.navigation,
+      fontSize: theme.fonts.size.navigation,
     },
   });
 
@@ -47,9 +49,27 @@ const Menu = ({ children, shadow, width, withinPortal, position }: Props) => {
   );
 };
 
+const StyledMenuItem = styled(MantineMenu.Item)(({ theme }) => css`
+  color: ${theme.colors.global.textDefault};
+  font-family: ${theme.fonts.family.navigation};
+  font-size: ${theme.fonts.size.navigation};
+  padding-left: 20px;
+  padding-right: 20px;
+`);
+
+const StyledMenuDivider = styled(MantineMenu.Divider)(({ theme }) => css`
+  border-color: ${theme.colors.global.textDefault};
+`);
+
+const StyledMenuLabel = styled(MantineMenu.Label)(({ theme }) => css`
+  font-size: ${theme.fonts.size.navigation};
+`);
+
 Menu.Target = MantineMenu.Target;
 Menu.Dropdown = MantineMenu.Dropdown;
-Menu.Item = MantineMenu.Item;
+Menu.Item = StyledMenuItem;
+Menu.Divider = StyledMenuDivider;
+Menu.Label = StyledMenuLabel;
 
 Menu.defaultProps = {
   position: undefined,

--- a/graylog2-web-interface/src/components/bootstrap/Menu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Menu.tsx
@@ -78,7 +78,7 @@ Menu.defaultProps = {
   shadow: undefined,
   width: undefined,
   withinPortal: false,
-  opened: false,
+  opened: undefined,
 };
 
 export default Menu;

--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -14,9 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-
 import * as React from 'react';
-
 // eslint-disable-next-line no-restricted-imports
 import { NavDropdown as BootstrapNavDropdown } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
@@ -65,8 +63,6 @@ const StyledMenuDropdown = styled(Menu.Dropdown)`
 `;
 
 const DropdownTrigger = styled.button(({ theme, $active }) => css`
-  font-family: ${theme.fonts.family.navigation};
-  font-size: ${theme.fonts.size.navigation};
   background: transparent;
   border: 0;
   padding: 15px;

--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -16,14 +16,18 @@
  */
 
 import * as React from 'react';
+
 // eslint-disable-next-line no-restricted-imports
 import { NavDropdown as BootstrapNavDropdown } from 'react-bootstrap';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
-import NavItemStateIndicator from 'components/common/NavItemStateIndicator';
+import Menu from 'components/bootstrap/Menu';
+import { NAV_ITEM_HEIGHT } from 'theme/constants';
 
 import menuItemStyles from './styles/menuItem';
+
+import Icon from '../common/Icon';
 
 class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
   // eslint-disable-next-line class-methods-use-this
@@ -45,10 +49,6 @@ class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
   }
 }
 
-const StyledNavDropdown = styled(BootstrapNavDropdown)`
-  ${menuItemStyles}
-`;
-
 type Props = {
   title?: React.ReactNode,
   id: string,
@@ -58,13 +58,43 @@ type Props = {
   noCaret?: boolean,
 }
 
-const NavDropdown = ({ title, inactiveTitle, badge: Badge, ...props }: React.PropsWithChildren<Props>) => {
+const StyledMenuDropdown = styled(Menu.Dropdown)`
+  z-index: 1032 !important;
+`;
+
+const DropdownIcon = styled(Icon)(({ theme }) => css`
+  padding-left: 0.1rem;
+  color: ${theme.colors.global.textDefault};
+`);
+const DropdownTrigger = styled.button(({ theme }) => css`
+  font-family: ${theme.fonts.family.navigation};
+  font-size: ${theme.fonts.size.navigation};
+  background: transparent;
+  border: 0;
+`);
+
+const NavItem = styled.span`
+  display: inline-flex;
+  align-items: center;
+  min-height: ${NAV_ITEM_HEIGHT};
+`;
+
+const NavDropdown = ({ title, inactiveTitle, badge: Badge, noCaret, children }: React.PropsWithChildren<Props>) => {
   const isActive = inactiveTitle ? inactiveTitle !== title : undefined;
 
   return (
-    <StyledNavDropdown {...props}
-                       title={<NavItemStateIndicator>{Badge ? <Badge text={title} /> : title}</NavItemStateIndicator>}
-                       active={isActive} />
+    <Menu>
+      <NavItem>
+        <Menu.Target>
+          <DropdownTrigger>
+            {Badge ? <Badge text={title} /> : title} {noCaret ? null : <DropdownIcon name="caret-down" />}
+          </DropdownTrigger>
+        </Menu.Target>
+      </NavItem>
+      <StyledMenuDropdown>
+        {children}
+      </StyledMenuDropdown>
+    </Menu>
   );
 };
 

--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -24,10 +24,12 @@ import PropTypes from 'prop-types';
 
 import Menu from 'components/bootstrap/Menu';
 import { NAV_ITEM_HEIGHT } from 'theme/constants';
+import NavItemStateIndicator, {
+  hoverIndicatorStyles,
+  activeIndicatorStyles,
+} from 'components/common/NavItemStateIndicator';
 
 import menuItemStyles from './styles/menuItem';
-
-import Icon from '../common/Icon';
 
 class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
   // eslint-disable-next-line class-methods-use-this
@@ -62,21 +64,32 @@ const StyledMenuDropdown = styled(Menu.Dropdown)`
   z-index: 1032 !important;
 `;
 
-const DropdownIcon = styled(Icon)(({ theme }) => css`
-  padding-left: 0.1rem;
-  color: ${theme.colors.global.textDefault};
-`);
-const DropdownTrigger = styled.button(({ theme }) => css`
+const DropdownTrigger = styled.button(({ theme, $active }) => css`
   font-family: ${theme.fonts.family.navigation};
   font-size: ${theme.fonts.size.navigation};
   background: transparent;
   border: 0;
+  padding: 15px;
+
+  &:hover {
+    ${hoverIndicatorStyles(theme)}
+  }
+
+  ${$active ? activeIndicatorStyles(theme) : ''}
+
+
+  &:hover,
+  &:focus {
+    color: ${theme.colors.variant.darker.default};
+    background-color: transparent;
+  }
 `);
 
 const NavItem = styled.span`
   display: inline-flex;
   align-items: center;
   min-height: ${NAV_ITEM_HEIGHT};
+  padding: 0;
 `;
 
 const NavDropdown = ({ title, inactiveTitle, badge: Badge, noCaret, children }: React.PropsWithChildren<Props>) => {
@@ -86,8 +99,12 @@ const NavDropdown = ({ title, inactiveTitle, badge: Badge, noCaret, children }: 
     <Menu>
       <NavItem>
         <Menu.Target>
-          <DropdownTrigger>
-            {Badge ? <Badge text={title} /> : title} {noCaret ? null : <DropdownIcon name="caret-down" />}
+          <DropdownTrigger $active={isActive}>
+            <NavItemStateIndicator>
+              {Badge ? <Badge text={title} /> : title}
+            </NavItemStateIndicator>
+            {' '}
+            {noCaret ? null : <span className="caret" />}
           </DropdownTrigger>
         </Menu.Target>
       </NavItem>

--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -51,10 +51,8 @@ class ModifiedBootstrapNavDropdown extends BootstrapNavDropdown {
 
 type Props = {
   title?: React.ReactNode,
-  id: string,
   inactiveTitle?: string,
   badge?: React.ComponentType<{ text: React.ReactNode }>,
-  active?: boolean,
   noCaret?: boolean,
 }
 
@@ -121,7 +119,6 @@ NavDropdown.defaultProps = {
   inactiveTitle: undefined,
   badge: undefined,
   noCaret: false,
-  active: false,
 };
 
 const ModifiedNavDropdown = styled(ModifiedBootstrapNavDropdown)`

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
@@ -17,15 +17,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { MenuItem, NavDropdown } from 'components/bootstrap';
-import { ExternalLink, Icon } from 'components/common';
+import { NavDropdown } from 'components/bootstrap';
+import { Icon } from 'components/common';
 import AppConfig from 'util/AppConfig';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
+import Menu from 'components/bootstrap/Menu';
 
 type Props = {
   active: boolean,
 }
+
+const HelpMenuItem = ({ href, children }: React.PropsWithChildren<{ href: string }>) => (
+  <Menu.Item component="a" href={href} target="_blank" icon={<Icon name="external-link-alt" />}>
+    {children}
+  </Menu.Item>
+);
 const HelpMenu = ({ active }: Props) => (
   <NavDropdown active={active}
                id="help-menu-dropdown"
@@ -33,14 +40,14 @@ const HelpMenu = ({ active }: Props) => (
                aria-label="Help"
                noCaret>
 
-    <MenuItem href={DocsHelper.versionedDocsHomePage()} target="_blank">
-      <ExternalLink>Documentation</ExternalLink>
-    </MenuItem>
+    <HelpMenuItem href={DocsHelper.versionedDocsHomePage()}>
+      Documentation
+    </HelpMenuItem>
 
     {AppConfig.isCloud() && (
-    <MenuItem href={Routes.global_api_browser()} target="_blank">
-      <ExternalLink>Cluster Global API browser</ExternalLink>
-    </MenuItem>
+    <HelpMenuItem href={Routes.global_api_browser()}>
+      Cluster Global API browser
+    </HelpMenuItem>
     )}
   </NavDropdown>
 );

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
@@ -14,8 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
 
 import { NavDropdown } from 'components/bootstrap';
 import { Icon } from 'components/common';
@@ -24,19 +23,13 @@ import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 import Menu from 'components/bootstrap/Menu';
 
-type Props = {
-  active: boolean,
-}
-
 const HelpMenuItem = ({ href, children }: React.PropsWithChildren<{ href: string }>) => (
   <Menu.Item component="a" href={href} target="_blank" icon={<Icon name="external-link-alt" />}>
     {children}
   </Menu.Item>
 );
-const HelpMenu = ({ active }: Props) => (
-  <NavDropdown active={active}
-               id="help-menu-dropdown"
-               title={<Icon name="question-circle" size="lg" />}
+const HelpMenu = () => (
+  <NavDropdown title={<Icon name="question-circle" size="lg" />}
                aria-label="Help"
                noCaret>
 
@@ -51,9 +44,5 @@ const HelpMenu = ({ active }: Props) => (
     )}
   </NavDropdown>
 );
-
-HelpMenu.propTypes = {
-  active: PropTypes.bool.isRequired,
-};
 
 export default HelpMenu;

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -90,7 +90,6 @@ const formatPluginRoute = (pluginRoute: PluginNavigation, currentUserPermissions
       <NavDropdown key={title}
                    title={title}
                    badge={renderBadge ? BadgeComponent : null}
-                   id="enterprise-dropdown"
                    inactiveTitle={pluginRoute.description}>
         {pluginRoute.children.map((child) => formatSinglePluginRoute(child, currentUserPermissions, false))}
       </NavDropdown>
@@ -186,7 +185,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
           </InactiveNavItem>
           <ScratchpadToggle />
 
-          <HelpMenu active={_isActive(pathname, Routes.WELCOME)} />
+          <HelpMenu />
 
           <LinkContainer relativeActive to={Routes.WELCOME}>
             <NavItem id="welcome-nav-link" aria-label="Welcome">

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -42,7 +42,7 @@ import InactiveNavItem from './InactiveNavItem';
 import ScratchpadToggle from './ScratchpadToggle';
 import StyledNavbar from './Navigation.styles';
 
-const _isActive = (requestPath, path, end = undefined) => (
+const _isActive = (requestPath: string, path: string, end = undefined) => (
   end ? requestPath === appPrefixed(path) : requestPath.indexOf(appPrefixed(path)) === 0
 );
 

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.test.tsx
@@ -19,23 +19,38 @@ import { render, screen } from 'wrappedTestingLibrary';
 
 import { appPrefixed } from 'util/URLUtils';
 import { asMock } from 'helpers/mocking';
+import Menu from 'components/bootstrap/Menu';
 
-import NavigationLink from './NavigationLink';
+import OriginalNavigationLink from './NavigationLink';
 
 jest.mock('util/URLUtils', () => ({ appPrefixed: jest.fn((path) => path), qualifyUrl: jest.fn((path) => path) }));
 
+const NavigationLink = (props: React.ComponentProps<typeof OriginalNavigationLink>) => (props.topLevel
+  ? <OriginalNavigationLink {...props} />
+  : (
+    <Menu opened>
+      <Menu.Dropdown>
+        <OriginalNavigationLink {...props} />
+      </Menu.Dropdown>
+    </Menu>
+  ));
+
 describe('NavigationLink', () => {
-  it('renders with simple props', () => {
+  it('renders with simple props', async () => {
     render(<NavigationLink description="Hello there!" path="/hello" />);
 
-    expect(screen.getByText('Hello there!')).toHaveAttribute('href', '/hello');
+    const link = await screen.findByRole('menuitem', { name: 'Hello there!' });
+
+    expect(link).toHaveAttribute('href', '/hello');
   });
 
-  it('does not prefix URL with app prefix', () => {
+  it('does not prefix URL with app prefix', async () => {
     asMock(appPrefixed).mockImplementation((path) => `/someprefix${path}`);
     render(<NavigationLink description="Hello there!" path="/hello" />);
 
-    expect(screen.getByText('Hello there!')).toHaveAttribute('href', '/hello');
+    const link = await screen.findByRole('menuitem', { name: 'Hello there!' });
+
+    expect(link).toHaveAttribute('href', '/hello');
     expect(appPrefixed).not.toHaveBeenCalled();
   });
 

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -16,9 +16,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled, {css} from 'styled-components';
 
+import Menu from 'components/bootstrap/Menu';
 import { LinkContainer } from 'components/common/router';
-import { MenuItem, NavItem } from 'components/bootstrap';
+import { NavItem } from 'components/bootstrap';
 
 // We render a NavItem if topLevel is set to avoid errors when the NavigationLink is place in the navigation
 // bar instead of a navigation drop-down menu.
@@ -27,9 +29,16 @@ type Props = {
   path: string,
   topLevel: boolean,
 }
+
+const StyledMenuItem = styled(Menu.Item)(({ theme }) => css`
+  color: ${theme.colors.global.textDefault};
+  font-family: ${theme.fonts.family.navigation};
+  font-size: ${theme.fonts.size.navigation};
+`);
+
 const NavigationLink = ({ description, path, topLevel, ...rest }: Props) => (
   <LinkContainer key={path} to={path} {...rest}>
-    {topLevel ? <NavItem>{description}</NavItem> : <MenuItem>{description}</MenuItem>}
+    {topLevel ? <NavItem>{description}</NavItem> : <StyledMenuItem>{description}</StyledMenuItem>}
   </LinkContainer>
 );
 

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -16,7 +16,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, {css} from 'styled-components';
 
 import Menu from 'components/bootstrap/Menu';
 import { LinkContainer } from 'components/common/router';
@@ -30,15 +29,9 @@ type Props = {
   topLevel: boolean,
 }
 
-const StyledMenuItem = styled(Menu.Item)(({ theme }) => css`
-  color: ${theme.colors.global.textDefault};
-  font-family: ${theme.fonts.family.navigation};
-  font-size: ${theme.fonts.size.navigation};
-`);
-
 const NavigationLink = ({ description, path, topLevel, ...rest }: Props) => (
   <LinkContainer key={path} to={path} {...rest}>
-    {topLevel ? <NavItem>{description}</NavItem> : <StyledMenuItem>{description}</StyledMenuItem>}
+    {topLevel ? <NavItem>{description}</NavItem> : <Menu.Item>{description}</Menu.Item>}
   </LinkContainer>
 );
 

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -26,7 +26,7 @@ import { NavItem } from 'components/bootstrap';
 type Props = {
   description: string,
   path: string,
-  topLevel: boolean,
+  topLevel?: boolean,
 }
 
 const NavigationLink = ({ description, path, topLevel, ...rest }: Props) => (

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.tsx
@@ -25,9 +25,9 @@ import IfPermitted from 'components/common/IfPermitted';
 import Routes from 'routing/Routes';
 import { appPrefixed } from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
+import usePluginEntities from 'hooks/usePluginEntities';
 
 import NavigationLink from './NavigationLink';
-import usePluginEntities from 'hooks/usePluginEntities';
 
 const TITLE_PREFIX = 'System';
 const PATH_PREFIX = '/system';
@@ -93,7 +93,7 @@ const SystemMenu = () => {
     });
 
   return (
-    <NavDropdown title={_systemTitle(location.pathname, _pluginSystemNavigations)} id="system-menu-dropdown" inactiveTitle={TITLE_PREFIX}>
+    <NavDropdown title={_systemTitle(location.pathname, _pluginSystemNavigations)} inactiveTitle={TITLE_PREFIX}>
       <NavigationLink path={Routes.SYSTEM.OVERVIEW} description="Overview" />
       <IfPermitted permissions={['clusterconfigentry:read']}>
         <NavigationLink path={Routes.SYSTEM.CONFIGURATIONS} description="Configurations" />

--- a/graylog2-web-interface/src/components/navigation/UserMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.tsx
@@ -16,13 +16,15 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
 import { LinkContainer } from 'components/common/router';
-import { NavDropdown, MenuItem } from 'components/bootstrap';
+import { NavDropdown } from 'components/bootstrap';
 import { Icon } from 'components/common';
 import Routes from 'routing/Routes';
 import { SessionActions } from 'stores/sessions/SessionStore';
 import useHistory from 'routing/useHistory';
+import Menu from 'components/bootstrap/Menu';
 
 import ThemeModeToggle from './ThemeModeToggle';
 
@@ -31,6 +33,11 @@ type Props = {
   userId: string,
   readOnly: boolean,
 };
+
+const FullName = styled.span`
+  text-transform: uppercase;
+  font-weight: 700;
+`;
 
 const UserMenu = ({ fullName, readOnly = true, userId }: Props) => {
   const history = useHistory();
@@ -55,16 +62,16 @@ const UserMenu = ({ fullName, readOnly = true, userId }: Props) => {
                  aria-label={`User Menu for ${fullName}`}
                  id="user-menu-dropdown"
                  noCaret>
-      <MenuItem header>{fullName}</MenuItem>
-      <MenuItem divider />
-      <MenuItem header>
+      <Menu.Label><FullName>{fullName}</FullName></Menu.Label>
+      <Menu.Divider />
+      <Menu.Label>
         <ThemeModeToggle />
-      </MenuItem>
-      <MenuItem divider />
+      </Menu.Label>
+      <Menu.Divider />
       <LinkContainer to={route}>
-        <MenuItem>{label}</MenuItem>
+        <Menu.Item>{label}</Menu.Item>
       </LinkContainer>
-      <MenuItem onSelect={onLogoutClicked} icon="sign-out-alt">Log out</MenuItem>
+      <Menu.Item onSelect={onLogoutClicked} icon={<Icon name="sign-out-alt" />}>Log out</Menu.Item>
     </NavDropdown>
   );
 };

--- a/graylog2-web-interface/src/components/navigation/UserMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.tsx
@@ -60,7 +60,6 @@ const UserMenu = ({ fullName, readOnly = true, userId }: Props) => {
   return (
     <NavDropdown title={<Icon name="user" size="lg" />}
                  aria-label={`User Menu for ${fullName}`}
-                 id="user-menu-dropdown"
                  noCaret>
       <Menu.Label><FullName>{fullName}</FullName></Menu.Label>
       <Menu.Divider />

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -21,6 +21,7 @@ import DefaultProviders from 'DefaultProviders';
 import type { RouteObject } from 'react-router-dom';
 import { createBrowserRouter, createMemoryRouter } from 'react-router-dom';
 import { defaultUser } from 'defaultMockValues';
+import type { PluginExports } from 'graylog-web-plugin/plugin';
 
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import mockComponent from 'helpers/mocking/MockComponent';
@@ -72,6 +73,13 @@ const setInitialPath = (path: string) => {
   }));
 };
 
+const mockRoutes = (routes: PluginExports['routes']) => {
+  const pluginExports: PluginExports = {
+    routes,
+  };
+  asMock(usePluginEntities).mockImplementation((key: keyof PluginExports) => pluginExports[key] ?? []);
+};
+
 describe('AppRouter', () => {
   beforeEach(() => {
     asMock(usePluginEntities).mockReturnValue([]);
@@ -94,7 +102,7 @@ describe('AppRouter', () => {
 
   describe('plugin routes', () => {
     it('renders simple plugin routes', async () => {
-      asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route' }]);
+      mockRoutes([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route' }]);
       setInitialPath('/a-plugin-route');
       const { findByText } = render(<AppRouterWithContext />);
 
@@ -102,7 +110,7 @@ describe('AppRouter', () => {
     });
 
     it('renders null-parent component plugin routes without application chrome', async () => {
-      asMock(usePluginEntities).mockReturnValue([{ parentComponent: null, component: () => <span>Hey there!</span>, path: '/without-chrome' }]);
+      mockRoutes([{ parentComponent: null, component: () => <span>Hey there!</span>, path: '/without-chrome' }]);
 
       setInitialPath('/without-chrome');
       const { findByText, queryByTitle } = render(<AppRouterWithContext />);
@@ -113,7 +121,7 @@ describe('AppRouter', () => {
     });
 
     it('does not render plugin route when required feature flag is not enabled', async () => {
-      asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
+      mockRoutes([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
       setInitialPath('/a-plugin-route');
       render(<AppRouterWithContext />);
 
@@ -124,7 +132,7 @@ describe('AppRouter', () => {
 
     it('render plugin route when required feature flag is enabled', async () => {
       asMock(AppConfig.isFeatureEnabled).mockReturnValue(true);
-      asMock(usePluginEntities).mockReturnValue([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
+      mockRoutes([{ component: () => <span>Hey there!</span>, path: '/a-plugin-route', requiredFeatureFlag: 'a_feature_flag' }]);
       setInitialPath('/a-plugin-route');
       const { findByText } = render(<AppRouterWithContext />);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is reimplementing the `NavDropdown` & `NavigationLink` components using Mantine. This is one of the requirements for migrating to React 18, as the `react-bootstrap` is not working on React 18.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.