### PR TITLE
Profile usages are fetched as part of response

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -53,6 +53,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String FIELD_CREATION_DATE = "creation_date";
     public static final String FIELD_INDEX_TEMPLATE_TYPE = "index_template_type";
     public static final String FIELD_REGULAR = "regular";
+    public static final String FIELD_PROFILE_ID = "field_type_profile";
     public static final String INDEX_PREFIX_REGEX = "^[a-z0-9][a-z0-9_+-]*$";
 
     public static final String DEFAULT_INDEX_TEMPLATE_TYPE = MessageIndexTemplateProvider.MESSAGE_TEMPLATE_TYPE;
@@ -150,7 +151,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @JsonProperty("custom_field_mappings")
     public abstract CustomFieldMappings customFieldMappings();
 
-    @JsonProperty("field_type_profile")
+    @JsonProperty(FIELD_PROFILE_ID)
     @Nullable
     public abstract String fieldTypeProfile();
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfile.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfile.java
@@ -24,6 +24,9 @@ import org.mongojack.ObjectId;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Represents profile as it is stored in Mongo.
+ */
 public record IndexFieldTypeProfile(@JsonProperty(ID_FIELD_NAME) @Nullable @Id @ObjectId String id,
                                     @JsonProperty(NAME_FIELD_NAME) String name,
                                     @JsonProperty(DESCRIPTION_FIELD_NAME) String description,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileService.java
@@ -39,6 +39,10 @@ import javax.ws.rs.BadRequestException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.graylog2.indexer.indexset.profile.IndexFieldTypeProfile.CUSTOM_MAPPINGS_FIELD_NAME;
 import static org.graylog2.indexer.indexset.profile.IndexFieldTypeProfile.DESCRIPTION_FIELD_NAME;
@@ -73,14 +77,29 @@ public class IndexFieldTypeProfileService extends PaginatedDbService<IndexFieldT
     private final MongoCollection<IndexFieldTypeProfile> collection;
     private final DbQueryCreator dbQueryCreator;
 
+    private final IndexFieldTypeProfileUsagesService indexFieldTypeProfileUsagesService;
+
     @Inject
     public IndexFieldTypeProfileService(final MongoConnection mongoConnection,
                                         final MongoJackObjectMapperProvider mapper,
-                                        final MongoCollections mongoCollections) {
+                                        final MongoCollections mongoCollections,
+                                        final IndexFieldTypeProfileUsagesService indexFieldTypeProfileUsagesService) {
         super(mongoConnection, mapper, IndexFieldTypeProfile.class, INDEX_FIELD_TYPE_PROFILE_MONGO_COLLECTION_NAME);
         this.db.createIndex(new BasicDBObject(IndexFieldTypeProfile.NAME_FIELD_NAME, 1), new BasicDBObject("unique", false));
         this.collection = mongoCollections.get(INDEX_FIELD_TYPE_PROFILE_MONGO_COLLECTION_NAME, IndexFieldTypeProfile.class);
         this.dbQueryCreator = new DbQueryCreator(IndexFieldTypeProfile.NAME_FIELD_NAME, ATTRIBUTES);
+        this.indexFieldTypeProfileUsagesService = indexFieldTypeProfileUsagesService;
+    }
+
+    public Optional<IndexFieldTypeProfileWithUsages> getWithUsages(final String profileId) {
+        final Optional<IndexFieldTypeProfile> indexFieldTypeProfile = this.get(profileId);
+
+        return indexFieldTypeProfile.map(profile ->
+                new IndexFieldTypeProfileWithUsages(
+                        profile,
+                        indexFieldTypeProfileUsagesService.usagesOfProfile(profile.id())
+                )
+        );
     }
 
     @Override
@@ -95,7 +114,7 @@ public class IndexFieldTypeProfileService extends PaginatedDbService<IndexFieldT
         return writeResult.getN() > 0;
     }
 
