### PR TITLE
Fix matrix tests configurations, calculate unique variants for flags and additional params

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
@@ -201,7 +201,7 @@ public class DatanodeDevContainerBuilder implements org.graylog.testing.datanode
 
         final Path pluginsDir = getPath().resolve(Path.of("opensearch", "plugins"));
         final List<String> pluginNames = getPluginNames(pluginsDir);
-        LOG.info("Detected following opensearch plugins: " + String.join(", ", pluginNames));
+        LOG.debug("Detected following opensearch plugins: " + String.join(", ", pluginNames));
 
         final ImageFromDockerfile image = new ImageFromDockerfile("local/graylog-datanode:latest", false);
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ContainerizedGraylogBackend.java
@@ -34,7 +34,6 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
@@ -54,7 +53,6 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
     public synchronized static ContainerizedGraylogBackend createStarted(ContainerizedGraylogBackendServicesProvider servicesProvider,
                                                                          final SearchVersion version,
                                                                          final MongodbServer mongodbVersion,
-                                                                         final int[] extraPorts,
                                                                          final List<URL> mongoDBFixtures,
                                                                          final PluginJarsProvider pluginJarsProvider,
                                                                          final MavenProjectDirProvider mavenProjectDirProvider,
@@ -68,11 +66,10 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
         final Services services = servicesProvider.getServices(version, mongodbVersion, withMailServerEnabled, webhookServerEnabled, enabledFeatureFlags);
         LOG.debug("Done creating backend services");
 
-        return new ContainerizedGraylogBackend().create(services, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, configParams);
+        return new ContainerizedGraylogBackend().create(services, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, configParams);
     }
 
     private ContainerizedGraylogBackend create(Services services,
-                                               final int[] extraPorts,
                                                final List<URL> mongoDBFixtures,
                                                final PluginJarsProvider pluginJarsProvider,
                                                final MavenProjectDirProvider mavenProjectDirProvider,
@@ -92,7 +89,7 @@ public class ContainerizedGraylogBackend implements GraylogBackend, AutoCloseabl
 
         var searchServer = services.getSearchServerInstance();
         try {
-            var nodeContainerConfig = new NodeContainerConfig(services.getNetwork(), mongoDB.internalUri(), PASSWORD_SECRET, ROOT_PASSWORD_SHA_2, searchServer.internalUri(), searchServer.version(), extraPorts, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, configParams);
+            var nodeContainerConfig = new NodeContainerConfig(services.getNetwork(), mongoDB.internalUri(), PASSWORD_SECRET, ROOT_PASSWORD_SHA_2, searchServer.internalUri(), searchServer.version(), pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, configParams);
             this.node = NodeInstance.createStarted(nodeContainerConfig);
 
             // ensure that all containers and networks will be removed after all tests finish

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/ContainerMatrixTestEngine.java
@@ -25,6 +25,7 @@ import org.graylog.testing.completebackend.MavenProjectDirProvider;
 import org.graylog.testing.completebackend.PluginJarsProvider;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog2.storage.SearchVersion;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.engine.config.CachingJupiterConfiguration;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
@@ -48,7 +49,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -93,14 +94,6 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                 .collect(Collectors.toSet());
     }
 
-    private Set<Class<? extends MavenProjectDirProvider>> getMavenProjectDirProvider(Set<Class<?>> annotatedClasses) {
-        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.mavenProjectDirProvider()));
-    }
-
-    private Set<Class<? extends PluginJarsProvider>> getPluginJarsProvider(Set<Class<?>> annotatedClasses) {
-        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.pluginJarsProvider()));
-    }
-
     /**
      * Property has to be in the form of Elasticsearch|OpenSearch:x.x.x
      *
@@ -112,10 +105,6 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
             return Optional.empty();
         }
         return Optional.of(SearchVersion.decode(property));
-    }
-
-    private Stream<SearchVersion> defaultOrOverride() {
-        return Stream.of(getSearchVersionOverride().orElse(SearchServer.DEFAULT_VERSION.getSearchVersion()));
     }
 
     /**
@@ -138,30 +127,12 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         }
     }
 
-    private Set<SearchVersion> getSearchServerVersions(Set<Class<?>> annotatedClasses) {
-        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> {
-            if (annotation.searchVersions().length == 0) {
-                return defaultOrOverride();
-            } else {
-                return filterForCompatibleVersionOrDrop(annotation.searchVersions());
-            }
-        });
-    }
-
-    private Set<MongodbServer> getMongoVersions(Set<Class<?>> annotatedClasses) {
-        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Stream.of(annotation.mongoVersions()));
-    }
-
     private Map<String, String> getAdditionalConfigurationParameters(Set<Class<?>> annotatedClasses) {
         return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Arrays.stream(annotation.additionalConfigurationParameters()))
                 .stream().collect(Collectors.toMap(
                         ContainerMatrixTestsConfiguration.ConfigurationParameter::key,
                         ContainerMatrixTestsConfiguration.ConfigurationParameter::value
                 ));
-    }
-
-    private Set<Integer> getExtraPorts(Set<Class<?>> annotatedClasses) {
-        return get(annotatedClasses, (ContainerMatrixTestsConfiguration annotation) -> Arrays.stream(annotation.extraPorts()).boxed());
     }
 
     public static List<String> getEnabledFeatureFlags(Lifecycle lifecycle, Class<?> annotatedClass) {
@@ -197,13 +168,6 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
         return urls;
     }
 
-    private List<String> getEnabledFeatureFlags(Lifecycle lifecycle, Set<Class<?>> annotatedClasses) {
-        return annotatedClasses.stream()
-                .map(zclass -> getEnabledFeatureFlags(lifecycle, zclass))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-    }
-
     private List<URL> getMongoDBFixtures(Set<Class<?>> annotatedClasses) {
         final List<URL> urls = new LinkedList<>();
         for (Class<?> aClass : annotatedClasses) {
@@ -232,92 +196,53 @@ public class ContainerMatrixTestEngine extends ContainerMatrixHierarchicalTestEn
                 new DefaultJupiterConfiguration(discoveryRequest.getConfigurationParameters()));
         final ContainerMatrixEngineDescriptor engineDescriptor = new ContainerMatrixEngineDescriptor(uniqueId, "Graylog Container Matrix Tests", configuration);
 
-        final Set<Integer> extraPorts = getExtraPorts(annotatedClasses);
-        final List<URL> mongoDBFixtures = getMongoDBFixtures(annotatedClasses);
-        final boolean withMailServerEnabled = isMailServerRequired(annotatedClasses);
-        final boolean withWebhookServerEnabled = isWebhookServerRequired(annotatedClasses);
-        final Map<String, String> additionalConfig = getAdditionalConfigurationParameters(annotatedClasses);
-
         if (testAgainstRunningESMongoDB()) {
             // if you test from inside an IDE against running containers
             ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestWithRunningESMongoTestsDescriptor(
                     engineDescriptor,
-                    extraPorts,
-                    mongoDBFixtures);
+                    getMongoDBFixtures(annotatedClasses));
             new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
             engineDescriptor.addChild(testsDescriptor);
         } else {
-            // for full tests, create all combinations of tests. First differentiate for maven builds.
-            getMavenProjectDirProvider(annotatedClasses)
-                    .forEach(mavenProjectDirProvider -> getPluginJarsProvider(annotatedClasses)
-                            .forEach(pluginJarsProvider -> {
-                                MavenProjectDirProvider mpdp = instantiateFactory(mavenProjectDirProvider);
-                                PluginJarsProvider pjp = instantiateFactory(pluginJarsProvider);
-                                // now add all grouped tests for Lifecycle.VM
-                                getSearchServerVersions(annotatedClasses)
-                                        .forEach(searchVersion -> getMongoVersions(annotatedClasses)
-                                                .forEach(mongoVersion -> {
-                                                    ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
-                                                            Lifecycle.VM,
-                                                            mavenProjectDirProvider,
-                                                            mpdp.getUniqueId(),
-                                                            pluginJarsProvider,
-                                                            pjp.getUniqueId(),
-                                                            searchVersion,
-                                                            mongoVersion,
-                                                            extraPorts,
-                                                            mongoDBFixtures,
-                                                            getEnabledFeatureFlags(Lifecycle.VM, annotatedClasses),
-                                                            withMailServerEnabled,
-                                                            withWebhookServerEnabled,
-                                                            additionalConfig);
-                                                    new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
-                                                    engineDescriptor.addChild(testsDescriptor);
-                                                })
-                                        );
-                                // add separate test classes (Lifecycle.CLASS)
-                                getSearchServerVersions(annotatedClasses)
-                                        .forEach(esVersion -> getMongoVersions(annotatedClasses)
-                                                        .forEach(mongoVersion -> {
-                                                            ContainerMatrixTestsDescriptor testsDescriptor = new ContainerMatrixTestsDescriptor(engineDescriptor,
-                                                                    Lifecycle.CLASS,
-                                                                    mavenProjectDirProvider,
-                                                                    mpdp.getUniqueId(),
-                                                                    pluginJarsProvider,
-                                                                    pjp.getUniqueId(),
-                                                                    esVersion,
-                                                                    mongoVersion,
-                                                                    extraPorts,
-                                                                    new ArrayList<>(),
-                                                                    getEnabledFeatureFlags(Lifecycle.CLASS, annotatedClasses), withMailServerEnabled, withWebhookServerEnabled, additionalConfig);
-                                                            new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, testsDescriptor);
-                                                            engineDescriptor.addChild(testsDescriptor);
-                                                        })
-                                                );
-                                    }
-                            )
-                    );
+            annotatedClasses.stream()
+                    .flatMap(clazz -> testClassToDescriptors(clazz, engineDescriptor))
+                    .forEach(descriptor -> {
+                        new ContainerMatrixTestsDiscoverySelectorResolver(engineDescriptor).resolveSelectors(discoveryRequest, descriptor);
+                        engineDescriptor.addChild(descriptor);
+                    });
         }
 
         return engineDescriptor;
     }
 
-    private boolean isWebhookServerRequired(Set<Class<?>> annotatedClasses) {
-        return annotatedClasses
-                .stream()
-                .map(aClass -> AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .anyMatch(ContainerMatrixTestsConfiguration::withWebhookServerEnabled);
-    }
-
-    private boolean isMailServerRequired(Set<Class<?>> annotatedClasses) {
-         return annotatedClasses
-                .stream()
-                .map(aClass -> AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .anyMatch(ContainerMatrixTestsConfiguration::withMailServerEnabled);
+    @NotNull
+    private Stream<ContainerMatrixTestsDescriptor> testClassToDescriptors(Class<?> clazz, ContainerMatrixEngineDescriptor engineDescriptor) {
+        final ContainerMatrixTestsConfiguration annotation = clazz.getAnnotation(ContainerMatrixTestsConfiguration.class);
+        final Class<? extends MavenProjectDirProvider> mavenProjectDirProvider = annotation.mavenProjectDirProvider();
+        final Class<? extends PluginJarsProvider> pluginJarsProvider = annotation.pluginJarsProvider();
+        final Lifecycle lifecycle = annotation.serverLifecycle();
+        final String mavenProjectDirProviderID = instantiateFactory(mavenProjectDirProvider).getUniqueId();
+        final String pluginJarsProviderID = instantiateFactory(pluginJarsProvider).getUniqueId();
+        final List<URL> mongoFixtures = getMongoDBFixtures(Lifecycle.VM, clazz);
+        final Map<String, String> additionalParams = getAdditionalConfigurationParameters(Collections.singleton(clazz));
+        return Arrays.stream(annotation.searchVersions()).flatMap(searchServer ->
+                Arrays.stream(annotation.mongoVersions()).map(mongodbServer ->
+                        new ContainerMatrixTestsDescriptor(
+                                engineDescriptor,
+                                lifecycle,
+                                mavenProjectDirProvider,
+                                mavenProjectDirProviderID,
+                                pluginJarsProvider,
+                                pluginJarsProviderID,
+                                searchServer.getSearchVersion(),
+                                mongodbServer,
+                                mongoFixtures,
+                                Arrays.stream(annotation.enabledFeatureFlags()).collect(Collectors.toList()),
+                                annotation.withMailServerEnabled(),
+                                annotation.withWebhookServerEnabled(),
+                                additionalParams)
+                )
+        ).distinct();
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -27,7 +27,7 @@ public enum SearchServer {
     OS1(OPENSEARCH, "1.3.12"),
     OS2(OPENSEARCH, "2.0.1"),
     OS2_4(OPENSEARCH, "2.4.1"),
-    OS2_LATEST(OPENSEARCH, "2.11.0"),
+    OS2_LATEST(OPENSEARCH, "2.12.0"),
     DATANODE_PRE_52(DATANODE, "5.1.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/annotations/ContainerMatrixTestsConfiguration.java
@@ -75,9 +75,6 @@ public @interface ContainerMatrixTestsConfiguration {
      */
     MongodbServer[] mongoVersions() default {MongodbServer.MONGO5};
 
