### PR TITLE
Disable `media-query-no-invalid` and `selector-class-pattern` rules.

### DIFF
--- a/graylog2-web-interface/packages/stylelint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/stylelint-config-graylog/index.js
@@ -28,6 +28,7 @@ module.exports = {
     'function-name-case': null,
     'function-whitespace-after': null,
     'max-empty-lines': 2,
+    'media-query-no-invalid': null,
     'no-descending-specificity': null,
     'no-empty-first-line': null,
     'no-empty-source': null,

--- a/graylog2-web-interface/packages/stylelint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/stylelint-config-graylog/index.js
@@ -41,6 +41,7 @@ module.exports = {
     'property-no-vendor-prefix': [true, {
       ignoreProperties: ['grid-rows', 'grid-columns', 'grid-row', 'grid-column'],
     }],
+    'selector-class-pattern': null,
     'string-quotes': 'single',
     'value-no-vendor-prefix': [true, {
       ignoreValues: ['grid', 'inline-grid'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are disabling to rules:
- `media-query-no-invalid`. We are always defining media queries using breakpoints from the theme and the rule throws an error in this case.
- `selector-class-pattern`. When we use classes as selectors in our CSS, we want to override the styling of a library like the ACE editor. In these cases we have no control over the way the classes are named.

/nocl