### PR TITLE
Consider availability for initially selected perspective.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -192,7 +192,7 @@ const useNavigationItems = () => {
       navigationItems.push(securityNavigation);
     }
 
-    const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective);
+    const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective.id);
 
     return sortItemsByPosition(itemsForActivePerspective);
   }, [activePerspective, allNavigationItems, permissions]);

--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -192,7 +192,7 @@ const useNavigationItems = () => {
       navigationItems.push(securityNavigation);
     }
 
-    const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective.id);
+    const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective?.id);
 
     return sortItemsByPosition(itemsForActivePerspective);
   }, [activePerspective, allNavigationItems, permissions]);

--- a/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
+++ b/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
@@ -43,7 +43,7 @@ const ActivePerspectiveBrand = ({ children, className }: PropsWithChildren<{ cla
 
   return (
     <BrandContainer className={className}>
-      <BrandLink to={activePerspective.brandLink}>
+      <BrandLink to={activePerspective.welcomeRoute}>
         <ActiveBrandComponent />
       </BrandLink>
       {children}

--- a/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
+++ b/graylog2-web-interface/src/components/perspectives/ActivePerspectiveBrand.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { Link } from 'components/common/router';
 import { NAV_ITEM_HEIGHT } from 'theme/constants';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
-import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 
 const BrandContainer = styled.div`
   display: flex;
@@ -35,9 +34,7 @@ const BrandLink = styled(Link)`
 `;
 
 const ActivePerspectiveBrand = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
-  const perspectives = usePerspectives();
-  const { activePerspective: activePerspectiveId } = useActivePerspective();
-  const activePerspective = perspectives.find(({ id }) => id === activePerspectiveId);
+  const { activePerspective } = useActivePerspective();
   const ActiveBrandComponent = activePerspective?.brandComponent;
 
   if (!ActiveBrandComponent) {

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
@@ -39,13 +39,13 @@ describe('PerspectivesSwitcher', () => {
       id: 'default',
       title: 'Default Perspective',
       brandComponent: () => <div>Default perspective</div>,
-      brandLink: '',
+      welcomeRoute: '',
     },
     {
       id: 'example-perspective',
       title: 'Example Perspective',
       brandComponent: () => <div />,
-      brandLink: '/example-perspective',
+      welcomeRoute: '/example-perspective',
     },
   ];
 

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
@@ -34,28 +34,29 @@ jest.mock('routing/useHistory');
 describe('PerspectivesSwitcher', () => {
   let history;
   const setActivePerspective = jest.fn();
+  const mockedPerspectives = [
+    {
+      id: 'default',
+      title: 'Default Perspective',
+      brandComponent: () => <div>Default perspective</div>,
+      brandLink: '',
+    },
+    {
+      id: 'example-perspective',
+      title: 'Example Perspective',
+      brandComponent: () => <div />,
+      brandLink: '/example-perspective',
+    },
+  ];
 
   beforeEach(() => {
     history = mockHistory();
     asMock(useHistory).mockReturnValue(history);
 
-    asMock(usePerspectives).mockReturnValue([
-      {
-        id: 'default',
-        title: 'Default Perspective',
-        brandComponent: () => <div>Default perspective</div>,
-        brandLink: '',
-      },
-      {
-        id: 'example-perspective',
-        title: 'Example Perspective',
-        brandComponent: () => <div />,
-        brandLink: '/example-perspective',
-      },
-    ]);
+    asMock(usePerspectives).mockReturnValue(mockedPerspectives);
 
     asMock(useActivePerspective).mockReturnValue({
-      activePerspective: 'default',
+      activePerspective: mockedPerspectives[0],
       setActivePerspective,
     });
   });

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
@@ -23,6 +23,7 @@ import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 import { asMock } from 'helpers/mocking';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 import mockHistory from 'helpers/mocking/mockHistory';
+import { defaultPerspective, examplePerspective } from 'fixtures/perspectives';
 
 import PerspectivesSwitcher from './PerspectivesSwitcher';
 
@@ -34,20 +35,7 @@ jest.mock('routing/useHistory');
 describe('PerspectivesSwitcher', () => {
   let history;
   const setActivePerspective = jest.fn();
-  const mockedPerspectives = [
-    {
-      id: 'default',
-      title: 'Default Perspective',
-      brandComponent: () => <div>Default perspective</div>,
-      welcomeRoute: '',
-    },
-    {
-      id: 'example-perspective',
-      title: 'Example Perspective',
-      brandComponent: () => <div />,
-      welcomeRoute: '/example-perspective',
-    },
-  ];
+  const mockedPerspectives = [defaultPerspective, examplePerspective];
 
   beforeEach(() => {
     history = mockHistory();
@@ -71,10 +59,10 @@ describe('PerspectivesSwitcher', () => {
     render(<PerspectivesSwitcher />);
 
     userEvent.click(await screen.findByRole('button', { name: /change ui perspective/i }));
-    userEvent.click(await screen.findByText(/example perspective/i));
+    userEvent.click(await screen.findByText(new RegExp(examplePerspective.title, 'i')));
 
-    await waitFor(() => expect(history.push).toHaveBeenCalledWith('/example-perspective'));
+    await waitFor(() => expect(history.push).toHaveBeenCalledWith(examplePerspective.welcomeRoute));
 
-    expect(setActivePerspective).toHaveBeenCalledWith('example-perspective');
+    expect(setActivePerspective).toHaveBeenCalledWith(examplePerspective.id);
   });
 });

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -64,9 +64,9 @@ const Switcher = () => {
   const history = useHistory();
 
   const onChangePerspective = useCallback((nextPerspectiveId: string) => () => {
-    const { brandLink } = perspectives.find(({ id }) => id === nextPerspectiveId);
+    const { welcomeRoute } = perspectives.find(({ id }) => id === nextPerspectiveId);
 
-    history.push(brandLink);
+    history.push(welcomeRoute);
     setActivePerspective(nextPerspectiveId);
   }, [history, perspectives, setActivePerspective]);
 

--- a/graylog2-web-interface/src/components/perspectives/bindings.ts
+++ b/graylog2-web-interface/src/components/perspectives/bindings.ts
@@ -24,7 +24,7 @@ const perspectivesBindings = {
     {
       id: 'default',
       title: 'General',
-      brandLink: Routes.WELCOME,
+      welcomeRoute: Routes.WELCOME,
       brandComponent: DefaultBrand,
     },
   ],

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesContext.ts
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesContext.ts
@@ -20,7 +20,7 @@ import { singleton } from 'logic/singleton';
 import type { Perspective } from 'components/perspectives/types';
 
 type PerspectivesContextType = {
-  activePerspective: string,
+  activePerspective: Perspective,
   availablePerspectives: Array<Perspective>
   setActivePerspective: (perspectiveId: string) => void
 }

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
@@ -28,6 +28,12 @@ import type { Perspective } from 'components/perspectives/types';
 
 import PerspectivesContext from './PerspectivesContext';
 
+const DEFAULT_PERSPECTIVE = 'default';
+
+const findPerspective = (perspectives: Array<Perspective>, perspectiveId: string) => (
+  perspectives.find(({ id }) => id === perspectiveId)
+);
+
 const usePersistedSetting = (settingKey: string) => {
   const { userIsReadOnly, username } = useStore(CurrentUserStore, (userStore) => ({
     username: userStore.currentUser?.username,
@@ -54,19 +60,17 @@ const usePersistedSetting = (settingKey: string) => {
 
 const useActivePerspectiveState = (availablePerspectives: Array<Perspective>) => {
   const [persistedPerspective, setPersistedPerspective] = usePersistedSetting('perspective');
-  const [activePerspective, setActivePerspective] = useState(persistedPerspective ?? 'default');
+  const [activePerspective, setActivePerspective] = useState<string>(
+    findPerspective(availablePerspectives, persistedPerspective) ? persistedPerspective : DEFAULT_PERSPECTIVE,
+  );
   const setActivePerspectiveWithPersistence = useCallback((newPerspective: string) => {
     setActivePerspective(newPerspective);
 
     return setPersistedPerspective(newPerspective);
   }, [setPersistedPerspective]);
 
-  const findPerspective = useCallback((perspective: string) => (
-    availablePerspectives.find(({ id }) => id === perspective)
-  ), [availablePerspectives]);
-
   return {
-    activePerspective: findPerspective(activePerspective) ?? findPerspective('default'),
+    activePerspective: findPerspective(availablePerspectives, activePerspective),
     setActivePerspective: setActivePerspectiveWithPersistence,
   };
 };

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
@@ -76,7 +76,6 @@ const PerspectivesProvider = ({ children }: PropsWithChildren) => {
   const availablePerspectives = allPerspectives
     .filter((perspective) => (perspective.useCondition ? !!perspective.useCondition() : true));
   const { activePerspective, setActivePerspective } = useActivePerspectiveState(availablePerspectives);
-
   const contextValue = useMemo(() => ({
     activePerspective,
     availablePerspectives,

--- a/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
+++ b/graylog2-web-interface/src/components/perspectives/contexts/PerspectivesProvider.tsx
@@ -61,8 +61,12 @@ const useActivePerspectiveState = (availablePerspectives: Array<Perspective>) =>
     return setPersistedPerspective(newPerspective);
   }, [setPersistedPerspective]);
 
+  const findPerspective = useCallback((perspective: string) => (
+    availablePerspectives.find(({ id }) => id === perspective)
+  ), [availablePerspectives]);
+
   return {
-    activePerspective: availablePerspectives.find(({ id }) => id === activePerspective) ? activePerspective : 'default',
+    activePerspective: findPerspective(activePerspective) ?? findPerspective('default'),
     setActivePerspective: setActivePerspectiveWithPersistence,
   };
 };

--- a/graylog2-web-interface/src/components/perspectives/hooks/useActivePerspective.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/useActivePerspective.test.tsx
@@ -21,20 +21,14 @@ import useActivePerspective from 'components/perspectives/hooks/useActivePerspec
 import PerspectivesProvider from 'components/perspectives/contexts/PerspectivesProvider';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { asMock } from 'helpers/mocking';
+import { defaultPerspective } from 'fixtures/perspectives';
 
 jest.mock('hooks/usePluginEntities');
 
 describe('useActivePerspective', () => {
   beforeEach(() => {
     asMock(usePluginEntities).mockImplementation((entityKey) => ({
-      perspectives: [
-        {
-          id: 'default',
-          title: 'Default Perspective',
-          brandComponent: () => <div>Default perspective</div>,
-          welcomeRoute: '',
-        },
-      ],
+      perspectives: [defaultPerspective],
     }[entityKey]));
   });
 
@@ -47,7 +41,7 @@ describe('useActivePerspective', () => {
   it('should return active perspective', async () => {
     const { result } = renderHook(() => useActivePerspective(), { wrapper });
 
-    expect(result.current.activePerspective.id).toEqual('default');
+    expect(result.current.activePerspective).toEqual(defaultPerspective);
   });
 
   it('should throw error when being used outside of PerspectivesContext', async () => {

--- a/graylog2-web-interface/src/components/perspectives/hooks/useActivePerspective.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/useActivePerspective.test.tsx
@@ -19,10 +19,23 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 import PerspectivesProvider from 'components/perspectives/contexts/PerspectivesProvider';
+import usePluginEntities from 'hooks/usePluginEntities';
+import { asMock } from 'helpers/mocking';
+
+jest.mock('hooks/usePluginEntities');
 
 describe('useActivePerspective', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  beforeEach(() => {
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({
+      perspectives: [
+        {
+          id: 'default',
+          title: 'Default Perspective',
+          brandComponent: () => <div>Default perspective</div>,
+          welcomeRoute: '',
+        },
+      ],
+    }[entityKey]));
   });
 
   const wrapper = ({ children }: React.PropsWithChildren) => (
@@ -34,7 +47,7 @@ describe('useActivePerspective', () => {
   it('should return active perspective', async () => {
     const { result } = renderHook(() => useActivePerspective(), { wrapper });
 
-    expect(result.current.activePerspective).toEqual('default');
+    expect(result.current.activePerspective.id).toEqual('default');
   });
 
   it('should throw error when being used outside of PerspectivesContext', async () => {

--- a/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
@@ -25,19 +25,19 @@ jest.mock('hooks/usePluginEntities', () => () => ([
     id: 'default',
     title: 'Default Perspective',
     brandComponent: () => {},
-    brandLink: '',
+    welcomeRoute: '',
   },
   {
     id: 'example-perspective',
     title: 'Example Perspective',
     brandComponent: () => {},
-    brandLink: '',
+    welcomeRoute: '',
   },
   {
     id: 'unavailable-perspective',
     title: 'Unavailable Perspective',
     brandComponent: () => {},
-    brandLink: '',
+    welcomeRoute: '',
     useCondition: () => false,
   },
 ]));

--- a/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
@@ -19,28 +19,9 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 
 import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 import PerspectivesProvider from 'components/perspectives/contexts/PerspectivesProvider';
+import { defaultPerspective, examplePerspective, unavailablePerspective } from 'fixtures/perspectives';
 
-jest.mock('hooks/usePluginEntities', () => () => ([
-  {
-    id: 'default',
-    title: 'Default Perspective',
-    brandComponent: () => {},
-    welcomeRoute: '',
-  },
-  {
-    id: 'example-perspective',
-    title: 'Example Perspective',
-    brandComponent: () => {},
-    welcomeRoute: '',
-  },
-  {
-    id: 'unavailable-perspective',
-    title: 'Unavailable Perspective',
-    brandComponent: () => {},
-    welcomeRoute: '',
-    useCondition: () => false,
-  },
-]));
+jest.mock('hooks/usePluginEntities', () => () => [defaultPerspective, examplePerspective, unavailablePerspective]);
 
 describe('usePerspectives', () => {
   afterEach(() => {
@@ -56,7 +37,7 @@ describe('usePerspectives', () => {
   it('should return available perspectives', async () => {
     const { result } = renderHook(() => usePerspectives(), { wrapper });
 
-    expect(result.current.map(({ id }) => id)).toEqual(['default', 'example-perspective']);
+    expect(result.current.map(({ id }) => id)).toEqual([defaultPerspective.id, examplePerspective.id]);
   });
 
   it('should throw error when being used outside of PerspectivesContext', async () => {

--- a/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/hooks/usePerspectives.test.tsx
@@ -21,7 +21,8 @@ import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 import PerspectivesProvider from 'components/perspectives/contexts/PerspectivesProvider';
 import { defaultPerspective, examplePerspective, unavailablePerspective } from 'fixtures/perspectives';
 
-jest.mock('hooks/usePluginEntities', () => () => [defaultPerspective, examplePerspective, unavailablePerspective]);
+const mockedPerspectives = [defaultPerspective, examplePerspective, unavailablePerspective];
+jest.mock('hooks/usePluginEntities', () => () => mockedPerspectives);
 
 describe('usePerspectives', () => {
   afterEach(() => {

--- a/graylog2-web-interface/src/components/perspectives/types.ts
+++ b/graylog2-web-interface/src/components/perspectives/types.ts
@@ -20,7 +20,7 @@ import type * as React from 'react';
 export type Perspective = {
   id: string,
   title: string,
-  brandLink: string,
+  welcomeRoute: string,
   brandComponent: React.ComponentType<{
     className?: string,
     disabled?: boolean,

--- a/graylog2-web-interface/src/pages/StartPage.tsx
+++ b/graylog2-web-interface/src/pages/StartPage.tsx
@@ -21,9 +21,11 @@ import Routes from 'routing/Routes';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import { useStore } from 'stores/connect';
 import useHistory from 'routing/useHistory';
+import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 
 const StartPage = () => {
   const { currentUser } = useStore(CurrentUserStore);
+  const { activePerspective } = useActivePerspective();
   const isLoading = !currentUser;
   const history = useHistory();
 
@@ -49,8 +51,9 @@ const StartPage = () => {
       return;
     }
 
+    console.log('startpage', { activePerspective });
     redirect(Routes.WELCOME);
-  }, [currentUser?.startpage, redirect]);
+  }, [activePerspective, currentUser?.startpage, redirect]);
 
   useEffect(() => {
     CurrentUserStore.reload();

--- a/graylog2-web-interface/src/pages/StartPage.tsx
+++ b/graylog2-web-interface/src/pages/StartPage.tsx
@@ -51,8 +51,7 @@ const StartPage = () => {
       return;
     }
 
-    console.log('startpage', { activePerspective });
-    redirect(Routes.WELCOME);
+    redirect(activePerspective.brandLink);
   }, [activePerspective, currentUser?.startpage, redirect]);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/pages/StartPage.tsx
+++ b/graylog2-web-interface/src/pages/StartPage.tsx
@@ -51,7 +51,7 @@ const StartPage = () => {
       return;
     }
 
-    redirect(activePerspective.brandLink);
+    redirect(activePerspective.welcomeRoute);
   }, [activePerspective, currentUser?.startpage, redirect]);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -30,6 +30,7 @@ import usePluginEntities from 'hooks/usePluginEntities';
 import AppConfig from 'util/AppConfig';
 import GlobalContextProviders from 'contexts/GlobalContextProviders';
 import HotkeysProvider from 'contexts/HotkeysProvider';
+import { defaultPerspective } from 'fixtures/perspectives';
 
 import AppRouter from './AppRouter';
 
@@ -86,14 +87,7 @@ const mockRoutes = (routes: PluginExports['routes']) => {
 
 describe('AppRouter', () => {
   const defaultPlugins = {
-    perspectives: [
-      {
-        id: 'default',
-        title: 'Default Perspective',
-        brandComponent: () => <div />,
-        welcomeRoute: '',
-      },
-    ],
+    perspectives: [defaultPerspective],
   };
 
   beforeEach(() => {

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -91,7 +91,7 @@ describe('AppRouter', () => {
         id: 'default',
         title: 'Default Perspective',
         brandComponent: () => <div />,
-        brandLink: '',
+        welcomeRoute: '',
       },
     ],
   };

--- a/graylog2-web-interface/test/fixtures/perspectives.tsx
+++ b/graylog2-web-interface/test/fixtures/perspectives.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import React from 'react';
+
+export const defaultPerspective = {
+  id: 'default',
+  title: 'Default Perspective',
+  brandComponent: () => <div>Default perspective</div>,
+  welcomeRoute: '',
+};
+
+export const examplePerspective = {
+  id: 'example-perspective',
+  title: 'Example Perspective',
+  brandComponent: () => <div />,
+  welcomeRoute: '',
+};
+
+export const unavailablePerspective = {
+  id: 'unavailable-perspective',
+  title: 'Unavailable Perspective',
+  brandComponent: () => <div />,
+  welcomeRoute: '',
+  useCondition: () => false,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the following scenario resulted in a problem:

1. A user selects a perspective from a plugin
2. The perspective becomes unavailable, e.g. because a required licence or permissions are missing
3. The user logs in again

Before this change the previously selected perspective was still the active one. Now we are considering if the selected perspective is actually available.

When testing this locally please test these changes together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/6320 and https://github.com/Graylog2/graylog-plugin-enterprise/pull/6309

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6320

/nocl