### PR TITLE
Fix "name has an out-of-range pointer." on TXT lookup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClient.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClient.java
@@ -24,6 +24,7 @@ import com.google.common.net.HostAndPort;
 import com.google.common.net.InetAddresses;
 import com.google.common.net.InternetDomainName;
 import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
 import io.netty.handler.codec.dns.DefaultDnsPtrRecord;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsRawRecord;
@@ -45,6 +46,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -362,10 +364,12 @@ public class DnsClient {
     }
 
     private static String decodeTxtRecord(DefaultDnsRawRecord record) {
-
         LOG.debug("Attempting to read TXT value from DNS record [{}]", record);
 
-        return DefaultDnsRecordDecoder.decodeName(record.content());
+        ByteBuf data = ((DefaultDnsRawRecord) record).content();
+        int idx = data.readerIndex();
+        int len = data.getUnsignedByte(idx++);
+        return data.toString(idx, len, CharsetUtil.UTF_8);
     }
 
     public String getInverseAddressFormat(String ipAddress) {


### PR DESCRIPTION
Hello,

## Description
This PR fix "name has an out-of-range pointer." on TXT lookup.

In pipeline using TXT lookup data adapter, we see the message :
```2024-01-01 01:02:03,456 ERROR o.g.l.a.DnsLookupDataAdapter [query-engine-1] Could not perform TXT DNS lookup for [example.org]. Cause [name has an out-of-range pointer.]```
We see this error on the same domains, which have somewhat complex TXT entries. "omnicell.com" is one of those.

## Motivation and Context
Currently, decodeTxtRecord call decodeName() function from netty. [According to netty](https://github.com/netty/netty/issues/13839), this is not the right method to read TXT records.
This fix use their recommandation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Successfully tested on Graylog 5.2.3 Community

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

Just to say, https://www.graylog.org/get-involved/ is a dead-end (from CONTRIBUTING.md)
