### PR TITLE
Wrap ContentTooLongException into a BatchSizeTooLargeException (5.2)

### DIFF
--- a/changelog/unreleased/pr-17449.toml
+++ b/changelog/unreleased/pr-17449.toml
@@ -1,0 +1,10 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix archiving when batch size exceeds ES/OS http.max_content_length."
+
+issues = ["Graylog2/graylog-plugin-enterprise#3318"]
+pulls = ["17449"]
+


### PR DESCRIPTION
* Wrap ContentTooLongException into an BatchSizeTooLargeException

The dynamic batch size of archiving depends on catching these exceptions and then retrying the scroll query with a smaller batch size.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/3318

* Add changelog

(cherry picked from commit 32cf4375adcc794f953c027a4b7a44963b34159f)

