### PR TITLE
Publish and show data node state information

### DIFF
--- a/changelog/unreleased/issue-17247.toml
+++ b/changelog/unreleased/issue-17247.toml
@@ -1,0 +1,3 @@
+type = "a"
+message = "Provide backend for data node table including status information."
+issues = ["17247"]

--- a/data-node/src/main/java/org/graylog/datanode/process/ProcessState.java
+++ b/data-node/src/main/java/org/graylog/datanode/process/ProcessState.java
@@ -16,31 +16,54 @@
  */
 package org.graylog.datanode.process;
 
+import org.graylog2.cluster.DataNodeStatus;
+
 public enum ProcessState {
     /**
      * Fresh created process, not started yet
      */
-    WAITING_FOR_CONFIGURATION,
+    WAITING_FOR_CONFIGURATION(DataNodeStatus.UNCONFIGURED),
     /**
      * The process is running on the underlying OS and has a process ID. It's not responding to the REST API yet
      */
-    STARTING,
+    STARTING(DataNodeStatus.STARTING),
     /**
      * Opensearch is now available on the default port with GREEN cluster status, all good
      */
-    AVAILABLE,
+    AVAILABLE(DataNodeStatus.AVAILABLE),
     /**
      * There are problems in the REST communication with the opensearch. We'll retry several times before
      * we go to the FAILED state, giving up.
      */
-    NOT_RESPONDING,
+    NOT_RESPONDING(DataNodeStatus.UNAVAILABLE),
 
     /**
      * Failed to reach the opensearch REST API, but the underlying process is still alive
      */
-    FAILED,
+    FAILED(DataNodeStatus.UNAVAILABLE),
+
+    /**
+     * Removal of node from Opensearch cluster requested
+     */
+    REMOVING(DataNodeStatus.REMOVING),
+    /**
+     * Removal of node from Opensearch cluster completed
+     */
+    REMOVED(DataNodeStatus.REMOVED),
+
     /**
      * The OS process is not running anymore on the underlying system, it has been terminated
      */
-    TERMINATED
+    TERMINATED(DataNodeStatus.UNAVAILABLE);
+
+
+    private final DataNodeStatus dataNodeStatus;
+
+    ProcessState(DataNodeStatus dataNodeStatus) {
+        this.dataNodeStatus = dataNodeStatus;
+    }
+
+    public DataNodeStatus getDataNodeStatus() {
+        return dataNodeStatus;
+    }
 }

--- a/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/periodicals/NodePingPeriodicalTest.java
@@ -17,6 +17,7 @@
 package org.graylog.datanode.periodicals;
 
 import org.graylog.datanode.Configuration;
+import org.graylog.datanode.process.ProcessState;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.plugin.system.SimpleNodeId;
@@ -44,7 +45,8 @@ class NodePingPeriodicalTest {
                 configuration,
                 () -> uri,
                 () -> cluster,
-                () -> true
+                () -> true,
+                () -> ProcessState.AVAILABLE
         );
 
         task.doRun();
@@ -53,7 +55,8 @@ class NodePingPeriodicalTest {
                 Mockito.eq(nodeID),
                 Mockito.eq(true),
                 Mockito.eq(uri),
-                Mockito.eq(cluster));
+                Mockito.eq(cluster),
+                Mockito.eq(ProcessState.AVAILABLE.getDataNodeStatus()));
     }
 
 
@@ -66,7 +69,7 @@ class NodePingPeriodicalTest {
 
         final NodeService nodeService = Mockito.mock(NodeService.class);
 
-        Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster);
+        Mockito.doThrow(new NodeNotFoundException("Node not found")).when(nodeService).markAsAlive(nodeID, true, uri, cluster, ProcessState.STARTING.getDataNodeStatus());
 
         Configuration configuration = Mockito.mock(Configuration.class);
         Mockito.when(configuration.getHostname()).thenReturn("hostname.setting.from.config");
@@ -77,7 +80,8 @@ class NodePingPeriodicalTest {
                 configuration,
                 () -> uri,
                 () -> cluster,
-                () -> true
+                () -> true,
+                () -> ProcessState.STARTING
         );
 
         task.doRun();

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertRenewalService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertRenewalService.java
@@ -16,16 +16,23 @@
  */
 package org.graylog.security.certutil;
 
