### PR TITLE
Retain position of navigation items when merging duplicate dropdowns.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -132,6 +132,7 @@ const mergeDuplicateDropdowns = (navigationItems: Array<PluginNavigation>): Arra
   if (existingDropdownItemIndex >= 0) {
     const existingDropdownItem = result[existingDropdownItemIndex];
     const newDropdownItem = {
+      ...current,
       ...existingDropdownItem,
       children: [
         ...existingDropdownItem.children,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is possible to extend e.g. the system menu dropdown by registering an entry to the plugin system like
```
{
    description: 'System',
    children: {...}
}
```

This entry will be merged with the existing entry from core, which contains all other menu items. It also includes the position info for the dropdown. Before this change it was possible that the position info got lost when merging the items, depending on the order of entities in the plugin store.

/nocl