### PR TITLE
Go back when cancelling field type profile creation.

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
@@ -27,6 +27,7 @@ import type {
 } from 'components/indices/IndexSetFieldTypeProfiles/types';
 import useProfileMutations from 'components/indices/IndexSetFieldTypeProfiles/hooks/useProfileMutations';
 import Routes from 'routing/Routes';
+import useHistory from 'routing/useHistory';
 
 const CreateProfile = () => {
   const sendTelemetry = useSendTelemetry();
@@ -35,6 +36,7 @@ const CreateProfile = () => {
   const { createProfile } = useProfileMutations();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
   const location = useLocation();
+  const history = useHistory();
   const initialValues = useMemo<IndexSetFieldTypeProfileForm>(() => {
     const defaultCustomFieldMappings = location?.state?.customFieldMappings;
 
@@ -66,8 +68,8 @@ const CreateProfile = () => {
 
   const onCancel = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.INDEX_SET_FIELD_TYPE_PROFILE.NEW_CANCELED, { app_pathname: telemetryPathName, app_action_value: 'create-new-index-set-field-type-profile-canceled' });
-    navigate(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
-  }, [navigate, sendTelemetry, telemetryPathName]);
+    history.goBack();
+  }, [history, sendTelemetry, telemetryPathName]);
 
   return (
     <ProfileForm initialValues={initialValues} onCancel={onCancel} submitButtonText="Create profile" submitLoadingText="Creating profile..." onSubmit={onSubmit} />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Go back in history instead of jumping to field types profile overview when cancelling field type profile creation step.

This avoids ending up in a different place when opening the dialog from the bulk actions on the index field types page.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.