+import org.graylog2.cluster.DataNodeStatus;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.preflight.DataNodeProvisioningConfig;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 public interface CertRenewalService {
-    record DataNode(String nodeId, Node.Type type, String transportAddress, DataNodeProvisioningConfig.State status, String errorMsg, String hostname, String shortNodeId, LocalDateTime certValidUntil) {}
+
+    record DataNode(String nodeId, Node.Type type, DataNodeStatus dataNodeStatus, String transportAddress,
+                    DataNodeProvisioningConfig.State status, String errorMsg, String hostname, String shortNodeId,
+                    LocalDateTime certValidUntil) {}
 
     void checkCertificatesForRenewal();
     void initiateRenewalForNode(String nodeId);
     List<DataNode> findNodes();
+
+    List<DataNode> addProvisioningInformation(Collection<Node> nodes);
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -20,6 +20,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.cluster.NodeServiceImpl;
+import org.graylog2.cluster.PaginatedNodeService;
 import org.graylog2.database.suggestions.EntitySuggestionService;
 import org.graylog2.database.suggestions.MongoEntitySuggestionService;
 import org.graylog2.indexer.IndexFailureService;
@@ -54,6 +55,7 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(NotificationService.class).to(NotificationServiceImpl.class).asEagerSingleton();
         bind(IndexFailureService.class).to(IndexFailureServiceImpl.class).asEagerSingleton();
         bind(NodeService.class).to(NodeServiceImpl.class);
+        bind(PaginatedNodeService.class).asEagerSingleton();
         bind(IndexRangeService.class).to(MongoIndexRangeService.class).asEagerSingleton();
         bind(InputService.class).to(InputServiceImpl.class);
         bind(UserService.class).to(UserServiceImpl.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/cluster/DataNodeStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/DataNodeStatus.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.cluster;
+
+public enum DataNodeStatus {
+    UNCONFIGURED, STARTING, AVAILABLE, UNAVAILABLE, REMOVING, REMOVED
+}

--- a/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
@@ -53,6 +53,8 @@ public interface Node {
 
     String getHostname();
 
+    DataNodeStatus getDataNodeStatus();
+
     default String getShortNodeId() {
         return getNodeId().split("-")[0];
     }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -23,7 +23,6 @@ import org.bson.types.ObjectId;
 import org.graylog2.database.DbEntity;
 import org.graylog2.database.PersistedImpl;
 import org.graylog2.plugin.database.validators.Validator;
-import org.graylog2.shared.utilities.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -105,5 +104,13 @@ public class NodeImpl extends PersistedImpl implements Node {
     @Override
     public String toString() {
         return getTitle();
+    }
+
+    @Override
+    public DataNodeStatus getDataNodeStatus() {
+        if (!fields.containsKey("datanode_status")) {
+            return null;
+        }
+        return DataNodeStatus.valueOf(fields.get("datanode_status").toString());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -16,8 +16,10 @@
  */
 package org.graylog2.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.undercouch.bson4jackson.types.Timestamp;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.ObjectId;
 import org.graylog2.database.DbEntity;
@@ -33,6 +35,8 @@ import java.util.Map;
 @DbEntity(collection = "nodes", titleField = "node_id")
 public class NodeImpl extends PersistedImpl implements Node {
 
+
+    @JsonCreator
     public NodeImpl(Map<String, Object> fields) {
         super(fields);
     }
@@ -70,6 +74,9 @@ public class NodeImpl extends PersistedImpl implements Node {
         }
         if (rawLastSeen instanceof BSONTimestamp) {
             return new DateTime(((BSONTimestamp) rawLastSeen).getTime() * 1000L, DateTimeZone.UTC);
+        }
+        if (rawLastSeen instanceof Timestamp ts) {
+            return new DateTime(ts.getTime() * 1000L, DateTimeZone.UTC);
         }
         return new DateTime(((Integer) rawLastSeen) * 1000L, DateTimeZone.UTC);
     }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.cluster;
 
-import org.graylog2.plugin.database.PersistedService;
 import org.graylog2.plugin.system.NodeId;
 
 import java.net.URI;
@@ -49,9 +48,9 @@ public interface NodeService {
 
     void dropOutdated();
 
-    void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress, String clusterAddress) throws NodeNotFoundException;
+    void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress, String clusterAddress, DataNodeStatus dataNodeStatus) throws NodeNotFoundException;
     default void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress) throws NodeNotFoundException {
-        markAsAlive(node, isLeader, restTransportAddress, null);
+        markAsAlive(node, isLeader, restTransportAddress, null, null);
     }
 
     boolean isOnlyLeader(NodeId nodeIde);

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -77,8 +77,9 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
         var newMap = new HashMap<>(orig);
         if (Objects.nonNull(clusterUri)) {
             newMap.put("cluster_address", clusterUri);
-        } else if (Objects.nonNull(dataNodeStatus)) {
-            newMap.put("datanode_status", dataNodeStatus.toString());
+        }
+        if (Objects.nonNull(dataNodeStatus)) {
+            newMap.put("datanode_status", dataNodeStatus);
         }
         return Map.copyOf(newMap);
     }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/PaginatedNodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/PaginatedNodeService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.cluster;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.search.SearchQuery;
+import org.mongojack.DBQuery;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class PaginatedNodeService extends PaginatedDbService<NodeImpl> {
+    private static final String NODE_COLLECTION_NAME = "nodes";
+
+    @Inject
+    public PaginatedNodeService(MongoConnection mongoConnection, MongoJackObjectMapperProvider mapper) {
+        super(mongoConnection, mapper, NodeImpl.class, NODE_COLLECTION_NAME);
+    }
+
+    public PaginatedList<Node> searchPaginated(SearchQuery query,
+                                               String sortByField, String sortOrder, int page, int perPage) {
+        final PaginatedList<NodeImpl> results = findPaginatedWithQueryFilterAndSort(query.toDBQuery(), node -> true,
+                getSortBuilder(sortOrder, sortByField), page, perPage);
+        return new PaginatedList<>(results.delegate().stream().map(n -> (Node) n).toList(),
+                results.pagination().total(), results.pagination().page(), results.pagination().perPage());
+    }
+
+    public PaginatedList<Node> searchPaginatedDatanodes(SearchQuery query,
+                                                        String sortByField, String sortOrder, int page, int perPage) {
+        final DBQuery.Query dbQuery = DBQuery.and(query.toDBQuery(),
+                DBQuery.is("type", Node.Type.DATANODE));
+        final PaginatedList<NodeImpl> results = findPaginatedWithQueryFilterAndSort(dbQuery, node -> true,
+                getSortBuilder(sortOrder, sortByField), page, perPage);
+        return new PaginatedList<>(results.delegate().stream().map(n -> (Node) n).toList(),
+                results.pagination().total(), results.pagination().page(), results.pagination().perPage());
+    }
+
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.cluster.DataNodeStatus;
+
+import javax.annotation.Nullable;
 
 @AutoValue
 @WithBeanGetter
@@ -56,6 +59,10 @@ public abstract class NodeSummary {
     @JsonProperty
     public abstract String hostname();
 
+    @JsonProperty
+    @Nullable
+    public abstract DataNodeStatus datanodeStatus();
+
     @JsonCreator
     public static NodeSummary create(@JsonProperty("cluster_id") String clusterId,
                                      @JsonProperty("node_id") String nodeId,
@@ -64,7 +71,8 @@ public abstract class NodeSummary {
                                      @JsonProperty("transport_address") String transportAddress,
                                      @JsonProperty("last_seen") String lastSeen,
                                      @JsonProperty("short_node_id") String shortNodeId,
-                                     @JsonProperty("hostname") String hostname) {
-        return new AutoValue_NodeSummary(clusterId, nodeId, type, isLeader, transportAddress, lastSeen, shortNodeId, hostname);
+                                     @JsonProperty("hostname") String hostname,
+                                     @Nullable @JsonProperty("datanode_status") DataNodeStatus datanodeStatus) {
+        return new AutoValue_NodeSummary(clusterId, nodeId, type, isLeader, transportAddress, lastSeen, shortNodeId, hostname, datanodeStatus);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/TestNodeService.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/TestNodeService.java
@@ -49,7 +49,7 @@ public class TestNodeService implements NodeService {
 
     @Override
     public boolean registerServer(String nodeId, boolean isLeader, URI httpPublishUri, String clusterUri, String hostname) {
-        return nodes.add(new NodeRecord(type, nodeId, isLeader, httpPublishUri.toString(), clusterUri, hostname, DateTime.now(DateTimeZone.UTC)));
+        return nodes.add(new NodeRecord(type, nodeId, isLeader, httpPublishUri.toString(), clusterUri, hostname, DateTime.now(DateTimeZone.UTC), null));
     }
 
     @Override
@@ -94,11 +94,12 @@ public class TestNodeService implements NodeService {
     }
 
     @Override
-    public void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress, String clusterAddress) {
+    public void markAsAlive(NodeId node, boolean isLeader, URI restTransportAddress, String clusterAddress, DataNodeStatus dataNodeStatus) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 
-    record NodeRecord(Type type, String nodeId, boolean isLeader, String transportAddress, String clusterAddress, String hostname, DateTime lastSeen) implements Node {
+    record NodeRecord(Type type, String nodeId, boolean isLeader, String transportAddress, String clusterAddress,
+                      String hostname, DateTime lastSeen, DataNodeStatus dataNodeStatus) implements Node {
 
         @Override
         public String getNodeId() {
@@ -133,6 +134,11 @@ public class TestNodeService implements NodeService {
         @Override
         public String getHostname() {
             return hostname;
+        }
+
+        @Override
+        public DataNodeStatus getDataNodeStatus() {
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Description
Data nodes now publish the state of the state machine in the database.
This information is also included in the node in Graylog. An endpoint specifically for data nodes has been added which provides this information in the paginated list needed for the new data table.

## Motivation and Context
The data node page should include status information.
Also needed for using the status information to validated actions performed against data nodes in the future.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

