### PR TITLE
SearchJob is aware of executing node.

### DIFF
--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
@@ -105,7 +105,7 @@ public class ElasticsearchBackendErrorHandlingTest {
                 .queries(ImmutableSet.of(query))
                 .build();
 
-        this.searchJob = new SearchJob("job1", search, "admin");
+        this.searchJob = new SearchJob("job1", search, "admin", "test-node-id");
 
         this.queryContext = new ESGeneratedQueryContext(
                 this.backend,

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.elasticsearch7.views;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
@@ -51,8 +52,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import jakarta.inject.Provider;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,7 +110,7 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
                 .id("search1")
                 .queries(ImmutableSet.of(query))
                 .build();
-        return new SearchJob("job1", search, "admin");
+        return new SearchJob("job1", search, "admin", "test-node-id");
     }
 
     TimeRange timeRangeForTest() {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendTest.java
@@ -19,6 +19,7 @@ package org.graylog.storage.elasticsearch7.views;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
@@ -42,8 +43,6 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Before;
 import org.junit.Test;
-
-import jakarta.inject.Provider;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,7 +93,7 @@ public class ElasticsearchBackendTest {
                 .timerange(RelativeRange.create(300))
                 .build();
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
-        final SearchJob job = new SearchJob("deadbeef", search, "admin");
+        final SearchJob job = new SearchJob("deadbeef", search, "admin", "test-node-id");
 
         final ESGeneratedQueryContext queryContext = mock(ESGeneratedQueryContext.class);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7.views;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
@@ -47,8 +48,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import jakarta.inject.Provider;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -115,7 +114,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .id("search1")
                 .queries(ImmutableSet.of(query))
                 .build();
-        this.job = new SearchJob("job1", search, "admin");
+        this.job = new SearchJob("job1", search, "admin", "test-node-id");
     }
 
     @After
@@ -177,7 +176,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .filter(StreamFilter.ofId(streamId))
                 .build();
         final Search search = dummySearch(query);
-        final SearchJob job = new SearchJob("job1", search, "admin");
+        final SearchJob job = new SearchJob("job1", search, "admin", "test-node-id");
         final ESGeneratedQueryContext context = backend.generate(query, Collections.emptySet());
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
@@ -198,7 +197,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest {
                 .filter(AndFilter.and(StreamFilter.ofId("stream1"), StreamFilter.ofId("stream2")))
                 .build();
         final Search search = dummySearch(query);
-        final SearchJob job = new SearchJob("job1", search, "admin");
+        final SearchJob job = new SearchJob("job1", search, "admin", "test-node-id");
         final ESGeneratedQueryContext context = backend.generate(query, Collections.emptySet());
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendErrorHandlingTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendErrorHandlingTest.java
@@ -105,7 +105,7 @@ public class OpenSearchBackendErrorHandlingTest {
                 .queries(ImmutableSet.of(query))
                 .build();
 
-        this.searchJob = new SearchJob("job1", search, "admin");
+        this.searchJob = new SearchJob("job1", search, "admin", "test-node-id");
 
         this.queryContext = new OSGeneratedQueryContext(
                 this.backend,

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendGeneratedRequestTestBase.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.opensearch2.views;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
@@ -51,8 +52,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import jakarta.inject.Provider;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,7 +110,7 @@ public class OpenSearchBackendGeneratedRequestTestBase {
                 .id("search1")
                 .queries(ImmutableSet.of(query))
                 .build();
-        return new SearchJob("job1", search, "admin");
+        return new SearchJob("job1", search, "admin", "test-node-id");
     }
 
     TimeRange timeRangeForTest() {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendTest.java
@@ -19,6 +19,7 @@ package org.graylog.storage.opensearch2.views;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
@@ -42,8 +43,6 @@ import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Before;
 import org.junit.Test;
-
-import jakarta.inject.Provider;
 
 import java.util.Collections;
 import java.util.List;
@@ -93,7 +92,7 @@ public class OpenSearchBackendTest {
                 .timerange(RelativeRange.create(300))
                 .build();
         final Search search = Search.builder().queries(ImmutableSet.of(query)).build();
-        final SearchJob job = new SearchJob("deadbeef", search, "admin");
+        final SearchJob job = new SearchJob("deadbeef", search, "admin", "test-node-id");
 
         final OSGeneratedQueryContext queryContext = mock(OSGeneratedQueryContext.class);
 

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendUsingCorrectIndicesTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendUsingCorrectIndicesTest.java
@@ -18,6 +18,7 @@ package org.graylog.storage.opensearch2.views;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Provider;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
@@ -47,8 +48,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import jakarta.inject.Provider;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -115,7 +114,7 @@ public class OpenSearchBackendUsingCorrectIndicesTest {
                 .id("search1")
                 .queries(ImmutableSet.of(query))
                 .build();
-        this.job = new SearchJob("job1", search, "admin");
+        this.job = new SearchJob("job1", search, "admin", "test-node-id");
     }
 
     @After
@@ -177,7 +176,7 @@ public class OpenSearchBackendUsingCorrectIndicesTest {
                 .filter(StreamFilter.ofId(streamId))
                 .build();
         final Search search = dummySearch(query);
-        final SearchJob job = new SearchJob("job1", search, "admin");
+        final SearchJob job = new SearchJob("job1", search, "admin", "test-node-id");
         final OSGeneratedQueryContext context = backend.generate(query, Collections.emptySet());
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
@@ -198,7 +197,7 @@ public class OpenSearchBackendUsingCorrectIndicesTest {
                 .filter(AndFilter.and(StreamFilter.ofId("stream1"), StreamFilter.ofId("stream2")))
                 .build();
         final Search search = dummySearch(query);
-        final SearchJob job = new SearchJob("job1", search, "admin");
+        final SearchJob job = new SearchJob("job1", search, "admin", "test-node-id");
         final OSGeneratedQueryContext context = backend.generate(query, Collections.emptySet());
 
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import one.util.streamex.EntryStream;
@@ -35,11 +36,11 @@ import java.util.concurrent.CompletableFuture;
 // execution must come before results, as it signals the overall "done" state
 @JsonPropertyOrder({"execution", "results"})
 public class SearchJob implements ParameterProvider {
-    private final String id;
+
+    @JsonUnwrapped
+    private SearchJobIdentifier searchJobIdentifier;
 
     private final Search search;
-
-    private final String owner;
 
     private CompletableFuture<Void> resultFuture;
 
@@ -47,15 +48,14 @@ public class SearchJob implements ParameterProvider {
 
     private Set<SearchError> errors = Sets.newHashSet();
 
-    public SearchJob(String id, Search search, String owner) {
-        this.id = id;
+    public SearchJob(String id, Search search, String owner, String executingNodeId) {
         this.search = search;
-        this.owner = owner;
+        this.searchJobIdentifier = new SearchJobIdentifier(id, search.id(), owner, executingNodeId);
     }
 
     @JsonProperty
     public String getId() {
-        return id;
+        return searchJobIdentifier.id();
     }
 
     @JsonIgnore
@@ -63,14 +63,19 @@ public class SearchJob implements ParameterProvider {
         return search;
     }
 
+    @JsonIgnore
+    public SearchJobIdentifier getSearchJobIdentifier() {
+        return searchJobIdentifier;
+    }
+
     @JsonProperty("search_id")
     public String getSearchId() {
-        return search.id();
+        return searchJobIdentifier.searchId();
     }
 
     @JsonProperty
     public String getOwner() {
-        return owner;
+        return searchJobIdentifier.owner();
     }
 
     @JsonProperty("errors")

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJobIdentifier.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJobIdentifier.java
@@ -14,15 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.plugins.views.search.db;
+package org.graylog.plugins.views.search;
 
-import org.graylog.plugins.views.search.Search;
-import org.graylog.plugins.views.search.SearchJob;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Optional;
+public record SearchJobIdentifier(@JsonProperty String id,
+                                  @JsonProperty("search_id") String searchId,
+                                  @JsonProperty String owner,
+                                  @JsonProperty("executing_node") String executingNodeId) {
 
-public interface SearchJobService {
 
-    SearchJob create(Search search, String owner);
-    Optional<SearchJob> load(String id, String owner);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/InMemorySearchJobService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/InMemorySearchJobService.java
@@ -18,14 +18,12 @@ package org.graylog.plugins.views.search.db;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.types.ObjectId;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
-import org.graylog.plugins.views.search.Search;
-import org.graylog.plugins.views.search.SearchJob;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
+import org.graylog2.plugin.system.NodeId;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -35,9 +33,11 @@ import java.util.concurrent.TimeUnit;
 public class InMemorySearchJobService implements SearchJobService {
 
     private final Cache<String, SearchJob> cache;
+    private final NodeId nodeId;
 
     @Inject
-    public InMemorySearchJobService() {
+    public InMemorySearchJobService(final NodeId nodeId) {
+        this.nodeId = nodeId;
         cache = CacheBuilder.newBuilder()
                 .expireAfterAccess(5, TimeUnit.MINUTES)
                 .maximumSize(1000)
@@ -46,9 +46,10 @@ public class InMemorySearchJobService implements SearchJobService {
     }
 
     @Override
-    public SearchJob create(Search query, String owner) {
+    public SearchJob create(final Search search,
+                            final String owner) {
         final String id = new ObjectId().toHexString();
-        final SearchJob searchJob = new SearchJob(id, query, owner);
+        final SearchJob searchJob = new SearchJob(id, search, owner, nodeId.getNodeId());
         cache.put(id, searchJob);
         return searchJob;
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -20,9 +20,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.SearchJobIdentifier;
 import org.graylog.plugins.views.search.errors.SearchError;
 
 import java.util.Map;
@@ -32,14 +34,8 @@ import java.util.Set;
 @JsonAutoDetect
 @JsonPropertyOrder({"execution", "results"})
 public abstract class SearchJobDTO {
-    @JsonProperty
-    abstract String id();
-
-    @JsonProperty("search_id")
-    abstract String searchId();
-
-    @JsonProperty
-    abstract String owner();
+    @JsonUnwrapped
+    abstract SearchJobIdentifier searchJobIdentifier();
 
     @JsonProperty("errors")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -53,22 +49,16 @@ public abstract class SearchJobDTO {
 
     public static SearchJobDTO fromSearchJob(SearchJob searchJob) {
         return Builder.create()
-                .id(searchJob.getId())
-                .owner(searchJob.getOwner())
+                .searchJobIdentifier(searchJob.getSearchJobIdentifier())
                 .errors(searchJob.getErrors())
                 .results(searchJob.results())
-                .searchId(searchJob.getSearchId())
                 .execution(ExecutionInfo.fromExecutionInfo(searchJob.execution()))
                 .build();
     }
 
     @AutoValue.Builder
     abstract static class Builder {
-        abstract Builder id(String id);
-
-        abstract Builder searchId(String searchId);
-
-        abstract Builder owner(String owner);
+        abstract Builder searchJobIdentifier(SearchJobIdentifier searchJobIdentifier);
 
         abstract Builder errors(Set<SearchError> errors);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -21,6 +21,20 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.search.Search;
@@ -38,23 +52,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-
-import jakarta.validation.constraints.NotNull;
-
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
 import java.util.List;
@@ -164,7 +161,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
 
         final SearchJobDTO searchJobDTO = SearchJobDTO.fromSearchJob(searchJob);
 
-        return Response.created(URI.create(BASE_PATH + "/status/" + searchJobDTO.id()))
+        return Response.created(URI.create(BASE_PATH + "/status/" + searchJobDTO.searchJobIdentifier().id()))
                 .entity(searchJob)
                 .build();
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.engine;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.ws.rs.NotFoundException;
 import org.assertj.core.api.Condition;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
@@ -39,6 +40,7 @@ import org.graylog.plugins.views.search.rest.ExecutionStateGlobalOverride;
 import org.graylog.plugins.views.search.rest.TestSearchUser;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.rest.exceptions.MissingStreamPermissionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,8 +52,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import jakarta.ws.rs.NotFoundException;
-
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -61,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,6 +75,9 @@ public class SearchExecutorTest {
     @Mock
     private QueryEngine queryEngine;
 
+    @Mock
+    private NodeId nodeId;
+
     @Captor
     private ArgumentCaptor<SearchJob> searchJobCaptor;
 
@@ -81,7 +85,8 @@ public class SearchExecutorTest {
 
     @BeforeEach
     void setUp() {
-        final SearchJobService searchJobService = new InMemorySearchJobService();
+        doReturn("The-best-node").when(nodeId).getNodeId();
+        final SearchJobService searchJobService = new InMemorySearchJobService(nodeId);
         this.searchExecutor = new SearchExecutor(searchDomain,
                 searchJobService,
                 queryEngine,

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -18,6 +18,8 @@ package org.graylog.plugins.views.search.rest;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.Response;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
@@ -34,6 +36,7 @@ import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.rest.exceptions.MissingStreamPermissionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,9 +48,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import jakarta.ws.rs.ForbiddenException;
-import jakarta.ws.rs.core.Response;
-
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -83,13 +84,17 @@ public class SearchResourceExecutionTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private SearchUser searchUser;
 
+    @Mock
+    private NodeId nodeId;
+
     private SearchResource searchResource;
 
     private SearchJobService searchJobService;
 
     @BeforeEach
     public void setUp() {
-        this.searchJobService = new InMemorySearchJobService();
+        doReturn("The-best-node").when(nodeId).getNodeId();
+        this.searchJobService = new InMemorySearchJobService(nodeId);
         final SearchExecutor searchExecutor = new SearchExecutor(searchDomain,
                 searchJobService,
                 queryEngine,
@@ -159,7 +164,7 @@ public class SearchResourceExecutionTest {
 
         final SearchDTO search = makeSearchDTO();
 
-        final SearchJob searchJob = new SearchJob("deadbeef", search.toSearch(), "peterchen");
+        final SearchJob searchJob = new SearchJob("deadbeef", search.toSearch(), "peterchen", "The-best-node");
         searchJob.addQueryResultFuture("query", CompletableFuture.completedFuture(QueryResult.emptyResult()));
         searchJob.seal();
 
@@ -207,7 +212,7 @@ public class SearchResourceExecutionTest {
         final Response response = this.searchResource.executeSyncJob(search, 100, searchUser);
 
         final SearchJobDTO responseSearchJob = (SearchJobDTO) response.getEntity();
-        assertThat(responseSearchJob.owner()).isEqualTo("peterchen");
+        assertThat(responseSearchJob.searchJobIdentifier().owner()).isEqualTo("peterchen");
     }
 
     @Test
@@ -309,7 +314,7 @@ public class SearchResourceExecutionTest {
     }
 
     private SearchJob makeSearchJob(Search search) {
-        final SearchJob searchJob = new SearchJob("deadbeef", search, "peterchen");
+        final SearchJob searchJob = new SearchJob("deadbeef", search, "peterchen", "The-best-node");
         searchJob.addQueryResultFuture("query1", CompletableFuture.completedFuture(QueryResult.emptyResult()));
         searchJob.seal();
 


### PR DESCRIPTION
## Description
SearchJob is aware of executing node.
/jpd Graylog2/graylog-plugin-enterprise#6677
/nocl

## Motivation and Context
Status/cancel request will have to direct their calls to proper node, the one executing certain search job.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

