### PR TITLE
Refactor sidecar default collector migration (5.2 backport)

### DIFF
--- a/changelog/unreleased/issue-17526.toml
+++ b/changelog/unreleased/issue-17526.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix filebeat path for sidecar default templates and default configurations."
+
+issues = ["17526"]
+pulls = ["17624"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -226,13 +226,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
             return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
 
-        // Don't overwrite CRC of an existing collector. We need the original value to
-        // know that the entry has been modified.
-        Collector existingCollector = collectorService.findByNameAndOs(collector.name(), collector.nodeOperatingSystem());
-        if (existingCollector != null && existingCollector.defaultTemplateCRC() != null) {
-            collector = collector.toBuilder().defaultTemplateCRC(existingCollector.defaultTemplateCRC()).build();
-        }
-
         etagService.invalidateAllCollectors();
         return Response.ok().entity(collectorService.save(collector)).build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -101,8 +101,8 @@ public class CollectorService extends PaginatedDbService<Collector> {
                 request.executablePath(),
                 request.executeParameters(),
                 request.validationParameters(),
-                request.defaultTemplate(),
-                null); // this is only ever written by 20180212165000_AddDefaultCollectors
+                request.defaultTemplate()
+                );
     }
 
     public Collector fromRequest(String id, Collector request) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/SidecarServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/SidecarServiceTest.java
@@ -365,7 +365,7 @@ public class SidecarServiceTest {
 
     private static Collector getCollector() {
         return Collector.create("collector-id", "collector-name", "service", "linux",
-                "/path", "param", "valid param", "", null);
+                "/path", "param", "valid param", "");
     }
 
     private Sidecar getTestSidecar() {


### PR DESCRIPTION
* Refactor sidecar default collector migration

Refactoring of #17246

Fixes https://github.com/Graylog2/graylog2-server/issues/17526

Move the state of known default template checksums into the cluster config. This makes it easier to use the checksum for configurations and collectors alike.

* Fix up known configurations

* add comment about OLD_CHECKSUMS

* changelog

* Fix wrong yml path not paths

* Extend checksum entries with collector name and version

(cherry picked from commit 32e19492411eed4131fe2cba465286fa354d5fb5)


