### PR TITLE
Use browser color scheme preference for login screen.

### DIFF
--- a/graylog2-web-interface/docs/StyleGuideWrapper.tsx
+++ b/graylog2-web-interface/docs/StyleGuideWrapper.tsx
@@ -60,7 +60,7 @@ const StyleGuideWrapper = ({ children }: Props) => {
     element: (
       <CurrentUserContext.Provider value={adminUser}>
         <UserDateTimeProvider>
-          <GraylogThemeProvider initialThemeModeOverride="light">
+          <GraylogThemeProvider initialThemeModeOverride="light" userIsLoggedIn={false}>
             <StyleGuideStyles />
             {children}
           </GraylogThemeProvider>

--- a/graylog2-web-interface/src/contexts/ThemeAndUserProvider.tsx
+++ b/graylog2-web-interface/src/contexts/ThemeAndUserProvider.tsx
@@ -28,7 +28,7 @@ const ThemeAndUserProvider = ({ children }: React.PropsWithChildren<{}>) => (
   <CurrentUserProvider>
     <UserDateTimeProvider>
       <CurrentUserPreferencesProvider>
-        <GraylogThemeProvider>
+        <GraylogThemeProvider userIsLoggedIn>
           <GlobalThemeStyles />
           {children}
         </GraylogThemeProvider>

--- a/graylog2-web-interface/src/index.tsx
+++ b/graylog2-web-interface/src/index.tsx
@@ -23,13 +23,11 @@ import Reflux from 'reflux';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import AppFacade from 'routing/AppFacade';
-import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 import CustomizationProvider from 'contexts/CustomizationProvider';
 import ViewsBindings from 'views/bindings';
 import ThreatIntelBindings from 'threatintel/bindings';
 import AwsBindings from 'aws/bindings';
 import IntegrationsBindings from 'integrations/bindings';
-import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 import CancellablePromise from 'logic/rest/CancellablePromise';
 import TelemetryInit from 'logic/telemetry/TelemetryInit';
 import LoginQueryClientProvider from 'contexts/LoginQueryClientProvider';
@@ -54,10 +52,7 @@ root.render((
   <CustomizationProvider>
     <TelemetryInit>
       <LoginQueryClientProvider>
-        <GraylogThemeProvider>
-          <GlobalThemeStyles />
-          <AppFacade />
-        </GraylogThemeProvider>
+        <AppFacade />
       </LoginQueryClientProvider>
     </TelemetryInit>
   </CustomizationProvider>

--- a/graylog2-web-interface/src/routing/AppFacade.tsx
+++ b/graylog2-web-interface/src/routing/AppFacade.tsx
@@ -28,12 +28,21 @@ import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import { ServerAvailabilityStore } from 'stores/sessions/ServerAvailabilityStore';
 import type { SessionStoreState } from 'stores/sessions/SessionStore';
 import { SessionStore } from 'stores/sessions/SessionStore';
+import GraylogThemeProvider from 'theme/GraylogThemeProvider';
+import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 const LoginPage = loadAsync(() => import(/* webpackChunkName: "LoginPage" */ 'pages/LoginPage'));
 const LoadingPage = loadAsync(() => import(/* webpackChunkName: "LoadingPage" */ 'pages/LoadingPage'));
 const LoggedInPage = loadAsync(() => import(/* webpackChunkName: "LoggedInPage" */ 'pages/LoggedInPage'));
 
 const SERVER_PING_TIMEOUT = 20000;
+
+const LoggedOutThemeProvider = ({ children }: React.PropsWithChildren) => (
+  <GraylogThemeProvider userIsLoggedIn={false}>
+    <GlobalThemeStyles />
+    {children}
+  </GraylogThemeProvider>
+);
 
 const AppFacade = () => {
   const currentUser = useStore(CurrentUserStore as Store<CurrentUserStoreState>, (state) => state?.currentUser);
@@ -47,15 +56,27 @@ const AppFacade = () => {
   }, []);
 
   if (server.up === false) {
-    return <ServerUnavailablePage server={server} />;
+    return (
+      <LoggedOutThemeProvider>
+        <ServerUnavailablePage server={server} />
+      </LoggedOutThemeProvider>
+    );
   }
 
   if (!username) {
-    return <LoginPage />;
+    return (
+      <LoggedOutThemeProvider>
+        <LoginPage />
+      </LoggedOutThemeProvider>
+    );
   }
 
   if (!currentUser) {
-    return <LoadingPage text="We are preparing Graylog for you..." />;
+    return (
+      <LoggedOutThemeProvider>
+        <LoadingPage text="We are preparing Graylog for you..." />
+      </LoggedOutThemeProvider>
+    );
   }
 
   return <LoggedInPage />;

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.tsx
@@ -33,7 +33,8 @@ import usePreferredColorScheme from './hooks/usePreferredColorScheme';
 
 type Props = {
   children: React.ReactNode,
-  initialThemeModeOverride: ColorScheme
+  initialThemeModeOverride: ColorScheme,
+  userIsLoggedIn: boolean,
 }
 
 const useSCTheme = (
@@ -70,8 +71,8 @@ const useMantineTheme = (
   }), [colorScheme, customThemeColors]);
 };
 
-const GraylogThemeProvider = ({ children, initialThemeModeOverride }: Props) => {
-  const [colorScheme, changeColorScheme] = usePreferredColorScheme(initialThemeModeOverride);
+const GraylogThemeProvider = ({ children, initialThemeModeOverride, userIsLoggedIn }: Props) => {
+  const [colorScheme, changeColorScheme] = usePreferredColorScheme(initialThemeModeOverride, userIsLoggedIn);
   const themeCustomizer = usePluginEntities('customization.theme.customizer');
   const useCustomThemeColors = themeCustomizer?.[0]?.hooks.useCustomThemeColors;
   const mantineTheme = useMantineTheme(colorScheme, useCustomThemeColors);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/18185.

Before this change we were using the color scheme, saved in local storage, for the login screen. With this PR we are now  using the browser color scheme preference for the login page instead.

These changes include another improvement, we now do not render the `GraylogThemeProvider` twice.

/nocl