### PR TITLE
Mock debounce in `UserCreate` test to make test less flaky.

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.tsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.tsx
@@ -61,6 +61,8 @@ jest.mock('stores/roles/AuthzRolesStore', () => ({
   },
 }));
 
+jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
+
 const extendedTimeout = applyTimeoutMultiplier(15000);
 
 describe('<UserCreate />', () => {
@@ -74,22 +76,23 @@ describe('<UserCreate />', () => {
     const lastNameInput = await findByLabelText('Last Name');
     const emailInput = await findByLabelText('E-Mail Address');
     const timeoutAmountInput = await findByPlaceholderText('Timeout amount');
-    // const timeoutUnitSelect = getByTestId('Timeout unit');
     const timezoneSelect = await findByLabelText('Time Zone');
     const roleSelect = await findByText(/search for roles/i);
     const passwordInput = await findByPlaceholderText('Password');
     const passwordRepeatInput = await findByPlaceholderText('Repeat password');
     const submitButton = await findSubmitButton();
-
     await userEvent.type(usernameInput, 'The username');
-    await userEvent.type(firstNameInput, 'The first name');
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.type(firstNameInput, 'The first name');
+    });
+
     await userEvent.type(lastNameInput, 'The last name');
     await userEvent.type(emailInput, 'username@example.org');
     await userEvent.clear(timeoutAmountInput);
     await userEvent.type(timeoutAmountInput, '40');
 
-    // await selectEvent.openMenu(timeoutUnitSelect);
-    // await act(async () => { await selectEvent.select(timeoutUnitSelect, 'Seconds'); });
     await act(async () => {
       await selectEvent.openMenu(timezoneSelect);
     });
@@ -106,10 +109,10 @@ describe('<UserCreate />', () => {
       await selectEvent.select(roleSelect, 'Manager');
     });
 
-    userEvent.type(passwordInput, 'thepassword');
-    userEvent.type(passwordRepeatInput, 'thepassword');
+    await userEvent.type(passwordInput, 'thepassword');
+    await userEvent.type(passwordRepeatInput, 'thepassword');
 
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     await waitFor(() => expect(UsersActions.create).toHaveBeenCalledWith({
       username: 'The username',
@@ -137,7 +140,12 @@ describe('<UserCreate />', () => {
 
     await userEvent.type(usernameInput, '   username   ');
     await userEvent.type(firstNameInput, 'The first name');
-    await userEvent.type(lastNameInput, 'The last name');
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      await userEvent.type(lastNameInput, 'The last name');
+    });
+
     await userEvent.type(emailInput, 'username@example.org');
     await userEvent.type(passwordInput, 'thepassword');
     await userEvent.type(passwordRepeatInput, 'thepassword');
@@ -161,6 +169,7 @@ describe('<UserCreate />', () => {
     const usernameInput = await findByLabelText('Username');
 
     await userEvent.type(usernameInput, existingUser.username);
+
     await userEvent.tab();
 
     await findByText(/Username is already taken/);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/18190.

The `UserCreate` test failed sometimes with the warning:

```
[INFO] FAIL src/components/users/UserCreate/UserCreate.test.tsx (13.998 s)
[INFO]   ● <UserCreate /> › should create user
[INFO] 
[INFO]     Warning: The current testing environment is not configured to support act(...)
[INFO] 
[INFO]       at console.<anonymous> (node_modules/jest-preset-graylog/lib/setup-files/console-warnings-fail-tests.js:49:11)
[INFO]       at printWarning (node_modules/react-dom/cjs/react-dom.development.js:86:30)
[INFO]       at error (node_modules/react-dom/cjs/react-dom.development.js:60:7)
[INFO]       at isConcurrentActEnvironment (node_modules/react-dom/cjs/react-dom.development.js:25260:7)
[INFO]       at warnIfUpdatesNotWrappedWithActDEV (node_modules/react-dom/cjs/react-dom.development.js:27559:12)
[INFO]       at scheduleUpdateOnFiber (node_modules/react-dom/cjs/react-dom.development.js:25508:5)
[INFO]       at dispatchSetState (node_modules/react-dom/cjs/react-dom.development.js:17527:7)
[INFO]       at setIteration (node_modules/formik/src/Formik.tsx:193:36)
[INFO]       at dispatch (node_modules/formik/src/Formik.tsx:338:11)
```

This should not be a problem, because the testing environment is configured to support `act()`. Mocking `debounceWithPromise` seems to fix this problem. My assumption is that, due to the usage of `debounce` the related code ran at a time when `global.IS_REACT_ACT_ENVIRONMENT` is `false`.

/nocl
