### PR TITLE
Disable flaky `DashboardActions` test.

### DIFF
--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -19,7 +19,7 @@ import { render, waitFor, screen } from 'wrappedTestingLibrary';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-// import Immutable from 'immutable';
+import Immutable from 'immutable';
 
 import { asMock } from 'helpers/mocking';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -91,18 +91,19 @@ describe('DashboardActions', () => {
     expect(ViewManagementActions.delete).toHaveBeenCalledWith(expect.objectContaining({ id: 'foo' }));
   });
 
-  // it('does not offer deletion when user has only read permissions', async () => {
-  //   const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
-  //   asMock(useCurrentUser).mockReturnValue(currentUser);
-  //
-  //   render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
-  //
-  //   userEvent.click(await screen.findByText('More'));
-  //
-  //   await screen.findByRole('menu');
-  //
-  //   expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
-  // });
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('does not offer deletion when user has only read permissions', async () => {
+    const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
+    asMock(useCurrentUser).mockReturnValue(currentUser);
+
+    render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
+
+    userEvent.click(await screen.findByText('More'));
+
+    await screen.findByRole('menu');
+
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  });
 
   describe('supports dashboard deletion hook', () => {
     const deletingDashboard = jest.fn(() => Promise.resolve(true));

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -19,7 +19,7 @@ import { render, waitFor, screen } from 'wrappedTestingLibrary';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import Immutable from 'immutable';
+// import Immutable from 'immutable';
 
 import { asMock } from 'helpers/mocking';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -91,18 +91,18 @@ describe('DashboardActions', () => {
     expect(ViewManagementActions.delete).toHaveBeenCalledWith(expect.objectContaining({ id: 'foo' }));
   });
 
-  it('does not offer deletion when user has only read permissions', async () => {
-    const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
-    asMock(useCurrentUser).mockReturnValue(currentUser);
-
-    render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
-
-    userEvent.click(await screen.findByText('More'));
-
-    await screen.findByRole('menu');
-
-    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
-  });
+  // it('does not offer deletion when user has only read permissions', async () => {
+  //   const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
+  //   asMock(useCurrentUser).mockReturnValue(currentUser);
+  //
+  //   render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
+  //
+  //   userEvent.click(await screen.findByText('More'));
+  //
+  //   await screen.findByRole('menu');
+  //
+  //   expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  // });
 
   describe('supports dashboard deletion hook', () => {
     const deletingDashboard = jest.fn(() => Promise.resolve(true));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since a refactoring of the dropdown component (https://github.com/Graylog2/graylog2-server/pull/17527) one dashboard became flaky. This PR disables the test, to make sure this test does not block other PR's, until we have a proper solution.

/nocl

