### PR TITLE
Set option ignore_unavailable for querying (#18146)

### DIFF
--- a/changelog/unreleased/issue-18127.toml
+++ b/changelog/unreleased/issue-18127.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Suppress index_not_found_exception when there is a race between querying and deleting an index."
+
+issues = ["18127"]
+pulls = ["18146"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -190,7 +190,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     public Map<String, Object> getIndexMetaData(@Nonnull String index) {
         final GetMappingsRequest request = new GetMappingsRequest()
                 .indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         final GetMappingsResponse result = client.execute((c, requestOptions) -> c.indices().getMapping(request, requestOptions),
                 "Couldn't read mapping of index " + index);
@@ -223,7 +223,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     public Optional<DateTime> indexCreationDate(String index) {
         final GetSettingsRequest request = new GetSettingsRequest()
                 .indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         final GetSettingsResponse result = client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Couldn't read settings of index " + index);
@@ -319,7 +319,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
     private GetSettingsResponse settingsFor(String indexOrAlias) {
         final GetSettingsRequest request = new GetSettingsRequest().indices(indexOrAlias)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED);
         return client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Unable to retrieve settings for index/alias " + indexOrAlias);
     }
@@ -578,7 +578,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
     @Override
     public String getIndexId(String index) {
         final GetSettingsRequest request = new GetSettingsRequest().indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED);
         final GetSettingsResponse response = client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Unable to retrieve settings for index/alias " + index);
         return response.getSetting(index, "index.uuid");

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -60,7 +60,7 @@ import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.Qu
 
 public class MoreSearchAdapterES7 implements MoreSearchAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(MoreSearchAdapterES7.class);
-    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false);
+    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.LENIENT_EXPAND_OPEN;
     private final ElasticsearchClient client;
     private final Boolean allowLeadingWildcard;
     private final SortOrderMapper sortOrderMapper;
@@ -114,7 +114,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
-            LOG.debug("Execute search: {}", searchRequest.toString());
+            LOG.debug("Execute search: {}", searchRequest);
         }
 
         final SearchResponse searchResult = client.search(searchRequest, "Unable to perform search query");

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationES7.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7;
 
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.results.ChunkedResult;
 import org.graylog2.indexer.results.MultiChunkResultRetriever;
@@ -48,6 +49,7 @@ public class PaginationES7 implements MultiChunkResultRetriever {
     private SearchRequest buildSearchRequest(final SearchSourceBuilder query,
                                              final Set<String> indices) {
         return new SearchRequest(indices.toArray(new String[0]))
-                .source(query);
+                .source(query)
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationResultES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationResultES7.java
@@ -23,6 +23,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchR
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.SearchHit;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -41,6 +42,7 @@ public class PaginationResultES7 extends ChunkedQueryResultES7 {
     }
 
     @Override
+    @Nullable
     protected SearchResponse nextSearchResult() throws IOException {
         final SearchSourceBuilder initialQuery = initialSearchRequest.source();
         final SearchHit[] hits = lastSearchResponse.getHits().getHits();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7;
 
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.results.ChunkedResult;
 import org.graylog2.indexer.results.MultiChunkResultRetriever;
@@ -53,6 +54,7 @@ public class Scroll implements MultiChunkResultRetriever {
     private SearchRequest scrollBuilder(SearchSourceBuilder query, Set<String> indices) {
         return new SearchRequest(indices.toArray(new String[0]))
                 .source(query)
-                .scroll(DEFAULT_SCROLLTIME);
+                .scroll(DEFAULT_SCROLLTIME)
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ScrollResultES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ScrollResultES7.java
@@ -23,10 +23,9 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchR
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchScrollRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.unit.TimeValue;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class ScrollResultES7 extends ChunkedQueryResultES7 {
 
@@ -46,13 +45,17 @@ public class ScrollResultES7 extends ChunkedQueryResultES7 {
                            @Assisted List<String> fields,
                            @Assisted int limit) {
         super(client, initialResult, query, fields, limit);
-        checkArgument(initialResult.getScrollId() != null, "Unable to extract scroll id from supplied search result!");
         this.scroll = scroll;
 
     }
 
     @Override
+    @Nullable
     protected SearchResponse nextSearchResult() throws IOException {
+        if (this.lastSearchResponse.getScrollId() == null) {
+            //with ignore_unavailable=true and no available indices, response does not contain scrollId
+            return null;
+        }
         final SearchScrollRequest scrollRequest = new SearchScrollRequest(this.lastSearchResponse.getScrollId());
         scrollRequest.scroll(TimeValue.parseTimeValue(this.scroll, DEFAULT_SCROLL, "scroll time"));
         return client.executeWithIOException((c, requestOptions) -> c.scroll(scrollRequest, requestOptions),
@@ -61,6 +64,10 @@ public class ScrollResultES7 extends ChunkedQueryResultES7 {
 
     @Override
     public void cancel() throws IOException {
+        if (this.lastSearchResponse.getScrollId() == null) {
+            //with ignore_unavailable=true and no available indices, response does not contain scrollId, there is nothing to cancel
+            return;
+        }
         final ClearScrollRequest request = new ClearScrollRequest();
         request.addScrollId(this.lastSearchResponse.getScrollId());
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -239,7 +239,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                     return new SearchRequest()
                             .source(searchTypeQueries.get(searchTypeId))
                             .indices(indices.toArray(new String[0]))
-                            .indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+                            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
                 })
                 .collect(Collectors.toList());
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndexToolsAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndexToolsAdapterOS2.java
@@ -114,7 +114,7 @@ public class IndexToolsAdapterOS2 implements IndexToolsAdapter {
     @Override
     public long count(Set<String> indices, Optional<Set<String>> includedStreams) {
         final CountRequest request = new CountRequest(indices.toArray(new String[0]), buildStreamIdFilter(includedStreams))
-                .indicesOptions(IndicesOptions.fromOptions(true, false, true, false));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         final CountResponse result = client.execute((c, requestOptions) -> c.count(request, requestOptions), "Unable to count documents of index.");
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -188,7 +188,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     public Map<String, Object> getIndexMetaData(@Nonnull String index) {
         final GetMappingsRequest request = new GetMappingsRequest()
                 .indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         final GetMappingsResponse result = client.execute((c, requestOptions) -> c.indices().getMapping(request, requestOptions),
                 "Couldn't read mapping of index " + index);
@@ -221,7 +221,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     public Optional<DateTime> indexCreationDate(String index) {
         final GetSettingsRequest request = new GetSettingsRequest()
                 .indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, false));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         final GetSettingsResponse result = client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Couldn't read settings of index " + index);
@@ -317,7 +317,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
 
     private GetSettingsResponse settingsFor(String indexOrAlias) {
         final GetSettingsRequest request = new GetSettingsRequest().indices(indexOrAlias)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED);
         return client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Unable to retrieve settings for index/alias " + indexOrAlias);
     }
@@ -576,7 +576,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     @Override
     public String getIndexId(String index) {
         final GetSettingsRequest request = new GetSettingsRequest().indices(index)
-                .indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED);
         final GetSettingsResponse response = client.execute((c, requestOptions) -> c.indices().getSettings(request, requestOptions),
                 "Unable to retrieve settings for index/alias " + index);
         return response.getSetting(index, "index.uuid");

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -60,7 +60,7 @@ import static org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBui
 
 public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(MoreSearchAdapterOS2.class);
-    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false);
+    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.LENIENT_EXPAND_OPEN;
     private final OpenSearchClient client;
     private final Boolean allowLeadingWildcard;
     private final SortOrderMapper sortOrderMapper;
@@ -114,7 +114,7 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
-            LOG.debug("Execute search: {}", searchRequest.toString());
+            LOG.debug("Execute search: {}", searchRequest);
         }
 
         final SearchResponse searchResult = client.search(searchRequest, "Unable to perform search query");

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationOS2.java
@@ -18,6 +18,7 @@ package org.graylog.storage.opensearch2;
 
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.action.support.IndicesOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.results.ChunkedResult;
 import org.graylog2.indexer.results.MultiChunkResultRetriever;
@@ -48,6 +49,7 @@ public class PaginationOS2 implements MultiChunkResultRetriever {
     private SearchRequest buildSearchRequest(final SearchSourceBuilder query,
                                              final Set<String> indices) {
         return new SearchRequest(indices.toArray(new String[0]))
-                .source(query);
+                .source(query)
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationResultOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationResultOS2.java
@@ -23,6 +23,7 @@ import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRespons
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHit;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -41,6 +42,7 @@ public class PaginationResultOS2 extends ChunkedQueryResultOS2 {
     }
 
     @Override
+    @Nullable
     protected SearchResponse nextSearchResult() throws IOException {
         final SearchSourceBuilder initialQuery = initialSearchRequest.source();
         final SearchHit[] hits = lastSearchResponse.getHits().getHits();

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
@@ -18,6 +18,7 @@ package org.graylog.storage.opensearch2;
 
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.action.support.IndicesOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.results.ChunkedResult;
 import org.graylog2.indexer.results.MultiChunkResultRetriever;
@@ -53,6 +54,7 @@ public class Scroll implements MultiChunkResultRetriever {
     private SearchRequest scrollBuilder(SearchSourceBuilder query, Set<String> indices) {
         return new SearchRequest(indices.toArray(new String[0]))
                 .source(query)
-                .scroll(DEFAULT_SCROLLTIME);
+                .scroll(DEFAULT_SCROLLTIME)
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ScrollResultOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ScrollResultOS2.java
@@ -23,10 +23,9 @@ import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRespons
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchScrollRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.common.unit.TimeValue;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class ScrollResultOS2 extends ChunkedQueryResultOS2 {
     private static final TimeValue DEFAULT_SCROLL = TimeValue.timeValueMinutes(1);
@@ -45,13 +44,17 @@ public class ScrollResultOS2 extends ChunkedQueryResultOS2 {
                            @Assisted List<String> fields,
                            @Assisted int limit) {
         super(client, initialResult, query, fields, limit);
-        checkArgument(initialResult.getScrollId() != null, "Unable to extract scroll id from supplied search result!");
         this.scroll = scroll;
 
     }
 
     @Override
+    @Nullable
     protected SearchResponse nextSearchResult() throws IOException {
+        if (this.lastSearchResponse.getScrollId() == null) {
+            //with ignore_unavailable=true and no available indices, response does not contain scrollId
+            return null;
+        }
         final SearchScrollRequest scrollRequest = new SearchScrollRequest(this.lastSearchResponse.getScrollId());
         scrollRequest.scroll(TimeValue.parseTimeValue(this.scroll, DEFAULT_SCROLL, "scroll time"));
         return client.executeWithIOException((c, requestOptions) -> c.scroll(scrollRequest, requestOptions),
@@ -60,6 +63,10 @@ public class ScrollResultOS2 extends ChunkedQueryResultOS2 {
 
     @Override
     public void cancel() throws IOException {
+        if (this.lastSearchResponse.getScrollId() == null) {
+            //with ignore_unavailable=true and no available indices, response does not contain scrollId, there is nothing to cancel
+            return;
+        }
         final ClearScrollRequest request = new ClearScrollRequest();
         request.addScrollId(this.lastSearchResponse.getScrollId());
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -238,7 +238,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
                     return new SearchRequest()
                             .source(searchTypeQueries.get(searchTypeId))
                             .indices(indices.toArray(new String[0]))
-                            .indicesOptions(IndicesOptions.fromOptions(false, false, true, false));
+                            .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
                 })
                 .collect(Collectors.toList());
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/ChunkedQueryResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/ChunkedQueryResult.java
@@ -20,6 +20,7 @@ import org.apache.shiro.crypto.hash.Md5Hash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -58,6 +59,7 @@ public abstract class ChunkedQueryResult<C, R> extends IndexQueryResult implemen
     }
 
     @Override
+    @Nullable
     public ResultChunk nextChunk() throws IOException {
         if (limitReached()) {
             LOG.debug("[{}] Reached limit for query {}", queryHash, getOriginalQuery());
@@ -70,7 +72,7 @@ public abstract class ChunkedQueryResult<C, R> extends IndexQueryResult implemen
 
         final List<ResultMessage> resultMessages = result != null ? collectMessagesFromResult(result) : List.of();
 
-        if (resultMessages.size() == 0) {
+        if (resultMessages.isEmpty()) {
             // chunking exhausted
             LOG.debug("[{}] Reached end of {} results for query {}", queryHash, getChunkingMethodName(), getOriginalQuery());
             return null;
@@ -89,6 +91,7 @@ public abstract class ChunkedQueryResult<C, R> extends IndexQueryResult implemen
 
     protected abstract List<ResultMessage> collectMessagesFromResult(R result);
 
+    @Nullable
     protected abstract R nextSearchResult() throws IOException;
 
     protected abstract String getChunkingMethodName();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/ChunkedResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/ChunkedResult.java
@@ -16,9 +16,11 @@
  */
 package org.graylog2.indexer.results;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 public interface ChunkedResult {
+    @Nullable
     ResultChunk nextChunk() throws IOException;
 
     String getQueryHash();

--- a/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -194,7 +195,7 @@ public abstract class MoreSearchAdapterIT extends ElasticsearchBaseTest {
         final AtomicInteger count = new AtomicInteger(0);
         final List<ResultMessage> allResults = new ArrayList<>(expectedNumberOfMessages);
 
-        toTest.scrollEvents("*", RelativeRange.allTime(), Set.of("unavailable"), ALL_STREAMS, Collections.emptyList(), batchSize,
+        toTest.scrollEvents("*", RelativeRange.allTime(), Set.of("unavailable"), ALL_STREAMS, batchSize,
                 getCountingAndCollectingScrollEventsCallback(count, allResults));
         assertThat(allResults).isEmpty();
     }

--- a/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
@@ -84,6 +84,23 @@ public abstract class MoreSearchAdapterIT extends ElasticsearchBaseTest {
     }
 
     @Test
+    public void eventSearchNoExceptionIfIndexUnavailable() {
+        final MoreSearch.Result result = toTest.eventSearch("*", RelativeRange.allTime(), Set.of("unavailable"), Sorting.DEFAULT, 1, 10, ALL_STREAMS, "", Set.of());
+        assertThat(result.results()).isEmpty();
+    }
+
+    @Test
+    public void eventSearchPartiallyAvailable() {
+        int expectedNumberOfMessages = 7;
+
+        final MoreSearch.Result result = toTest.eventSearch("*", RelativeRange.allTime(), Set.of("unavailable", INDEX_NAME), Sorting.DEFAULT, 1, 10, ALL_STREAMS, "", Set.of());
+        assertThat(result.results()).hasSize(expectedNumberOfMessages);
+        for (int i = 0; i < expectedNumberOfMessages; i++) {
+            verifyResult(result, i, expectedNumberOfMessages - i);
+        }
+    }
+
+    @Test
     public void scrollEventsReturnsAllMessages() throws Exception {
         int expectedNumberOfMessages = 7;
         int batchSize = 2;
@@ -167,6 +184,18 @@ public abstract class MoreSearchAdapterIT extends ElasticsearchBaseTest {
 
         assertThat(count).hasValue(0);
 
+        assertThat(allResults).isEmpty();
+    }
+
+    @Test
+    public void scrollEventsNoExceptionIfIndexUnavailable() throws Exception {
+        int expectedNumberOfMessages = 7;
+        int batchSize = 2;
+        final AtomicInteger count = new AtomicInteger(0);
+        final List<ResultMessage> allResults = new ArrayList<>(expectedNumberOfMessages);
+
+        toTest.scrollEvents("*", RelativeRange.allTime(), Set.of("unavailable"), ALL_STREAMS, Collections.emptyList(), batchSize,
+                getCountingAndCollectingScrollEventsCallback(count, allResults));
         assertThat(allResults).isEmpty();
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/ChunkedQueryResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/ChunkedQueryResultTest.java
@@ -17,7 +17,9 @@
 package org.graylog2.indexer.results;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.indexer.results.ChunkedQueryResultTest.ServerlessChunkedQueryResultSimulation.BACKING_RESULT_LIST;
+import static org.mockito.Mockito.doReturn;
 
 
 public class ChunkedQueryResultTest {
@@ -32,6 +35,21 @@ public class ChunkedQueryResultTest {
     private static final String INDEX_NAME = "graylog_0";
 
     private ServerlessChunkedQueryResultSimulation toTest;
+
+    @Test
+    void emptyResultWhenNextSearchResultReturnsNull() throws Exception {
+        toTest = Mockito.spy(new ServerlessChunkedQueryResultSimulation("Client",
+                List.of(),
+                "",
+                List.of("name"),
+                100,
+                20
+        ));
+        doReturn(null).when(toTest).nextSearchResult();
+
+        final ResultChunk resultChunk = toTest.nextChunk();
+        assertThat(resultChunk).isNull();
+    }
 
     @Test
     void emptyResultWhenLimitIsZero() throws Exception {
@@ -198,6 +216,7 @@ public class ChunkedQueryResultTest {
         }
 
         @Override
+        @Nullable
         protected List<String> nextSearchResult() throws IOException {
             final int toIndex = Math.min(fromIndex + batchSize, BACKING_RESULT_LIST.size());
             if (fromIndex >= toIndex) {


### PR DESCRIPTION
Backport for issue #18127 

* set option ignore_unavailable
* CL
* suppress missing index exception in event query
* unit tests
* ignore failing scroll request
* more strict index options
* add comments
* use symbolic constants
* No exception when search request returns no scrollID value and there are no available indices
* annotate nullable
---------
Co-authored-by: luk-kaminski <lukasz.kaminski@graylog.com>
(cherry picked from commit 7acdc1ddc8baaa1bf030c2d49da5dedb4580d935)

When issuing a simple search query we now set option ignoreUnavailable=true and allowNoIndices=true. This serves to suppress the exception in case of missing indices, but otherwise leaves behavior unaltered.