### PR TITLE
Add permission check for displaying content pack uninstall details

### DIFF
--- a/changelog/unreleased/pr-18177.toml
+++ b/changelog/unreleased/pr-18177.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Add permission check for displaying content pack uninstall details."
+
+pulls = ["18177"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -24,6 +24,20 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.bson.types.ObjectId;
 import org.graylog2.audit.AuditEventTypes;
@@ -50,23 +64,6 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
 import java.util.Map;
@@ -334,6 +331,8 @@ public class ContentPackResource extends RestResource {
             @PathParam("contentPackId") ModelId id,
             @ApiParam(name = "installationId", value = "Installation ID", required = true)
             @PathParam("installationId") String installationId) {
+        checkPermission(RestPermissions.CONTENT_PACK_READ);
+
         final ContentPackInstallation installation = contentPackInstallationPersistenceService.findById(new ObjectId(installationId))
                 .orElseThrow(() -> new NotFoundException("Couldn't find installation " + installationId));
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -331,7 +331,7 @@ public class ContentPackResource extends RestResource {
             @PathParam("contentPackId") ModelId id,
             @ApiParam(name = "installationId", value = "Installation ID", required = true)
             @PathParam("installationId") String installationId) {
-        checkPermission(RestPermissions.CONTENT_PACK_READ);
+        checkPermission(RestPermissions.CONTENT_PACK_READ, id.toString());
 
         final ContentPackInstallation installation = contentPackInstallationPersistenceService.findById(new ObjectId(installationId))
                 .orElseThrow(() -> new NotFoundException("Couldn't find installation " + installationId));


### PR DESCRIPTION
Fixes a missing permission check for fetching "uninstall details" of installed content packs.

Previously, uninstall details could be fetched from the API even when the basic `contentpack:read` permission was missing.
If the content pack ID and installation ID were known, a request like the following would return results for any registered Graylog user:

http://localhost:8080/api/system/content_packs/5408f50a-b2fb-4430-977f-1351577e2841/installations/659bbce0057e576276644765/uninstall_details

With this change, the user needs to have at least `contentpack:read` permission (scoped by content pack ID) for the call to succeed.


