### PR TITLE
allow generic overriding of config params in full backend tests

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/AutomaticLeaderElectionStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/AutomaticLeaderElectionStartupIT.java
@@ -23,7 +23,7 @@ import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfi
 
 import static io.restassured.RestAssured.given;
 
-@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, withMailServerEnabled = true, additionalConfigurationParameters = {
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, additionalConfigurationParameters = {
         @ContainerMatrixTestsConfiguration.ConfigurationParameter(key = "GRAYLOG_LEADER_ELECTION_MODE", value = "automatic")
 })
 class AutomaticLeaderElectionStartupIT {

--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/AutomaticLeaderElectionStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/AutomaticLeaderElectionStartupIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.fullbackend;
+
+import org.graylog.testing.completebackend.Lifecycle;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+import static io.restassured.RestAssured.given;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, withMailServerEnabled = true, additionalConfigurationParameters = {
+        @ContainerMatrixTestsConfiguration.ConfigurationParameter(key = "GRAYLOG_LEADER_ELECTION_MODE", value = "automatic")
+})
+class AutomaticLeaderElectionStartupIT {
+    private final GraylogApis api;
+
+    public AutomaticLeaderElectionStartupIT(GraylogApis api) {
+        this.api = api;
+    }
+
+    @ContainerMatrixTest
+    void canReachApi() {
+        given()
+                .config(api.withGraylogBackendFailureConfig())
+                .spec(api.requestSpecification())
+                .when()
+                .get()
+                .then()
+                .statusCode(200);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -20,6 +20,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.graylog.testing.completebackend.ContainerizedGraylogBackendServicesProvider.Services;
 import org.graylog.testing.containermatrix.MongodbServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
 import org.graylog.testing.graylognode.MavenPackager;
 import org.graylog.testing.graylognode.NodeContainerConfig;
@@ -33,8 +34,10 @@ import org.testcontainers.containers.Network;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseable {
@@ -58,13 +61,14 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
                                                                          final MavenProjectDirProvider mavenProjectDirProvider,
                                                                          final List<String> enabledFeatureFlags,
                                                                          final boolean preImportLicense,
-                                                                         final boolean withMailServerEnabled) {
+                                                                         final boolean withMailServerEnabled,
+                                                                         Map<String, String> configParams) {
 
         LOG.debug("Creating Backend services {} {} {} flags <{}>", version, mongodbVersion, withMailServerEnabled ? "mail" : "", enabledFeatureFlags);
-        final Services services = servicesProvider.getServices(version, mongodbVersion, withMailServerEnabled, enabledFeatureFlags);
+        final Services services = servicesProvider.getServices(version, mongodbVersion, withMailServerEnabled, enabledFeatureFlags, configParams);
         LOG.debug("Done creating backend services");
 
-        return new ContainerizedGraylogBackend().create(services, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense);
+        return new ContainerizedGraylogBackend().create(services, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, configParams);
     }
 
     private ContainerizedGraylogBackend create(Services services,
@@ -73,7 +77,8 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
                                                final PluginJarsProvider pluginJarsProvider,
                                                final MavenProjectDirProvider mavenProjectDirProvider,
                                                final List<String> enabledFeatureFlags,
-                                               final boolean preImportLicense) {
+                                               final boolean preImportLicense,
+                                               Map<String, String> configParams) {
         this.services = services;
 
         var mongoDB = services.getMongoDBInstance();
@@ -87,7 +92,7 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
 
         var searchServer = services.getSearchServerInstance();
         try {
-            var nodeContainerConfig = new NodeContainerConfig(services.getNetwork(), mongoDB.internalUri(), PASSWORD_SECRET, ROOT_PASSWORD_SHA_2, searchServer.internalUri(), searchServer.version(), extraPorts, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags);
+            var nodeContainerConfig = new NodeContainerConfig(services.getNetwork(), mongoDB.internalUri(), PASSWORD_SECRET, ROOT_PASSWORD_SHA_2, searchServer.internalUri(), searchServer.version(), extraPorts, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, configParams);
             this.node = NodeInstance.createStarted(nodeContainerConfig);
 
             // ensure that all containers and networks will be removed after all tests finish

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -65,7 +65,7 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
                                                                          Map<String, String> configParams) {
 
         LOG.debug("Creating Backend services {} {} {} flags <{}>", version, mongodbVersion, withMailServerEnabled ? "mail" : "", enabledFeatureFlags);
-        final Services services = servicesProvider.getServices(version, mongodbVersion, withMailServerEnabled, enabledFeatureFlags, configParams);
+        final Services services = servicesProvider.getServices(version, mongodbVersion, withMailServerEnabled, enabledFeatureFlags);
         LOG.debug("Done creating backend services");
 
         return new ContainerizedGraylogBackend().create(services, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, configParams);

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -151,6 +152,14 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.mongoVersions()));
     }
 
+    private Map<String, String> getAdditionalConfigurationParameters(Set<Class<?>> annotatedClasses) {
+        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Arrays.stream(annotation.additionalConfigurationParameters()))
+                .stream().collect(Collectors.toMap(
+                        ContainerMatrixTestsConfiguration.ConfigurationParameter::key,
+                        ContainerMatrixTestsConfiguration.ConfigurationParameter::value
+                ));
+    }
+
     private Set<Integer> getExtraPorts(Set<Class<?>> annotatedClasses) {
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Arrays.stream(annotation.extraPorts()).boxed());
     }
