### PR TITLE
Fix color scheme for mantine provider in preflight UI.

### DIFF
--- a/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
+++ b/graylog2-web-interface/src/preflight/theme/PreflightThemeProvider.tsx
@@ -55,7 +55,7 @@ const PreflightThemeProvider = ({ children }: Props) => {
   const scTheme = useSCTheme(colorScheme, setColorScheme, mantineTheme);
 
   return (
-    <MantineProvider theme={mantineTheme}>
+    <MantineProvider theme={mantineTheme} forceColorScheme={colorScheme}>
       <ThemeProvider theme={scTheme}>
         {children}
       </ThemeProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/18269 and fixes the defined color scheme for the mantine provider in the preflight UI.

Before e.g. the help dropdown looked like this:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/b70f826b-7719-4cd3-ba89-e1a58b71f15b)

Now it looks like this again:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/da22fe9f-db72-4c28-ba68-ed55379e214c)


/nocl