### PR TITLE
State machine and rest api for datanode migration

### DIFF
--- a/changelog/unreleased/pr-18001.toml
+++ b/changelog/unreleased/pr-18001.toml
@@ -1,0 +1,4 @@
+type = "added"
+message = "Added state map and corresponding rest resources for datanode migration wizard"
+
+pulls = ["18001"]

--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -401,7 +401,6 @@
         <dependency>
             <groupId>com.github.stateless4j</groupId>
             <artifactId>stateless4j</artifactId>
-            <version>2.6.0</version>
         </dependency>
 
         <dependency>

--- a/full-backend-tests/src/test/java/org/graylog/datanode/RemoteReindexingMigrationIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/datanode/RemoteReindexingMigrationIT.java
@@ -100,7 +100,7 @@ public class RemoteReindexingMigrationIT {
 
         LOG.info("Requesting remote reindex: " + request);
 
-        final ValidatableResponse migrationResponse = apis.post("/migration/remoteReindex", request, 200);
+        final ValidatableResponse migrationResponse = apis.post("/remote-reindex-migration/remoteReindex", request, 200);
 
         // one document migrated
         migrationResponse.assertThat().body("results.created", Matchers.hasSize(1));

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -442,6 +442,11 @@
                 <artifactId>unboundid-ldapsdk</artifactId>
                 <version>${unboundid-ldap.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.stateless4j</groupId>
+                <artifactId>stateless4j</artifactId>
+                <version>${stateless4j.version}</version>
+            </dependency>
 
             <!-- Tracing dependencies -->
             <dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -711,7 +711,10 @@
             <groupId>one.util</groupId>
             <artifactId>streamex</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.stateless4j</groupId>
+            <artifactId>stateless4j</artifactId>
+        </dependency>
         <!-- our basic test libraries, please only add infrastructure dependencies here -->
         <dependency>
             <groupId>junit</groupId>

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.storage.migration;
 
 import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
@@ -1,0 +1,20 @@
+package org.graylog.plugins.views.storage.migration;
+
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActionsImpl;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineProvider;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfigurationImpl;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationPersistence;
+import org.graylog.plugins.views.storage.migration.state.rest.MigrationStateResource;
+import org.graylog2.plugin.inject.Graylog2Module;
+
+public class DatanodeMigrationBindings extends Graylog2Module {
+    @Override
+    protected void configure() {
+        addSystemRestResource(MigrationStateResource.class);
+        bind(MigrationStateMachine.class).toProvider(MigrationStateMachineProvider.class);
+        bind(DatanodeMigrationPersistence.class).to(DatanodeMigrationConfigurationImpl.class);
+        bind(MigrationActions.class).to(MigrationActionsImpl.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
@@ -34,7 +34,7 @@ import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.shared.security.RestPermissions;
 
-@Path("/migration")
+@Path("/remote-reindex-migration")
 @RequiresAuthentication
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
@@ -38,7 +38,7 @@ import org.graylog2.shared.security.RestPermissions;
 @RequiresAuthentication
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-@Api(value = "Migration", description = "Migrate data from existing cluster")
+@Api(value = "ReindexMigration", description = "Migrate data from existing cluster")
 public class RemoteReindexResource {
     private final RemoteReindexingMigrationAdapter migrationService;
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.actions;
+
+/**
+ * Set of callbacks used during the migration in different states.
+ */
+public interface MigrationActions {
+    void resetMigration();
+
+    void migrateIndexTemplates();
+
+    void migrateWithoutDowntime();
+
+    void migrateWithDowntime();
+
+    boolean isOldClusterStopped();
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.actions;
+
+import jakarta.inject.Inject;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfiguration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+
+public class MigrationActionsImpl implements MigrationActions {
+
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public MigrationActionsImpl(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public void resetMigration() {
+        clusterConfigService.remove(DatanodeMigrationConfiguration.class);
+    }
+
+    @Override
+    public void migrateIndexTemplates() {
+        // TODO!
+    }
+
+    @Override
+    public void migrateWithoutDowntime() {
+        // TODO!
+    }
+
+    @Override
+    public void migrateWithDowntime() {
+        // TODO!
+    }
+
+    @Override
+    public boolean isOldClusterStopped() {
+        return false;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/DatanodeMigrationPersistanceTrace.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/DatanodeMigrationPersistanceTrace.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import com.github.oxo42.stateless4j.delegates.Trace;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfiguration;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationPersistence;
+
+/**
+ * This is a {@link Trace} that gets notified every time a state machine is transitioning between two states.
+ * We use this information to persist the state in the database.
+ */
+public class DatanodeMigrationPersistanceTrace implements Trace<MigrationState, MigrationStep> {
+
+    private final DatanodeMigrationPersistence delegate;
+
+    public DatanodeMigrationPersistanceTrace(DatanodeMigrationPersistence persistenceService) {
+        this.delegate = persistenceService;
+    }
+
+    @Override
+    public void trigger(MigrationStep trigger) {
+        // do nothing, ignored
+    }
+
+    @Override
+    public void transition(MigrationStep trigger, MigrationState source, MigrationState destination) {
+        // persist each transition destination as the current state in the database
+        delegate.saveConfiguration(new DatanodeMigrationConfiguration(destination));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+public enum MigrationState {
+    NEW,
+    ROLLING_UPGRADE_MIGRATION_WELCOME,
+    PROVISION_DATANODE_CERTIFICATES,
+    EXISTING_DATA_MIGRATION_QUESTION,
+    MIGRATE_WITH_DOWNTIME_QUESTION,
+    ASK_TO_SHUTDOWN_OLD_CLUSTER,
+    MANUALLY_REMOVE_OLD_CONNECTION_STRING_FROM_CONFIG,
+    REMOTE_REINDEX_WELCOME,
+    DIRECTORY_COMPATIBILITY_CHECK_PAGE,
+    PROVISION_ROLLING_UPGRADE_NODES_WITH_CERTIFICATES,
+    JOURNAL_SIZE_DOWNTIME_WARNING,
+    FAILED,
+    FINISHED
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachine.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import java.util.List;
+
+public interface MigrationStateMachine {
+    MigrationState trigger(MigrationStep step);
+    MigrationState getState();
+
+    List<MigrationStep> nextSteps();
+
+    String serialize();
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import com.github.oxo42.stateless4j.StateMachine;
+import com.github.oxo42.stateless4j.StateMachineConfig;
+import com.github.oxo42.stateless4j.delegates.Trace;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfiguration;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationPersistence;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MigrationStateMachineBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MigrationStateMachineBuilder.class);
+
+    @NotNull
+    private static StateMachineConfig<MigrationState, MigrationStep> configureStates(MigrationActions migrationActions) {
+        StateMachineConfig<MigrationState, MigrationStep> config = new StateMachineConfig<>();
+
+        // Major decision - remote reindexing or rolling upgrade(in-place)?
+        config.configure(MigrationState.NEW)
+                .permit(MigrationStep.SELECT_ROLLING_UPGRADE_MIGRATION, MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME, () -> {
+                    LOG.info("Selected inplace migration");
+                })
+                .permit(MigrationStep.SELECT_REMOTE_REINDEX_MIGRATION, MigrationState.REMOTE_REINDEX_WELCOME, () -> {
+                    LOG.info("Selected remote reindex migration");
+                });
+
+
+        // remote reindexing branch of the migration
+        config.configure(MigrationState.REMOTE_REINDEX_WELCOME)
+                .permit(MigrationStep.DISCOVER_NEW_DATANODES, MigrationState.PROVISION_DATANODE_CERTIFICATES, () -> {
+                    LOG.info("Compatibility check succeeded");
+                });
+
+        config.configure(MigrationState.PROVISION_DATANODE_CERTIFICATES)
+                .permit(MigrationStep.MIGRATE_INDEX_TEMPLATES, MigrationState.EXISTING_DATA_MIGRATION_QUESTION, migrationActions::migrateIndexTemplates);
+
+        config.configure(MigrationState.EXISTING_DATA_MIGRATION_QUESTION)
+                .permit(MigrationStep.MIGRATE_EXISTING_DATA, MigrationState.MIGRATE_WITH_DOWNTIME_QUESTION)
+                .permit(MigrationStep.SKIP_EXISTING_DATA_MIGRATION, MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER);
+
+        config.configure(MigrationState.MIGRATE_WITH_DOWNTIME_QUESTION)
+                .permit(MigrationStep.MIGRATE_CLUSTER_WITH_DOWNTIME, MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER, migrationActions::migrateWithDowntime)
+                .permit(MigrationStep.MIGRATE_CLUSTER_WITHOUT_DOWNTIME, MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER, migrationActions::migrateWithoutDowntime);
+
+        config.configure(MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER)
+                .permitIf(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED, MigrationState.MANUALLY_REMOVE_OLD_CONNECTION_STRING_FROM_CONFIG, migrationActions::isOldClusterStopped);
+
+
+        // inplace / rolling upgrade branch of the migration
+        config.configure(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME)
+                .permit(MigrationStep.INSTALL_DATANODES_ON_EVERY_NODE, MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE);
+
+        config.configure(MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE)
+                .permit(MigrationStep.DIRECTORY_COMPATIBILITY_CHECK_OK, MigrationState.PROVISION_ROLLING_UPGRADE_NODES_WITH_CERTIFICATES);
+
+
+        config.configure(MigrationState.PROVISION_ROLLING_UPGRADE_NODES_WITH_CERTIFICATES)
+                .permit(MigrationStep.CALCULATE_JOURNAL_SIZE, MigrationState.JOURNAL_SIZE_DOWNTIME_WARNING);
+
+        config.configure(MigrationState.JOURNAL_SIZE_DOWNTIME_WARNING)
+                .permit(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED, MigrationState.MANUALLY_REMOVE_OLD_CONNECTION_STRING_FROM_CONFIG);
+
+        // common cleanup steps
+        config.configure(MigrationState.MANUALLY_REMOVE_OLD_CONNECTION_STRING_FROM_CONFIG)
+                .permit(MigrationStep.CONFIRM_OLD_CONNECTION_STRING_FROM_CONFIG_REMOVED, MigrationState.FINISHED);
+
+        return config;
+    }
+
+    private static StateMachine<MigrationState, MigrationStep> fromState(MigrationState state, Trace<MigrationState, MigrationStep> persistence, MigrationActions migrationActions) {
+        final StateMachineConfig<MigrationState, MigrationStep> config = configureStates(migrationActions);
+        final StateMachine<MigrationState, MigrationStep> stateMachine = new StateMachine<>(state, config);
+        stateMachine.setTrace(persistence);
+        return stateMachine;
+    }
+
+    public static StateMachine<MigrationState, MigrationStep> buildFromPersistedState(DatanodeMigrationPersistence persistenceService, MigrationActions migrationActions) {
+        final MigrationState state = persistenceService.getConfiguration().map(DatanodeMigrationConfiguration::currentState).orElse(MigrationState.NEW);
+        final Trace<MigrationState, MigrationStep> persitanceTrace = new DatanodeMigrationPersistanceTrace(persistenceService);
+        return fromState(state, persitanceTrace, migrationActions);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import com.github.oxo42.stateless4j.StateMachine;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class MigrationStateMachineImpl implements MigrationStateMachine {
+    private final StateMachine<MigrationState, MigrationStep> stateMachine;
+
+    public MigrationStateMachineImpl(StateMachine<MigrationState, MigrationStep> stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @Override
+    public MigrationState trigger(MigrationStep step) {
+        stateMachine.fire(step);
+        return stateMachine.getState();
+    }
+
+    @Override
+    public MigrationState getState() {
+        return stateMachine.getState();
+    }
+
+    @Override
+    public List<MigrationStep> nextSteps() {
+        return stateMachine.getPermittedTriggers();
+    }
+
+    @Override
+    public String serialize() {
+        try {
+            final ByteArrayOutputStream os = new ByteArrayOutputStream();
+            stateMachine.configuration().generateDotFileInto(os, true);
+            return os.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize state map", e);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import com.github.oxo42.stateless4j.StateMachine;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationPersistence;
+
+@Singleton
+public class MigrationStateMachineProvider implements Provider<MigrationStateMachine> {
+
+    private final DatanodeMigrationPersistence persistenceService;
+    private final MigrationActions migrationActions;
+
+    @Inject
+    public MigrationStateMachineProvider(DatanodeMigrationPersistence persistenceService, MigrationActions migrationActions) {
+       this.persistenceService = persistenceService;
+       this.migrationActions = migrationActions;
+    }
+
+    @Override
+    public MigrationStateMachine get() {
+        final StateMachine<MigrationState, MigrationStep> stateMachine = MigrationStateMachineBuilder.buildFromPersistedState(persistenceService, migrationActions);
+        return new MigrationStateMachineImpl(stateMachine);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStep.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStep.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+public enum MigrationStep {
+
+    SELECT_ROLLING_UPGRADE_MIGRATION,
+    SELECT_REMOTE_REINDEX_MIGRATION,
+    DISCOVER_NEW_DATANODES,
+    START_DATANODE_CLUSTER,
+    MIGRATE_INDEX_TEMPLATES,
+    MIGRATE_EXISTING_DATA,
+    SKIP_EXISTING_DATA_MIGRATION,
+    MIGRATE_CLUSTER_WITH_DOWNTIME,
+    MIGRATE_CLUSTER_WITHOUT_DOWNTIME,
+    INSTALL_DATANODES_ON_EVERY_NODE,
+    DIRECTORY_COMPATIBILITY_CHECK_OK,
+    CONFIRM_OLD_CLUSTER_STOPPED,
+    CALCULATE_JOURNAL_SIZE,
+    CONFIRM_OLD_CONNECTION_STRING_FROM_CONFIG_REMOVED,
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.persistence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+
+/**
+ * DTO used in {@link org.graylog2.plugin.cluster.ClusterConfigService} to store and retrieve latest migration state
+ */
+public record DatanodeMigrationConfiguration(@JsonProperty("current_state") MigrationState currentState) {
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationConfigurationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationConfigurationImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.persistence;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+
+import java.util.Optional;
+
+@Singleton
+public class DatanodeMigrationConfigurationImpl implements DatanodeMigrationPersistence {
+
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public DatanodeMigrationConfigurationImpl(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public Optional<DatanodeMigrationConfiguration> getConfiguration() {
+        return Optional.ofNullable(clusterConfigService.get(DatanodeMigrationConfiguration.class));
+    }
+
+    @Override
+    public void saveConfiguration(DatanodeMigrationConfiguration configuration) {
+        clusterConfigService.write(configuration);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationPersistence.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/persistence/DatanodeMigrationPersistence.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.persistence;
+
+import java.util.Optional;
+
+public interface DatanodeMigrationPersistence {
+    Optional<DatanodeMigrationConfiguration> getConfiguration();
+    void saveConfiguration(DatanodeMigrationConfiguration configuration);
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/CurrentStateInformation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/CurrentStateInformation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.rest;
+
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+
+import java.util.List;
+
+public record CurrentStateInformation(MigrationState state, List<MigrationStep> nextSteps) {
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.rest;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.shared.security.RestPermissions;
+
+@Path("/migration")
+@RequiresAuthentication
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "Migration", description = "Resource for managing migration to datanode from open/elasticsearch")
+public class MigrationStateResource {
+
+    private final MigrationStateMachine stateMachine;
+
+    @Inject
+    public MigrationStateResource(MigrationStateMachine stateMachine) {
+        this.stateMachine = stateMachine;
+    }
+
+    @POST
+    @Path("/trigger")
+    @NoAuditEvent("No Audit Event needed") // TODO: do we need audit log here?
+    @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
+    @ApiOperation(value = "trigger migration step")
+    public CurrentStateInformation migrate(@ApiParam(name = "request") @NotNull MigrationStepRequest request) {
+        final MigrationState newState = stateMachine.trigger(request.step());
+        return new CurrentStateInformation(newState, stateMachine.nextSteps());
+    }
+
+    @GET
+    @Path("/state")
+    @NoAuditEvent("No Audit Event needed")
+    @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
+    @ApiOperation(value = "Migration status", notes = "Current status of the datanode migration")
+    public CurrentStateInformation status() {
+        return new CurrentStateInformation(stateMachine.getState(), stateMachine.nextSteps());
+    }
+
+    @GET
+    @Path("/serialize")
+    @NoAuditEvent("No Audit Event needed")
+    @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = "Serialize", notes = "Serialize migration graph as graphviz source")
+    public String serialize() {
+        // you can use https://dreampuf.github.io/GraphvizOnline/ to vizualize the result
+        return stateMachine.serialize();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStepRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStepRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+
+public record MigrationStepRequest(@JsonProperty("step") MigrationStep step) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -42,6 +42,7 @@ import org.graylog.plugins.views.ViewsBindings;
 import org.graylog.plugins.views.ViewsConfig;
 import org.graylog.plugins.views.search.rest.scriptingapi.ScriptingApiModule;
 import org.graylog.plugins.views.search.searchfilters.module.SearchFiltersModule;
+import org.graylog.plugins.views.storage.migration.DatanodeMigrationBindings;
 import org.graylog.scheduler.JobSchedulerConfiguration;
 import org.graylog.scheduler.JobSchedulerModule;
 import org.graylog.security.SecurityModule;
@@ -207,7 +208,8 @@ public class Server extends ServerBootstrap {
                 new ScopedEntitiesModule(),
                 new ScriptingApiModule(featureFlags),
                 new StreamsModule(),
-                new TracingModule()
+                new TracingModule(),
+                new DatanodeMigrationBindings()
         );
 
         if (featureFlags.isOn(FIELD_TYPES_MANAGEMENT_FEATURE)) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
@@ -16,8 +16,8 @@
  */
 package org.graylog2.rest.resources;
 
-import org.graylog.plugins.views.storage.migration.RemoteReindexResource;
 import org.graylog.plugins.views.search.engine.monitoring.data.histogram.rest.HistogramResponseWriter;
+import org.graylog.plugins.views.storage.migration.RemoteReindexResource;
 import org.graylog2.Configuration;
 import org.graylog2.bootstrap.preflight.web.resources.CAResource;
 import org.graylog2.bootstrap.preflight.web.resources.CertificateRenewalResource;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/InMemoryStateMachinePersistence.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/InMemoryStateMachinePersistence.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state;
+
+import com.github.oxo42.stateless4j.delegates.Trace;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfiguration;
+import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationPersistence;
+
+import java.util.Optional;
+
+public class InMemoryStateMachinePersistence implements DatanodeMigrationPersistence {
+
+    private MigrationState currentState = MigrationState.NEW;
+
+    @Override
+    public Optional<DatanodeMigrationConfiguration> getConfiguration() {
+        return Optional.of(new DatanodeMigrationConfiguration(currentState));
+    }
+
+    @Override
+    public void saveConfiguration(DatanodeMigrationConfiguration configuration) {
+        this.currentState = configuration.currentState();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/MigrationStateMachineTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/MigrationStateMachineTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state;
+
+import org.assertj.core.api.Assertions;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineProvider;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+
+class MigrationStateMachineTest {
+
+    @Test
+    void testPersistence() {
+        final InMemoryStateMachinePersistence persistence = new InMemoryStateMachinePersistence();
+        final MigrationActions actions = Mockito.mock(MigrationActions.class);
+
+        final MigrationStateMachine migrationStateMachine = new MigrationStateMachineProvider(persistence, actions).get();
+        migrationStateMachine.trigger(MigrationStep.SELECT_ROLLING_UPGRADE_MIGRATION);
+
+        Assertions.assertThat(persistence.getConfiguration())
+                .isPresent()
+                .hasValueSatisfying(configuration -> {
+                    Assertions.assertThat(configuration.currentState()).isEqualTo(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME);
+                });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
         <cron-utils.version>9.2.1</cron-utils.version>
         <asciitable.version>0.3.2</asciitable.version>
         <jjwt.version>0.11.5</jjwt.version>
+        <stateless4j.version>2.6.0</stateless4j.version>
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>


### PR DESCRIPTION
This PR creates infrastructure for controlled datanode migration. It introduces a state machine that will be used by frontend in the migration wizard. Transitions have guards and actions, which should do all the migration tasks. 

For the frontend, there are 2 new API endpoints:

GET `/api/migration/state`

```
{
  "state": "REMOTE_REINDEX_WELCOME",
  "next_steps": [
    "DISCOVER_NEW_DATANODES"
  ]
}
```
The `state` is the db-persisted state of the migration. Frontend should be able to display a wizard page corresponding to this state. The `next_steps` array delivers possible steps/transitions that the user can trigger.


POST `http://localhost:9000/api/migration/trigger`
```
{
  "step":"DISCOVER_NEW_DATANODES"
}
```
Performs the requested transition. We can extend the request with some additional user-provided parameters if needed. 


Additionally, there is a GET `/api/migration/serialize` endpoint that returns a textual graphviz representation of the state machine. This is useful for rendering a graph of the state map, either for development/debugging purposes or for documentation.

To render the code, for example https://dreampuf.github.io/GraphvizOnline can be used.   
![image](https://github.com/Graylog2/graylog2-server/assets/4102775/7ce6d79f-bbaa-4d62-98df-8110ced9a489)

## How Has This Been Tested?
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

