### PR TITLE
Display dashboard actions dropdown button in dashboards overview only when it contains actions.

### DIFF
--- a/graylog2-web-interface/src/components/events/events/EventDetails.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.tsx
@@ -27,6 +27,18 @@ import EventFields from 'components/events/events/EventFields';
 import EventDefinitionLink from 'components/event-definitions/event-definitions/EventDefinitionLink';
 import LinkToReplaySearch from 'components/event-definitions/replay-search/LinkToReplaySearch';
 
+const usePluggableEventActions = (event: Event) => {
+  const pluggableEventActions = usePluginEntities('views.components.eventActions');
+
+  return pluggableEventActions.filter(
+    (perspective) => (perspective.useCondition ? !!perspective.useCondition() : true),
+  ).map(
+    ({ component: PluggableEventAction, key }) => (
+      <PluggableEventAction key={key} event={event} />
+    ),
+  );
+};
+
 type Props = {
   event: Event,
   eventDefinitionContext: EventDefinitionContext,
@@ -34,12 +46,7 @@ type Props = {
 
 const EventDetails = ({ event, eventDefinitionContext }: Props) => {
   const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes');
-  const pluggableEventActions = usePluginEntities('views.components.eventActions');
-  const eventActions = useMemo(() => pluggableEventActions.map(
-    ({ component: PluggableEventAction, key }) => (
-      <PluggableEventAction key={key} event={event} />
-    ),
-  ), [pluggableEventActions, event]);
+  const pluggableActions = usePluggableEventActions(event);
 
   const plugin = useMemo(() => {
     if (event.event_definition_type === undefined) {
@@ -69,13 +76,13 @@ const EventDetails = ({ event, eventDefinitionContext }: Props) => {
             ({(plugin && plugin.displayName) || event.event_definition_type})
           </dd>
           {event.replay_info && (
-          <>
-            <dt>Actions</dt>
-            <dd>
-              <LinkToReplaySearch id={event.id} isEvent />
-            </dd>
-            {eventActions}
-          </>
+            <>
+              <dt>Actions</dt>
+              <dd>
+                <LinkToReplaySearch id={event.id} isEvent />
+              </dd>
+              {pluggableActions}
+            </>
           )}
         </dl>
       </Col>

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -45,7 +45,7 @@ describe('DashboardActions', () => {
   const menuIsHidden = () => expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 
   const clickDashboardAction = async (action: string) => {
-    userEvent.click(await screen.findByText('More'));
+    userEvent.click(await screen.findByRole('button', { name: /more/i }));
     userEvent.click(await screen.findByRole('button', { name: action }));
     await waitFor(() => menuIsHidden());
   };
@@ -91,18 +91,15 @@ describe('DashboardActions', () => {
     expect(ViewManagementActions.delete).toHaveBeenCalledWith(expect.objectContaining({ id: 'foo' }));
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('does not offer deletion when user has only read permissions', async () => {
+  it('does not display more actions dropdown when user has no permissions for deletion and there are no pluggable actions', async () => {
     const currentUser = adminUser.toBuilder().permissions(Immutable.List([`view:read:${simpleDashboard.id}`])).build();
     asMock(useCurrentUser).mockReturnValue(currentUser);
 
     render(<DashboardActions dashboard={simpleDashboard} refetchDashboards={() => Promise.resolve()} />);
 
-    userEvent.click(await screen.findByText('More'));
+    await screen.findByRole('button', { name: /share/i });
 
-    await screen.findByRole('menu');
-
-    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /'more'/i })).not.toBeInTheDocument();
   });
 
   describe('supports dashboard deletion hook', () => {

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
@@ -14,12 +14,12 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useState, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import UserNotification from 'util/UserNotification';
-import { IfPermitted, ShareButton } from 'components/common';
+import { ShareButton } from 'components/common';
 import { MenuItem } from 'components/bootstrap';
 import type View from 'views/logic/views/View';
 import EntityShareModal from 'components/permissions/EntityShareModal';
@@ -32,6 +32,8 @@ import { MORE_ACTIONS_TITLE, MORE_ACTIONS_HOVER_TITLE } from 'components/common/
 import DropdownButton from 'components/bootstrap/DropdownButton';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
 import type FetchError from 'logic/errors/FetchError';
+import { isAnyPermitted } from 'util/PermissionsMixin';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 // eslint-disable-next-line no-alert
 const defaultDashboardDeletionHook = async (view: View) => window.confirm(`Are you sure you want to delete "${view.title}"?`);
@@ -50,20 +52,32 @@ const DeleteItem = styled.span(({ theme }) => css`
   color: ${theme.colors.variant.danger};
 `);
 
-const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
-  const { deselectEntity } = useSelectedEntities();
-  const [showShareModal, setShowShareModal] = useState(false);
-  const paginationQueryParameter = usePaginationQueryParameter();
-  const pluggableDashboardActions = usePluginEntities('views.components.dashboardActions');
+const usePluggableDashboardActions = (dashboard: View) => {
   const modalRefs = useRef({});
-  const dashboardActions = useMemo(() => pluggableDashboardActions.map(({ component: PluggableDashboardAction, key }) => (
-    <PluggableDashboardAction key={`dashboard-action-${key}`} dashboard={dashboard} modalRef={() => modalRefs.current[key]} />
-  )), [pluggableDashboardActions, dashboard]);
-  const dashboardActionModals = useMemo(() => pluggableDashboardActions
+  const pluggableActions = usePluginEntities('views.components.dashboardActions');
+  const availableActions = pluggableActions.filter(
+    (perspective) => (perspective.useCondition ? !!perspective.useCondition() : true),
+  );
+  const actions = availableActions.map(({ component: PluggableDashboardAction, key }) => (
+    <PluggableDashboardAction key={`dashboard-action-${key}`}
+                              dashboard={dashboard}
+                              modalRef={() => modalRefs.current[key]} />
+  ));
+
+  const actionModals = availableActions
     .filter(({ modal }) => !!modal)
     .map(({ modal: ActionModal, key }) => (
-      <ActionModal key={`dashboard-action-modal-${key}`} dashboard={dashboard} ref={(r) => { modalRefs.current[key] = r; }} />
-    )), [pluggableDashboardActions, dashboard]);
+      <ActionModal key={`dashboard-action-modal-${key}`}
+                   dashboard={dashboard}
+                   ref={(r) => { modalRefs.current[key] = r; }} />
+    ));
+
+  return ({ actions, actionModals });
+};
+
+const DashboardDeleteAction = ({ dashboard, refetchDashboards }: { dashboard: View, refetchDashboards: () => void }) => {
+  const { deselectEntity } = useSelectedEntities();
+  const paginationQueryParameter = usePaginationQueryParameter();
 
   const onDashboardDelete = useCallback(async () => {
     const pluginDashboardDeletionHooks = PluginStore.exports('views.hooks.confirmDeletingDashboard');
@@ -83,24 +97,36 @@ const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
   }, [dashboard, deselectEntity, refetchDashboards, paginationQueryParameter]);
 
   return (
+    <MenuItem onClick={onDashboardDelete}>
+      <DeleteItem role="button">Delete</DeleteItem>
+    </MenuItem>
+  );
+};
+
+const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
+  const [showShareModal, setShowShareModal] = useState(false);
+  const { actions: pluggableActions, actionModals: pluggableActionModals } = usePluggableDashboardActions(dashboard);
+  const currentUser = useCurrentUser();
+
+  const moreActions = [
+    pluggableActions.length ? pluggableActions : null,
+    pluggableActions.length ? <MenuItem divider key="divider" /> : null,
+    isAnyPermitted(currentUser.permissions, [`view:edit:${dashboard.id}`, 'view:edit'])
+      ? <DashboardDeleteAction dashboard={dashboard} refetchDashboards={refetchDashboards} key="delete-action" />
+      : null,
+  ].filter(Boolean);
+
+  return (
     <>
       <ShareButton bsSize="xsmall"
                    entityId={dashboard.id}
                    entityType="dashboard"
                    onClick={() => setShowShareModal(true)} />
-      <DropdownButton bsSize="xsmall" title={MORE_ACTIONS_TITLE} buttonTitle={MORE_ACTIONS_HOVER_TITLE}>
-        {dashboardActions.length > 0 ? (
-          <>
-            {dashboardActions}
-            <MenuItem divider />
-          </>
-        ) : null}
-        <IfPermitted permissions={[`view:edit:${dashboard.id}`, 'view:edit']} anyPermissions>
-          <MenuItem onClick={onDashboardDelete}>
-            <DeleteItem role="button">Delete</DeleteItem>
-          </MenuItem>
-        </IfPermitted>
-      </DropdownButton>
+      {!!moreActions.length && (
+        <DropdownButton bsSize="xsmall" title={MORE_ACTIONS_TITLE} buttonTitle={MORE_ACTIONS_HOVER_TITLE}>
+          {moreActions.map((action) => action)}
+        </DropdownButton>
+      )}
       {showShareModal && (
         <EntityShareModal entityId={dashboard.id}
                           entityType="dashboard"
@@ -108,7 +134,7 @@ const DashboardActions = ({ dashboard, refetchDashboards }: Props) => {
                           entityTitle={dashboard.title}
                           onClose={() => setShowShareModal(false)} />
       )}
-      {dashboardActionModals}
+      {pluggableActionModals}
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo } from 'react';
 import type * as Immutable from 'immutable';
 
 import { LinkContainer } from 'components/common/router';
@@ -71,6 +70,16 @@ const _getTestAgainstStreamButton = (streams: Immutable.List<any>, index: string
   );
 };
 
+const usePluggableMessageActions = (id: string, index: string) => {
+  const pluggableMenuActions = usePluginEntities('views.components.widgets.messageTable.messageActions');
+
+  return pluggableMenuActions.filter(
+    (perspective) => (perspective.useCondition ? !!perspective.useCondition() : true),
+  ).map(
+    ({ component: PluggableMenuAction, key }) => <PluggableMenuAction key={key} id={id} index={index} />,
+  );
+};
+
 type Props = {
   index: string,
   id: string,
@@ -100,10 +109,7 @@ const MessageActions = ({
   streams,
   searchConfig,
 }: Props) => {
-  const pluggableMenuActions = usePluginEntities('views.components.widgets.messageTable.messageActions');
-  const menuActions = useMemo(() => pluggableMenuActions.map(
-    ({ component: PluggableMenuAction, key }) => <PluggableMenuAction key={key} id={id} index={index} />,
-  ), [id, index, pluggableMenuActions]);
+  const pluggableActions = usePluggableMessageActions(id, index);
 
   if (disabled) {
     return <ButtonGroup />;
@@ -127,7 +133,7 @@ const MessageActions = ({
     <ButtonGroup>
       {showChanges}
       <Button bsSize="small" href={messageUrl}>Permalink</Button>
-      {menuActions}
+      {pluggableActions}
 
       <ClipboardButton title="Copy ID" text={id} bsSize="small" />
       <ClipboardButton title="Copy message" bsSize="small" text={JSON.stringify(fields, null, 2)} />

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -274,6 +274,7 @@ type DashboardAction = {
   key: string,
   component: React.ComponentType<DashboardActionComponentProps>,
   modal?: React.ComponentType<DashboardActionModalProps>,
+  useCondition?: () => boolean,
 }
 
 type AssetInformation = {
@@ -418,6 +419,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.assetInformationActions'?: Array<AssetInformation>;
     'views.components.dashboardActions'?: Array<DashboardAction>;
     'views.components.eventActions'?: Array<{
+      useCondition: () => boolean,
       component: React.ComponentType<EventActionComponentProps>,
       key: string,
     }>;
@@ -428,10 +430,12 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.widgets.messageTable.messageActions'?: Array<{
       component: React.ComponentType<MessageActionComponentProps>,
       key: string,
+      useCondition: () => boolean,
     }>;
     'views.components.searchActions'?: Array<{
       component: React.ComponentType<SearchActionComponentProps>,
       key: string,
+      useCondition: () => boolean,
     }>;
     'views.components.searchBar'?: Array<() => SearchBarControl | null>;
     'views.components.saveViewForm'?: Array<() => SaveViewControls | null>;


### PR DESCRIPTION
**Please note**, this PR needs to be merged together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/6438

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible that users have no required permissions for any actions in the "More" dropdown.

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/65bc52d6-c730-4bbd-8bff-0eae6615f15c)

This occurs for example for reader users who have only read access for a dashboard

With this change we are now hiding the dropdown button:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/fdc75cda-9fc6-4f3a-8b22-19dc50217246)


To make this possible we had to adjust the pluggable actions.
This change also improves the flaky test mentioned in https://github.com/Graylog2/graylog2-server/pull/17954

/nocl
/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/6438
