### PR TITLE
Resolve stream references to a view's state value widgets in addition to searches

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
@@ -42,6 +42,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.SearchEntity;
 import org.graylog2.contentpacks.model.entities.ViewEntity;
 import org.graylog2.contentpacks.model.entities.ViewStateEntity;
+import org.graylog2.contentpacks.model.entities.WidgetEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
@@ -216,6 +217,13 @@ public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, Vie
         final MutableGraph<Entity> mutableGraph = GraphBuilder.directed().build();
         mutableGraph.addNode(entity);
         viewEntity.search().usedStreamIds().stream()
+                .map(s -> EntityDescriptor.create(s, ModelTypes.STREAM_V1))
+                .map(entities::get)
+                .filter(Objects::nonNull)
+                .forEach(stream -> mutableGraph.putEdge(entity, stream));
+        viewEntity.state().values().stream()
+                .flatMap(s -> s.widgets().stream())
+                .flatMap(w -> w.streams().stream())
                 .map(s -> EntityDescriptor.create(s, ModelTypes.STREAM_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes issue with content pack installations where the stream reference of the `search` entity has been removed but not the stream reference in the associated `state` `widget`.

## Description
<!--- Describe your changes in detail -->
Seams to be a bug in conjunction with the code here: https://github.com/Graylog2/graylog2-server/blob/38c3bc6ad085f007f4d4b29ed2729d06f06cf9bf/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackPersistenceService.java#L130-L168

Added in https://github.com/Graylog2/graylog2-server/pull/10972

This issue occurs when you have a content pack with a dashboard and stream where the dashboard references the stream.
If the referenced stream doesn't exist when the content pack is uploaded, the code linked above removes the stream reference from the `search` entity but not the `widget` entities in the `state`.

When this happens the content pack installation will sometimes fail (sometimes not) depending of the random order of the set containing the entites to install, because the resolution code changed in this PR is not handling the `widgets` in the search to ensure the proper order of entities: 
https://github.com/Graylog2/graylog2-server/blob/38c3bc6ad085f007f4d4b29ed2729d06f06cf9bf/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java#L119
https://github.com/Graylog2/graylog2-server/blob/38c3bc6ad085f007f4d4b29ed2729d06f06cf9bf/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java#L414

Not sure if the best solution is this fix, handling the `widget` entities in `ContentPackPersistenceService.filterMissingResourcesAndInsert()`, or both.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was able to reproduce this reliably with these two identical content packs (minus identifying info), but because of the non-deterministic nature of this can't guarantee the same results when testing elsewhere.

Upload both on a system where the `Illuminate:Cisco Device Messages` does NOT exist.
Installing this pack fails:
[content-pack-ebe297d5-469c-4c5c-a978-0a1ca7d558ce-1.json](https://github.com/Graylog2/graylog2-server/files/13397959/content-pack-ebe297d5-469c-4c5c-a978-0a1ca7d558ce-1.json)

But this
[content-pack-2a26feda-c426-4c78-989d-4a05e68ace8a-1.json](https://github.com/Graylog2/graylog2-server/files/13397960/content-pack-2a26feda-c426-4c78-989d-4a05e68ace8a-1.json)
 one succeeds:


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

