### PR TITLE
Fixing style of active state for page navigation items.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -126,6 +126,7 @@ const generateStyles = (other: Other, bsStyle: StyleProps, bsSize: BsSize, disab
     },
     label: {
       gap: '0.25em',
+      overflow: 'visible',
     },
   };
 };

--- a/graylog2-web-interface/src/components/common/PageNavigation.tsx
+++ b/graylog2-web-interface/src/components/common/PageNavigation.tsx
@@ -32,37 +32,28 @@ const Container = styled(ButtonToolbar)`
 const StyledButton = styled(Button)(({ theme }) => css`
   font-family: ${theme.fonts.family.navigation};
   font-size: ${theme.fonts.size.navigation};
+  color: ${theme.colors.variant.darker.default};
+  
+  &:hover,
+  &:focus {
+    background: inherit;
+    text-decoration: none;
+  }
 
-  &&&& {
-    color: ${theme.colors.variant.darker.default};
-    
+  &:hover {
+    color: inherit;
+    ${hoverIndicatorStyles(theme)}
+  }
+
+  &.active {
+    color: ${theme.colors.global.textDefault};
+
+    ${activeIndicatorStyles(theme)}
+
     &:hover,
     &:focus {
-      text-decoration: none;
-    }
-
-    > div {
-      &:hover,
-      &:focus {
-        color: ${theme.colors.variant.darker.default};
-      }
-    }
-
-    &:hover {
-      ${hoverIndicatorStyles(theme)}
-    }
-
-    &.active {
-      color: ${theme.colors.global.textDefault};
-
       ${activeIndicatorStyles(theme)}
-
-      &:hover,
-      &:focus {
-        ${activeIndicatorStyles(theme)}
-      }
     }
-  }
 `);
 
 StyledButton.displayName = 'Button';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this change the active state for page navigation items was not being displayed. This is related to recent changes we made for the button component.

Now we display the active state again:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/75b8adcf-1b79-4d84-878e-565e2d023885)

/nocl

