### PR TITLE
Query Validation never treats special GL fields as unknown

### DIFF
--- a/changelog/unreleased/issue-13856.toml
+++ b/changelog/unreleased/issue-13856.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix problems with unknown-field validation warnings on fields like gl2_source_input. From now on, Query Validation never treats special GL fields as unknown."
+
+issues = ["13856"]
+pulls = ["17515"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidator.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.graylog2.plugin.Message.RESERVED_SETTABLE_FIELDS;
 import static org.graylog2.plugin.Message.SEARCHABLE_ES_FIELDS;
 
 @Singleton
@@ -65,6 +66,7 @@ public class UnknownFieldsValidator implements QueryValidator {
         final Map<String, List<ParsedTerm>> groupedByField = terms.stream()
                 .filter(t -> !t.isDefaultField())
                 .filter(term -> !SEARCHABLE_ES_FIELDS.contains(term.getRealFieldName()))
+                .filter(term -> !RESERVED_SETTABLE_FIELDS.contains(term.getRealFieldName()))
                 .filter(term -> !availableFields.contains(term.getRealFieldName()))
                 .distinct()
                 .collect(Collectors.groupingBy(ParsedTerm::getRealFieldName));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidatorTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.plugin.Message.RESERVED_SETTABLE_FIELDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -50,6 +52,15 @@ class UnknownFieldsValidatorTest {
         final List<ParsedTerm> unknownFields = toTest.identifyUnknownFields(
                 Set.of("some_normal_field"),
                 List.of(ParsedTerm.create("_id", "buba"))
+        );
+        assertTrue(unknownFields.isEmpty());
+    }
+
+    @Test
+    void testDoesNotIdentifyGraylogReservedFieldsAsUnknown() {
+        final List<ParsedTerm> unknownFields = toTest.identifyUnknownFields(
+                Set.of("some_normal_field"),
+                RESERVED_SETTABLE_FIELDS.stream().map(f -> ParsedTerm.create(f, "buba")).collect(Collectors.toList())
         );
         assertTrue(unknownFields.isEmpty());
     }


### PR DESCRIPTION
## Description
Fixes #[13856](https://github.com/Graylog2/graylog2-server/issues/13856)
Query Validation never treats special GL fields as unknown.


## Motivation and Context
See #[13856](https://github.com/Graylog2/graylog2-server/issues/13856)

## How Has This Been Tested?
Manually and with new unit test.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

