### PR TITLE
Debounce keyword validation request.

### DIFF
--- a/changelog/unreleased/pr-18343.toml
+++ b/changelog/unreleased/pr-18343.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Improve keyword validation in time range picker."
+
+pulls = ["18219"]

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
@@ -28,6 +28,8 @@ jest.mock('stores/tools/ToolsStore', () => ({
   testNaturalDate: jest.fn(),
 }));
 
+jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
+
 const TabKeywordTimeRange = ({ defaultValue, ...props }: { defaultValue: string } & React.ComponentProps<typeof TabKeywordTimeRange>) => (
   <Formik initialValues={{ timeRangeTabs: { keyword: { type: 'keyword', keyword: defaultValue } }, activeTab: 'keyword' }}
           onSubmit={() => {}}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -30,6 +30,7 @@ import type { KeywordTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { InputDescription } from 'components/common';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
+import type FetchError from 'logic/errors/FetchError';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
 
@@ -73,13 +74,13 @@ const debouncedTestNaturalDate = debounceWithPromise((
   userTZ: string,
   mounted: React.RefObject<boolean>,
   setSuccessfulPreview: (response: KeywordPreview) => void,
-  setFailedPreview: (error: Error) => void,
+  setFailedPreview: () => void,
 ) => ToolsStore.testNaturalDate(keyword, userTZ).then((response) => {
   if (mounted.current) {
     setSuccessfulPreview(response);
   }
-}).catch((re) => {
-  setFailedPreview(re);
+}).catch(() => {
+  setFailedPreview();
 
   return 'Unable to parse keyword.';
 }), 350);
@@ -100,8 +101,6 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
 
   const _setFailedPreview = useCallback(() => {
     setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE, timezone: userTimezone });
-
-    return 'Unable to parse keyword.';
   }, [userTimezone]);
 
   const _validateKeyword = useCallback((keyword: string) => {

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -30,7 +30,6 @@ import type { KeywordTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { InputDescription } from 'components/common';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
-import type FetchError from 'logic/errors/FetchError';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -29,8 +29,11 @@ import ToolsStore from 'stores/tools/ToolsStore';
 import type { KeywordTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { InputDescription } from 'components/common';
+import debounceWithPromise from 'views/logic/debounceWithPromise';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
+
+type KeywordPreview = { from: string, to: string, timezone: string }
 
 const Headline = styled.h3`
   margin-bottom: 5px;
@@ -62,20 +65,36 @@ const _parseKeywordPreview = (data: Pick<KeywordTimeRange, 'from' | 'to' | 'time
 type Props = {
   defaultValue: string,
   disabled: boolean,
-  setValidatingKeyword: (boolean) => void
+  setValidatingKeyword: (isValidating: boolean) => void
 };
+
+const debouncedTestNaturalDate = debounceWithPromise((
+  keyword: string,
+  userTZ: string,
+  mounted: React.RefObject<boolean>,
+  setSuccessfulPreview: (response: KeywordPreview) => void,
+  setFailedPreview: (error: Error) => void,
+) => ToolsStore.testNaturalDate(keyword, userTZ).then((response) => {
+  if (mounted.current) {
+    setSuccessfulPreview(response);
+  }
+}).catch((re) => {
+  setFailedPreview(re);
+
+  return 'Unable to parse keyword.';
+}), 350);
 
 const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
   const [nextRangeProps, , nextRangeHelpers] = useField('timeRangeTabs.keyword');
   const mounted = useRef(true);
   const keywordRef = useRef<string>();
-  const [keywordPreview, setKeywordPreview] = useState({ from: '', to: '', timezone: '' });
+  const [keywordPreview, setKeywordPreview] = useState<KeywordPreview>({ from: '', to: '', timezone: '' });
 
-  const _setSuccessfulPreview = useCallback((response: { from: string, to: string, timezone: string }) => {
+  const _setSuccessfulPreview = useCallback((response: KeywordPreview) => {
     setValidatingKeyword(false);
 
-    return setKeywordPreview(_parseKeywordPreview(response, formatTime));
+    setKeywordPreview(_parseKeywordPreview(response, formatTime));
   },
   [setValidatingKeyword, formatTime]);
 
@@ -97,11 +116,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
 
       return trim(keyword) === ''
         ? Promise.resolve('Keyword must not be empty!')
-        : ToolsStore.testNaturalDate(keyword, userTimezone)
-          .then((response) => {
-            if (mounted.current) _setSuccessfulPreview(response);
-          })
-          .catch(_setFailedPreview);
+        : debouncedTestNaturalDate(keyword, userTimezone, mounted, _setSuccessfulPreview, _setFailedPreview);
     }
 
     return undefined;
@@ -125,7 +140,7 @@ const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: P
           keyword,
           ...restPreview,
           ...keywordPreview,
-        });
+        }, false);
       }
     }
   }, [nextRangeProps.value, keywordPreview, nextRangeHelpers]);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -29,6 +29,7 @@ import { adminUser } from 'fixtures/users';
 import OriginalTimeRangePicker from './TimeRangePicker';
 
 jest.mock('hooks/useCurrentUser');
+jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
 
 jest.mock('views/stores/SearchConfigStore', () => ({
   SearchConfigActions: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When defining a keyword time range in the time range picker, the keyword is being validated in the backend.
With this PR we are debouncing the request. We also make sure that the validation does not run another time, after the request finished.

These changes also slightly improve the validation, before you could have an initial value like "Last five minutes" and see no validation error when removing the last two characters.
