### PR TITLE
Define default time range for alerts overview request.

### DIFF
--- a/graylog2-web-interface/src/stores/events/EventsStore.js
+++ b/graylog2-web-interface/src/stores/events/EventsStore.js
@@ -83,7 +83,13 @@ export const EventsStore = singletonStore(
       });
     },
 
-    search({ query = '', page = 1, pageSize = 25, filter = { alerts: 'only' }, timerange }) {
+    search({
+      query = '',
+      page = 1,
+      pageSize = 25,
+      filter = { alerts: 'only' },
+      timerange = { type: 'relative', range: 86400 }, // 1 day
+    }) {
       const promise = fetch('POST', this.eventsUrl({}), {
         query: query,
         page: page,


### PR DESCRIPTION
Please note, this PR needs a backport for `5.1` and `5.2`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When there is no index set yet, the alerts overview page shows just an error:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/281bb037-9040-48d1-b5b6-8207cd9feb35)

The error occurs because the frontend expects a time range parameter for the alerts search. This information either comes from the previous search (localStore) or from the request response.

Fixes https://github.com/Graylog2/graylog2-server/issues/17995

/nocl

