### PR TITLE
Dont show a bar if a job doesn't have a progress

### DIFF
--- a/graylog2-web-interface/src/components/systemjobs/SystemJob.tsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJob.tsx
@@ -117,7 +117,7 @@ const SystemJob = ({ job }) => {
           : (<AcknowledgeButton type="button" bsStyle="link" onClick={_onAcknowledge()} bsSize="xs" className="pull-right" title="Acknowledge"><Icon name="close" /></AcknowledgeButton>)}
       </JobWrap>
 
-      {!jobIsOver && <StyledProgressBar bars={[{ value: job.percent_complete, bsStyle: 'info', animated: true }]} />}
+      {!jobIsOver && job.provides_progress && <StyledProgressBar bars={[{ value: job.percent_complete, bsStyle: 'info', animated: true }]} />}
     </div>
   );
 };


### PR DESCRIPTION
/nocl

Two jobs, one without the other with progress after this change:

![image](https://github.com/Graylog2/graylog2-server/assets/3034831/1ca73f6b-8e81-4cb0-9da8-44c9b097b00d)
