### PR TITLE
Support passing static search results/customizing search execution.

### DIFF
--- a/graylog2-web-interface/src/components/PluggableStoreProvider.tsx
+++ b/graylog2-web-interface/src/components/PluggableStoreProvider.tsx
@@ -27,6 +27,7 @@ import type { QuerySet } from 'views/logic/search/Search';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { UndoRedoState } from 'views/logic/slices/undoRedoSlice';
 import type { RootState } from 'views/types';
+import useSearchExecutors from 'views/components/contexts/useSearchExecutors';
 
 type Props = {
   initialQuery: QueryId,
@@ -73,7 +74,8 @@ const PluggableStoreProvider = ({ initialQuery, children, isNew, view, execution
   const reducers = usePluginEntities('views.reducers');
   const activeQuery = useActiveQuery(initialQuery, view);
   const initialState = useInitialState(undoRedoState, view, isNew, activeQuery, executionState, result);
-  const store = useMemo(() => createStore(reducers, initialState), [initialState, reducers]);
+  const searchExecutors = useSearchExecutors();
+  const store = useMemo(() => createStore(reducers, initialState, searchExecutors), [initialState, reducers, searchExecutors]);
 
   return (
     <Provider store={store}>

--- a/graylog2-web-interface/src/components/PluggableStoreProvider.tsx
+++ b/graylog2-web-interface/src/components/PluggableStoreProvider.tsx
@@ -26,6 +26,7 @@ import type { QueryId } from 'views/logic/queries/Query';
 import type { QuerySet } from 'views/logic/search/Search';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { UndoRedoState } from 'views/logic/slices/undoRedoSlice';
+import type { RootState } from 'views/types';
 
 type Props = {
   initialQuery: QueryId,
@@ -33,45 +34,45 @@ type Props = {
   view: View,
   executionState: SearchExecutionState,
   undoRedoState?: UndoRedoState,
+  result?: RootState['searchExecution']['result'],
 }
 
-const PluggableStoreProvider = ({ initialQuery, children, isNew, view, executionState, undoRedoState }: React.PropsWithChildren<Props>) => {
+const useActiveQuery = (initialQuery: Props['initialQuery'], view: Props['view']) => useMemo(() => {
+  const queries: QuerySet = view?.search?.queries ?? Immutable.Set();
+
+  if (initialQuery && queries.find((q) => q.id === initialQuery) !== undefined) {
+    return initialQuery;
+  }
+
+  return queries.first()?.id;
+}, [initialQuery, view?.search?.queries]);
+
+const useInitialState = (undoRedoState: UndoRedoState, view: View, isNew: boolean, activeQuery, executionState: SearchExecutionState, result?: Props['result']): Partial<RootState> => useMemo(() => {
+  const undoRedo = undoRedoState ? { undoRedo: undoRedoState } : {};
+
+  return ({
+    view: {
+      view,
+      isDirty: false,
+      isNew,
+      activeQuery,
+    },
+    searchExecution: {
+      widgetsToSearch: undefined,
+      executionState,
+      isLoading: false,
+      result,
+    },
+    ...undoRedo,
+  });
+},
+// eslint-disable-next-line react-hooks/exhaustive-deps
+[executionState, isNew, view]);
+
+const PluggableStoreProvider = ({ initialQuery, children, isNew, view, executionState, undoRedoState, result }: React.PropsWithChildren<Props>) => {
   const reducers = usePluginEntities('views.reducers');
-  const activeQuery = useMemo(() => {
-    const queries: QuerySet = view?.search?.queries ?? Immutable.Set();
-
-    if (initialQuery && queries.find((q) => q.id === initialQuery) !== undefined) {
-      return initialQuery;
-    }
-
-    return queries.first()?.id;
-  }, [initialQuery, view?.search?.queries]);
-  const initialState = useMemo(() => {
-    const undoRedo = undoRedoState ? {
-      undoRedo: undoRedoState,
-    } : {};
-
-    return ({
-      view: {
-        view,
-        isDirty:
-            false,
-        isNew,
-        activeQuery,
-      },
-      searchExecution: {
-        widgetsToSearch: undefined,
-        executionState,
-        isLoading:
-            false,
-        result:
-          undefined,
-      },
-      ...undoRedo,
-    });
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [executionState, isNew, view]);
+  const activeQuery = useActiveQuery(initialQuery, view);
+  const initialState = useInitialState(undoRedoState, view, isNew, activeQuery, executionState, result);
   const store = useMemo(() => createStore(reducers, initialState), [initialState, reducers]);
 
   return (
@@ -83,6 +84,7 @@ const PluggableStoreProvider = ({ initialQuery, children, isNew, view, execution
 
 PluggableStoreProvider.defaultProps = {
   undoRedoState: undefined,
+  result: undefined,
 };
 
 export default PluggableStoreProvider;

--- a/graylog2-web-interface/src/store.ts
+++ b/graylog2-web-interface/src/store.ts
@@ -18,8 +18,9 @@ import { configureStore } from '@reduxjs/toolkit';
 import type { PluggableReducer } from 'graylog-web-plugin';
 
 import type { RootState } from 'views/types';
+import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
 
-const createStore = (reducers: PluggableReducer[], initialState: Partial<RootState>) => {
+const createStore = (reducers: PluggableReducer[], initialState: Partial<RootState>, searchExecutors: SearchExecutors) => {
   const reducer = Object.fromEntries(reducers.map((r) => [r.key, r.reducer]));
 
   return configureStore({
@@ -28,6 +29,9 @@ const createStore = (reducers: PluggableReducer[], initialState: Partial<RootSta
     middleware: (getDefaultMiddleware) => getDefaultMiddleware({
       serializableCheck: false,
       immutableCheck: false,
+      thunk: {
+        extraArgument: { searchExecutors },
+      },
     }),
   });
 };

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -122,9 +122,9 @@ const Search = ({ InfoBarSlot, SearchAreaContainer }: Props) => {
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
   const { sidebar: { isShown: showSidebar } } = useSearchPageLayout();
 
-  /* useEffect(() => {
+  useEffect(() => {
     refreshSearch();
-  }, [refreshSearch]); */
+  }, [refreshSearch]);
 
   useEffect(() => {
     SearchConfigActions.refresh();

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -122,9 +122,9 @@ const Search = ({ InfoBarSlot, SearchAreaContainer }: Props) => {
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
   const { sidebar: { isShown: showSidebar } } = useSearchPageLayout();
 
-  useEffect(() => {
+  /* useEffect(() => {
     refreshSearch();
-  }, [refreshSearch]);
+  }, [refreshSearch]); */
 
   useEffect(() => {
     SearchConfigActions.refresh();

--- a/graylog2-web-interface/src/views/components/contexts/SearchExecutorsContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchExecutorsContext.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
+import executeSearch from 'views/logic/slices/executeSearch';
+import parseSearch from 'views/logic/slices/parseSearch';
+
+const defaultSearchExecutors: SearchExecutors = {
+  resultMapper: (r) => r,
+  execute: executeSearch,
+  parse: parseSearch,
+};
+const SearchExecutorsContext = React.createContext<SearchExecutors>(defaultSearchExecutors);
+export default SearchExecutorsContext;

--- a/graylog2-web-interface/src/views/components/contexts/SearchExecutorsContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchExecutorsContext.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 
 import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';

--- a/graylog2-web-interface/src/views/components/contexts/useSearchExecutors.ts
+++ b/graylog2-web-interface/src/views/components/contexts/useSearchExecutors.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import SearchExecutorsContext from 'views/components/contexts/SearchExecutorsContext';
+
+const useSearchExecutors = () => useContext(SearchExecutorsContext);
+
+export default useSearchExecutors;

--- a/graylog2-web-interface/src/views/components/contexts/useSearchExecutors.ts
+++ b/graylog2-web-interface/src/views/components/contexts/useSearchExecutors.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useContext } from 'react';
 
 import SearchExecutorsContext from 'views/components/contexts/SearchExecutorsContext';

--- a/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
+++ b/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
@@ -18,7 +18,7 @@ import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { AppDispatch } from 'stores/useAppDispatch';
-import type { RootState, SearchExecutionResult } from 'views/types';
+import type { RootState, SearchExecutionResult, ExtraArguments } from 'views/types';
 import { selectView } from 'views/logic/slices/viewSelectors';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import {
@@ -30,8 +30,8 @@ import { executeWithExecutionState } from 'views/logic/slices/searchExecutionSli
 
 const reexecuteSearchTypes = (
   searchTypes: SearchTypeOptions,
-  effectiveTimerange?: TimeRange,
-) => (dispatch: AppDispatch, getState: () => RootState) => {
+  effectiveTimerange: TimeRange,
+) => (dispatch: AppDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
   const state = getState();
   const globalOverride = selectGlobalOverride(state);
   const globalQuery = globalOverride?.query;
@@ -56,7 +56,7 @@ const reexecuteSearchTypes = (
     return { result: result.updateSearchTypes(updatedSearchTypes), widgetMapping };
   };
 
-  return dispatch(executeWithExecutionState(view, [], executionState, handleSearchResult));
+  return dispatch(executeWithExecutionState(view, [], executionState, { ...searchExecutors, resultMapper: handleSearchResult }));
 };
 
 export default reexecuteSearchTypes;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -218,8 +218,8 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       .sort(sort.map(SortConfig.fromJSON))
       .visualization(visualization)
       .rollup(rollup)
-      .visualizationConfig(visualization_config !== null ? VisualizationConfig.fromJSON(visualization, visualization_config) : null)
-      .formattingSettings(formatting_settings === null ? undefined : WidgetFormattingSettings.fromJSON(formatting_settings))
+      .visualizationConfig(visualization_config ? VisualizationConfig.fromJSON(visualization, visualization_config) : null)
+      .formattingSettings(formatting_settings ? WidgetFormattingSettings.fromJSON(formatting_settings) : undefined)
       .eventAnnotation(event_annotation)
       .build();
   }

--- a/graylog2-web-interface/src/views/logic/slices/searchMetadataSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchMetadataSlice.ts
@@ -21,8 +21,6 @@ import type SearchMetadata from 'views/logic/search/SearchMetadata';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type Search from 'views/logic/search/Search';
 
-import _parseSearch from './parseSearch';
-
 const searchMetadataSlice = createSlice({
   name: 'searchMetadata',
   initialState: {
@@ -47,9 +45,11 @@ const { finishedLoading, loading } = searchMetadataSlice.actions;
 
 export const searchMetadataSliceReducer = searchMetadataSlice.reducer;
 
-export const parseSearch = (search: Search) => async (dispatch: AppDispatch) => {
+export type SearchParser = (search: Search) => Promise<SearchMetadata>;
+
+export const parseSearch = (search: Search, parse: SearchParser) => async (dispatch: AppDispatch) => {
   dispatch(loading());
 
-  return _parseSearch(search)
+  return parse(search)
     .then((result) => dispatch(finishedLoading(result)));
 };

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -33,6 +33,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { HistoryFunction } from 'routing/useHistory';
 import useHistory from 'routing/useHistory';
 import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
+import type { SearchExecutionResult } from 'views/types';
 
 type SearchComponentSlots = { InfoBarSlot: React.ComponentType }
 
@@ -44,6 +45,7 @@ type Props = React.PropsWithChildren<{
   executionState?: SearchExecutionState,
   SearchComponentSlots?: SearchComponentSlots,
   SearchAreaContainer?: React.ComponentType,
+  searchResult?: SearchExecutionResult,
 }>;
 
 const SearchPageTitle = ({ children }: { children: React.ReactNode }) => {
@@ -56,7 +58,17 @@ const SearchPageTitle = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-const SearchPage = ({ children, isNew, view: viewPromise, loadNewView: _loadNewView = defaultLoadNewView, loadView: _loadView = defaultLoadView, executionState: initialExecutionState, SearchComponentSlots, SearchAreaContainer }: Props) => {
+const SearchPage = ({
+  children,
+  isNew,
+  view: viewPromise,
+  loadNewView: _loadNewView = defaultLoadNewView,
+  loadView: _loadView = defaultLoadView,
+  executionState: initialExecutionState,
+  SearchComponentSlots,
+  SearchAreaContainer,
+  searchResult,
+}: Props) => {
   const query = useQuery();
   const initialQuery = query?.page as string;
   const history = useHistory();
@@ -76,7 +88,7 @@ const SearchPage = ({ children, isNew, view: viewPromise, loadNewView: _loadNewV
 
   return view
     ? (
-      <PluggableStoreProvider view={view} executionState={executionState} isNew={isNew} initialQuery={initialQuery}>
+      <PluggableStoreProvider view={view} executionState={executionState} isNew={isNew} initialQuery={initialQuery} result={searchResult}>
         <SearchPageTitle>
           <DashboardPageContextProvider>
             <NewViewLoaderContext.Provider value={loadNewView}>
@@ -102,6 +114,7 @@ SearchPage.defaultProps = {
   executionState: SearchExecutionState.empty(),
   SearchComponentSlots: {},
   SearchAreaContainer: undefined,
+  searchResult: undefined,
 };
 
 export default React.memo(SearchPage);

--- a/graylog2-web-interface/src/views/test/mockDispatch.ts
+++ b/graylog2-web-interface/src/views/test/mockDispatch.ts
@@ -14,18 +14,19 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { RootState, ExtraArguments } from 'views/types';
+import type { RootState, ExtraArguments, SearchExecutionResult } from 'views/types';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import { asMock } from 'helpers/mocking';
 import { createSearch } from 'fixtures/searches';
 import type View from 'views/logic/views/View';
 import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
+import SearchMetadata from 'views/logic/search/SearchMetadata';
 
 const defaultState = { view: { view: createSearch(), activeQuery: 'query-id-1' } } as RootState;
 const mockSearchExecutors: SearchExecutors = {
   resultMapper: (r) => r,
-  parse: async () => {},
-  execute: async () => {},
+  parse: async () => SearchMetadata.empty(),
+  execute: async () => ({}) as SearchExecutionResult,
 };
 
 const mockDispatch = (state: RootState = defaultState) => {

--- a/graylog2-web-interface/src/views/test/mockDispatch.ts
+++ b/graylog2-web-interface/src/views/test/mockDispatch.ts
@@ -14,19 +14,25 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { RootState } from 'views/types';
+import type { RootState, ExtraArguments } from 'views/types';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import { asMock } from 'helpers/mocking';
 import { createSearch } from 'fixtures/searches';
 import type View from 'views/logic/views/View';
+import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
 
 const defaultState = { view: { view: createSearch(), activeQuery: 'query-id-1' } } as RootState;
+const mockSearchExecutors: SearchExecutors = {
+  resultMapper: (r) => r,
+  parse: async () => {},
+  execute: async () => {},
+};
 
 const mockDispatch = (state: RootState = defaultState) => {
   const dispatch: AppDispatch = jest.fn();
 
-  asMock(dispatch).mockImplementation((fn: (d: AppDispatch, getState: () => RootState) => unknown) => (typeof fn === 'function'
-    ? fn(dispatch, () => state)
+  asMock(dispatch).mockImplementation((fn: (d: AppDispatch, getState: () => RootState, extraArgs: ExtraArguments) => unknown) => (typeof fn === 'function'
+    ? fn(dispatch, () => state, { searchExecutors: mockSearchExecutors })
     : fn));
 
   return dispatch;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -56,6 +56,7 @@ import type { WidgetMapping } from 'views/logic/views/types';
 import type { Event } from 'components/events/events/types';
 import type Parameter from 'views/logic/parameters/Parameter';
 import type { UndoRedoState } from 'views/logic/slices/undoRedoSlice';
+import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
 
 export type ArrayElement<ArrayType extends readonly unknown[]> =
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
@@ -378,6 +379,10 @@ export interface RootState {
   searchExecution: SearchExecution;
   searchMetadata: SearchMetadataState;
   undoRedo: UndoRedoState
+}
+
+export interface ExtraArguments {
+  searchExecutors: SearchExecutors;
 }
 
 export type GetState = () => RootState;

--- a/graylog2-web-interface/src/views/viewsReducers.ts
+++ b/graylog2-web-interface/src/views/viewsReducers.ts
@@ -22,10 +22,10 @@ import { searchMetadataSliceReducer } from 'views/logic/slices/searchMetadataSli
 import { undoRedoSliceReducer } from 'views/logic/slices/undoRedoSlice';
 
 const viewsReducers: PluginExports['views.reducers'] = [{
-  key: 'view' as const,
+  key: 'view',
   reducer: viewSliceReducer,
 }, {
-  key: 'searchExecution' as const,
+  key: 'searchExecution',
   reducer: searchExecutionSliceReducer,
 }, {
   key: 'searchMetadata',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the search store and actions in the following ways:

  - Search parsing/execution can be customized using the `SearchExecutorsContext`
  - The `PluggableStoreProvider` takes a static search result in its `result` prop


In combination, these changes allow reusing the search components with static result data and/or using different means to retrieve search results.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.