### PR TITLE
Fixing up permissions checking bugs in `ChangeFieldType`/`AssignIndexSetAction`.

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetAction.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetAction.tsx
@@ -20,7 +20,6 @@ import { useCallback, useState } from 'react';
 import { Formik, Form } from 'formik';
 
 import MenuItem from 'components/bootstrap/MenuItem';
-import { isPermitted } from 'util/PermissionsMixin';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import StringUtils from 'util/StringUtils';
 import type FetchError from 'logic/errors/FetchError';
@@ -30,6 +29,7 @@ import { Streams } from '@graylog/server-api';
 import { Modal } from 'components/bootstrap';
 import ModalSubmit from 'components/common/ModalSubmit';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
+import usePermissions from 'hooks/usePermissions';
 
 type ModalProps = {
   descriptor: string,
@@ -112,6 +112,7 @@ const AssignIndexSetAction = ({
   refetchStreams,
   onSelect,
 }: Props) => {
+  const { isPermitted } = usePermissions();
   const [showIndexSetModal, setShowIndexSetModal] = useState(false);
 
   const toggleAssignIndexSetModal = useCallback(() => {

--- a/graylog2-web-interface/src/hooks/usePermissions.ts
+++ b/graylog2-web-interface/src/hooks/usePermissions.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useCallback, useMemo } from 'react';
+
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
+
+const usePermissions = () => {
+  const currentUser = useCurrentUser();
+  const _isPermitted = useCallback((permissions: Array<string> | string) => isPermitted(currentUser?.permissions, permissions), [currentUser?.permissions]);
+
+  return useMemo(() => ({ isPermitted: _isPermitted }), [_isPermitted]);
+};
+
+export default usePermissions;

--- a/graylog2-web-interface/src/util/PermissionsMixin.ts
+++ b/graylog2-web-interface/src/util/PermissionsMixin.ts
@@ -14,9 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-const _isWildCard = (permissionSet) => (permissionSet.indexOf('*') > -1);
+import type * as Immutable from 'immutable';
 
-const _permissionPredicate = (permissionSet, p) => {
+type Permission = string;
+type Permissions = Array<Permission>;
+type UserPermissions = Immutable.List<Permission>;
+
+const _isWildCard = (permissionSet: UserPermissions | Permissions) => (permissionSet.indexOf('*') > -1);
+
+const _permissionPredicate = (permissionSet: UserPermissions | Permissions, p: Permission) => {
   if ((permissionSet.indexOf(p) > -1) || (permissionSet.indexOf('*') > -1)) {
     return true;
   }
@@ -36,7 +42,7 @@ const _permissionPredicate = (permissionSet, p) => {
   return (permissionSet.indexOf(`${p}:*`) > -1);
 };
 
-export const isPermitted = (possessedPermissions, requiredPermissions) => {
+export const isPermitted = (possessedPermissions: UserPermissions | Permissions, requiredPermissions: Permissions | Permission) => {
   if (!requiredPermissions || requiredPermissions.length === 0) {
     return true;
   }
@@ -49,14 +55,14 @@ export const isPermitted = (possessedPermissions, requiredPermissions) => {
     return true;
   }
 
-  if (requiredPermissions.every) {
+  if (typeof requiredPermissions === 'object') {
     return requiredPermissions.every((p) => _permissionPredicate(possessedPermissions, p));
   }
 
   return _permissionPredicate(possessedPermissions, requiredPermissions);
 };
 
-export const isAnyPermitted = (possessedPermissions, requiredPermissions) => {
+export const isAnyPermitted = (possessedPermissions: UserPermissions, requiredPermissions: Permissions) => {
   if (!requiredPermissions || requiredPermissions.length === 0) {
     return true;
   }

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
@@ -45,7 +45,7 @@ const ChangeFieldType = ({
   ) : null;
 };
 
-const hasMappingPermission = (currentUser: User) => isPermitted(currentUser, 'typemappings:edit');
+const hasMappingPermission = (currentUser: User) => isPermitted(currentUser?.permissions, 'typemappings:edit');
 
 export const isChangeFieldTypeEnabled = ({ field, type, contexts }: ActionHandlerArguments) => {
   const { currentUser } = contexts;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing two invalid usages of `isPermitted` in `ChangeFieldType`/`AssignIndexSetAction`. To fix this, this PR is:

  - Typing `PermissionsMixin` to catch errors like this in the future
  - Introduce `usePermissions` hook which returns an `isPermitted` function where current user's permissions are pre-bound
  - Uses this hook in `AssignIndexSetAction`
  - Fixes `ChangeFieldType` so it passes permissions instead of whole user object to `isPermitted`

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.