### PR TITLE
Reduce scope of trusted header auth

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -34,7 +34,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.ConnectionCallback;
 import javax.ws.rs.core.Context;
@@ -126,30 +125,14 @@ public abstract class ProxiedResource extends RestResource {
     }
 
     /**
-     * Gets an authentication token to be used in an Authorization header of forwarded requests by extracting
-     * authentication information from the original request.
-     * <p>
-     * Only extracts an auth token from the request if the request is authenticated. This is to make sure that
-     * forwarded requests will also not be authenticated.
-     * <p>
-     * If the request is authenticated, but not by means of an authentication token, this method will fail with
-     * a {@link NotAuthorizedException} because we can't easily make up a token to use for forwarded requests in that
-     * case.
+     * Gets an authentication token to be used in an Authorization header of forwarded requests. It was extracted
+     * from the authentication information of the original request.
      *
      * @return An authentication token if the request was authenticated and one could be extracted from the original
-     * request. Null otherwise.
-     * @throws NotAuthorizedException if the original request was authenticated, but no authentication token could
-     *                                be created from the request headers.
      */
     @Nullable
     protected String getAuthenticationToken() {
-        if (getSubject().isAuthenticated()) {
-            if (authenticationToken == null) {
-                throw new NotAuthorizedException("Basic realm=\"Graylog Server\"");
-            }
-            return authenticationToken;
-        }
-        return null;
+        return authenticationToken;
     }
 
     /**
@@ -408,7 +391,8 @@ public abstract class ProxiedResource extends RestResource {
 
     /**
      * Helper function to remove the {@link CallResult} wrapper
-     * @param input   responses that are wrapped with a {@link CallResult}
+     *
+     * @param input responses that are wrapped with a {@link CallResult}
      * @return the response in the legacy format of {@code Map<String, Optional<T>>}
      */
     protected <T> Map<String, Optional<T>> stripCallResult(Map<String, CallResult<T>> input) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/PossibleTrustedHeaderToken.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/PossibleTrustedHeaderToken.java
@@ -16,18 +16,23 @@
  */
 package org.graylog2.shared.security;
 
+import org.apache.commons.collections4.SetUtils;
 import org.apache.shiro.authc.HostAuthenticationToken;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Set;
 
 public class PossibleTrustedHeaderToken implements HostAuthenticationToken, RemoteAddressAuthenticationToken {
 
     private final String host;
     private final String remoteAddr;
+    private final Set<Class<?>> matchedResources;
 
-    public PossibleTrustedHeaderToken(String host, String remoteAddr) {
+    public PossibleTrustedHeaderToken(String host, String remoteAddr, Set<Class<?>> matchedResources) {
         this.host = host;
         this.remoteAddr = remoteAddr;
+        this.matchedResources = SetUtils.emptyIfNull(matchedResources);
     }
 
     /**
@@ -65,5 +70,13 @@ public class PossibleTrustedHeaderToken implements HostAuthenticationToken, Remo
      */
     public String getRemoteAddr() {
         return remoteAddr;
+    }
+
+    /**
+     * The resource classes that have matched for the request this token is associated with.
+     */
+    @Nonnull
+    public Set<Class<?>> getMatchedResources() {
+        return matchedResources;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/ShiroSecurityContextFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/ShiroSecurityContextFilterTest.java
@@ -35,6 +35,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
@@ -64,6 +65,7 @@ public class ShiroSecurityContextFilterTest {
     public void setUp() throws Exception {
         when(securityContext.isSecure()).thenReturn(false);
         when(requestContext.getSecurityContext()).thenReturn(securityContext);
+        when(requestContext.getUriInfo()).thenReturn(mock(UriInfo.class));
 
         final DefaultSecurityManager securityManager = new DefaultSecurityManager();
         final Provider<Request> grizzlyRequestProvider = () -> mock(Request.class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Only allow trusted header auth for the SessionsResource.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Trusted header auth is only used until a session has been created for the user. From then on, if a session cookie is set on a request, it takes precedence over trusted headers to authenticate a request.

This was causing issues for proxied requests when a session expired. Our authentication chain would fail to authenticate the session cookie, because it was expired, and would then fall back to the next authentication method in the chain, which was trusted header auth. When trying to forward the request to other servers, we failed to extract an authentication token from the original request and caused the forwarded request to fail because it was unauthenticated.

With this fix, we are only allowing trusted header authentication for requests that target the sessions resource. Requests to other resources will fail fast if they require authentication but only have trusted header set.

For the mentioned scenario of session expiration, this will cause any background REST call to to a proxied endpoint fail with a 401 once the session expires, even if trusted headers are set. This in turn will cause the UI to call the sessions endpoint which will then refresh the session based on the trusted headers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See steps to reproduce [here](https://github.com/Graylog2/graylog2-server/issues/13721#issue-1413261980).