-    // additional Parameter, gets concatenated for all tests below the above rules
-    int[] extraPorts() default {};
-
     // are run after the initialization of mongoDb, gets concatenated for all tests below the above rules
     String[] mongoDBFixtures() default {};
 

--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/discovery/IsContainerMatrixTestClass.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/discovery/IsContainerMatrixTestClass.java
@@ -17,7 +17,6 @@
 package org.graylog.testing.containermatrix.discovery;
 
 import com.google.common.collect.Sets;
-import org.graylog.testing.containermatrix.ContainerMatrixTestEngine;
 import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
@@ -33,6 +32,9 @@ import org.junit.platform.commons.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -68,38 +70,12 @@ public class IsContainerMatrixTestClass extends IsTestClassWithTests {
             if (container instanceof ContainerMatrixTestWithRunningESMongoTestsDescriptor) {
                 return true;
             } else {
-                return config.serverLifecycle().equals(container.getLifecycle())
-                        && config.mavenProjectDirProvider().equals(container.getMavenProjectDirProvider())
-                        && config.pluginJarsProvider().equals(container.getPluginJarsProvider())
-                        && isMatchingSearchServer(config)
-                        && getMongodbServers(config).contains(container.getMongoVersion());
+                return container.matches(config);
             }
         } else {
             // Annotation should be present!
             return false;
         }
