### PR TITLE
Disable query input keyboard shortcuts outside of query input.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -184,29 +184,36 @@ const useCompleter = ({ streams, timeRange, completerFactory, view }: Pick<Props
 };
 
 const useShowHotkeysInOverview = () => {
+  const options = { enabled: false };
+
   useHotkey({
     scope: 'query-input',
     actionKey: 'submit-search',
+    options,
   });
 
   useHotkey({
     scope: 'query-input',
     actionKey: 'insert-newline',
+    options,
   });
 
   useHotkey({
     scope: 'query-input',
     actionKey: 'create-search-filter',
+    options,
   });
 
   useHotkey({
     scope: 'query-input',
     actionKey: 'show-suggestions',
+    options,
   });
 
   useHotkey({
     scope: 'query-input',
     actionKey: 'show-history',
+    options,
   });
 };
 
@@ -282,8 +289,6 @@ const QueryInput = React.forwardRef<Editor, Props>(({
       name: 'Show completions',
       bindKey: { win: 'Alt-Space', mac: 'Alt-Space' },
       exec: async (editor: Editor) => {
-        console.log('test', editor.getValue());
-
         if (editor.getValue()) {
           startAutocomplete(editor);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently we made sure we show the query input keyboard shortcuts in the shortcuts overview. The challenge was to show the hotkeys in the overview, without providing a callback, because the ace editor takes care of registering the keyboard shortcuts.

With this PR we ensure the keyboard shortcuts are only active when the input is focused.

/nocl