### PR TITLE
Only render children of `CurrentUserProvider` when current user has been loaded.

### DIFF
--- a/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
@@ -69,7 +69,9 @@ describe('CurrentUserPreferencesProvider', () => {
   });
 
   it('provides default user preferences if the user has none', () => {
-    asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: adminUser.toBuilder().preferences(undefined as PreferencesMap).build().toJSON() });
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({
+      currentUser: adminUser.toBuilder().preferences(undefined as PreferencesMap).build().toJSON(),
+    });
 
     const consume = renderSUT();
 
@@ -77,7 +79,9 @@ describe('CurrentUserPreferencesProvider', () => {
   });
 
   it('provides empty user preferences of current user', () => {
-    asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: adminUser.toBuilder().preferences({} as PreferencesMap).build().toJSON() });
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({
+      currentUser: adminUser.toBuilder().preferences({} as PreferencesMap).build().toJSON(),
+    });
 
     const consume = renderSUT();
 

--- a/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserPreferencesProvider.test.tsx
@@ -18,17 +18,20 @@ import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import { defaultUser } from 'defaultMockValues';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-import useCurrentUser from 'hooks/useCurrentUser';
 import { adminUser } from 'fixtures/users';
 import type { PreferencesMap } from 'stores/users/PreferencesStore';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 import type { UserPreferences } from './UserPreferencesContext';
 import UserPreferencesContext, { defaultUserPreferences } from './UserPreferencesContext';
 import CurrentUserProvider from './CurrentUserProvider';
 import CurrentUserPreferencesProvider from './CurrentUserPreferencesProvider';
 
-jest.mock('hooks/useCurrentUser');
+jest.mock('stores/users/CurrentUserStore', () => ({
+  CurrentUserStore: MockStore(['getInitialState', jest.fn(() => ({}))]),
+}));
 
 describe('CurrentUserPreferencesProvider', () => {
   const SimpleCurrentUserPreferencesProvider = ({ children }: { children: (value: UserPreferences) => React.ReactNode }) => (
@@ -54,7 +57,7 @@ describe('CurrentUserPreferencesProvider', () => {
   };
 
   beforeEach(() => {
-    asMock(useCurrentUser).mockReturnValue(defaultUser);
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: defaultUser.toJSON() });
   });
 
   it('provides default user preferences when CurrentUserContext is not provided', () => {
@@ -65,14 +68,8 @@ describe('CurrentUserPreferencesProvider', () => {
     expect(consume).toHaveBeenCalledWith(defaultUserPreferences);
   });
 
-  it('provides default user preferences with empty store', () => {
-    const consume = renderSUT();
-
-    expect(consume).toHaveBeenCalledWith(defaultUserPreferences);
-  });
-
   it('provides default user preferences if the user has none', () => {
-    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().preferences(undefined as PreferencesMap).build());
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: adminUser.toBuilder().preferences(undefined as PreferencesMap).build().toJSON() });
 
     const consume = renderSUT();
 
@@ -80,7 +77,7 @@ describe('CurrentUserPreferencesProvider', () => {
   });
 
   it('provides empty user preferences of current user', () => {
-    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().preferences({} as PreferencesMap).build());
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: adminUser.toBuilder().preferences({} as PreferencesMap).build().toJSON() });
 
     const consume = renderSUT();
 
@@ -88,9 +85,11 @@ describe('CurrentUserPreferencesProvider', () => {
   });
 
   it('provides user preferences of current user', () => {
-    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().preferences(
-      { enableSmartSearch: false, updateUnfocussed: true } as PreferencesMap,
-    ).build());
+    asMock(CurrentUserStore.getInitialState).mockReturnValue({
+      currentUser: adminUser.toBuilder().preferences(
+        { enableSmartSearch: false, updateUnfocussed: true } as PreferencesMap,
+      ).build().toJSON(),
+    });
 
     const consume = renderSUT();
 

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, screen, act } from 'wrappedTestingLibrary';
 
 import asMock from 'helpers/mocking/AsMock';
 import { alice } from 'fixtures/users';
@@ -28,6 +28,8 @@ import CurrentUserProvider from './CurrentUserProvider';
 jest.mock('stores/users/CurrentUserStore', () => ({
   CurrentUserStore: MockStore(['getInitialState', jest.fn(() => ({}))]),
 }));
+
+jest.useFakeTimers();
 
 describe('CurrentUserProvider', () => {
   const renderSUT = () => {
@@ -45,10 +47,14 @@ describe('CurrentUserProvider', () => {
     return consume;
   };
 
-  it('provides no data when user store is empty', () => {
-    const consume = renderSUT();
+  it('shows spinner while current user is loading', async () => {
+    render(<CurrentUserProvider>Content</CurrentUserProvider>);
 
-    expect(consume).toHaveBeenCalledWith(undefined);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    await screen.findByText('Loading...');
   });
 
   it('provides current user', () => {

--- a/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserProvider.tsx
@@ -21,6 +21,7 @@ import get from 'lodash/get';
 import { useStore } from 'stores/connect';
 import User from 'logic/users/User';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
+import Spinner from 'components/common/Spinner';
 
 import CurrentUserContext from './CurrentUserContext';
 
@@ -28,13 +29,15 @@ const CurrentUserProvider = ({ children }) => {
   const currentUserJSON = useStore(CurrentUserStore, (state) => get(state, 'currentUser'));
   const currentUser = currentUserJSON ? User.fromJSON(currentUserJSON) : undefined;
 
-  return currentUser
-    ? (
-      <CurrentUserContext.Provider value={currentUser}>
-        {children}
-      </CurrentUserContext.Provider>
-    )
-    : children;
+  if (!currentUser) {
+    return <Spinner />;
+  }
+
+  return (
+    <CurrentUserContext.Provider value={currentUser}>
+      {children}
+    </CurrentUserContext.Provider>
+  );
 };
 
 CurrentUserProvider.propTypes = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some scenarios, for example sometimes after the login, the following error occurs:

`useCurrentUser hook needs to be used inside CurrentUserContext.Provider`

This most likely happened because we were only rendering the `CurrentUserProvider` once the current user has been loaded, otherwise we were rendering its children. I only saw this error during development.

We are now just rendering a spinner while the current user is being loaded. This is possible, because we only implement the `CurrentUserProvider` on pages where we load the current user. 

/nocl