### PR TITLE
Keeping "More Actions" menu mounted to allow rendering of "Full Screen" mode modal.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -147,6 +147,7 @@ const DashboardActionsMenu = () => {
         <DropdownButton title={<Icon name="ellipsis-h" />}
                         id="query-tab-actions-dropdown"
                         pullRight
+                        keepMounted
                         buttonTitle="More Actions"
                         noCaret>
           {dashboardActions.length > 0 && (


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the migration of dropdowns to Mantine, the content of dropdowns is now not rendered anymore by default, when they are not open. This leads to the "Full Screen" mode configuration modal closing immediately after the menu item has been clicked, due to the dropdown content (which is containing the modal) unmounting immediately.

This PR is fixing this by adding the `keepMounted` prop to ensure that the content of the dropdown is rendered even if it's not open.

This is fallout from a change that is previously unreleased, so no active version of the product is affected.

Fixes #17978.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.