### PR TITLE
Calculate journal size estimate for data node migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
@@ -59,4 +59,5 @@ public interface MigrationActions {
 
     void requestMigrationStatus();
 
+    void calculateTrafficEstimate();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/TrafficSnapshot.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/TrafficSnapshot.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.actions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TrafficSnapshot(@JsonProperty("start_bytes") long startInputBytes,
+                              @JsonProperty("start_ts") long startTimestamp) {
+
+    public static final String TRAFFIC_SNAPSHOT = "traffic_snapshot";
+    public static final String ESTIMATED_TRAFFIC_PER_MINUTE = "estimated_traffic";
+
+    public TrafficSnapshot(long startInputBytes) {
+        this(startInputBytes, System.currentTimeMillis());
+    }
+
+    public long calculateEstimatedTrafficPerMinute(long currentInputBytes) {
+        return calculateEstimatedTrafficPerMinute(currentInputBytes, System.currentTimeMillis());
+    }
+
+    long calculateEstimatedTrafficPerMinute(long currentInputBytes, long endTimestamp) {
+        double elapsedTimeMin = (endTimestamp - startTimestamp) / (double) (1000 * 60);
+        long inputTraffic = currentInputBytes - startInputBytes;
+        return (long) (inputTraffic / elapsedTimeMin);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
@@ -112,6 +112,7 @@ public class MigrationStateMachineBuilder {
                 .permitIf(MigrationStep.CALCULATE_JOURNAL_SIZE, MigrationState.JOURNAL_SIZE_DOWNTIME_WARNING, migrationActions::provisioningFinished);
 
         config.configure(MigrationState.JOURNAL_SIZE_DOWNTIME_WARNING)
+                .onEntry(migrationActions::calculateTrafficEstimate)
                 .permit(MigrationStep.SHOW_STOP_PROCESSING_PAGE, MigrationState.MESSAGE_PROCESSING_STOP, migrationActions::stopMessageProcessing);
 
         config.configure(MigrationState.MESSAGE_PROCESSING_STOP)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineContext.java
@@ -19,8 +19,10 @@ package org.graylog.plugins.views.storage.migration.state.machine;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -96,6 +98,13 @@ public class MigrationStateMachineContext {
         }
         Object value = this.extendedState.get(name);
         if (!type.isInstance(value)) {
+            if (value instanceof LinkedHashMap<?, ?> map) {
+                try {
+                    return Optional.of(new ObjectMapper().convertValue(map, type));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Argument " + name + " must be of type " + type);
+                }
+            }
             throw new IllegalArgumentException("Argument " + name + " must be of type " + type);
         }
         return Optional.of((T) value);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
@@ -40,6 +40,7 @@ public class MigrationStateMachineImpl implements MigrationStateMachine {
         this.migrationActions = migrationActions;
         this.persistenceService = persistenceService;
         this.context = persistenceService.getStateMachineContext().orElse(new MigrationStateMachineContext());
+        migrationActions.setStateMachineContext(context);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResource.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog.plugins.views.storage.migration.state.actions.TrafficSnapshot;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineContext;
 import org.graylog2.audit.jersey.NoAuditEvent;
@@ -94,5 +95,16 @@ public class MigrationStateResource {
     public CurrentStateInformation resetState() {
         stateMachine.reset();
         return new CurrentStateInformation(stateMachine.getState(), stateMachine.nextSteps());
+    }
+
+    @GET
+    @Path("/journalestimate")
+    @NoAuditEvent("No audit event needed")
+    @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
+    @ApiOperation(value = "Get journal size estimate (bytes/minute)")
+    public long getTrafficPerMinute() {
+        return stateMachine.getContext()
+                .getExtendedState(TrafficSnapshot.ESTIMATED_TRAFFIC_PER_MINUTE, Long.class)
+                .orElse(0L);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/actions/TrafficSnapshotTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/actions/TrafficSnapshotTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TrafficSnapshotTest {
+
+    @Test
+    public void testEstimation() {
+        long startTimeStamp = 0L;
+        long endTimeStamp = 120000L; // 2 min
+        long startBytes = 0L;
+        long endBytes = 10000L;
+        TrafficSnapshot trafficSnapshot = new TrafficSnapshot(startBytes, startTimeStamp);
+        assertThat(trafficSnapshot.calculateEstimatedTrafficPerMinute(endBytes, endTimeStamp))
+                .isEqualTo(5000L);
+    }
+
+    @Test
+    public void testEstimationRounded() {
+        long startTimeStamp = 0L;
+        long endTimeStamp = 90000L; // 1.5 min
+        long startBytes = 0L;
+        long endBytes = 10000L;
+        TrafficSnapshot trafficSnapshot = new TrafficSnapshot(startBytes, startTimeStamp);
+        assertThat(trafficSnapshot.calculateEstimatedTrafficPerMinute(endBytes, endTimeStamp))
+                .isEqualTo(6666L);
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
@@ -51,6 +51,11 @@ public class MigrationActionsAdapter implements MigrationActions {
     }
 
     @Override
+    public void calculateTrafficEstimate() {
+
+    }
+
+    @Override
     public boolean runDirectoryCompatibilityCheck() {
         return false;
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
@@ -218,6 +218,7 @@ public class MigrationStateMachineBuilderTest {
         stateMachine.fire(MigrationStep.PROVISION_DATANODE_CERTIFICATES);
         Mockito.when(migrationActions.provisioningFinished()).thenReturn(true);
         stateMachine.fire(MigrationStep.CALCULATE_JOURNAL_SIZE);
+        verify(migrationActions, times(1)).calculateTrafficEstimate();
         assertThat(stateMachine.getState()).isEqualTo(MigrationState.JOURNAL_SIZE_DOWNTIME_WARNING);
         assertThat(stateMachine.getPermittedTriggers()).containsOnly(MigrationStep.SHOW_STOP_PROCESSING_PAGE);
         verify(migrationActions, times(1)).provisionDataNodes();


### PR DESCRIPTION
## Description
Calculates a current estimate of the input rate by measuring the input traffic starting from selecting in-place upgrade to the journal size warning step. 

/nocl

## Motivation and Context
Show journal size estimate in warning step

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

