### PR TITLE
Do not display link styles for button with href.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -49,6 +49,11 @@ const styleProps = (style: StyleProps) => {
 
 const StyledButton = styled(MantineButton)`
   font-weight: 400;
+  text-decoration: none !important;
+
+  &:hover, &:focus {
+    color: inherit;
+  }
 `;
 
 type Props = React.PropsWithChildren<{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this change, buttons with an `href` displayed some link related style on hover:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/2e7087a2-3c12-477b-bee4-970861a486a0)

Now they look like other buttons:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/ed3e46e6-c086-4da2-88f8-55752c8a6acc)



/nocl
