### PR TITLE
Return default theme mode when theme mode in local storage does not match expected format (`4.0`)

### DIFF
--- a/changelog/unreleased/pr-17446.toml
+++ b/changelog/unreleased/pr-17446.toml
@@ -1,0 +1,5 @@
+type = "f"
+
+message = "Fixing problem with legacy theme mode in local storage, which can occur for read-only users when downgrading Graylog."
+
+pulls = ["17446"]

--- a/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
+++ b/graylog2-web-interface/src/theme/UseCurrentThemeMode.jsx
@@ -29,6 +29,12 @@ import usePrefersColorScheme from '../hooks/usePrefersColorScheme';
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { PreferencesStore } = CombinedProvider.get('Preferences');
 
+const storeThemePreference = () => {
+  const preference = Store.get(PREFERENCES_THEME_MODE);
+
+  return preference === THEME_MODE_LIGHT || preference === THEME_MODE_DARK ? preference : null;
+};
+
 const useCurrentThemeMode = () => {
   const browserThemePreference = usePrefersColorScheme();
 
@@ -39,7 +45,7 @@ const useCurrentThemeMode = () => {
   }));
 
   const userPreferences = useContext(UserPreferencesContext);
-  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? Store.get(PREFERENCES_THEME_MODE);
+  const userThemePreference = userPreferences[PREFERENCES_THEME_MODE] ?? storeThemePreference();
   const initialThemeMode = userThemePreference ?? browserThemePreference ?? DEFAULT_THEME_MODE;
   const [currentThemeMode, setCurrentThemeMode] = useState<string>(initialThemeMode);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

With `5.2` we renamed the theme modes `teint` and `noir` to `dark` and `light`. With this change make sure read-only users do not face a problem when downgrading Graylog from `5.2` to a previous version.

To test this change, checkout the branch, open the web interface, login with the system admin user, configure e.g. `themeMode: "dark"` in the local storage.