### PR TITLE
More restrictive file permissions for support bundle files

### DIFF
--- a/changelog/unreleased/pr-18174.toml
+++ b/changelog/unreleased/pr-18174.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "More restrictive file permissions for support bundle files."
+
+pulls = ["18174"]


### PR DESCRIPTION
Changes permissions for support bundle files from `-rw-r--r--` to `rw-------`.  

Previously, support bundle files were created with `-rw-r--r--` permissions.

The enclosing support bundle directory has `drwx------` permissions, so files were not accessible to anyone other than the user running Graylog. But it is probably still a good idea to create the files with more restrictive permissions.

