### PR TITLE
Return default theme mode when theme mode in local storage does not match expected format (`4.2`).

### DIFF
--- a/changelog/unreleased/pr-17444.toml
+++ b/changelog/unreleased/pr-17444.toml
@@ -1,0 +1,5 @@
+type = "f"
+
+message = "Fixing problem with legacy theme mode in local storage, which can occur for read-only users when downgrading Graylog."
+
+pulls = ["17444"]

--- a/graylog2-web-interface/src/theme/UseCurrentThemeMode.tsx
+++ b/graylog2-web-interface/src/theme/UseCurrentThemeMode.tsx
@@ -20,7 +20,7 @@ import { useStore } from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
 import Store from 'logic/local-storage/Store';
 
-import { PREFERENCES_THEME_MODE, DEFAULT_THEME_MODE, ThemeMode } from './constants';
+import { PREFERENCES_THEME_MODE, DEFAULT_THEME_MODE, ThemeMode, THEME_MODE_LIGHT, THEME_MODE_DARK } from './constants';
 
 import UserPreferencesContext from '../contexts/UserPreferencesContext';
 import usePrefersColorScheme from '../hooks/usePrefersColorScheme';
@@ -35,12 +35,18 @@ type CurrentUser = {
   };
 };
 
+const storeThemePreference = () => {
+  const preference = Store.get(PREFERENCES_THEME_MODE);
+
+  return preference === THEME_MODE_LIGHT || preference === THEME_MODE_DARK ? preference : null;
+};
+
 const _getInitialThemeMode = (userPreferences, browserThemePreference, initialThemeModeOverride) => {
   if (initialThemeModeOverride) {
     return initialThemeModeOverride;
   }
 
-  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? Store.get(PREFERENCES_THEME_MODE);
+  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? storeThemePreference();
 
   return userThemePreference ?? browserThemePreference ?? DEFAULT_THEME_MODE;
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

With `5.2` we renamed the theme modes `teint` and `noir` to `dark` and `light`. With this change make sure read-only users do not face a problem when downgrading Graylog from `5.2` to a previous version.

To test this change, checkout the branch, open the web interface, login with the system admin user, configure e.g. `themeMode: "dark"` in the local storage.