### PR TITLE
Enabling mouse events for disabled buttons.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -106,6 +106,7 @@ const disabledStyles = (style: ColorVariant, other: Other) => {
 
   return {
     ':disabled': {
+      pointerEvents: 'all',
       color: colors.color,
       backgroundColor: colors.background,
       opacity: '0.65',

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.test.tsx
@@ -112,10 +112,9 @@ describe('SavedSearchForm', () => {
                               saveAsSearch={onSaveAs} />);
 
       const saveAsButton = await screen.findByRole('button', { name: 'Save as' });
+      userEvent.click(saveAsButton);
 
-      expect(() => userEvent.click(saveAsButton)).toThrow(new Error('unable to click element as it has or inherits pointer-events set to "none".'));
-
-      expect(onSaveAs).toHaveBeenCalledTimes(0);
+      expect(onSaveAs).not.toHaveBeenCalled();
     });
 
     it('should handle create new', async () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When migrating `Button` components over to Mantine, we broke displaying inline hover/tooltip-components in the button's caption when the button is disabled.

This PR is fixing this, by enabling pointer events when disabling the button.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.