### PR TITLE
Fix time range preset creation on search page.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/SaveTimeRangeAsPresetButton.tsx
@@ -98,7 +98,7 @@ const TimeRangeAddToQuickListForm = ({ children, addTimerange, toggleModal, show
                         id="time-range-preset-popover"
                         data-testid="time-range-preset-popover">
         <Formik<FormValues> onSubmit={onSubmit} initialValues={{ description: '' }} validate={validate}>
-          {({ isValid }) => (
+          {({ isValid, submitForm }) => (
             <Form>
               <FormikInput type="text"
                            name="description"
@@ -107,15 +107,17 @@ const TimeRangeAddToQuickListForm = ({ children, addTimerange, toggleModal, show
                            aria-label="Time range description"
                            formGroupClassName="" />
               {!!equalTimerange && (
-              <p>
-                <Icon name="exclamation-triangle" />
-                You already have similar time range in{' '}
-                <Link to={Routes.SYSTEM.CONFIGURATIONS} target="_blank">Range configuration</Link>
-                <br />
-                <i>({equalTimerange.description})</i>
-              </p>
+                <p>
+                  <Icon name="exclamation-triangle" />
+                  You already have similar time range in{' '}
+                  <Link to={Routes.SYSTEM.CONFIGURATIONS} target="_blank">Range configuration</Link>
+                  <br />
+                  <i>({equalTimerange.description})</i>
+                </p>
               )}
               <StyledModalSubmit disabledSubmit={!isValid}
+                                 submitButtonType="button"
+                                 onSubmit={submitForm}
                                  submitButtonText="Save preset"
                                  isAsyncSubmit={false}
                                  displayCancel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In https://github.com/Graylog2/graylog2-server/pull/18230 we were fixing the form submit for nested forms.

The time range picker form currently uses the `NestedForm` component which implements `onSubmitCapture`. This does not seems to work well, when the `NestedForm` contains another nested form, no matter if this form is being displayed in a portal or implements the `NestedForm` component as well. In this case the inner nested form will still submit the parent form.

This is currently the case for the time range preset form in the time range picker.
With this PR we are fixing the problem by not using a button with type "submit" in the time range preset form.

Another solution could be
- implementing the `NestedForm` for the time range preset form
- implementing the `NestedForm` for the time range picker form when it is being used on the search configuration page
- implementing the formik `Form` component for the time range picker form when it is being used on the search page

/nocl

