### PR TITLE
Add handling for JSON arrays in array_contains function

### DIFF
--- a/changelog/unreleased/pr-17611.toml
+++ b/changelog/unreleased/pr-17611.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix issue preventing the array_contains pipeline function from working with json arrays"
+
+pulls = ["17611"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/ArrayContains.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/ArrayContains.java
@@ -16,6 +16,11 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.arrays;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
 import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -23,6 +28,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderFunctionGroup;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,8 +38,11 @@ public class ArrayContains extends AbstractArrayFunction<Boolean> {
     private final ParameterDescriptor<Object, List> elementsParam;
     private final ParameterDescriptor<Object, Object> valueParam;
     private final ParameterDescriptor<Boolean, Boolean> caseSensitiveParam;
+    private final ObjectMapper objectMapper;
 
-    public ArrayContains() {
+    @Inject
+    public ArrayContains(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         elementsParam = ParameterDescriptor.type("elements", Object.class, List.class)
                 .transform(AbstractArrayFunction::toList)
                 .description("The input array, may be null")
@@ -61,6 +70,29 @@ public class ArrayContains extends AbstractArrayFunction<Boolean> {
                     .anyMatch(e -> e.toString().equalsIgnoreCase(String.valueOf(value)));
         }
 
+        return arrayContains(elements, value);
+    }
+
+    private boolean arrayContains(List<Object> elements, Object value) {
+        for (Object element : elements) {
+            if (element instanceof IntNode || element instanceof LongNode) {
+                /* Allow ints and longs to be compared. Sometimes the array will contain ints,
+                 * but a single number passed as the value will be typed as a long.
+                 */
+                final Number number = ((NumericNode) element).numberValue();
+                if (value.equals(number.intValue())) {
+                    return true;
+                }
+                else if (value.equals(number.longValue())) {
+                    return true;
+                }
+            } else if (element instanceof JsonNode) {
+                // Extract embedded JsonNode elements for comparison.
+                if (objectMapper.convertValue(element, Object.class).equals(value)) {
+                    return true;
+                }
+            }
+        }
         return elements.contains(value);
     }
 

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
@@ -7,5 +7,24 @@ then
     set_field("contains_string", array_contains(["test", "test2"], "test"));
     set_field("contains_string_case_insensitive", array_contains(["test", "test2"], "TEST"));
     set_field("contains_string_case_sensitive", array_contains(["test", "test2"], "TEST", true));
+
+    let json = parse_json(to_string($message.json_with_arrays));
+            let selectedPath = select_jsonpath(json: json,
+                paths: { numbers: "$.numbers[*].value",
+                         number: "$.numbers[0].value",
+                         decimals: "$.decimals[*].value",
+                         booleans: "$.booleans[*].value",
+                         strings: "$.strings[*].value"});
+
+    set_field(field: "path_array_strings_contains", value: array_contains(elements: selectedPath.strings, value: "two"));
+    set_field(field: "path_array_numbers_contains", value: array_contains(elements: selectedPath.numbers, value: 2));
+    set_field(field: "path_array_decimals_contains", value: array_contains(elements: selectedPath.decimals, value: 2.2));
+    set_field(field: "path_array_booleans_contains", value: array_contains(elements: selectedPath.booleans, value: true));
+
+    set_field(field: "path_array_not_strings_contains", value: array_contains(elements: selectedPath.strings, value: "ten"));
+    set_field(field: "path_array_not_numbers_contains", value: array_contains(elements: selectedPath.numbers, value: 10));
+    set_field(field: "path_array_not_decimals_contains", value: array_contains(elements: selectedPath.decimals, value: 10.1));
+    set_field(field: "path_array_not_booleans_contains", value: array_contains(elements: selectedPath.booleans, value: false));
+
     trigger_test();
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/with-arrays.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/with-arrays.json
@@ -33,5 +33,46 @@
     {
       "value": "text"
     }
+  ],
+  "numbers": [
+    {
+      "value": 1
+    },
+    {
+      "value": 2
+    },
+    {
+      "value": 3
+    }
+  ],
+  "decimals": [
+    {
+      "value": 1.1
+    },
+    {
+      "value": 2.2
+    },
+    {
+      "value": 3.3
+    }
+  ],
+  "booleans": [
+    {
+      "value": true
+    },
+    {
+      "value": true
+    }
+  ],
+  "strings": [
+    {
+      "value": "one"
+    },
+    {
+      "value": "two"
+    },
+    {
+      "value": "three"
+    }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for JSON nodes in `array_contains` pipeline function. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When array elements are selected from the `json_path` pipeline function, the array will include Jackson `JsonNode` elements containing the actual object values within. When passed to the `array_contains` pipeline function, the function will fail to detect that a string or number is present in the array due to the JSON objects. This fix includes support for the string, number, and boolean data types.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Well-covered with unit tests and manual testing was performed. See PR unit tests for examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

