### PR TITLE
Make sure to use legacy config for cloud with data tiering disabled

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.tsx
@@ -191,6 +191,8 @@ const IndexSetConfigurationForm = ({
   const [fieldTypeRefreshIntervalUnit, setFieldTypeRefreshIntervalUnit] = useState<Unit>('seconds');
   const { loadingIndexDefaultsConfig, indexDefaultsConfig } = useIndexDefaults();
   const [indexSet] = useIndexSet(initialIndexSet);
+  const isCloud = AppConfig.isCloud();
+  const enableDataTieringCloud = useFeature('data_tiering_cloud');
 
   const retentionConfigSegments: Array<{value: RetentionConfigSegment, label: string}> = [
     { value: 'data_tiering', label: 'Data Tiering' },
@@ -206,8 +208,14 @@ const IndexSetConfigurationForm = ({
   const [selectedRetentionSegment, setSelectedRetentionSegment] = useState<RetentionConfigSegment>(initialSegment());
 
   const prepareRetentionConfigBeforeSubmit = useCallback((values: IndexSetFormValues) : IndexSet => {
+    const legacyConfig = { ...values, data_tiering: indexDefaultsConfig.data_tiering, use_legacy_rotation: true };
+
+    if (isCloud && !enableDataTieringCloud) {
+      return legacyConfig;
+    }
+
     if (selectedRetentionSegment === 'legacy') {
-      return { ...values, data_tiering: indexDefaultsConfig.data_tiering, use_legacy_rotation: true };
+      return legacyConfig;
     }
 
     const configWithDataTiering = prepareDataTieringConfig(values, PluginStore);
@@ -222,7 +230,7 @@ const IndexSetConfigurationForm = ({
     };
 
     return { ...configWithDataTiering, ...legacyDefaultConfig, use_legacy_rotation: false };
-  }, [loadingIndexDefaultsConfig, indexDefaultsConfig, selectedRetentionSegment]);
+  }, [loadingIndexDefaultsConfig, indexDefaultsConfig, selectedRetentionSegment, enableDataTieringCloud, isCloud]);
 
   const saveConfiguration = (values: IndexSetFormValues) => onUpdate(prepareRetentionConfigBeforeSubmit(values));
 
@@ -237,8 +245,6 @@ const IndexSetConfigurationForm = ({
     setFieldTypeRefreshIntervalUnit(unit);
   };
 
-  const enableDataTieringCloud = useFeature('data_tiering_cloud');
-
   if (!indexSet) return null;
 
   const {
@@ -249,8 +255,6 @@ const IndexSetConfigurationForm = ({
   } = indexSet;
 
   const onCancel = () => history.push(cancelLink);
-
-  const isCloud = AppConfig.isCloud();
 
   if (loadingIndexDefaultsConfig) return (<Spinner />);
 


### PR DESCRIPTION
Currently, on cloud with the data tiering feature disabled it is not able to create a new index set due to incorrect data sent.

With this change it should be possible to create index sets
- on cloud with Data Tiering disabled
- on cloud with Data Tiering enabled and Data Tiering config
- on cloud with Data Tiering enabled and Legacy config
- on prem with Data Tiering config
- on prem with Legacy config

/nocl

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

