### PR TITLE
Array Contains function: Fix unhandled exception when passed null array

### DIFF
--- a/changelog/unreleased/pr-17909.toml
+++ b/changelog/unreleased/pr-17909.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fixed bug causing null response from `array_contains` pipeline function when passed null array."
+
+pulls = ["17909"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/AbstractArrayFunction.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/AbstractArrayFunction.java
@@ -27,7 +27,7 @@ abstract public class AbstractArrayFunction<T> extends AbstractFunction<T> {
     @SuppressWarnings("rawtypes")
     static List toList(Object obj) {
         if (obj == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         else if (obj instanceof Collection) {
             return ImmutableList.copyOf((Collection) obj);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/AbstractArrayFunction.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/AbstractArrayFunction.java
@@ -20,12 +20,16 @@ import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 abstract public class AbstractArrayFunction<T> extends AbstractFunction<T> {
     @SuppressWarnings("rawtypes")
     static List toList(Object obj) {
-        if (obj instanceof Collection) {
+        if (obj == null) {
+            return Collections.EMPTY_LIST;
+        }
+        else if (obj instanceof Collection) {
             return ImmutableList.copyOf((Collection) obj);
         } else {
             throw new IllegalArgumentException("Unsupported data type for parameter 'elements': " + obj.getClass().getCanonicalName());

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/ArrayContains.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/ArrayContains.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
@@ -74,7 +75,7 @@ public class ArrayContains extends AbstractArrayFunction<Boolean> {
     }
 
     private boolean arrayContains(List<Object> elements, Object value) {
-        for (Object element : elements) {
+        for (Object element : elements.stream().filter(e -> !(e instanceof NullNode)).toList()) {
             if (element instanceof IntNode || element instanceof LongNode) {
                 /* Allow ints and longs to be compared. Sometimes the array will contain ints,
                  * but a single number passed as the value will be typed as a long.
@@ -82,8 +83,7 @@ public class ArrayContains extends AbstractArrayFunction<Boolean> {
                 final Number number = ((NumericNode) element).numberValue();
                 if (value.equals(number.intValue())) {
                     return true;
-                }
-                else if (value.equals(number.longValue())) {
+                } else if (value.equals(number.longValue())) {
                     return true;
                 }
             } else if (element instanceof JsonNode) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1617,6 +1617,9 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("contains_string_case_insensitive")).isEqualTo(true);
             assertThat(message.getField("contains_string_case_sensitive")).isEqualTo(false);
             assertThat(message.getField("contains_null_array")).isEqualTo(false);
+            assertThat(message.getField("contains_null_value")).isEqualTo(false);
+            assertThat(message.getField("contains_null_json_value_in_array_string")).isEqualTo(true);
+            assertThat(message.getField("contains_null_json_value_in_array_int")).isEqualTo(true);
 
             assertThat(message.getField("path_array_strings_contains")).isEqualTo(true);
             assertThat(message.getField("path_array_numbers_contains")).isEqualTo(true);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1616,6 +1616,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("contains_string")).isEqualTo(true);
             assertThat(message.getField("contains_string_case_insensitive")).isEqualTo(true);
             assertThat(message.getField("contains_string_case_sensitive")).isEqualTo(false);
+            assertThat(message.getField("contains_null_array")).isEqualTo(false);
 
             assertThat(message.getField("path_array_strings_contains")).isEqualTo(true);
             assertThat(message.getField("path_array_numbers_contains")).isEqualTo(true);

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
@@ -25,6 +25,7 @@ then
     set_field(field: "path_array_not_numbers_contains", value: array_contains(elements: selectedPath.numbers, value: 10));
     set_field(field: "path_array_not_decimals_contains", value: array_contains(elements: selectedPath.decimals, value: 10.1));
     set_field(field: "path_array_not_booleans_contains", value: array_contains(elements: selectedPath.booleans, value: false));
+    set_field("contains_null_array", array_contains(selectedPath.null, "test"));
 
     trigger_test();
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
@@ -25,7 +25,7 @@ then
     set_field(field: "path_array_not_numbers_contains", value: array_contains(elements: selectedPath.numbers, value: 10));
     set_field(field: "path_array_not_decimals_contains", value: array_contains(elements: selectedPath.decimals, value: 10.1));
     set_field(field: "path_array_not_booleans_contains", value: array_contains(elements: selectedPath.booleans, value: false));
-    set_field("contains_null_array", array_contains(selectedPath.null, "test"));
+    set_field("contains_null_array", array_contains(selectedPath.nullPath, "test"));
 
     trigger_test();
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/arrayContains.txt
@@ -14,7 +14,8 @@ then
                          number: "$.numbers[0].value",
                          decimals: "$.decimals[*].value",
                          booleans: "$.booleans[*].value",
-                         strings: "$.strings[*].value"});
+                         strings: "$.strings[*].value",
+                         has_null_value: "$.has_null_value[*].value"});
 
     set_field(field: "path_array_strings_contains", value: array_contains(elements: selectedPath.strings, value: "two"));
     set_field(field: "path_array_numbers_contains", value: array_contains(elements: selectedPath.numbers, value: 2));
@@ -26,6 +27,9 @@ then
     set_field(field: "path_array_not_decimals_contains", value: array_contains(elements: selectedPath.decimals, value: 10.1));
     set_field(field: "path_array_not_booleans_contains", value: array_contains(elements: selectedPath.booleans, value: false));
     set_field("contains_null_array", array_contains(selectedPath.nullPath, "test"));
+    set_field("contains_null_value", array_contains(selectedPath.strings, selectedPath.nullPath));
+    set_field("contains_null_json_value_in_array_string", array_contains(selectedPath.has_null_value, "two"));
+    set_field("contains_null_json_value_in_array_int", array_contains(selectedPath.has_null_value, 3));
 
     trigger_test();
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/with-arrays.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/with-arrays.json
@@ -74,5 +74,16 @@
     {
       "value": "three"
     }
+  ],
+  "has_null_value": [
+    {
+      "value": null
+    },
+    {
+      "value": "two"
+    },
+    {
+      "value": 3
+    }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the `array_contains` pipeline function was passed a null array (for example through selecting a non-existent path through `json_path`), the function would internally throw an exception and return null. This fix resolves that, and correctly returns `false` since a null array cannot contain an values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Needed for Illuminate processing content. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Well-covered with unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

