### PR TITLE
Support indexing internal data via the OutputBuffer

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -57,6 +57,7 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
     private static final Logger LOG = LoggerFactory.getLogger(OutputBufferProcessor.class);
 
     private static final String INCOMING_MESSAGES_METRICNAME = name(OutputBufferProcessor.class, "incomingMessages");
+    private static final String INCOMING_SYSTEM_MESSAGES_METRICNAME = name(OutputBufferProcessor.class, "incomingSystemMessages");
     private static final String PROCESS_TIME_METRICNAME = name(OutputBufferProcessor.class, "processTime");
 
     private final ExecutorService executor;
@@ -65,6 +66,7 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
     private final ServerStatus serverStatus;
 
     private final Meter incomingMessages;
+    private final Meter incomingSystemMessages;
     private final Counter outputThroughput;
     private final Timer processTime;
 
@@ -89,6 +91,7 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
         this.executor = executorService(globalMetricRegistry, corePoolSize);
 
         this.incomingMessages = globalMetricRegistry.meter(INCOMING_MESSAGES_METRICNAME);
+        this.incomingSystemMessages = globalMetricRegistry.meter(INCOMING_SYSTEM_MESSAGES_METRICNAME);
         this.outputThroughput = globalMetricRegistry.counter(GlobalMetricNames.OUTPUT_THROUGHPUT);
         this.processTime = globalMetricRegistry.timer(PROCESS_TIME_METRICNAME);
     }
