### PR TITLE
Check for reserved words in variable naming

### DIFF
--- a/changelog/unreleased/issue-7006.toml
+++ b/changelog/unreleased/issue-7006.toml
@@ -1,0 +1,9 @@
+type = "c"
+message = "An error message is displayed if a variable in a pipeline rule is given a reserved name."
+details.user = """
+The rule language includes a number of reserved keywords, e.g. `let`, `and`, `then`, etc.
+Variable names may not match any of these keywords.
+"""
+
+issues = ["7006"]
+pulls = [""]

--- a/changelog/unreleased/issue-7006.toml
+++ b/changelog/unreleased/issue-7006.toml
@@ -1,5 +1,5 @@
 type = "c"
-message = "An error message is displayed if a variable in a pipeline rule is given a reserved name."
+message = "Pipeline rule builder displays an error message if a variable name is a reserved keyword."
 details.user = """
 The rule language includes a number of reserved keywords, e.g. `let`, `and`, `then`, etc.
 Variable names may not match any of these keywords.

--- a/changelog/unreleased/issue-7006.toml
+++ b/changelog/unreleased/issue-7006.toml
@@ -6,4 +6,4 @@ Variable names may not match any of these keywords.
 """
 
 issues = ["7006"]
-pulls = [""]
+pulls = ["17680"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariables.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariables.java
@@ -40,7 +40,7 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 public class ValidVariables implements Validator {
 
     private final Map<String, RuleFragment> actions;
-    private Map<String, Class<?>> variables;
+    private final Map<String, Class<?>> variables;
     private final Set<String> tokenNames;
 
     @Inject
@@ -48,7 +48,7 @@ public class ValidVariables implements Validator {
         this.actions = ruleBuilderRegistry.actions();
         this.variables = new HashMap<>();
 
-        this.tokenNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        this.tokenNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         this.tokenNames.addAll(Arrays.asList(RuleLangLexer.tokenNames));
     }
 
@@ -72,7 +72,6 @@ public class ValidVariables implements Validator {
         ImmutableList<ParameterDescriptor> parameterDescriptors = functionDescriptor.params();
         for(ParameterDescriptor parameterDescriptor: parameterDescriptors) {
             String parameterName = parameterDescriptor.name();
-
             Object value = stepParameters.get(parameterName);
             Class<?> variableType = getVariableType(value);
 


### PR DESCRIPTION
References #7006 

Extend pipeline variable validator to also check for reserved keywords.
E.g. this does not work and we now alert the user to this fact in the rulebuilder UI.

> let match=regex(a,b);

However, this does nothing for source code editor. The experience is still broken.