### PR TITLE
Make `Timestamp` `dateTime` prop more explicit.

### DIFF
--- a/graylog2-web-interface/src/components/common/Timestamp.md
+++ b/graylog2-web-interface/src/components/common/Timestamp.md
@@ -40,3 +40,8 @@ import { DATE_TIME_FORMATS } from 'util/DateTime';
   </tbody>
 </table>
 ```
+
+#### Current time
+```tsx
+<Timestamp dateTime={new Date()} />
+```

--- a/graylog2-web-interface/src/components/common/Timestamp.test.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.test.tsx
@@ -43,20 +43,8 @@ describe('Timestamp', () => {
     expect(screen.getByText('2020-01-01T13:00:00.000+03:00')).toBeInTheDocument();
   });
 
-  it('should display current time, when date time is not defined', () => {
-    render(<Timestamp />);
-
-    expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
-  });
-
-  it('should display current time, when date time is undefined', () => {
-    render(<Timestamp dateTime={undefined} />);
-
-    expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
-  });
-
-  it('should display current time, when date time is null', () => {
-    render(<Timestamp dateTime={null} />);
+  it('should display current time', () => {
+    render(<Timestamp dateTime={new Date()} />);
 
     expect(screen.getByText('2020-01-01 01:00:00')).toBeInTheDocument();
   });

--- a/graylog2-web-interface/src/components/common/Timestamp.tsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.tsx
@@ -23,7 +23,7 @@ import useUserDateTime from 'hooks/useUserDateTime';
 import { adjustFormat } from 'util/DateTime';
 
 type Props = {
-  dateTime?: string | number | Date | Moment,
+  dateTime: string | number | Date | Moment | undefined,
   field?: string,
   format?: DateTimeFormats,
   render?: React.ComponentType<{ value: string, field: string | undefined }>,
@@ -41,9 +41,14 @@ type Props = {
  * from a UTC time that was used in the server.
  *
  */
-const Timestamp = ({ dateTime: dateTimeProp, field, format, render: Component, tz, className }: Props) => {
+const Timestamp = ({ dateTime, field, format, render: Component, tz, className }: Props) => {
   const { formatTime: formatWithUserTz } = useUserDateTime();
-  const dateTime = dateTimeProp ?? new Date();
+
+  if (!dateTime) {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <></>;
+  }
+
   const formattedDateTime = tz ? adjustFormat(dateTime, format, tz) : formatWithUserTz(dateTime, format);
   const dateTimeString = adjustFormat(dateTime, 'internal');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the `Timestamp` component displayed the current date, when the `dateTime` prop is not defined.
With this PR we are now displaying nothing, when the `dateTime` prop is empty. If you want to display the current date, you need to define it explicitly. In case you want to display a specific timestamp, which can be `undefined`, you now no longer end up in a state where you display the current time accidentally.

There are few cases where we actually want to display the current timestamp in these cases we already define `new Date()` for the `dateTime` prop.

/nocl