### PR TITLE
Implement custom abstraction of `Menu` component for `OverlayDropdown`.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Menu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Menu.tsx
@@ -22,24 +22,30 @@ import styled, { css, useTheme } from 'styled-components';
 type Props = PropsWithChildren<{
   closeOnItemClick?: boolean,
   onChange?: (isOpen: boolean) => void,
+  onClose?: () => void,
   opened?: boolean,
+  portalProps?: { target: HTMLElement },
   keepMounted?: boolean,
   position?: MenuProps['position'],
   shadow?: MenuProps['shadow'],
   width?: number,
   withinPortal?: boolean,
+  zIndex?: number,
 }>
 
 const Menu = ({
   children,
+  closeOnItemClick,
+  onClose,
   shadow,
   width,
   withinPortal,
   position,
   opened,
   onChange,
+  portalProps,
   keepMounted,
-  closeOnItemClick,
+  zIndex,
 }: Props) => {
   const theme = useTheme();
 
@@ -54,14 +60,17 @@ const Menu = ({
 
   return (
     <MantineMenu closeOnItemClick={closeOnItemClick}
+                 onClose={onClose}
                  shadow={shadow}
                  opened={opened}
                  onChange={onChange}
+                 portalProps={portalProps}
                  width={width}
                  position={position}
                  withinPortal={withinPortal}
                  styles={styles}
-                 keepMounted={keepMounted}>
+                 keepMounted={keepMounted}
+                 zIndex={zIndex}>
       {children}
     </MantineMenu>
   );
@@ -95,12 +104,15 @@ Menu.Label = StyledMenuLabel;
 Menu.defaultProps = {
   closeOnItemClick: true,
   position: undefined,
+  portalProps: undefined,
   shadow: undefined,
   width: undefined,
   withinPortal: false,
   opened: undefined,
   onChange: undefined,
+  onClose: undefined,
   keepMounted: undefined,
+  zIndex: undefined,
 };
 
 export default Menu;

--- a/graylog2-web-interface/src/components/common/EntityFilters/CreateFilterDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/CreateFilterDropdown.tsx
@@ -79,7 +79,6 @@ const CreateFilterDropdown = ({ filterableAttributes, filterValueRenderers, onCr
                              buttonTitle="Create Filter"
                              onToggle={onToggleDropdown}
                              closeOnSelect={false}
-                             dropdownMinWidth={120}
                              dropdownZIndex={1000}>
         {({ toggleDropdown }) => {
           const _onCreateFilter = (filter: { title: string, value: string }, closeDropdown = true) => {

--- a/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdown.tsx
@@ -16,8 +16,9 @@
  */
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import styled, { useTheme, css } from 'styled-components';
-import { Menu } from '@mantine/core';
+import styled, { css } from 'styled-components';
+
+import Menu from 'components/bootstrap/Menu';
 
 type Placement = 'top' | 'right' | 'bottom' | 'left';
 
@@ -39,7 +40,6 @@ type Props = {
   alwaysShowCaret?: boolean,
   children: React.ReactNode,
   closeOnSelect?: boolean,
-  dropdownMinWidth?: number,
   dropdownZIndex?: number,
   menuContainer?: HTMLElement,
   onToggle: () => void,
@@ -52,7 +52,6 @@ const OverlayDropdown = ({
   alwaysShowCaret,
   children,
   closeOnSelect,
-  dropdownMinWidth,
   dropdownZIndex,
   menuContainer,
   onToggle,
@@ -62,25 +61,11 @@ const OverlayDropdown = ({
 }: Props) => {
   const toggleTarget = useRef<HTMLButtonElement>();
 
-  const theme = useTheme();
-
-  const styles = {
-    dropdown: {
-      minWidth: dropdownMinWidth,
-      backgroundColor: theme.colors.global.contentBackground,
-      border: `1px solid ${theme.colors.variant.lighter.default}`,
-      fontFamily: theme.fonts.family.body,
-      fontSize: theme.fonts.size.body,
-    },
-  };
-
   return (
     <Menu opened={show}
           withinPortal
           position={placement}
-          closeOnClickOutside
           closeOnItemClick={closeOnSelect}
-          styles={styles}
           onClose={onToggle}
           portalProps={{ target: menuContainer }}
           zIndex={dropdownZIndex}>
@@ -114,7 +99,6 @@ OverlayDropdown.propTypes = {
 OverlayDropdown.defaultProps = {
   alwaysShowCaret: false,
   closeOnSelect: true,
-  dropdownMinWidth: undefined,
   dropdownZIndex: undefined,
   menuContainer: document.body,
   placement: 'bottom',

--- a/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
+++ b/graylog2-web-interface/src/components/common/OverlayDropdownButton.tsx
@@ -29,7 +29,6 @@ type Props = {
   children: React.ReactNode | ((payload: { toggleDropdown: () => void }) => React.ReactNode),
   closeOnSelect?: boolean,
   disabled?: boolean
-  dropdownMinWidth?: number
   dropdownZIndex?: number,
   onToggle?: (isOpen: boolean) => void,
   title: React.ReactNode,
@@ -45,7 +44,6 @@ const OverlayDropdownButton = ({
   children,
   closeOnSelect,
   disabled,
-  dropdownMinWidth,
   dropdownZIndex,
   onToggle: onToggleProp,
   title,
@@ -64,7 +62,6 @@ const OverlayDropdownButton = ({
     <OverlayDropdown show={show}
                      closeOnSelect={closeOnSelect}
                      dropdownZIndex={dropdownZIndex}
-                     dropdownMinWidth={dropdownMinWidth}
                      alwaysShowCaret={alwaysShowCaret}
                      toggleChild={(
                        <div className={`dropdown btn-group ${show ? 'open' : ''}`}>
@@ -90,7 +87,6 @@ OverlayDropdownButton.defaultProps = {
   buttonTitle: undefined,
   closeOnSelect: true,
   disabled: false,
-  dropdownMinWidth: undefined,
   dropdownZIndex: undefined,
   onToggle: undefined,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/17527. With this PR we are now using the `Menu` component from `components/bootstrap` instead of `@mantine/core` in the `OverlayDropdown` component. By using our abstraction we only have to adjust e.g. the menu styles in one place.

/nocl