### PR TITLE
ProxiedResource can direct a call to any single node

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -45,7 +45,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -382,7 +381,7 @@ public abstract class ProxiedResource extends RestResource {
         final Node executionNode = nodeService.allActive().values().stream()
                 .filter(node -> Objects.equals(nodeId, node.getNodeId()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException(String.format(Locale.ENGLISH, "Node %s cannot be found among active nodes", nodeId)));
+                .orElseThrow(() -> new IllegalStateException(StringUtils.f("Node %s cannot be found among active nodes", nodeId)));
         return doNodeApiCall(executionNode.getNodeId(), interfaceClass, remoteInterfaceFunction, Function.identity(), timeout);
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -381,7 +381,7 @@ public abstract class ProxiedResource extends RestResource {
         final Node executionNode = nodeService.allActive().values().stream()
                 .filter(node -> Objects.equals(nodeId, node.getNodeId()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Node cannot be found among active nodes, node id : " + nodeId));
+                .orElseThrow(() -> new IllegalStateException(String.format("Node %s cannot be found among active nodes", nodeId)));
         return doNodeApiCall(executionNode.getNodeId(), interfaceClass, remoteInterfaceFunction, Function.identity(), timeout);
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -45,6 +45,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -381,7 +382,7 @@ public abstract class ProxiedResource extends RestResource {
         final Node executionNode = nodeService.allActive().values().stream()
                 .filter(node -> Objects.equals(nodeId, node.getNodeId()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException(String.format("Node %s cannot be found among active nodes", nodeId)));
+                .orElseThrow(() -> new IllegalStateException(String.format(Locale.ENGLISH, "Node %s cannot be found among active nodes", nodeId)));
         return doNodeApiCall(executionNode.getNodeId(), interfaceClass, remoteInterfaceFunction, Function.identity(), timeout);
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -19,6 +19,13 @@ package org.graylog2.shared.rest.resources;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Stopwatch;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ConnectionCallback;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.HttpHeaders;
 import okhttp3.ResponseBody;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
@@ -32,16 +39,6 @@ import retrofit2.Response;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-
-import jakarta.ws.rs.container.AsyncResponse;
-import jakarta.ws.rs.container.ConnectionCallback;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.Cookie;
-import jakarta.ws.rs.core.HttpHeaders;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +46,7 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -363,6 +361,45 @@ public abstract class ProxiedResource extends RestResource {
             Class<RemoteInterfaceType> interfaceClass
     ) throws IOException {
         return requestOnLeader(remoteInterfaceFunction, interfaceClass, getDefaultProxyCallTimeout());
+    }
+
+    /**
+     * Execute the given remote interface function on the given node.
+     * <p>
+     * This is used to forward an API request to the given node. It is useful in situations where an API call has to
+     * be executed on a particular, chosen node.
+     * <p>
+     * The returned {@link NodeResponse} object is constructed from the remote response's status code and body.
+     */
+    protected <RemoteInterfaceType, RemoteCallResponseType> NodeResponse<RemoteCallResponseType> requestOnNode(
+            String nodeId,
+            Function<RemoteInterfaceType, Call<RemoteCallResponseType>> remoteInterfaceFunction,
+            Class<RemoteInterfaceType> interfaceClass,
+            Duration timeout
+    ) throws IOException {
+
+        final Node executionNode = nodeService.allActive().values().stream()
+                .filter(node -> Objects.equals(nodeId, node.getNodeId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Node cannot be found among active nodes, node id : " + nodeId));
+        return doNodeApiCall(executionNode.getNodeId(), interfaceClass, remoteInterfaceFunction, Function.identity(), timeout);
+
+    }
+
+    /**
+     * Execute the given remote interface function on the given node.
+     * <p>
+     * This is used to forward an API request to the given node. It is useful in situations where an API call has to
+     * be executed on a particular, chosen node.
+     * <p>
+     * The returned {@link NodeResponse} object is constructed from the remote response's status code and body.
+     */
+    protected <RemoteInterfaceType, RemoteCallResponseType> NodeResponse<RemoteCallResponseType> requestOnNode(
+            String nodeId,
+            Function<RemoteInterfaceType, Call<RemoteCallResponseType>> remoteInterfaceFunction,
+            Class<RemoteInterfaceType> interfaceClass
+    ) throws IOException {
+        return requestOnNode(nodeId, remoteInterfaceFunction, interfaceClass, getDefaultProxyCallTimeout());
     }
 
     protected <RemoteInterfaceType, RemoteCallResponseType, FinalResponseType> NodeResponse<FinalResponseType> doNodeApiCall(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
ProxiedResource can direct a call to any single node.
/nocl

## Motivation and Context
With this change, it would be possible to cancel a long-running async task started on a particular node by directing a separate cancel call to that node.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

