### PR TITLE
Fix debouncing async functions. (`5.1`)

### DIFF
--- a/changelog/unreleased/pr-18467.toml
+++ b/changelog/unreleased/pr-18467.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix potential deadlock in async query string validation."
+
+issues = ["16883"]
+pulls = ["18467"]

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -80,6 +80,7 @@
     "moment-precise-range-plugin": "^1.3.0",
     "mousetrap": "^1.6.5",
     "numeral": "^2.0.6",
+    "p-debounce": "^4.0.0",
     "plotly.js": "2.21.0",
     "posthog-js": "^1.52.0",
     "promise-polyfill": "^8.2.0",

--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -59,5 +59,5 @@ module.exports = {
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',
   },
-  transformIgnorePatterns: ['node_modules/(?!(@react-hook|uuid|@?react-leaflet|jest-preset-graylog|graylog-web-plugin)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(@react-hook|uuid|@?react-leaflet|jest-preset-graylog|graylog-web-plugin|p-debounce)/)'],
 };

--- a/graylog2-web-interface/src/views/logic/debounceWithPromise.test.ts
+++ b/graylog2-web-interface/src/views/logic/debounceWithPromise.test.ts
@@ -14,8 +14,26 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import debounce from 'p-debounce';
+import debounceWithPromise from './debounceWithPromise';
 
-const debounceWithPromise = debounce;
+describe('debounceWithPromise', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
 
-export default debounceWithPromise;
+  it('never returns a pending promise', async () => {
+    const fn = jest.fn(async (attempt: number) => attempt);
+
+    const debouncedFn = debounceWithPromise(fn, 300);
+
+    const result1 = debouncedFn(1);
+    const result2 = debouncedFn(2);
+    const result3 = debouncedFn(3);
+
+    jest.advanceTimersByTime(400);
+
+    await expect(result1).resolves.toBe(3);
+    await expect(result2).resolves.toBe(3);
+    await expect(result3).resolves.toBe(3);
+  });
+});

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -11121,6 +11121,11 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+p-debounce@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-4.0.0.tgz#348e3f44489baa9435cc7d807f17b3bb2fb16b24"
+  integrity sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A==
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"


### PR DESCRIPTION
**Note:** This is a backport of #18450 to `5.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the debounceWithPromise function. Previously, it was using lodash/debounce to promisify debouncing async functions. Unfortunately, due to limitations of lodash/debounce, it will lead to first invocations of the function that is debounced to return promises which are never resolved, leading to suble bugs like #16883.

This PR is solving this using p-debounce, which is tailored for debouncing async functions and does not have the same limitations as lodash/debounce.

Fixes #16883.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.