### PR TITLE
More search does not explode when affected indices are null or empty.

### DIFF
--- a/changelog/unreleased/issue-18002.toml
+++ b/changelog/unreleased/issue-18002.toml
@@ -1,0 +1,7 @@
+type = "fixed"
+message = "Fixes MoreSearch, so that it does not throw errors when affected indices are null or empty. Because of that, MoreSearch is safer to user on fresh installation, with no messages and therefore no index ranges."
+
+issues = ["18002"]
+pulls = ["18023"]
+
+

--- a/changelog/unreleased/issue-18002.toml
+++ b/changelog/unreleased/issue-18002.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Fixes MoreSearch, so that it does not throw errors when affected indices are null or empty. Because of that, MoreSearch is safer to user on fresh installation, with no messages and therefore no index ranges."
+message = "Fixes MoreSearch, so that it does not throw errors when affected indices are null or empty. Because of that, MoreSearch is safer to use on fresh installation, with no events and therefore no index ranges for events indices."
 
 issues = ["18002"]
 pulls = ["18023"]

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -17,6 +17,7 @@
 package org.graylog.events.search;
 
 import com.google.auto.value.AutoValue;
+import jakarta.inject.Inject;
 import org.graylog.events.processor.EventProcessorException;
 import org.graylog.plugins.views.search.IndexRangeContainsOneOfStreams;
 import org.graylog.plugins.views.search.Parameter;
@@ -34,8 +35,6 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.util.HashSet;
 import java.util.List;
@@ -89,6 +88,15 @@ public class MoreSearch {
         final String queryString = parameters.query().trim();
         final Set<String> affectedIndices = getAffectedIndices(eventStreams, parameters.timerange());
 
+        if (affectedIndices == null || affectedIndices.isEmpty()) {
+            return Result.builder()
+                    .resultsCount(0)
+                    .results(List.of())
+                    .usedIndexNames(Set.of())
+                    .duration(0)
+                    .executedQuery(queryString)
+                    .build();
+        }
         return moreSearchAdapter.eventSearch(queryString, parameters.timerange(), affectedIndices, sorting, parameters.page(), parameters.perPage(), eventStreams, filterString, forbiddenSourceStreams);
     }
 


### PR DESCRIPTION
## Description
More search does not explode when affected indices are null or empty.
It returns empty result instead, with empty `used_indices` indicating that there was no index that could be queried.
Fixes #18002.
/nocl

## Motivation and Context
Related to HS-2268747609.
If you have a fresh installation (or let someone delete your documents in `index_ranges` collection), you may encounter ugly errors in the UI before the first even is ingested, and first index range is calculated.

## How Has This Been Tested?
Manually, on fresh Mongo DB and with index_ranges for `gl_events` / `gl_system_events` removed by hand.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

