### PR TITLE
Allow overriding `events` search type pagination through execution state.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchTypeExecutionState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchTypeExecutionState.java
@@ -42,6 +42,12 @@ public abstract class SearchTypeExecutionState {
     @JsonProperty
     public abstract Optional<Integer> offset();
 
+    @JsonProperty
+    public abstract Optional<Integer> page();
+
+    @JsonProperty
+    public abstract Optional<Integer> perPage();
+    
     @Nullable
     @JsonProperty("after")
     public abstract List<Object> searchAfter();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchTypeExecutionState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchTypeExecutionState.java
@@ -47,7 +47,7 @@ public abstract class SearchTypeExecutionState {
 
     @JsonProperty
     public abstract Optional<Integer> perPage();
-    
+
     @Nullable
     @JsonProperty("after")
     public abstract List<Object> searchAfter();
@@ -63,6 +63,12 @@ public abstract class SearchTypeExecutionState {
         public abstract Builder limit(Integer limit);
         @JsonProperty
         public abstract Builder offset(Integer offset);
+
+        @JsonProperty
+        public abstract Builder page(Integer page);
+
+        @JsonProperty
+        public abstract Builder perPage(Integer perPage);
         @JsonProperty("after")
         public abstract Builder searchAfter(@Nullable List<Object> searchAfter);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -106,6 +106,13 @@ public abstract class EventList implements SearchType {
 
     @Override
     public SearchType applyExecutionContext(SearchTypeExecutionState state) {
+        if (state.page().isPresent() || state.perPage().isPresent()) {
+            final var builder = toBuilder();
+            state.page().ifPresent(builder::page);
+            state.perPage().ifPresent(builder::perPage);
+            return builder.build();
+        }
+
         return this;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding `page`/`per_page` parameters to the execution state and uses them in the `event` search type if present.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.