### PR TITLE
Support migration action request arguments

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
@@ -16,10 +16,13 @@
  */
 package org.graylog.plugins.views.storage.migration.state.actions;
 
+import java.util.Map;
+
 /**
  * Set of callbacks used during the migration in different states.
  */
-public interface MigrationActions {
+public interface MigrationActions extends WithArgs {
+
     void resetMigration();
 
     void migrateIndexTemplates();
@@ -29,4 +32,6 @@ public interface MigrationActions {
     void migrateWithDowntime();
 
     boolean isOldClusterStopped();
+
+    void rollingUpgradeSelected();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/WithArgs.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/WithArgs.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.actions;
+
+import java.util.Map;
+
+/**
+ * This allows handling request parameters inside {@link MigrationActions}. The original state machine
+ * doesn't support action parameters and typed triggers are clumsy to use. In the same time there is no
+ * simple way to extend the state machine to support parameters in transition actions.
+ *
+ * With this interface, we support them inside {@link MigrationActions} where we actually need them.
+ */
+public interface WithArgs {
+    ThreadLocal<Map<String, Object>> requestArguments = new ThreadLocal<>();
+
+    /**
+     * @return request arguments provided by the frontend to the state machine transition action
+     */
+    default Map<String, Object> args() {
+        return requestArguments.get();
+    }
+
+    default void setArgs(Map<String, Object> args) {
+        requestArguments.set(args);
+    }
+
+    default void clearArgs() {
+        requestArguments.remove();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachine.java
@@ -17,9 +17,10 @@
 package org.graylog.plugins.views.storage.migration.state.machine;
 
 import java.util.List;
+import java.util.Map;
 
 public interface MigrationStateMachine {
-    MigrationState trigger(MigrationStep step);
+    MigrationState trigger(MigrationStep step, Map<String, Object> args);
     MigrationState getState();
 
     List<MigrationStep> nextSteps();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
@@ -36,9 +36,7 @@ public class MigrationStateMachineBuilder {
 
         // Major decision - remote reindexing or rolling upgrade(in-place)?
         config.configure(MigrationState.NEW)
-                .permit(MigrationStep.SELECT_ROLLING_UPGRADE_MIGRATION, MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME, () -> {
-                    LOG.info("Selected inplace migration");
-                })
+                .permit(MigrationStep.SELECT_ROLLING_UPGRADE_MIGRATION, MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME, migrationActions::rollingUpgradeSelected)
                 .permit(MigrationStep.SELECT_REMOTE_REINDEX_MIGRATION, MigrationState.REMOTE_REINDEX_WELCOME, () -> {
                     LOG.info("Selected remote reindex migration");
                 });

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
@@ -17,25 +17,31 @@
 package org.graylog.plugins.views.storage.migration.state.machine;
 
 import com.github.oxo42.stateless4j.StateMachine;
-import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
-import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
-import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 public class MigrationStateMachineImpl implements MigrationStateMachine {
     private final StateMachine<MigrationState, MigrationStep> stateMachine;
+    private final MigrationActions migrationActions;
 
-    public MigrationStateMachineImpl(StateMachine<MigrationState, MigrationStep> stateMachine) {
+    public MigrationStateMachineImpl(StateMachine<MigrationState, MigrationStep> stateMachine, MigrationActions migrationActions) {
         this.stateMachine = stateMachine;
+        this.migrationActions = migrationActions;
     }
 
     @Override
-    public MigrationState trigger(MigrationStep step) {
-        stateMachine.fire(step);
+    public MigrationState trigger(MigrationStep step, Map<String, Object> args) {
+        try {
+            migrationActions.setArgs(args);
+            stateMachine.fire(step);
+        } finally {
+            migrationActions.clearArgs();
+        }
         return stateMachine.getState();
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineProvider.java
@@ -38,6 +38,6 @@ public class MigrationStateMachineProvider implements Provider<MigrationStateMac
     @Override
     public MigrationStateMachine get() {
         final StateMachine<MigrationState, MigrationStep> stateMachine = MigrationStateMachineBuilder.buildFromPersistedState(persistenceService, migrationActions);
-        return new MigrationStateMachineImpl(stateMachine);
+        return new MigrationStateMachineImpl(stateMachine, migrationActions);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
@@ -54,7 +54,7 @@ public class MigrationStateResource {
     @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
     @ApiOperation(value = "trigger migration step")
     public CurrentStateInformation migrate(@ApiParam(name = "request") @NotNull MigrationStepRequest request) {
-        final MigrationState newState = stateMachine.trigger(request.step());
+        final MigrationState newState = stateMachine.trigger(request.step(), request.args());
         return new CurrentStateInformation(newState, stateMachine.nextSteps());
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStepRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStepRequest.java
@@ -19,5 +19,7 @@ package org.graylog.plugins.views.storage.migration.state.rest;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
 
-public record MigrationStepRequest(@JsonProperty("step") MigrationStep step) {
+import java.util.Map;
+
+public record MigrationStepRequest(@JsonProperty("step") MigrationStep step, @JsonProperty("args") Map<String, Object> args) {
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
@@ -14,39 +14,29 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.plugins.views.storage.migration.state.actions;
+package org.graylog.plugins.views.storage.migration.state.machine;
 
-import jakarta.inject.Inject;
-import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfiguration;
-import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
 
-public class MigrationActionsImpl implements MigrationActions {
-
-    private final ClusterConfigService clusterConfigService;
-
-    @Inject
-    public MigrationActionsImpl(ClusterConfigService clusterConfigService) {
-        this.clusterConfigService = clusterConfigService;
-    }
-
+public class MigrationActionsAdapter implements MigrationActions {
     @Override
     public void resetMigration() {
-        clusterConfigService.remove(DatanodeMigrationConfiguration.class);
+
     }
 
     @Override
     public void migrateIndexTemplates() {
-        // TODO!
+
     }
 
     @Override
     public void migrateWithoutDowntime() {
-        // TODO!
+
     }
 
     @Override
     public void migrateWithDowntime() {
-        // TODO!
+
     }
 
     @Override


### PR DESCRIPTION
/nocl
Support parameters for migration actions

## Description
Some migration state machine transition actions require user-entered parameters (think url and credentials of remotely reindexed cluster). This PR adds support for these:


POST: /api/migration/trigger
```
{
  "step": "MIGRATE_INDEX_TEMPLATES",
  "args": {
    "foo":"bar",
    "lorem":"ipsum"
  }
}
```

## How Has This Been Tested?
Added unit test


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

