### PR TITLE
Add option to send HTTP notification API key/secret as header

### DIFF
--- a/changelog/unreleased/issue-14691.toml
+++ b/changelog/unreleased/issue-14691.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added support for sending HTTP Notification API Key/Secret as a header"
+
+issues = ["14691"]
+pulls = ["17369"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -93,7 +93,7 @@ public class HTTPEventNotification extends HTTPNotification implements EventNoti
 
         final Request.Builder builder = new Request.Builder();
         addAuthHeader(builder, config.basicAuth());
-        addApiKey(builder, httpUrl, config.apiKey(), config.apiSecret());
+        addApiKey(builder, httpUrl, config.apiKey(), config.apiSecret(), config.apiKeyAsHeader());
 
         final byte[] body;
         try {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -45,6 +45,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
     private static final String FIELD_URL = "url";
     private static final String FIELD_BASIC_AUTH = "basic_auth";
+    private static final String FIELD_API_KEY_AS_HEADER = "api_key_as_header";
     private static final String FIELD_API_KEY = "api_key";
     private static final String FIELD_API_SECRET = "api_secret";
     private static final String FIELD_SKIP_TLS_VERIFICATION = "skip_tls_verification";
@@ -52,6 +53,9 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonProperty(FIELD_BASIC_AUTH)
     @Nullable
     public abstract EncryptedValue basicAuth();
+
+    @JsonProperty(FIELD_API_KEY_AS_HEADER)
+    public abstract boolean apiKeyAsHeader();
 
     @JsonProperty(FIELD_API_KEY)
     @Nullable
@@ -67,6 +71,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonProperty(FIELD_SKIP_TLS_VERIFICATION)
     public abstract boolean skipTLSVerification();
 
+    @Override
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
@@ -77,6 +82,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     }
 
     public abstract Builder toBuilder();
+    @Override
     @JsonIgnore
     public ValidationResult validate() {
         final ValidationResult validation = new ValidationResult();
@@ -130,6 +136,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             return new AutoValue_HTTPEventNotificationConfig.Builder()
                     .basicAuth(EncryptedValue.createUnset())
                     .apiSecret(EncryptedValue.createUnset())
+                    .apiKeyAsHeader(false)
                     .apiKey("")
                     .skipTLSVerification(false)
                     .type(TYPE_NAME);
@@ -137,6 +144,9 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
         @JsonProperty(FIELD_BASIC_AUTH)
         public abstract Builder basicAuth(EncryptedValue basicAuth);
+
+        @JsonProperty(FIELD_API_KEY_AS_HEADER)
+        public abstract Builder apiKeyAsHeader(boolean apiKey);
 
         @JsonProperty(FIELD_API_KEY)
         public abstract Builder apiKey(String apiKey);

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfigV2.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfigV2.java
@@ -54,6 +54,7 @@ public abstract class HTTPEventNotificationConfigV2 implements EventNotification
     public static final String FIELD_BODY_TEMPLATE = "body_template";
     public static final String FIELD_SKIP_TLS_VERIFICATION = "skip_tls_verification";
     private static final String FIELD_BASIC_AUTH = "basic_auth";
+    private static final String FIELD_API_KEY_AS_HEADER = "api_key_as_header";
     private static final String FIELD_API_KEY = "api_key";
     private static final String FIELD_API_SECRET = "api_secret";
 
@@ -68,6 +69,9 @@ public abstract class HTTPEventNotificationConfigV2 implements EventNotification
     @JsonProperty(FIELD_BASIC_AUTH)
     @Nullable
     public abstract EncryptedValue basicAuth();
+
+    @JsonProperty(FIELD_API_KEY_AS_HEADER)
+    public abstract boolean apiKeyAsHeader();
 
     @JsonProperty(FIELD_API_KEY)
     @Nullable
@@ -200,6 +204,7 @@ public abstract class HTTPEventNotificationConfigV2 implements EventNotification
                     .basicAuth(EncryptedValue.createUnset())
                     .apiSecret(EncryptedValue.createUnset())
                     .apiKey("")
+                    .apiKeyAsHeader(false)
                     .skipTLSVerification(false)
                     .type(TYPE_NAME)
                     .httpMethod(HttpMethod.POST)
@@ -210,6 +215,9 @@ public abstract class HTTPEventNotificationConfigV2 implements EventNotification
 
         @JsonProperty(FIELD_BASIC_AUTH)
         public abstract Builder basicAuth(EncryptedValue basicAuth);
+
+        @JsonProperty(FIELD_API_KEY_AS_HEADER)
+        public abstract Builder apiKeyAsHeader(boolean apiKeyAsHeader);
 
         @JsonProperty(FIELD_API_KEY)
         public abstract Builder apiKey(String apiKey);

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
@@ -137,7 +137,7 @@ public class HTTPEventNotificationV2 extends HTTPNotification implements EventNo
 
         final Request.Builder builder = new Request.Builder();
         addAuthHeader(builder, config.basicAuth());
-        addApiKey(builder, httpUrl, config.apiKey(), config.apiSecret());
+        addApiKey(builder, httpUrl, config.apiKey(), config.apiSecret(), config.apiKeyAsHeader());
         addHeaders(builder, config.headers());
 
         final String body;

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPNotification.java
@@ -65,13 +65,17 @@ public class HTTPNotification {
         }
     }
 
-    public void addApiKey(Request.Builder builder, HttpUrl httpUrl, String apiKey, EncryptedValue apiSecret) {
+    public void addApiKey(Request.Builder builder, HttpUrl httpUrl, String apiKey, EncryptedValue apiSecret, boolean sendAsHeader) {
         // Add API key if it exists
         if (!Strings.isNullOrEmpty(apiKey)) {
             final String apiKeyValue = getApiKeyValue(apiSecret);
-            builder.url(httpUrl.newBuilder().addQueryParameter(apiKey, apiKeyValue).build());
-        }
-        else {
+            if (sendAsHeader) {
+                builder.url(httpUrl);
+                builder.addHeader(apiKey, apiKeyValue);
+            } else {
+                builder.url(httpUrl.newBuilder().addQueryParameter(apiKey, apiKeyValue).build());
+            }
+        } else {
             builder.url(httpUrl);
         }
     }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
@@ -19,14 +19,20 @@ import PropTypes from 'prop-types';
 
 import { ReadOnlyFormGroup } from 'components/common';
 
-const HttpNotificationDetails = ({ notification }) => (
-  <>
-    <ReadOnlyFormGroup label="URL" value={notification.config.url} />
-    <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
-    <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
-    <ReadOnlyFormGroup label="API Secret" value={notification.config.api_secret?.is_set ? '******' : null} />
-  </>
-);
+const HttpNotificationDetails = ({ notification }) => {
+  const apiKeySet = notification.config.api_secret?.is_set;
+  const apiSentAs = notification.config.api_key_as_header ? 'Header' : 'Query Parameter';
+
+  return (
+    <>
+      <ReadOnlyFormGroup label="URL" value={notification.config.url} />
+      <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
+      <ReadOnlyFormGroup label="API Key/Secret Sent As" value={apiKeySet ? apiSentAs : null} />
+      <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
+      <ReadOnlyFormGroup label="API Secret" value={apiKeySet ? '******' : null} />
+    </>
+  );
+};
 
 HttpNotificationDetails.propTypes = {
   notification: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetailsV2.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetailsV2.tsx
@@ -26,25 +26,32 @@ type Props = {
   notification: HttpEventNotificationV2,
 }
 
-const HttpNotificationDetailsV2 = ({ notification } : Props) => (
-  <>
-    <ReadOnlyFormGroup label="URL" value={notification.config.url} />
-    <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
-    <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
-    <ReadOnlyFormGroup label="API Secret" value={notification.config.api_secret?.is_set ? '******' : null} />
-    <ReadOnlyFormGroup label="Method" value={notification.config.method} />
-    {notification.config.time_zone && (<ReadOnlyFormGroup label="Time Zone" value={notification.config.time_zone} />)}
-    {notification.config.content_type && (<ReadOnlyFormGroup label="Content Type" value={notification.config.content_type} />)}
-    {notification.config.headers && (<ReadOnlyFormGroup label="Headers" value={notification.config.headers} />)}
-    {notification.config.body_template && (
-    <ReadOnlyFormGroup label="Body Template"
-                       value={(
-                         <Well bsSize="small" className={styles.bodyPreview}>
-                           {notification.config.body_template}
-                         </Well>
-    )} />
-    )}
-  </>
-);
+const HttpNotificationDetailsV2 = ({ notification } : Props) => {
+  const apiKeySet: boolean = notification.config.api_secret?.is_set;
+  const apiSentAs: string = notification.config.api_key_as_header ? 'Header' : 'Query Parameter';
+
+  return (
+    <>
+      <ReadOnlyFormGroup label="URL" value={notification.config.url} />
+      <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
+      <ReadOnlyFormGroup label="API Key/Secret Sent As" value={apiKeySet ? apiSentAs : null} />
+      <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
+      <ReadOnlyFormGroup label="API Secret" value={apiKeySet ? '******' : null} />
+      <ReadOnlyFormGroup label="Method" value={notification.config.method} />
+      {notification.config.time_zone && (<ReadOnlyFormGroup label="Time Zone" value={notification.config.time_zone} />)}
+      {notification.config.content_type && (
+      <ReadOnlyFormGroup label="Content Type" value={notification.config.content_type} />)}
+      {notification.config.headers && (<ReadOnlyFormGroup label="Headers" value={notification.config.headers} />)}
+      {notification.config.body_template && (
+      <ReadOnlyFormGroup label="Body Template"
+                         value={(
+                           <Well bsSize="small" className={styles.bodyPreview}>
+                             {notification.config.body_template}
+                           </Well>
+                         )} />
+      )}
+    </>
+  );
+};
 
 export default HttpNotificationDetailsV2;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -40,6 +40,7 @@ class HttpNotificationForm extends React.Component {
 
   static defaultConfig = {
     url: '',
+    api_key_as_header: false,
     api_key: '',
     api_secret: { keep_value: true },
     basic_auth: { keep_value: true },
@@ -201,6 +202,12 @@ class HttpNotificationForm extends React.Component {
                        </Button>
                      ) : undefined} />
             )}
+            <Checkbox id="api_key_as_header"
+                      name="api_key_as_header"
+                      onChange={this.handleChange}
+                      checked={config.api_key_as_header}>
+              Send API Key/Secret as Header
+            </Checkbox>
           </Col>
         </Row>
       </>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationFormV2.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationFormV2.tsx
@@ -60,6 +60,7 @@ const shouldPopulateTemplate = (currentType: string, currentBody: string): boole
 class HttpNotificationFormV2 extends React.Component<Props, any> {
   static defaultConfig = {
     url: '',
+    api_key_as_header: false,
     api_key: '',
     api_secret: { keep_value: true },
     basic_auth: { keep_value: true },
@@ -252,6 +253,12 @@ class HttpNotificationFormV2 extends React.Component<Props, any> {
                    bsStyle={validation.errors.api_key ? 'error' : null}
                    help={get(validation, 'errors.api_key[0]', 'Must be set if an API secret is set')}
                    value={config.api_key} />
+            <Checkbox id="api_key_as_header"
+                      name="api_key_as_header"
+                      onChange={this.handleChange}
+                      checked={config.api_key_as_header}>
+              Send API Key/Secret as Header
+            </Checkbox>
           </Col>
           <Col md={6}>
             {api_secret?.keep_value ? (

--- a/graylog2-web-interface/src/components/event-notifications/types.d.ts
+++ b/graylog2-web-interface/src/components/event-notifications/types.d.ts
@@ -29,6 +29,7 @@ export type HttpNotificationConfigV2 = {
   type: 'http-notification-v2',
   url: string,
   basic_auth?: EncryptedValue,
+  api_key_as_header: boolean,
   api_key?: string,
   api_secret?: EncryptedValue,
   skip_tls_verification: boolean,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds ability to send the API key/secret as either an HTTP header or query param (as it does now). Just finished up the new Custom HTTP Notification and found this issue on the backlog. Figured I'd preemptively clean it up for the new notification as well as the existing one. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #14691 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

