### PR TITLE
Allow more db types for IPinfo mmdb files / reenable IPinfo in data adapter UI (5.2)

### DIFF
--- a/changelog/unreleased/pr-18124.toml
+++ b/changelog/unreleased/pr-18124.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Fix support for changed IPinfo ASN mmdb files."
+
+issues = ["Graylog2/graylog-plugin-enterprise#6436"]
+pulls = ["18124"]
+

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/config/GeoIpProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/config/GeoIpProcessorConfig.java
@@ -20,6 +20,7 @@ import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.validators.PathReadableValidator;
 import org.graylog2.configuration.PathConfiguration;
 
+
 import javax.inject.Singleton;
 import java.nio.file.Path;
 
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 public class GeoIpProcessorConfig extends PathConfiguration {
     private static final String PREFIX = "geo_ip_processor";
     public static final String S3_DOWNLOAD_LOCATION = PREFIX + "_s3_download_location";
+    public static final String DISABLE_IPINFO_DB_TYPE_CHECK = PREFIX + "_disable_ipinfo_db_type_check";
 
     @Parameter(value = S3_DOWNLOAD_LOCATION, required = true, validators = PathReadableValidator.class)
     private final Path s3DownloadLocation = DEFAULT_DATA_DIR.resolve("geolocation");
@@ -35,4 +37,6 @@ public class GeoIpProcessorConfig extends PathConfiguration {
         return s3DownloadLocation;
     }
 
+    @Parameter(value = DISABLE_IPINFO_DB_TYPE_CHECK)
+    private final boolean disableIpInfoDBTypeCheck = false;
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IPinfoIPLocationDatabaseAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IPinfoIPLocationDatabaseAdapter.java
@@ -45,14 +45,16 @@ public class IPinfoIPLocationDatabaseAdapter implements IPLocationDatabaseAdapte
             .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
 
     private final Reader reader;
+    private final boolean disableIpInfoDbTypeCheck;
 
-    public IPinfoIPLocationDatabaseAdapter(File databaseFile) throws IOException {
+    public IPinfoIPLocationDatabaseAdapter(File databaseFile, boolean disableIpInfoDbTypeCheck) throws IOException {
         this.reader = new Reader(databaseFile, Reader.FileMode.MEMORY_MAPPED, NoCache.getInstance());
+        this.disableIpInfoDbTypeCheck = disableIpInfoDbTypeCheck;
     }
 
     private ObjectNode get(InetAddress ipAddress, String type) throws IOException, AddressNotFoundException {
         final String databaseType = reader.getMetadata().getDatabaseType();
-        if (!databaseType.contains(type)) {
+        if (!disableIpInfoDbTypeCheck && (!databaseType.contains("ipinfo") || !databaseType.contains(type))) {
             final String caller = Thread.currentThread().getStackTrace()[2].getMethodName();
             throw new UnsupportedOperationException("Invalid attempt to open a \"" + databaseType + "\" database using the " + caller + " method");
         }
@@ -74,12 +76,12 @@ public class IPinfoIPLocationDatabaseAdapter implements IPLocationDatabaseAdapte
 
     @Override
     public IPinfoStandardLocation ipInfoStandardLocation(InetAddress ipAddress) throws IOException, AddressNotFoundException {
-        return OBJECT_MAPPER.convertValue(get(ipAddress, "ipinfo standard_location"), IPinfoStandardLocation.class);
+        return OBJECT_MAPPER.convertValue(get(ipAddress, "standard_location"), IPinfoStandardLocation.class);
     }
 
     @Override
     public IPinfoASN ipInfoASN(InetAddress ipAddress) throws IOException, AddressNotFoundException {
-        return OBJECT_MAPPER.convertValue(get(ipAddress, "ipinfo asn"), IPinfoASN.class);
+        return OBJECT_MAPPER.convertValue(get(ipAddress, "asn"), IPinfoASN.class);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpAsnResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpAsnResolver.java
@@ -21,11 +21,15 @@ import com.codahale.metrics.Timer;
 import com.google.inject.assistedinject.Assisted;
 import com.maxmind.geoip2.exception.AddressNotFoundException;
 
+
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Locale;
 import java.util.Optional;
+
+import static org.graylog.plugins.map.config.GeoIpProcessorConfig.DISABLE_IPINFO_DB_TYPE_CHECK;
 
 /**
  * A {@link GeoIpResolver} to load IP ASN data from {@link org.graylog.plugins.map.config.DatabaseVendorType#IPINFO}.
@@ -35,8 +39,9 @@ public class IpInfoIpAsnResolver extends IpInfoIpResolver<GeoAsnInformation> {
     @Inject
     public IpInfoIpAsnResolver(@Assisted Timer timer,
                                @Assisted String configPath,
-                               @Assisted boolean enabled) {
-        super(timer, configPath, enabled);
+                               @Assisted boolean enabled,
+                               @Named(DISABLE_IPINFO_DB_TYPE_CHECK) boolean disableIpInfoDbTypeCheck) {
+        super(timer, configPath, enabled, disableIpInfoDbTypeCheck);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpResolver.java
@@ -26,17 +26,19 @@ import java.io.IOException;
 
 abstract class IpInfoIpResolver<T> extends GeoIpResolver<T> {
     protected static final Logger LOG = LoggerFactory.getLogger(IpInfoIpResolver.class);
+    private final boolean disableIpInfoDbTypeCheck;
     protected IPinfoIPLocationDatabaseAdapter adapter;
 
-    IpInfoIpResolver(Timer resolveTime, String configPath, boolean enabled) {
+    IpInfoIpResolver(Timer resolveTime, String configPath, boolean enabled, boolean disableIpInfoDbTypeCheck) {
         super(resolveTime, configPath, enabled);
+        this.disableIpInfoDbTypeCheck = disableIpInfoDbTypeCheck;
     }
 
     @Override
     boolean createDataProvider(File configFile) {
 
         try {
-            adapter = new IPinfoIPLocationDatabaseAdapter(configFile);
+            adapter = new IPinfoIPLocationDatabaseAdapter(configFile, disableIpInfoDbTypeCheck);
         } catch (IOException e) {
             LOG.warn("Error creating IPinfoIPLocationDatabaseAdapter for '{}' from file '{}'", getClass().getSimpleName(), configFile);
             adapter = null;

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
@@ -20,12 +20,14 @@ package org.graylog.plugins.map.geoip;
 import com.codahale.metrics.Timer;
 import com.google.inject.assistedinject.Assisted;
 import com.maxmind.geoip2.exception.AddressNotFoundException;
-
-import javax.inject.Inject;
+import jakarta.inject.Inject;
+import javax.inject.Named;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Locale;
 import java.util.Optional;
+
+import static org.graylog.plugins.map.config.GeoIpProcessorConfig.DISABLE_IPINFO_DB_TYPE_CHECK;
 
 /**
  * A {@link GeoIpResolver} to load IP Location data from {@link org.graylog.plugins.map.config.DatabaseVendorType#IPINFO}.
@@ -35,8 +37,9 @@ public class IpInfoLocationResolver extends IpInfoIpResolver<GeoLocationInformat
     @Inject
     public IpInfoLocationResolver(@Assisted Timer resolveTime,
                                   @Assisted String configPath,
-                                  @Assisted boolean enabled) {
-        super(resolveTime, configPath, enabled);
+                                  @Assisted boolean enabled,
+                                  @Named(DISABLE_IPINFO_DB_TYPE_CHECK) boolean disableIpInfoDbTypeCheck) {
+        super(resolveTime, configPath, enabled, disableIpInfoDbTypeCheck);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
@@ -20,7 +20,8 @@ package org.graylog.plugins.map.geoip;
 import com.codahale.metrics.Timer;
 import com.google.inject.assistedinject.Assisted;
 import com.maxmind.geoip2.exception.AddressNotFoundException;
-import jakarta.inject.Inject;
+
+import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
 import java.net.InetAddress;

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -62,6 +63,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.graylog.plugins.map.config.GeoIpProcessorConfig.DISABLE_IPINFO_DB_TYPE_CHECK;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public class MaxmindDataAdapter extends LookupDataAdapter {
@@ -70,6 +72,7 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
 
     public static final String NAME = "maxmind_geoip";
     private final Config config;
+    private final boolean disableIpInfoDbTypeCheck;
     private final AtomicReference<IPLocationDatabaseAdapter> databaseAdapter = new AtomicReference<>();
     private FileInfo fileInfo = FileInfo.empty();
 
@@ -77,9 +80,11 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
     protected MaxmindDataAdapter(@Assisted("id") String id,
                                  @Assisted("name") String name,
                                  @Assisted LookupDataAdapterConfiguration config,
+                                 @Named(DISABLE_IPINFO_DB_TYPE_CHECK) boolean disableIpInfoDbTypeCheck,
                                  MetricRegistry metricRegistry) {
         super(id, name, config, metricRegistry);
         this.config = (Config) config;
+        this.disableIpInfoDbTypeCheck = disableIpInfoDbTypeCheck;
     }
 
     @Override
@@ -154,7 +159,7 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
                 return new MaxMindIPLocationDatabaseAdapter(file);
             case IPINFO_ASN:
             case IPINFO_STANDARD_LOCATION:
-                return new IPinfoIPLocationDatabaseAdapter(file);
+                return new IPinfoIPLocationDatabaseAdapter(file, disableIpInfoDbTypeCheck);
             default:
                 throw new IllegalStateException("Unexpected value: " + config.dbType());
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxmindDataAdapterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/MaxmindDataAdapterTest.java
@@ -40,12 +40,12 @@ import static org.mockito.Mockito.when;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-                            MaxmindDataAdapterTest.CityDatabaseTest.class,
-                            MaxmindDataAdapterTest.CountryDatabaseTest.class,
-                            MaxmindDataAdapterTest.AsnDatabaseTest.class,
-                            MaxmindDataAdapterTest.IPinfoStandardLocationDatabaseTest.class,
-                            MaxmindDataAdapterTest.IPinfoASNDatabaseTest.class,
-                    })
+        MaxmindDataAdapterTest.CityDatabaseTest.class,
+        MaxmindDataAdapterTest.CountryDatabaseTest.class,
+        MaxmindDataAdapterTest.AsnDatabaseTest.class,
+        MaxmindDataAdapterTest.IPinfoStandardLocationDatabaseTest.class,
+        MaxmindDataAdapterTest.IPinfoASNDatabaseTest.class,
+})
 public class MaxmindDataAdapterTest {
     private static final String GEO_LITE2_CITY_MMDB = "/GeoLite2-City.mmdb";
     private static final String GEO_LITE2_COUNTRY_MMDB = "/GeoLite2-Country.mmdb";
@@ -78,7 +78,7 @@ public class MaxmindDataAdapterTest {
                     .path(getTestDatabasePath(DB_PATH.get(databaseType)))
                     .type("test")
                     .build();
-            adapter = new MaxmindDataAdapter("test", "test", config, new MetricRegistry());
+            adapter = new MaxmindDataAdapter("test", "test", config, false, new MetricRegistry());
 
             adapter.doStart();
         }

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.tsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.tsx
@@ -58,7 +58,7 @@ const MaxmindAdapterFieldSet = ({ config, updateConfig, handleFormEvent, validat
   if (isCloud) {
     databaseTypes = ipInfoDatabaseTypes;
   } else {
-    databaseTypes.concat(ipInfoDatabaseTypes);
+    databaseTypes = databaseTypes.concat(ipInfoDatabaseTypes);
   }
 
   const update = (value: number, unit: string, enabled: boolean, name: string) => {


### PR DESCRIPTION

* Allow more db types for IPinfo mmdb files

IPinfo recently changed the info in their metadata.

old
```
mmdbctl metadata 24/asn.mmdb
- Binary Format 2.0
- Database Type ipinfo asn.mmdb
```

new
```
mmdbctl metadata newest/asn.mmdb
- Binary Format 2.0
- Database Type ipinfo generic_asn_mmdb_v4.mmdb
```

This is likely because they changed something
in their release process, because the db type is just their import filename:

 https://github.com/ipinfo/mmdbctl/blob/master/lib/cmd_import.go#L269

Relax our db type match to support this.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6436

* Changelog

* Allow selecting IPinfo DB types in Data Adapters

This probably got broken with PR #13911

* Add config to disable IPinfo database type check

The database type check is only a convenience feature to give a meaningful error if the wrong type of mmdb is used.

In case the upstream metadata format changes again, allow the check to be disabled temporarly.

The check can be disabled using:
`geo_ip_processor_disable_ipinfo_db_type_check=true`

(cherry picked from commit 4a46e2b0d6b04ef652e2e8f673a17ef1b5ccdbc1)