-    public PageListResponse<IndexFieldTypeProfile> getPaginated(final String query,
+    public PageListResponse<IndexFieldTypeProfileWithUsages> getPaginated(final String query,
                                                                 final List<String> filters,
                                                                 final int page,
                                                                 final int perPage,
@@ -106,13 +125,22 @@ public class IndexFieldTypeProfileService extends PaginatedDbService<IndexFieldT
         final Bson dbSort = "desc".equalsIgnoreCase(order) ? Sorts.descending(sortField) : Sorts.ascending(sortField);
 
         final long total = collection.countDocuments(dbQuery);
-        List<IndexFieldTypeProfile> pageResults = new ArrayList<>(perPage);
+        List<IndexFieldTypeProfile> singlePageOfProfiles = new ArrayList<>(perPage);
         collection.find(dbQuery)
                 .sort(dbSort)
                 .limit(perPage)
                 .skip(perPage * Math.max(0, page - 1))
-                .into(pageResults);
-        PaginatedList<IndexFieldTypeProfile> paginated = new PaginatedList<>(pageResults, Ints.saturatedCast(total), page, perPage);
+                .into(singlePageOfProfiles);
+
+        final Map<String, Set<String>> profileUsagesInIndexSets = indexFieldTypeProfileUsagesService.usagesOfProfiles(singlePageOfProfiles.stream().map(IndexFieldTypeProfile::id).collect(Collectors.toSet()));
+
+        final PaginatedList<IndexFieldTypeProfileWithUsages> paginated = new PaginatedList<>(
+                singlePageOfProfiles.stream()
+                        .map(profile -> new IndexFieldTypeProfileWithUsages(profile, profileUsagesInIndexSets.get(profile.id())))
+                        .collect(Collectors.toList()),
+                Ints.saturatedCast(total),
+                page,
+                perPage);
 
         return PageListResponse.create(query,
                 paginated,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileUsagesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileUsagesService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indexset.profile;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.MongoIndexSetService;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Service returning usages of profiles - documents in Mongo that reference profiles.
+ * In current states profiles are only used in index sets. If it ever changed, this class would need to be changed significantly as well.
+ */
+public class IndexFieldTypeProfileUsagesService {
+
+    public static final String INDEX_SET_ID = "_id";
+    private final MongoCollection<Document> indexSetsCollection;
+
+    @Inject
+    public IndexFieldTypeProfileUsagesService(final MongoConnection mongoConnection) {
+        indexSetsCollection = mongoConnection.getMongoDatabase().getCollection(MongoIndexSetService.COLLECTION_NAME);
+    }
+
+    public Set<String> usagesOfProfile(final String profileId) {
+        Set<String> usagesInIndexSet = new HashSet<>();
+        indexSetsCollection
+                .find(Filters.eq(IndexSetConfig.FIELD_PROFILE_ID, profileId))
+                .projection(Projections.include(INDEX_SET_ID))
+                .map(document -> document.getObjectId(INDEX_SET_ID).toString())
+                .into(usagesInIndexSet);
+        return usagesInIndexSet;
+    }
+
+    public Map<String, Set<String>> usagesOfProfiles(final Set<String> profilesIds) {
+        Map<String, Set<String>> usagesInIndexSet = new HashMap<>();
+        profilesIds.forEach(profId -> usagesInIndexSet.put(profId, new HashSet<>()));
+        indexSetsCollection
+                .find(Filters.in(IndexSetConfig.FIELD_PROFILE_ID, profilesIds))
+                .projection(Projections.include(INDEX_SET_ID, IndexSetConfig.FIELD_PROFILE_ID))
+                .forEach(document -> {
+                    final String indexSetId = document.getObjectId(INDEX_SET_ID).toString();
+                    final String profileId = document.getString(IndexSetConfig.FIELD_PROFILE_ID);
+                    usagesInIndexSet.get(profileId).add(indexSetId);
+                });
+
+        return usagesInIndexSet;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileWithUsages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileWithUsages.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indexset.profile;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import java.util.Set;
+
+/**
+ * Profile enriched with usage information, fetched from other collections.
+ */
+public record IndexFieldTypeProfileWithUsages(@JsonUnwrapped IndexFieldTypeProfile profile,
+                                              @JsonProperty("index_set_ids") Set<String> usagesInIndexSets) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexFieldTypeProfileResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexFieldTypeProfileResource.java
@@ -26,6 +26,7 @@ import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfile;
 import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileData;
 import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileService;
+import org.graylog2.indexer.indexset.profile.IndexFieldTypeProfileWithUsages;
 import org.graylog2.rest.models.tools.responses.PageListResponse;
 import org.graylog2.shared.rest.resources.RestResource;
 
@@ -68,8 +69,8 @@ public class IndexFieldTypeProfileResource extends RestResource {
     @Timed
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Gets profile by id")
-    public IndexFieldTypeProfile retrieveById(@ApiParam(name = "profile_id") @PathParam("profile_id") String profileId) {
-        return profileService.get(profileId)
+    public IndexFieldTypeProfileWithUsages retrieveById(@ApiParam(name = "profile_id") @PathParam("profile_id") String profileId) {
+        return profileService.getWithUsages(profileId)
                 .orElseThrow(() -> new NotFoundException("No profile with id : " + profileId));
     }
 
@@ -78,7 +79,7 @@ public class IndexFieldTypeProfileResource extends RestResource {
     @Timed
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Gets profile by id")
-    public PageListResponse<IndexFieldTypeProfile> getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+    public PageListResponse<IndexFieldTypeProfileWithUsages> getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
                                                            @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
                                                            @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
                                                            @ApiParam(name = "filters") @QueryParam("filters") List<String> filters,

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileUsagesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/profile/IndexFieldTypeProfileUsagesServiceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.indexset.profile;
+
+import org.graylog.testing.mongodb.MongoDBInstance;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.indexer.indexset.CustomFieldMappings;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.MongoIndexSetService;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.streams.StreamService;
+import org.joda.time.Duration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class IndexFieldTypeProfileUsagesServiceTest {
+
+    @Rule
+    public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
+
+    private IndexFieldTypeProfileUsagesService toTest;
+
+    @Before
+    public void setUp() {
+        final MongoConnection mongoConnection = mongodb.mongoConnection();
+        final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(new ObjectMapperProvider().get());
+        final MongoIndexSetService mongoIndexSetService = new MongoIndexSetService(mongoConnection,
+                objectMapperProvider,
+                mock(StreamService.class),
+                mock(ClusterConfigService.class),
+                mock(ClusterEventBus.class)
+        );
+        mongoIndexSetService.save(createIndexSetConfigForTest("000000000000000000000001", "profile1"));
+        mongoIndexSetService.save(createIndexSetConfigForTest("000000000000000000000011", "profile1"));
+        mongoIndexSetService.save(createIndexSetConfigForTest("000000000000000000000002", "profile2"));
+        mongoIndexSetService.save(createIndexSetConfigForTest("000000000000000000000042", null));
+        toTest = new IndexFieldTypeProfileUsagesService(mongoConnection);
+    }
+
+    @Test
+    public void testReturnsProperUsagesForSingleProfile() {
+        assertEquals(Set.of("000000000000000000000001", "000000000000000000000011"),
+                toTest.usagesOfProfile("profile1"));
+        assertEquals(Set.of("000000000000000000000002"),
+                toTest.usagesOfProfile("profile2"));
+        assertEquals(Set.of(),
+                toTest.usagesOfProfile("unused_profile"));
+    }
+
+    @Test
+    public void testReturnsProperUsagesForMultipleProfiles() {
+        Map<String, Set<String>> expectedResult = Map.of(
+                "profile1", Set.of("000000000000000000000001", "000000000000000000000011"),
+                "profile2", Set.of("000000000000000000000002"),
+                "unused_profile", Set.of()
+        );
+
+        assertEquals(expectedResult, toTest.usagesOfProfiles(Set.of("profile1", "profile2", "unused_profile")));
+    }
+
+    private IndexSetConfig createIndexSetConfigForTest(final String id, final String profileId) {
+        return IndexSetConfig.create(
+                id, "title", "description",
+                true,
+                true, "prefix_" + id, null, null,
+                1, 0,
+                MessageCountRotationStrategyConfig.class.getCanonicalName(),
+                MessageCountRotationStrategyConfig.create(3),
+                DeletionRetentionStrategy.class.getCanonicalName(),
+                DeletionRetentionStrategyConfig.createDefault(),
+                ZonedDateTime.now(ZoneId.systemDefault()),
+                null, null, null,
+                1, true,
+                Duration.standardSeconds(5),
+                new CustomFieldMappings(),
+                profileId);
+    }
+
+}


### PR DESCRIPTION
## Description
Profile usages are fetched as part of response in `System/IndexSets/FieldTypeProfiles` endpoint.
/nocl

## Motivation and Context
Needed by FE for profile summary page implementation.

## How Has This Been Tested?
Manually and with unit automatic tests.

## Screenshots (if appropriate):
![image](https://github.com/Graylog2/graylog2-server/assets/100699120/9832d784-ec91-4965-8fe5-ce73f07d270c)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

