### PR TITLE
Simplify state of `DatePicker` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/DatePicker.test.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.test.tsx
@@ -28,23 +28,9 @@ const mockCurrentUser = alice.toBuilder()
 jest.mock('hooks/useCurrentUser', () => () => mockCurrentUser);
 
 describe('DatePicker', () => {
-  describe('should consider user time zone when displaying selected date', () => {
-    it('for beginning of day (date with user tz)', async () => {
-      render(<DatePicker date="2023-10-19T00:00:00.000+02:00" onChange={() => {}} />);
+  it('should highlight selected day', async () => {
+    render(<DatePicker date="2023-10-19" onChange={() => {}} />);
 
-      expect(await screen.findByText('19')).toHaveAttribute('aria-selected', 'true');
-    });
-
-    it('for end of day (date with user tz)', async () => {
-      render(<DatePicker date="2023-10-19T00:00:00.000+02:00" onChange={() => {}} />);
-
-      expect(await screen.findByText('19')).toHaveAttribute('aria-selected', 'true');
-    });
-
-    it('for end of day (date with UTC tz)', async () => {
-      render(<DatePicker date="2023-10-19T23:59:00.000+00:00" onChange={() => {}} />);
-
-      expect(await screen.findByText('20')).toHaveAttribute('aria-selected', 'true');
-    });
+    expect(await screen.findByText('19')).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/graylog2-web-interface/src/components/common/DatePicker.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.tsx
@@ -59,6 +59,14 @@ const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   }
 `);
 
+const isValidDateProp = (date: string | undefined) => {
+  if (!date) {
+    return true;
+  }
+
+  return isValidDate(toDateObject(date, ['date']));
+};
+
 type Props = {
   date?: string | undefined,
   onChange: (day: Date, modifiers: DayModifiers, event: React.MouseEvent<HTMLDivElement>) => void,
@@ -67,6 +75,10 @@ type Props = {
 };
 
 const DatePicker = ({ date, fromDate, onChange, showOutsideDays }: Props) => {
+  if (!isValidDateProp(date)) {
+    throw Error(`Date time provided for date picker "${date}" is not valid. The expected format is ${DATE_TIME_FORMATS.date}.`);
+  }
+
   const modifiers = useMemo(() => ({
     selected: (moddedDate: Date) => {
       if (!date) {

--- a/graylog2-web-interface/src/components/common/DatePicker.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.tsx
@@ -22,9 +22,7 @@ import styled, { css } from 'styled-components';
 
 import 'react-day-picker/lib/style.css';
 
-import type { DateTime } from 'util/DateTime';
-import { isValidDate } from 'util/DateTime';
-import useUserDateTime from 'hooks/useUserDateTime';
+import { isValidDate, toDateObject, adjustFormat, DATE_TIME_FORMATS } from 'util/DateTime';
 
 const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   width: 100%;
@@ -61,42 +59,29 @@ const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   }
 `);
 
-const useSelectedDate = (date: DateTime | undefined) => {
-  const { toUserTimezone } = useUserDateTime();
-
-  if (!isValidDate(date)) {
-    return undefined;
-  }
-
-  return toUserTimezone(date);
-};
-
 type Props = {
-  date?: DateTime | undefined,
+  date?: string | undefined,
   onChange: (day: Date, modifiers: DayModifiers, event: React.MouseEvent<HTMLDivElement>) => void,
   fromDate?: Date,
   showOutsideDays?: boolean,
 };
 
 const DatePicker = ({ date, fromDate, onChange, showOutsideDays }: Props) => {
-  const { formatTime } = useUserDateTime();
-  const selectedDate = useSelectedDate(date);
-
   const modifiers = useMemo(() => ({
     selected: (moddedDate: Date) => {
-      if (!selectedDate) {
+      if (!date) {
         return false;
       }
 
-      return formatTime(selectedDate, 'date') === formatTime(moddedDate, 'date');
+      return date === adjustFormat(moddedDate, 'date');
     },
     disabled: {
       before: new Date(fromDate),
     },
-  }), [formatTime, fromDate, selectedDate]);
+  }), [fromDate, date]);
 
   return (
-    <StyledDayPicker initialMonth={selectedDate ? selectedDate.toDate() : undefined}
+    <StyledDayPicker initialMonth={date ? toDateObject(date).toDate() : undefined}
                      onDayClick={onChange}
                      modifiers={modifiers}
                      showOutsideDays={showOutsideDays} />

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
@@ -31,6 +31,7 @@ type Props = {
 const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
   const { userTimezone, formatTime } = useUserDateTime();
   const initialDateTime = toUTCFromTz(dateTime, userTimezone);
+  const initialDate = formatTime(initialDateTime, 'date');
 
   const _onDatePicked = (selectedDate: Date) => {
     if (!!startDate && DateUtils.isDayBefore(selectedDate, startDate)) {
@@ -48,7 +49,7 @@ const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
   };
 
   return (
-    <DatePicker date={initialDateTime}
+    <DatePicker date={initialDate}
                 onChange={_onDatePicked}
                 fromDate={startDate} />
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the `DatePicker` component allowed any date time as input for the selected date. It could be a moment date or a string like `2023-10-17T01:00:00.000Z`.

Since the date could include a time we had to consider the user time zone when highlighting the selected day.

With this PR we are simplifying the related logic, the component now expects the provided selected date to have the following format: `YYYY-MM-DD`. `onChange` it now also just provides a date with this format.

/nocl