### PR TITLE
Datanode: ensure `password_secret` meets length requirement

### DIFF
--- a/changelog/unreleased/issue-17523.toml
+++ b/changelog/unreleased/issue-17523.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Ensure password secret meets the minimum length requirement."
+
+issues = ["17523"]
+pulls = [""]

--- a/changelog/unreleased/issue-17523.toml
+++ b/changelog/unreleased/issue-17523.toml
@@ -2,4 +2,4 @@ type = "c"
 message = "Ensure password secret meets the minimum length requirement."
 
 issues = ["17523"]
-pulls = [""]
+pulls = ["17719"]

--- a/changelog/unreleased/issue-17523.toml
+++ b/changelog/unreleased/issue-17523.toml
@@ -1,5 +1,5 @@
 type = "c"
-message = "Ensure password secret meets the minimum length requirement."
+message = "Ensure password secret meets the minimum length requirement if using/for the DataNode."
 
 issues = ["17523"]
 pulls = ["17719"]

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -289,7 +289,7 @@ public class Configuration extends BaseConfiguration {
     @SuppressWarnings("unused")
     public void validatePasswordSecret() throws ValidationException {
         if (passwordSecret == null || passwordSecret.length() < 64) {
-            throw new ValidationException("The minimum length for \"password_secret\" is 16 characters.");
+            throw new ValidationException("The minimum length for \"password_secret\" is 64 characters.");
         }
     }
 

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -288,7 +288,7 @@ public class Configuration extends BaseConfiguration {
     @ValidatorMethod
     @SuppressWarnings("unused")
     public void validatePasswordSecret() throws ValidationException {
-        if (passwordSecret == null || passwordSecret.length() < 16) {
+        if (passwordSecret == null || passwordSecret.length() < 64) {
             throw new ValidationException("The minimum length for \"password_secret\" is 16 characters.");
         }
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -20,7 +20,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.graylog.testing.completebackend.ContainerizedGraylogBackendServicesProvider.Services;
 import org.graylog.testing.containermatrix.MongodbServer;
-import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
 import org.graylog.testing.graylognode.MavenPackager;
 import org.graylog.testing.graylognode.NodeContainerConfig;
@@ -37,12 +36,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(ContainerizedGraylogBackend.class);
-    public static final String PASSWORD_SECRET = "M4lteserKreuzHerrStrack?-warZuKurzDeshalbMussdaNochWasdran";
+    public static final String PASSWORD_SECRET = "M4lteserKreuzHerrStrack?-warZuKurzDeshalbMussdaNochWasdranHasToBeAtLeastSixtyFourCharactersInLength";
     public static final String ROOT_PASSWORD_PLAINTEXT = "admin";
     public static final String ROOT_PASSWORD_SHA_2 = DigestUtils.sha256Hex(ROOT_PASSWORD_PLAINTEXT);
 


### PR DESCRIPTION
Resolves #17523 

Update validation for `password_secret` to ensure it meets minimum length requirement.