### PR TITLE
Profiles are used to construct templates

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -127,14 +127,15 @@ Added fields:
 
 The following Java Code API changes have been made.
 
-| File/method                                       | Description                    |
-|---------------------------------------------------|--------------------------------|
-| `org.graylog2.plugin.Message#addStringFields`     | Deprecated method removed      |
-| `org.graylog2.plugin.Message#addLongFields`       | Deprecated method removed      |
-| `org.graylog2.plugin.Message#addDoubleFields`     | Deprecated method removed      |
-| `org.graylog2.plugin.Message#getValidationErrors` | Deprecated method removed      |
-| `org.graylog2.plugin.SingletonMessages` | Unused class removed     |
-| `org.graylog.plugins.views.search.engine.LuceneQueryParsingException`        | Unused exception class removed |
+| File/method                                                           | Description                    |
+|-----------------------------------------------------------------------|--------------------------------|
+| `org.graylog2.plugin.Message#addStringFields`                         | Deprecated method removed      |
+| `org.graylog2.plugin.Message#addLongFields`                           | Deprecated method removed      |
+| `org.graylog2.plugin.Message#addDoubleFields`                         | Deprecated method removed      |
+| `org.graylog2.plugin.Message#getValidationErrors`                     | Deprecated method removed      |
+| `org.graylog2.plugin.SingletonMessages`                               | Unused class removed           |
+| `org.graylog.plugins.views.search.engine.LuceneQueryParsingException` | Unused exception class removed |
+| `org.graylog2.indexer.IndexMappingTemplate#toTemplate`                | Method parameter list modified |
 
 
 ## REST API Endpoint Changes

--- a/full-backend-tests/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -24,7 +24,6 @@ import com.google.common.eventbus.Subscribe;
 import org.apache.commons.codec.binary.Base64;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.containermatrix.MongodbServer;
-import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog.testing.elasticsearch.ContainerMatrixElasticsearchBaseTest;
@@ -40,6 +39,7 @@ import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.events.IndicesClosedEvent;
 import org.graylog2.indexer.indices.events.IndicesDeletedEvent;
@@ -122,7 +122,8 @@ public class IndicesIT extends ContainerMatrixElasticsearchBaseTest {
                 nodeId,
                 new NullAuditEventSender(),
                 eventBus,
-                searchServer().adapters().indicesAdapter()
+                searchServer().adapters().indicesAdapter(),
+                mock(IndexFieldTypeProfileService.class)
         );
     }
 
@@ -376,7 +377,8 @@ public class IndicesIT extends ContainerMatrixElasticsearchBaseTest {
                 nodeId,
                 new NullAuditEventSender(),
                 eventBus,
-                searchServer().adapters().indicesAdapter());
+                searchServer().adapters().indicesAdapter(),
+                mock(IndexFieldTypeProfileService.class));
 
         assertThatCode(() -> indices.ensureIndexTemplate(indexSet)).doesNotThrowAnyException();
 
