### PR TITLE
Metrics data streams: Prevent error when creating data stream < OS 2.11

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/datastream/policy/actions/RolloverAction.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datastream/policy/actions/RolloverAction.java
@@ -18,11 +18,7 @@ package org.graylog2.indexer.datastream.policy.actions;
 
 import javax.annotation.Nonnull;
 
-public record RolloverAction(@Nonnull String minIndexAge, boolean copyAlias) implements WrappedAction {
-
-    public RolloverAction(@Nonnull String minIndexAge) {
-        this(minIndexAge, false);
-    }
+public record RolloverAction(@Nonnull String minIndexAge) implements WrappedAction {
 
     @Override
     public Type getType() {


### PR DESCRIPTION
When creating a data stream on versions of OpenSearch earlier than 2.11, the following error occurs:

> “illegal_argument_exception”,“reason”:“Invalid field: [copy_alias] found in RolloverAction.”

This is because the `copy_alias` property was not supported until OpenSearch 2.11. See https://opensearch.org/docs/2.12/im-plugin/ism/policies/

This PR removes the property. With this change, I am able to create data streams successfully back to version `2.0.1`.

/nocl