### PR TITLE
Fix button hover color.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -47,15 +47,6 @@ const styleProps = (style: StyleProps) => {
   }
 };
 
-const StyledButton = styled(MantineButton)`
-  font-weight: 400;
-  text-decoration: none !important;
-
-  &:hover, &:focus {
-    color: inherit;
-  }
-`;
-
 type Props = React.PropsWithChildren<{
   active?: boolean,
   'aria-label'?: string,
@@ -128,8 +119,17 @@ const generateStyles = (other: Other, bsStyle: StyleProps, bsSize: BsSize, disab
   return {
     root: {
       ...sizeStyles,
-      ':disabled': disableStyles,
       color: other.colors.contrast[bsStyle],
+      fontWeight: 400,
+      ':disabled': disableStyles,
+      ':hover': {
+        color: other.colors.contrast[bsStyle],
+        textDecoration: 'none',
+      },
+      ':focus': {
+        color: other.colors.contrast[bsStyle],
+        textDecoration: 'none',
+      },
     },
     label: {
       gap: '0.25em',
@@ -164,25 +164,25 @@ const Button = React.forwardRef<HTMLButtonElement, Props>(
 
     if (href) {
       return (
-        <StyledButton component="a"
-                      href={href}
-                      target={target}
-                      rel={rel}
-                      onClick={onClick as (e: React.MouseEvent<HTMLAnchorElement>) => void}
-                      {...sharedProps}>
+        <MantineButton component="a"
+                       href={href}
+                       target={target}
+                       rel={rel}
+                       onClick={onClick as (e: React.MouseEvent<HTMLAnchorElement>) => void}
+                       {...sharedProps}>
           {children}
-        </StyledButton>
+        </MantineButton>
       );
     }
 
     return (
-      <StyledButton ref={ref}
-                    form={form}
-                    onClick={onClick as (e: React.MouseEvent<HTMLButtonElement>) => void}
-                    name={name}
-                    {...sharedProps}>
+      <MantineButton ref={ref}
+                     form={form}
+                     onClick={onClick as (e: React.MouseEvent<HTMLButtonElement>) => void}
+                     name={name}
+                     {...sharedProps}>
         {children}
-      </StyledButton>
+      </MantineButton>
     );
   });
 

--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -19,7 +19,6 @@ import { useMemo } from 'react';
 import type { ColorVariant } from '@graylog/sawmill';
 import type { MantineTheme } from '@graylog/sawmill/mantine';
 import { Button as MantineButton, useMantineTheme } from '@mantine/core';
-import styled from 'styled-components';
 
 import type { BsSize } from 'components/bootstrap/types';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/17862 and improving the way we define the button hover styles.

It looks like the button style specificity changed and there were some cases where `color: inherit` no longer had the desired effect.

/nocl
