### PR TITLE
Provide API endpoints to record/retrieve last used query strings.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -54,6 +54,8 @@ import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService;
+import org.graylog.plugins.views.search.querystrings.MongoLastUsedQueryStringsService;
 import org.graylog.plugins.views.search.rest.DashboardsResource;
 import org.graylog.plugins.views.search.rest.ExportJobsResource;
 import org.graylog.plugins.views.search.rest.FieldTypesResource;
@@ -261,6 +263,8 @@ public class ViewsBindings extends ViewsModule {
         viewResolverBinder();
 
         install(new EngineBindings());
+
+        bind(LastUsedQueryStringsService.class).to(MongoLastUsedQueryStringsService.class);
     }
 
     private void registerExportBackendProvider() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -63,6 +63,7 @@ import org.graylog.plugins.views.search.rest.MessageExportFormatFilter;
 import org.graylog.plugins.views.search.rest.MessagesResource;
 import org.graylog.plugins.views.search.rest.PivotSeriesFunctionsResource;
 import org.graylog.plugins.views.search.rest.QualifyingViewsResource;
+import org.graylog.plugins.views.search.rest.QueryStringsResource;
 import org.graylog.plugins.views.search.rest.QueryValidationResource;
 import org.graylog.plugins.views.search.rest.SavedSearchesResource;
 import org.graylog.plugins.views.search.rest.SearchMetadataResource;
@@ -265,6 +266,7 @@ public class ViewsBindings extends ViewsModule {
         install(new EngineBindings());
 
         bind(LastUsedQueryStringsService.class).to(MongoLastUsedQueryStringsService.class);
+        addSystemRestResource(QueryStringsResource.class);
     }
 
     private void registerExportBackendProvider() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/LastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/LastUsedQueryStringsService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.querystrings;
