### PR TITLE
Fixing problem with query input which can make the search bar disappear (`5.2`)

### DIFF
--- a/changelog/unreleased/issue-18053.toml
+++ b/changelog/unreleased/issue-18053.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing problem with query input which can make the search bar disappear."
+
+issues = ["18053"]
+pulls = ["18470"]

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -19,6 +19,7 @@ import { useCallback, useMemo, useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import type { FormikErrors } from 'formik';
+import styled, { css } from 'styled-components';
 
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
 import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
@@ -41,19 +42,27 @@ import type { Completer, FieldTypes } from '../SearchBarAutocompletions';
 
 const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBarAutoCompletions>) => new SearchBarAutoCompletions(...args);
 
+const Container = styled.div<{ $hasValue: boolean }>(({ $hasValue }) => css`
+  width: 100%;
+
+  .ace_hidden-cursors {
+    display: ${$hasValue ? 'block' : 'none'};
+  }
+`);
+
 const displayValidationErrors = () => {
   QueryValidationActions.displayValidationErrors();
 };
 
 const handleExecution = ({
-  editor,
-  onExecute,
-  value,
-  error,
-  disableExecution,
-  isValidating,
-  validate,
-}: {
+                           editor,
+                           onExecute,
+                           value,
+                           error,
+                           disableExecution,
+                           isValidating,
+                           validate,
+                         }: {
   editor: Editor,
   onExecute: (query: string) => void,
   value: string,
@@ -189,27 +198,27 @@ type Props = BaseProps & {
 };
 
 const QueryInput = ({
-  className,
-  commands,
-  completerFactory = defaultCompleterFactory,
-  disableExecution,
-  error,
-  height,
-  inputId,
-  isValidating,
-  maxLines,
-  onBlur,
-  onChange,
-  onExecute: onExecuteProp,
-  placeholder,
-  streams,
-  timeRange,
-  value,
-  validate,
-  warning,
-  wrapEnabled,
-  name,
-}: Props) => {
+                      className,
+                      commands,
+                      completerFactory = defaultCompleterFactory,
+                      disableExecution,
+                      error,
+                      height,
+                      inputId,
+                      isValidating,
+                      maxLines,
+                      onBlur,
+                      onChange,
+                      onExecute: onExecuteProp,
+                      placeholder,
+                      streams,
+                      timeRange,
+                      value,
+                      validate,
+                      warning,
+                      wrapEnabled,
+                      name,
+                    }: Props) => {
   const { userTimezone } = useUserDateTime();
   const isInitialTokenizerUpdate = useRef(true);
   const { enableSmartSearch } = useContext(UserPreferencesContext);
@@ -237,22 +246,24 @@ const QueryInput = ({
   }, [name, onChange]);
 
   return (
-    <BasicQueryInput height={height}
-                     className={className}
-                     disabled={false}
-                     enableAutocompletion={enableSmartSearch}
-                     error={error}
-                     inputId={inputId}
-                     warning={warning}
-                     maxLines={maxLines}
-                     onBlur={onBlur}
-                     onExecute={onExecute}
-                     onChange={_onChange}
-                     onLoad={onLoadEditor}
-                     placeholder={placeholder}
-                     ref={updateEditorConfiguration}
-                     value={value}
-                     wrapEnabled={wrapEnabled} />
+    <Container $hasValue={!!value}>
+      <BasicQueryInput height={height}
+                       className={className}
+                       disabled={false}
+                       enableAutocompletion={enableSmartSearch}
+                       error={error}
+                       inputId={inputId}
+                       warning={warning}
+                       maxLines={maxLines}
+                       onBlur={onBlur}
+                       onExecute={onExecute}
+                       onChange={_onChange}
+                       onLoad={onLoadEditor}
+                       placeholder={placeholder}
+                       ref={updateEditorConfiguration}
+                       value={value}
+                       wrapEnabled={wrapEnabled} />
+    </Container>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -55,14 +55,14 @@ const displayValidationErrors = () => {
 };
 
 const handleExecution = ({
-                           editor,
-                           onExecute,
-                           value,
-                           error,
-                           disableExecution,
-                           isValidating,
-                           validate,
-                         }: {
+  editor,
+  onExecute,
+  value,
+  error,
+  disableExecution,
+  isValidating,
+  validate,
+}: {
   editor: Editor,
   onExecute: (query: string) => void,
   value: string,
@@ -198,27 +198,27 @@ type Props = BaseProps & {
 };
 
 const QueryInput = ({
-                      className,
-                      commands,
-                      completerFactory = defaultCompleterFactory,
-                      disableExecution,
-                      error,
-                      height,
-                      inputId,
-                      isValidating,
-                      maxLines,
-                      onBlur,
-                      onChange,
-                      onExecute: onExecuteProp,
-                      placeholder,
-                      streams,
-                      timeRange,
-                      value,
-                      validate,
-                      warning,
-                      wrapEnabled,
-                      name,
-                    }: Props) => {
+  className,
+  commands,
+  completerFactory = defaultCompleterFactory,
+  disableExecution,
+  error,
+  height,
+  inputId,
+  isValidating,
+  maxLines,
+  onBlur,
+  onChange,
+  onExecute: onExecuteProp,
+  placeholder,
+  streams,
+  timeRange,
+  value,
+  validate,
+  warning,
+  wrapEnabled,
+  name,
+}: Props) => {
   const { userTimezone } = useUserDateTime();
   const isInitialTokenizerUpdate = useRef(true);
   const { enableSmartSearch } = useContext(UserPreferencesContext);

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
@@ -27,7 +27,7 @@ type Props = {
   disabled: boolean,
 };
 
-const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled, value }) => css`
+const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled }) => css`
   &.ace-queryinput {
     ${$height ? `height: ${$height}px !important` : ''}
     min-height: 34px;
@@ -54,10 +54,6 @@ const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled,
     .ace_cursor {
       color: ${$scTheme.colors.gray[50]};
       display: ${disabled ? 'none' : 'block'} !important;
-    }
-
-    .ace_hidden-cursors {
-      display: ${value ? 'block' : 'none'};
     }
 
     .ace_marker-layer .ace_selection {


### PR DESCRIPTION
_Please note_: This is a backport of #18470 for `5.2`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As reported in https://github.com/Graylog2/graylog2-server/issues/18053 and https://github.com/Graylog2/graylog-plugin-enterprise/issues/6627 the search bar can disappear when deleting the query input and triggering the "Add to query" action, multiple times.

The reason seems to be: We are using styled-components to style the editor, styled-components defines a CSS `class` for the main editor DOM element. Since the component styling implements the editor value (as a boolean), styled-components generates a new CSS `class` once the editor value gets defined or is being cleared.

Changing the editor CSS classes seems to be problematic for the `react-ace` component. https://github.com/securingsincity/react-ace/issues/823 

It can result in an essential ace-editor CSS `class` being removed, which breaks the styling.

With this PR we are fixing the behaviour by no longer referencing the value in the component styling and defining the styling in a parent component.

Fixes https://github.com/Graylog2/graylog2-server/issues/18053, https://github.com/Graylog2/graylog-plugin-enterprise/issues/6627