### PR TITLE
Fail proxied metrics requests fast when auth info is missing

### DIFF
--- a/changelog/unreleased/pr-17477.toml
+++ b/changelog/unreleased/pr-17477.toml
@@ -1,0 +1,8 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix excessive logging of warnings for metrics requests after session expiration."
+
+pulls = ["17477"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Workaround to fail fast with a 401 when an authenticated metrics request can't be forwarded properly because the auth token can't be extracted.

This is a band-aid to silence the log. It is kept simple to allow for easy backporting to versions `5.2` and `5.1`. I'm planning to implement a proper fix targeting version `6.0` in a separate PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes spamming the server log file with warnings of the following kind:

```
2023-11-27 10:13:58,527 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Failed to call API on node <c017185d-cc34-48a1-9e29-ac713d47470c>, cause: HTTP 401 Unauthorized (duration: 0 ms)
```

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/5971

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by following the steps to reproduce as documented [here](https://github.com/Graylog2/graylog2-server/issues/13721#issue-1413261980). Verified that before applying the fix, the error was logged and that after applying the fix the error wasn't logged and the UI triggered a a session refresh after the session expired.

