### PR TITLE
fix data tiering in default index set config migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfiguration.java
@@ -17,6 +17,7 @@
 package org.graylog2.configuration;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -24,6 +25,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.graylog2.datatiering.DataTieringConfig;
+import org.graylog2.datatiering.fallback.PlaceholderDataTieringConfig;
 import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
@@ -39,7 +41,7 @@ import static org.graylog2.indexer.indexset.IndexSetConfig.FIELD_DATA_TIERING;
  */
 @JsonAutoDetect
 @AutoValue
-@JsonDeserialize(builder = AutoValue_IndexSetsDefaultConfiguration.Builder.class)
+@JsonDeserialize(builder = IndexSetsDefaultConfiguration.Builder.class)
 public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean {
 
     public static final String INDEX_ANALYZER = "index_analyzer";
@@ -57,7 +59,7 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
     public static final String RETENTION_STRATEGY = "retention_strategy"; // alias for retention_strategy_config
 
     public static Builder builder() {
-        return new AutoValue_IndexSetsDefaultConfiguration.Builder();
+        return Builder.create();
     }
 
     @NotBlank
@@ -128,6 +130,13 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
 
     @AutoValue.Builder
     public abstract static class Builder {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_IndexSetsDefaultConfiguration.Builder()
+                    .dataTiering(new PlaceholderDataTieringConfig());
+        }
+
         @JsonProperty(INDEX_ANALYZER)
         public abstract Builder indexAnalyzer(String indexAnalyzer);
 

--- a/graylog2-server/src/main/java/org/graylog2/datatiering/fallback/PlaceholderDataTieringConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/datatiering/fallback/PlaceholderDataTieringConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.datatiering.fallback;
+
+import org.graylog2.datatiering.DataTieringConfig;
+import org.joda.time.Period;
+
+
+public class PlaceholderDataTieringConfig implements DataTieringConfig {
+
+    @Override
+    public String type() {
+        return "placeholder";
+    }
+
+    @Override
+    public Period indexLifetimeMin() {
+        return Period.ZERO;
+    }
+
+    @Override
+    public Period indexLifetimeMax() {
+        return Period.ZERO;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfig.java
@@ -16,14 +16,14 @@
  */
 package org.graylog2.migrations;
 
+import jakarta.inject.Inject;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.configuration.IndexSetsDefaultConfiguration;
 import org.graylog2.configuration.IndexSetsDefaultConfigurationFactory;
+import org.graylog2.datatiering.fallback.PlaceholderDataTieringConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.time.ZonedDateTime;
 
@@ -54,7 +54,7 @@ public class V202211021200_CreateDefaultIndexDefaultsConfig extends Migration {
 
         if (indexSetsDefaultConfiguration == null) {
             indexSetsDefaultConfiguration = factory.create();
-        } else if (indexSetsDefaultConfiguration.dataTiering() == null) {
+        } else if (indexSetsDefaultConfiguration.dataTiering() instanceof PlaceholderDataTieringConfig) {
             LOG.info("Applying data tiering to Indexset defaults");
             indexSetsDefaultConfiguration = factory.addDataTieringDefaults(indexSetsDefaultConfiguration);
         } else {


### PR DESCRIPTION
Since the `data_tiering` field in the `IndexSetsDefaultConfiguration` cannot be null, a placeholder implementation is now used if the field does not exist in the database.

/nocl
