### PR TITLE
Add permission check for displaying content pack uninstall details

### DIFF
--- a/changelog/unreleased/pr-18177.toml
+++ b/changelog/unreleased/pr-18177.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Add permission check for displaying content pack uninstall details."
+
+pulls = ["18177"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -331,6 +331,8 @@ public class ContentPackResource extends RestResource {
             @PathParam("contentPackId") ModelId id,
             @ApiParam(name = "installationId", value = "Installation ID", required = true)
             @PathParam("installationId") String installationId) {
+        checkPermission(RestPermissions.CONTENT_PACK_READ, id.toString());
+
         final ContentPackInstallation installation = contentPackInstallationPersistenceService.findById(new ObjectId(installationId))
                 .orElseThrow(() -> new NotFoundException("Couldn't find installation " + installationId));
 


### PR DESCRIPTION
(cherry picked from commit c8adb0b51ef97e1b37c01600868bf82d8a23477a)