-    }
-
-    private Set<MongodbServer> getMongodbServers(ContainerMatrixTestsConfiguration config) {
-        return Sets.newHashSet(config.mongoVersions());
-    }
-
-    private boolean isMatchingSearchServer(ContainerMatrixTestsConfiguration config) {
-        final var optional = getSearchVersionOverride();
-        if(optional.isPresent()) {
-            if(config.searchVersions().length == 0) {
-                return true;
-            } else {
-                final var override = optional.get();
-                return Arrays.stream(config.searchVersions()).anyMatch(version -> isCompatible(override, version));
-            }
-        } else {
-            return getSearchServers(config).contains(container.getEsVersion());
-        }
-    }
-
-    private Set<SearchVersion> getSearchServers(ContainerMatrixTestsConfiguration config) {
-        return Stream.of(config.searchVersions()).map(SearchServer::getSearchVersion).collect(Collectors.toSet());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
@@ -50,6 +50,7 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
     protected GenericContainer<?> container;
 
     protected static volatile boolean isFirstContainerStart = true;
+    private boolean closed = false;
 
     @Override
     public abstract Client client();
@@ -96,7 +97,11 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
 
     @Override
     public void cleanUp() {
-        client().cleanUp();
+        if (!closed) {
+            client().cleanUp();
+        } else {
+            LOG.debug("Cleanup skipped, client already closed");
+        }
     }
 
     @Override
@@ -108,6 +113,7 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet()) // intermediate collect to avoid modifying the containersByVersion while we iterate over it
                 .forEach(containersByVersion::remove);
