### PR TITLE
Log node ID only once

### DIFF
--- a/changelog/unreleased/pr-18219.toml
+++ b/changelog/unreleased/pr-18219.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Avoid logging Graylog node ID multiple times during server startup."
+
+pulls = ["18219"]

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -307,6 +307,7 @@ public abstract class ServerBootstrap extends CmdLineTool {
         LOG.info("Deployment: {}", configuration.getInstallationSource());
         LOG.info("OS: {}", os.getPlatformName());
         LOG.info("Arch: {}", os.getArch());
+        LOG.info("Node ID: {}", nodeId);
 
         try {
             if (configuration.isLeader() && configuration.runMigrations()) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/system/FilePersistedNodeIdProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/system/FilePersistedNodeIdProvider.java
@@ -58,7 +58,7 @@ public class FilePersistedNodeIdProvider implements Provider<NodeId> {
                 return generate(filename);
             }
 
-            LOG.info("Node ID: {}", read);
+            LOG.debug("Node ID: {}", read);
             return read;
         } catch (FileNotFoundException | NoSuchFileException e) {
             return generate(filename);


### PR DESCRIPTION
The server's node ID is currently logged multiple times during server startup because we use different startup stages. (e.g., pre-flight)
