### PR TITLE
Wrap ContentTooLongException into a BatchSizeTooLargeException (5.1)

### DIFF
--- a/changelog/unreleased/pr-17449.toml
+++ b/changelog/unreleased/pr-17449.toml
@@ -1,0 +1,10 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix archiving when batch size exceeds ES/OS http.max_content_length."
+
+issues = ["Graylog2/graylog-plugin-enterprise#3318"]
+pulls = ["17449"]
+

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.Streams;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import org.graylog.shaded.elasticsearch7.org.apache.http.ContentTooLongException;
 import org.graylog.shaded.elasticsearch7.org.apache.http.client.config.RequestConfig;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchRequest;
@@ -120,6 +121,9 @@ public class ElasticsearchClient {
         try {
             return fn.apply(client, requestOptions());
         } catch (IOException e) {
+            if (e.getCause() instanceof ContentTooLongException) {
+                throw new BatchSizeTooLargeException(e.getMessage());
+            }
             throw e;
         } catch (Exception e) {
             throw exceptionFrom(e, errorMessage);
@@ -154,6 +158,8 @@ public class ElasticsearchClient {
             if (isBatchSizeTooLargeException(elasticsearchException)) {
                 throw new BatchSizeTooLargeException(elasticsearchException.getMessage());
             }
+        } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
+            throw new BatchSizeTooLargeException(e.getMessage());
         }
         return new ElasticsearchException(errorMessage, e);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.Streams;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import org.graylog.shaded.opensearch2.org.apache.http.ContentTooLongException;
 import org.graylog.shaded.opensearch2.org.apache.http.client.config.RequestConfig;
 import org.graylog.shaded.opensearch2.org.opensearch.OpenSearchException;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.MultiSearchRequest;
@@ -120,6 +121,9 @@ public class OpenSearchClient {
         try {
             return fn.apply(client, requestOptions());
         } catch (IOException e) {
+            if (e.getCause() instanceof ContentTooLongException) {
+                throw new BatchSizeTooLargeException(e.getMessage());
+            }
             throw e;
         } catch (Exception e) {
             throw exceptionFrom(e, errorMessage);
@@ -154,6 +158,8 @@ public class OpenSearchClient {
             if (isBatchSizeTooLargeException(openSearchException)) {
                 throw new BatchSizeTooLargeException(openSearchException.getMessage());
             }
+        } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
+            throw new BatchSizeTooLargeException(e.getMessage());
         }
         return new OpenSearchException(errorMessage, e);
     }


### PR DESCRIPTION
* Wrap ContentTooLongException into an BatchSizeTooLargeException

The dynamic batch size of archiving depends on catching these exceptions and then retrying the scroll query with a smaller batch size.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3318

* Add changelog

(cherry picked from commit 32cf4375adcc794f953c027a4b7a44963b34159f)