+        this.closed = true;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -40,7 +40,6 @@ public class NodeContainerConfig {
     public final String rootPasswordSha2;
     public final SearchVersion elasticsearchVersion;
     public final String elasticsearchUri;
-    public final int[] extraPorts;
     public final boolean enableDebugging;
     public final boolean skipPackaging;
     public final PluginJarsProvider pluginJarsProvider;
@@ -55,7 +54,6 @@ public class NodeContainerConfig {
                                final String rootPasswordSha2,
                                String elasticsearchUri,
                                SearchVersion elasticsearchVersion,
-                               int[] extraPorts,
                                PluginJarsProvider pluginJarsProvider,
                                MavenProjectDirProvider mavenProjectDirProvider,
                                List<String> enabledFeatureFlags,
@@ -66,7 +64,6 @@ public class NodeContainerConfig {
         this.rootPasswordSha2 = rootPasswordSha2;
         this.elasticsearchUri = elasticsearchUri;
         this.elasticsearchVersion = elasticsearchVersion;
-        this.extraPorts = extraPorts == null ? new int[0] : extraPorts;
         this.enableDebugging = flagFromEnvVar("GRAYLOG_IT_DEBUG_SERVER");
         this.skipPackaging = flagFromEnvVar("GRAYLOG_IT_SKIP_PACKAGING");
         this.pluginJarsProvider = pluginJarsProvider;
@@ -86,7 +83,7 @@ public class NodeContainerConfig {
     }
 
     public Integer[] portsToExpose() {
-        int[] allPorts = ArrayUtils.add(extraPorts, 0, GELF_HTTP_PORT);
+        int[] allPorts = new int[] {GELF_HTTP_PORT};
         allPorts = ArrayUtils.add(allPorts, 0, API_PORT);
 
         if (enableDebugging) {

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestWithRunningESMongoTestsDescriptor.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestWithRunningESMongoTestsDescriptor.java
@@ -24,9 +24,8 @@ import java.util.Set;
 
 public class ContainerMatrixTestWithRunningESMongoTestsDescriptor extends ContainerMatrixTestsDescriptor {
     public ContainerMatrixTestWithRunningESMongoTestsDescriptor(TestDescriptor parent,
-                                                                Set<Integer> extraPorts,
                                                                 List<URL> mongoDBFixtures) {
-        super(parent, "Testing with running ES and MongoDB instances.", extraPorts, mongoDBFixtures);
+        super(parent, "Testing with running ES and MongoDB instances.", mongoDBFixtures);
     }
 }
 

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptor.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptor.java
@@ -17,6 +17,7 @@
 package org.junit.jupiter.engine.descriptor;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import org.graylog.testing.completebackend.DefaultMavenProjectDirProvider;
 import org.graylog.testing.completebackend.DefaultPluginJarsProvider;
 import org.graylog.testing.completebackend.Lifecycle;
@@ -24,6 +25,7 @@ import org.graylog.testing.completebackend.MavenProjectDirProvider;
 import org.graylog.testing.completebackend.PluginJarsProvider;
 import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.containermatrix.SearchServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog2.storage.SearchVersion;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -37,8 +39,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.graylog.testing.containermatrix.ContainerMatrixTestEngine.getSearchVersionOverride;
+import static org.graylog.testing.containermatrix.ContainerMatrixTestEngine.isCompatible;
 
 public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
     public static final String SEGMENT_TYPE = "matrix";
@@ -46,9 +53,8 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
     private final Lifecycle lifecycle;
     private final Class<? extends MavenProjectDirProvider> mavenProjectDirProvider;
     private final Class<? extends PluginJarsProvider> pluginJarsProvider;
-    private final SearchVersion esVersion;
+    private final SearchVersion searchVersion;
     private final MongodbServer mongoVersion;
-    private final Set<Integer> extraPorts = Collections.synchronizedSet(new HashSet<>());
     private final Set<URL> mongoDBFixtures = Collections.synchronizedSet(new HashSet<>());
     private final Set<String> enabledFeatureFlags = Collections.synchronizedSet(new HashSet<>());
     private final boolean withMailServerEnabled;
@@ -63,7 +69,6 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
                                           String pluginJarsProviderId,
                                           SearchVersion esVersion,
                                           MongodbServer mongoVersion,
-                                          Set<Integer> extraPorts,
                                           List<URL> mongoDBFixtures,
                                           List<String> enabledFeatureFlags, boolean withMailServerEnabled, boolean withWebhookServerEnabled, Map<String, String> additionalConfigurationParameters) {
         super(
@@ -74,9 +79,8 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
         this.lifecycle = lifecycle;
         this.mavenProjectDirProvider = mavenProjectDirProvider;
         this.pluginJarsProvider = pluginJarsProvider;
-        this.esVersion = esVersion;
+        this.searchVersion = esVersion;
         this.mongoVersion = mongoVersion;
-        this.extraPorts.addAll(extraPorts);
         this.mongoDBFixtures.addAll(mongoDBFixtures);
         this.enabledFeatureFlags.addAll(enabledFeatureFlags);
         this.withMailServerEnabled = withMailServerEnabled;
@@ -86,7 +90,6 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
 
     public ContainerMatrixTestsDescriptor(TestDescriptor parent,
                                           String displayName,
-                                          Set<Integer> extraPorts,
                                           List<URL> mongoDBFixtures) {
         super(parent.getUniqueId().append(SEGMENT_TYPE,
                         displayName),
@@ -95,9 +98,8 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
         this.lifecycle = Lifecycle.VM;
         this.mavenProjectDirProvider = DefaultMavenProjectDirProvider.class;
         this.pluginJarsProvider = DefaultPluginJarsProvider.class;
-        this.esVersion = SearchServer.DEFAULT_VERSION.getSearchVersion();
+        this.searchVersion = SearchServer.DEFAULT_VERSION.getSearchVersion();
         this.mongoVersion = MongodbServer.DEFAULT_VERSION;
-        this.extraPorts.addAll(extraPorts);
         this.mongoDBFixtures.addAll(mongoDBFixtures);
         this.withMailServerEnabled = false;
         this.withWebhookServerEnabled = false;
@@ -140,8 +142,8 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
         return lifecycle;
     }
 
-    public SearchVersion getEsVersion() {
-        return esVersion;
+    public SearchVersion getSearchVersion() {
+        return searchVersion;
     }
 
     public MongodbServer getMongoVersion() {
@@ -151,14 +153,6 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
     @Override
     public Type getType() {
         return Type.CONTAINER;
-    }
-
-    public void addExtraPorts(final int[] ports) {
-        Arrays.stream(ports).forEach(extraPorts::add);
-    }
-
-    public int[] getExtraPorts() {
-        return extraPorts.stream().mapToInt(i -> i).toArray();
     }
 
     public List<URL> getMongoDBFixtures() {
@@ -179,5 +173,53 @@ public class ContainerMatrixTestsDescriptor extends AbstractTestDescriptor {
 
     public boolean withEnabledWebhookServer() {
         return withWebhookServerEnabled;
+    }
+
+    public boolean matches(ContainerMatrixTestsConfiguration config) {
+        return config.serverLifecycle().equals(this.getLifecycle())
+                && config.mavenProjectDirProvider().equals(this.getMavenProjectDirProvider())
+                && config.pluginJarsProvider().equals(this.getPluginJarsProvider())
+                && isMatchingSearchServer(config)
+                && getMongodbServers(config).contains(this.getMongoVersion())
+                && config.withMailServerEnabled() == this.withEnabledMailServer()
+                && config.withWebhookServerEnabled() == this.withEnabledWebhookServer()
+                && featureFlagsMatching(config)
+                && paramsMatching(config);
+    }
+
+    private boolean paramsMatching(ContainerMatrixTestsConfiguration config) {
+        final Map<String, String> params = Arrays.stream(config.additionalConfigurationParameters())
+                .collect(Collectors.toMap(ContainerMatrixTestsConfiguration.ConfigurationParameter::key, ContainerMatrixTestsConfiguration.ConfigurationParameter::value));
+        final Map<String, String> containerParams = this.getAdditionalConfigurationParameters();
+        return containerParams.size() == params.size() && containerParams.entrySet().stream().allMatch(entry -> Objects.equals(params.get(entry.getKey()), entry.getValue()));
+    }
+
+    private boolean featureFlagsMatching(ContainerMatrixTestsConfiguration config) {
+        final List<String> configFlags = Arrays.stream(config.enabledFeatureFlags()).toList();
+        final List<String> containerFlags = this.getEnabledFeatureFlags();
+        return containerFlags.size() == configFlags.size() && containerFlags.containsAll(configFlags);
+    }
+
+
+    private static  Set<MongodbServer> getMongodbServers(ContainerMatrixTestsConfiguration config) {
+        return Sets.newHashSet(config.mongoVersions());
+    }
+
+    private boolean isMatchingSearchServer(ContainerMatrixTestsConfiguration config) {
+        final var optional = getSearchVersionOverride();
+        if(optional.isPresent()) {
+            if(config.searchVersions().length == 0) {
+                return true;
+            } else {
+                final var override = optional.get();
+                return Arrays.stream(config.searchVersions()).anyMatch(version -> isCompatible(override, version));
+            }
+        } else {
+            return getSearchServers(config).contains(this.getSearchVersion());
+        }
+    }
+
+    private static Set<SearchVersion> getSearchServers(ContainerMatrixTestsConfiguration config) {
+        return Stream.of(config.searchVersions()).map(SearchServer::getSearchVersion).collect(Collectors.toSet());
     }
 }

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/discovery/ContainerMatrixClassSelectorResolver.java
@@ -139,14 +139,14 @@ public class ContainerMatrixClassSelectorResolver implements SelectorResolver {
 
     private boolean preImportLicense(Class<?> aClass) {
         Optional<ContainerMatrixTestsConfiguration> annotation = AnnotationSupport.findAnnotation(aClass, ContainerMatrixTestsConfiguration.class);
-        return annotation.isPresent() ? annotation.get().importLicenses() : ContainerMatrixTestsConfiguration.defaultImportLicenses;
+        return annotation.map(ContainerMatrixTestsConfiguration::importLicenses).orElse(ContainerMatrixTestsConfiguration.defaultImportLicenses);
     }
 
     private ClassBasedTestDescriptor newClassTestDescriptor(TestDescriptor parent, Class<?> testClass) {
         Optional<ContainerMatrixTestsDescriptor> containerMatrixTestsDescriptor = findContainerMatrixTestsDescriptor(parent);
 
         if (containerMatrixTestsDescriptor.isPresent()) {
-            final SearchVersion esVersion = containerMatrixTestsDescriptor.get().getEsVersion();
+            final SearchVersion esVersion = containerMatrixTestsDescriptor.get().getSearchVersion();
             final MongodbServer mongoVersion = containerMatrixTestsDescriptor.get().getMongoVersion();
 
             return new ContainerMatrixTestClassDescriptor(

--- a/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
+++ b/graylog2-server/src/test/java/org/junit/platform/engine/support/hierarchical/ContainerMatrixHierarchicalTestEngine.java
@@ -77,9 +77,8 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
     }
 
     private void executeWithContainerizedGraylogBackend(ExecutionRequest request, ContainerMatrixTestsDescriptor descriptor, ContainerizedGraylogBackendServicesProvider servicesProvider) {
-        SearchVersion esVersion = descriptor.getEsVersion();
+        SearchVersion esVersion = descriptor.getSearchVersion();
         MongodbServer mongoVersion = descriptor.getMongoVersion();
-        int[] extraPorts = descriptor.getExtraPorts();
         List<URL> mongoDBFixtures = descriptor.getMongoDBFixtures();
         List<String> enabledFeatureFlags = descriptor.getEnabledFeatureFlags();
         PluginJarsProvider pluginJarsProvider = instantiateFactory(descriptor.getPluginJarsProvider());
@@ -89,7 +88,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
         final Map<String, String> configParams = descriptor.getAdditionalConfigurationParameters();
 
         if (Lifecycle.VM.equals(descriptor.getLifecycle())) {
-            try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer, withEnabledWebhookServer, configParams)) {
+            try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, mongoDBFixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, ContainerMatrixTestsConfiguration.defaultImportLicenses, withEnabledMailServer, withEnabledWebhookServer, configParams)) {
                 this.execute(request, descriptor.getChildren(), backend);
             } catch (Exception exception) {
                 /* Fail hard if the containerized backend failed to start. */
@@ -104,7 +103,7 @@ public abstract class ContainerMatrixHierarchicalTestEngine<C extends EngineExec
                     fixtures = ((ContainerMatrixTestClassDescriptor) td).getMongoFixtures();
                     preImportLicense = ((ContainerMatrixTestClassDescriptor) td).isPreImportLicense();
                 }
-                try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, extraPorts, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, withEnabledMailServer, withEnabledWebhookServer, configParams)) {
+                try (ContainerizedGraylogBackend backend = ContainerizedGraylogBackend.createStarted(servicesProvider, esVersion, mongoVersion, fixtures, pluginJarsProvider, mavenProjectDirProvider, enabledFeatureFlags, preImportLicense, withEnabledMailServer, withEnabledWebhookServer, configParams)) {
                     this.execute(request, Collections.singleton(td), backend);
                 } catch (Exception exception) {
                     /* Fail hard if the containerized backend failed to start. */


### PR DESCRIPTION
The existing implementation collected all the feature flags, mongodb resources and additional configuration parameters into one bucket and every instance got this bucket. One configuration change in any of the test (ContainerMatrixTestConfiguration) would change configuration for all tests everywhere. 

This PR changes that and fixes problems where test configurations go against each other (changing the same property).  Additionally it simplifies the code a bit, removes duplicities and places needed to adapt when new ContainerMatrixTestConfiguration option will be added.

The performance of the whole setup seems to be better now, even if we now have more possible combinations of containers and their configuration. But we are now starting some containers (mailserver, http notification server) only where they are actually needed. After several builds, it seems that the build is now faster by ~10 minutes.

Additionally, this PR updates opensearch in integration tests to 2.12.0 and removes extraPorts option from the matrix tests, as there are no usages for it.

Before:
![image](https://github.com/Graylog2/graylog2-server/assets/4102775/1c68de95-ec35-4aac-89aa-f5a6a2d0063e)


After:
![image](https://github.com/Graylog2/graylog2-server/assets/4102775/d5a94d52-0bd4-4abc-9e38-a12b1cb0911d)


/nocl

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Broken integration tests if two or more change the same configuration key.

## How Has This Been Tested?
Existing set of integration tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

