### PR TITLE
Switch "CI" detection to a common variable.

### DIFF
--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -132,7 +132,7 @@ public class ElasticsearchInstanceES7 extends TestableSearchServerInstance {
     public GenericContainer<?> buildContainer(String image, Network network) {
         return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
-                .withReuse(isNull(System.getenv("BUILD_ID")))
+                .withReuse(isNull(System.getenv("CI")))
                 .withEnv("ES_JAVA_OPTS", getEsJavaOpts())
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", "false")

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpenSearch13Instance.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/OpenSearch13Instance.java
@@ -124,7 +124,7 @@ public class OpenSearch13Instance extends TestableSearchServerInstance {
     public GenericContainer<?> buildContainer(String image, Network network) {
         return new OpenSearchContainer(DockerImageName.parse(image))
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
-                .withReuse(isNull(System.getenv("BUILD_ID")))
+                .withReuse(isNull(System.getenv("CI")))
                 .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms2g -Xmx2g -Dlog4j2.formatMsgNoLookups=true")
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", "false")

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/DatanodeInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/DatanodeInstance.java
@@ -66,7 +66,7 @@ public class DatanodeInstance extends OpenSearchInstance {
         return new GenericContainer<>(DockerImageName.parse(image))
                 .withImagePullPolicy(PullPolicy.alwaysPull())
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
-                .withReuse(isNull(System.getenv("BUILD_ID")))
+                .withReuse(isNull(System.getenv("CI")))
                 .withEnv("OPENSEARCH_JAVA_OPTS", getEsJavaOpts())
                 .withEnv("GRAYLOG_DATANODE_PASSWORD_SECRET", passwordSecret)
                 .withEnv("GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2", rootPasswordSha2)

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/OpenSearchInstance.java
@@ -82,7 +82,7 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
         this.fixtureImporter = new FixtureImporterOS2(this.openSearchClient);
         adapters = new AdaptersOS2(openSearchClient);
         Runtime.getRuntime().addShutdownHook(new Thread(this::close));
-        if(isFirstContainerStart) {
+        if (isFirstContainerStart) {
             afterContainerCreated();
         }
         return this;
@@ -187,7 +187,7 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
     public GenericContainer<?> buildContainer(String image, Network network) {
         var container = new OpensearchContainer(DockerImageName.parse(image))
                 // Avoids reuse warning on Jenkins (we don't want reuse in our CI environment)
-                .withReuse(isNull(System.getenv("BUILD_ID")))
+                .withReuse(isNull(System.getenv("CI")))
                 .withEnv("OPENSEARCH_JAVA_OPTS", getEsJavaOpts())
                 .withEnv("cluster.info.update.interval", "10s")
                 .withEnv("cluster.routing.allocation.disk.reroute_interval", "5s")
@@ -199,7 +199,7 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
 
         // disabling the performance plugin in 2.0.1 consistently created errors during CI runs, but keeping it running
         // in later versions sometimes created errors on CI, too.
-        if(version().satisfies(SearchVersion.Distribution.OPENSEARCH, "^2.7.0")) {
+        if (version().satisfies(SearchVersion.Distribution.OPENSEARCH, "^2.7.0")) {
             return container.withCommand("sh", "-c", "opensearch-plugin remove opensearch-performance-analyzer && ./opensearch-docker-entrypoint.sh");
         } else {
             return container;


### PR DESCRIPTION
Unlike Jenkins, Github Actions does not provide a BUILD_ID env variable. Using CI should work with both, since this was already used in BlockingBatchedESOutputTest.

/nocl

