### PR TITLE
Revert opensearch in integration tests to 2.11

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -27,7 +27,7 @@ public enum SearchServer {
     OS1(OPENSEARCH, "1.3.12"),
     OS2(OPENSEARCH, "2.0.1"),
     OS2_4(OPENSEARCH, "2.4.1"),
-    OS2_LATEST(OPENSEARCH, "2.12.0"),
+    OS2_LATEST(OPENSEARCH, "2.11.0"),
     DATANODE_PRE_52(DATANODE, "5.1.0"),
     DATANODE_DEV(DATANODE, "5.2.0");
 


### PR DESCRIPTION
/nocl

The 2.12 causes some unexpected behavior when splitting large batches of messages. Before we fix that, let's revert back to 2.11. 

