### PR TITLE
Make Mantine loader element invisible.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -122,6 +122,9 @@ const StyledButton = styled(MantineButton)<{
     gap: 0.25em;
     overflow: visible;
   }
+  .mantine-Button-loader {
+    visibility: hidden;
+  }
 `);
 
 type Props = React.PropsWithChildren<{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the introduction of Mantine 7.5.2, a loader element was added to buttons, which is rendered even if the `loading` prop is `false`. This element was falsely detected by cypress to cover up the button, leading to e2e test failures.

This PR is now setting the CSS visibility of that element to `hidden`, making cypress able to detect it is not actually covering up the button element.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.