### PR TITLE
Set failed_message_streams type as stream

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
@@ -83,6 +83,7 @@ public class FieldTypeMapper {
 
     private static final Map<String, FieldTypes.Type> FIELD_MAP = Map.of(
             Message.FIELD_STREAMS, STREAMS_TYPE,
+            Message.FIELD_FAILED_MESSAGE_STREAMS, STREAMS_TYPE,
             Message.FIELD_GL2_SOURCE_INPUT, INPUT_TYPE,
             Message.FIELD_GL2_SOURCE_NODE, NODE_TYPE
     );

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -104,7 +104,7 @@ public class Message implements Messages, Indexable {
     public static final String FIELD_TIMESTAMP = "timestamp";
     public static final String FIELD_LEVEL = "level";
     public static final String FIELD_STREAMS = "streams";
-
+    public static final String FIELD_FAILED_MESSAGE_STREAMS = "failed_message_streams";
     /**
      * Graylog is writing internal metadata to messages using this field prefix. Users must not use this prefix for
      * custom message fields.
@@ -275,6 +275,7 @@ public class Message implements Messages, Indexable {
             .addAll(RESERVED_SETTABLE_FIELDS)
             .add(FIELD_GL2_MESSAGE_ID)
             .add(FIELD_STREAMS)
+            .add(FIELD_FAILED_MESSAGE_STREAMS)
             .build();
 
     public static final ImmutableSet<String> RESERVED_FIELDS = new ImmutableSet.Builder<String>()


### PR DESCRIPTION
This PR set failed_message_streams type as `stream`. This helps FE to show values properly. 
## Description
before 
<img width="814" alt="Screenshot 2024-03-07 at 11 50 31" src="https://github.com/Graylog2/graylog2-server/assets/10741557/c358361f-07c8-46e3-a536-640289daba42">
after
<img width="413" alt="Screenshot 2024-03-07 at 11 50 40" src="https://github.com/Graylog2/graylog2-server/assets/10741557/3b95335e-0aa4-4793-a92a-ec38ac225043">


## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/17754 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
