### PR TITLE
Backport to 5.2: Fail proxied metrics requests fast when auth info is missing (#17477)

### DIFF
--- a/changelog/unreleased/pr-17477.toml
+++ b/changelog/unreleased/pr-17477.toml
@@ -1,0 +1,8 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix excessive logging of warnings for metrics requests after session expiration."
+
+pulls = ["17477"]


### PR DESCRIPTION
Backport of #17477 

* Fail proxied metrics requests fast when auth info is missing

* Add changelog

(cherry picked from commit af4c9085b1f72ec77996b5117e06f9b85fcc2790)