### PR TITLE
Fix throwing error on editing timestamp date on timerange popover

### DIFF
--- a/graylog2-web-interface/src/components/common/DatePicker.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.tsx
@@ -22,7 +22,7 @@ import styled, { css } from 'styled-components';
 
 import 'react-day-picker/lib/style.css';
 
-import { isValidDate, toDateObject, adjustFormat, DATE_TIME_FORMATS } from 'util/DateTime';
+import { isValidDate, toDateObject, adjustFormat } from 'util/DateTime';
 
 const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   width: 100%;
@@ -59,13 +59,15 @@ const StyledDayPicker = styled(DayPicker)(({ theme }) => css`
   }
 `);
 
-const isValidDateProp = (date: string | undefined) => {
-  if (!date) {
-    return true;
+const useSelectedDate = (date: string | undefined) => useMemo(() => {
+  const isDateValid = !date || isValidDate(toDateObject(date, ['date']));
+
+  if (isDateValid) {
+    return date;
   }
 
-  return isValidDate(toDateObject(date, ['date']));
-};
+  return undefined;
+}, [date]);
 
 type Props = {
   date?: string | undefined,
@@ -75,25 +77,23 @@ type Props = {
 };
 
 const DatePicker = ({ date, fromDate, onChange, showOutsideDays }: Props) => {
-  if (!isValidDateProp(date)) {
-    throw Error(`Date time provided for date picker "${date}" is not valid. The expected format is ${DATE_TIME_FORMATS.date}.`);
-  }
+  const selectedDate = useSelectedDate(date);
 
   const modifiers = useMemo(() => ({
     selected: (moddedDate: Date) => {
-      if (!date) {
+      if (!selectedDate) {
         return false;
       }
 
-      return date === adjustFormat(moddedDate, 'date');
+      return selectedDate === adjustFormat(moddedDate, 'date');
     },
     disabled: {
       before: new Date(fromDate),
     },
-  }), [fromDate, date]);
+  }), [fromDate, selectedDate]);
 
   return (
-    <StyledDayPicker initialMonth={date ? toDateObject(date).toDate() : undefined}
+    <StyledDayPicker initialMonth={selectedDate ? toDateObject(selectedDate).toDate() : undefined}
                      onDayClick={onChange}
                      modifiers={modifiers}
                      showOutsideDays={showOutsideDays} />

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { DateUtils } from 'react-day-picker';
-import moment from 'moment';
 
 import { DatePicker } from 'components/common';
 import { toUTCFromTz, toDateObject } from 'util/DateTime';
@@ -40,7 +39,7 @@ const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
     }
 
     const selectedDateObject = toDateObject(selectedDate);
-    const validInitialDateTime = initialDateTime.isValid() ? initialDateTime : moment().tz(userTimezone);
+    const validInitialDateTime = initialDateTime.isValid() ? initialDateTime : toUTCFromTz(undefined, userTimezone);
     const newDate = validInitialDateTime.set({
       year: selectedDateObject.year(),
       month: selectedDateObject.month(),

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/AbsoluteDatePicker.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { DateUtils } from 'react-day-picker';
+import moment from 'moment';
 
 import { DatePicker } from 'components/common';
 import { toUTCFromTz, toDateObject } from 'util/DateTime';
@@ -39,7 +40,8 @@ const AbsoluteDatePicker = ({ dateTime, onChange, startDate }: Props) => {
     }
 
     const selectedDateObject = toDateObject(selectedDate);
-    const newDate = initialDateTime.set({
+    const validInitialDateTime = initialDateTime.isValid() ? initialDateTime : moment().tz(userTimezone);
+    const newDate = validInitialDateTime.set({
       year: selectedDateObject.year(),
       month: selectedDateObject.month(),
       date: selectedDateObject.date(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The bug happens because during editing the `Timestamp` input (from or to) on the Absolute tab, the user might type an invalid date format, and `DatePicker`  throws an error in this case. 
This PR removes throwing errors in case of an invalid date. 
Also, PR fixes another problem. When the user typed an invalid date in the timestamp, it was impossible to rewrite the date using DatePicker (by clicking on some date). Now, in the case of date selection, we are taking the selected date and current time 

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/18200

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl