### PR TITLE
Render navigation dropdown options as anchors instead of buttons.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -16,10 +16,18 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import Menu from 'components/bootstrap/Menu';
 import { LinkContainer } from 'components/common/router';
 import { NavItem } from 'components/bootstrap';
+
+const DropdownOption = styled(Menu.Item)`
+  &:hover, &:focus {
+    color: inherit;
+    text-decoration: none;
+  }
+`;
 
 // We render a NavItem if topLevel is set to avoid errors when the NavigationLink is place in the navigation
 // bar instead of a navigation drop-down menu.
@@ -31,7 +39,7 @@ type Props = {
 
 const NavigationLink = ({ description, path, topLevel, ...rest }: Props) => (
   <LinkContainer key={path} to={path} {...rest}>
-    {topLevel ? <NavItem>{description}</NavItem> : <Menu.Item>{description}</Menu.Item>}
+    {topLevel ? <NavItem>{description}</NavItem> : <DropdownOption component="a">{description}</DropdownOption>}
   </LinkContainer>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently, we migrated the navigation dropdown components from react-bootstrap to mantine. One result was that the dropdown options were rendered as buttons. With this PR we are rendering them as anchors again.

/nocl