### PR TITLE
Improve styling of documentation links on hover.

### DIFF
--- a/graylog2-web-interface/src/components/support/DocumentationLink.tsx
+++ b/graylog2-web-interface/src/components/support/DocumentationLink.tsx
@@ -25,6 +25,14 @@ import Icon from '../common/Icon';
 const Container = styled.a`
   display: inline-flex;
   align-items: center;
+
+  &:hover, &:focus {
+    text-decoration: none;
+
+    .documentation-link-text {
+      text-decoration: underline;
+    }
+  }
 `;
 
 const StyledIcon = styled(Icon)`
@@ -40,8 +48,12 @@ type Props = {
 
 const DocumentationLink = ({ page, title = '', text, displayIcon }: Props) => (
   <Container href={DocsHelper.toString(page)} title={title} target="_blank">
-    {text}
-    {displayIcon && <StyledIcon name="lightbulb_circle" type="regular" size="lg" />}
+    <span className="documentation-link-text">{text}</span>
+    {displayIcon && (
+      <StyledIcon name="lightbulb_circle"
+                  type="regular"
+                  size="lg" />
+    )}
   </Container>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/0fabc7e4-d7be-4ecd-95a0-26c45db3eb1d)


After:

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/349fb8cb-1c4b-49fb-a4a3-7a0e2318addb)


/nocl