### PR TITLE
More verbose error messaging in HTTP JSONPath data adapter

### DIFF
--- a/changelog/unreleased/issue-17649.toml
+++ b/changelog/unreleased/issue-17649.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Provide more verbose error messages for HTTPJSONPath data adapter."
+
+issues = ["17649"]
+pulls = [""]

--- a/changelog/unreleased/issue-17649.toml
+++ b/changelog/unreleased/issue-17649.toml
@@ -2,4 +2,4 @@ type = "c"
 message = "Provide more verbose error messages for HTTPJSONPath data adapter."
 
 issues = ["17649"]
-pulls = [""]
+pulls = ["17801"]

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -160,7 +160,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
         final String urlString = templateEngine.transform(config.url(), ImmutableMap.of("key", encodedKey));
 
         if (!urlWhitelistService.isWhitelisted(urlString)) {
-            LOG.error("URL <{}> is not whitelisted. Aborting lookup request.", urlString);
+            LOG.error("Data adapter <{}>: URL <{}> is not whitelisted. Aborting lookup request.", name(), urlString);
             publishSystemNotificationForWhitelistFailure();
             setError(UrlNotWhitelistedException.forUrl(urlString));
             return getErrorResult();
@@ -173,7 +173,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
         final HttpUrl url = HttpUrl.parse(urlString);
 
         if (url == null) {
-            LOG.error("Couldn't parse URL <{}> - returning empty result", urlString);
+            LOG.error("Data adapter <{}>: Couldn't parse URL <{}> - returning empty result", name(), urlString);
             httpURLErrors.mark();
             return getErrorResult();
         }
@@ -198,7 +198,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
             }
             return result;
         } catch (IOException e) {
-            LOG.error("HTTP request error for key <{}>", key, e);
+            LOG.error("Data adapter <{}>: HTTP request error for key <{}> from URL <{}>", name(), key, urlString, e);
             httpRequestErrors.mark();
             return getErrorResult();
         } finally {


### PR DESCRIPTION
Resolves #17649

Error messages do not provide enough information to identify which adapter is failing, when there are many of them.
We now include the adapter name and URL.