### PR TITLE
Improve dropdown related tests, by waiting for menu to be mounted and unmounted

### DIFF
--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -43,7 +43,9 @@ jest.mock('stores/users/UsersStore', () => ({
 const clickMoreActions = async (username: string) => {
   const actions = await screen.findByRole('cell', { name: new RegExp(`edit user ${username}`, 'i') });
 
-  return fireEvent.click(await within(actions).findByRole('button', { name: /more actions/i }));
+  fireEvent.click(await within(actions).findByRole('button', { name: /more actions/i }));
+
+  await screen.findByRole('menu');
 };
 
 describe('UsersOverview', () => {
@@ -124,6 +126,7 @@ describe('UsersOverview', () => {
       await clickMoreActions(modifiableUser.fullName);
       const deleteButton = await screen.findByTitle(`Delete user ${modifiableUser.fullName}`);
       fireEvent.click(deleteButton);
+      await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
 
       await waitFor(() => {
         expect(screen.queryByTitle(`Delete user ${modifiableUser.fullName}`)).not.toBeInTheDocument();

--- a/graylog2-web-interface/src/views/components/Value.test.tsx
+++ b/graylog2-web-interface/src/views/components/Value.test.tsx
@@ -35,8 +35,9 @@ const Value = (props: React.ComponentProps<typeof OriginalValue>) => (
 );
 
 describe('Value', () => {
-  const openActionsMenu = (value: string | RegExp) => {
+  const openActionsMenu = async (value: string | RegExp) => {
     userEvent.click(screen.getByText(value));
+    await screen.findByRole('menu');
   };
 
   beforeEach(() => {
@@ -55,7 +56,7 @@ describe('Value', () => {
     it('renders without type information but no children', async () => {
       render(<Value field="foo" value={42} type={FieldType.Unknown} />);
 
-      openActionsMenu('42');
+      await openActionsMenu('42');
 
       await screen.findByText('foo = 42');
     });
@@ -66,7 +67,7 @@ describe('Value', () => {
                     render={({ value }) => <>The date {value}</>}
                     type={new FieldType('date', [], [])} />);
 
-      openActionsMenu('The date 2018-10-02 16:45:40.000');
+      await openActionsMenu('The date 2018-10-02 16:45:40.000');
       const title = await screen.findByTestId('value-actions-title');
 
       expect(title).toHaveTextContent('foo = 2018-10-02 16:45:40.000');
@@ -86,7 +87,7 @@ describe('Value', () => {
                     value={false}
                     type={new FieldType('boolean', [], [])} />);
 
-      openActionsMenu('false');
+      await openActionsMenu('false');
 
       await screen.findByText('foo = false');
     });
@@ -94,7 +95,7 @@ describe('Value', () => {
     it('renders booleans as strings even if field type is unknown', async () => {
       render(<Value field="foo" value={false} type={FieldType.Unknown} />);
 
-      openActionsMenu('false');
+      await openActionsMenu('false');
 
       await screen.findByText('foo = false');
     });
@@ -104,7 +105,7 @@ describe('Value', () => {
                     value={[23, 'foo']}
                     type={FieldType.Unknown} />);
 
-      openActionsMenu('[23,"foo"]');
+      await openActionsMenu('[23,"foo"]');
 
       await screen.findByText('foo = [23,"foo"]');
     });
@@ -114,7 +115,7 @@ describe('Value', () => {
                     value={{ foo: 23 }}
                     type={FieldType.Unknown} />);
 
-      openActionsMenu('{"foo":23}');
+      await openActionsMenu('{"foo":23}');
 
       await screen.findByText('foo = {"foo":23}');
     });
@@ -124,7 +125,7 @@ describe('Value', () => {
                     value="sophon unbound: [84785:0] error: outgoing tcp: connect: Address already in use for 1.0.0.1"
                     type={new FieldType('string', [], [])} />);
 
-      openActionsMenu('sophon unbound: [84785:0] error: outgoing tcp: connect: Address already in use for 1.0.0.1');
+      await openActionsMenu('sophon unbound: [84785:0] error: outgoing tcp: connect: Address already in use for 1.0.0.1');
 
       await screen.findByText('message = sophon unbound: [84785:0] e...');
     });
@@ -171,7 +172,7 @@ describe('Value', () => {
                                       value={{ foo: 23 }}
                                       type={FieldType.Unknown} />);
 
-      openActionsMenu('{"foo":23}');
+      userEvent.click(screen.getByText('{"foo":23}'));
 
       expect(screen.queryByText('foo = {"foo":23}')).not.toBeInTheDocument();
     });
@@ -183,7 +184,7 @@ describe('Value', () => {
                                    value={{ foo: 23 }}
                                    type={FieldType.Unknown} />);
 
-      openActionsMenu('{"foo":23}');
+      await openActionsMenu('{"foo":23}');
 
       await screen.findByText('foo = {"foo":23}');
     });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -59,8 +59,10 @@ const plugin: PluginRegistration = { exports: { visualizationTypes: [dataTable] 
 const selectEventConfig = { container: document.body };
 
 const addElement = async (key: 'Grouping' | 'Metric' | 'Sort') => {
-  await userEvent.click(await screen.findByRole('button', { name: 'Add' }));
-  await userEvent.click(await screen.findByRole('menuitem', { name: key }));
+  userEvent.click(await screen.findByRole('button', { name: 'Add' }));
+  await screen.findByRole('menu');
+  userEvent.click(await screen.findByRole('menuitem', { name: key }));
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
 };
 
 const selectField = async (fieldName: string, groupingIndex: number = 0, fieldSelectLabel = 'Add a field') => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -56,8 +56,10 @@ const selectEventConfig = { container: document.body };
 const plugin: PluginRegistration = { exports: { visualizationTypes: [dataTable] } };
 
 const addElement = async (key: 'Grouping' | 'Metric' | 'Sort') => {
-  await userEvent.click(await screen.findByRole('button', { name: 'Add' }));
-  await userEvent.click(await screen.findByRole('menuitem', { name: key }));
+  userEvent.click(await screen.findByRole('button', { name: 'Add' }));
+  await screen.findByRole('menu');
+  userEvent.click(await screen.findByRole('menuitem', { name: key }));
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
 };
 
 const submitWidgetConfigForm = async () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -60,8 +60,10 @@ const widgetConfig = AggregationWidgetConfig
 const selectEventConfig = { container: document.body };
 
 const addSortElement = async () => {
-  await userEvent.click(await screen.findByRole('button', { name: 'Add' }));
-  await userEvent.click(await screen.findByRole('menuitem', { name: 'Sort' }));
+  userEvent.click(await screen.findByRole('button', { name: 'Add' }));
+  await screen.findByRole('menu');
+  userEvent.click(await screen.findByRole('menuitem', { name: 'Sort' }));
+  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
 };
 
 const findWidgetConfigFormSubmitButton = () => screen.findByRole('button', { name: /update preview/i });

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
@@ -45,10 +45,13 @@ describe('DashboardsOverview BulkActionsRow', () => {
     userEvent.click(await screen.findByRole('button', {
       name: /bulk actions/i,
     }));
+
+    await screen.findByRole('menu');
   };
 
   const deleteDashboards = async () => {
     userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   };
 
   beforeEach(() => {

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
@@ -27,6 +27,14 @@ import TimeRangePresetDropdown from './TimeRangePresetDropdown';
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
 
 describe('TimeRangePresetDropdown', () => {
+  const openTimeRangePresetSelect = async () => {
+    userEvent.click(await screen.findByRole('button', {
+      name: /open time range preset select/i,
+    }));
+
+    await screen.findByRole('menu');
+  };
+
   it('should not call onChange prop when selecting "Configure Ranges" option.', async () => {
     asMock(useSearchConfiguration).mockReturnValue({
       config: mockSearchClusterConfig,
@@ -36,16 +44,15 @@ describe('TimeRangePresetDropdown', () => {
     const onSelectOption = jest.fn();
     render(<TimeRangePresetDropdown onChange={onSelectOption} />);
 
-    const timeRangePresetButton = screen.getByRole('button', {
-      name: /open time range preset select/i,
-    });
-    userEvent.click(timeRangePresetButton);
+    await openTimeRangePresetSelect();
     await screen.findByRole('menuitem', { name: /15 minutes/i });
 
     const rangePresetOption = screen.getByRole('menuitem', {
       name: /configure presets/i,
     });
     userEvent.click(rangePresetOption);
+
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
 
     expect(onSelectOption).not.toHaveBeenCalled();
 
@@ -86,11 +93,9 @@ describe('TimeRangePresetDropdown', () => {
 
     render(<TimeRangePresetDropdown onChange={onSelectOption} />);
 
-    const timeRangePresetButton = await screen.findByRole('button', {
-      name: /open time range preset select/i,
-    });
-    userEvent.click(timeRangePresetButton);
+    await openTimeRangePresetSelect();
 
+    await screen.findByRole('menu');
     await screen.findByRole('menuitem', { name: /5 minutes/i });
 
     expect(screen.queryByText('Keyword ten min')).not.toBeInTheDocument();

--- a/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
@@ -51,6 +51,11 @@ const SimplePieVisualization = (props: Pick<React.ComponentProps<typeof PieVisua
 );
 
 describe('PieVisualization', () => {
+  const openActionsDropdown = async () => {
+    userEvent.click(await screen.findByText('show'));
+    await screen.findByRole('menu');
+  };
+
   beforeAll(loadViewsPlugin);
 
   afterAll(unloadViewsPlugin);
@@ -69,8 +74,7 @@ describe('PieVisualization', () => {
       .series([Series.forFunction('count()')])
       .build();
     render(<SimplePieVisualization config={config} data={oneRowPivot} />);
-    const legendItem = await screen.findByText('show');
-    await userEvent.click(legendItem);
+    await openActionsDropdown();
 
     await screen.findByText('action = show');
   });
@@ -82,9 +86,7 @@ describe('PieVisualization', () => {
       .series([Series.forFunction('count()')])
       .build();
     render(<SimplePieVisualization config={config} data={oneRowPivotOneColumnPivot} />);
-    const legendItem = await screen.findByText('show');
-    await userEvent.click(legendItem);
-
+    await openActionsDropdown();
     await screen.findByText('action = show');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This PR is a follow-up for https://github.com/Graylog2/graylog2-server/pull/17527. It should improve the behaviour of related flaky frontend tests.

With this PR we are waiting in tests for the dropdown menu to mount after opening it and to unmount after closing it.

/nocl