### PR TITLE
Log actual rotation class in audit events

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/datatiering/rotation/DataTierRotation.java
+++ b/graylog2-server/src/main/java/org/graylog2/datatiering/rotation/DataTierRotation.java
@@ -33,7 +33,6 @@ import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 
-import static org.graylog2.indexer.rotation.common.IndexRotator.createResult;
 import static org.graylog2.shared.utilities.StringUtils.f;
 import static org.graylog2.shared.utilities.StringUtils.humanReadableByteCount;
 
@@ -69,6 +68,10 @@ public class DataTierRotation {
 
     public void rotate(IndexSet indexSet) {
         indexRotator.rotate(indexSet, this::shouldRotate);
+    }
+
+    private IndexRotator.Result createResult(boolean shouldRotate, String message) {
+        return IndexRotator.createResult(shouldRotate, message, this.getClass().getCanonicalName());
     }
 
     @Nonnull

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/common/IndexRotator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/common/IndexRotator.java
@@ -46,14 +46,13 @@ public class IndexRotator {
         this.nodeId = nodeId;
     }
 
-    public static Result createResult(boolean shouldRotate, String message) {
-        return new Result(shouldRotate, message);
+    public static Result createResult(boolean shouldRotate, String message, String rotatorClass) {
+        return new Result(shouldRotate, message, rotatorClass);
     }
 
     public void rotate(IndexSet indexSet, RotationChecker rotationChecker) {
         requireNonNull(indexSet, "indexSet must not be null");
         final String indexSetTitle = requireNonNull(indexSet.getConfig(), "Index set configuration must not be null").title();
-        final String strategyName = this.getClass().getCanonicalName();
         final String indexName;
         try {
             indexName = indexSet.getNewestIndex();
@@ -67,7 +66,7 @@ public class IndexRotator {
 
         final Result rotate = rotationChecker.shouldRotate(indexName, indexSet);
         if (rotate == null) {
-            LOG.error("Cannot perform rotation of index <{}> in index set <{}> with strategy <{}> at this moment", indexName, indexSetTitle, strategyName);
+            LOG.error("Cannot perform rotation of index <{}> in index set <{}> at this moment", indexName, indexSetTitle);
             return;
         }
         LOG.debug("Rotation strategy result: {}", rotate.getDescription());
@@ -76,24 +75,26 @@ public class IndexRotator {
             indexSet.cycle();
             auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_ROTATION_COMPLETE, ImmutableMap.of(
                     "index_name", indexName,
-                    "rotation_strategy", strategyName
+                    "rotation_strategy", rotate.getRotatorClass()
             ));
         } else {
             LOG.debug("Deflector index <{}> should not be rotated. Not doing anything.", indexName);
         }
     }
 
-    public interface RotationChecker{
+    public interface RotationChecker {
         Result shouldRotate(String indexName, IndexSet indexSet);
     }
 
     public static class Result {
         private final boolean shouldRotate;
         private final String message;
+        private final String rotatorClass;
 
-        public Result(boolean shouldRotate, String message) {
+        public Result(boolean shouldRotate, String message, String rotatorClass) {
             this.shouldRotate = shouldRotate;
             this.message = message;
+            this.rotatorClass = rotatorClass;
             LOG.debug("{} because of: {}", shouldRotate ? "Rotating" : "Not rotating", message);
         }
 
@@ -103,6 +104,10 @@ public class IndexRotator {
 
         public boolean shouldRotate() {
             return shouldRotate;
+        }
+
+        public String getRotatorClass() {
+            return rotatorClass;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -30,7 +30,7 @@ import javax.inject.Inject;
 import java.text.MessageFormat;
 import java.util.Locale;
 
-import static org.graylog2.indexer.rotation.common.IndexRotator.*;
+import static org.graylog2.indexer.rotation.common.IndexRotator.Result;
 import static org.graylog2.indexer.rotation.common.IndexRotator.createResult;
 
 public class MessageCountRotationStrategy implements RotationStrategy {
@@ -47,9 +47,10 @@ public class MessageCountRotationStrategy implements RotationStrategy {
         this.indexRotator = indexRotator;
 
     }
+
     @Override
     public void rotate(IndexSet indexSet) {
-        indexRotator.rotate(indexSet,this::shouldRotate);
+        indexRotator.rotate(indexSet, this::shouldRotate);
     }
 
     @Override
@@ -76,13 +77,13 @@ public class MessageCountRotationStrategy implements RotationStrategy {
             final boolean shouldRotate = numberOfMessages > config.maxDocsPerIndex();
             final MessageFormat format = shouldRotate ?
                     new MessageFormat(
-                    "Number of messages in <{0}> ({1}) is higher than the limit ({2}). Pointing deflector to new index now!",
-                    Locale.ENGLISH) :
+                            "Number of messages in <{0}> ({1}) is higher than the limit ({2}). Pointing deflector to new index now!",
+                            Locale.ENGLISH) :
                     new MessageFormat(
-                    "Number of messages in <{0}> ({1}) is lower than the limit ({2}). Not doing anything.",
-                    Locale.ENGLISH);
+                            "Number of messages in <{0}> ({1}) is lower than the limit ({2}). Not doing anything.",
+                            Locale.ENGLISH);
             String message = format.format(new Object[]{index, numberOfMessages, config.maxDocsPerIndex()});
-            return createResult(shouldRotate, message);
+            return createResult(shouldRotate, message, this.getClass().getCanonicalName());
         } catch (IndexNotFoundException e) {
             log.error("Unknown index, cannot perform rotation", e);
             return null;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -45,7 +45,7 @@ public class SizeBasedRotationStrategy implements RotationStrategy {
 
     @Override
     public void rotate(IndexSet indexSet) {
-        indexRotator.rotate(indexSet,this::shouldRotate);
+        indexRotator.rotate(indexSet, this::shouldRotate);
     }
 
     @Override
@@ -77,9 +77,9 @@ public class SizeBasedRotationStrategy implements RotationStrategy {
         final MessageFormat format = shouldRotate ?
                 new MessageFormat("Storage size for index <{0}> is {1} bytes, exceeding the maximum of {2} bytes. Rotating index.", Locale.ENGLISH) :
                 new MessageFormat("Storage size for index <{0}> is {1} bytes, below the maximum of {2} bytes. Not doing anything.", Locale.ENGLISH);
-        final String message = format.format(new Object[] { index, sizeInBytes, config.maxSize() });
+        final String message = format.format(new Object[]{index, sizeInBytes, config.maxSize()});
 
-        return createResult(shouldRotate, message);
+        return createResult(shouldRotate, message, this.getClass().getCanonicalName());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -48,8 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
-import static org.graylog2.indexer.rotation.common.IndexRotator.*;
-import static org.graylog2.indexer.rotation.common.IndexRotator.createResult;
+import static org.graylog2.indexer.rotation.common.IndexRotator.Result;
 import static org.joda.time.DateTimeFieldType.dayOfMonth;
 import static org.joda.time.DateTimeFieldType.hourOfDay;
 import static org.joda.time.DateTimeFieldType.minuteOfHour;
@@ -188,6 +187,10 @@ public class TimeBasedRotationStrategy implements RotationStrategy {
      */
     public void reset() {
         this.anchor.clear();
+    }
+
+    private IndexRotator.Result createResult(boolean shouldRotate, String message) {
+        return IndexRotator.createResult(shouldRotate, message, this.getClass().getCanonicalName());
     }
 
     @Nullable

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategy.java
@@ -36,7 +36,6 @@ import javax.inject.Inject;
 import java.time.Duration;
 import java.time.Instant;
 
-import static org.graylog2.indexer.rotation.common.IndexRotator.createResult;
 import static org.graylog2.shared.utilities.StringUtils.f;
 import static org.graylog2.shared.utilities.StringUtils.humanReadableByteCount;
 
@@ -68,7 +67,7 @@ public class TimeBasedSizeOptimizingStrategy implements RotationStrategy {
 
     @Override
     public void rotate(IndexSet indexSet) {
-        indexRotator.rotate(indexSet,this::shouldRotate);
+        indexRotator.rotate(indexSet, this::shouldRotate);
     }
 
     @Override
@@ -84,10 +83,13 @@ public class TimeBasedSizeOptimizingStrategy implements RotationStrategy {
                 .build();
     }
 
+    private IndexRotator.Result createResult(boolean shouldRotate, String message) {
+        return IndexRotator.createResult(shouldRotate, message, this.getClass().getCanonicalName());
+    }
 
     @Nonnull
     protected Result shouldRotate(final String index, IndexSet indexSet) {
-        final DateTime creationDate = indices.indexCreationDate(index).orElseThrow(()-> new IllegalStateException("No index creation date"));
+        final DateTime creationDate = indices.indexCreationDate(index).orElseThrow(() -> new IllegalStateException("No index creation date"));
         final Long sizeInBytes = indices.getStoreSizeInBytes(index).orElseThrow(() -> new IllegalStateException("No index size"));
 
         if (!(indexSet.getConfig().rotationStrategy() instanceof TimeBasedSizeOptimizingStrategyConfig config)) {


### PR DESCRIPTION
This got changed by refactorings and was logging audit events for rotation with
strategy "org.graylog2.indexer.rotation.common.IndexRotator"

regardless of the actual rotation.

/nocl
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6091