### PR TITLE
added progress value in percent for remote reindex migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexMigration.java
@@ -99,4 +99,20 @@ public class RemoteReindexMigration {
         }
         status(Status.FINISHED);
     }
+
+    /**
+     * @return How much of the migration is done, in percent, int value between 0 a 100.
+     */
+    @JsonProperty("progress")
+    public int progress() {
+        final int countOfIndices = indices.size();
+
+        if(indices.isEmpty()) {
+            return 0; // avoid division by zero
+        }
+
+        final int done = (int) indices.stream().map(RemoteReindexIndex::getStatus).filter(i -> i == Status.FINISHED || i == Status.ERROR).count();
+        float percent = (100.0f / countOfIndices) * done;
+        return (int) Math.ceil(percent);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/migration/RemoteReindexMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/migration/RemoteReindexMigrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer.migration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.assertj.core.api.Assertions;
+import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class RemoteReindexMigrationTest {
+
+    @Test
+    void testProgress() {
+        final RemoteReindexMigration migration = withIndices(
+                new RemoteReindexIndex("one", RemoteReindexingMigrationAdapter.Status.FINISHED),
+                new RemoteReindexIndex("two", RemoteReindexingMigrationAdapter.Status.FINISHED),
+                new RemoteReindexIndex("three", RemoteReindexingMigrationAdapter.Status.ERROR),
+                new RemoteReindexIndex("four", RemoteReindexingMigrationAdapter.Status.RUNNING),
+                new RemoteReindexIndex("five", RemoteReindexingMigrationAdapter.Status.NOT_STARTED)
+        );
+        Assertions.assertThat(migration.progress()).isEqualTo(60);
+    }
+
+    @Test
+    void testProgressOneIndex() {
+        final RemoteReindexMigration migration = withIndices(
+                new RemoteReindexIndex("one", RemoteReindexingMigrationAdapter.Status.FINISHED)
+        );
+        Assertions.assertThat(migration.progress()).isEqualTo(100);
+    }
+
+    @Test
+    void testProgressOneIndexNotStarted() {
+        final RemoteReindexMigration migration = withIndices(
+                new RemoteReindexIndex("one", RemoteReindexingMigrationAdapter.Status.NOT_STARTED)
+        );
+        Assertions.assertThat(migration.progress()).isEqualTo(0);
+    }
+
+    @Test
+    void testProgressNoIndex() {
+        final RemoteReindexMigration migration = withIndices();
+        Assertions.assertThat(migration.progress()).isEqualTo(0);
+    }
+
+    @Test
+    void testSerializeToJson() throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapperProvider().get();
+        final RemoteReindexMigration migration = withIndices(
+                new RemoteReindexIndex("one", RemoteReindexingMigrationAdapter.Status.FINISHED),
+                new RemoteReindexIndex("two", RemoteReindexingMigrationAdapter.Status.RUNNING)
+        );
+        final String serialized = mapper.writeValueAsString(migration);
+        final Integer progress = JsonPath.parse(serialized).read("progress");
+        Assertions.assertThat(progress).isEqualTo(50);
+    }
+
+    @NotNull
+    private static RemoteReindexMigration withIndices(RemoteReindexIndex... indices) {
+        final RemoteReindexMigration migration = new RemoteReindexMigration();
+        migration.setIndices(Arrays.asList(indices));
+        return migration;
+    }
+}


### PR DESCRIPTION
/nocl

RemoteReindexMigration structure now provides a `progress` value, representing overall state of the remote reindex migration. For now the number, an integer between 0-100, shows how many percents of all indices ended with FINISHED or ERROR states. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

