### PR TITLE
De-confuse port in elasticsearch_hosts comment

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -190,7 +190,7 @@ stream_aware_field_types=false
 # requires authentication.
 #
 # Default: http://127.0.0.1:9200
-#elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
+#elasticsearch_hosts = http://node1:9200,http://user:password@node2:9200
 
 # Maximum number of attempts to connect to elasticsearch on boot for the version probe.
 #


### PR DESCRIPTION
## Description

The port in the comment was 19200, which was likely a typo, and this caused some confusion as to why the port was different.

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [-] I have added tests to cover my changes.

