### PR TITLE
Always use own abstraction for `useLocation`.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.tsx
@@ -16,20 +16,15 @@
  */
 import React from 'react';
 import { render, fireEvent, screen } from 'wrappedTestingLibrary';
-import { useLocation } from 'react-router-dom';
 import type { Location } from 'history';
 
+import useLocation from 'routing/useLocation';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import { asMock } from 'helpers/mocking';
 
 import PaginatedList from './PaginatedList';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(() => ({
-    search: '',
-  })),
-}));
+jest.mock('routing/useLocation', () => jest.fn(() => ({ search: '' })));
 
 describe('PaginatedList', () => {
   it('should display Pagination', () => {

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.tsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
+import useLocation from 'routing/useLocation';
 import ErrorPage from 'components/errors/ErrorPage';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import type { ReportedError } from 'logic/errors/ReportedErrors';

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
@@ -17,12 +17,13 @@
 import * as React from 'react';
 import { mount, mountUnwrapped } from 'wrappedEnzyme';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import { Route, Routes, MemoryRouter, useLocation } from 'react-router-dom';
+import { Route, Routes, MemoryRouter } from 'react-router-dom';
 import DefaultProviders from 'DefaultProviders';
 import Immutable from 'immutable';
 import type { Location } from 'history';
 import { defaultUser } from 'defaultMockValues';
 
+import useLocation from 'routing/useLocation';
 import mockComponent from 'helpers/mocking/MockComponent';
 import { adminUser } from 'fixtures/users';
 import { asMock } from 'helpers/mocking';
@@ -44,13 +45,7 @@ jest.mock('hooks/useCurrentUser');
 jest.mock('./DevelopmentHeaderBadge', () => () => <span />);
 jest.mock('routing/withLocation', () => (x) => x);
 jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(() => ({
-    pathname: '',
-  })),
-}));
+jest.mock('routing/useLocation', () => jest.fn(() => ({ pathname: '' })));
 
 jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useLocation } from 'react-router-dom';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import type { PluginNavigationDropdownItem, PluginNavigation } from 'graylog-web-plugin';
 import type * as Immutable from 'immutable';
 
+import useLocation from 'routing/useLocation';
 import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import { LinkContainer } from 'components/common/router';
 import { appPrefixed } from 'util/URLUtils';

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { render, screen } from 'wrappedTestingLibrary';
-import { useLocation } from 'react-router-dom';
 import type { Location } from 'history';
 
+import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { adminUser } from 'fixtures/users';
@@ -36,12 +36,7 @@ jest.mock('util/AppConfig', () => ({
 }));
 
 jest.mock('hooks/useCurrentUser');
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(),
-}));
-
+jest.mock('routing/useLocation', () => jest.fn());
 jest.mock('hooks/usePluginEntities');
 
 const openSystemMenu = async () => {

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.tsx
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 import type { SystemNavigationItem } from 'graylog-web-plugin';
 
+import useLocation from 'routing/useLocation';
 import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import { NavDropdown } from 'components/bootstrap';
 import HideOnCloud from 'util/conditional/HideOnCloud';

--- a/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.test.tsx
+++ b/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.test.tsx
@@ -17,9 +17,10 @@
 import React from 'react';
 import { renderHook } from 'wrappedTestingLibrary/hooks';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import type { Location } from 'react-router-dom';
 
+import useLocation from 'routing/useLocation';
 import {
   mockedMappedAggregation,
   mockEventData,
@@ -29,12 +30,10 @@ import asMock from 'helpers/mocking/AsMock';
 import useAlertAndEventDefinitionData from 'hooks/useAlertAndEventDefinitionData';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
+jest.mock('routing/useLocation', () => jest.fn(() => ({ pathname: '/' })));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: jest.fn(() => ({
-    pathname: '/',
-  })),
   useParams: jest.fn(() => ({})),
 }));
 

--- a/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.tsx
+++ b/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.tsx
@@ -16,9 +16,9 @@
  */
 
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
+import useLocation from 'routing/useLocation';
 import Routes from 'routing/Routes';
 import useParams from 'routing/useParams';
 import type { Event } from 'components/events/events/types';

--- a/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
+++ b/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { renderHook, act } from 'wrappedTestingLibrary/hooks';
-import { useLocation } from 'react-router-dom';
 import { stringify } from 'qs';
 
+import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 
 import useLocationSearchPagination from './useLocationSearchPagination';
@@ -27,11 +27,9 @@ const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useLocation: jest.fn(() => ({
-    pathname: '',
-    search: '',
-  })),
 }));
+
+jest.mock('routing/useLocation', () => jest.fn(() => ({ search: '' })));
 
 describe('useLocationSearchPagination custom hook', () => {
   const DEFAULT_PAGINATION = { page: 999, perPage: 999, query: 'foobar' };

--- a/graylog2-web-interface/src/hooks/useLocationSearchPagination.ts
+++ b/graylog2-web-interface/src/hooks/useLocationSearchPagination.ts
@@ -15,9 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useEffect, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { parse, stringify } from 'qs';
 
+import useLocation from 'routing/useLocation';
 import type { Pagination } from 'stores/PaginationTypes';
 
 type UseLocationSearchPaginationType = {

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.test.ts
@@ -15,9 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { renderHook, act } from 'wrappedTestingLibrary/hooks';
-import { useLocation, MemoryRouter as Router } from 'react-router-dom';
+import { MemoryRouter as Router } from 'react-router-dom';
 import type { Location } from 'history';
 
+import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 
 import usePaginationQueryParameter, { DEFAULT_PAGE } from './usePaginationQueryParameter';
@@ -28,11 +29,9 @@ const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useLocation: jest.fn(() => ({
-    pathname: '',
-    search: '',
-  })),
 }));
+
+jest.mock('routing/useLocation', () => jest.fn(() => ({ pathname: '', search: '' })));
 
 const options = { wrapper: Router };
 

--- a/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
+++ b/graylog2-web-interface/src/hooks/usePaginationQueryParameter.ts
@@ -15,9 +15,10 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import URI from 'urijs';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
 
+import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 
 export const DEFAULT_PAGE = 1;

--- a/graylog2-web-interface/src/routing/useQuery.ts
+++ b/graylog2-web-interface/src/routing/useQuery.ts
@@ -15,8 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import qs from 'qs';
+
+import useLocation from 'routing/useLocation';
 
 const useQuery = () => {
   const { search } = useLocation();

--- a/graylog2-web-interface/src/routing/withLocation.tsx
+++ b/graylog2-web-interface/src/routing/withLocation.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import type { Subtract } from 'utility-types';
+
+import useLocation from 'routing/useLocation';
 
 import useQuery from './useQuery';
 

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
-import { useLocation } from 'react-router-dom';
 
+import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
@@ -31,11 +31,9 @@ const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useLocation: jest.fn(() => ({
-    pathname: '',
-    search: '',
-  })),
 }));
+
+jest.mock('routing/useLocation', () => jest.fn(() => ({ search: '', pathname: '' })));
 
 const emptyLocation = {
   pathname: '',

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -16,9 +16,10 @@
  */
 import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import URI from 'urijs';
 
+import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 import useAppSelector from 'stores/useAppSelector';

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent } from 'wrappedTestingLibrary';
-import { useLocation } from 'react-router-dom';
 
+import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import type { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are replacing the remaining direct imports of `useLocation` from `react-router-dom` with our own abstraction.

/nocl