### PR TITLE
Wrap ContentTooLongException into a BatchSizeTooLargeException

### DIFF
--- a/changelog/unreleased/pr-17449.toml
+++ b/changelog/unreleased/pr-17449.toml
@@ -1,0 +1,10 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix archiving when batch size exceeds ES/OS http.max_content_length."
+
+issues = ["Graylog2/graylog-plugin-enterprise#3318"]
+pulls = ["17449"]
+


### PR DESCRIPTION
The dynamic batch size of archiving depends on catching these exceptions
and then retrying the scroll query with a smaller batch size.
    
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3318

Tested with ES/OS containers with  `http.max_content_length=10mb`  env.

ES:
```
docker run --name elasticsearch -e "http.host=0.0.0.0" -p 9200:9200 -e "xpack.security.enabled=false" -e "http.max_content_length=10mb" -e "discovery.type=single-node" -e "action.auto_create_index=.watches,.triggered_watches,.watcher-history-*"   docker.elastic.co/elasticsearch/elasticsearch:7.10.2
```
OS:
```
docker run -d --name opensearch -p 9200:9200 -p 9600:9600 -e "http.max_content_length=10mb" -e "discovery.type=single-node" -e "DISABLE_INSTALL_DEMO_CONFIG=true" -e "DISABLE_SECURITY_PLUGIN=true" -e "action.auto_create_index=false" opensearchproject/opensearch:2.6.0
```

Ideally that should have an integration test, but that's just so much work :-/ 
