### PR TITLE
OpenSearchClientProvider should be a singleton

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClientProvider.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClientProvider.java
@@ -19,6 +19,7 @@ package org.graylog.storage.opensearch2;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
@@ -26,6 +27,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.rest_client.RestClientOptions;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
 
+@Singleton
 public class OpenSearchClientProvider implements Provider<OpenSearchClient> {
     private final RestClientTransport transport;
 


### PR DESCRIPTION
## Description
OpenSearchClientProvider should be a singleton.
/nocl

## Motivation and Context
OpenSearchClientProvider is not constructed before each request to provide a client, new RestClientTransport instance is not constructed with every call to provide.

## How Has This Been Tested?
Manually.

## Considerations for close future.
Should we at all used provider for OpenSearchClients?
If yes, shouldn't we use a trick with memoize(), as in RestHighLevelClientProvider, to have only one instance of OpenSearchClient?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

