### PR TITLE
Wait till datanode becomes available during startup

### DIFF
--- a/changelog/unreleased/pr-17758.toml
+++ b/changelog/unreleased/pr-17758.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Wait for Datanode to become available during graylog server startup"
+
+pulls = ["17758"]

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -53,6 +53,20 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_version_probe_delay", validators = {PositiveDurationValidator.class})
     Duration elasticsearchVersionProbeDelay = Duration.seconds(5L);
 
+    /**
+     * Zero means unlimited attempts, will try until one datanode appears. The elasticsearch_version_probe_attempts
+     * fallback property is used because the
+     */
+    @Parameter(value = "datanode_startup_connection_attempts", fallbackPropertyName = "elasticsearch_version_probe_attempts", validators = {PositiveIntegerValidator.class})
+    int datanodeStartupConnectionAttempts = 0;
+
+    /**
+     * Seconds between each attempt to access datanode. Too long and you'll be waiting unnecessarily, too short and you
+     * will be flooded by error messages in your logs.
+     */
+    @Parameter(value = "datanode_startup_connection_delay", fallbackPropertyName = "elasticsearch_version_probe_delay", validators = {PositiveDurationValidator.class})
+    Duration datanodeStartupConnectionDelay = Duration.seconds(5L);
+
     @Parameter(value = "elasticsearch_max_total_connections", validators = {PositiveIntegerValidator.class})
     int elasticsearchMaxTotalConnections = 200;
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
@@ -29,18 +29,15 @@ import org.graylog2.bootstrap.preflight.PreflightConfigService;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.nodes.DataNodeDto;
 import org.graylog2.cluster.nodes.NodeService;
