### PR TITLE
New reserved field. More safe custom mapping handling. New unit tests.

### DIFF
--- a/changelog/unreleased/issue-17728.toml
+++ b/changelog/unreleased/issue-17728.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Field `gl2_message_id` is now reserved and cannot be changed by custom mappings. No reserved field can be changed when you manually change custom mappings in MongoDB - it will be ignored."
+message = "Fields `gl2_message_id` and `streams` are now reserved and cannot be changed by custom mappings. No reserved field can be changed when you manually change custom mappings in MongoDB - it will be ignored."
 
 issues = ["17728"]
 pulls = ["17766"]

--- a/changelog/unreleased/issue-17728.toml
+++ b/changelog/unreleased/issue-17728.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Field `gl2_message_id` is now reserved and cannot be changed by custom mappings. No reserved field can be changed when you manually change custom mappings in MongoDB - it will be ignored."
+
+issues = ["17728"]
+pulls = ["17766"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -107,6 +107,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_MESSAGE_ID, notAnalyzedString())
+                .put(Message.FIELD_STREAMS, notAnalyzedString())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
                 .put(Message.FIELD_SOURCE, analyzedString("analyzer_keyword", true));
 
@@ -117,10 +118,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                     .forEach(customMapping -> builder.put(customMapping.fieldName(), type(customMapping.toPhysicalType())));
         }
 
