### PR TITLE
Fixing `PropTypes` error on search page.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetContainer.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetContainer.tsx
@@ -26,12 +26,11 @@ const Container = styled.div`
   margin-bottom: 0;
 `;
 
-type Props = {
+type Props = React.PropsWithChildren<{
   isFocused: boolean,
-  children: React.ReactNode,
   className?: string,
   style?: React.CSSProperties,
-}
+}>
 
 const WidgetContainer = React.forwardRef<HTMLDivElement, Props>(({ children, className, isFocused, style, ...rest }, ref) => {
   let containerStyle = {
@@ -63,7 +62,7 @@ WidgetContainer.defaultProps = {
 };
 
 WidgetContainer.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.any.isRequired,
   className: PropTypes.string,
   isFocused: PropTypes.bool.isRequired,
   style: PropTypes.object,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the following error was displayed in the browser console,  when opening on the search page, during development.

```
Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `ForwardRef`, expected a single ReactElement.
```

/nocl
