### PR TITLE
Fix saving of system notification event definition (5.2)

### DIFF
--- a/changelog/unreleased/pr-17435.toml
+++ b/changelog/unreleased/pr-17435.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix editing of system notification event defitinions."
+
+issues = [""]
+pulls = ["17435"]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -72,7 +72,7 @@ public class EventDefinitionHandler {
      * Creates a new event definition and a corresponding scheduler job definition and trigger.
      *
      * @param unsavedEventDefinition the event definition to save
-     * @param user the user who created this eventDefinition. If empty, no ownership will be registered.
+     * @param user                   the user who created this eventDefinition. If empty, no ownership will be registered.
      * @return the created event definition
      */
     public EventDefinitionDto create(EventDefinitionDto unsavedEventDefinition, Optional<User> user) {
@@ -95,8 +95,9 @@ public class EventDefinitionHandler {
      * Duplicates an existing event definition.
      * The new copy will be disabled by default and will have the {@link DefaultEntityScope}.
      * Also the title will be prefixed with the string "COPY-".
+     *
      * @param eventDefinition the event definition to copy
-     * @param user the user who copied this eventDefinition. If empty, no ownership will be registered.
+     * @param user            the user who copied this eventDefinition. If empty, no ownership will be registered.
      * @return the newly created event definition
      */
     public EventDefinitionDto duplicate(EventDefinitionDto eventDefinition, Optional<User> user) {
@@ -236,7 +237,8 @@ public class EventDefinitionHandler {
         final EventDefinitionDto eventDefinition = getEventDefinitionOrThrowIAE(eventDefinitionId);
 
         if (SystemNotificationEventEntityScope.NAME.equals(eventDefinition.scope())) {
-            throw new IllegalArgumentException("Cannot disable system notification events");
+            LOG.debug("Ignoring disable for system notification events");
+            return;
         }
 
         getJobDefinition(eventDefinition)


### PR DESCRIPTION
* Fix saving of system notification event definition

On save, the UI is passing back the "scheduled=false" param from the context.

There's several ways we could fix this, but it's probably easiest to not throw an exception, but just ignore the unschedule call.

This probably got broken with #14502

* changelog

(cherry picked from commit d1b77ed1ec9bcce422114112797b39720e7a598d)