@@ -149,14 +152,18 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
      */
     @Override
     public void onEvent(MessageEvent event) throws Exception {
-        incomingMessages.mark();
-
         final Message msg = event.getMessage();
         if (msg == null) {
             LOG.debug("Skipping null message.");
             return;
         }
         LOG.trace("Processing message <{}> from OutputBuffer.", msg.getId());
+
+        if (msg.isSystemMessage()) {
+            incomingSystemMessages.mark();
+        } else {
+            incomingMessages.mark();
+        }
 
         final Set<MessageOutput> messageOutputs = outputRouter.getStreamOutputsForMessage(msg);
         msg.recordCounter(serverStatus, "matched-outputs", messageOutputs.size());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResultCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexingResultCallback.java
@@ -16,12 +16,7 @@
  */
 package org.graylog2.indexer.messages;
 
-public interface IndexingResult {
-    Indexable message();
+import java.util.function.Consumer;
 
-    String index();
-
-    default boolean isSuccess() {
-        return this instanceof IndexingSuccess;
-    }
+public interface IndexingResultCallback extends Consumer<IndexingResult> {
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -26,6 +26,8 @@ import com.github.rholder.retry.WaitStrategies;
 import com.github.rholder.retry.WaitStrategy;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog.failure.FailureSubmissionService;
 import org.graylog2.indexer.InvalidWriteTargetException;
 import org.graylog2.indexer.MasterNotDiscoveredException;
@@ -36,10 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -20,7 +20,8 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public final class GlobalMetricNames {
 
-    private GlobalMetricNames() {}
+    private GlobalMetricNames() {
+    }
 
     public static final String OLDEST_SEGMENT_SUFFIX = "oldest-segment";
     public static final String RATE_SUFFIX = "1-sec-rate";
@@ -43,6 +44,7 @@ public final class GlobalMetricNames {
 
     public static final String OUTPUT_BUFFER_USAGE = "org.graylog2.buffers.output.usage";
     public static final String OUTPUT_BUFFER_SIZE = "org.graylog2.buffers.output.size";
+    public static final String OUTPUT_BUFFER_RATELIMIT = "org.graylog2.buffers.output.ratelimit";
 
     public static final String JOURNAL_APPEND_RATE = name("org.graylog2.journal.append", RATE_SUFFIX);
     public static final String JOURNAL_READ_RATE = name("org.graylog2.journal.read", RATE_SUFFIX);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -37,6 +37,8 @@ import org.graylog.failure.FailureCause;
 import org.graylog.failure.ProcessingFailureCause;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.messages.Indexable;
+import org.graylog2.indexer.messages.IndexingResult;
+import org.graylog2.indexer.messages.IndexingResultCallback;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.utilities.date.DateTimeConverter;
 import org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory;
@@ -322,6 +324,9 @@ public class Message implements Messages, Indexable {
      */
     private Map<String, Object> metadata;
 
+    private final static String SYSTEM_MESSAGE_METADATA_FLAG = "is-system-message";
+    private final static String SYSTEM_MESSAGE_INDEXING_RESULT_CALLBACK = "indexing-result-callback";
+
     private com.codahale.metrics.Counter sizeCounter = new com.codahale.metrics.Counter();
 
     private List<ProcessingError> processingErrors;
@@ -367,6 +372,26 @@ public class Message implements Messages, Indexable {
 
     public Message(final Map<String, Object> fields) {
         this((String) fields.get(FIELD_ID), Maps.filterKeys(fields, not(equalTo(FIELD_ID))));
+    }
+
+    /**
+     * Creates a Message that is used for System purposes like restoring Archives.
+     * The message has the following properties:
+     * <ul>
+     *  <li>A size of 0, so its traffic is not accounted</li>
+     *  <li>A single predetermined IndexSet</li>
+     *  <li>No streams, so it will only be routed to the {@link org.graylog2.outputs.DefaultMessageOutput}</li>
+     *  <li>Returns true to {@link #isSystemMessage()}</li>
+     * </ul>
+     */
+    public static Message createSystemMessage(@Nonnull String id, @Nonnull IndexSet indexSet, Map<String, Object> fields) {
+        var message = new Message(id, fields);
+        message.sizeCounter = new com.codahale.metrics.Counter();
+        message.indexSets = Set.of(indexSet);
+        message.streams = Set.of();
+        message.markAsSystemMessage();
+
+        return message;
     }
 
     private Message(String id, Map<String, Object> newFields) {
@@ -927,6 +952,29 @@ public class Message implements Messages, Indexable {
 
     private boolean shouldNotRecord(ServerStatus serverStatus) {
         return !serverStatus.getDetailedMessageRecordingStrategy().shouldRecord(this);
+    }
+
+    private void markAsSystemMessage() {
+        setMetadata(SYSTEM_MESSAGE_METADATA_FLAG, true);
+    }
+
+    public boolean isSystemMessage() {
+        return getMetadataValue(SYSTEM_MESSAGE_METADATA_FLAG) != null;
+    }
+
+    public void registerIndexingResultCallback(IndexingResultCallback callback) {
+        setMetadata(SYSTEM_MESSAGE_INDEXING_RESULT_CALLBACK, callback);
+    }
+
+    public boolean hasIndexingResultCallback() {
+        return getMetadataValue(SYSTEM_MESSAGE_INDEXING_RESULT_CALLBACK) != null;
+    }
+
+    public void runIndexingResultCallback(IndexingResult result) {
+        var callBack = getMetadataValue(SYSTEM_MESSAGE_INDEXING_RESULT_CALLBACK);
+        if (callBack instanceof IndexingResultCallback indexingResultCallback) {
+            indexingResultCallback.accept(result);
+        }
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/plugin/buffers/Buffer.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/buffers/Buffer.java
@@ -56,6 +56,10 @@ public abstract class Buffer implements EventBuffer {
         return (long) ringBuffer.getBufferSize() - ringBuffer.remainingCapacity();
     }
 
+    public int getUsagePercent() {
+        return (int) (getUsage() * 100 / getRingBufferSize());
+    }
+
     protected void insert(Message message) {
         long sequence = ringBuffer.next();
         MessageEvent event = ringBuffer.get(sequence);
@@ -78,7 +82,7 @@ public abstract class Buffer implements EventBuffer {
                 return new BusySpinWaitStrategy();
             default:
                 log.warn("Invalid setting for [{}]:"
-                                + " Falling back to default: BlockingWaitStrategy.", configOptionName);
+                        + " Falling back to default: BlockingWaitStrategy.", configOptionName);
                 return new BlockingWaitStrategy();
         }
     }
@@ -91,7 +95,7 @@ public abstract class Buffer implements EventBuffer {
         long lo = hi - (length - 1);
         for (long sequence = lo; sequence <= hi; sequence++) {
             MessageEvent event = ringBuffer.get(sequence);
-            event.setMessage(messages[(int)(sequence - lo)]);
+            event.setMessage(messages[(int) (sequence - lo)]);
         }
         ringBuffer.publish(lo, hi);
         afterInsert(length);


### PR DESCRIPTION
This is needed to allow us to restore Archives by using the common OutputBuffer.

Sharing the Output buffer with the regluar Messages gives us backpressure and the possibility for a self regulating rate limit for Archiving.

