### PR TITLE
fix: Add saved searches and new searches working again

### DIFF
--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -265,10 +265,22 @@ type DashboardActionModalProps = {
   ref: React.Ref<unknown>,
 }
 
+type SearchActionModalProps = {
+  search: View,
+  ref: React.Ref<unknown>,
+}
+
 type AssetInformationComponentProps = {
   identifiers: unknown,
   addToQuery: (id: string) => void;
 }
+
+type SearchAction = {
+  component: React.ComponentType<SearchActionComponentProps>,
+  key: string,
+  modals: Array<{ key: string, component: React.ComponentType<SearchActionModalProps> }>,
+  useCondition: () => boolean,
+};
 
 type DashboardAction = {
   key: string,
@@ -292,7 +304,8 @@ type MessageActionComponentProps = {
 
 type SearchActionComponentProps = {
   loaded: boolean,
-  view: View,
+  search: View,
+  modalRefs?: { [key: string]: () => unknown },
 }
 
 export type CopyParamsToView = (sourceView: View, targetView: View) => View;
@@ -432,11 +445,7 @@ declare module 'graylog-web-plugin/plugin' {
       key: string,
       useCondition: () => boolean,
     }>;
-    'views.components.searchActions'?: Array<{
-      component: React.ComponentType<SearchActionComponentProps>,
-      key: string,
-      useCondition: () => boolean,
-    }>;
+    'views.components.searchActions'?: Array<SearchAction>;
     'views.components.searchBar'?: Array<() => SearchBarControl | null>;
     'views.components.saveViewForm'?: Array<() => SaveViewControls | null>;
     'views.elements.header'?: Array<React.ComponentType>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix flashing modals when trying to add a saved search as evidence for an investigation

/nocl
/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/6466

## Description
<!--- Describe your changes in detail -->
There was a change on how the dropdown menu works on buttons, which was causing the modals to add a saved search for an investigation to show up only for an instant. With this PR the investigations search plugin follows the same pattern as the dashboard solution allowing to put the modal views outside the dropdown menu component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug found with E2E

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

