### PR TITLE
Enforce that the build uses the maven version that is defined in the wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,10 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-          cache: maven
       - name: License check
-        run: mvn -B --fail-fast license:check
+        run: ./mvnw -B --fail-fast license:check
       - name: Build with Maven
-        run: mvn -B --fail-fast -Pedantic -Dspotbugs.skip -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 verify javadoc:javadoc
+        run: ./mvnw -B --fail-fast -Pedantic -Dspotbugs.skip -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 verify javadoc:javadoc
         env:
           JAVA_OPTS: -Xmx6G
           TIMEOUT_MULTIPLIER: 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,8 @@
                                 </bannedDependencies>
                                 <banDuplicatePomDependencyVersions/>
                                 <requireMavenVersion>
-                                    <version>[3.6.0,)</version>
+                                    <!-- Enforce the same version we define in the maven wrapper -->
+                                    <version>[3.9.6]</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[17.0,17.99]</version>


### PR DESCRIPTION
- [x] Checked and fixed all our repos for maven builds that don't use the wrapper

/nocl

