### PR TITLE
Fixing text alignment for highlighted numbers. (`5.2`)

### DIFF
--- a/changelog/unreleased/pr-17678.toml
+++ b/changelog/unreleased/pr-17678.toml
@@ -1,0 +1,6 @@
+type = "f"
+message = "Fixing text alignment of highlighted numbers in data tables."
+
+pulls = ["17678"]
+
+

--- a/graylog2-web-interface/src/views/components/highlighting/Highlight.tsx
+++ b/graylog2-web-interface/src/views/components/highlighting/Highlight.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 
-const BackgroundColor = styled.div<{ $color: string }>(({ theme, $color }) => css`
+const BackgroundColor = styled.span<{ $color: string }>(({ theme, $color }) => css`
   background-color: ${$color};
   color: ${theme.utils.contrastingColor($color)};
   width: fit-content;


### PR DESCRIPTION
**Note:** This is a backport of #17678 to `5.2`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing up the text alignment of numbers in data tables which is usually right, but changed to be left-aligned when the number is highlighted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.