### PR TITLE
Use `flushSync` to force propagation of dirty flag.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { flushSync } from 'react-dom';
+
 import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import { loadDashboard } from 'views/logic/views/Actions';
@@ -26,8 +28,12 @@ import type View from './View';
 export default (view: View, history: HistoryFunction) => async (dispatch: AppDispatch) => {
   try {
     const savedView = await ViewManagementActions.create(view);
-    dispatch(setIsDirty(false));
-    dispatch(setIsNew(false));
+
+    flushSync(() => {
+      dispatch(setIsDirty(false));
+      dispatch(setIsNew(false));
+    });
+
     loadDashboard(history, savedView.id);
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');
   } catch (error) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the update to React 18, state updates will be batched automatically. This leads to the dirty flag which is updated through `dispatch(setIsDirty(false))` after saving a new dashboard not being propagated to the `WindowLeaveMessage` component, before the redirect to the saved dashboard is happening.

This PR is now wrapping the store updates with `flushSync`, enforcing a rerender before the redirect. This is a workaround used to fix the regression asap, but the underlying problem indicating a code smell should be addressed too in a future PR.

Fixes #18279.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.