### PR TITLE
Trigger notification for IO exception in HTTP data adapter lookup

### DIFF
--- a/changelog/unreleased/pr-18022.toml
+++ b/changelog/unreleased/pr-18022.toml
@@ -1,0 +1,5 @@
+type = "C"
+message = "Trigger system notification for IO exceptions during HTTP data adapater lookup."
+
+pulls = ["18022"]
+issues=["Graylog2/graylog-plugin-enterprise#6292"]


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-enterprise#6292

Trigger system notification when HTTP data adapater lookup throws an IO exception. 