-import org.graylog2.storage.SearchVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -65,8 +62,8 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
     @Inject
     public IndexerDiscoveryProvider(
             @Named("elasticsearch_hosts") List<URI> hosts,
-            @Named("elasticsearch_version_probe_attempts") int connectionAttempts,
-            @Named("elasticsearch_version_probe_delay") Duration delayBetweenAttempts,
+            @Named("datanode_startup_connection_attempts") int connectionAttempts,
+            @Named("datanode_startup_connection_delay") Duration delayBetweenAttempts,
             PreflightConfigService preflightConfigService,
             NodeService<DataNodeDto> nodeService) {
         this.hosts = hosts;

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
@@ -100,7 +100,7 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
                         .withRetryListener(new RetryListener() {
                             @Override
                             public void onRetry(Attempt attempt) {
-                                if (!attempt.hasResult()) {
+                                if (!attempt.hasResult() || isEmptyList(attempt.getResult())) {
                                     if (connectionAttempts == 0) {
                                         LOG.info("Datanode is not available. Retry #{}", attempt.getAttemptNumber());
                                     } else {
@@ -123,6 +123,10 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
         LOG.info("No indexer hosts configured, using fallback {}", DEFAULT_INDEXER_HOST);
         return Collections.singletonList(DEFAULT_INDEXER_HOST);
 
+    }
+
+    private boolean isEmptyList(Object result) {
+        return result instanceof List<?> && ((List<?>)result).isEmpty();
     }
 
     private List<URI> discover() {

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
@@ -16,21 +16,32 @@
  */
 package org.graylog2.configuration;
 
+import com.github.joschi.jadconfig.util.Duration;
+import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryListener;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Suppliers;
 import org.graylog2.bootstrap.preflight.PreflightConfigResult;
 import org.graylog2.bootstrap.preflight.PreflightConfigService;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.nodes.DataNodeDto;
 import org.graylog2.cluster.nodes.NodeService;
+import org.graylog2.storage.SearchVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -47,12 +58,20 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
 
     private final Supplier<List<URI>> resultsCachingSupplier;
 
+    private final int connectionAttempts;
+    private final Duration delayBetweenAttempts;
+
+
     @Inject
     public IndexerDiscoveryProvider(
             @Named("elasticsearch_hosts") List<URI> hosts,
+            @Named("elasticsearch_version_probe_attempts") int connectionAttempts,
+            @Named("elasticsearch_version_probe_delay") Duration delayBetweenAttempts,
             PreflightConfigService preflightConfigService,
             NodeService<DataNodeDto> nodeService) {
         this.hosts = hosts;
+        this.connectionAttempts = connectionAttempts;
+        this.delayBetweenAttempts = delayBetweenAttempts;
         this.preflightConfigService = preflightConfigService;
         this.nodeService = nodeService;
         this.resultsCachingSupplier = Suppliers.memoize(this::doGet);
@@ -74,12 +93,28 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
 
         // if preflight is finished, we assume that there will be some datanode registered via node-service.
         if (preflightResult == PreflightConfigResult.FINISHED) {
-            final List<URI> discovered = discover();
-            if (!discovered.isEmpty()) {
-                return discovered;
-            } else {
-                // TODO: we could wait here(or in the preflight check) for a datanode to register.
-                throw new IllegalStateException("No Datanode available, terminating.");
+            try {
+                //noinspection UnstableApiUsage
+                return RetryerBuilder.<List<URI>>newBuilder()
+                        .retryIfResult(List::isEmpty)
+                        .withRetryListener(new RetryListener() {
+                            @Override
+                            public void onRetry(Attempt attempt) {
+                                if (!attempt.hasResult()) {
+                                    if (connectionAttempts == 0) {
+                                        LOG.info("Datanode is not available. Retry #{}", attempt.getAttemptNumber());
+                                    } else {
+                                        LOG.info("Datanode is not available. Retry #{}/{}", attempt.getAttemptNumber(), connectionAttempts);
+                                    }
+                                }
+                            }
+                        })
+                        .withWaitStrategy(WaitStrategies.fixedWait(delayBetweenAttempts.getQuantity(), delayBetweenAttempts.getUnit()))
+                        .withStopStrategy((connectionAttempts == 0) ? StopStrategies.neverStop() : StopStrategies.stopAfterAttempt(connectionAttempts))
+                        .build().call(this::discover);
+            } catch (ExecutionException | RetryException e) {
+                LOG.error("Unable to retrieve Datanode connection: ", e);
+                throw new IllegalStateException("Unable to retrieve Datanode connection", e);
             }
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/configuration/IndexerDiscoveryProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/IndexerDiscoveryProviderTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.configuration;
 
+import com.github.joschi.jadconfig.util.Duration;
 import org.assertj.core.api.Assertions;
 import org.graylog2.bootstrap.preflight.PreflightConfigResult;
 import org.graylog2.bootstrap.preflight.PreflightConfigService;
@@ -42,6 +43,8 @@ class IndexerDiscoveryProviderTest {
     void testAutomaticDiscovery() {
         final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
                 Collections.emptyList(),
+                1,
+                Duration.seconds(1),
                 preflightConfig(PreflightConfigResult.FINISHED),
                 nodes("http://localhost:9200", "http://other:9201")
         );
@@ -57,6 +60,8 @@ class IndexerDiscoveryProviderTest {
     void testPreconfiguredIndexers() {
         final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
                 List.of(URI.create("http://my-host:9200")),
+                1,
+                Duration.seconds(1),
                 preflightConfig(null),
                 nodes()
         );
@@ -71,6 +76,8 @@ class IndexerDiscoveryProviderTest {
     void testSkippedConfigWithDefaultIndexer() {
         final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
                 Collections.emptyList(),
+                1,
+                Duration.seconds(1),
                 preflightConfig(PreflightConfigResult.SKIPPED),
                 nodes()
         );
@@ -85,13 +92,15 @@ class IndexerDiscoveryProviderTest {
     void testFailedAutodiscovery() {
         final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
                 Collections.emptyList(), // no configured indexers
+                1,
+                Duration.seconds(1),
                 preflightConfig(PreflightConfigResult.FINISHED), // preflight correctly finished
                 nodes() // but still no nodes discovered
         );
 
         Assertions.assertThatThrownBy(provider::get)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageStartingWith("No Datanode available");
+                .hasMessageStartingWith("Unable to retrieve Datanode connection");
     }
 
     private NodeService<DataNodeDto> nodes(String... transportAddress) {

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -304,6 +304,15 @@ stream_aware_field_types=false
 #elasticsearch_shards = 1
 #elasticsearch_replicas = 0
 
+# Maximum number of attempts to connect to datanode on boot.
+# Default: 0, retry indefinitely with the given delay until a connection could be established
+#datanode_startup_connection_attempts = 5
+
+# Waiting time in between connection attempts for datanode_startup_connection_attempts
+#
+# Default: 5s
+# datanode_startup_connection_delay = 5s
+
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
 # cycled indices.


### PR DESCRIPTION
Similarly as with elastic/opensearch, graylog server now waits for an available datanode. Number of attempts and their delay is configurable, reusing `elasticsearch_version_probe_attempts` and `elasticsearch_version_probe_delay`, which will be most likely renamed in 6.0.

## Motivation and Context
Without the waiting logic, users need to start datanode first and then graylog server, otherwise the server immediately crashes with exception.

## How Has This Been Tested?
Existing set of unit tests, manually tested starts


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

