### PR TITLE
Revert: Log failure warning message even if input is already failing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/InputFailureRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/InputFailureRecorder.java
@@ -51,7 +51,6 @@ public class InputFailureRecorder {
      * @param e the exception leading to the error
      */
     public void setFailing(Class<?> loggingClass, String error, @Nullable Throwable e) {
-        LoggerFactory.getLogger(loggingClass).warn(error, e);
         if (inputState.getState().equals(IOState.Type.FAILING)) {
             return;
         }
@@ -60,6 +59,7 @@ public class InputFailureRecorder {
         } else {
             inputState.setState(IOState.Type.FAILING, error);
         }
+        LoggerFactory.getLogger(loggingClass).warn(error, e);
     }
 
     /**


### PR DESCRIPTION
Reverts https://github.com/Graylog2/graylog2-server/pull/18148. We already capture when inputs enter the `failing` state and again enter the `running` state in the server log. For any in-between error messages, the system notification can be referenced, or debug logging for a specific input can be enabled. Also see conversion on the above PR for more info.

/nocl