### PR TITLE
Extend upgrade notes and remove types for `systemnavigation` plugin.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,15 @@ The name of the `jvm_classes_loaded` metric [has been changed](https://github.co
 Prometheus queries referencing `jvm_classes_loaded` need to be adapted to
 the new name `jvm_classes_currently_loaded`.
 
+### Plugins
+
+Removal of `systemnavigation` web interface plugin. Previously it was possible to register options for the
+system dropdown in the navigation, by using the `systemnavigation` plugin.
+Now this can be achieved by registering a `navigation` plugin.
+The plugin entity needs the `description` `System` and `children` (array).
+Every child represents a dropdown option and needs a `path` and `description` attribute.
+
+
 ## Java API Changes
 
 The following Java Code API changes have been made.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,6 @@ Now this can be achieved by registering a `navigation` plugin.
 The plugin entity needs the `description` `System` and `children` (array).
 Every child represents a dropdown option and needs a `path` and `description` attribute.
 
-
 ## Java API Changes
 
 The following Java Code API changes have been made.

--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -53,12 +53,6 @@ interface PluginNavigationItems {
   key: string;
   component: React.ComponentType<{ smallScreen?: boolean }>;
 }
-interface SystemNavigationItem {
-  description: string;
-  path: string;
-  permissions: string | Array<string>;
-  perspective?: string,
-}
 interface GlobalNotification {
   key: string;
   component: React.ComponentType;
@@ -135,7 +129,6 @@ declare module 'graylog-web-plugin/plugin' {
     navigation?: Array<PluginNavigation>;
     defaultNavigation?: Array<PluginNavigation>;
     navigationItems?: Array<PluginNavigationItems>;
-    systemnavigation?: Array<SystemNavigationItem>;
     globalNotifications?: Array<GlobalNotification>
     // Global context providers allow to fetch and process data once
     // and provide the result for all components in your plugin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up for https://github.com/Graylog2/graylog2-server/pull/17309. Since we removed the `systemnavigation` plugin we had to extend the upgrade notes and remove the related types.

/nocl