### PR TITLE
Improve error handling for event definition with missing field value (#17819)

### DIFF
--- a/changelog/unreleased/issue-17367.toml
+++ b/changelog/unreleased/issue-17367.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve migration and error handling for event definitions that are missing a field value."
+
+issues = ["17367"]
+pulls = [""]

--- a/changelog/unreleased/issue-17367.toml
+++ b/changelog/unreleased/issue-17367.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Improve migration and error handling for event definitions that are missing a field value."
 
 issues = ["17367"]
-pulls = [""]
+pulls = ["18051"]

--- a/graylog2-server/src/main/java/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries.java
+++ b/graylog2-server/src/main/java/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries.java
@@ -22,9 +22,14 @@ import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 import org.bson.Document;
+import org.graylog.events.processor.EventDefinition;
+import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.migrations.Migration;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.shared.utilities.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,18 +37,23 @@ import javax.inject.Inject;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class V20230629140000_RenameFieldTypeOfEventDefinitionSeries extends Migration {
     private static final Logger LOG = LoggerFactory.getLogger(V20230629140000_RenameFieldTypeOfEventDefinitionSeries.class);
     private static final String SERIES_PATH_STRING = "config.series";
     private final ClusterConfigService clusterConfigService;
     private final MongoCollection<Document> collection;
+    private final NotificationService notificationService;
+
 
     @Inject
     public V20230629140000_RenameFieldTypeOfEventDefinitionSeries(ClusterConfigService clusterConfigService,
-                                                                  MongoConnection mongoConnection) {
+                                                                  MongoConnection mongoConnection,
+                                                                  NotificationService notificationService) {
         this.clusterConfigService = clusterConfigService;
         this.collection = mongoConnection.getMongoDatabase().getCollection("event_definitions");
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -65,36 +75,67 @@ public class V20230629140000_RenameFieldTypeOfEventDefinitionSeries extends Migr
         ));
 
         var bulkOperations = new ArrayList<WriteModel<? extends Document>>();
-
         for (Document doc : result) {
-            var config = doc.get("config", Document.class);
-            var series = config.getList("series", Document.class, Collections.emptyList());
-            var needsUpdate = false;
-            var newSeries = new ArrayList<Document>(series.size());
-
-            for (var s : series) {
-                if (!s.containsKey("function")) {
-                    newSeries.add(s);
-                } else {
-                    needsUpdate = true;
-                    s.put("type", s.get("function"));
-                    s.remove("function");
-                    newSeries.add(s);
-                }
-            }
-            if (needsUpdate) {
-                config.put("series", newSeries);
-                doc.put("config", config);
-                bulkOperations.add(new ReplaceOneModel<>(Filters.eq("_id", doc.getObjectId("_id")), doc, new ReplaceOptions().upsert(false)));
-            }
-
+            processDoc(doc, bulkOperations);
         }
         if (bulkOperations.size() > 0) {
             collection.bulkWrite(bulkOperations);
         }
-
         this.clusterConfigService.write(new MigrationCompleted());
     }
 
+    private void processDoc(Document doc, List<WriteModel<? extends Document>> bulkOperations) {
+        var config = doc.get("config", Document.class);
+        var series = config.getList("series", Document.class, Collections.emptyList());
+        var needsUpdate = false;
+        var invalidSeries = false;
+        var newSeries = new ArrayList<Document>(series.size());
+
+        for (var s : series) {
+            if (invalidSeries) {
+                break;
+            }
+            if (!s.containsKey("function")) {
+                newSeries.add(s);
+            } else {
+                needsUpdate = true;
+                s.put("type", s.get("function"));
+                s.remove("function");
+
+                if (s.containsKey("field") && s.get("field") == null
+                        && (s.get("type").equals("card") || s.get("type").equals("max") || s.get("type").equals("percentile"))) {
+                    invalidSeries = true;
+                } else {
+                    newSeries.add(s);
+                }
+            }
+        }
+        if (invalidSeries) {
+            newSeries.clear();
+            Document newConditions = new Document();
+            newConditions.put("expression", null);
+            config.put("conditions", newConditions);
+            doc.put(EventDefinitionDto.FIELD_STATE, EventDefinition.State.DISABLED);
+            raiseNotification(StringUtils.f("Disabled invalid event definition %s", doc.get("title", String.class)),
+                    "Definition is missing the required field name - please review and update the definition.",
+                    "/alerts/definitions/" + doc.getObjectId("_id"));
+        }
+        if (needsUpdate) {
+            config.put("series", newSeries);
+            doc.put("config", config);
+            bulkOperations.add(new ReplaceOneModel<>(Filters.eq("_id", doc.getObjectId("_id")), doc, new ReplaceOptions().upsert(false)));
+        }
+    }
+
     public record MigrationCompleted() {}
