### PR TITLE
Backport 5.1: Add option to send HTTP notification API Key/Value as header

### DIFF
--- a/changelog/unreleased/issue-14691.toml
+++ b/changelog/unreleased/issue-14691.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added support for sending HTTP Notification API Key/Secret as a header"
+
+issues = ["14691"]
+pulls = ["17369"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import joptsimple.internal.Strings;
+import com.google.common.base.Strings;
 import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.contentpack.entities.HttpEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
@@ -45,6 +45,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
     private static final String FIELD_URL = "url";
     private static final String FIELD_BASIC_AUTH = "basic_auth";
+    private static final String FIELD_API_KEY_AS_HEADER = "api_key_as_header";
     private static final String FIELD_API_KEY = "api_key";
     private static final String FIELD_API_SECRET = "api_secret";
     private static final String FIELD_SKIP_TLS_VERIFICATION = "skip_tls_verification";
@@ -52,6 +53,9 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonProperty(FIELD_BASIC_AUTH)
     @Nullable
     public abstract EncryptedValue basicAuth();
+
+    @JsonProperty(FIELD_API_KEY_AS_HEADER)
+    public abstract boolean apiKeyAsHeader();
 
     @JsonProperty(FIELD_API_KEY)
     @Nullable
@@ -67,6 +71,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonProperty(FIELD_SKIP_TLS_VERIFICATION)
     public abstract boolean skipTLSVerification();
 
+    @Override
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
@@ -77,6 +82,8 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     }
 
     public abstract Builder toBuilder();
+
+    @Override
     @JsonIgnore
     public ValidationResult validate() {
         final ValidationResult validation = new ValidationResult();
@@ -130,6 +137,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
             return new AutoValue_HTTPEventNotificationConfig.Builder()
                     .basicAuth(EncryptedValue.createUnset())
                     .apiSecret(EncryptedValue.createUnset())
+                    .apiKeyAsHeader(false)
                     .apiKey("")
                     .skipTLSVerification(false)
                     .type(TYPE_NAME);
@@ -137,6 +145,9 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
 
         @JsonProperty(FIELD_BASIC_AUTH)
         public abstract Builder basicAuth(EncryptedValue basicAuth);
+
+        @JsonProperty(FIELD_API_KEY_AS_HEADER)
+        public abstract Builder apiKeyAsHeader(boolean apiKey);
 
         @JsonProperty(FIELD_API_KEY)
         public abstract Builder apiKey(String apiKey);

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
@@ -20,12 +20,16 @@ import PropTypes from 'prop-types';
 import { ReadOnlyFormGroup } from 'components/common';
 
 const HttpNotificationDetails = ({ notification }) => {
+  const apiKeySet = notification.config.api_secret?.is_set;
+  const apiSentAs = notification.config.api_key_as_header ? 'Header' : 'Query Parameter';
+
   return (
     <>
       <ReadOnlyFormGroup label="URL" value={notification.config.url} />
       <ReadOnlyFormGroup label="Basic Authentication" value={notification.config.basic_auth?.is_set ? '******' : null} />
+      <ReadOnlyFormGroup label="API Key/Secret Sent As" value={apiKeySet ? apiSentAs : null} />
       <ReadOnlyFormGroup label="API Key" value={notification.config.api_key} />
-      <ReadOnlyFormGroup label="API Secret" value={notification.config.api_secret?.is_set ? '******' : null} />
+      <ReadOnlyFormGroup label="API Secret" value={apiKeySet ? '******' : null} />
     </>
   );
 };

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -40,6 +40,7 @@ class HttpNotificationForm extends React.Component {
 
   static defaultConfig = {
     url: '',
+    api_key_as_header: false,
     api_key: '',
     api_secret: { keep_value: true },
     basic_auth: { keep_value: true },
@@ -201,6 +202,12 @@ class HttpNotificationForm extends React.Component {
                        </Button>
                      ) : undefined} />
             )}
+            <Checkbox id="api_key_as_header"
+                      name="api_key_as_header"
+                      onChange={this.handleChange}
+                      checked={config.api_key_as_header}>
+              Send API Key/Secret as Header
+            </Checkbox>
           </Col>
         </Row>
       </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
backport #17369 to 5.1
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

