### PR TITLE
feat: Enable filters when editing an Illuminate event definition

### DIFF
--- a/changelog/unreleased/pr-18130.toml
+++ b/changelog/unreleased/pr-18130.toml
@@ -1,4 +1,0 @@
-type = "c"
-message = "Enable condition form in event definitions for Illuminate events"
-
-pulls = ["18130"]

--- a/changelog/unreleased/pr-18130.toml
+++ b/changelog/unreleased/pr-18130.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Enable condition form in event definitions for Illuminate events"
+
+pulls = ["18130"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -109,6 +109,7 @@ const EventConditionForm = ({ action, entityTypes, eventDefinition, validation, 
   };
 
   const disabledSelect = () => !formattedEventDefinitionTypes().some((edt) => eventDefinition.config.type === edt.value) && action === 'edit';
+  const onlyFilters = () => eventDefinition._scope === 'ILLUMINATE' && action === 'edit';
 
   const eventDefinitionType = getConditionPlugin(eventDefinition.config.type);
   const isSystemEventDefinition = eventDefinition.config.type === SYSTEM_EVENT_DEFINITION_TYPE;
@@ -148,7 +149,7 @@ const EventConditionForm = ({ action, entityTypes, eventDefinition, validation, 
                       value={eventDefinition.config.type}
                       onChange={handleEventDefinitionTypeChange}
                       clearable={false}
-                      disabled={disabledSelect()}
+                      disabled={disabledSelect() || onlyFilters()}
                       required />
               <HelpBlock>
                 {get(validation, 'errors.config[0]', 'Choose the type of Condition for this Event.')}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.tsx
@@ -131,6 +131,10 @@ const EventDefinitionForm = ({
     currentUser,
   };
 
+  const canEditCondition = React.useMemo(() => (
+    canEdit || eventDefinition._scope.toUpperCase() === 'ILLUMINATE'
+  ), [canEdit, eventDefinition._scope]);
+
   const eventDefinitionType = getConditionPlugin(eventDefinition.config.type);
 
   const steps = [
@@ -142,7 +146,7 @@ const EventDefinitionForm = ({
     {
       key: STEP_KEYS[1],
       title: defaultTo(eventDefinitionType.displayName, 'Condition'),
-      component: <EventConditionForm {...defaultStepProps} canEdit={canEdit} />,
+      component: <EventConditionForm {...defaultStepProps} canEdit={canEditCondition} />,
     },
     {
       key: STEP_KEYS[2],

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -129,6 +129,8 @@ class FilterAggregationForm extends React.Component {
     const { conditionType } = this.state;
     const { entityTypes, eventDefinition, streams, validation, currentUser } = this.props;
 
+    const onlyFilters = eventDefinition._scope === 'ILLUMINATE';
+
     return (
       <>
         <Row>
@@ -139,24 +141,26 @@ class FilterAggregationForm extends React.Component {
                         currentUser={currentUser}
                         onChange={this.props.onChange} />
 
-            <FormGroup>
-              <ControlLabel>Create Events for Definition if...</ControlLabel>
-              <Radio id="filter-type"
-                     name="conditionType"
-                     value={conditionTypes.FILTER}
-                     checked={conditionType === conditionTypes.FILTER}
-                     onChange={this.handleTypeChange}>
-                Filter has results
-              </Radio>
-              <Radio id="aggregation-type"
-                     name="conditionType"
-                     value={conditionTypes.AGGREGATION}
-                     checked={conditionType === conditionTypes.AGGREGATION}
-                     onChange={this.handleTypeChange}>
-                Aggregation of results reaches a threshold
-              </Radio>
-            </FormGroup>
-            {conditionType === conditionTypes.FILTER && (
+            {onlyFilters || (
+              <FormGroup>
+                <ControlLabel>Create Events for Definition if...</ControlLabel>
+                <Radio id="filter-type"
+                       name="conditionType"
+                       value={conditionTypes.FILTER}
+                       checked={conditionType === conditionTypes.FILTER}
+                       onChange={this.handleTypeChange}>
+                  Filter has results
+                </Radio>
+                <Radio id="aggregation-type"
+                       name="conditionType"
+                       value={conditionTypes.AGGREGATION}
+                       checked={conditionType === conditionTypes.AGGREGATION}
+                       onChange={this.handleTypeChange}>
+                  Aggregation of results reaches a threshold
+                </Radio>
+              </FormGroup>
+            )}
+            {(conditionType === conditionTypes.FILTER && !onlyFilters) && (
               <Row>
                 <Col md={12}>
                   <Input id="event-limit"
@@ -171,13 +175,12 @@ class FilterAggregationForm extends React.Component {
                 </Col>
               </Row>
             )}
-
           </Col>
           <Col md={5} lgOffset={1}>
             <FilterPreviewContainer eventDefinition={eventDefinition} />
           </Col>
         </Row>
-        {conditionType === conditionTypes.AGGREGATION && (
+        {(conditionType === conditionTypes.AGGREGATION && !onlyFilters) && (
           <Row>
             <Col md={12}>
               <AggregationForm eventDefinition={eventDefinition}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -332,6 +332,8 @@ class FilterForm extends React.Component {
     const { eventDefinition, streams, validation } = this.props;
     const { searchWithinMsDuration, searchWithinMsUnit, executeEveryMsDuration, executeEveryMsUnit } = this.state;
 
+    const onlyFilters = eventDefinition._scope === 'ILLUMINATE';
+
     // Ensure deleted streams are still displayed in select
     const allStreamIds = union(streams.map((s) => s.id), defaultTo(eventDefinition.config.streams, []));
     const formattedStreams = this.formatStreamIds(allStreamIds);
@@ -340,25 +342,27 @@ class FilterForm extends React.Component {
       <fieldset>
         <h2 className={commonStyles.title}>Filter</h2>
         <p>Add information to filter the log messages that are relevant for this Event Definition.</p>
-        <Input id="filter-query"
-               name="query"
-               label="Search Query"
-               type="text"
-               help={(
-                 <span>
-                   Search query that Messages should match. You can use the same syntax as in the Search page,
-                   including declaring Query Parameters from Lookup Tables by using the <code>$newParameter$</code> syntax.
-                 </span>
-               )}
-               value={defaultTo(eventDefinition.config.query, '')}
-               onChange={this.handleQueryChange} />
+        {onlyFilters || (
+          <Input id="filter-query"
+                 name="query"
+                 label="Search Query"
+                 type="text"
+                 help={(
+                   <span>
+                     Search query that Messages should match. You can use the same syntax as in the Search page,
+                     including declaring Query Parameters from Lookup Tables by using the <code>$newParameter$</code> syntax.
+                   </span>
+                 )}
+                 value={defaultTo(eventDefinition.config.query, '')}
+                 onChange={this.handleQueryChange} />
+        )}
 
-        {this.renderQueryParameters()}
+        {onlyFilters || this.renderQueryParameters()}
 
         {!this.state.searchFiltersHidden && (
           <FormGroup controlId="search-filters">
             <ControlLabel>Search Filters <small className="text-muted">(Optional)</small></ControlLabel>
-            <div style={{ maring: '8px 0' }}>
+            <div style={{ maring: '16px 0' }}>
               <SearchFiltersFormControls filters={eventDefinition.config.filters}
                                          onChange={this.handleSearchFiltersChange}
                                          hideFiltersPreview={this.hideFiltersPreview} />
@@ -366,48 +370,52 @@ class FilterForm extends React.Component {
           </FormGroup>
         )}
 
-        <FormGroup controlId="filter-streams">
-          <ControlLabel>Streams <small className="text-muted">(Optional)</small></ControlLabel>
-          <MultiSelect id="filter-streams"
-                       matchProp="label"
-                       onChange={(selected) => this.handleStreamsChange(selected === '' ? [] : selected.split(','))}
-                       options={formattedStreams}
-                       value={defaultTo(eventDefinition.config.streams, []).join(',')} />
-          <HelpBlock>Select streams the search should include. Searches in all streams if empty.</HelpBlock>
-        </FormGroup>
+        {onlyFilters || (
+          <>
+            <FormGroup controlId="filter-streams">
+              <ControlLabel>Streams <small className="text-muted">(Optional)</small></ControlLabel>
+              <MultiSelect id="filter-streams"
+                           matchProp="label"
+                           onChange={(selected) => this.handleStreamsChange(selected === '' ? [] : selected.split(','))}
+                           options={formattedStreams}
+                           value={defaultTo(eventDefinition.config.streams, []).join(',')} />
+              <HelpBlock>Select streams the search should include. Searches in all streams if empty.</HelpBlock>
+            </FormGroup>
 
-        <FormGroup controlId="search-within" validationState={validation.errors.search_within_ms ? 'error' : null}>
-          <TimeUnitInput label="Search within the last"
-                         update={this.handleTimeRangeChange('search_within_ms')}
-                         value={searchWithinMsDuration}
-                         unit={searchWithinMsUnit}
-                         units={TIME_UNITS}
-                         clearable
-                         required />
-          {validation.errors.search_within_ms && (
-            <HelpBlock>{get(validation, 'errors.search_within_ms[0]')}</HelpBlock>
-          )}
-        </FormGroup>
+            <FormGroup controlId="search-within" validationState={validation.errors.search_within_ms ? 'error' : null}>
+              <TimeUnitInput label="Search within the last"
+                             update={this.handleTimeRangeChange('search_within_ms')}
+                             value={searchWithinMsDuration}
+                             unit={searchWithinMsUnit}
+                             units={TIME_UNITS}
+                             clearable
+                             required />
+              {validation.errors.search_within_ms && (
+                <HelpBlock>{get(validation, 'errors.search_within_ms[0]')}</HelpBlock>
+              )}
+            </FormGroup>
 
-        <FormGroup controlId="execute-every" validationState={validation.errors.execute_every_ms ? 'error' : null}>
-          <TimeUnitInput label="Execute search every"
-                         update={this.handleTimeRangeChange('execute_every_ms')}
-                         value={executeEveryMsDuration}
-                         unit={executeEveryMsUnit}
-                         units={TIME_UNITS}
-                         clearable
-                         required />
-          {validation.errors.execute_every_ms && (
-            <HelpBlock>{get(validation, 'errors.execute_every_ms[0]')}</HelpBlock>
-          )}
-        </FormGroup>
-        <Input id="schedule-checkbox"
-               type="checkbox"
-               name="_is_scheduled"
-               label="Enable"
-               help="Should this event definition be executed automatically?"
-               checked={defaultTo(eventDefinition.config._is_scheduled, true)}
-               onChange={this.handleConfigChange} />
+            <FormGroup controlId="execute-every" validationState={validation.errors.execute_every_ms ? 'error' : null}>
+              <TimeUnitInput label="Execute search every"
+                             update={this.handleTimeRangeChange('execute_every_ms')}
+                             value={executeEveryMsDuration}
+                             unit={executeEveryMsUnit}
+                             units={TIME_UNITS}
+                             clearable
+                             required />
+              {validation.errors.execute_every_ms && (
+                <HelpBlock>{get(validation, 'errors.execute_every_ms[0]')}</HelpBlock>
+              )}
+            </FormGroup>
+            <Input id="schedule-checkbox"
+                   type="checkbox"
+                   name="_is_scheduled"
+                   label="Enable"
+                   help="Should this event definition be executed automatically?"
+                   checked={defaultTo(eventDefinition.config._is_scheduled, true)}
+                   onChange={this.handleConfigChange} />
+          </>
+        )}
       </fieldset>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable condition form in event definitions when editing an Illuminate event

/nocl

## Description
<!--- Describe your changes in detail -->
With this modifications users will be able to add search-filters to Illuminate event definitions. The rest of the form is disabled so the only changes that can be done to this type of events are, add filters and notifications.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

