### PR TITLE
delete ism policy if an error occurs on reading

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/DataStreamAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/DataStreamAdapterOS2.java
@@ -120,7 +120,15 @@ public class DataStreamAdapterOS2 implements DataStreamAdapter {
         if (Objects.isNull(id)) {
             throw new IllegalArgumentException("Policy Id may not be null");
         }
-        final Optional<IsmPolicy> osPolicy = ismApi.getPolicy(id);
+        Optional<IsmPolicy> osPolicy;
+        try {
+            osPolicy = ismApi.getPolicy(id);
+        } catch (Exception e) {
+            // delete non-readable policies
+            ismApi.removePolicyFromIndex(dataStreamName);
+            ismApi.deletePolicy(id);
+            osPolicy = Optional.empty();
+        }
         if (osPolicy.isPresent()) {
             ismApi.removePolicyFromIndex(dataStreamName);
             ismApi.deletePolicy(id);


### PR DESCRIPTION
## Description
When ISM policies are created, an existing policy with the given id will be loaded first. If this is present, it is removed from the data stream and deleted before the new policy is created and applied.
If the policy cannot be read, e.g. due to data model changes, the new policy won't be applied.

This PR tries to delete also policies which can't be read.

/nocl

## Motivation and Context
change to RolloverAction caused existing ISM policies in the data node to not be read.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

