### PR TITLE
Prevent some duplicate `type` fields in serialized JSON

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpec.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = SortSpec.TYPE_FIELD,
         visible = true)
 public interface SortSpec {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
@@ -16,17 +16,16 @@
  */
 package org.graylog2.plugin.lookup;
 
-import com.google.common.collect.Multimap;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Multimap;
 
 import java.util.Optional;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = LookupCacheConfiguration.TYPE_FIELD,
         visible = true,
         defaultImpl = FallbackCacheConfig.class)

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = LookupDataAdapterConfiguration.TYPE_FIELD,
         visible = true,
         defaultImpl = FallbackAdapterConfig.class)

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/SortSpecTest.java
@@ -16,10 +16,12 @@
  */
 package org.graylog.plugins.views.search.searchtypes.pivot;
 
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import org.assertj.core.api.Assertions;
+import org.graylog.testing.jackson.JacksonSubtypesAssertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
 class SortSpecTest {
 
@@ -30,8 +32,8 @@ class SortSpecTest {
         Assertions.assertThat(SortSpec.Direction.deserialize("  ")).isNull();
 
         Assertions.assertThatThrownBy(() -> SortSpec.Direction.deserialize("blah"))
-                        .isInstanceOf(IllegalArgumentException.class)
-                        .hasMessageContaining("Failed to parse sort direction");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to parse sort direction");
 
         Assertions.assertThat(SortSpec.Direction.deserialize("asc")).isEqualTo(SortSpec.Direction.Ascending);
         Assertions.assertThat(SortSpec.Direction.deserialize("ascending")).isEqualTo(SortSpec.Direction.Ascending);
@@ -40,5 +42,18 @@ class SortSpecTest {
 
         Assertions.assertThat(SortSpec.Direction.deserialize("desc")).isEqualTo(SortSpec.Direction.Descending);
         Assertions.assertThat(SortSpec.Direction.deserialize("descending")).isEqualTo(SortSpec.Direction.Descending);
+    }
+
+    @Test
+    void subtypes() {
+        JacksonSubtypesAssertions.assertThat(PivotSort.create("field", SortSpec.Direction.Ascending))
+                .withRegisteredSubtypes(List.of(new NamedType(PivotSort.class, PivotSort.Type)))
+                .doesNotSerializeWithDuplicateFields()
+                .deserializesWhenGivenSupertype(SortSpec.class);
+
+        JacksonSubtypesAssertions.assertThat(SeriesSort.create("field", SortSpec.Direction.Ascending))
+                .withRegisteredSubtypes(List.of(new NamedType(SeriesSort.class, SeriesSort.Type)))
+                .doesNotSerializeWithDuplicateFields()
+                .deserializesWhenGivenSupertype(SortSpec.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/jackson/JacksonSubtypesAssertions.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/jackson/JacksonSubtypesAssertions.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+
+import java.util.List;
+
+public class JacksonSubtypesAssertions<T> extends AbstractAssert<JacksonSubtypesAssertions<T>, T> {
+
+    private ObjectMapper objectMapper;
+    private List<NamedType> subtypes;
+
+    /**
+     * Create an assertion to check that Jackson subtype resolving is working as expected.
+     *
+     * @param actual The object to assert
+     */
+    public static <T> JacksonSubtypesAssertions<T> assertThat(T actual) {
+        return new JacksonSubtypesAssertions<>(actual);
+    }
+
+    protected JacksonSubtypesAssertions(T actual) {
+        super(actual, JacksonSubtypesAssertions.class);
+        this.objectMapper = new ObjectMapperProvider().get();
+        this.subtypes = List.of();
+    }
+
+    public JacksonSubtypesAssertions<T> withObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
+        return this;
+    }
+
+    public JacksonSubtypesAssertions<T> withRegisteredSubtypes(List<NamedType> subtypes) {
+        this.subtypes = subtypes;
+        objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
+        return this;
+    }
+
+    public JacksonSubtypesAssertions<T> doesNotSerializeWithDuplicateFields() {
+
+        final JsonNode jsonNode = objectMapper.valueToTree(actual);
+
+        Assertions.assertThat(serializeToJson(jsonNode))
+                .as("Serializing directly to JSON yields different results from serializing with an " +
+                        "intermediate JsonNode step. This is an indicator for duplicate fields.")
+                .isEqualTo(serializeToJson(actual));
+
+        return this;
+    }
+
+
+    public JacksonSubtypesAssertions<T> deserializesWhenGivenSupertype(Class<? super T> superType) {
+        Object deserializedObject = null;
+
+        try {
+            deserializedObject = objectMapper.readValue(serializeToJson(actual), superType);
+        } catch (Exception e) {
+            failWithMessage("Deserializing from JSON failed with:\n" + ExceptionUtils.getStackTrace(e));
+        }
+
+        Assertions.assertThat(deserializedObject).isInstanceOf(actual.getClass());
+
+        return this;
+    }
+
+    private String serializeToJson(Object o) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            failWithMessage("Serializing to JSON failed with:\n" + ExceptionUtils.getStackTrace(e));
+        }
+        return null;
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupCacheConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupCacheConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.lookup;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.graylog.testing.jackson.JacksonSubtypesAssertions;
+import org.graylog2.lookup.caches.CaffeineLookupCache;
+import org.graylog2.lookup.caches.NullCache;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+class LookupCacheConfigurationTest {
+    @Test
+    void subtypes() {
+
+        final var objectMapper = new ObjectMapperProvider().get();
+        objectMapper.registerSubtypes(
+                new NamedType(CaffeineLookupCache.Config.class, CaffeineLookupCache.NAME),
+                new NamedType(NullCache.Config.class, NullCache.NAME)
+        );
+
+        final var caffeineCacheConfig = CaffeineLookupCache.Config.builder()
+                .type(CaffeineLookupCache.NAME)
+                .maxSize(1)
+                .expireAfterAccess(1)
+                .expireAfterWrite(1)
+                .build();
+
+        final var nullCacheConfig = NullCache.Config.builder()
+                .type(NullCache.NAME)
+                .build();
+
+        JacksonSubtypesAssertions.assertThat(caffeineCacheConfig)
+                .withObjectMapper(objectMapper)
+                .deserializesWhenGivenSupertype(LookupCacheConfiguration.class)
+                .doesNotSerializeWithDuplicateFields();
+
+        JacksonSubtypesAssertions.assertThat(nullCacheConfig)
+                .withObjectMapper(objectMapper)
+                .deserializesWhenGivenSupertype(LookupCacheConfiguration.class)
+                .doesNotSerializeWithDuplicateFields();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupDataAdapterConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupDataAdapterConfigurationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.lookup;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.graylog.plugins.threatintel.whois.ip.WhoisDataAdapter;
+import org.graylog.testing.jackson.JacksonSubtypesAssertions;
+import org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+class LookupDataAdapterConfigurationTest {
+    @Test
+    void subtypes() {
+        final var objectMapper = new ObjectMapperProvider().get();
+        objectMapper.registerSubtypes(
+                new NamedType(WhoisDataAdapter.Config.class, WhoisDataAdapter.NAME),
+                new NamedType(HTTPJSONPathDataAdapter.Config.class, HTTPJSONPathDataAdapter.NAME)
+        );
+
+        final var httpConfig = HTTPJSONPathDataAdapter.Config.builder()
+                .type(HTTPJSONPathDataAdapter.NAME)
+                .url("http://graylog.local")
+                .singleValueJSONPath(".")
+                .userAgent("test")
+                .build();
+
+        final var whoisConfig = WhoisDataAdapter.Config.builder()
+                .type(WhoisDataAdapter.NAME)
+                .connectTimeout(1)
+                .readTimeout(1)
+                .build();
+
+        JacksonSubtypesAssertions.assertThat(httpConfig)
+                .withObjectMapper(objectMapper)
+                .deserializesWhenGivenSupertype(LookupDataAdapterConfiguration.class)
+                .doesNotSerializeWithDuplicateFields();
+        JacksonSubtypesAssertions.assertThat(whoisConfig)
+                .withObjectMapper(objectMapper)
+                .deserializesWhenGivenSupertype(LookupDataAdapterConfiguration.class)
+                .doesNotSerializeWithDuplicateFields();
+
+    }
+}


### PR DESCRIPTION
Fixes some instances of `JsonTypeInfo` annotations to prevent duplicate `type` fields in serialized JSON.

The duplicate fields didn't break anything, because they contained the same value, but they are also not necessary.

/nocl