### PR TITLE
Do not display info for dashboard query filter in aggregation builder, when dashboard query is empty

### DIFF
--- a/changelog/unreleased/pr-18241.toml
+++ b/changelog/unreleased/pr-18241.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Do not display info for dashboard query filter in aggregation builder, when dashboard query is empty"
+
+pulls = ["18241"]

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -133,7 +133,14 @@ describe('WidgetQueryControls', () => {
       renderSUT();
 
       expect(screen.queryByRole('button', { name: resetTimeRangeButtonTitle })).toBeNull();
-      expect(screen.queryByRole('button', { name: resetTimeRangeButtonTitle })).toBeNull();
+      expect(screen.queryByRole('button', { name: resetQueryButtonTitle })).toBeNull();
+    });
+
+    it('does not show global override query indicator if global override query is an object with an empty query string', async () => {
+      asMock(useGlobalOverride).mockReturnValue(GlobalOverride.create(undefined, { type: 'elasticsearch', query_string: '' }));
+      renderSUT();
+
+      expect(screen.queryByRole('button', { name: resetQueryButtonTitle })).toBeNull();
     });
 
     it('triggers resetting global override when reset time range override button is clicked', async () => {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -171,7 +171,7 @@ const WidgetQueryControls = ({ availableStreams }: Props) => {
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const limitDuration = moment.duration(config?.query_time_range_limit).asSeconds() ?? 0;
   const hasTimeRangeOverride = globalOverride?.timerange !== undefined;
-  const hasQueryOverride = globalOverride?.query !== undefined;
+  const hasQueryOverride = !!globalOverride?.query?.query_string;
   const formRef = useRef(null);
   const { parameters } = useParameters();
   const handlerContext = useHandlerContext();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible to see the following info for the dashboard query filter in the aggregation builder for widgets.

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/8d8ce1b9-0092-49f7-871f-533cd76e4b80)

This happened when you
1. go to a dashboard
2. click on the search button, while the query input is empty
3. edit a widget