### PR TITLE
Fix Reporting erroneous distribution of table column width 5.1

### DIFF
--- a/changelog/unreleased/pr-17642.toml
+++ b/changelog/unreleased/pr-17642.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix distribution of table column width for print version of data table and message list widget"
+
+issues = ["Graylog2/graylog-plugin-enterprise#6158"]
+pulls = ["17642"]

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
@@ -142,12 +142,6 @@ const StyledTable = styled(Table)(({ theme, $stickyHeader, $borderedHeader }: { 
   th:hover i.sort-order-item {
     color: ${theme.colors.global.textAlt};
   }
-  
-  @media print {
-    tr.fields-row > td {
-      min-width: 0;
-    }
-  }
 `);
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -62,7 +62,6 @@ const Table = styled.table(({ theme }) => css`
       left: 0;
       padding: 5px !important;
       position: static;
-      min-width: 0 !important;
     }
   }
 `);


### PR DESCRIPTION
Note: This is a backport of https://github.com/Graylog2/graylog2-server/pull/17642 to 5.1.

## Description
This pr removes min-width 0 style from td in printing mode 

## Motivation and Context
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/6158
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.