### PR TITLE
SearchType.Result implementations have to support deserialization

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -53,6 +53,7 @@ public abstract class MessageList implements SearchType {
     public static final String NAME = "messages";
 
     @Override
+    @JsonProperty
     public abstract String type();
 
     @Override
@@ -203,6 +204,8 @@ public abstract class MessageList implements SearchType {
 
     @AutoValue
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    @JsonDeserialize(builder = Result.Builder.class)
+    @JsonTypeName(MessageList.NAME)
     public abstract static class Result implements SearchType.Result {
 
         @Override
@@ -210,10 +213,7 @@ public abstract class MessageList implements SearchType {
         public abstract String id();
 
         @Override
-        @JsonProperty
-        public String type() {
-            return NAME;
-        }
+        public abstract String type();
 
         @JsonProperty
         public abstract List<ResultMessageSummary> messages();
@@ -228,7 +228,7 @@ public abstract class MessageList implements SearchType {
         public abstract long totalResults();
 
         public static Builder builder() {
-            return new AutoValue_MessageList_Result.Builder();
+            return new AutoValue_MessageList_Result.Builder().type(MessageList.NAME);
         }
 
         public static Builder result(String searchTypeId) {
@@ -237,16 +237,31 @@ public abstract class MessageList implements SearchType {
 
         @AutoValue.Builder
         public abstract static class Builder {
+
+            @JsonCreator
+            public static Result.Builder create() {
+                return new AutoValue_MessageList_Result.Builder().type(MessageList.NAME);
+            }
+
+            @JsonProperty
             public abstract Builder id(String id);
 
+            @JsonProperty
             public abstract Builder name(@Nullable String name);
 
+            @JsonProperty
+            public abstract Builder type(String type);
+
+            @JsonProperty
             public abstract Builder messages(List<ResultMessageSummary> messages);
 
+            @JsonProperty
             public abstract Builder totalResults(long totalResults);
 
+            @JsonProperty
             public abstract Builder decorationStats(DecorationStats decorationStats);
 
+            @JsonProperty
             public abstract Builder effectiveTimerange(AbsoluteRange effectiveTimerange);
 
             public abstract Result build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -203,6 +203,8 @@ public abstract class EventList implements SearchType {
     }
 
     @AutoValue
+    @JsonTypeName(EventList.NAME)
+    @JsonDeserialize(builder = EventList.Result.Builder.class)
     public abstract static class Result implements SearchType.Result {
         @Override
         @JsonProperty
@@ -210,15 +212,13 @@ public abstract class EventList implements SearchType {
 
         @Override
         @JsonProperty
-        public String type() {
-            return NAME;
-        }
+        public abstract String type();
 
         @JsonProperty
         public abstract List<CommonEventSummary> events();
 
         public static Builder builder() {
-            return new AutoValue_EventList_Result.Builder();
+            return new AutoValue_EventList_Result.Builder().type(EventList.NAME);
         }
 
         abstract Builder toBuilder();
@@ -233,10 +233,21 @@ public abstract class EventList implements SearchType {
 
         @AutoValue.Builder
         public abstract static class Builder {
+            @JsonCreator
+            public static Builder create() {
+                return new AutoValue_EventList_Result.Builder().type(EventList.NAME);
+            }
+
+            @JsonProperty
             public abstract Builder id(String id);
 
+            @JsonProperty
             public abstract Builder name(String name);
 
+            @JsonProperty
+            public abstract Builder type(String type);
+
+            @JsonProperty
             public abstract Builder events(List<CommonEventSummary> events);
 
             public abstract Result build();


### PR DESCRIPTION
## Description
SearchType.Result implementations have to support deserialization.
/nocl

## Motivation and Context
Because of a need to use those classes in a remote calls, they have to support not only serialization, but deserialization as well.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