+
+import org.graylog2.plugin.database.users.User;
+
+import java.util.List;
+
+public interface LastUsedQueryStringsService {
+    List<QueryString> get(User user);
+
+    void save(User user, String queryString);
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/LastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/LastUsedQueryStringsService.java
@@ -21,7 +21,13 @@ import org.graylog2.plugin.database.users.User;
 import java.util.List;
 
 public interface LastUsedQueryStringsService {
-    List<QueryString> get(User user);
+    int DEFAULT_LIMIT = 10;
+
+    default List<QueryString> get(User user) {
+        return get(user, DEFAULT_LIMIT);
+    }
+
+    List<QueryString> get(User user, int limit);
 
     void save(User user, String queryString);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
@@ -24,6 +24,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.PushOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.startpage.lastOpened.LastOpenedDTO;
 import org.graylog.plugins.views.startpage.lastOpened.LastOpenedForUserDTO;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -31,7 +32,6 @@ import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.users.events.UserDeletedEvent;
 
-import javax.inject.Inject;
 import java.time.Clock;
 import java.util.Date;
 import java.util.List;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.querystrings;
+
+import com.google.common.eventbus.EventBus;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.PushOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import org.graylog.plugins.views.startpage.lastOpened.LastOpenedDTO;
+import org.graylog.plugins.views.startpage.lastOpened.LastOpenedForUserDTO;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.database.users.User;
+
+import javax.inject.Inject;
+import java.time.Clock;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.graylog.plugins.views.search.querystrings.QueryString.FIELD_QUERY;
+import static org.graylog.plugins.views.search.querystrings.QueryStringForUser.FIELD_ITEMS;
+import static org.graylog.plugins.views.search.querystrings.QueryStringForUser.FIELD_USER_ID;
+
+public class MongoLastUsedQueryStringsService implements LastUsedQueryStringsService {
+    public static final String COLLECTION_NAME = "query_strings";
+    private static final Integer MAX_LENGTH = 100;
+    private final Integer maxLength;
+    private final MongoCollection<QueryStringForUser> collection;
+    private final Clock clock;
+
+    public MongoLastUsedQueryStringsService(MongoConnection mongoConnection,
+                                            MongoJackObjectMapperProvider mapper,
+                                            EventBus eventBus,
+                                            Integer maxLength) {
+        this.collection = mongoConnection.getMongoDatabase().getCollection(COLLECTION_NAME, QueryStringForUser.class);
+        this.clock = Clock.systemDefaultZone();
+        this.maxLength = maxLength;
+
+        eventBus.register(this);
+
+        this.collection.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_USER_ID, 1));
+        this.collection.createIndex(new BasicDBObject(LastOpenedForUserDTO.FIELD_ITEMS + "." + LastOpenedDTO.FIELD_GRN, 1));
+    }
+
+    @Inject
+    public MongoLastUsedQueryStringsService(MongoConnection mongoConnection,
+                                            MongoJackObjectMapperProvider mapper,
+                                            EventBus eventBus) {
+        this(mongoConnection, mapper, eventBus, MAX_LENGTH);
+    }
+
+    @Override
+    public List<QueryString> get(User user) {
+        return findForUser(user.getId()).map(QueryStringForUser::items).orElse(List.of());
+    }
+
+    private Optional<QueryStringForUser> findForUser(final String userId) {
+        return Optional.ofNullable(this.collection.find(Filters.eq(FIELD_USER_ID, userId), QueryStringForUser.class).first());
+    }
+
+
+    @Override
+    public void save(User user, String queryString) {
+        final var newItem = new QueryString(queryString, Date.from(clock.instant()));
+        this.collection.updateOne(Filters.eq(FIELD_USER_ID, user.getId()),
+                Updates.pull(FIELD_ITEMS, Filters.eq(FIELD_QUERY, queryString)));
+        this.collection.updateOne(Filters.eq(FIELD_USER_ID, user.getId()),
+                Updates.pushEach(FIELD_ITEMS, List.of(newItem), new PushOptions().position(0).slice(maxLength)),
+                new UpdateOptions().upsert(true));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
@@ -68,8 +68,11 @@ public class MongoLastUsedQueryStringsService implements LastUsedQueryStringsSer
     }
 
     @Override
-    public List<QueryString> get(User user) {
-        return findForUser(user.getId()).map(QueryStringForUser::items).orElse(List.of());
+    public List<QueryString> get(User user, int limit) {
+        return findForUser(user.getId())
+                .map(QueryStringForUser::items)
+                .map(items -> items.stream().limit(limit).toList())
+                .orElse(List.of());
     }
 
     private Optional<QueryStringForUser> findForUser(final String userId) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsService.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.querystrings;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
@@ -28,6 +29,7 @@ import org.graylog.plugins.views.startpage.lastOpened.LastOpenedForUserDTO;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.users.events.UserDeletedEvent;
 
 import javax.inject.Inject;
 import java.time.Clock;
@@ -88,5 +90,10 @@ public class MongoLastUsedQueryStringsService implements LastUsedQueryStringsSer
         this.collection.updateOne(Filters.eq(FIELD_USER_ID, user.getId()),
                 Updates.pushEach(FIELD_ITEMS, List.of(newItem), new PushOptions().position(0).slice(maxLength)),
                 new UpdateOptions().upsert(true));
+    }
+
+    @Subscribe
+    public void removeQueryStringsUponUserDeletion(final UserDeletedEvent userDeletedEvent) {
+        this.collection.deleteOne(Filters.eq(FIELD_USER_ID, userDeletedEvent.userId()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
@@ -25,7 +25,7 @@ import java.util.Date;
 public record QueryString(@JsonProperty(FIELD_QUERY) @NotNull @NotEmpty String query,
                           @JsonProperty(FIELD_LAST_USED) @NotNull Date lastUsed) {
     public static final String FIELD_QUERY = "query";
-    public static final String FIELD_LAST_USED = "last_user";
+    public static final String FIELD_LAST_USED = "last_used";
 
     public static QueryString create(@NotNull @NotEmpty String query, @NotNull Date lastUsed) {
         return new QueryString(query, lastUsed);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.querystrings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+
+public record QueryString(@JsonProperty(FIELD_QUERY) @NotNull @NotEmpty String query,
+                          @JsonProperty(FIELD_LAST_USED) @NotNull Date lastUsed) {
+    public static final String FIELD_QUERY = "query";
+    public static final String FIELD_LAST_USED = "last_user";
+
+    public static QueryString create(@NotNull @NotEmpty String query, @NotNull Date lastUsed) {
+        return new QueryString(query, lastUsed);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryString.java
@@ -17,9 +17,9 @@
 package org.graylog.plugins.views.search.querystrings;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import java.util.Date;
 
 public record QueryString(@JsonProperty(FIELD_QUERY) @NotNull @NotEmpty String query,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryStringForUser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/querystrings/QueryStringForUser.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.querystrings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public record QueryStringForUser(@ObjectId
+                                 @Id
+                                 @Nullable
+                                 @JsonProperty(FIELD_ID)
+                                 String id,
+                                 @JsonProperty(FIELD_USER_ID)
+                                 String userId,
+                                 @Nullable
+                                 @JsonProperty(FIELD_ITEMS)
+                                 List<QueryString> items) {
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_USER_ID = "user_id";
+    public static final String FIELD_ITEMS = "items";
+
+    public QueryStringForUser {
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+    }
+
+    public QueryStringForUser(String userId, @Nullable List<QueryString> items) {
+        this(null, userId, items);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
@@ -1,0 +1,9 @@
+package org.graylog.plugins.views.search.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+public record QueryStringUsedDTO(@JsonProperty("query_string") @NotNull @NotEmpty String queryString) {
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringUsedDTO.java
@@ -17,9 +17,8 @@
 package org.graylog.plugins.views.search.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record QueryStringUsedDTO(@JsonProperty("query_string") @NotNull @NotEmpty String queryString) {
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest;
 
 import io.swagger.annotations.Api;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
@@ -1,0 +1,46 @@
+package org.graylog.plugins.views.search.rest;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
+@RequiresAuthentication
+@Api(value = "Search/Query Strings", tags = {CLOUD_VISIBLE})
+@Path("/search/query_strings")
+public class QueryStringsResource extends RestResource implements PluginRestResource {
+    private final LastUsedQueryStringsService lastUsedQueryStringsService;
+
+    @Inject
+    public QueryStringsResource(LastUsedQueryStringsService lastUsedQueryStringsService) {
+        this.lastUsedQueryStringsService = lastUsedQueryStringsService;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation("Register a query string used")
+    @NoAuditEvent("No audit event needed for this operation")
+    public Response queryStringUsed(@ApiParam(name = "queryStringRequest") @Valid @NotNull final QueryStringUsedDTO queryStringUsed,
+                                    @Context final SearchUser searchUser) {
+        this.lastUsedQueryStringsService.save(searchUser.getUser(), queryStringUsed.queryString());
+        return Response.noContent().build();
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QueryStringsResource.java
@@ -19,22 +19,21 @@ package org.graylog.plugins.views.search.rest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
-
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
@@ -20,6 +20,14 @@ import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.search.engine.QuerySuggestionsService;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionFieldType;
@@ -46,15 +54,6 @@ import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityIdenti
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleRequest;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleResponse;
 import org.graylog2.shared.rest.resources.RestResource;
-
-import jakarta.inject.Inject;
-
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
 
 import java.util.Collections;
 import java.util.List;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SuggestionsResource.java
@@ -26,6 +26,8 @@ import org.graylog.plugins.views.search.engine.suggestions.SuggestionFieldType;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionRequest;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionResponse;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService;
+import org.graylog.plugins.views.search.querystrings.QueryString;
 import org.graylog.plugins.views.search.rest.suggestions.SuggestionEntryDTO;
 import org.graylog.plugins.views.search.rest.suggestions.SuggestionsDTO;
 import org.graylog.plugins.views.search.rest.suggestions.SuggestionsErrorDTO;
@@ -47,6 +49,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 
 import jakarta.inject.Inject;
 
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -59,11 +62,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService.DEFAULT_LIMIT;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
 @Api(value = "Search/Suggestions", tags = {CLOUD_VISIBLE})
 @Path("/search/suggest")
+@Produces(MediaType.APPLICATION_JSON)
 public class SuggestionsResource extends RestResource implements PluginRestResource {
 
     public static final int SUGGESTIONS_COUNT_MAX = 100;
@@ -74,18 +79,29 @@ public class SuggestionsResource extends RestResource implements PluginRestResou
 
     private final EntityTitleService entityTitleService;
     private final NodeService nodeService;
+    private final LastUsedQueryStringsService lastUsedQueryStringsService;
 
     @Inject
-    public SuggestionsResource(PermittedStreams permittedStreams, QuerySuggestionsService querySuggestionsService, MappedFieldTypesService mappedFieldTypesService, EntityTitleService entityTitleService, NodeService nodeService) {
+    public SuggestionsResource(PermittedStreams permittedStreams, QuerySuggestionsService querySuggestionsService,
+                               MappedFieldTypesService mappedFieldTypesService, EntityTitleService entityTitleService,
+                               NodeService nodeService, LastUsedQueryStringsService lastUsedQueryStringsService) {
         this.permittedStreams = permittedStreams;
         this.querySuggestionsService = querySuggestionsService;
         this.mappedFieldTypesService = mappedFieldTypesService;
         this.entityTitleService = entityTitleService;
         this.nodeService = nodeService;
+        this.lastUsedQueryStringsService = lastUsedQueryStringsService;
+    }
+
+    @GET
+    @Path("/query_strings")
+    @ApiOperation("Suggest last used query strings")
+    public List<QueryString> suggestQueryStrings(@Context SearchUser searchUser,
+                                                 @ApiParam("limit") @QueryParam("limit") Integer limit) {
+        return lastUsedQueryStringsService.get(searchUser.getUser(), Optional.ofNullable(limit).orElse(DEFAULT_LIMIT));
     }
 
     @POST
-    @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation("Suggest field value")
     @NoAuditEvent("Only suggesting field value for query, not changing any data")
     public SuggestionsDTO suggestFieldValue(@ApiParam(name = "validationRequest") SuggestionsRequestDTO suggestionsRequest,

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/querystrings/MongoLastUsedQueryStringsServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.querystrings;
+
+import com.google.common.eventbus.EventBus;
+import org.graylog.plugins.views.search.rest.TestUser;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.plugin.database.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MongoJackExtension.class)
+class MongoLastUsedQueryStringsServiceTest {
+    private User user;
+    private User admin;
+
+    private LastUsedQueryStringsService service;
+
+    @BeforeEach
+    void setUp(MongoDBTestService mongodb,
+               MongoJackObjectMapperProvider mongoJackObjectMapperProvider) {
+
+        admin = TestUser.builder().withId("637748db06e1d74da0a54331").withUsername("local:admin").isLocalAdmin(true).build();
+        user = TestUser.builder().withId("637748db06e1d74da0a54330").withUsername("test").isLocalAdmin(false).build();
+
+        this.service = new MongoLastUsedQueryStringsService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, new EventBus(), 3);
+    }
+
+    @Test
+    void storedQueryStringCanBeRetrieved() {
+        assertThat(queryStrings(service.get(user))).isEmpty();
+
+        service.save(user, "http_method:GET");
+
+        assertThat(queryStrings(service.get(user))).containsExactly("http_method:GET");
+
+        assertThat(queryStrings(service.get(admin))).isEmpty();
+    }
+
+    @Test
+    void queryStringsAreScopedByUser() {
+        assertThat(service.get(user)).isEmpty();
+
+        service.save(user, "http_method:GET");
+
+        assertThat(queryStrings(service.get(admin))).isEmpty();
+
+        service.save(admin, "action:foo");
+
+        assertThat(queryStrings(service.get(user))).containsExactly("http_method:GET");
+    }
+
+    @Test
+    void queryStringsAreCappedAtMaximumLength() {
+        service.save(user, "query string 1");
+        service.save(user, "query string 2");
+        service.save(user, "query string 3");
+        service.save(user, "query string 4");
+
+        assertThat(queryStrings(service.get(user))).containsExactly(
+                "query string 4",
+                "query string 3",
+                "query string 2"
+        );
+    }
+
+    @Test
+    void queryStringsAreDeduplicated() {
+        service.save(user, "query string 1");
+        service.save(user, "query string 2");
+        service.save(user, "query string 1");
+
+        assertThat(queryStrings(service.get(user))).containsExactly(
+                "query string 1",
+                "query string 2"
+        );
+    }
+
+    private List<String> queryStrings(List<QueryString> queryStrings) {
+        return queryStrings.stream().map(QueryString::query).toList();
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is providing endpoints to record/retrieve last used query strings for auto-completion in the query input.

API endpoints provided are:

 - `POST /search/query_strings`: record a query string (body is `{ "query_string": "..." }`)
 - `GET /search/suggest/query_strings`: retrieve last used query strings (optional query parameter `limit`, defaulting to 10), ordered by time of last use

The persistence behind this is ensuring that:

  - users can only see their last used query strings
  - number of query strings is bounded (defaulting to 100)
  - query strings are deleted when user is deleted
  - query strings are deduplicated (right now in the simplest way)

Fixes #17946.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.