### PR TITLE
Disable retention strategy `close` for new installs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,9 +19,9 @@ The plugin entity needs the `description` `System` and `children` (array).
 Every child represents a dropdown option and needs a `path` and `description` attribute.
 
 ## Configuration File Changes
-| Option                                         | Action    | Description                                                                                                                                                                                                                                                                          |
-|------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. This is introduced in order to deprecate obsolete strategies in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not disable a strategy while an active index is configured to use it.** |
+| Option                                         | Action    | Description                                                                                                                                                                                                                                                                        |
+|------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. By default, strategies `none` and `close` are now disabled in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not disable a strategy while an active index is configured to use it.** |
 
 
 ## Asset Import Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,9 +19,9 @@ The plugin entity needs the `description` `System` and `children` (array).
 Every child represents a dropdown option and needs a `path` and `description` attribute.
 
 ## Configuration File Changes
-| Option                                         | Action    | Description                                                                                                                                                                                                                                                                        |
-|------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. By default, strategies `none` and `close` are now disabled in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not disable a strategy while an active index is configured to use it.** |
+| Option                                         | Action    | Description                                                                                                                                                                                                                                             |
+|------------------------------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. By default, strategies `none` and `close` are now disabled in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not extend this list on existing installs!** |
 
 
 ## Asset Import Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,12 @@ Now this can be achieved by registering a `navigation` plugin.
 The plugin entity needs the `description` `System` and `children` (array).
 Every child represents a dropdown option and needs a `path` and `description` attribute.
 
+## Configuration File Changes
+| Option                                         | Action    | Description                                                                                                                                                                                                                                                                          |
+|------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. This is introduced in order to deprecate obsolete strategies in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not disable a strategy while an active index is configured to use it.** |
+
+
 ## Asset Import Changes
 
 Graylog 5.2 introduced the Assets feature and the ability to import Assets from Active Directory.
@@ -32,9 +38,9 @@ Any existing Active Directory User Asset import configurations will be automatic
 
 The following Java Code API changes have been made.
 
-| File/method                   | Description              |
-|-------------------------------|--------------------------|
-| `ExampleClass#exampleFuntion` | TODO placeholder comment |
+| File/method                    | Description              |
+|--------------------------------|--------------------------|
+| `ExampleClass#exampleFunction` | TODO placeholder comment |
 
 ## REST API Endpoint Changes
 

--- a/changelog/unreleased/pr-17552.toml
+++ b/changelog/unreleased/pr-17552.toml
@@ -8,5 +8,5 @@ details.user = """
 Configuration setting `disabled_retention_strategies` disables the specified retention strategies.
 This is introduced in order to deprecate obsolete strategies in new installations. Strategies can be re-enabled
 simply by removing from this list.<br/>
-**Do not disable a strategy while an active index is configured to use it.**
+**Do not extend this list on existing installs!**
 """

--- a/changelog/unreleased/pr-17552.toml
+++ b/changelog/unreleased/pr-17552.toml
@@ -1,0 +1,12 @@
+type = "f"
+message = "By default, `none` and `close` retention strategies are disabled for new installations."
+
+issues = ["graylog-plugin-enterprise#5888"]
+pulls = ["17552"]
+
+details.user = """
+Configuration setting `disabled_retention_strategies` disables the specified retention strategies.
+This is introduced in order to deprecate obsolete strategies in new installations. Strategies can be re-enabled
+simply by removing from this list.<br/>
+**Do not disable a strategy while an active index is configured to use it.**
+"""

--- a/changelog/unreleased/pr-17552.toml
+++ b/changelog/unreleased/pr-17552.toml
@@ -1,5 +1,5 @@
 type = "f"
-message = "By default, `none` and `close` retention strategies are disabled for new installations."
+message = "By default, `none` and `close` index retention strategies are disabled for new installations."
 
 issues = ["graylog-plugin-enterprise#5888"]
 pulls = ["17552"]

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -394,8 +394,8 @@ stream_aware_field_types=false
 #   - delete # Deletes the index completely (Default)
 #   - close # Closes the index and hides it from the system. Can be re-opened later.
 #   - none #  No operation is performed. The index stays open. (Not recommended)
-# WARNING: At least one strategy must be enabled
-disabled_retention_strategies = none
+# WARNING: At least one strategy must be enabled. Do not disable a strategy that is currently in use.
+disabled_retention_strategies = none, close
 
 # How many indices do you want to keep for the delete and close retention types?
 #

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -394,8 +394,8 @@ stream_aware_field_types=false
 #   - delete # Deletes the index completely (Default)
 #   - close # Closes the index and hides it from the system. Can be re-opened later.
 #   - none #  No operation is performed. The index stays open. (Not recommended)
-# WARNING: At least one strategy must be enabled. Do not disable a strategy that is currently in use.
-disabled_retention_strategies = none, close
+# WARNING: At least one strategy must be enabled. Only intended for new installs!
+disabled_retention_strategies = none,close
 
 # How many indices do you want to keep for the delete and close retention types?
 #

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -394,7 +394,7 @@ stream_aware_field_types=false
 #   - delete # Deletes the index completely (Default)
 #   - close # Closes the index and hides it from the system. Can be re-opened later.
 #   - none #  No operation is performed. The index stays open. (Not recommended)
-# WARNING: At least one strategy must be enabled. Only intended for new installs!
+# WARNING: At least one strategy must be enabled. Be careful when extending this list on existing installations!
 disabled_retention_strategies = none,close
 
 # How many indices do you want to keep for the delete and close retention types?


### PR DESCRIPTION
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/5888

Adding to #16927 we now also disable retention strategy `close` in example configuration to be used by new installations. 