### PR TITLE
Require authentication to visit API browser

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,9 @@ Upgrading to Graylog 6.0.x
 ==========================
 
 ## Breaking Changes
+
 - Default value for `data_dir` configuration option has been removed and must be specified in `graylog.conf`.
+
 ### Changed default number of process-buffer and output-buffer processors
 
 The default values for the configuration settings `processbuffer_processors` and `outputbuffer_processors` have been
@@ -23,6 +25,14 @@ The name of the `jvm_classes_loaded` metric [has been changed](https://github.co
 
 Prometheus queries referencing `jvm_classes_loaded` need to be adapted to
 the new name `jvm_classes_currently_loaded`.
+
+### Authentication required to use API browser
+
+Users now have to log in before visiting the API browser. It is sufficient to log in with any user known to Graylog. No
+particular permissions are required.
+
+The username/password field was removed from the header of the API browser. If users want to perform API requests with
+different credentials, they must log out of Graylog and re-login with another user.
 
 ### Plugins
 

--- a/changelog/unreleased/pr-18328.toml
+++ b/changelog/unreleased/pr-18328.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Require authentication for visiting API browser to limit information exposure."
+
+pulls = ["18328"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -19,16 +19,7 @@ package org.graylog2.shared.rest.resources.documentation;
 import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import org.graylog2.Configuration;
-import org.graylog2.configuration.HttpConfiguration;
-import org.graylog2.rest.RestTools;
-import org.graylog2.shared.rest.resources.RestResource;
-import org.graylog2.shared.rest.resources.csp.CSP;
-
-import javax.activation.MimetypesFileTypeMap;
-
 import jakarta.inject.Inject;
-
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -39,7 +30,14 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.Configuration;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.RestTools;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.rest.resources.csp.CSP;
 
+import javax.activation.MimetypesFileTypeMap;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -50,6 +48,7 @@ import static java.util.Objects.requireNonNull;
 
 @Path("/api-browser")
 @CSP(group = CSP.SWAGGER)
+@RequiresAuthentication
 public class DocumentationBrowserResource extends RestResource {
     private final MimetypesFileTypeMap mimeTypes;
     private final HttpConfiguration httpConfiguration;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -22,6 +22,16 @@ import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -31,17 +41,6 @@ import org.graylog2.shared.rest.documentation.generator.Generator;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.rest.resources.csp.CSP;
 
-import jakarta.inject.Inject;
-
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,9 +49,11 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
 
+
 @Api(value = "Documentation", description = "Documentation of this API in JSON format.")
 @Path("/api-docs")
 @CSP(group = CSP.SWAGGER)
+@RequiresAuthentication
 public class DocumentationResource extends RestResource {
 
     private final Generator generator;

--- a/graylog2-server/src/main/resources/swagger/index.html.template
+++ b/graylog2-server/src/main/resources/swagger/index.html.template
@@ -40,7 +40,6 @@
         $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
 
         if ("${isCloud}") {
-          $('#api_selector').css('visibility', 'hidden');
           $('.warning-box').css('visibility', 'hidden');
         } else if ("${showWarning}") {
           $('.warning-box').css('visibility', '');
@@ -54,16 +53,6 @@
       },
       docExpansion: "none"
     });
-
-    var updateApiAuth = function() {
-        var user = $('#input_apiUser')[0].value;
-        var pass = $('#input_apiPassword')[0].value;
-        if(user && user.trim() != "" && pass && pass.trim() != "") {
-            window.authorizations.add("basic", new PasswordAuthorization("creds", user, pass));
-        }
-    };
-    $('#input_apiUser').change(updateApiAuth);
-    $('#input_apiPassword').change(updateApiAuth);
 
     // Add CSRF header
     window.authorizations.add("csrf", new ApiKeyAuthorization("X-Requested-By", "Graylog API Browser", "header"));
@@ -86,14 +75,6 @@
   <div class="swagger-ui-wrap">
     <img src="images/toplogo.png">
     <span class="subtitle">REST API browser</span>
-    <form id="api_selector">
-      <div class="input">
-        <input type="text" name="user" id="input_apiUser" placeholder="Username"/>
-      </div>
-      <div class="input">
-        <input type="password" name="password" id="input_apiPassword" placeholder="Password"/>
-      </div>
-    </form>
   </div>
 </div>
 


### PR DESCRIPTION
Previously, the API browser could be accessed without any restrictions. A user only had to provide credentials when executing API requests through the API browser, which required an authenticated user to succeed.

With this change, a user has to log in before visiting the API browser. It is sufficient to log in with any user known to Graylog. No particular permissions are required.

The username/password field has been removed from the header of the API browser because a valid user is now required. If users want to perform API requests with different credentials, they now have to log out of Graylog and re-login again with a different user.

When users navigate to the API browser at `/api/api-browser` (or the cluster-global version) directly, without first logging into Graylog, they will be presented with a Basic Auth credentials prompt. This isn't very nice, but I didn't deem replacing this with a proper redirect to the login page worthwhile because that would entail additional changes. We should move away from our customised API browser anyway, so I didn't want to invest energy here.

