### PR TITLE
Fix event definition and field type reset bulk action.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/BulkActions.tsx
@@ -140,10 +140,12 @@ const BulkActions = () => {
   };
 
   return (
-    <BulkActionsDropdown>
-      <MenuItem onSelect={() => handleAction(ACTION_TYPES.ENABLE)}>Enable</MenuItem>
-      <MenuItem onSelect={() => handleAction(ACTION_TYPES.DISABLE)}>Disable</MenuItem>
-      <MenuItem onSelect={() => handleAction(ACTION_TYPES.DELETE)}>Delete</MenuItem>
+    <>
+      <BulkActionsDropdown>
+        <MenuItem onSelect={() => handleAction(ACTION_TYPES.ENABLE)}>Enable</MenuItem>
+        <MenuItem onSelect={() => handleAction(ACTION_TYPES.DISABLE)}>Disable</MenuItem>
+        <MenuItem onSelect={() => handleAction(ACTION_TYPES.DELETE)}>Delete</MenuItem>
+      </BulkActionsDropdown>
       {showDialog && (
         <ConfirmDialog title={ACTION_TEXT[actionType]?.dialogTitle}
                        show
@@ -152,7 +154,7 @@ const BulkActions = () => {
           {ACTION_TEXT[actionType]?.dialogBody(selectedItemsAmount)}
         </ConfirmDialog>
       )}
-    </BulkActionsDropdown>
+    </>
   );
 };
 

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/BulkActions.tsx
@@ -34,15 +34,17 @@ const BulkActions = ({ indexSetId }: Props) => {
   const toggleResetModal = () => setShowResetModal((cur) => !cur);
 
   return (
-    <BulkActionsDropdown>
-      <MenuItem onSelect={toggleResetModal}>Reset</MenuItem>
+    <>
+      <BulkActionsDropdown>
+        <MenuItem onSelect={toggleResetModal}>Reset</MenuItem>
+      </BulkActionsDropdown>
       {showResetModal && (
         <IndexSetCustomFieldTypeRemoveModal show
                                             fields={selectedEntities}
                                             onClose={toggleResetModal}
                                             indexSetIds={[indexSetId]} />
       )}
-    </BulkActionsDropdown>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Since we refactored the dropdown button component with https://github.com/Graylog2/graylog2-server/pull/17527 the dropdown options are now only being rendered when the dropdown is actually open.

This resulted in a bug with the modal for the field type removal and event definitions enable / disable bulk action, because the modal disappeared after clicking on the dropdown option.

Fixes https://github.com/Graylog2/graylog2-server/issues/17970
/nocl