+
+    private void raiseNotification(String title, String details, String url) {
+        final Notification systemNotification = notificationService.buildNow()
+                .addType(Notification.Type.GENERIC_WITH_LINK)
+                .addSeverity(Notification.Severity.URGENT)
+                .addDetail("title", title)
+                .addDetail("GENERIC_DETAILS", details)
+                .addDetail("GENERIC_URL", url);
+        notificationService.publishIfFirst(systemNotification);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -81,6 +81,7 @@ public interface Notification extends Persisted {
         OUTPUT_FAILING,
         INDEX_RANGES_RECALCULATION,
         GENERIC,
+        GENERIC_WITH_LINK,
         ES_INDEX_BLOCKED,
         ES_NODE_DISK_WATERMARK_LOW,
         ES_NODE_DISK_WATERMARK_HIGH,

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/generic_with_link.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/generic_with_link.ftl
@@ -1,0 +1,13 @@
+<#if _title>
+${title}
+</#if>
+
+<#if _description>
+    <#if GENERIC_DETAILS?has_content>
+        ${GENERIC_DETAILS}
+    </#if>
+    <br>
+    <#if GENERIC_URL?has_content>
+        You can click <a href="${GENERIC_URL}" target="_blank" rel="noreferrer">here</a> to solve this.
+    </#if>
+</#if>

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/generic_with_link.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/generic_with_link.ftl
@@ -1,0 +1,13 @@
+<#if _title>
+${title}
+</#if>
+
+<#if _description>
+    <#if GENERIC_DETAILS?has_content>
+        ${GENERIC_DETAILS}
+    </#if>
+    <br>
+    <#if GENERIC_URL?has_content>
+        You can click here to solve this: ${GENERIC_URL}
+    </#if>
+</#if>

--- a/graylog2-server/src/test/java/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeriesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeriesTest.java
@@ -21,12 +21,14 @@ import org.bson.Document;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.migrations.Migration;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -59,6 +61,8 @@ public class V20230629140000_RenameFieldTypeOfEventDefinitionSeriesTest {
 
     @Mock
     private ClusterConfigService clusterConfigService;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private NotificationService notificationService;
 
     private MongoCollection<Document> eventDefinitionsCollection;
 
@@ -68,7 +72,8 @@ public class V20230629140000_RenameFieldTypeOfEventDefinitionSeriesTest {
     public void setUp() {
         this.migration = new V20230629140000_RenameFieldTypeOfEventDefinitionSeries(
                 clusterConfigService,
-                mongodb.mongoConnection()
+                mongodb.mongoConnection(),
+                notificationService
         );
         this.eventDefinitionsCollection = mongodb.mongoConnection().getMongoDatabase().getCollection("event_definitions");
     }
@@ -94,32 +99,25 @@ public class V20230629140000_RenameFieldTypeOfEventDefinitionSeriesTest {
     @Test
     @MongoDBFixtures("V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions.json")
     public void migratesEventDefinitionsProperly() {
-        this.migration.upgrade();
-
-        final V20230629140000_RenameFieldTypeOfEventDefinitionSeries.MigrationCompleted migrationCompleted = captureMigrationCompleted();
-        assertThat(migrationCompleted).isNotNull();
-
-        assertThat(eventDefinitionsCollection.countDocuments()).isEqualTo(4);
-
-        var actualCollection = collectionToJson();
         var expectedCollection = resourceFile("V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json");
-
-        uncheckedJSONAssertEquals(expectedCollection, actualCollection);
+        runMigration(5, expectedCollection);
     }
 
     @Test
     @MongoDBFixtures("V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json")
     public void doesNotChangeMigratedEventDefinitions() {
+        var expectedCollection = resourceFile("V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json");
+        runMigration(5, expectedCollection);
+    }
+
+    private void runMigration(int expectedCount, String expectedCollection) {
         this.migration.upgrade();
 
         final V20230629140000_RenameFieldTypeOfEventDefinitionSeries.MigrationCompleted migrationCompleted = captureMigrationCompleted();
         assertThat(migrationCompleted).isNotNull();
-
-        assertThat(eventDefinitionsCollection.countDocuments()).isEqualTo(4);
+        assertThat(eventDefinitionsCollection.countDocuments()).isEqualTo(expectedCount);
 
         var actualCollection = collectionToJson();
-        var expectedCollection = resourceFile("V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json");
-
         uncheckedJSONAssertEquals(expectedCollection, actualCollection);
     }
 

--- a/graylog2-server/src/test/resources/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json
+++ b/graylog2-server/src/test/resources/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions-after.json
@@ -179,6 +179,44 @@
         }
       ],
       "state" : "ENABLED"
+    },
+    {
+      "_id" : { "$oid": "658ee55d69d2bd68430e0463" },
+      "_scope" : "DEFAULT",
+      "title" : "missing_field",
+      "description" : "illegal event definition",
+      "updated_at" : { "$date": "2023-12-29T15:27:25.628Z" },
+      "priority" : 2,
+      "alert" : false,
+      "config" : {
+        "type" : "aggregation-v1",
+        "query" : "",
+        "query_parameters" : [],
+        "streams" : [],
+        "group_by" : [],
+        "series" : [],
+        "conditions" : {
+          "expression" : null
+        },
+        "search_within_ms" : 300000,
+        "execute_every_ms" : 300000
+      },
+      "field_spec" : {},
+      "key_spec" : [],
+      "notification_settings" : {
+        "grace_period_ms" : 300000,
+        "backlog_size" : 0
+      },
+      "notifications" : [],
+      "storage" : [
+        {
+          "type" : "persist-to-streams-v1",
+          "streams" : [
+            "000000000000000000000002"
+          ]
+        }
+      ],
+      "state" : "DISABLED"
     }
   ]
 }