-        //those 2 fields have not been yet made reserved, so they can be added to ImmutableMap only if they do not exist in Custom Mapping
-        if (customFieldMappings == null || !customFieldMappings.containsCustomMappingForField(Message.FIELD_STREAMS)) {
-            builder.put(Message.FIELD_STREAMS, notAnalyzedString());
-        }
+        //those FIELD_FULL_MESSAGE field have not been yet made reserved, so it can be added to ImmutableMap only if they do not exist in Custom Mapping
         if (customFieldMappings == null || !customFieldMappings.containsCustomMappingForField(Message.FIELD_FULL_MESSAGE)) {
             builder.put(Message.FIELD_FULL_MESSAGE, analyzedString(analyzer, false));
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -26,6 +26,8 @@ import org.graylog2.plugin.Message;
 import java.util.List;
 import java.util.Map;
 
+import static org.graylog2.plugin.Message.FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS;
+
 /**
  * Representing the message type mapping in Elasticsearch. This is giving ES more
  * information about what the fields look like and how it should analyze them.
@@ -98,7 +100,6 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                                                                final CustomFieldMappings customFieldMappings) {
         final ImmutableMap.Builder<String, Map<String, Object>> builder = ImmutableMap.<String, Map<String, Object>>builder()
                 .put(Message.FIELD_MESSAGE, analyzedString(analyzer, false))
-                .put(Message.FIELD_FULL_MESSAGE, analyzedString(analyzer, false))
                 // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
                 // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
                 .put(Message.FIELD_TIMESTAMP, typeTimeWithMillis())
@@ -107,11 +108,21 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_MESSAGE_ID, notAnalyzedString())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-                .put(Message.FIELD_SOURCE, analyzedString("analyzer_keyword", true))
-                .put(Message.FIELD_STREAMS, notAnalyzedString());
+                .put(Message.FIELD_SOURCE, analyzedString("analyzer_keyword", true));
+
 
         if (customFieldMappings != null) {
-            customFieldMappings.forEach(customMapping -> builder.put(customMapping.fieldName(), type(customMapping.toPhysicalType())));
+            customFieldMappings.stream()
+                    .filter(customMapping -> !FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS.contains(customMapping.fieldName())) //someone might have hardcoded reserved field mapping on MongoDB level, bypassing checks
+                    .forEach(customMapping -> builder.put(customMapping.fieldName(), type(customMapping.toPhysicalType())));
+        }
+
+        //those 2 fields have not been yet made reserved, so they can be added to ImmutableMap only if they do not exist in Custom Mapping
+        if (customFieldMappings == null || !customFieldMappings.containsCustomMappingForField(Message.FIELD_STREAMS)) {
+            builder.put(Message.FIELD_STREAMS, notAnalyzedString());
+        }
+        if (customFieldMappings == null || !customFieldMappings.containsCustomMappingForField(Message.FIELD_FULL_MESSAGE)) {
+            builder.put(Message.FIELD_FULL_MESSAGE, analyzedString(analyzer, false));
         }
 
         return builder.build();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesListService.java
@@ -21,11 +21,11 @@ import org.graylog2.database.PaginatedList;
 import org.graylog2.database.filtering.inmemory.InMemoryFilterExpressionParser;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
-import org.graylog2.indexer.fieldtypes.mapping.FieldTypeMappingsService;
 import org.graylog2.indexer.fieldtypes.utils.FieldTypeDTOsMerger;
 import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.plugin.Message;
 import org.graylog2.rest.models.tools.responses.PageListResponse;
 import org.graylog2.rest.resources.entities.Sorting;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType;
@@ -132,7 +132,7 @@ public class IndexFieldTypesListService {
                                 fieldTypeDTO.fieldName(),
                                 REVERSE_TYPES.get(TYPE_MAP.get(fieldTypeDTO.physicalType())),
                                 customFieldMappings.containsCustomMappingForField(fieldTypeDTO.fieldName()),
-                                FieldTypeMappingsService.BLACKLISTED_FIELDS.contains(fieldTypeDTO.fieldName())
+                        Message.FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS.contains(fieldTypeDTO.fieldName())
                         )
                 )
                 .filter(indexSetFieldType -> indexSetFieldType.fieldName().contains(fieldNameQuery))

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/mapping/FieldTypeMappingsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/mapping/FieldTypeMappingsService.java
@@ -22,6 +22,7 @@ import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indexset.MongoIndexSetService;
+import org.graylog2.plugin.Message;
 import org.graylog2.rest.bulk.model.BulkOperationFailure;
 import org.graylog2.rest.bulk.model.BulkOperationResponse;
 import org.slf4j.Logger;
@@ -37,13 +38,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.graylog2.plugin.Message.RESERVED_SETTABLE_FIELDS;
-
 public class FieldTypeMappingsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(FieldTypeMappingsService.class);
-
-    public static final Set<String> BLACKLISTED_FIELDS = RESERVED_SETTABLE_FIELDS;
 
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory mongoIndexSetFactory;
@@ -61,7 +58,7 @@ public class FieldTypeMappingsService {
     public void changeFieldType(final CustomFieldMapping customMapping,
                                 final Set<String> indexSetsIds,
                                 final boolean rotateImmediately) {
-        if (BLACKLISTED_FIELDS.contains(customMapping.fieldName())) {
+        if (Message.FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS.contains(customMapping.fieldName())) {
             throw new IllegalArgumentException("Changing field type of " + customMapping.fieldName() + " is not allowed.");
         }
         for (String indexSetId : indexSetsIds) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -268,6 +268,7 @@ public class Message implements Messages, Indexable {
     public static final ImmutableSet<String> FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS = new ImmutableSet.Builder<String>()
             .addAll(RESERVED_SETTABLE_FIELDS)
             .add(FIELD_GL2_MESSAGE_ID)
+            .add(FIELD_STREAMS)
             .build();
 
     public static final ImmutableSet<String> RESERVED_FIELDS = new ImmutableSet.Builder<String>()

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -265,6 +265,10 @@ public class Message implements Messages, Indexable {
             .addAll(GRAYLOG_FIELDS)
             .addAll(CORE_MESSAGE_FIELDS)
             .build();
+    public static final ImmutableSet<String> FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS = new ImmutableSet.Builder<String>()
+            .addAll(RESERVED_SETTABLE_FIELDS)
+            .add(FIELD_GL2_MESSAGE_ID)
+            .build();
 
     public static final ImmutableSet<String> RESERVED_FIELDS = new ImmutableSet.Builder<String>()
             .addAll(RESERVED_SETTABLE_FIELDS)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/field_types/FieldTypeMappingsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/field_types/FieldTypeMappingsResource.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 
 import static org.graylog2.audit.AuditEventTypes.FIELD_TYPE_MAPPING_CREATE;
 import static org.graylog2.audit.AuditEventTypes.FIELD_TYPE_MAPPING_DELETE;
-import static org.graylog2.indexer.fieldtypes.mapping.FieldTypeMappingsService.BLACKLISTED_FIELDS;
+import static org.graylog2.plugin.Message.FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
@@ -114,8 +114,8 @@ public class FieldTypeMappingsResource extends RestResource {
     }
 
     private void checkFieldIsAllowedToBeChanged(String fieldName) {
-        if (BLACKLISTED_FIELDS.contains(fieldName)) {
-            throw new BadRequestException("Unable to change field type of " + fieldName + ", not allowed to change type of these fields: " + BLACKLISTED_FIELDS);
+        if (FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS.contains(fieldName)) {
+            throw new BadRequestException("Unable to change field type of " + fieldName + ", not allowed to change type of these fields: " + FIELDS_UNCHANGEABLE_BY_CUSTOM_MAPPINGS);
         }
     }
 


### PR DESCRIPTION
## Description
New reserved field (gl2_message_id). 
More safe custom mapping handling (you cannot change reserved field by manually playing with MongoDB). 
New unit tests.
Fixes #17728.


## Motivation and Context
See #17728.

## How Has This Been Tested?
With new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

