### PR TITLE
Make rendering time range preset picket in portal optional.

### DIFF
--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
@@ -90,7 +90,7 @@ const TimeRangePresetFormItem = ({ idx, id, timerange, description, onChange, on
 
   return (
     <ItemWrapper data-testid={`time-range-preset-${id}`}>
-      <TimeRangeFilter onChange={handleOnChangeRange} limitDuration={limitDuration} value={timerange} />
+      <TimeRangeFilter onChange={handleOnChangeRange} limitDuration={limitDuration} value={timerange} withinPortal={false} />
       <Description>
         <StyledInput type="text"
                      id={`quick-access-time-range-description-${id}`}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
@@ -137,7 +137,7 @@ TimeRangeFilter.defaultProps = {
   hasErrorOnMount: false,
   noOverride: false,
   validTypes: undefined,
-  position: 'bottom',
+  position: 'bottom-start',
   showPresetDropdown: true,
   withinPortal: true,
 };

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
@@ -56,6 +56,7 @@ type Props = {
   showPresetDropdown?: boolean,
   validTypes?: Array<SupportedTimeRangeType>,
   value: TimeRange | NoTimeRangeOverride,
+  withinPortal?: boolean,
 };
 
 const TimeRangeFilter = ({
@@ -69,6 +70,7 @@ const TimeRangeFilter = ({
   className,
   showPresetDropdown = true,
   limitDuration,
+  withinPortal,
 }: Props) => {
   const containerRef = useRef();
   const { showDropdownButton } = useContext(TimeRangeFilterSettingsContext);
@@ -103,7 +105,8 @@ const TimeRangeFilter = ({
                      setCurrentTimeRange={onChange}
                      toggleDropdownShow={toggleShow}
                      validTypes={validTypes}
-                     position={position}>
+                     position={position}
+                     withinPortal={withinPortal}>
       <FlexContainer className={className} ref={containerRef}>
         {showDropdownButton && (
         <TimeRangeFilterButtons disabled={disabled}
@@ -125,6 +128,7 @@ TimeRangeFilter.propTypes = {
   hasErrorOnMount: PropTypes.bool,
   noOverride: PropTypes.bool,
   validTypes: PropTypes.arrayOf(PropTypes.string),
+  withinPortal: PropTypes.bool,
 };
 
 TimeRangeFilter.defaultProps = {
@@ -135,6 +139,7 @@ TimeRangeFilter.defaultProps = {
   validTypes: undefined,
   position: 'bottom',
   showPresetDropdown: true,
+  withinPortal: true,
 };
 
 export default TimeRangeFilter;

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -19,7 +19,6 @@ import { useCallback, useContext, useMemo, useState } from 'react';
 import { Form, Formik } from 'formik';
 import styled, { css } from 'styled-components';
 import moment from 'moment';
-import { Portal } from '@mantine/core';
 
 import { Button, Col, Row } from 'components/bootstrap';
 import Popover from 'components/common/Popover';

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -134,6 +134,7 @@ type Props = React.PropsWithChildren<{
   setCurrentTimeRange: (timeRange: SearchBarFormValues['timerange'] | NoTimeRangeOverride) => void,
   toggleDropdownShow: () => void,
   validTypes?: Array<SupportedTimeRangeType>,
+  withinPortal?: boolean,
 }>;
 
 const TimeRangePicker = ({
@@ -146,6 +147,7 @@ const TimeRangePicker = ({
   validTypes = allTimeRangeTypes,
   position,
   limitDuration: configLimitDuration,
+  withinPortal,
 }: Props) => {
   const { ignoreLimitDurationInTimeRangeDropdown } = useContext(TimeRangeInputSettingsContext);
   const limitDuration = useMemo(() => (ignoreLimitDurationInTimeRangeDropdown ? 0 : configLimitDuration), [configLimitDuration, ignoreLimitDurationInTimeRangeDropdown]);
@@ -209,50 +211,49 @@ const TimeRangePicker = ({
              data-testid="timerange-type"
              opened={show}
              position={position}
+             withinPortal={withinPortal}
              withArrow
              width={735}
              zIndex={1060}>
       <Popover.Target>
         {children}
       </Popover.Target>
-      <Portal>
-        <Popover.Dropdown title={title}>
-          <Formik<TimeRangePickerFormValues> initialValues={initialValues}
-                                             validate={_validateTimeRange}
-                                             onSubmit={handleSubmit}
-                                             validateOnMount>
-            {(({ isValid, submitForm }) => (
-              <KeyCapture shortcuts={[
-                { actionKey: 'submit-form', callback: submitForm, scope: 'general', options: { displayInOverview: false } },
-                { actionKey: 'close-modal', callback: handleCancel, scope: 'general', options: { displayInOverview: false } },
-              ]}>
-                <Form>
-                  <Row>
-                    <Col md={12}>
-                      <TimeRangePresetRow />
-                      <TimeRangeTabs limitDuration={limitDuration}
-                                     validTypes={validTypes}
-                                     setValidatingKeyword={setValidatingKeyword} />
-                    </Col>
-                  </Row>
+      <Popover.Dropdown title={title}>
+        <Formik<TimeRangePickerFormValues> initialValues={initialValues}
+                                           validate={_validateTimeRange}
+                                           onSubmit={handleSubmit}
+                                           validateOnMount>
+          {(({ isValid, submitForm }) => (
+            <KeyCapture shortcuts={[
+              { actionKey: 'submit-form', callback: submitForm, scope: 'general', options: { displayInOverview: false } },
+              { actionKey: 'close-modal', callback: handleCancel, scope: 'general', options: { displayInOverview: false } },
+            ]}>
+              <Form>
+                <Row>
+                  <Col md={12}>
+                    <TimeRangePresetRow />
+                    <TimeRangeTabs limitDuration={limitDuration}
+                                   validTypes={validTypes}
+                                   setValidatingKeyword={setValidatingKeyword} />
+                  </Col>
+                </Row>
 
-                  <Row className="row-sm">
-                    <Col md={6}>
-                      <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
-                    </Col>
-                    <Col md={6}>
-                      <ModalSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
-                                   onCancel={handleCancel}
-                                   disabledSubmit={!isValid || validatingKeyword}
-                                   submitButtonText="Update time range" />
-                    </Col>
-                  </Row>
-                </Form>
-              </KeyCapture>
-            ))}
-          </Formik>
-        </Popover.Dropdown>
-      </Portal>
+                <Row className="row-sm">
+                  <Col md={6}>
+                    <Timezone>All timezones using: <b>{userTimezone}</b></Timezone>
+                  </Col>
+                  <Col md={6}>
+                    <ModalSubmit leftCol={noOverride && <Button bsStyle="link" onClick={handleNoOverride}>No Override</Button>}
+                                 onCancel={handleCancel}
+                                 disabledSubmit={!isValid || validatingKeyword}
+                                 submitButtonText="Update time range" />
+                  </Col>
+                </Row>
+              </Form>
+            </KeyCapture>
+          ))}
+        </Formik>
+      </Popover.Dropdown>
     </Popover>
   );
 };
@@ -260,6 +261,7 @@ const TimeRangePicker = ({
 TimeRangePicker.defaultProps = {
   noOverride: false,
   validTypes: allTimeRangeTypes,
+  withinPortal: true,
 };
 
 export default TimeRangePicker;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue introduced in #18033. The time range preset picker on the configurations -> search -> time range presets page is not working, due to losing its form when rendered in a portal.

This PR is fixing this by allowing to pass a `withinPortal` prop to the time range picker which can be set to `false` on the search configuration page.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.