### PR TITLE
Prevent adding same entity data table filter multiple times. (`5.1`)

### DIFF
--- a/changelog/unreleased/pr-17362.toml
+++ b/changelog/unreleased/pr-17362.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Prevent adding same entity data table filter multiple times"
+
+pulls = ["17362"]

--- a/graylog2-web-interface/src/components/common/EntityFilters/CreateFilterDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/CreateFilterDropdown.tsx
@@ -40,7 +40,7 @@ const AttributeSelect = ({
   <>
     <MenuItem header>Create Filter</MenuItem>
     {attributes.map(({ id, title, type }) => {
-      const hasActiveFilter = !!activeFilters?.[id]?.length;
+      const hasActiveFilter = !!activeFilters?.get(id)?.length;
       const disabled = type === 'BOOLEAN' ? hasActiveFilter : false;
 
       return (

--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
@@ -52,6 +52,23 @@ describe('<EntityFilters />', () => {
       ],
     },
     {
+      id: 'type',
+      title: 'Type',
+      type: 'STRING',
+      sortable: true,
+      filterable: true,
+      filter_options: [
+        {
+          value: 'string',
+          title: 'String (aggregatable)',
+        },
+        {
+          value: 'long',
+          title: 'Number',
+        },
+      ],
+    },
+    {
       id: 'index_set_id',
       filterable: true,
       related_collection: 'index_sets',
@@ -140,6 +157,29 @@ describe('<EntityFilters />', () => {
       ));
 
       await waitFor(() => expect(setUrlQueryFilters).toHaveBeenCalledWith(OrderedMap({ disabled: ['true'] })));
+    });
+
+    it('should prevent creating multiple filter for boolean value', async () => {
+      asMock(useFiltersWithTitle).mockReturnValue({
+        data: OrderedMap({ disabled: [{ title: 'Running', value: 'false' }] }),
+        onChange: onChangeFiltersWithTitle,
+        isInitialLoading: false,
+      });
+
+      render(
+        <EntityFilters attributes={attributes}
+                       setUrlQueryFilters={() => {}}
+                       urlQueryFilters={OrderedMap({ disabled: ['false'] })} />,
+      );
+
+      await screen.findByTestId('disabled-filter-false');
+
+      userEvent.click(await screen.findByRole('button', {
+        name: /create filter/i,
+      }));
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(screen.getByRole('menuitem', { name: /status/i }).closest('li')).toHaveClass('disabled');
     });
   });
 
@@ -309,6 +349,37 @@ describe('<EntityFilters />', () => {
       ));
 
       await waitFor(() => expect(setUrlQueryFilters).toHaveBeenCalledWith(OrderedMap({ created_at: ['2019-12-31T23:55:00.001+00:00><'] })));
+    });
+  });
+
+  describe('string attribute', () => {
+    it('should prevent creating same filter multiple times', async () => {
+      const setUrlQueryFilters = jest.fn();
+
+      asMock(useFiltersWithTitle).mockReturnValue({
+        data: OrderedMap({ type: [{ title: 'String', value: 'string' }] }),
+        onChange: onChangeFiltersWithTitle,
+        isInitialLoading: false,
+      });
+
+      render(
+        <EntityFilters attributes={attributes}
+                       setUrlQueryFilters={setUrlQueryFilters}
+                       urlQueryFilters={OrderedMap({ type: ['string'] })} />,
+      );
+
+      await screen.findByTestId('type-filter-string');
+
+      userEvent.click(await screen.findByRole('button', {
+        name: /create filter/i,
+      }));
+
+      userEvent.click(await screen.findByRole('menuitem', {
+        name: /type/i,
+      }));
+
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(screen.getByRole('menuitem', { name: /string/i }).closest('li')).toHaveClass('disabled');
     });
   });
 

--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/FilterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/FilterConfiguration.tsx
@@ -48,7 +48,8 @@ export const FilterConfiguration = ({
     {isAttributeWithFilterOptions(attribute) && (
       <StaticOptionsList attribute={attribute}
                          filterValueRenderer={filterValueRenderer}
-                         onSubmit={onSubmit} />
+                         onSubmit={onSubmit}
+                         allActiveFilters={allActiveFilters} />
     )}
     {isAttributeWithRelatedCollection(attribute) && (
       <SuggestionsList attribute={attribute}

--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/StaticOptionsList.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/StaticOptionsList.tsx
@@ -18,20 +18,29 @@ import React from 'react';
 
 import type { Attribute } from 'stores/PaginationTypes';
 import MenuItem from 'components/bootstrap/MenuItem';
+import { defaultCompare } from 'logic/DefaultCompare';
+import type { Filters } from 'components/common/EntityFilters/types';
 
 type Props = {
+  allActiveFilters: Filters | undefined,
   attribute: Attribute,
   filterValueRenderer: (value: unknown, title: string) => React.ReactNode | undefined,
   onSubmit: (filter: { title: string, value: string }) => void,
 }
 
-const StaticOptionsList = ({ attribute, filterValueRenderer, onSubmit }: Props) => (
+const StaticOptionsList = ({ allActiveFilters, attribute, filterValueRenderer, onSubmit }: Props) => (
   <>
-    {attribute.filter_options.map(({ title, value }) => (
-      <MenuItem onSelect={() => onSubmit({ value, title })} key={`filter-value-${title}`}>
-        {filterValueRenderer ? filterValueRenderer(value, title) : title}
-      </MenuItem>
-    ))}
+    {attribute.filter_options
+      .sort(({ title: title1 }, { title: title2 }) => defaultCompare(title1.toLowerCase(), title2.toLowerCase()))
+      .map(({ title, value }) => {
+        const disabled = !!allActiveFilters?.get(attribute.id)?.find(({ value: filterValue }) => value === filterValue);
+
+        return (
+          <MenuItem onSelect={() => onSubmit({ value, title })} key={`filter-value-${title}`} disabled={disabled}>
+            {filterValueRenderer ? filterValueRenderer(value, title) : title}
+          </MenuItem>
+        );
+      })}
   </>
 );
 


### PR DESCRIPTION
**Please note**: This is a backport of #17362 for 5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is fixing two bugs with the entity data table filter select.

1. Before it was possible to create multiple filters for boolean values. Now it is no longer possible to create another filter for a boolean value, when a filter already exists:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/217cda7e-fd8b-46bc-9961-a9e18921e5da)


2. We are now also making sure it is not possible to select the same static filter option multiple times:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/133799b7-8498-4508-a360-856faf42a0c9)
