### PR TITLE
Remove duplicate filters Aggregation event config builder

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -120,8 +120,7 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
     }
 
     public static Builder builder() {
-        return Builder.create()
-                .filters(Collections.emptyList());
+        return Builder.create();
     }
 
     public abstract Builder toBuilder();


### PR DESCRIPTION
While reviewing https://github.com/Graylog2/graylog-plugin-enterprise/pull/6492, I noticed that the `filters()` for aggregation events are set twice (once in `Builder.create()` and again in the root builder method that calls `create`). Cleaning that up at the same time. 

/nocl