### PR TITLE
DataNode: rename cluster manager property

### DIFF
--- a/changelog/unreleased/pr-18339.toml
+++ b/changelog/unreleased/pr-18339.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "OpenSearch renamed cluster.initial_master_nodes to initial_cluster_manager_nodes, which was not reflected yet and is a possible cause of startup bugs."
+
+pulls = ["18339"]

--- a/changelog/unreleased/pr-18342.toml
+++ b/changelog/unreleased/pr-18342.toml
@@ -1,4 +1,4 @@
 type = "f"
 message = "OpenSearch renamed cluster.initial_master_nodes to initial_cluster_manager_nodes, which was not reflected yet and is a possible cause of startup bugs."
 
-pulls = ["18339"]
+pulls = ["18342"]

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -107,8 +107,8 @@ public class Configuration extends BaseConfiguration {
     /**
      * Comma separated list of opensearch nodes that are eligible as manager nodes.
      */
-    @Parameter(value = "cluster_initial_manager_nodes")
-    private String initialManagerNodes;
+    @Parameter(value = "initial_cluster_manager_nodes")
+    private String initialClusterManagerNodes;
 
     @Parameter(value = "opensearch_http_port", converter = IntegerConverter.class)
     private int opensearchHttpPort = 9200;
@@ -340,8 +340,8 @@ public class Configuration extends BaseConfiguration {
         return datanodeNodeName != null && !datanodeNodeName.isBlank() ? datanodeNodeName : getHostname();
     }
 
-    public String getInitialManagerNodes() {
-        return initialManagerNodes;
+    public String getInitialClusterManagerNodes() {
+        return initialClusterManagerNodes;
     }
 
     public int getOpensearchHttpPort() {

--- a/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
@@ -96,11 +96,11 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
         try {
             ImmutableMap.Builder<String, String> opensearchProperties = ImmutableMap.builder();
 
-            if (localConfiguration.getInitialManagerNodes() != null && !localConfiguration.getInitialManagerNodes().isBlank()) {
-                opensearchProperties.put("cluster.initial_master_nodes", localConfiguration.getInitialManagerNodes());
+            if (localConfiguration.getInitialClusterManagerNodes() != null && !localConfiguration.getInitialClusterManagerNodes().isBlank()) {
+                opensearchProperties.put("cluster.initial_cluster_manager_nodes", localConfiguration.getInitialClusterManagerNodes());
             } else if (isPreflight()) {
                 final var nodeList = String.join(",", nodeService.allActive().values().stream().map(Node::getHostname).collect(Collectors.toSet()));
-                opensearchProperties.put("cluster.initial_master_nodes", nodeList);
+                opensearchProperties.put("cluster.initial_cluster_manager_nodes", nodeList);
             }
             opensearchProperties.putAll(commonOpensearchConfig(localConfiguration));
 

--- a/data-node/src/test/java/org/graylog/datanode/integration/DataNodePluginsIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DataNodePluginsIT.java
@@ -24,6 +24,8 @@ import org.graylog.datanode.testinfra.DatanodeTestExtension;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -33,6 +35,7 @@ import static io.restassured.RestAssured.given;
 
 @ExtendWith(DatanodeTestExtension.class)
 public class DataNodePluginsIT {
+    private static final Logger LOG = LoggerFactory.getLogger(DataNodePluginsIT.class);
     private final DatanodeContainerizedBackend backend;
 
     public DataNodePluginsIT(DatanodeContainerizedBackend backend) {
@@ -43,25 +46,30 @@ public class DataNodePluginsIT {
     void ensureUnneededPluginsAreNotLoaded() throws Exception {
         final var opensearchRestPort = backend.getOpensearchRestPort();
         final var baseUrl = "http://localhost:" + opensearchRestPort;
-        waitForOpensearch(baseUrl);
+        try {
+            waitForOpensearch(baseUrl);
 
-        given()
-                .get(baseUrl + "/_cat/plugins")
-                .then()
-                .statusCode(200)
-                .body(
-                        Matchers.not(Matchers.containsString("opensearch-alerting")),
-                        Matchers.not(Matchers.containsString("opensearch-custom-codecs")),
-                        Matchers.not(Matchers.containsString("opensearch-geospatial")),
-                        Matchers.not(Matchers.containsString("opensearch-knn")),
-                        Matchers.not(Matchers.containsString("opensearch-neural-search")),
-                        Matchers.not(Matchers.containsString("opensearch-notifications")),
-                        Matchers.not(Matchers.containsString("opensearch-notifications-core")),
-                        Matchers.not(Matchers.containsString("opensearch-performance-analyzer")),
-                        Matchers.not(Matchers.containsString("opensearch-reports-scheduler")),
-                        Matchers.not(Matchers.containsString("opensearch-security-analytics")),
-                        Matchers.not(Matchers.containsString("opensearch-sql"))
-                );
+            given()
+                    .get(baseUrl + "/_cat/plugins")
+                    .then()
+                    .statusCode(200)
+                    .body(
+                            Matchers.not(Matchers.containsString("opensearch-alerting")),
+                            Matchers.not(Matchers.containsString("opensearch-custom-codecs")),
+                            Matchers.not(Matchers.containsString("opensearch-geospatial")),
+                            Matchers.not(Matchers.containsString("opensearch-knn")),
+                            Matchers.not(Matchers.containsString("opensearch-neural-search")),
+                            Matchers.not(Matchers.containsString("opensearch-notifications")),
+                            Matchers.not(Matchers.containsString("opensearch-notifications-core")),
+                            Matchers.not(Matchers.containsString("opensearch-performance-analyzer")),
+                            Matchers.not(Matchers.containsString("opensearch-reports-scheduler")),
+                            Matchers.not(Matchers.containsString("opensearch-security-analytics")),
+                            Matchers.not(Matchers.containsString("opensearch-sql"))
+                    );
+        } catch (Exception exception) {
+            LOG.error("DataNode Container logs follow:\n" + backend.getLogs());
+            throw exception;
+        }
     }
 
     private void waitForOpensearch(String baseUrl) throws ExecutionException, RetryException {

--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
@@ -222,7 +222,7 @@ public class DatanodeClusterIT {
                 datanodeContainer -> {
                     datanodeContainer.withNetwork(network);
                     datanodeContainer.withEnv("GRAYLOG_DATANODE_PASSWORD_SECRET", DatanodeContainerizedBackend.SIGNING_SECRET);
-                    datanodeContainer.withEnv("GRAYLOG_DATANODE_CLUSTER_INITIAL_MANAGER_NODES", hostnameNodeA);
+                    datanodeContainer.withEnv("GRAYLOG_DATANODE_INITIAL_CLUSTER_MANAGER_NODES", hostnameNodeA);
                     datanodeContainer.withEnv("GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS", hostnameNodeA + ":9300");
 
                     datanodeContainer.withFileSystemBind(transportKeystore.location().toAbsolutePath().toString(), IMAGE_WORKING_DIR + "/config/datanode-transport-certificates.p12");

--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
@@ -120,12 +120,12 @@ public class DatanodeDevContainerBuilder implements org.graylog.testing.datanode
 
     public GenericContainer<?> build() {
         final Path graylog = getPath().resolve("graylog-datanode-" + getProjectVersion() + ".jar");
-        if(!Files.exists(graylog)) {
+        if (!Files.exists(graylog)) {
             LOG.info("Searching for {} failed.", graylog.toAbsolutePath());
             LOG.info("Project repos path: {}, absolute path: {}", getProjectReposPath(), getProjectReposPath().toAbsolutePath());
-            if(Files.exists(getPath())) {
+            if (Files.exists(getPath())) {
                 LOG.info("contents of base path {}:", getPath());
-                try(var files = Files.list(getPath())) {
+                try (var files = Files.list(getPath())) {
                     files.forEach(file -> LOG.info("{}", file.toString()));
                 } catch (IOException ex) {
                     LOG.info("listing files failed with exception: {}", ex.getMessage());
@@ -155,7 +155,7 @@ public class DatanodeDevContainerBuilder implements org.graylog.testing.datanode
                 .withEnv("GRAYLOG_DATANODE_OPENSEARCH_DISCOVERY_SEED_HOSTS", nodeName + ":" + openSearchTransportPort)
 
                 .withEnv("GRAYLOG_DATANODE_OPENSEARCH_NETWORK_HOST", nodeName)
-                .withEnv("GRAYLOG_DATANODE_CLUSTER_INITIAL_MANAGER_NODES", nodeName)
+                .withEnv("GRAYLOG_DATANODE_INITIAL_CLUSTER_MANAGER_NODES", nodeName)
 
                 .withEnv("GRAYLOG_DATANODE_ROOT_USERNAME", rootUsername)
                 .withEnv("GRAYLOG_DATANODE_PASSWORD_SECRET", passwordSecret)

--- a/misc/datanode.conf
+++ b/misc/datanode.conf
@@ -123,7 +123,7 @@ mongodb_uri = mongodb://localhost/graylog
 # if you're not using the automatic data node setup and want to create a cluster, you have to setup the initial manager nodes
 # make sure to remove this setting after the cluster has formed
 #
-# cluster_initial_manager_nodes =
+# initial_cluster_manager_nodes =
 
 #### OpenSearch folders
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

OpenSearch renamed cluster.initial_master_nodes to initial_cluster_manager_nodes, which was not reflected yet and is a possible cause of startup bugs.

https://github.com/opensearch-project/OpenSearch/issues/2769

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

