### PR TITLE
Fixing problem with query input which can make the search bar disappear

### DIFF
--- a/changelog/unreleased/issue-18053.toml
+++ b/changelog/unreleased/issue-18053.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing problem with query input which can make the search bar disappear."
+
+issues = ["18053"]
+pulls = ["18470"]

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -19,7 +19,7 @@ import { useCallback, useMemo, useContext, useRef, useImperativeHandle } from 'r
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import type { FormikErrors } from 'formik';
-import { createGlobalStyle } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
@@ -51,6 +51,14 @@ const GlobalEditorStyles = createGlobalStyle<{ $width?: number; $offsetLeft: num
     left: ${(props) => (props.$offsetLeft ?? 143) + 7}px !important;
   }
 `;
+
+const Container = styled.div<{ $hasValue: boolean }>(({ $hasValue }) => css`
+  width: 100%;
+
+  .ace_hidden-cursors {
+    display: ${$hasValue ? 'block' : 'none'};
+  }
+`);
 
 const displayValidationErrors = () => {
   QueryValidationActions.displayValidationErrors();
@@ -323,7 +331,7 @@ const QueryInput = React.forwardRef<Editor, Props>(({
   useImperativeHandle(outerRef, () => innerRef.current, []);
 
   return (
-    <>
+    <Container $hasValue={!!value}>
       <GlobalEditorStyles $width={inputWidth} $offsetLeft={inputElement?.offsetLeft} />
       <BasicQueryInput height={height}
                        className={className}
@@ -342,7 +350,7 @@ const QueryInput = React.forwardRef<Editor, Props>(({
                        value={value}
                        wrapEnabled={wrapEnabled} />
 
-    </>
+    </Container>
   );
 });
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
@@ -27,7 +27,7 @@ type Props = {
   disabled: boolean,
 };
 
-const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled, value }) => css`
+const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled }) => css`
   &.ace-queryinput {
     ${$height ? `height: ${$height}px !important` : ''}
     min-height: 34px;
@@ -54,10 +54,6 @@ const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled,
     .ace_cursor {
       color: ${$scTheme.colors.gray[50]};
       display: ${disabled ? 'none' : 'block'} !important;
-    }
-
-    .ace_hidden-cursors {
-      display: ${value ? 'block' : 'none'};
     }
 
     .ace_marker-layer .ace_selection {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As reported in https://github.com/Graylog2/graylog2-server/issues/18053 and https://github.com/Graylog2/graylog-plugin-enterprise/issues/6627 the search bar can disappear when deleting the query input and triggering the "Add to query" action, multiple times.

The reason seems to be: We are using styled-components to style the editor, styled-components defines a CSS `class` for the main editor DOM element. Since the component styling implements the editor value (as a boolean), styled-components generates a new CSS `class` once the editor value gets defined or is being cleared.

Changing the editor CSS classes seems to be problematic for the `react-ace` component. https://github.com/securingsincity/react-ace/issues/823 

It can result in an essential ace-editor CSS `class` being removed, which breaks the styling.

With this PR we are fixing the behaviour by no longer referencing the value in the component styling and defining the styling in a parent component.

Fixes https://github.com/Graylog2/graylog2-server/issues/18053, https://github.com/Graylog2/graylog-plugin-enterprise/issues/6627