### PR TITLE
Verbose processing error when streamrule fails

### DIFF
--- a/changelog/unreleased/issue-13499.toml
+++ b/changelog/unreleased/issue-13499.toml
@@ -1,5 +1,5 @@
 type = "f"
 message = "Provide more diagnostic information when stream rule fails."
 
-pulls = [""]
+pulls = ["18539"]
 issues=["13499"]

--- a/changelog/unreleased/issue-13499.toml
+++ b/changelog/unreleased/issue-13499.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Provide more diagnostic information when stream rule fails."
+
+pulls = [""]
+issues=["13499"]

--- a/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/ProcessingFailureCause.java
@@ -22,6 +22,7 @@ public enum ProcessingFailureCause implements FailureCause {
     ExtractorException("ExtractorException"),
     MessageFilterException("MessageFilterException"),
     InvalidTimestampException("InvalidTimestampException"),
+    StreamMatchException("StreamMatchException"),
     UNKNOWN("UNKNOWN"),
     ;
 

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -45,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -299,12 +300,11 @@ public class StreamRouterEngine {
         public Stream match(Message message) {
             // TODO Add missing message recordings!
             try (final Timer.Context ignored = streamMetrics.getExecutionTimer(streamId, streamRuleId).time()) {
-                throw new RuntimeException("test");
-//                if (matcher.match(message, rule)) {
-//                    return stream;
-//                } else {
-//                    return null;
-//                }
+                if (matcher.match(message, rule)) {
+                    return stream;
+                } else {
+                    return null;
+                }
             } catch (Exception e) {
                 streamMetrics.markExceptionMeter(streamId);
                 final String error = f("Error matching stream rule <%s> %s <%s/%s> for stream %s",
@@ -322,14 +322,13 @@ public class StreamRouterEngine {
         private Stream matchWithTimeOut(final Message message, long timeout, TimeUnit unit) {
             Stream matchedStream = null;
             try (final Timer.Context ignored = streamMetrics.getExecutionTimer(streamId, streamRuleId).time()) {
-                throw new RuntimeException("test");
-//                matchedStream = timeLimiter.callWithTimeout(new Callable<Stream>() {
-//                    @Override
-//                    @Nullable
-//                    public Stream call() throws Exception {
-//                        return match(message);
-//                    }
-//                }, timeout, unit);
+                matchedStream = timeLimiter.callWithTimeout(new Callable<Stream>() {
+                    @Override
+                    @Nullable
+                    public Stream call() throws Exception {
+                        return match(message);
+                    }
+                }, timeout, unit);
             } catch (UncheckedTimeoutException e) {
                 streamFaultManager.registerFailure(stream);
             } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -45,7 +45,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -300,17 +299,19 @@ public class StreamRouterEngine {
         public Stream match(Message message) {
             // TODO Add missing message recordings!
             try (final Timer.Context ignored = streamMetrics.getExecutionTimer(streamId, streamRuleId).time()) {
-                if (matcher.match(message, rule)) {
-                    return stream;
-                } else {
-                    return null;
-                }
+                throw new RuntimeException("test");
+//                if (matcher.match(message, rule)) {
+//                    return stream;
+//                } else {
+//                    return null;
+//                }
             } catch (Exception e) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Error matching stream rule <" + rule.getType() + "/" + rule.getValue() + ">: " + e.getMessage(), e);
-                }
                 streamMetrics.markExceptionMeter(streamId);
-                final String error = f("Error matching stream rule <%s> (%s)", streamRuleId, rule.getDescription());
+                final String error = f("Error matching stream rule <%s> %s <%s/%s> for stream %s",
+                        streamRuleId, rule.getDescription(), rule.getType(), rule.getValue(), stream.getTitle());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(error + ": " + e.getMessage(), e);
+                }
                 message.addProcessingError(new Message.ProcessingError(
                         ProcessingFailureCause.StreamMatchException, error, ExceptionUtils.getRootCauseMessage(e)));
                 return null;
@@ -321,18 +322,20 @@ public class StreamRouterEngine {
         private Stream matchWithTimeOut(final Message message, long timeout, TimeUnit unit) {
             Stream matchedStream = null;
             try (final Timer.Context ignored = streamMetrics.getExecutionTimer(streamId, streamRuleId).time()) {
-                matchedStream = timeLimiter.callWithTimeout(new Callable<Stream>() {
-                    @Override
-                    @Nullable
-                    public Stream call() throws Exception {
-                        return match(message);
-                    }
-                }, timeout, unit);
+                throw new RuntimeException("test");
+//                matchedStream = timeLimiter.callWithTimeout(new Callable<Stream>() {
+//                    @Override
+//                    @Nullable
+//                    public Stream call() throws Exception {
+//                        return match(message);
+//                    }
+//                }, timeout, unit);
             } catch (UncheckedTimeoutException e) {
                 streamFaultManager.registerFailure(stream);
             } catch (Exception e) {
                 streamMetrics.markExceptionMeter(streamId);
-                final String error = f("Error matching stream rule <%s> (%s)", streamRuleId, rule.getDescription());
+                final String error = f("Error matching stream rule <%s> %s <%s/%s> for stream %s",
+                        streamRuleId, rule.getDescription(), rule.getType(), rule.getValue(), stream.getTitle());
                 LOG.warn(error, e);
                 message.addProcessingError(new Message.ProcessingError(
                         ProcessingFailureCause.StreamMatchException, error, ExceptionUtils.getRootCauseMessage(e)));

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -331,9 +331,9 @@ public class StreamRouterEngine {
             } catch (UncheckedTimeoutException e) {
                 streamFaultManager.registerFailure(stream);
             } catch (Exception e) {
-                LOG.warn("Unexpected error during stream matching", e);
                 streamMetrics.markExceptionMeter(streamId);
                 final String error = f("Error matching stream rule <%s> (%s)", streamRuleId, rule.getDescription());
+                LOG.warn(error, e);
                 message.addProcessingError(new Message.ProcessingError(
                         ProcessingFailureCause.StreamMatchException, error, ExceptionUtils.getRootCauseMessage(e)));
             }


### PR DESCRIPTION
Resolves #13499

<!--- Provide a general summary of your changes in the Title above -->
Adds a processing error to the message when a stream rule fails to match - both for normal conditions and regex matching.

## How Has This Been Tested?
Force an exception and check processing errors stream messages for the new error message.

