### PR TITLE
Remove direct notifications dependency from StreamService, use events instead

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -36,6 +36,7 @@ import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.InputServiceImpl;
 import org.graylog2.inputs.persistence.InputStatusService;
 import org.graylog2.inputs.persistence.MongoInputStatusService;
+import org.graylog2.notifications.DeletedStreamNotificationListener;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.notifications.NotificationServiceImpl;
 import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
@@ -58,6 +59,7 @@ public class PersistenceServicesBindings extends AbstractModule {
     protected void configure() {
         bind(SystemMessageService.class).to(SystemMessageServiceImpl.class).asEagerSingleton();
         bind(NotificationService.class).to(NotificationServiceImpl.class).asEagerSingleton();
+        bind(DeletedStreamNotificationListener.class).asEagerSingleton();
         bind(IndexFailureService.class).to(IndexFailureServiceImpl.class).asEagerSingleton();
         bind(org.graylog2.cluster.NodeService.class).to(NodeServiceImpl.class);
         bind(new TypeLiteral<NodeService<ServerNodeDto>>() {}).to(ServerNodeClusterService.class);

--- a/graylog2-server/src/main/java/org/graylog2/notifications/DeletedStreamNotificationListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/DeletedStreamNotificationListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.notifications;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import jakarta.inject.Inject;
+import org.graylog2.streams.events.StreamDeletedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeletedStreamNotificationListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeletedStreamNotificationListener.class);
+
+    private final NotificationService notificationService;
+
+    @Inject
+    public DeletedStreamNotificationListener(EventBus eventBus, NotificationService notificationService) {
+        this.notificationService = notificationService;
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    @SuppressWarnings("unused")
+    public void handleStreamDeleted(StreamDeletedEvent streamDeletedEvent) {
+        final String streamId = streamDeletedEvent.streamId();
+        for (Notification notification : notificationService.all()) { // TODO: this could be optimized to select only notifications linked to the stream ID
+            Object rawValue = notification.getDetail("stream_id");
+            if (rawValue != null && rawValue.toString().equals(streamId)) {
+                LOG.debug("Removing notification that references stream: {}", notification);
+                notificationService.destroy(notification);
+            }
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -36,8 +36,6 @@ import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
-import org.graylog2.notifications.Notification;
-import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
@@ -83,7 +81,6 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
     private final OutputService outputService;
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory indexSetFactory;
-    private final NotificationService notificationService;
     private final EntityOwnershipService entityOwnershipService;
     private final ClusterEventBus clusterEventBus;
 
@@ -93,7 +90,6 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
                              OutputService outputService,
                              IndexSetService indexSetService,
                              MongoIndexSet.Factory indexSetFactory,
-                             NotificationService notificationService,
                              EntityOwnershipService entityOwnershipService,
                              ClusterEventBus clusterEventBus) {
         super(mongoConnection);
@@ -101,7 +97,6 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         this.outputService = outputService;
         this.indexSetService = indexSetService;
         this.indexSetFactory = indexSetFactory;
-        this.notificationService = notificationService;
         this.entityOwnershipService = entityOwnershipService;
         this.clusterEventBus = clusterEventBus;
     }
@@ -310,13 +305,8 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         }
 
         final String streamId = stream.getId();
-        for (Notification notification : notificationService.all()) {
-            Object rawValue = notification.getDetail("stream_id");
-            if (rawValue != null && rawValue.toString().equals(streamId)) {
-                LOG.debug("Removing notification that references stream: {}", notification);
-                notificationService.destroy(notification);
-            }
-        }
+        // we need to remove notifications referencing this stream. This happens in the DeletedStreamNotificationListener
+        // triggered by the StreamDeletedEvent below.
         super.destroy(stream);
 
         clusterEventBus.post(StreamsChangedEvent.create(streamId));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -87,8 +87,6 @@ public class StreamCatalogTest {
     @Mock
     private MongoIndexSet.Factory mongoIndexSetFactory;
     @Mock
-    private NotificationService notificationService;
-    @Mock
     private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
     @Mock
     private EntityOwnershipService entityOwnershipService;
@@ -108,7 +106,6 @@ public class StreamCatalogTest {
                 outputService,
                 indexSetService,
                 mongoIndexSetFactory,
-                notificationService,
                 entityOwnershipService,
                 clusterEventBus);
         when(outputService.load("5adf239e4b900a0fdb4e5197")).thenReturn(

--- a/graylog2-server/src/test/java/org/graylog2/notifications/DeletedStreamNotificationListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/notifications/DeletedStreamNotificationListenerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.notifications;
+
+import com.google.common.eventbus.EventBus;
+import org.assertj.core.api.Assertions;
+import org.graylog2.streams.events.StreamDeletedEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+class DeletedStreamNotificationListenerTest {
+
+
+    @Test
+    void testNotificationDeletion() {
+        EventBus eventBus = new EventBus();
+        final NotificationService notificationService = mockNotificationService("123", "456");
+        new DeletedStreamNotificationListener(eventBus, notificationService);
+
+        eventBus.post(StreamDeletedEvent.create("123"));
+
+        final ArgumentCaptor<Notification> argumentCaptor = ArgumentCaptor.forClass(Notification.class);
+        Mockito.verify(notificationService, Mockito.times(1)).destroy(argumentCaptor.capture());
+        Assertions.assertThat(argumentCaptor.getValue().getDetail("stream_id"))
+                .isEqualTo("123");
+    }
+
+    private NotificationService mockNotificationService(String... streamIDs) {
+        final List<Notification> allNotifications = Arrays.stream(streamIDs).map(id -> new NotificationImpl().addDetail("stream_id", id)).toList();
+        final NotificationService notificationService = Mockito.mock(NotificationService.class);
+        Mockito.when(notificationService.all()).thenReturn(allNotifications);
+        return notificationService;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -25,7 +25,6 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.indexset.IndexSetService;
-import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.junit.Before;
@@ -55,8 +54,6 @@ public class StreamServiceImplTest {
     @Mock
     private MongoIndexSet.Factory factory;
     @Mock
-    private NotificationService notificationService;
-    @Mock
     private EntityOwnershipService entityOwnershipService;
 
     private StreamService streamService;
@@ -64,7 +61,7 @@ public class StreamServiceImplTest {
     @Before
     public void setUp() throws Exception {
         this.streamService = new StreamServiceImpl(mongodb.mongoConnection(), streamRuleService,
-                outputService, indexSetService, factory, notificationService, entityOwnershipService, new ClusterEventBus());
+                outputService, indexSetService, factory, entityOwnershipService, new ClusterEventBus());
     }
 
     @Test


### PR DESCRIPTION
/nocl

This PR fights dependency obesity. We don't need the notification service in the streams service. It has been used only to delete notifications related to streams that are being deleted. For that, we have the StreamDeletedEvent already in place. We just need a listener that removes related notifications. 

This simplifies dependencies of the heavily used StreamService and reduces complexity in it. 

## Motivation and Context
Datanode server doesn't use full set of dependencies. Every additional dependency complicates creation of injectors.

## How Has This Been Tested?
Added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