@@ -408,7 +410,8 @@ public class IndicesIT extends ContainerMatrixElasticsearchBaseTest {
                 nodeId,
                 new NullAuditEventSender(),
                 eventBus,
-                searchServer().adapters().indicesAdapter());
+                searchServer().adapters().indicesAdapter(),
+                mock(IndexFieldTypeProfileService.class));
 
         assertThatCode(() -> indices.ensureIndexTemplate(indexSet))
                 .isExactlyInstanceOf(IndexTemplateNotFoundException.class)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -18,19 +18,19 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
 import org.graylog2.indexer.indices.Template;
 
 import java.util.Map;
 
 public abstract class EventsIndexMapping implements IndexMappingTemplate {
     @Override
-    public Template toTemplate(IndexSetConfig indexSetConfig, String indexPattern, Long order) {
+    public Template toTemplate(TemplateIndexSetConfig indexSetConfig, Long order) {
         final String indexRefreshInterval = "1s"; // TODO: Index refresh interval must be configurable
 
         var mappings = new Template.Mappings(buildMappings());
         var settings = new Template.Settings(Map.of("index.refresh_interval", indexRefreshInterval));
-        return Template.create(indexPattern, mappings, order, settings);
+        return Template.create(indexSetConfig.indexWildcard(), mappings, order, settings);
     }
 
     protected ImmutableMap<String, Object> buildMappings() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -19,7 +19,7 @@ package org.graylog2.indexer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.indexer.indexset.CustomFieldMappings;
-import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
 import org.graylog2.indexer.indices.Template;
 import org.graylog2.plugin.Message;
 
@@ -36,9 +36,12 @@ public abstract class IndexMapping implements IndexMappingTemplate {
     public static final String TYPE_MESSAGE = "message";
 
     @Override
-    public Template toTemplate(IndexSetConfig indexSetConfig, String indexPattern, Long order) {
-        //TODO: in next step, combine profile with customFieldMappings
-        return messageTemplate(indexPattern, indexSetConfig.indexAnalyzer(), order, indexSetConfig.customFieldMappings());
+    public Template toTemplate(final TemplateIndexSetConfig indexSetConfig,
+                               final Long order) {
+        return messageTemplate(indexSetConfig.indexWildcard(),
+                indexSetConfig.indexAnalyzer(),
+                order,
+                indexSetConfig.customFieldMappings());
     }
 
     protected Map<String, Object> analyzerKeyword() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
@@ -38,11 +38,6 @@ public class IndexMapping7 extends IndexMapping {
     }
 
     @Override
-    Template createTemplate(String indexPattern, Long order, Template.Settings settings, Template.Mappings mappings) {
-        return Template.create(indexPattern, mappings, order, settings);
-    }
-
-    @Override
     protected String dateFormat() {
         return ConstantsES7.ES_DATE_FORMAT;
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingTemplate.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingTemplate.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.indexer;
 
-import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
 import org.graylog2.indexer.indices.Template;
 
 /**
@@ -26,21 +26,19 @@ public interface IndexMappingTemplate {
     /**
      * Returns the index template as a map.
      *
-     * @param indexSetConfig the index set configuration
-     * @param indexPattern   the index pattern the returned template should be applied to
+     * @param indexSetConfig template-related index set configuration
      * @param order          the order value of the index template
      * @return the index template
      */
-    Template toTemplate(IndexSetConfig indexSetConfig, String indexPattern, Long order);
+    Template toTemplate(TemplateIndexSetConfig indexSetConfig, Long order);
 
     /**
-     * Returns the index template as a map. (with an default order of -1)
+     * Returns the index template as a map. (with a default order of -1)
      *
-     * @param indexSetConfig the index set configuration
-     * @param indexPattern   the index pattern the returned template should be applied to
+     * @param indexSetConfig template-related index set configuration
      * @return the index template
      */
-    default Template toTemplate(IndexSetConfig indexSetConfig, String indexPattern) {
-        return toTemplate(indexSetConfig, indexPattern, -1L);
+    default Template toTemplate(TemplateIndexSetConfig indexSetConfig) {
+        return toTemplate(indexSetConfig, -1L);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/TemplateIndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/TemplateIndexSetConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indexset;
+
+/**
+ * Part of {@link IndexSetConfig} and {@link org.graylog2.indexer.IndexSet} needed by index template building.
+ */
+public record TemplateIndexSetConfig(String indexAnalyzer,
+                                     String indexWildcard,
+                                     CustomFieldMappings customFieldMappings) {
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -29,7 +29,11 @@ import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
+import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfile;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.indices.events.IndicesClosedEvent;
 import org.graylog2.indexer.indices.events.IndicesDeletedEvent;
@@ -68,18 +72,21 @@ public class Indices {
     private final AuditEventSender auditEventSender;
     private final EventBus eventBus;
     private final IndicesAdapter indicesAdapter;
+    private final IndexFieldTypeProfileService profileService;
 
     @Inject
     public Indices(IndexMappingFactory indexMappingFactory,
                    NodeId nodeId,
                    AuditEventSender auditEventSender,
                    EventBus eventBus,
-                   IndicesAdapter indicesAdapter) {
+                   IndicesAdapter indicesAdapter,
+                   IndexFieldTypeProfileService profileService) {
         this.indexMappingFactory = indexMappingFactory;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;
         this.eventBus = eventBus;
         this.indicesAdapter = indicesAdapter;
+        this.profileService = profileService;
     }
 
     public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
@@ -183,8 +190,9 @@ public class Indices {
     }
 
     public Template getIndexTemplate(IndexSet indexSet) {
+        final TemplateIndexSetConfig templateIndexSetConfig = getTemplateIndexSetConfig(indexSet, indexSet.getConfig(), profileService);
         return indexMappingFactory.createIndexMapping(indexSet.getConfig())
-                .toTemplate(indexSet.getConfig(), indexSet.getIndexWildcard());
+                .toTemplate(templateIndexSetConfig);
     }
 
     public void deleteIndexTemplate(IndexSet indexSet) {
@@ -217,8 +225,29 @@ public class Indices {
     }
 
     private Template buildTemplate(IndexSet indexSet, IndexSetConfig indexSetConfig) throws IgnoreIndexTemplate {
+        final TemplateIndexSetConfig templateIndexSetConfig = getTemplateIndexSetConfig(indexSet, indexSetConfig, profileService);
         return indexMappingFactory.createIndexMapping(indexSetConfig)
-                .toTemplate(indexSetConfig, indexSet.getIndexWildcard(), 0L);
+                .toTemplate(templateIndexSetConfig, 0L);
+    }
+
+    public TemplateIndexSetConfig getTemplateIndexSetConfig(
+            final IndexSet indexSet,
+            final IndexSetConfig indexSetConfig,
+            final IndexFieldTypeProfileService profileService) {
+        final String profileId = indexSetConfig.fieldTypeProfile();
+        final CustomFieldMappings customFieldMappings = indexSetConfig.customFieldMappings();
+        if (profileId != null && !profileId.isEmpty()) {
+            final Optional<IndexFieldTypeProfile> fieldTypeProfile = profileService.get(profileId);
+            if (fieldTypeProfile.isPresent() && !fieldTypeProfile.get().customFieldMappings().isEmpty()) {
+                return new TemplateIndexSetConfig(indexSetConfig.indexAnalyzer(),
+                        indexSet.getIndexWildcard(),
+                        customFieldMappings.mergeWith(fieldTypeProfile.get().customFieldMappings()));
+            }
+        }
+
+        return new TemplateIndexSetConfig(indexSetConfig.indexAnalyzer(),
+                indexSet.getIndexWildcard(),
+                customFieldMappings);
     }
 
     public Map<String, Set<String>> getAllMessageFieldsForIndices(final String[] writeIndexWildcards) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -195,6 +195,12 @@ public class Indices {
                 .toTemplate(templateIndexSetConfig);
     }
 
+    Template buildTemplate(IndexSet indexSet, IndexSetConfig indexSetConfig) throws IgnoreIndexTemplate {
+        final TemplateIndexSetConfig templateIndexSetConfig = getTemplateIndexSetConfig(indexSet, indexSetConfig, profileService);
+        return indexMappingFactory.createIndexMapping(indexSetConfig)
+                .toTemplate(templateIndexSetConfig, 0L);
+    }
+
     public void deleteIndexTemplate(IndexSet indexSet) {
         final String templateName = indexSet.getConfig().indexTemplateName();
 
@@ -222,12 +228,6 @@ public class Indices {
 
         auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
         return true;
-    }
-
-    private Template buildTemplate(IndexSet indexSet, IndexSetConfig indexSetConfig) throws IgnoreIndexTemplate {
-        final TemplateIndexSetConfig templateIndexSetConfig = getTemplateIndexSetConfig(indexSet, indexSetConfig, profileService);
-        return indexMappingFactory.createIndexMapping(indexSetConfig)
-                .toTemplate(templateIndexSetConfig, 0L);
     }
 
     public TemplateIndexSetConfig getTemplateIndexSetConfig(

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -241,7 +241,7 @@ public class Indices {
             if (fieldTypeProfile.isPresent() && !fieldTypeProfile.get().customFieldMappings().isEmpty()) {
                 return new TemplateIndexSetConfig(indexSetConfig.indexAnalyzer(),
                         indexSet.getIndexWildcard(),
-                        customFieldMappings.mergeWith(fieldTypeProfile.get().customFieldMappings()));
+                        fieldTypeProfile.get().customFieldMappings().mergeWith(customFieldMappings));
             }
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.indexer.indexset.CustomFieldMapping;
 import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.storage.SearchVersion;
 import org.junit.Assert;
@@ -51,12 +52,13 @@ class IndexMappingTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-    private IndexSetConfig indexSetConfig;
+    private TemplateIndexSetConfig templateIndexSetConfig;
 
     @BeforeEach
     void setUp() {
-        indexSetConfig = mock(IndexSetConfig.class);
-        when(indexSetConfig.indexAnalyzer()).thenReturn("standard");
+        templateIndexSetConfig = mock(TemplateIndexSetConfig.class);
+        when(templateIndexSetConfig.indexAnalyzer()).thenReturn("standard");
+        when(templateIndexSetConfig.indexWildcard()).thenReturn("sampleIndexTemplate");
     }
 
     @Test
@@ -87,7 +89,7 @@ class IndexMappingTest {
         final SearchVersion version = SearchVersion.decode(versionString);
         final IndexMappingTemplate mapping = new MessageIndexTemplateProvider().create(version, Mockito.mock(IndexSetConfig.class));
 
-        var template = mapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
+        var template = mapping.toTemplate(templateIndexSetConfig);
         final String fixture = resourceFile(expectedTemplateFileName);
 
         JSONAssert.assertEquals(json(template), fixture, true);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -28,6 +28,7 @@ import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
@@ -98,7 +99,8 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
                 new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000"),
                 new NullAuditEventSender(),
                 mock(EventBus.class),
-                createIndicesAdapter()
+                createIndicesAdapter(),
+                mock(IndexFieldTypeProfileService.class)
         );
         final Configuration withStreamAwarenessOff = spy(new Configuration());
         doReturn(false).when(withStreamAwarenessOff).maintainsStreamAwareFieldTypes();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -25,6 +25,7 @@ import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.cluster.NodeAdapter;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.plugin.system.SimpleNodeId;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,7 +59,8 @@ public abstract class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest
                 new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000"),
                 new NullAuditEventSender(),
                 new EventBus(),
-                indicesAdapter()
+                indicesAdapter(),
+                mock(IndexFieldTypeProfileService.class)
         );
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -20,9 +20,14 @@ import com.google.common.eventbus.EventBus;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.IgnoreIndexTemplate;
 import org.graylog2.indexer.IndexMappingFactory;
+import org.graylog2.indexer.IndexMappingTemplate;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
 import org.graylog2.indexer.TestIndexSet;
+import org.graylog2.indexer.indexset.CustomFieldMapping;
+import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.TemplateIndexSetConfig;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfile;
 import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
@@ -39,11 +44,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -131,7 +141,126 @@ class IndicesTest {
         assertEquals(0, indicesBlocksStatus.countBlockedIndices());
     }
 
-    private TestIndexSet indexSetConfig(String indexPrefix, String indexTemplaNameName, String indexTemplateType) {
+    @Test
+    void testUsesCustomMappingsAndProfileWhileGettingTemplate() {
+        final TestIndexSet testIndexSet = indexSetConfig("test",
+                "test-template-profiles",
+                "custom",
+                "000000000000000000000013",
+                new CustomFieldMappings(List.of(
+                        new CustomFieldMapping("f1", "string"),
+                        new CustomFieldMapping("f2", "long")
+                )));
+        doReturn(Optional.of(new IndexFieldTypeProfile(
+                "000000000000000000000013",
+                "test_profile",
+                "Test profile",
+                new CustomFieldMappings(List.of(
+                        new CustomFieldMapping("f1", "ip"),
+                        new CustomFieldMapping("f3", "ip")
+                )))
+        )).when(profileService).get("000000000000000000000013");
+        IndexMappingTemplate indexMappingTemplateMock = mock(IndexMappingTemplate.class);
+        doReturn(indexMappingTemplateMock).when(indexMappingFactory).createIndexMapping(testIndexSet.getConfig());
+        underTest.getIndexTemplate(testIndexSet);
+
+        verify(indexMappingTemplateMock).toTemplate(
+                new TemplateIndexSetConfig("standard", "test_*",
+                        new CustomFieldMappings(List.of(
+                                new CustomFieldMapping("f1", "ip"), //from profile
+                                new CustomFieldMapping("f2", "long"), //from individual custom mapping
+                                new CustomFieldMapping("f3", "ip") //from profile
+                        )))
+        );
+    }
+
+    @Test
+    void testUsesCustomMappingsWhileGettingTemplateWhenProfileIsNull() {
+        final CustomFieldMappings individualCustomFieldMappings = new CustomFieldMappings(List.of(
+                new CustomFieldMapping("f1", "string"),
+                new CustomFieldMapping("f2", "long")
+        ));
+        final TestIndexSet testIndexSet = indexSetConfig("test",
+                "test-template-profiles",
+                "custom",
+                "000000000000000000000013",
+                individualCustomFieldMappings);
+        doReturn(Optional.of(new IndexFieldTypeProfile(
+                "000000000000000000000013",
+                "empty_test_profile",
+                "Empty test profile",
+                new CustomFieldMappings(List.of()))
+        )).when(profileService).get("000000000000000000000013");
+        IndexMappingTemplate indexMappingTemplateMock = mock(IndexMappingTemplate.class);
+        doReturn(indexMappingTemplateMock).when(indexMappingFactory).createIndexMapping(testIndexSet.getConfig());
+        underTest.getIndexTemplate(testIndexSet);
+
+        verify(indexMappingTemplateMock).toTemplate(
+                new TemplateIndexSetConfig("standard", "test_*",
+                        individualCustomFieldMappings)
+        );
+    }
+
+    @Test
+    void testUsesCustomMappingsWhileGettingTemplateWhenProfileHasNoOwnMappings() {
+        final CustomFieldMappings individualCustomFieldMappings = new CustomFieldMappings(List.of(
+                new CustomFieldMapping("f1", "string"),
+                new CustomFieldMapping("f2", "long")
+        ));
+        final TestIndexSet testIndexSet = indexSetConfig("test",
+                "test-template-profiles",
+                "custom",
+                "000000000000000000000013",
+                individualCustomFieldMappings);
+        IndexMappingTemplate indexMappingTemplateMock = mock(IndexMappingTemplate.class);
+        doReturn(indexMappingTemplateMock).when(indexMappingFactory).createIndexMapping(testIndexSet.getConfig());
+        underTest.getIndexTemplate(testIndexSet);
+
+        verify(indexMappingTemplateMock).toTemplate(
+                new TemplateIndexSetConfig("standard", "test_*",
+                        individualCustomFieldMappings)
+        );
+    }
+
+    @Test
+    void testUsesCustomMappingsAndProfileWhileBuildingTemplate() {
+        final TestIndexSet testIndexSet = indexSetConfig("test",
+                "test-template-profiles",
+                "custom",
+                "000000000000000000000013",
+                new CustomFieldMappings(List.of(
+                        new CustomFieldMapping("f1", "string"),
+                        new CustomFieldMapping("f2", "long")
+                )));
+        doReturn(Optional.of(new IndexFieldTypeProfile(
+                "000000000000000000000013",
+                "test_profile",
+                "Test profile",
+                new CustomFieldMappings(List.of(
+                        new CustomFieldMapping("f1", "ip"),
+                        new CustomFieldMapping("f3", "ip")
+                )))
+        )).when(profileService).get("000000000000000000000013");
+        IndexMappingTemplate indexMappingTemplateMock = mock(IndexMappingTemplate.class);
+        doReturn(indexMappingTemplateMock).when(indexMappingFactory).createIndexMapping(testIndexSet.getConfig());
+        underTest.buildTemplate(testIndexSet, testIndexSet.getConfig());
+
+        verify(indexMappingTemplateMock).toTemplate(
+                new TemplateIndexSetConfig("standard", "test_*",
+                        new CustomFieldMappings(List.of(
+                                new CustomFieldMapping("f1", "ip"), //from profile
+                                new CustomFieldMapping("f2", "long"), //from individual custom mapping
+                                new CustomFieldMapping("f3", "ip") //from profile
+                        ))),
+                0L
+        );
+    }
+
+    private TestIndexSet indexSetConfig(final String indexPrefix,
+                                        final String indexTemplaNameName,
+                                        final String indexTemplateType,
+                                        final String profileId,
+                                        final CustomFieldMappings customFieldMappings) {
         return new TestIndexSet(IndexSetConfig.builder()
                 .id("index-set-1")
                 .title("Index set 1")
@@ -149,6 +278,12 @@ class IndicesTest {
                 .indexTemplateType(indexTemplateType)
                 .indexOptimizationMaxNumSegments(1)
                 .indexOptimizationDisabled(false)
+                .fieldTypeProfile(profileId)
+                .customFieldMappings(customFieldMappings)
                 .build());
+    }
+
+    private TestIndexSet indexSetConfig(String indexPrefix, String indexTemplaNameName, String indexTemplateType) {
+        return indexSetConfig(indexPrefix, indexTemplaNameName, indexTemplateType, null, new CustomFieldMappings(List.of()));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -167,7 +167,7 @@ class IndicesTest {
         verify(indexMappingTemplateMock).toTemplate(
                 new TemplateIndexSetConfig("standard", "test_*",
                         new CustomFieldMappings(List.of(
-                                new CustomFieldMapping("f1", "ip"), //from profile
+                                new CustomFieldMapping("f1", "string"), //from individual custom mapping
                                 new CustomFieldMapping("f2", "long"), //from individual custom mapping
                                 new CustomFieldMapping("f3", "ip") //from profile
                         )))
@@ -248,7 +248,7 @@ class IndicesTest {
         verify(indexMappingTemplateMock).toTemplate(
                 new TemplateIndexSetConfig("standard", "test_*",
                         new CustomFieldMappings(List.of(
-                                new CustomFieldMapping("f1", "ip"), //from profile
+                                new CustomFieldMapping("f1", "string"), //from individual custom mapping
                                 new CustomFieldMapping("f2", "long"), //from individual custom mapping
                                 new CustomFieldMapping("f3", "ip") //from profile
                         ))),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -23,6 +23,7 @@ import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
 import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
@@ -63,6 +64,8 @@ class IndicesTest {
 
     @Mock
     private IndicesAdapter indicesAdapter;
+    @Mock
+    private IndexFieldTypeProfileService profileService;
 
     @BeforeEach
     public void setup() {
@@ -71,7 +74,8 @@ class IndicesTest {
                 nodeId,
                 auditEventSender,
                 eventBus,
-                indicesAdapter
+                indicesAdapter,
+                profileService
         );
     }
 


### PR DESCRIPTION
## Description
Profiles are used to construct templates.
/jpd Graylog2/graylog-plugin-enterprise#6355
/nocl

## Motivation and Context
Profiles that are set on index set level are not used to construct templates.

## How Has This Been Tested?
Manually and with unit tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

