### PR TITLE
Remove Jenkins build configuration

### DIFF
--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -1,3 +1,0 @@
-@Library('ci-pipeline-shared') _
-
-buildSnapshot(jdk_version: '17')


### PR DESCRIPTION
We no longer use Jenkins to run builds for pull requests and
regular snapshots.

/nocl
