### PR TITLE
If cannot access any message streams, other streams are tried as defa…

### DIFF
--- a/changelog/unreleased/issue-4333.toml
+++ b/changelog/unreleased/issue-4333.toml
@@ -1,0 +1,7 @@
+type = "fixed"
+message = "Error page was shown when navigating to search page with permissions to some streams (usually non-mesage streams, like events), but no permission for default stream. It has been fixed."
+
+issues = ["Graylog2/graylog-plugin-enterprise#4333"]
+pulls = ["17548","Graylog2/graylog-plugin-enterprise#6245"]
+
+

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -226,7 +226,7 @@ public class AggregationEventProcessor implements EventProcessor {
                               EventConsumer<List<EventWithContext>> eventsConsumer) throws EventProcessorException {
         Set<String> streams = getStreams(parameters);
         if (streams.isEmpty()) {
-            streams = new HashSet<>(permittedStreams.load(streamId -> true));
+            streams = new HashSet<>(permittedStreams.loadAllMessageStreams(streamId -> true));
         }
 
         final AtomicInteger messageCount = new AtomicInteger(0);

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -26,7 +26,6 @@ import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventProcessorException;
 import org.graylog.events.search.MoreSearch;
 import org.graylog.plugins.views.search.Filter;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.ParameterProvider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
@@ -38,7 +37,6 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringDecorators;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.QueryEngine;
-import org.graylog.plugins.views.search.engine.normalization.SearchNormalization;
 import org.graylog.plugins.views.search.errors.EmptyParameterError;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
@@ -369,7 +367,7 @@ public class PivotAggregationSearch implements AggregationSearch {
         // This adds all streams if none were provided
         // TODO: Once we introduce "EventProcessor owners" this should only load the permitted streams of the
         //       user who created this EventProcessor.
-        search = search.addStreamsToQueriesWithoutStreams(() -> permittedStreams.load((streamId) -> true));
+        search = search.addStreamsToQueriesWithoutStreams(() -> permittedStreams.loadAllMessageStreams((streamId) -> true));
         final SearchJob searchJob = queryEngine.execute(searchJobService.create(search, username), Collections.emptySet());
         try {
             Uninterruptibles.getUninterruptibly(

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/PluggableSearchNormalization.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/PluggableSearchNormalization.java
@@ -64,7 +64,7 @@ public class PluggableSearchNormalization implements SearchNormalization {
 
     @Override
     public Search preValidation(Search search, SearchUser searchUser, ExecutionState executionState) {
-        final Search searchWithStreams = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadStreamsForEmptyStreamsReplacement());
+        final Search searchWithStreams = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadMessageStreamsWithFallback());
         Search normalizedSearch = searchWithStreams.applyExecutionState(firstNonNull(executionState, ExecutionState.empty()));
 
         return normalize(normalizedSearch, pluggableNormalizers);
@@ -79,7 +79,7 @@ public class PluggableSearchNormalization implements SearchNormalization {
     public Query preValidation(final Query query, final ParameterProvider parameterProvider, SearchUser searchUser, ExecutionState executionState) {
         Query normalizedQuery = query;
         if (!query.hasStreams()) {
-            normalizedQuery = query.addStreamsToFilter(searchUser.streams().loadStreamsForEmptyStreamsReplacement());
+            normalizedQuery = query.addStreamsToFilter(searchUser.streams().loadMessageStreamsWithFallback());
         }
 
         if (!executionState.equals(ExecutionState.empty())) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/PluggableSearchNormalization.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/PluggableSearchNormalization.java
@@ -64,7 +64,7 @@ public class PluggableSearchNormalization implements SearchNormalization {
 
     @Override
     public Search preValidation(Search search, SearchUser searchUser, ExecutionState executionState) {
-        final Search searchWithStreams = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadAll());
+        final Search searchWithStreams = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadStreamsForEmptyStreamsReplacement());
         Search normalizedSearch = searchWithStreams.applyExecutionState(firstNonNull(executionState, ExecutionState.empty()));
 
         return normalize(normalizedSearch, pluggableNormalizers);
@@ -79,7 +79,7 @@ public class PluggableSearchNormalization implements SearchNormalization {
     public Query preValidation(final Query query, final ParameterProvider parameterProvider, SearchUser searchUser, ExecutionState executionState) {
         Query normalizedQuery = query;
         if (!query.hasStreams()) {
-            normalizedQuery = query.addStreamsToFilter(searchUser.streams().loadAll());
+            normalizedQuery = query.addStreamsToFilter(searchUser.streams().loadStreamsForEmptyStreamsReplacement());
         }
 
         if (!executionState.equals(ExecutionState.empty())) {
@@ -93,4 +93,6 @@ public class PluggableSearchNormalization implements SearchNormalization {
     public Query postValidation(final Query query, final ParameterProvider parameterProvider) {
         return normalize(query, parameterProvider, postValidationNormalizers);
     }
+
+
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
@@ -40,8 +40,22 @@ public class UserStreams {
         this.permittedStreams = permittedStreams;
     }
 
-    public ImmutableSet<String> loadAll() {
+    public ImmutableSet<String> loadAllMessageStreams() {
         return permittedStreams.load(streamPermissions);
+    }
+
+    public ImmutableSet<String> loadAllStreams() {
+        return permittedStreams.loadAll(streamPermissions);
+    }
+
+    public ImmutableSet<String> loadStreamsForEmptyStreamsReplacement() {
+        final ImmutableSet<String> messageStreams = loadAllMessageStreams();
+        if (!messageStreams.isEmpty()) {
+            return messageStreams;
+        } else {
+            //if a user cannot access any message streams, load others (non-message) as default
+            return loadAllStreams();
+        }
     }
 
     /**
@@ -53,7 +67,7 @@ public class UserStreams {
      */
     public ImmutableSet<String> readableOrAllIfEmpty(@Nullable final Set<String> requestedStreams) {
         if (requestedStreams == null || requestedStreams.isEmpty()) {
-            return loadAll();
+            return loadStreamsForEmptyStreamsReplacement();
         } else {
 
             final Set<String> notPermittedStreams = requestedStreams.stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
@@ -41,7 +41,7 @@ public class UserStreams {
     }
 
     public ImmutableSet<String> loadAllMessageStreams() {
-        return permittedStreams.load(streamPermissions);
+        return permittedStreams.loadAllMessageStreams(streamPermissions);
     }
 
     public ImmutableSet<String> loadAllStreams() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/permissions/UserStreams.java
@@ -48,7 +48,7 @@ public class UserStreams {
         return permittedStreams.loadAll(streamPermissions);
     }
 
-    public ImmutableSet<String> loadStreamsForEmptyStreamsReplacement() {
+    public ImmutableSet<String> loadMessageStreamsWithFallback() {
         final ImmutableSet<String> messageStreams = loadAllMessageStreams();
         if (!messageStreams.isEmpty()) {
             return messageStreams;
@@ -67,7 +67,7 @@ public class UserStreams {
      */
     public ImmutableSet<String> readableOrAllIfEmpty(@Nullable final Set<String> requestedStreams) {
         if (requestedStreams == null || requestedStreams.isEmpty()) {
-            return loadStreamsForEmptyStreamsReplacement();
+            return loadMessageStreamsWithFallback();
         } else {
 
             final Set<String> notPermittedStreams = requestedStreams.stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -56,7 +56,7 @@ public class FieldTypesResource extends RestResource implements PluginRestResour
     @GET
     @ApiOperation(value = "Retrieve the list of all fields present in the system")
     public Set<MappedFieldTypeDTO> allFieldTypes(@Context SearchUser searchUser) {
-        final ImmutableSet<String> streams = searchUser.streams().loadAll();
+        final ImmutableSet<String> streams = searchUser.streams().loadAllMessageStreams();
         return mappedFieldTypesService.fieldTypesByStreamIds(streams, RelativeRange.allTime());
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
@@ -133,7 +133,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
         MessagesRequest request = requestFromClient != null ? requestFromClient : MessagesRequest.withDefaults();
 
         if (request.streams().isEmpty()) {
-            request = request.withStreams(searchUser.streams().loadAll());
+            request = request.withStreams(searchUser.streams().loadStreamsForEmptyStreamsReplacement());
         }
 
         if (!request.timeZone().isPresent()) {
@@ -242,7 +242,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
         Search search = searchDomain.getForUser(searchId, searchUser)
                 .orElseThrow(() -> new NotFoundException("Search with id " + searchId + " does not exist"));
 
-        search = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadAll());
+        search = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadStreamsForEmptyStreamsReplacement());
 
         search = search.applyExecutionState(executionState);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
@@ -133,7 +133,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
         MessagesRequest request = requestFromClient != null ? requestFromClient : MessagesRequest.withDefaults();
 
         if (request.streams().isEmpty()) {
-            request = request.withStreams(searchUser.streams().loadStreamsForEmptyStreamsReplacement());
+            request = request.withStreams(searchUser.streams().loadMessageStreamsWithFallback());
         }
 
         if (!request.timeZone().isPresent()) {
@@ -242,7 +242,7 @@ public class MessagesResource extends RestResource implements PluginRestResource
         Search search = searchDomain.getForUser(searchId, searchUser)
                 .orElseThrow(() -> new NotFoundException("Search with id " + searchId + " does not exist"));
 
-        search = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadStreamsForEmptyStreamsReplacement());
+        search = search.addStreamsToQueriesWithoutStreams(() -> searchUser.streams().loadMessageStreamsWithFallback());
 
         search = search.applyExecutionState(executionState);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
@@ -39,7 +39,7 @@ public class PermittedStreams {
         this(() -> streamService.loadAll().stream().map(org.graylog2.plugin.streams.Stream::getId));
     }
 
-    public ImmutableSet<String> load(StreamPermissions streamPermissions) {
+    public ImmutableSet<String> loadAllMessageStreams(final StreamPermissions streamPermissions) {
         return allStreamsProvider.get()
                 // Unless explicitly queried, exclude event and failure indices by default
                 // Having these indices in every search, makes sorting almost impossible
@@ -50,7 +50,7 @@ public class PermittedStreams {
                 .collect(ImmutableSet.toImmutableSet());
     }
 
-    public ImmutableSet<String> loadAll(StreamPermissions streamPermissions) {
+    public ImmutableSet<String> loadAll(final StreamPermissions streamPermissions) {
         return allStreamsProvider.get()
                 .filter(streamPermissions::canReadStream)
                 .collect(ImmutableSet.toImmutableSet());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
@@ -21,10 +21,7 @@ import org.graylog.plugins.views.search.permissions.StreamPermissions;
 import org.graylog2.streams.StreamService;
 
 import javax.inject.Inject;
-
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.graylog2.plugin.streams.Stream.NON_MESSAGE_STREAM_IDS;
@@ -49,6 +46,12 @@ public class PermittedStreams {
                 // because it triggers https://github.com/Graylog2/graylog2-server/issues/6378
                 // TODO: this filter could be removed, once we implement https://github.com/Graylog2/graylog2-server/issues/6490
                 .filter(id -> !NON_MESSAGE_STREAM_IDS.contains(id))
+                .filter(streamPermissions::canReadStream)
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+    public ImmutableSet<String> loadAll(StreamPermissions streamPermissions) {
+        return allStreamsProvider.get()
                 .filter(streamPermissions::canReadStream)
                 .collect(ImmutableSet.toImmutableSet());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
@@ -180,7 +180,7 @@ public class SuggestionsResource extends RestResource implements PluginRestResou
     }
 
     private ImmutableSet<String> loadAllAllowedStreamsForUser(SearchUser searchUser) {
-        return permittedStreams.load(searchUser);
+        return permittedStreams.loadAllMessageStreams(searchUser);
     }
 
     private SuggestionFieldType getFieldType(Set<String> streams, TimeRange timerange, final String fieldName) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -153,7 +153,7 @@ public class IndexSetsMappingResource extends RestResource {
 
     private Set<String> normalizeStreamIds(Set<String> streams, SearchUser searchUser) {
         return (streams == null || streams.isEmpty())
-                ? permittedStreams.load(searchUser)
+                ? permittedStreams.loadAllMessageStreams(searchUser)
                 : streams;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/PermittedStreamsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/PermittedStreamsTest.java
@@ -28,28 +28,28 @@ public class PermittedStreamsTest {
     @Test
     public void findsStreams() {
         final PermittedStreams sut = new PermittedStreams(() -> java.util.stream.Stream.of("oans", "zwoa", "gsuffa"));
-        ImmutableSet<String> result = sut.load(id -> true);
+        ImmutableSet<String> result = sut.loadAllMessageStreams(id -> true);
         assertThat(result).containsExactlyInAnyOrder("oans", "zwoa", "gsuffa");
     }
 
     @Test
     public void filtersOutNonPermittedStreams() {
         final PermittedStreams sut = new PermittedStreams(() -> java.util.stream.Stream.of("oans", "zwoa", "gsuffa"));
-        ImmutableSet<String> result = sut.load(id -> id.equals("gsuffa"));
+        ImmutableSet<String> result = sut.loadAllMessageStreams(id -> id.equals("gsuffa"));
         assertThat(result).containsExactly("gsuffa");
     }
 
     @Test
     public void returnsEmptyListIfNoStreamsFound() {
         final PermittedStreams sut = new PermittedStreams(() -> java.util.stream.Stream.of("oans", "zwoa", "gsuffa"));
-        ImmutableSet<String> result = sut.load(id -> false);
+        ImmutableSet<String> result = sut.loadAllMessageStreams(id -> false);
         assertThat(result).isEmpty();
     }
 
     @Test
     public void filtersDefaultStreams() {
         final PermittedStreams sut = new PermittedStreams(() -> Streams.concat(NON_MESSAGE_STREAM_IDS.stream(), java.util.stream.Stream.of("i'm ok")));
-        ImmutableSet<String> result = sut.load(id -> true);
+        ImmutableSet<String> result = sut.loadAllMessageStreams(id -> true);
         assertThat(result).containsExactly("i'm ok");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -102,7 +102,7 @@ public class SearchResourceExecutionTest {
             }
         };
 
-        when(searchUser.streams().loadAll()).thenReturn(ImmutableSet.of("Default Stream"));
+        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of("Default Stream"));
     }
 
     @Test
@@ -234,7 +234,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         persistSearch(search);
 
-        when(searchUser.streams().loadAll()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeQuery(search.id(), null, searchUser));
@@ -245,7 +245,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         final SearchDTO searchDTO = SearchDTO.fromSearch(search);
 
-        when(searchUser.streams().loadAll()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeSyncJob(searchDTO, 0, searchUser));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -102,7 +102,7 @@ public class SearchResourceExecutionTest {
             }
         };
 
-        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of("Default Stream"));
+        when(searchUser.streams().loadMessageStreamsWithFallback()).thenReturn(ImmutableSet.of("Default Stream"));
     }
 
     @Test
@@ -234,7 +234,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         persistSearch(search);
 
-        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadMessageStreamsWithFallback()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeQuery(search.id(), null, searchUser));
@@ -245,7 +245,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         final SearchDTO searchDTO = SearchDTO.fromSearch(search);
 
-        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadMessageStreamsWithFallback()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeSyncJob(searchDTO, 0, searchUser));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -102,7 +102,7 @@ public class SearchResourceExecutionTest {
             }
         };
 
-        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of("Default Stream"));
+        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of("Default Stream"));
     }
 
     @Test
@@ -234,7 +234,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         persistSearch(search);
 
-        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeQuery(search.id(), null, searchUser));
@@ -245,7 +245,7 @@ public class SearchResourceExecutionTest {
         final Search search = makeNewSearch("search1");
         final SearchDTO searchDTO = SearchDTO.fromSearch(search);
 
-        when(searchUser.streams().loadAllMessageStreams()).thenReturn(ImmutableSet.of());
+        when(searchUser.streams().loadStreamsForEmptyStreamsReplacement()).thenReturn(ImmutableSet.of());
 
         assertThatExceptionOfType(MissingStreamPermissionException.class)
                 .isThrownBy(() -> this.searchResource.executeSyncJob(searchDTO, 0, searchUser));


### PR DESCRIPTION
…ult as well, to prevent unnecessary errors.

## Description
Fixes #https://github.com/Graylog2/graylog-plugin-enterprise/issues/4333
/jpd Graylog2/graylog-plugin-enterprise#6245
## Motivation and Context
Users that can access only non-messages streams (like `events` or `failures`) should still be able to use search page, instead of facing errors, even if they do not specify any stream in the UI. In that case non-messages streams are used as default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

