### PR TITLE
Fix saving of system notification event definition (5.1)

### DIFF
--- a/changelog/unreleased/pr-17435.toml
+++ b/changelog/unreleased/pr-17435.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix editing of system notification event defitinions."
+
+issues = [""]
+pulls = ["17435"]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -187,7 +187,8 @@ public class EventDefinitionHandler {
         final EventDefinitionDto eventDefinition = getEventDefinitionOrThrowIAE(eventDefinitionId);
 
         if (SystemNotificationEventEntityScope.NAME.equals(eventDefinition.scope())) {
-            throw new IllegalArgumentException("Cannot disable system notification events");
+            LOG.debug("Ignoring disable for system notification events");
+	    return;
         }
 
         getJobDefinition(eventDefinition)


### PR DESCRIPTION
On save, the UI is passing back the "scheduled=false" param from the context.

There's several ways we could fix this, but it's probably easiest to not throw an exception, but just ignore the unschedule call.

This probably got broken with #14502

cherry-picked from d1b77ed