--- a/graylog2-server/src/test/resources/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions.json
+++ b/graylog2-server/src/test/resources/org/graylog/events/migrations/V20230629140000_RenameFieldTypeOfEventDefinitionSeries/mixed_event_definitions.json
@@ -179,6 +179,60 @@
         }
       ],
       "state" : "ENABLED"
+    },
+    {
+      "_id" : { "$oid": "658ee55d69d2bd68430e0463" },
+      "_scope" : "DEFAULT",
+      "title" : "missing_field",
+      "description" : "illegal event definition",
+      "updated_at" : { "$date": "2023-12-29T15:27:25.628Z" },
+      "priority" : 2,
+      "alert" : false,
+      "config" : {
+        "type" : "aggregation-v1",
+        "query" : "",
+        "query_parameters" : [],
+        "streams" : [],
+        "group_by" : [],
+        "series" : [
+          {
+            "id" : "card-",
+            "function" : "card",
+            "field" : null
+          }
+        ],
+        "conditions" : {
+          "expression" : {
+            "expr" : "<",
+            "left" : {
+              "expr" : "number-ref",
+              "ref" : "card-"
+            },
+            "right" : {
+              "expr" : "number",
+              "value" : 0.0
+            }
+          }
+        },
+        "search_within_ms" : 300000,
+        "execute_every_ms" : 300000
+      },
+      "field_spec" : {},
+      "key_spec" : [],
+      "notification_settings" : {
+        "grace_period_ms" : 300000,
+        "backlog_size" : 0
+      },
+      "notifications" : [],
+      "storage" : [
+        {
+          "type" : "persist-to-streams-v1",
+          "streams" : [
+            "000000000000000000000002"
+          ]
+        }
+      ],
+      "state" : "ENABLED"
     }
   ]
 }

--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -47,11 +47,14 @@ const validateExpressionTree = (expression, series, validationTree = {}) => {
       const selectedSeries = series.find((s) => s.id === expression.ref);
 
       if (selectedSeries?.type === 'percentage' && selectedSeries?.strategy === 'SUM' && !selectedSeries?.field) {
-        return 'Field must be set';
+        return { message: 'Field must be set' };
       }
 
-      if (selectedSeries?.type === 'percentile' && !selectedSeries?.field) {
-        return 'Field must be set';
+      if ((selectedSeries?.type === 'percentile'
+        || selectedSeries?.type === 'max'
+        || selectedSeries?.type === 'card')
+        && !selectedSeries?.field) {
+        return { message: 'Field must be set' };
       }
 
       return (selectedSeries?.type ? {} : error);


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/17819

* Improve error handling for missing field value

* limit to max, card, percentile functions

* refactor and add unit test

* publish notification for disabled definitions

* add link to event definition

(cherry picked from commit a310be13c1ab928b55689370dedfafe9a037b06b)


