### PR TITLE
Fix legacy TLS for LDAP / AD authentication (#18028)

### DIFF
--- a/changelog/unreleased/pr-18028.toml
+++ b/changelog/unreleased/pr-18028.toml
@@ -1,0 +1,11 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "fixed"
+message = "Fix LDAP / AD authentication with legacy TLS."
+
+issues = [""]
+pulls = ["18028"]
+
+contributors = [""]


### PR DESCRIPTION
* Fix legacy TLS for LDAP / AD authentication

The Unbound ldapsdk update from 5.1.1 to 6.0.10
 https://github.com/Graylog2/graylog2-server/pull/16624

Introduced a change which restricts the default ciphers of the Unbound TLS implementation.
 https://github.com/pingidentity/ldapsdk/commit/837b8f0fe2947e64fcee0209e9b8ef713028515e

If `enabled_tls_protocols` with TLS <= 1.1 is configured, manually enable all known ciphers for Unbound using their SSLUtil restores support for legacy implementations.

This can be tested by running the LDAP Test server connection feature against  tls-v1-1.badssl.com:1011

* readme

---------

Co-authored-by: Patrick Mann <patrickmann@users.noreply.github.com>
(cherry picked from commit 50c7ee4fb69174bcad17322e1111950942c99d5b)

