### PR TITLE
added a testing flag to enable the use of retention periods other tha…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -58,6 +58,7 @@ public class ElasticsearchConfiguration {
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MIN_SHARD_SIZE = "time_size_optimizing_rotation_min_shard_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE = "time_size_optimizing_rotation_max_shard_size";
     public static final String TIME_SIZE_OPTIMIZING_ROTATION_PERIOD = "time_size_optimizing_rotation_period";
+    public static final String ALLOW_FLEXIBLE_RETENTION_PERIOD = "allow_flexible_retention_period";
 
     @Parameter(value = "elasticsearch_index_prefix", required = true)
     private String defaultIndexPrefix = "graylog";
@@ -136,6 +137,9 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_RETENTION_FIXED_LEEWAY)
     private Period timeSizeOptimizingRetentionFixedLeeway;
+
+    @Parameter(value = ALLOW_FLEXIBLE_RETENTION_PERIOD)
+    private boolean allowFlexibleRetentionPeriod = false;
 
     @Parameter(value = "elasticsearch_disable_version_check")
     private boolean disableVersionCheck = false;
@@ -297,6 +301,8 @@ public class ElasticsearchConfiguration {
     public int getIndexOptimizationJobs() {
         return indexOptimizationJobs;
     }
+
+    public boolean allowFlexibleRetentionPeriod() { return allowFlexibleRetentionPeriod; }
 
     @ValidatorMethod
     @SuppressWarnings("unused")

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/tso/TimeSizeOptimizingValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/tso/TimeSizeOptimizingValidator.java
@@ -63,11 +63,11 @@ public class TimeSizeOptimizingValidator {
                     ElasticsearchConfiguration.MAX_INDEX_RETENTION_PERIOD, maxRetentionPeriod)));
         }
 
-        if (periodOtherThanDays(indexLifetimeMax)) {
+        if (periodOtherThanDays(indexLifetimeMax) && !elasticsearchConfiguration.allowFlexibleRetentionPeriod()) {
             return Optional.of(IndexSetValidator.Violation.create(f("Lifetime setting %s <%s> can only be a multiple of days",
                     FIELD_INDEX_LIFETIME_MAX, indexLifetimeMax)));
         }
-        if (periodOtherThanDays(indexLifetimeMin)) {
+        if (periodOtherThanDays(indexLifetimeMin) && !elasticsearchConfiguration.allowFlexibleRetentionPeriod()) {
             return Optional.of(IndexSetValidator.Violation.create(f("Lifetime setting %s <%s> can only be a multiple of days",
                     FIELD_INDEX_LIFETIME_MIN, indexLifetimeMin)));
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/tso/TimeSizeOptimizingValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/tso/TimeSizeOptimizingValidatorTest.java
@@ -100,4 +100,20 @@ public class TimeSizeOptimizingValidatorTest {
         assertThat(periodOtherThanDays(Period.weeks(5))).isTrue();
         assertThat(periodOtherThanDays(Period.days(5).withHours(3))).isTrue();
     }
+
+    @Test
+    void testAllowFlexiblePeriodFlag() {
+        when(elasticConfig.getTimeSizeOptimizingRotationPeriod()).thenReturn(Period.minutes(1));
+        when(elasticConfig.getTimeSizeOptimizingRetentionFixedLeeway()).thenReturn(Period.minutes(1));
+        IndexLifetimeConfig config = IndexLifetimeConfig.builder()
+                .indexLifetimeMin(Period.minutes(3))
+                .indexLifetimeMax(Period.minutes(5))
+                .build();
+
+        assertThat(validate(elasticConfig, config)).hasValueSatisfying(v -> assertThat(v.message())
+                .contains("can only be a multiple of days"));
+
+        when(elasticConfig.allowFlexibleRetentionPeriod()).thenReturn(true);
+        assertThat(validate(elasticConfig, config)).isEmpty();
+    }
 }


### PR DESCRIPTION
Added allow_flexible_retention_period flag so that we can use periods other than days. 
Allows us to test rotation and retention in minutes without having to wait 

/nocl
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6182