### PR TITLE
(Backport 5.1) - Illuminate parsing updates

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -182,7 +182,7 @@ Changed fields:
 Added fields:
 - `event_created`: Contains the `published` log value.
 - `event_source_product`: Contains the static value `okta`.
-- `vendor_subtype`: Contains the `eventType` log value.
+- `vendor_event_type`: Contains the `eventType` log value.
 - `vendor_version`: Contains the `version` log value.
 
 ### F5 BIG-IP input

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -140,6 +140,63 @@ Removed fields:
 
 Note that additional CrowdStrike message parsing is expected to be released in a future release of Graylog Illuminate.
 
+## Input log parsing changes
+
+Log parsing changes have been made several inputs in preparation for Illuminate parsing content. Note that additional 
+message parsing for these inputs is expected to be released in an upcoming release of Graylog Illuminate.
+
+### AWS Security Lake input
+
+Changed fields:
+- `message`: Now contains the full JSON content of the log message. The `vendor_event_description` field now contains the previous `message` field value for backwards-compatibility. 
+- The message `timestamp` field is now set to the current Graylog system date/time, instead of the previously used log `time` value. The `event_created` field now contains the previous `time` value for backwards-compatibility.
+
+Added fields:
+- `event_created`: Contains the `time` log value.
+- `event_source_input`: Contains the static value `aws_security_lake`.
+- `vendor_event_description`: Contains the value which was previously present in the `message` log field.
+- `vendor_version`: Contains the `metadata.product.version` log value.
+
+### Office 365 input
+
+Changed fields:
+- `message`: Now contains the full JSON content of the log message. The `vendor_event_description` field now contains the previous `message` field value for backwards-compatibility. 
+- The message `timestamp` field is now set to the current Graylog system date/time, instead of the previously used log `CreationTime` value. The `event_created` field now contains the previous `CreationTime` value for backwards-compatibility.
+- `vendor_event_description`: Now contains the value which was previously present in the `message` log field.
+
+Added fields:
+- `event_created`: Contains the `CreationTime` log value.
+- `event_source_product`: Contains the static value `o365`.
+- `vendor_subtype`: Contains the `Workload` log value.
+- `vendor_version`: Contains the `Version` log value.
+
+### Okta Log Events input
+
+Several log parsing changes have been made to the Okta Log Events input in preparation for Illuminate parsing content.
+
+Changed fields:
+- `message`: Now contains the full JSON content of the log message. The `vendor_event_description` field now contains the previous `message` field value for backwards-compatibility. 
+- The message `timestamp` field is now set to the current Graylog system date/time, instead of the previously used log `published` value. The `event_created` field now contains the previous `published` value for backwards-compatibility.
+- `vendor_event_description`: Now contains the value which was previously present in the `message` log field.
+
+Added fields:
+- `event_created`: Contains the `published` log value.
+- `event_source_product`: Contains the static value `okta`.
+- `vendor_subtype`: Contains the `eventType` log value.
+- `vendor_version`: Contains the `version` log value.
+
+### F5 BIG-IP input
+
+Changed fields:
+- `message`: Now contains the full text content of the log message. The `vendor_event_description` field now contains the previous `message` field value for backwards-compatibility.
+- The message `timestamp` field is now set to the current Graylog system date/time, instead of the previously used log `vendorTimestamp`, `eventCreated`, or `timestamp` values. The `event_created` field now contains the previous `vendorTimestamp`, `eventCreated`, or `timestamp` value for backwards-compatibility.
+- `source`: Now contains the `host` log value if present, or the static value `F5 BIG-IP` used previously if not.
+- `vendor_event_description`: Now contains the value which was previously present in the `message` log field.
+
+Added fields:
+- `event_created`: Contains the `vendorTimestamp`, `eventCreated`, or `timestamp` log value.
+- `event_source_product`: Contains the static value `f5_big-ip`.
+
 ## Java API Changes
 The following Java Code API changes have been made.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -145,18 +145,6 @@ Note that additional CrowdStrike message parsing is expected to be released in a
 Log parsing changes have been made several inputs in preparation for Illuminate parsing content. Note that additional 
 message parsing for these inputs is expected to be released in an upcoming release of Graylog Illuminate.
 
-### AWS Security Lake input
-
-Changed fields:
-- `message`: Now contains the full JSON content of the log message. The `vendor_event_description` field now contains the previous `message` field value for backwards-compatibility. 
-- The message `timestamp` field is now set to the current Graylog system date/time, instead of the previously used log `time` value. The `event_created` field now contains the previous `time` value for backwards-compatibility.
-
-Added fields:
-- `event_created`: Contains the `time` log value.
-- `event_source_input`: Contains the static value `aws_security_lake`.
-- `vendor_event_description`: Contains the value which was previously present in the `message` log field.
-- `vendor_version`: Contains the `metadata.product.version` log value.
-
 ### Office 365 input
 
 Changed fields:

--- a/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
@@ -23,7 +23,6 @@ public class EventFields {
     public static final String EVENT_END = "event_end";
     public static final String EVENT_ERROR_CODE = "event_error_code";
     public static final String EVENT_ERROR_DESCRIPTION = "event_error_description";
-    public static final String EVENT_INPUT_SOURCE = "event_input_source";
     public static final String EVENT_LOG_NAME = "event_log_name";
     public static final String EVENT_OBSERVER_HOSTNAME = "event_observer_hostname";
     public static final String EVENT_OBSERVER_ID = "event_observer_id";
@@ -34,6 +33,7 @@ public class EventFields {
     public static final String EVENT_REPORTER = "event_reporter";
     public static final String EVENT_SOURCE = "event_source";
     public static final String EVENT_SOURCE_API_VERSION = "event_source_api_version";
+    public static final String EVENT_SOURCE_INPUT = "event_source_input";
     public static final String EVENT_SOURCE_PRODUCT = "event_source_product";
     public static final String EVENT_START = "event_start";
     public static final String EVENT_UID = "event_uid";

--- a/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
@@ -23,6 +23,7 @@ public class EventFields {
     public static final String EVENT_END = "event_end";
     public static final String EVENT_ERROR_CODE = "event_error_code";
     public static final String EVENT_ERROR_DESCRIPTION = "event_error_description";
+    public static final String EVENT_INPUT_SOURCE = "event_input_source";
     public static final String EVENT_LOG_NAME = "event_log_name";
     public static final String EVENT_OBSERVER_HOSTNAME = "event_observer_hostname";
     public static final String EVENT_OBSERVER_ID = "event_observer_id";

--- a/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
@@ -27,6 +27,7 @@ public class VendorFields {
     public static final String VENDOR_EVENT_OUTCOME_REASON = "vendor_event_outcome_reason";
     public static final String VENDOR_EVENT_SEVERITY = "vendor_event_severity";
     public static final String VENDOR_EVENT_SEVERITY_LEVEL = "vendor_event_severity_level";
+    public static final String VENDOR_EVENT_TYPE = "vendor_event_type";
     public static final String VENDOR_PRIVATE_IP = "vendor_private_ip";
     public static final String VENDOR_PRIVATE_IPV6 = "vendor_private_ipv6";
     public static final String VENDOR_PUBLIC_IP = "vendor_public_ip";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Backport to 5.2 of `event_source_input` and `vendor_event_type` GIM fields added for input parsing adjustments and UNPRADING.md updates:
- https://github.com/Graylog2/graylog2-server/pull/17554
- https://github.com/Graylog2/graylog2-server/pull/17622
- https://github.com/Graylog2/graylog2-server/pull/17651
- https://github.com/Graylog2/graylog2-server/pull/17571

/nocl