### PR TITLE
Validation of series specs without required fields in Event Definitions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -35,6 +35,7 @@ import org.graylog.events.processor.EventProcessorSchedulerConfig;
 import org.graylog.events.processor.SearchFilterableConfig;
 import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
+import org.graylog.plugins.views.search.searchtypes.pivot.HasField;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
@@ -70,7 +71,7 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
     private static final String FIELD_FILTERS = "filters";
     private static final String FIELD_STREAMS = "streams";
     private static final String FIELD_GROUP_BY = "group_by";
-    private static final String FIELD_SERIES = "series";
+    static final String FIELD_SERIES = "series";
     private static final String FIELD_CONDITIONS = "conditions";
     private static final String FIELD_SEARCH_WITHIN_MS = "search_within_ms";
     private static final String FIELD_EXECUTE_EVERY_MS = "execute_every_ms";
@@ -218,6 +219,16 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         if (!series().isEmpty() && isConditionsEmpty()) {
             validationResult.addError(FIELD_CONDITIONS, "Aggregation with series must also contain conditions");
         }
+
+        series().stream()
+                .filter(ser -> ser instanceof HasField)
+                .forEach(ser -> {
+                    final String field = ((HasField) ser).field();
+                    if (field == null || field.isEmpty()) {
+                        validationResult.addError(FIELD_SERIES, "Aggregation's series of type " + ser.type() + " must contain non-empty value for field");
+                    }
+                });
+
         return validationResult;
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfigTest.java
@@ -35,6 +35,10 @@ import org.graylog.events.processor.storage.PersistToStreamsStorageHandler;
 import org.graylog.plugins.views.search.searchfilters.db.IgnoreSearchFilters;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Cardinality;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Latest;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
 import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog.testing.mongodb.MongoDBFixtures;
@@ -59,6 +63,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.events.processor.aggregation.AggregationEventProcessorConfig.FIELD_SERIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class AggregationEventProcessorConfigTest {
@@ -169,6 +176,41 @@ public class AggregationEventProcessorConfigTest {
         final ValidationResult validationResult2 = invalidConfig2.validate();
         assertThat(validationResult2.failed()).isTrue();
         assertThat(validationResult2.getErrors()).containsOnlyKeys("search_within_ms");
+    }
+
+    @Test
+    public void testValidateWithAggregationSeriesMissingFields() {
+        final AggregationConditions trueConditionThatDoesNotMatter = AggregationConditions.builder().expression(Expr.True.create()).build();
+        final AggregationEventProcessorConfig configWithSingleSeriesWithoutField = getConfig().toBuilder()
+                .searchWithinMs(100)
+                .series(List.of(Cardinality.builder().field("").build()))
+                .conditions(trueConditionThatDoesNotMatter)
+                .build();
+
+        ValidationResult validationResult = configWithSingleSeriesWithoutField.validate();
+        assertTrue(validationResult.failed());
+        assertEquals(1, validationResult.getErrors().get(FIELD_SERIES).size());
+        assertThat(validationResult.getErrors()).containsOnlyKeys(FIELD_SERIES);
+
+        final AggregationEventProcessorConfig configWithMultipleSeriesWithoutField = getConfig().toBuilder()
+                .searchWithinMs(100)
+                .series(
+                        List.of(
+                                Cardinality.builder().field("").build(),
+                                Max.builder().field("").build(),
+                                Average.builder().field("").build(),
+                                Latest.builder().field("").build(),
+                                Sum.builder().field("").build()
+                        )
+                )
+                .conditions(trueConditionThatDoesNotMatter)
+                .build();
+
+        validationResult = configWithMultipleSeriesWithoutField.validate();
+        assertTrue(validationResult.failed());
+        assertThat(validationResult.getErrors()).containsOnlyKeys(FIELD_SERIES);
+        assertEquals(5, validationResult.getErrors().get(FIELD_SERIES).size());
+
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Validation of series specs without required fields in Event Definitions
/nocl
Is a fix for #18034 together with [#17819.](https://github.com/Graylog2/graylog2-server/pull/17819)

## Motivation and Context
#18034
#17367

## How Has This Been Tested?
Manually and with new unit tests.

## Screenshots (if appropriate):
![image](https://github.com/Graylog2/graylog2-server/assets/100699120/906c7412-2574-4d40-a1c5-3461f978c5e3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

