### PR TITLE
handle nullable use_legacy_rotation field in index set config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -54,7 +54,7 @@ public record IndexSetUpdateRequest(@JsonProperty("title") @NotBlank String titl
                                     @JsonProperty("field_type_refresh_interval") Duration fieldTypeRefreshInterval,
                                     @JsonProperty(FIELD_PROFILE_ID) @ValidObjectId @Nullable String fieldTypeProfile,
                                     @JsonProperty(FIELD_DATA_TIERING) @Nullable DataTieringConfig dataTiering,
-                                    @JsonProperty(FIELD_USE_LEGACY_ROTATION) Boolean useLegacyRotation) {
+                                    @JsonProperty(FIELD_USE_LEGACY_ROTATION) @Nullable Boolean useLegacyRotation) {
 
 
     public static IndexSetUpdateRequest fromIndexSetConfig(final IndexSetConfig indexSet) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.datatiering.DataTieringConfig;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -29,12 +33,6 @@ import org.graylog2.validation.SizeInBytes;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
-
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
@@ -74,7 +72,7 @@ public abstract class IndexSetSummary {
                                          @JsonProperty("index_template_type") @Nullable String templateType,
                                          @JsonProperty(FIELD_PROFILE_ID) @Nullable String fieldTypeProfile,
                                          @JsonProperty(FIELD_DATA_TIERING) @Nullable DataTieringConfig dataTiering,
-                                         @JsonProperty(FIELD_USE_LEGACY_ROTATION) Boolean userLegacyRotation) {
+                                         @JsonProperty(FIELD_USE_LEGACY_ROTATION) @Nullable Boolean userLegacyRotation) {
         if (Objects.isNull(creationDate)) {
             creationDate = ZonedDateTime.now();
         }
@@ -191,6 +189,7 @@ public abstract class IndexSetSummary {
     @JsonProperty(FIELD_DATA_TIERING)
     public abstract DataTieringConfig dataTiering();
 
+    @Nullable
     @JsonProperty(FIELD_USE_LEGACY_ROTATION)
     public abstract Boolean useLegacyRotation();
 


### PR DESCRIPTION
For better backward compatibility, the `use_legacy_rotation` field can be null. In this case, the old rotation strategies are used.

/nocl