### PR TITLE
Add string_entropy pipeline function (5.1)

### DIFF
--- a/changelog/unreleased/pr-15682.toml
+++ b/changelog/unreleased/pr-15682.toml
@@ -1,0 +1,20 @@
+type = "a"
+message = "Added the string_entropy pipeline function."
+
+issues = ["graylog-plugin-enterprise#4839"]
+pulls = ["15682"]
+
+details.user = """
+The `string_entropy` pipeline function is now avaialble and can be used to compute Shannon Entropy for input strings.
+
+Example usage:
+
+```
+rule "string_entropy"
+when
+    true
+then
+    set_field("entropy_value", string_entropy(to_string($message.my_field)));
+end
+```
+"""

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -118,6 +118,7 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.RegexReplace;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Replace;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Split;
 import org.graylog.plugins.pipelineprocessor.functions.strings.StartsWith;
+import org.graylog.plugins.pipelineprocessor.functions.strings.StringEntropy;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
@@ -201,6 +202,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Replace.NAME, Replace.class);
         addMessageProcessorFunction(Length.NAME, Length.class);
         addMessageProcessorFunction(FirstNonNull.NAME, FirstNonNull.class);
+        addMessageProcessorFunction(StringEntropy.NAME, StringEntropy.class);
 
         // json
         addMessageProcessorFunction(JsonParse.NAME, JsonParse.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/ShannonEntropy.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/ShannonEntropy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/*
+ * Shannon Entropy is a common method for quantifying the randomness/sameness of the types withing a collection of
+ * entities. If entities are all the same type, then the entropy is 0. As more and more types are introduced,
+ * the entropy increases. This Java implementation applies a Shannon Entropy calculation to characters within a
+ * string.
+ * <br>
+ * Examples:
+ * - Input: 1111, Entropy: 0
+ * - Input: 5555555555, Entropy: 0.0
+ * - Input: 5555555555, Entropy: 0.0
+ * - Input: 1555555555, Entropy: 0.47
+ * - Input: 1111155555, Entropy: 1.0
+ * - Input: 1234567890, Entropy: 3.32
+ * - Input: 1234567890qwertyuiopasdfghjklzxcvbnm, Entropy: 5.17
+ */
+public class ShannonEntropy {
+
+    /**
+     * Calculate Shannon Entropy for the characters in a string.
+     *
+     * @param input The input string.
+     * @return a double representing the entropy.
+     */
+    public static double calculateForChars(String input) {
+        final Map<Character, Long> charCountMap = input.chars()
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.groupingBy(p -> p, Collectors.counting()));
+
+        double result = 0;
+        for (Character c : charCountMap.keySet()) {
+            double probabilityForChar = (double) charCountMap.get(c) / input.length();
+            result += probabilityForChar * logBaseTwo(1 / probabilityForChar);
+        }
+        return result;
+    }
+
+    private static double logBaseTwo(double input) {
+        return Math.log(input) / Math.log(2);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/StringEntropy.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/StringEntropy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+
+import static com.google.common.collect.ImmutableList.of;
+
+public class StringEntropy extends AbstractFunction<Double> {
+    public static final String NAME = "string_entropy";
+    private final ParameterDescriptor<String, String> valueParam;
+
+    public StringEntropy() {
+        valueParam = ParameterDescriptor.string("value").description("The string to compute Shannon Entropy for.").build();
+    }
+
+    @Override
+    public Double evaluate(FunctionArgs args, EvaluationContext context) {
+        final String value = valueParam.required(args, context);
+        return ShannonEntropy.calculateForChars(value);
+    }
+
+    @Override
+    public FunctionDescriptor<Double> descriptor() {
+        return FunctionDescriptor.<Double>builder()
+                .name(NAME)
+                .returnType(Double.class)
+                .params(of(valueParam))
+                .description("Compute Shannon Entropy for the characters within a string.")
+                .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -122,6 +122,7 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.RegexReplace;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Replace;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Split;
 import org.graylog.plugins.pipelineprocessor.functions.strings.StartsWith;
+import org.graylog.plugins.pipelineprocessor.functions.strings.StringEntropy;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Substring;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Swapcase;
 import org.graylog.plugins.pipelineprocessor.functions.strings.Uncapitalize;
@@ -276,6 +277,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(Replace.NAME, new Replace());
         functions.put(Length.NAME, new Length());
         functions.put(FirstNonNull.NAME, new FirstNonNull());
+        functions.put(StringEntropy.NAME, new StringEntropy());
 
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         functions.put(JsonParse.NAME, new JsonParse(objectMapper));
@@ -1328,6 +1330,16 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    public void stringEntropy() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        final Message message = evaluateRule(rule);
+        assertThat(actionsTriggered.get()).isTrue();
+        assertThat(message).isNotNull();
+        assertThat(message.getField("zero_entropy")).isEqualTo(0.0D);
+        assertThat(message.getField("one_entropy")).isEqualTo(1.0D);
+    }
+
+    @   Test
     public void notExpressionTypeCheck() {
         try {
             Rule rule = parser.parseRule(ruleForTest(), true);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/strings/ShannonEntropyTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/strings/ShannonEntropyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.strings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ShannonEntropyTest {
+    @Test
+    public void testEntropyCalcForChars() {
+        assertEquals(0D, ShannonEntropy.calculateForChars("1111"));
+        assertEquals(0D, ShannonEntropy.calculateForChars("5555555555"), 0.0D);
+        assertEquals(0D, ShannonEntropy.calculateForChars("5555555555"), 0.0D);
+        assertEquals(0.46899559358928133D, ShannonEntropy.calculateForChars("1555555555"));
+        assertEquals(1.0D, ShannonEntropy.calculateForChars("1111155555"));
+        assertEquals(3.3219280948873635D, ShannonEntropy.calculateForChars("1234567890"));
+        assertEquals(5.1699250014423095D, ShannonEntropy.calculateForChars("1234567890qwertyuiopasdfghjklzxcvbnm"));
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/stringEntropy.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/stringEntropy.txt
@@ -1,0 +1,8 @@
+rule "string_entropy"
+when
+    true
+then
+    set_field("zero_entropy", string_entropy("1111"));
+    set_field("one_entropy", string_entropy("1111155555"));
+    trigger_test();
+end


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/15682 to the `5.1` branch. 

Content that uses this function is being worked on in https://github.com/Graylog2/graylog-project-illuminate/issues/1676, and it would be helpful to include this function in 5.1 as well for backwards compatibility for those using that version.
