### PR TITLE
Unify page navigation for index set field types overview page.

### DIFF
--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.tsx
@@ -18,16 +18,16 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DocumentTitle, PageHeader } from 'components/common';
-import { Row, Col, Button } from 'components/bootstrap';
+import { Row, Col } from 'components/bootstrap';
 import { useStore } from 'stores/connect';
 import { IndexSetsActions, IndexSetsStore } from 'stores/indices/IndexSetsStore';
 import useParams from 'routing/useParams';
 import DocsHelper from 'util/DocsHelper';
-import { LinkContainer } from 'components/common/router';
 import Routes from 'routing/Routes';
 import IndexSetFieldTypesList from 'components/indices/IndexSetFieldTypes/IndexSetFieldTypesList';
 import ChangeFieldTypeButton from 'components/indices/IndexSetFieldTypes/ChangeFieldTypeButton';
 import useHasTypeMappingPermission from 'hooks/useHasTypeMappingPermission';
+import { IndicesPageNavigation } from 'components/indices';
 
 const IndexSetFieldTypesPage = () => {
   const { indexSetId } = useParams();
@@ -45,29 +45,23 @@ const IndexSetFieldTypesPage = () => {
 
   return (
     <DocumentTitle title={`Index Set - ${indexSet ? indexSet.title : ''}`}>
-      <div>
-        <PageHeader title={`Configure ${indexSet ? indexSet.title : 'Index Set'} Field Types`}
-                    documentationLink={{
-                      title: 'Index model documentation',
-                      path: DocsHelper.PAGES.INDEX_MODEL,
-                    }}
-                    topActions={(
-                      <LinkContainer to={Routes.SYSTEM.INDEX_SETS.SHOW(indexSetId)}>
-                        <Button bsStyle="info">Index set overview</Button>
-                      </LinkContainer>
-                    )}
-                    actions={<ChangeFieldTypeButton indexSetId={indexSetId} />}>
-          <span>
-            The data represents field types from 2 last indices and the fields with custom field type. You can modify the current field types configuration for this index set.
-          </span>
-        </PageHeader>
+      <IndicesPageNavigation />
+      <PageHeader title={`Configure ${indexSet ? indexSet.title : 'Index Set'} Field Types`}
+                  documentationLink={{
+                    title: 'Index model documentation',
+                    path: DocsHelper.PAGES.INDEX_MODEL,
+                  }}
+                  actions={<ChangeFieldTypeButton indexSetId={indexSetId} />}>
+        <span>
+          The data represents field types from 2 last indices and the fields with custom field type. You can modify the current field types configuration for this index set.
+        </span>
+      </PageHeader>
 
-        <Row className="content">
-          <Col md={12}>
-            <IndexSetFieldTypesList />
-          </Col>
-        </Row>
-      </div>
+      <Row className="content">
+        <Col md={12}>
+          <IndexSetFieldTypesList />
+        </Col>
+      </Row>
     </DocumentTitle>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are unifying the page navigation of the index set field types overview page with the page navigation on other indices related pages.

/nocl