### PR TITLE
Restoring `aria-label` prop for button.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/DropdownButton.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/DropdownButton.tsx
@@ -46,7 +46,11 @@ const position = (pullRight: boolean, dropup: boolean): 'top' | 'bottom' | 'top-
 
 const DropdownButton = ({ buttonTitle, children, closeOnItemClick, dropup, title, onMouseDown, onToggle, pullRight, noCaret, keepMounted, ...rest }: Props) => (
   <Menu position={position(pullRight, dropup)} onChange={onToggle} keepMounted={keepMounted} closeOnItemClick={closeOnItemClick}>
-    <Menu.Target><Button onClick={onMouseDown} {...rest} title={buttonTitle}>{title}{noCaret ? null : <>{' '}<Icon name="caret-down" /></>}</Button></Menu.Target>
+    <Menu.Target>
+      <Button onClick={onMouseDown} aria-label={buttonTitle} {...rest} title={buttonTitle}>
+        {title}{noCaret ? null : <>{' '}<Icon name="caret-down" /></>}
+      </Button>
+    </Menu.Target>
     <Menu.Dropdown>{children}</Menu.Dropdown>
   </Menu>
 );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #17527, the `aria-label` prop of the button triggering the dropdown got lost. This decreases accessibility and breaks some e2e-tests.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.