@@ -226,6 +235,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         final Set<Integer> extraPorts = getExtraPorts(annotatedClasses);
         final List<URL> mongoDBFixtures = getMongoDBFixtures(annotatedClasses);
         final boolean withMailServerEnabled = isMailServerRequired(annotatedClasses);
+        final Map<String, String> additionalConfig = getAdditionalConfigurationParameters(annotatedClasses);
 
         if (testAgainstRunningESMongoDB()) {
             // if you test from inside an IDE against running containers
@@ -257,7 +267,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                                                             extraPorts,
                                                             mongoDBFixtures,
                                                             getEnabledFeatureFlags(Lifecycle.VM, annotatedClasses),
-                                                            withMailServerEnabled);
+                                                            withMailServerEnabled, additionalConfig);
                                                     new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
                                                     engineDescriptor.addChild(testsDescriptor);
                                                 })
@@ -276,7 +286,7 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                                                                     mongoVersion,
                                                                     extraPorts,
                                                                     new ArrayList<>(),
-                                                                    getEnabledFeatureFlags(Lifecycle.CLASS, annotatedClasses), withMailServerEnabled);
+                                                                    getEnabledFeatureFlags(Lifecycle.CLASS, annotatedClasses), withMailServerEnabled, additionalConfig);
                                                             new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
                                                             engineDescriptor.addChild(testsDescriptor);
                                                         })

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -47,6 +47,13 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 @Testable
 public @interface ContainerMatrixTestsConfiguration {
+
+    @interface ConfigurationParameter {
+        String key();
+
+        String value();
+    }
+
     // combination rule
     Lifecycle serverLifecycle() default Lifecycle.VM;
 
@@ -90,4 +97,7 @@ public @interface ContainerMatrixTestsConfiguration {
     boolean importLicenses() default defaultImportLicenses;
 
     boolean withMailServerEnabled() default false;
+
+    ConfigurationParameter[] additionalConfigurationParameters() default {};
+
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -25,6 +25,7 @@ import org.testcontainers.containers.Network;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class NodeContainerConfig {
@@ -46,6 +47,7 @@ public class NodeContainerConfig {
     public final MavenProjectDirProvider mavenProjectDirProvider;
     private final List<String> enabledFeatureFlags;
     public final Optional<String> proxiedRequestsTimeout;
+    public final Map<String, String> configParams;
 
     public NodeContainerConfig(Network network,
                                String mongoDbUri,
@@ -56,7 +58,8 @@ public class NodeContainerConfig {
                                int[] extraPorts,
                                PluginJarsProvider pluginJarsProvider,
                                MavenProjectDirProvider mavenProjectDirProvider,
-                               List<String> enabledFeatureFlags) {
+                               List<String> enabledFeatureFlags,
+                               Map<String, String> configParams) {
         this.network = network;
         this.mongoDbUri = mongoDbUri;
         this.passwordSecret = passwordSecret;
@@ -70,6 +73,7 @@ public class NodeContainerConfig {
         this.mavenProjectDirProvider = mavenProjectDirProvider;
         this.enabledFeatureFlags = enabledFeatureFlags == null ? Collections.emptyList() : enabledFeatureFlags;
         this.proxiedRequestsTimeout = stringFromEnvVar("GRAYLOG_IT_PROXIED_REQUESTS_TIMEOUT");
+        this.configParams = configParams;
     }
 
     private static boolean flagFromEnvVar(String flagName) {

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -141,6 +141,7 @@ public class NodeContainerFactory {
                 .withEnv("GRAYLOG_TRANSPORT_EMAIL_FROM_EMAIL", "developers@graylog.com")
 
                 .withEnv("GRAYLOG_ENABLE_DEBUG_RESOURCES", "true") // see RestResourcesModule#addDebugResources
+                .withEnv(config.configParams)
 
                 .waitingFor(new WaitAllStrategy()
                         .withStrategy(new WaitForSuccessOrFailureStrategy().withSuccessAndFailures(

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
@@ -23,11 +23,13 @@ import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog2.storage.SearchVersion;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 class ContainerMatrixTestsDescriptorTest {
 
     @Test
     void createKey() {
-        final String key = ContainerMatrixTestsDescriptor.createKey(Lifecycle.CLASS, "mavenDir", "jarDir", SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.2.3")), MongodbServer.MONGO5, true);
-        Assertions.assertThat(key).isEqualTo("Lifecycle: CLASS, MavenProjectDirProvider: mavenDir, PluginJarsProvider: jarDir, Search: OpenSearch:1.2.3, MongoDB: 5.0, Mailserver: enabled");
+        final String key = ContainerMatrixTestsDescriptor.createKey(Lifecycle.CLASS, "mavenDir", "jarDir", SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.2.3")), MongodbServer.MONGO5, true, Map.of("p1", "v1"));
+        Assertions.assertThat(key).isEqualTo("Lifecycle: CLASS, MavenProjectDirProvider: mavenDir, PluginJarsProvider: jarDir, Search: OpenSearch:1.2.3, MongoDB: 5.0, Mailserver: enabled, p1: v1");
     }
 }

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExecutionContext> implements TestEngine {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerMatrixTestEngine.class);
@@ -86,9 +85,10 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
         PluginJarsProvider pluginJarsProvider = instantiateFactory(descriptor.getPluginJarsProvider());
         MavenProjectDirProvider mavenProjectDirProvider = instantiateFactory(descriptor.getMavenProjectDirProvider());
         boolean withEnabledMailServer = descriptor.withEnabledMailServer();
+        final Map<String, String> configParams = descriptor.getAdditionalConfigurationParameters();
 
         if (Lifecycle.VM.equals(descriptor.getLifecycle())) {
-            try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer)) {
+            try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer, configParams)) {
                 this.execute(request, descriptor.getChildren(), backend);
             } catch (Exception exception) {
                 /* Fail hard if the containerized backend failed to start. */
@@ -103,7 +103,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                     fixtures = ((ContainerMatrixTestClassDescriptor) td).getMongoFixtures();
                     preImportLicense = ((ContainerMatrixTestClassDescriptor) td).isPreImportLicense();
                 }
-                try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, withEnabledMailServer)) {
+                try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, withEnabledMailServer, configParams)) {
                     this.execute(request, Collections.singleton(td), backend);
                 } catch (Exception exception) {
                     /* Fail hard if the containerized backend failed to start. */

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -43,6 +43,8 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExecutionContext> implements TestEngine {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerMatrixTestEngine.class);


### PR DESCRIPTION
## Description
Adds a `@ContainerMatrixTestsConfiguration.ConfigurationParameter` key-value array to the `@ContainerMatrixTestsConfiguration`
These values will override configuration parameters for the Graylog container started in full backend tests.

/nocl

## Motivation and Context
Adds an `AutomaticLeaderElectionStartupIT` which uses this to start a Graylog with `leader_election_mode=automatic` to check if startup works since there were binding issues in this case from time to time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

