### PR TITLE
Fixing deserialization of `events` search type with empty `page`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -172,12 +172,12 @@ public abstract class EventList implements SearchType {
         public abstract Builder streams(Set<String> streams);
 
         @JsonProperty
-        public abstract Builder page(int page);
+        public abstract Builder page(@Nullable Integer page);
 
         abstract Optional<Integer> page();
 
         @JsonProperty
-        public abstract Builder perPage(int pageSize);
+        public abstract Builder perPage(@Nullable Integer pageSize);
 
         abstract Optional<Integer> perPage();
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the deserialization of the `events` search type from MongoDB. Prior to this PR, instances which had a `null` `page` or `per_page` property, had a `page`/`per_page` attribute of `0` afterwards, due to `null` being deserialized as `0` for `int` attributes.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.