### PR TITLE
Consider `http_external_uri` when setting the cookie path

### DIFF
--- a/changelog/unreleased/pr-18472.toml
+++ b/changelog/unreleased/pr-18472.toml
@@ -1,0 +1,4 @@
+type = "changed"
+message = "Consider `http_external_uri`when setting the cookie path."
+
+pulls = ["18472"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
@@ -16,17 +16,18 @@
  */
 package org.graylog2.shared.bindings;
 
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
+import jakarta.ws.rs.container.DynamicFeature;
 import org.graylog2.Configuration;
 import org.graylog2.plugin.PluginModule;
 import org.graylog2.rest.resources.RestResourcesModule;
+import org.graylog2.rest.resources.system.CookieFactory;
 import org.graylog2.shared.rest.resources.RestResourcesSharedModule;
 import org.graylog2.shared.security.ShiroSecurityBinding;
 import org.graylog2.web.IndexHtmlGenerator;
 import org.graylog2.web.IndexHtmlGeneratorProvider;
 import org.graylog2.web.resources.WebResourcesModule;
-
-import jakarta.ws.rs.container.DynamicFeature;
 
 public class RestApiBindings extends PluginModule {
     private final Configuration configuration;
@@ -48,6 +49,7 @@ public class RestApiBindings extends PluginModule {
         jobResourceHandlerBinder();
 
         bind(IndexHtmlGenerator.class).toProvider(IndexHtmlGeneratorProvider.class);
+        bind(CookieFactory.class).in(Scopes.SINGLETON);
 
         // Install all resource modules
         install(new WebResourcesModule());

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/CookieFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/CookieFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.rest.resources.system;
 
 import com.github.joschi.jadconfig.JadConfig;

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/CookieFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/CookieFactoryTest.java
@@ -1,0 +1,94 @@
+package org.graylog2.rest.resources.system;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.models.system.sessions.responses.SessionResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CookieFactoryTest {
+
+    @Mock
+    SessionResponse sessionResponse;
+
+    @Mock
+    ContainerRequest containerRequest;
+
+    @BeforeEach
+    void setUp() {
+        when(sessionResponse.getAuthenticationToken()).thenReturn("secret-auth-value");
+        when(sessionResponse.validUntil()).thenReturn(new Date());
+        when(containerRequest.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+    }
+
+    @Test
+    void defaultPath() {
+        final CookieFactory cookieFactory = new CookieFactory(new HttpConfiguration());
+        final NewCookie cookie = cookieFactory.createAuthenticationCookie(sessionResponse, containerRequest);
+
+        assertThat(cookie.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    void pathFromConfig() throws Exception {
+        final HttpConfiguration httpConfiguration = new HttpConfiguration();
+        new JadConfig(new InMemoryRepository(
+                Map.of("http_external_uri", "http://graylog.local/path/from/config/")), httpConfiguration)
+                .process();
+
+        System.out.println(httpConfiguration.getHttpExternalUri());
+
+        final CookieFactory cookieFactory = new CookieFactory(httpConfiguration);
+        final NewCookie cookie = cookieFactory.createAuthenticationCookie(sessionResponse, containerRequest);
+
+        assertThat(cookie.getPath()).isEqualTo("/path/from/config/");
+    }
+
+    @Test
+    void pathFromRequest() {
+        containerRequest.getHeaders().put(HttpConfiguration.OVERRIDE_HEADER,
+                List.of("http://graylog.local/path/from/request/"));
+
+        final CookieFactory cookieFactory = new CookieFactory(new HttpConfiguration());
+        final NewCookie cookie = cookieFactory.createAuthenticationCookie(sessionResponse, containerRequest);
+
+        assertThat(cookie.getPath()).isEqualTo("/path/from/request/");
+    }
+
+    @Test
+    void safePath() {
+        containerRequest.getHeaders().put(HttpConfiguration.OVERRIDE_HEADER,
+                List.of("http://graylog.local/path/;authentication=overridden-auth-value;"));
+
+        final CookieFactory cookieFactory = new CookieFactory(new HttpConfiguration());
+        final NewCookie cookie = cookieFactory.createAuthenticationCookie(sessionResponse, containerRequest);
+
+
+        final String cookieString =
+                RuntimeDelegate.getInstance().createHeaderDelegate(NewCookie.class).toString(cookie);
+
+        final Cookie parsedCookie =
+                RuntimeDelegate.getInstance().createHeaderDelegate(Cookie.class).fromString(cookieString);
+
+        assertThat(parsedCookie.getName()).isEqualTo("authentication");
+        assertThat(parsedCookie.getValue()).isEqualTo("secret-auth-value");
+        assertThat(cookie.getPath()).isEqualTo("/path/authentication=overridden-auth-value/");
+    }
+}


### PR DESCRIPTION
Changes which path is chosen to populate the `Path` attribute in the authentication cookie.

Previously, the path was chosen as follows, highest priority first:

1. The path from the URL in the `X-Graylog-Server-URL` request header
2. The path from the `Origin` request header
3. `/`

With this PR, the value will be chosen as follows:
1. The path from the URL in the `X-Graylog-Server-URL` request header
2. The path from the `http_external_uri` configuration setting
3. `/`

The `Origin` header does not contain a path. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin):

> The Origin header is similar to the [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) header, but does not disclose the path, and may be null.

It was therefore removed as a potential source for the `Path` attribute.

The `http_external_url` does however provide a relevant value for restricting the cookie path. It will therefore now be considered.

Furthermore, to prevent the injection of cookie values via the `X-Graylog-Server-URL` header, all characters that are not valid for the `Path` attribute are now stripped.
