### PR TITLE
Remove Sidecar migration hint on config page

### DIFF
--- a/changelog/unreleased/pr-17602.toml
+++ b/changelog/unreleased/pr-17602.toml
@@ -1,0 +1,5 @@
+type = "r"
+message = "Removed legacy Sidecar collector migration link in UI."
+
+issues = [""]
+pulls = ["17602"]

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -338,12 +338,6 @@ const ConfigurationForm = ({
                         onClick={_onShowSource}>
                   Preview
                 </Button>
-                <Button className="pull-right"
-                        bsStyle="link"
-                        bsSize="sm"
-                        onClick={_onShowImports}>
-                  Migrate
-                </Button>
                 <HelpBlock>
                   {_formatValidationMessage('template', 'Required. Collector configuration, see quick reference for more information.')}
                 </HelpBlock>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -212,10 +212,6 @@ const ConfigurationForm = ({
     setShowPreviewModal(true);
   };
 
-  const _onShowImports = () => {
-    setShowUploadsModal(true);
-  };
-
   const _formatCollector = (collector) => (collector ? `${collector.name} on ${upperFirst(collector.node_operating_system)}` : 'Unknown collector');
 
   const _formatCollectorOptions = () => {


### PR DESCRIPTION
We don't support legacy Sidecar collectors and their migrations in 5.2 anymore.

Minimal backport version of PR #17589



