### PR TITLE
Fix deserialisation error of export jobs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportJob.java
@@ -20,8 +20,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.joda.time.DateTime;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = ExportJob.FIELD_TYPE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = ExportJob.FIELD_TYPE)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = MessagesRequestExportJob.class, name = MessagesRequestExportJob.TYPE),
         @JsonSubTypes.Type(value = SearchExportJob.class, name = SearchExportJob.TYPE),
@@ -31,6 +33,10 @@ public interface ExportJob {
     String FIELD_TYPE = "type";
     String FIELD_ID = "_id";
     String FIELD_CREATED_AT = "created_at";
+
+    @Id
+    @ObjectId
+    @JsonProperty(FIELD_ID)
     String id();
 
     @JsonProperty

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/ExportJobServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/ExportJobServiceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.export;
+
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith({MongoDBExtension.class, MongoJackExtension.class})
+class ExportJobServiceTest {
+
+    @Test
+    void roundTrip(MongoDBTestService mongoDBTestService, MongoJackObjectMapperProvider mongoJackObjectMapperProvider) {
+        final SearchTypeExportJob job = SearchTypeExportJob.create(
+                "000000000000000000000001",
+                "000000000000000000000002",
+                "000000000000000000000003",
+                ResultFormat.empty());
+
+        final ExportJobService service = new ExportJobService(mongoDBTestService.mongoConnection(),
+                mongoJackObjectMapperProvider);
+
+        assertThat(service.get(service.save(job))).isNotEmpty().containsInstanceOf(SearchTypeExportJob.class);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/ExportJobTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/ExportJobTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.export;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExportJobTest {
+    @Test
+    void subtypes() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+        final SearchTypeExportJob searchTypeJob = SearchTypeExportJob.create(
+                "000000000000000000000001",
+                "000000000000000000000002",
+                "000000000000000000000003",
+                ResultFormat.empty());
+        final SearchExportJob searchExportJob = SearchExportJob.create(
+                "000000000000000000000001",
+                "000000000000000000000002",
+                ResultFormat.empty());
+        final MessagesRequestExportJob messagesRequestExportJob = MessagesRequestExportJob.create(
+                "000000000000000000000001",
+                MessagesRequest.builder()
+                        .limit(10)
+                        .timeZone(DateTimeZone.UTC)
+                        .build());
+
+        assertThat(objectMapper.readValue(objectMapper.writeValueAsString(searchTypeJob), ExportJob.class))
+                .isInstanceOf(SearchTypeExportJob.class);
+        assertThat(objectMapper.readValue(objectMapper.writeValueAsString(searchExportJob), ExportJob.class))
+                .isInstanceOf(SearchExportJob.class);
+        assertThat(objectMapper.readValue(objectMapper.writeValueAsString(messagesRequestExportJob), ExportJob.class))
+                .isInstanceOf(MessagesRequestExportJob.class);
+    }
+}


### PR DESCRIPTION
Trying to deserialise export jobs from MongoDB fails with an error like the following:

```
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'AutoValue_SearchTypeExportJob' as a subtype of `org.graylog.plugins.views.search.export.ExportJob`: known type ids = []
 at [Source: (String); byte offset: #UNKNOWN]
```
This can be reproduced by navigating to `/search` and then exporting the search results.

The root cause lies in the `@JsonTypeInfo` annotation in the `JobExport` class. It is missing an `include = JsonTypeInfo.As.EXISTING_PROPERTY` attribute. This will cause Jackson to include an additional `type` field in the serialised JSON, even though a `type` property is also explicitly defined on the concrete classes which implement the `JobExport` interface.

A serialised `SearchTypeExportJob` will then look like this:

```
{
  "type": "AutoValue_SearchTypeExportJob",
  "created_at": "2024-02-13T15:45:21.026Z",
  "search_id": "000000000000000000000002",
  "search_type_id": "000000000000000000000003",
  "result_format": { ... },
  "type": "search_type_export"
}
```

The same happens when serialising to BSON with the new version of Mongojack. If this document is stored in MongoDB, it will contain both `type` fields, but only the one with the value `search_type_export` is visible when looking at the collection with, e.g. the Mongo shell. 

When deserialising the BSON object back to a Java class, Jackson's subtype lookup will only work for the value `search_type_export`. In this case, however, Jackson gets `AutoValue_SearchTypeExportJob` instead and fails the lookup.

This PR fixes this by setting the correct `include` attribute on the `@JsonTypeInfo` annotation and adding missing Jackson annotations for the `id` field.

Graylog version: `6.0.0-SNAPSHOT`

/nocl
