### PR TITLE
Bump aws-java-sdk-1.version from 1.12.607 to 1.12.675

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <auto-service.version>1.1.1</auto-service.version>
         <auto-value.version>1.10.4</auto-value.version>
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
-        <aws-java-sdk-1.version>1.12.607</aws-java-sdk-1.version>
+        <aws-java-sdk-1.version>1.12.675</aws-java-sdk-1.version>
         <aws-java-sdk-2.version>2.24.13</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.10</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.0.3</aws-msk-iam-auth.version>


### PR DESCRIPTION
Fixes CVE-2024-21634

Note for the kind reviewer:

I didn't read through the changelog and only tested the CloudTrail input to see if it could still fetch messages from AWS. IMHO, if the build passes, that should be good enough.

/nocl

