### PR TITLE
Define default time range in frontend for alerts overview request. (`5.1`)

### DIFF
--- a/changelog/unreleased/issue-18000.toml
+++ b/changelog/unreleased/issue-18000.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing UI runtime error when request for alerts overview returns an error."
+
+pulls=["18000"]
+issues=["17995"]

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import isObject from 'lodash/isObject';
 
 import { Spinner } from 'components/common';
+import UserNotification from 'util/UserNotification';
 import connect from 'stores/connect';
 import Store from 'logic/local-storage/Store';
 import { CurrentUserStore } from 'stores/users/CurrentUserStore';
@@ -41,6 +42,8 @@ const fetchEvents = ({ page, pageSize, query, filter, timerange }) => {
     pageSize: pageSize,
     filter: filter,
     timerange: timerange,
+  }).catch((error) => {
+    UserNotification.error(`Fetching alerts failed with status: ${error}`);
   });
 };
 

--- a/graylog2-web-interface/src/stores/events/EventsStore.js
+++ b/graylog2-web-interface/src/stores/events/EventsStore.js
@@ -83,7 +83,13 @@ export const EventsStore = singletonStore(
       });
     },
 
-    search({ query = '', page = 1, pageSize = 25, filter = { alerts: 'only' }, timerange }) {
+    search({
+      query = '',
+      page = 1,
+      pageSize = 25,
+      filter = { alerts: 'only' },
+      timerange = { type: 'relative', range: 3600 }, // 1 hour
+    }) {
       const promise = fetch('POST', this.eventsUrl({}), {
         query: query,
         page: page,


### PR DESCRIPTION
Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/18000 for `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is possible that the request `/api/events/search` for the alerts overview throws an error like:

`Unable to perform search query[]\n\nIndex not found for query: . Try recalculating your index ranges.`

In case of an error response we are using the default query params in the UI. Before this change there was no default value for the time range. Since the frontend expects a time range it threw the following error:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/281bb037-9040-48d1-b5b6-8207cd9feb35)

I was able to reproduce this with a fresh system and we will improve the `Index not found` error in a different PR.

We are now using the same default time range like the backend and we are displaying a user notification in case of an error.

Fixes https://github.com/Graylog2/graylog2-server/issues/17995

