### PR TITLE
allow deletion of index ranges that are no longer manged

### DIFF
--- a/changelog/unreleased/issue-17815.toml
+++ b/changelog/unreleased/issue-17815.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Allow the index range clean up periodcal to delete index ranges that are no longer managed by an index set"
+
+issues = ["17815"]
+pulls = ["17841"]

--- a/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
@@ -24,7 +24,6 @@ import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
-import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -43,13 +42,8 @@ public class IndexRangesCleanUpIT {
         this.api = api;
     }
 
-    @BeforeEach
-    public void setUp() {
-
-    }
-
     @ContainerMatrixTest
-    void testCleanUp() throws ExecutionException, RetryException, InterruptedException {
+    void testCleanUp() throws ExecutionException, RetryException {
         String indexSetId = api.indices().createIndexSet("Range clean up", "test index range clean up", RANGE_CLEANUP_PREFIX);
 
         //Rotate to create indices 0 & 1
@@ -63,7 +57,7 @@ public class IndexRangesCleanUpIT {
 
         assertThat(getIndexRangesList()).isNotEmpty().doesNotContain(INDEX_ONE);
 
-        //Deleting index set without deleting underyling indices
+        //Deleting index set without deleting underlying indices
         api.indices().deleteIndexSet(indexSetId, false);
         assertThat(getIndexRangesList()).isNotEmpty().contains(INDEX_TWO);
 

--- a/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.periodical;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import org.graylog.testing.completebackend.Lifecycle;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS)
+public class IndexRangesCleanUpIT {
+    public static final String RANGE_CLEANUP_PREFIX = "range-cleanup";
+    public static final String INDEX_TWO = RANGE_CLEANUP_PREFIX + "_1";
+    public static final String INDEX_ONE = RANGE_CLEANUP_PREFIX + "_0";
+    private final GraylogApis api;
+
+    public IndexRangesCleanUpIT(GraylogApis api) {
+        this.api = api;
+    }
+
+    @BeforeEach
+    public void setUp() {
+
+    }
+
+    @ContainerMatrixTest
+    void testCleanUp() throws ExecutionException, RetryException, InterruptedException {
+        String indexSetId = api.indices().createIndexSet("Range clean up", "test index range clean up", RANGE_CLEANUP_PREFIX);
+
+        //Rotate to create indices 0 & 1
+        api.indices().rotateIndexSet(indexSetId);
+        api.indices().rotateIndexSet(indexSetId);
+
+        assertThat(getIndexRangesList()).isNotEmpty().contains(INDEX_ONE, INDEX_TWO);
+
+        //Deleting index should automatically remove the range
+        api.indices().deleteIndex(INDEX_ONE);
+
+        assertThat(getIndexRangesList()).isNotEmpty().doesNotContain(INDEX_ONE);
+
+        //Deleting index set without deleting underyling indices
+        api.indices().deleteIndexSet(indexSetId, false);
+        assertThat(getIndexRangesList()).isNotEmpty().contains(INDEX_TWO);
+
+        //Trigger clean up periodical over api
+        api.indices().rebuildIndexRanges();
+        assertThat(getIndexRangesList()).isNotEmpty().doesNotContain(INDEX_TWO);
+    }
+
+    private List<String> getIndexRangesList() throws ExecutionException, RetryException {
+        return RetryerBuilder.<List<String>>newBuilder()
+                .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
+                .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                .retryIfResult(List::isEmpty)
+                .build()
+                .call(() -> api.indices().listIndexRanges().properJSONPath().read("ranges.*.index_name"));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -173,10 +173,6 @@ public class MongoIndexRangeService implements IndexRangeService {
     @AllowConcurrentEvents
     public void handleIndexDeletion(IndicesDeletedEvent event) {
         for (String index : event.indices()) {
-            if (!indexSetRegistry.isManagedIndex(index)) {
-                LOG.debug("Not handling deleted index <{}> because it's not managed by any index set.", index);
-                continue;
-            }
             LOG.debug("Index \"{}\" has been deleted. Removing index range.", index);
             if (remove(index)) {
                 auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_RANGE_DELETE, ImmutableMap.of("index_name", index));

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
@@ -103,4 +103,69 @@ public class Indices implements GraylogRestApi {
                 .statusCode(200);
         return new GraylogApiResponse(response);
     }
+
+    public void rotateIndexSet(String indexSetId) {
+        given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .post("/system/deflector/" + indexSetId + "/cycle")
+                .then()
+                .log().ifError()
+                .log()
+                .ifValidationFails()
+                .statusCode(204);
+    }
+
+    public void deleteIndexSet(String indexSetId, boolean deleteIndices) {
+        given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .param("delete_indices", deleteIndices)
+                .delete("/system/indices/index_sets/" + indexSetId)
+                .then()
+                .log().ifError()
+                .log().ifValidationFails()
+                .statusCode(204);
+    }
+
+    public void deleteIndex(String index) {
+        given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .delete("/system/indexer/indices/" + index)
+                .then()
+                .log().ifError()
+                .log().ifValidationFails()
+                .statusCode(204);
+    }
+
+    public GraylogApiResponse listIndexRanges() {
+        final ValidatableResponse response = given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .get("/system/indices/ranges")
+                .then()
+                .log().ifError()
+                .log()
+                .ifValidationFails()
+                .statusCode(200);
+        return new GraylogApiResponse(response);
+    }
+
+    public void rebuildIndexRanges() {
+        given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .post("/system/indices/ranges/rebuild")
+                .then()
+                .log().ifError()
+                .log()
+                .ifValidationFails()
+                .statusCode(202);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -256,8 +256,6 @@ public class MongoIndexRangeServiceTest {
     @Test
     @MongoDBFixtures("MongoIndexRangeServiceTest.json")
     public void testHandleIndexDeletion() throws Exception {
-        when(indexSetRegistry.isManagedIndex("graylog_1")).thenReturn(true);
-
         assertThat(indexRangeService.findAll()).hasSize(2);
 
         localEventBus.post(IndicesDeletedEvent.create(Collections.singleton("graylog_1")));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixes #17815
Allow deletion of index ranges that are no longer managed by an index set
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Its possible to delete index set without deleting the underlying index. 
Those ranges are never delete from the mongo db collection. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally + added integration test that triggers the clean up periodical


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

