### PR TITLE
Implement brand link for perspectives.

### DIFF
--- a/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
+++ b/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { Link } from 'components/common/router';
 import { NAV_ITEM_HEIGHT } from 'theme/constants';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
-import Routes from 'routing/Routes';
 import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 
 const BrandContainer = styled.div`
@@ -47,7 +46,7 @@ const ActivePerspectiveBrand = ({ children, className }: PropsWithChildren<{ cla
 
   return (
     <BrandContainer className={className}>
-      <BrandLink to={Routes.STARTPAGE}>
+      <BrandLink to={activePerspective.brandLink}>
         <ActiveBrandComponent />
       </BrandLink>
       {children}

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import useHistory from 'routing/useHistory';
+import usePerspectives from 'components/perspectives/hooks/usePerspectives';
+import { asMock } from 'helpers/mocking';
+import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
+import mockHistory from 'helpers/mocking/mockHistory';
+
+import PerspectivesSwitcher from './PerspectivesSwitcher';
+
+jest.mock('components/perspectives/hooks/usePerspectives', () => jest.fn());
+jest.mock('components/perspectives/hooks/useActivePerspective', () => jest.fn());
+jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_perspectives');
+jest.mock('routing/useHistory');
+
+describe('PerspectivesSwitcher', () => {
+  let history;
+  const setActivePerspective = jest.fn();
+
+  beforeEach(() => {
+    history = mockHistory();
+    asMock(useHistory).mockReturnValue(history);
+
+    asMock(usePerspectives).mockReturnValue([
+      {
+        id: 'default',
+        title: 'Default Perspective',
+        brandComponent: () => <div>Default perspective</div>,
+        brandLink: '',
+      },
+      {
+        id: 'example-perspective',
+        title: 'Example Perspective',
+        brandComponent: () => <div />,
+        brandLink: '/example-perspective',
+      },
+    ]);
+
+    asMock(useActivePerspective).mockReturnValue({
+      activePerspective: 'default',
+      setActivePerspective,
+    });
+  });
+
+  it('should render brand for active perspective', async () => {
+    render(<PerspectivesSwitcher />);
+
+    await screen.findByText('Default perspective');
+  });
+
+  it('should render dropdown with available perspectives', async () => {
+    render(<PerspectivesSwitcher />);
+
+    userEvent.click(await screen.findByRole('button', { name: /change ui perspective/i }));
+    userEvent.click(await screen.findByText(/example perspective/i));
+
+    await waitFor(() => expect(history.push).toHaveBeenCalledWith('/example-perspective'));
+
+    expect(setActivePerspective).toHaveBeenCalledWith('example-perspective');
+  });
+});

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -80,7 +80,7 @@ const Switcher = () => {
       <Menu shadow="md" withinPortal>
         <ActivePerspectiveBrand>
           <Menu.Target>
-            <DropdownTrigger type="button">
+            <DropdownTrigger type="button" title="Change UI perspective">
               <DropdownIcon name="caret-down" />
             </DropdownTrigger>
           </Menu.Target>

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -16,12 +16,14 @@
  */
 import * as React from 'react';
 import styled, { css } from 'styled-components';
+import { useCallback } from 'react';
 
 import Menu from 'components/bootstrap/Menu';
 import Icon from 'components/common/Icon';
 import useFeature from 'hooks/useFeature';
 import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
+import useHistory from 'routing/useHistory';
 
 import ActivePerspectiveBrand from './ActivePerspectiveBrand';
 
@@ -64,7 +66,14 @@ const DropdownIcon = styled(Icon)(({ theme }) => css`
 const Switcher = () => {
   const { setActivePerspective } = useActivePerspective();
   const perspectives = usePerspectives();
-  const onChangePerspective = (perspectiveId: string) => () => setActivePerspective(perspectiveId);
+  const history = useHistory();
+
+  const onChangePerspective = useCallback((nextPerspectiveId: string) => () => {
+    const { brandLink } = perspectives.find(({ id }) => id === nextPerspectiveId);
+
+    history.push(brandLink);
+    setActivePerspective(nextPerspectiveId);
+  }, [history, perspectives, setActivePerspective]);
 
   return (
     <Container className={CONTAINER_CLASS}>

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -77,7 +77,7 @@ const Switcher = () => {
 
   return (
     <Container className={CONTAINER_CLASS}>
-      <Menu shadow="md" width={300} withinPortal>
+      <Menu shadow="md" withinPortal>
         <ActivePerspectiveBrand>
           <Menu.Target>
             <DropdownTrigger type="button">

--- a/graylog2-web-interface/src/components/perspectives/bindings.ts
+++ b/graylog2-web-interface/src/components/perspectives/bindings.ts
@@ -15,6 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
+import Routes from 'routing/Routes';
+
 import DefaultBrand from './DefaultBrand';
 
 const perspectivesBindings = {
@@ -22,6 +24,7 @@ const perspectivesBindings = {
     {
       id: 'default',
       title: 'Classic Graylog UI',
+      brandLink: Routes.WELCOME,
       brandComponent: DefaultBrand,
     },
   ],

--- a/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
@@ -25,16 +25,19 @@ jest.mock('hooks/usePluginEntities', () => () => ([
     id: 'default',
     title: 'Default Perspective',
     brandComponent: () => {},
+    brandLink: '',
   },
   {
     id: 'example-perspective',
     title: 'Example Perspective',
     brandComponent: () => {},
+    brandLink: '',
   },
   {
     id: 'unavailable-perspective',
     title: 'Unavailable Perspective',
     brandComponent: () => {},
+    brandLink: '',
     useCondition: () => false,
   },
 ]));

--- a/graylog2-web-interface/src/components/perspectives/types.ts
+++ b/graylog2-web-interface/src/components/perspectives/types.ts
@@ -20,6 +20,7 @@ import type * as React from 'react';
 export type Perspective = {
   id: string,
   title: string,
+  brandLink: string,
   brandComponent: React.ComponentType<{
     className?: string,
     disabled?: boolean,

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -91,6 +91,7 @@ describe('AppRouter', () => {
         id: 'default',
         title: 'Default Perspective',
         brandComponent: () => <div />,
+        brandLink: '',
       },
     ],
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are adding another attribute for perspective plugins called `brandLink`. It will be used for the link which wraps the perspective brand component. The user will also be redirected to the link target when selecting a perspective.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6194
/nocl
