### PR TITLE
Display active state for navigation items on sub pages.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -38,7 +38,7 @@ type Props = {
 }
 
 const NavigationLink = ({ description, path, topLevel, ...rest }: Props) => (
-  <LinkContainer key={path} to={path} {...rest}>
+  <LinkContainer key={path} to={path} relativeActive {...rest}>
     {topLevel ? <NavItem>{description}</NavItem> : <DropdownOption component="a">{description}</DropdownOption>}
   </LinkContainer>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing the active state for navigation items on sub pages. This problem does not occur in released versions.

Before:
<img width="774" alt="image" src="https://github.com/Graylog2/graylog2-server/assets/46300478/4934fd6c-2562-4426-9faa-5f5e76addfc2">

After:
<img width="850" alt="image" src="https://github.com/Graylog2/graylog2-server/assets/46300478/2115c1b3-2ac4-448b-bbbf-c28c90d5bc14">

/nocl

