### PR TITLE
Store `SearchAreaContainer` and `InfoBar` in `SearchPageLayoutContext`.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -24,7 +24,7 @@ import { adminUser } from 'fixtures/users';
 import type { LayoutState } from 'views/components/contexts/SearchPageLayoutContext';
 import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
-import SearchPageLayoutContext, { SAVE_COPY, BLANK } from 'views/components/contexts/SearchPageLayoutContext';
+import { SAVE_COPY, BLANK } from 'views/components/contexts/SearchPageLayoutContext';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useCurrentUser from 'hooks/useCurrentUser';
@@ -32,6 +32,7 @@ import TestStoreProvider from 'views/test/TestStoreProvider';
 import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
 import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 import HotkeysProvider from 'contexts/HotkeysProvider';
+import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
 
 import DashboardActionsMenu from './DashboardActionsMenu';
 
@@ -68,12 +69,12 @@ describe('DashboardActionsMenu', () => {
     .createdAt(new Date('2019-10-16T14:38:44.681Z'))
     .build();
 
-  const SUT = ({ providerOverrides, view }: { providerOverrides?: LayoutState, view?: View }) => (
+  const SUT = ({ providerOverrides, view }: { providerOverrides?: Partial<LayoutState>, view?: View }) => (
     <TestStoreProvider view={view}>
       <HotkeysProvider>
-        <SearchPageLayoutContext.Provider value={providerOverrides}>
+        <SearchPageLayoutProvider value={providerOverrides}>
           <DashboardActionsMenu />
-        </SearchPageLayoutContext.Provider>
+        </SearchPageLayoutProvider>
       </HotkeysProvider>
     </TestStoreProvider>
   );

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -57,15 +57,10 @@ const DashboardActionsMenu = () => {
 
   const {
     viewActions: {
-      save: {
-        isShown: showSaveButton,
-      }, saveAs: {
-        isShown: showSaveNewButton,
-      }, share: {
-        isShown: showShareButton,
-      }, actionsDropdown: {
-        isShown: showDropDownButton,
-      },
+      save: { isShown: showSaveButton },
+      saveAs: { isShown: showSaveNewButton },
+      share: { isShown: showShareButton },
+      actionsDropdown: { isShown: showDropDownButton },
     },
   } = useSearchPageLayout();
   const pluggableSaveViewControls = useSaveViewFormControls();

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -112,14 +112,12 @@ const ViewAdditionalContextProvider = ({ children }: { children: React.ReactNode
 
 ViewAdditionalContextProvider.displayName = 'ViewAdditionalContextProvider';
 
-type Props = {
-  InfoBarSlot?: React.ComponentType,
-}
-
-const Search = ({ InfoBarSlot }: Props) => {
+const Search = () => {
   const dispatch = useAppDispatch();
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
-  const { sidebar: { isShown: showSidebar }, components } = useSearchPageLayout();
+  const { sidebar: { isShown: showSidebar }, searchAreaContainer, infoBar } = useSearchPageLayout();
+  const InfoBar = infoBar?.component;
+  const SearchAreaContainer = searchAreaContainer?.component;
 
   useEffect(() => {
     refreshSearch();
@@ -163,10 +161,10 @@ const Search = ({ InfoBarSlot }: Props) => {
                                 </ConnectedSidebar>
                                 )}
                               </IfInteractive>
-                              <SearchArea as={components?.SearchAreaContainer}>
+                              <SearchArea as={SearchAreaContainer}>
                                 <IfInteractive>
                                   <HeaderElements />
-                                  {InfoBarSlot && <InfoBarSlot />}
+                                  {InfoBar && <InfoBar />}
                                   <IfDashboard>
                                     {!editingWidget && <DashboardSearchBar />}
                                   </IfDashboard>
@@ -198,11 +196,6 @@ const Search = ({ InfoBarSlot }: Props) => {
       </ExternalValueActionsProvider>
     </>
   );
-};
-
-Search.defaultProps = {
-  InfoBarSlot: undefined,
-  SearchAreaContainer: undefined,
 };
 
 export default Search;

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -114,13 +114,12 @@ ViewAdditionalContextProvider.displayName = 'ViewAdditionalContextProvider';
 
 type Props = {
   InfoBarSlot?: React.ComponentType,
-  SearchAreaContainer?: React.ComponentType,
 }
 
-const Search = ({ InfoBarSlot, SearchAreaContainer }: Props) => {
+const Search = ({ InfoBarSlot }: Props) => {
   const dispatch = useAppDispatch();
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
-  const { sidebar: { isShown: showSidebar } } = useSearchPageLayout();
+  const { sidebar: { isShown: showSidebar }, components } = useSearchPageLayout();
 
   useEffect(() => {
     refreshSearch();
@@ -164,7 +163,7 @@ const Search = ({ InfoBarSlot, SearchAreaContainer }: Props) => {
                                 </ConnectedSidebar>
                                 )}
                               </IfInteractive>
-                              <SearchArea as={SearchAreaContainer}>
+                              <SearchArea as={components?.SearchAreaContainer}>
                                 <IfInteractive>
                                   <HeaderElements />
                                   {InfoBarSlot && <InfoBarSlot />}

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
@@ -58,6 +58,9 @@ export const BLANK: ViewActions = {
 export type LayoutState = {
   sidebar: { isShown: boolean }
   viewActions: ViewActions
+  components?: {
+    SearchAreaContainer: React.ComponentType
+  }
 }
 
 export const DEFAULT_STATE: LayoutState = {

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
@@ -19,36 +19,14 @@ import * as React from 'react';
 
 import { singleton } from 'logic/singleton';
 
-export interface ViewActions {
-  save: {
-    isShown: boolean,
-  };
-  saveAs: {
-    isShown: boolean,
-  };
-  share: {
-    isShown: boolean,
-  }
-  actionsDropdown: {
-    isShown: boolean,
-  }
-}
-
-export const FULL_MENU: ViewActions = {
-  save: { isShown: true },
-  saveAs: { isShown: true },
-  share: { isShown: true },
-  actionsDropdown: { isShown: true },
-};
-
-export const SAVE_COPY: ViewActions = {
+export const SAVE_COPY = {
   save: { isShown: false },
   saveAs: { isShown: true },
   share: { isShown: false },
   actionsDropdown: { isShown: false },
 };
 
-export const BLANK: ViewActions = {
+export const BLANK = {
   save: { isShown: false },
   saveAs: { isShown: false },
   share: { isShown: false },
@@ -56,16 +34,25 @@ export const BLANK: ViewActions = {
 };
 
 export type LayoutState = {
-  sidebar: { isShown: boolean }
-  viewActions: ViewActions
-  components?: {
-    SearchAreaContainer: React.ComponentType
-  }
+  sidebar: { isShown: boolean },
+  viewActions: {
+    save: { isShown: boolean },
+    saveAs: { isShown: boolean },
+    share: { isShown: boolean },
+    actionsDropdown: { isShown: boolean },
+  },
+  searchAreaContainer?: { component: React.ComponentType }
+  infoBar?: { component: React.ComponentType }
 }
 
 export const DEFAULT_STATE: LayoutState = {
   sidebar: { isShown: true },
-  viewActions: FULL_MENU,
+  viewActions: {
+    save: { isShown: true },
+    saveAs: { isShown: true },
+    share: { isShown: true },
+    actionsDropdown: { isShown: true },
+  },
 };
 
 const SearchPageLayoutContext = React.createContext<LayoutState>(DEFAULT_STATE);

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutProvider.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useMemo } from 'react';
+import merge from 'lodash/merge';
+
+import type { LayoutState } from './SearchPageLayoutContext';
+import SearchPageLayoutContext, { DEFAULT_STATE } from './SearchPageLayoutContext';
+
+type Props = {
+  children: React.ReactNode,
+  value: Partial<LayoutState>,
+};
+
+const SearchPageLayoutProvider = ({ children, value }: Props) => {
+  const contextValue = useMemo(() => merge({}, DEFAULT_STATE, value), [value]);
+
+  return (
+    <SearchPageLayoutContext.Provider value={contextValue}>
+      {children}
+    </SearchPageLayoutContext.Provider>
+  );
+};
+
+export default SearchPageLayoutProvider;

--- a/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 
 import useParams from 'routing/useParams';
 import useEventDefinition from 'hooks/useEventDefinition';
@@ -28,18 +28,21 @@ import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBa
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import useCreateSearch from 'views/hooks/useCreateSearch';
+import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
 
 const EventView = () => {
   const { eventDefinition, aggregations } = useAlertAndEventDefinitionData();
   const _view = useCreateViewForEventDefinition({ eventDefinition, aggregations });
   const view = useCreateSearch(_view);
+  const searchPageLayout = useMemo(() => ({
+    infoBar: { component: EventInfoBar },
+  }), []);
 
   return (
-    <SearchPage view={view}
-                isNew
-                SearchComponentSlots={{
-                  InfoBarSlot: EventInfoBar,
-                }} />
+    <SearchPageLayoutProvider value={searchPageLayout}>
+      <SearchPage view={view}
+                  isNew />
+    </SearchPageLayoutProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/EventReplaySearchPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 
 import useParams from 'routing/useParams';
 import useEventById from 'hooks/useEventById';
@@ -29,18 +29,21 @@ import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBa
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import useCreateSearch from 'views/hooks/useCreateSearch';
+import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
 
 const EventView = () => {
   const { eventData, eventDefinition, aggregations } = useAlertAndEventDefinitionData();
   const _view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
   const view = useCreateSearch(_view);
+  const searchPageLayout = useMemo(() => ({
+    infoBar: { component: EventInfoBar },
+  }), []);
 
   return (
-    <SearchPage view={view}
-                isNew
-                SearchComponentSlots={{
-                  InfoBarSlot: EventInfoBar,
-                }} />
+    <SearchPageLayoutProvider value={searchPageLayout}>
+      <SearchPage view={view}
+                  isNew />
+    </SearchPageLayoutProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -35,16 +35,12 @@ import useHistory from 'routing/useHistory';
 import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
 import type { SearchExecutionResult } from 'views/types';
 
-type SearchComponentSlots = { InfoBarSlot: React.ComponentType }
-
 type Props = React.PropsWithChildren<{
   isNew: boolean,
   view: Promise<View>,
   loadNewView?: (history: HistoryFunction) => unknown,
   loadView?: (history: HistoryFunction, viewId: string) => unknown,
   executionState?: SearchExecutionState,
-  SearchComponentSlots?: SearchComponentSlots,
-  SearchAreaContainer?: React.ComponentType,
   searchResult?: SearchExecutionResult,
 }>;
 
@@ -65,8 +61,6 @@ const SearchPage = ({
   loadNewView: _loadNewView = defaultLoadNewView,
   loadView: _loadView = defaultLoadView,
   executionState: initialExecutionState,
-  SearchComponentSlots,
-  SearchAreaContainer,
   searchResult,
 }: Props) => {
   const query = useQuery();
@@ -96,7 +90,7 @@ const SearchPage = ({
                 <AutoRefreshProvider>
                   {children}
                   <IfUserHasAccessToAnyStream>
-                    <Search InfoBarSlot={SearchComponentSlots.InfoBarSlot} SearchAreaContainer={SearchAreaContainer} />
+                    <Search />
                   </IfUserHasAccessToAnyStream>
                 </AutoRefreshProvider>
               </ViewLoaderContext.Provider>
@@ -112,8 +106,6 @@ SearchPage.defaultProps = {
   loadNewView: defaultLoadNewView,
   loadView: defaultLoadView,
   executionState: SearchExecutionState.empty(),
-  SearchComponentSlots: {},
-  SearchAreaContainer: undefined,
   searchResult: undefined,
 };
 

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -456,17 +456,3 @@ declare module 'graylog-web-plugin/plugin' {
     widgetCreators?: Array<WidgetCreator>;
   }
 }
-export interface ViewActions {
-  save: {
-    isShown: boolean,
-  };
-  saveAs: {
-    isShown: boolean,
-  };
-  share: {
-    isShown: boolean,
-  }
-  actionsDropdown: {
-    isShown: boolean,
-  }
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this refactoring we are now storing the `SearchAreaContainer` and `InfoBar` in the `SearchPageLayoutContext`, instead of passing them as props to the `Search` component.

/nocl
/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6197
