### PR TITLE
Fix `autocomplete` attribute spelling in login form.

### DIFF
--- a/graylog2-web-interface/src/components/login/LoginForm.tsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.tsx
@@ -57,14 +57,14 @@ const LoginForm = ({ onErrorChange }: Props) => {
       <Input id="username"
              type="text"
              label="Username"
-             autocomplete="username"
+             autoComplete="username"
              autoFocus
              required />
 
       <Input id="password"
              type="password"
              label="Password"
-             autocomplete="current-password"
+             autoComplete="current-password"
              required />
 
       <SigninButton displayCancel={false}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

React seems to expect the following spelling `autoComplete`, white we were using `autocomplete` in this case. This does not affect the functionalty.

/nocl

