### PR TITLE
Update stream throughput metric in route_to_stream pipeline function

### DIFF
--- a/changelog/unreleased/pr-1111.toml
+++ b/changelog/unreleased/pr-1111.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Show correct throughput when messages are routed via a pipeline rule."
+
+issues = ["Graylog2/graylog-plugin-enterprise#6138"]
+pulls = ["1111"]

--- a/changelog/unreleased/pr-17347.toml
+++ b/changelog/unreleased/pr-17347.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Show correct throughput when messages are routed via a pipeline rule."
 
 issues = ["Graylog2/graylog-plugin-enterprise#6138"]
-pulls = ["1111"]
+pulls = ["17347"]

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -161,6 +161,7 @@ import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.streams.StreamMetrics;
 import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -260,7 +261,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         streamCacheService = new StreamCacheService(eventBus, streamService, null);
         streamCacheService.startAsync().awaitRunning();
         final Provider<Stream> defaultStreamProvider = () -> defaultStream;
-        functions.put(RouteToStream.NAME, new RouteToStream(streamCacheService, defaultStreamProvider));
+        functions.put(RouteToStream.NAME, new RouteToStream(streamCacheService, defaultStreamProvider, mock(StreamMetrics.class)));
         functions.put(RemoveFromStream.NAME, new RemoveFromStream(streamCacheService, defaultStreamProvider));
 
         lookupTableService = mock(LookupTableService.class, RETURNS_DEEP_STUBS);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
@@ -44,6 +44,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
+import org.graylog2.streams.StreamMetrics;
 import org.graylog2.streams.StreamService;
 import org.junit.Before;
 import org.junit.Test;
@@ -122,7 +123,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
                 SetField.NAME, new SetField(),
                 LongConversion.NAME, new LongConversion(),
                 RemoveFromStream.NAME, new RemoveFromStream(streamCacheService, defaultStreamProvider),
-                RouteToStream.NAME, new RouteToStream(streamCacheService, defaultStreamProvider)
+                RouteToStream.NAME, new RouteToStream(streamCacheService, defaultStreamProvider, mock(StreamMetrics.class))
         );
 
         final FunctionRegistry functionRegistry = new FunctionRegistry(functions);


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-enterprise#6138

<!--- Provide a general summary of your changes in the Title above -->
Update stream metrics in  `route_to_stream` pipeline function.

## Description
<!--- Describe your changes in detail -->
Stream throughput did not reflect messages that were routed via `route_to_stream` pipeline function, since this code path does not involve the `StreamRouterEngine`.
