### PR TITLE
TTL for empty results in lookup tables

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -77,7 +77,11 @@ public abstract class LookupTable {
         }
         // The default value will only be used if single, multi and list values are empty
         if (result.isEmpty()) {
-            return LookupResult.addDefaults(defaultSingleValue(), defaultMultiValue()).hasError(result.hasError()).build();
+            LookupResult.Builder builder = LookupResult.addDefaults(defaultSingleValue(), defaultMultiValue()).hasError(result.hasError());
+            if (result.hasTTL()) {
+                builder.cacheTTL(result.cacheTTL());
+            }
+            return builder.build();
         }
         return result;
     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/CaffeineLookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/CaffeineLookupCache.java
@@ -30,6 +30,9 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import com.google.auto.value.AutoValue;
 import com.google.inject.assistedinject.Assisted;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.validation.constraints.Min;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.graylog.autovalue.WithBeanGetter;
@@ -41,12 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-
-import jakarta.validation.constraints.Min;
-
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +55,14 @@ public class CaffeineLookupCache extends LookupCache {
 
     // Use the old GuavaLookupCache name, so we don't have to deal with migrations
     public static final String NAME = "guava_cache";
+    public static final String MAX_SIZE = "max_size";
+    public static final String EXPIRE_AFTER_ACCESS = "expire_after_access";
+    public static final String EXPIRE_AFTER_ACCESS_UNIT = "expire_after_access_unit";
+    public static final String EXPIRE_AFTER_WRITE = "expire_after_write";
+    public static final String EXPIRE_AFTER_WRITE_UNIT = "expire_after_write_unit";
+    public static final String IGNORE_NULL = "ignore_null";
+    public static final String TTL_EMPTY = "ttl_empty";
+    public static final String TTL_EMPTY_UNIT = "ttl_empty_unit";
     private final Cache<LookupCacheKey, LookupResult> cache;
     private final Config config;
 
@@ -135,9 +140,15 @@ public class CaffeineLookupCache extends LookupCache {
             try {
                 final LookupResult result = loader.call();
                 if (ignoreResult(result, config.ignoreNull())) {
-                    LOG.debug("Ignoring failed lookup for key {}", key);
+                    LOG.info("Ignoring failed lookup for key {}", key);
                     return LookupResult.builder()
                             .cacheTTL(0L)
+                            .build();
+                }
+                if (isResultEmpty(result)) {
+                    LOG.info("Empty lookup for key {} with TTL {}", key, ttlEmptyMillis());
+                    return LookupResult.builder()
+                            .cacheTTL(ttlEmptyMillis())
                             .build();
                 }
                 return result;
@@ -156,8 +167,19 @@ public class CaffeineLookupCache extends LookupCache {
         if (ignoreNull == null || !ignoreNull) {
             return false;
         }
+        return isResultEmpty(result);
+    }
+
+    private boolean isResultEmpty(LookupResult result) {
         return (result == null ||
                 (result.singleValue() == null && result.multiValue() == null && result.stringListValue() == null));
+    }
+
+    private long ttlEmptyMillis() {
+        if (config.ttlEmpty() != null && config.ttlEmptyUnit() != null) {
+            return config.ttlEmptyUnit().toMillis(config.ttlEmpty());
+        }
+        return Long.MAX_VALUE;
     }
 
     @Override
@@ -222,28 +244,37 @@ public class CaffeineLookupCache extends LookupCache {
     public abstract static class Config implements LookupCacheConfiguration {
 
         @Min(0)
-        @JsonProperty("max_size")
+        @JsonProperty(MAX_SIZE)
         public abstract int maxSize();
 
         @Min(0)
-        @JsonProperty("expire_after_access")
+        @JsonProperty(EXPIRE_AFTER_ACCESS)
         public abstract long expireAfterAccess();
 
         @Nullable
-        @JsonProperty("expire_after_access_unit")
+        @JsonProperty(EXPIRE_AFTER_ACCESS_UNIT)
         public abstract TimeUnit expireAfterAccessUnit();
 
         @Min(0)
-        @JsonProperty("expire_after_write")
+        @JsonProperty(EXPIRE_AFTER_WRITE)
         public abstract long expireAfterWrite();
 
         @Nullable
-        @JsonProperty("expire_after_write_unit")
+        @JsonProperty(EXPIRE_AFTER_WRITE_UNIT)
         public abstract TimeUnit expireAfterWriteUnit();
 
         @Nullable
-        @JsonProperty("ignore_null")
+        @JsonProperty(IGNORE_NULL)
         public abstract Boolean ignoreNull();
+
+        @Min(0)
+        @Nullable
+        @JsonProperty(TTL_EMPTY)
+        public abstract Long ttlEmpty();
+
+        @Nullable
+        @JsonProperty(TTL_EMPTY_UNIT)
+        public abstract TimeUnit ttlEmptyUnit();
 
         public static Builder builder() {
             return new AutoValue_CaffeineLookupCache_Config.Builder();
@@ -254,23 +285,29 @@ public class CaffeineLookupCache extends LookupCache {
             @JsonProperty("type")
             public abstract Builder type(String type);
 
-            @JsonProperty("max_size")
+            @JsonProperty(MAX_SIZE)
             public abstract Builder maxSize(int maxSize);
 
-            @JsonProperty("expire_after_access")
+            @JsonProperty(EXPIRE_AFTER_ACCESS)
             public abstract Builder expireAfterAccess(long expireAfterAccess);
 
-            @JsonProperty("expire_after_access_unit")
+            @JsonProperty(EXPIRE_AFTER_ACCESS_UNIT)
             public abstract Builder expireAfterAccessUnit(@Nullable TimeUnit expireAfterAccessUnit);
 
-            @JsonProperty("expire_after_write")
+            @JsonProperty(EXPIRE_AFTER_WRITE)
             public abstract Builder expireAfterWrite(long expireAfterWrite);
 
-            @JsonProperty("expire_after_write_unit")
+            @JsonProperty(EXPIRE_AFTER_WRITE_UNIT)
             public abstract Builder expireAfterWriteUnit(@Nullable TimeUnit expireAfterWriteUnit);
 
-            @JsonProperty("ignore_null")
+            @JsonProperty(IGNORE_NULL)
             public abstract Builder ignoreNull(@Nullable Boolean ignoreNull);
+
+            @JsonProperty(TTL_EMPTY)
+            public abstract Builder ttlEmpty(@Nullable Long ttlEmpty);
+
+            @JsonProperty(TTL_EMPTY_UNIT)
+            public abstract Builder ttlEmptyUnit(@Nullable TimeUnit ttlEmptyUnit);
 
             public abstract Config build();
         }


### PR DESCRIPTION
Resolves #16466 

## Description
<!--- Describe your changes in detail -->
Adds optional TTL for empty results in lookup table caching. This is not available if _ignore null_ has been checked.

## Motivation and Context
If we are caching empty results, then by default they live forever. This is not compatible with data adapters where the value may change over time, specifically DNS. By tuning the TTL for empty results we can avoid requerying the data source excessively, while still becoming aware of changes in values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Simple test scenario:
- create a CSV file lookup table: 
-- data adapter _check interval = 10s_
-- cache: _empty TTL = 30s_ and _ignore null = false_)
- query for a non-existent key _x_: result null
- update CSV to include _x_
- requery before 30s have elapsed: result null
- requery after 30s: result is the newly saved CSV

Empty TTL overrides the expire after access setting. Otherwise we would never update a cached null value, that is being requeried very frequently.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

