### PR TITLE
Provide user timezone in query context.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -30,6 +30,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQuery
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.joda.time.DateTimeZone;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,12 +49,14 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
 
     private final FieldTypesLookup fieldTypes;
     private final MultiBucketsAggregation.Bucket rowBucket;
+    private final DateTimeZone timezone;
 
     @AssistedInject
     public ESGeneratedQueryContext(
             @Assisted ElasticsearchBackend elasticsearchBackend,
             @Assisted SearchSourceBuilder ssb,
             @Assisted Collection<SearchError> validationErrors,
+            @Assisted DateTimeZone timezone,
             FieldTypesLookup fieldTypes) {
         this.elasticsearchBackend = elasticsearchBackend;
         this.ssb = ssb;
@@ -62,6 +65,7 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
         this.rowBucket = null;
         this.contextMap = new HashMap<>();
         this.searchTypeQueries = new HashMap<>();
+        this.timezone = timezone;
     }
 
     private ESGeneratedQueryContext(
@@ -71,7 +75,8 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
             FieldTypesLookup fieldTypes,
             MultiBucketsAggregation.Bucket rowBucket,
             Map<String, SearchSourceBuilder> searchTypeQueries,
-            Map<Object, Object> contextMap) {
+            Map<Object, Object> contextMap,
+            DateTimeZone timezone) {
         this.elasticsearchBackend = elasticsearchBackend;
         this.ssb = ssb;
         this.fieldTypes = fieldTypes;
@@ -79,13 +84,15 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
         this.rowBucket = rowBucket;
         this.searchTypeQueries = searchTypeQueries;
         this.contextMap = contextMap;
+        this.timezone = timezone;
     }
 
     public interface Factory {
         ESGeneratedQueryContext create(
                 ElasticsearchBackend elasticsearchBackend,
                 SearchSourceBuilder ssb,
-                Collection<SearchError> validationErrors
+                Collection<SearchError> validationErrors,
+                DateTimeZone timezone
         );
     }
 
@@ -138,10 +145,15 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     }
 
     public ESGeneratedQueryContext withRowBucket(MultiBucketsAggregation.Bucket rowBucket) {
-        return new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypes, rowBucket, searchTypeQueries, contextMap);
+        return new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypes, rowBucket, searchTypeQueries, contextMap, timezone);
     }
 
     public Optional<MultiBucketsAggregation.Bucket> rowBucket() {
         return Optional.ofNullable(this.rowBucket);
+    }
+
+    @Override
+    public DateTimeZone timezone() {
+        return timezone;
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -57,6 +57,7 @@ import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @WithSpan
     @Override
-    public ESGeneratedQueryContext generate(Query query, Set<SearchError> validationErrors) {
+    public ESGeneratedQueryContext generate(Query query, Set<SearchError> validationErrors, DateTimeZone timezone) {
         final BackendQuery backendQuery = query.query();
 
         final Set<SearchType> searchTypes = query.searchTypes();
@@ -141,7 +142,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
         final DateTime nowUTCSharedBetweenSearchTypes = Tools.nowUTC();
 
-        final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, validationErrors);
+        final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, validationErrors, timezone);
         searchTypes.stream()
                 .filter(searchType -> !isSearchTypeWithError(queryContext, searchType.id()))
                 .forEach(searchType -> {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendErrorHandlingTest.java
@@ -24,12 +24,10 @@ import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.monitoring.collection.NoOpStatsCollector;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
@@ -73,14 +71,13 @@ public class ElasticsearchBackendErrorHandlingTest {
 
     @Before
     public void setUp() throws Exception {
-        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(
                 ImmutableMap.of(
                         "dummy", () -> mock(DummyHandler.class)
                 ),
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
+                ViewsUtils.createTestContextFactory(),
                 usedSearchFilters -> Collections.emptySet(),
                 new NoOpStatsCollector<>(),
                 false);
@@ -107,12 +104,7 @@ public class ElasticsearchBackendErrorHandlingTest {
 
         this.searchJob = new SearchJob("job1", search, "admin", "test-node-id");
 
-        this.queryContext = new ESGeneratedQueryContext(
-                this.backend,
-                new SearchSourceBuilder(),
-                Collections.emptySet(),
-                mock(FieldTypesLookup.class)
-        );
+        this.queryContext = ViewsUtils.createTestContext(backend);
 
         searchTypes.forEach(queryContext::searchSourceBuilder);
     }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -23,7 +23,6 @@ import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.monitoring.collection.NoOpStatsCollector;
 import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
@@ -76,9 +75,6 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
     @Mock
     protected IndexLookup indexLookup;
 
-    @Mock
-    protected FieldTypesLookup fieldTypesLookup;
-
     protected Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticSearchTypeHandlers;
 
     @Captor
@@ -96,7 +92,7 @@ public class ElasticsearchBackendGeneratedRequestTestBase {
         this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, errors) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
+                ViewsUtils.createTestContextFactory(),
                 usedSearchFilters -> usedSearchFilters.stream()
                         .filter(sf -> sf instanceof InlineQueryStringSearchFilter)
                         .map(inlineSf -> ((InlineQueryStringSearchFilter) inlineSf).queryString())

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypeOverridesTest.java
@@ -38,6 +38,7 @@ import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,7 +95,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = createContext(query);
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -149,7 +150,7 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final ESGeneratedQueryContext queryContext = this.elasticsearchBackend.generate(query, Collections.emptySet());
+        final ESGeneratedQueryContext queryContext = createContext(query);
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -163,5 +164,9 @@ public class ElasticsearchBackendSearchTypeOverridesTest extends ElasticsearchBa
                         "searchTypeIndex",
                         "queryIndex"
                 );
+    }
+
+    private ESGeneratedQueryContext createContext(Query query) {
+        return this.elasticsearchBackend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.storage.elasticsearch7.testing.TestMultisearchResponse;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -131,7 +132,7 @@ public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends Ela
 
     private List<SearchRequest> run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(query, Collections.emptySet());
+        final ESGeneratedQueryContext context = this.elasticsearchBackend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
 
         this.elasticsearchBackend.doRun(job, query, context);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ViewsUtils.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/ViewsUtils.java
@@ -16,15 +16,33 @@
  */
 package org.graylog.storage.elasticsearch7.views;
 
+import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.joda.time.DateTimeZone;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class ViewsUtils {
+import static org.mockito.Mockito.mock;
+
+public class ViewsUtils {
     static List<String> indicesOf(List<SearchRequest> clientRequest) {
         return clientRequest.stream()
                 .map(request -> String.join(",", request.indices()))
                 .collect(Collectors.toList());
+    }
+
+    public static ESGeneratedQueryContext.Factory createTestContextFactory(FieldTypesLookup fieldTypesLookup) {
+        return (elasticsearchBackend, ssb, errors, timezone) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, errors, timezone, fieldTypesLookup);
+    }
+
+    public static ESGeneratedQueryContext.Factory createTestContextFactory() {
+        return createTestContextFactory(mock(FieldTypesLookup.class));
+    }
+
+    public static ESGeneratedQueryContext createTestContext(ElasticsearchBackend backend) {
+        return new ESGeneratedQueryContext(backend, new SearchSourceBuilder(), Collections.emptyList(), DateTimeZone.UTC, mock(FieldTypesLookup.class));
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -30,6 +30,7 @@ import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilde
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
+import org.joda.time.DateTimeZone;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,16 +50,20 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
 
     private final MultiBucketsAggregation.Bucket rowBucket;
 
+    private final DateTimeZone timezone;
+
     @AssistedInject
     public OSGeneratedQueryContext(
             @Assisted OpenSearchBackend elasticsearchBackend,
             @Assisted SearchSourceBuilder ssb,
             @Assisted Collection<SearchError> validationErrors,
+            @Assisted DateTimeZone timezone,
             FieldTypesLookup fieldTypes) {
         this.openSearchBackend = elasticsearchBackend;
         this.ssb = ssb;
         this.fieldTypes = fieldTypes;
         this.errors = new HashSet<>(validationErrors);
+        this.timezone = timezone;
         this.rowBucket = null;
         this.contextMap = new HashMap<>();
         this.searchTypeQueries = new HashMap<>();
@@ -70,7 +75,8 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
                                     FieldTypesLookup fieldTypes,
                                     MultiBucketsAggregation.Bucket rowBucket,
                                     Map<String, SearchSourceBuilder> searchTypeQueries,
-                                    Map<Object, Object> contextMap) {
+                                    Map<Object, Object> contextMap,
+                                    DateTimeZone timezone) {
         this.openSearchBackend = openSearchBackend;
         this.ssb = ssb;
         this.errors = errors;
@@ -78,14 +84,15 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
         this.rowBucket = rowBucket;
         this.searchTypeQueries = searchTypeQueries;
         this.contextMap = contextMap;
-
+        this.timezone = timezone;
     }
 
     public interface Factory {
         OSGeneratedQueryContext create(
                 OpenSearchBackend elasticsearchBackend,
                 SearchSourceBuilder ssb,
-                Collection<SearchError> validationErrors
+                Collection<SearchError> validationErrors,
+                DateTimeZone timezone
         );
     }
 
@@ -138,10 +145,15 @@ public class OSGeneratedQueryContext implements GeneratedQueryContext {
     }
 
     public OSGeneratedQueryContext withRowBucket(MultiBucketsAggregation.Bucket rowBucket) {
-        return new OSGeneratedQueryContext(openSearchBackend, ssb, errors, fieldTypes, rowBucket, searchTypeQueries, contextMap);
+        return new OSGeneratedQueryContext(openSearchBackend, ssb, errors, fieldTypes, rowBucket, searchTypeQueries, contextMap, timezone);
     }
 
     public Optional<MultiBucketsAggregation.Bucket> rowBucket() {
         return Optional.ofNullable(this.rowBucket);
+    }
+
+    @Override
+    public DateTimeZone timezone() {
+        return timezone;
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -58,6 +58,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,7 +115,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
     }
 
     @Override
-    public OSGeneratedQueryContext generate(Query query, Set<SearchError> validationErrors) {
+    public OSGeneratedQueryContext generate(Query query, Set<SearchError> validationErrors, DateTimeZone timezone) {
         final BackendQuery backendQuery = query.query();
 
         final Set<SearchType> searchTypes = query.searchTypes();
@@ -140,7 +141,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
 
         final DateTime nowUTCSharedBetweenSearchTypes = Tools.nowUTC();
 
-        final OSGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, validationErrors);
+        final OSGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, validationErrors, timezone);
         searchTypes.stream()
                 .filter(searchType -> !isSearchTypeWithError(queryContext, searchType.id()))
                 .forEach(searchType -> {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendErrorHandlingTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendErrorHandlingTest.java
@@ -24,12 +24,10 @@ import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.monitoring.collection.NoOpStatsCollector;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.MultiSearchResponse;
-import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.opensearch2.OpenSearchClient;
 import org.graylog.storage.opensearch2.testing.TestMultisearchResponse;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
@@ -73,14 +71,13 @@ public class OpenSearchBackendErrorHandlingTest {
 
     @Before
     public void setUp() throws Exception {
-        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new OpenSearchBackend(
                 ImmutableMap.of(
                         "dummy", () -> mock(DummyHandler.class)
                 ),
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, errors) -> new OSGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
+                ViewsUtils.createTestContextFactory(),
                 usedSearchFilters -> Collections.emptySet(),
                 new NoOpStatsCollector<>(),
                 false);
@@ -107,12 +104,7 @@ public class OpenSearchBackendErrorHandlingTest {
 
         this.searchJob = new SearchJob("job1", search, "admin", "test-node-id");
 
-        this.queryContext = new OSGeneratedQueryContext(
-                this.backend,
-                new SearchSourceBuilder(),
-                Collections.emptySet(),
-                mock(FieldTypesLookup.class)
-        );
+        this.queryContext = ViewsUtils.createTestContext(backend);
 
         searchTypes.forEach(queryContext::searchSourceBuilder);
     }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendGeneratedRequestTestBase.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendGeneratedRequestTestBase.java
@@ -23,7 +23,6 @@ import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.monitoring.collection.NoOpStatsCollector;
 import org.graylog.plugins.views.search.searchfilters.model.InlineQueryStringSearchFilter;
@@ -76,9 +75,6 @@ public class OpenSearchBackendGeneratedRequestTestBase {
     @Mock
     protected IndexLookup indexLookup;
 
-    @Mock
-    protected FieldTypesLookup fieldTypesLookup;
-
     protected Map<String, Provider<OSSearchTypeHandler<? extends SearchType>>> elasticSearchTypeHandlers;
 
     @Captor
@@ -96,7 +92,7 @@ public class OpenSearchBackendGeneratedRequestTestBase {
         this.openSearchBackend = new OpenSearchBackend(elasticSearchTypeHandlers,
                 client,
                 indexLookup,
-                (elasticsearchBackend, ssb, errors) -> new OSGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
+                ViewsUtils.createTestContextFactory(),
                 usedSearchFilters -> usedSearchFilters.stream()
                         .filter(sf -> sf instanceof InlineQueryStringSearchFilter)
                         .map(inlineSf -> ((InlineQueryStringSearchFilter) inlineSf).queryString())

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendSearchTypeOverridesTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendSearchTypeOverridesTest.java
@@ -38,6 +38,7 @@ import org.graylog.storage.opensearch2.testing.TestMultisearchResponse;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,7 +95,7 @@ public class OpenSearchBackendSearchTypeOverridesTest extends OpenSearchBackendG
 
     @Test
     public void overridesInSearchTypeAreIncorporatedIntoGeneratedQueries() throws IOException {
-        final OSGeneratedQueryContext queryContext = this.openSearchBackend.generate(query, Collections.emptySet());
+        final OSGeneratedQueryContext queryContext = createContext(query);
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -149,7 +150,7 @@ public class OpenSearchBackendSearchTypeOverridesTest extends OpenSearchBackendG
         when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1"), tr))
                 .thenReturn(ImmutableSet.of("searchTypeIndex"));
 
-        final OSGeneratedQueryContext queryContext = this.openSearchBackend.generate(query, Collections.emptySet());
+        final OSGeneratedQueryContext queryContext = createContext(query);
         final MultiSearchResponse response = TestMultisearchResponse.fromFixture("successfulMultiSearchResponse.json");
         final List<MultiSearchResponse.Item> items = Arrays.stream(response.getResponses())
                 .collect(Collectors.toList());
@@ -163,5 +164,9 @@ public class OpenSearchBackendSearchTypeOverridesTest extends OpenSearchBackendG
                         "searchTypeIndex",
                         "queryIndex"
                 );
+    }
+
+    private OSGeneratedQueryContext createContext(Query query) {
+        return this.openSearchBackend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
     }
 }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.storage.opensearch2.testing.TestMultisearchResponse;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -131,7 +132,7 @@ public class OpenSearchBackendSearchTypesWithStreamsOverridesTest extends OpenSe
 
     private List<SearchRequest> run(Query query) throws IOException {
         final SearchJob job = searchJobForQuery(query);
-        final OSGeneratedQueryContext context = this.openSearchBackend.generate(query, Collections.emptySet());
+        final OSGeneratedQueryContext context = this.openSearchBackend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
 
         this.openSearchBackend.doRun(job, query, context);
 

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/OpenSearchBackendTest.java
@@ -27,7 +27,6 @@ import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.monitoring.collection.NoOpStatsCollector;
 import org.graylog.plugins.views.search.searchfilters.db.UsedSearchFiltersToQueryStringsMapper;
@@ -43,6 +42,7 @@ import org.graylog.storage.opensearch2.views.searchtypes.OSMessageList;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog2.indexer.results.TestResultMessageFactory;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,11 +67,10 @@ public class OpenSearchBackendTest {
 
         usedSearchFiltersToQueryStringsMapper = mock(UsedSearchFiltersToQueryStringsMapper.class);
         doReturn(Collections.emptySet()).when(usedSearchFiltersToQueryStringsMapper).map(any());
-        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         backend = new OpenSearchBackend(handlers,
                 null,
                 mock(IndexLookup.class),
-                (elasticsearchBackend, ssb, errors) -> new OSGeneratedQueryContext(elasticsearchBackend, ssb, errors, fieldTypesLookup),
+                ViewsUtils.createTestContextFactory(),
                 usedSearchFiltersToQueryStringsMapper,
                 new NoOpStatsCollector<>(),
                 false);
@@ -84,7 +83,7 @@ public class OpenSearchBackendTest {
                 .query(ElasticsearchQueryString.of(""))
                 .timerange(RelativeRange.create(300))
                 .build();
-        backend.generate(query, Collections.emptySet());
+        backend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
     }
 
     @Test
@@ -122,7 +121,7 @@ public class OpenSearchBackendTest {
                 .timerange(RelativeRange.create(300))
                 .build();
 
-        final OSGeneratedQueryContext queryContext = backend.generate(query, Collections.emptySet());
+        final OSGeneratedQueryContext queryContext = backend.generate(query, Collections.emptySet(), DateTimeZone.UTC);
         final QueryBuilder esQuery = queryContext.searchSourceBuilder(new SearchType.Fallback()).query();
         assertThat(esQuery)
                 .isNotNull()

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/ViewsUtils.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/ViewsUtils.java
@@ -16,15 +16,33 @@
  */
 package org.graylog.storage.opensearch2.views;
 
+import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
+import org.joda.time.DateTimeZone;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class ViewsUtils {
+import static org.mockito.Mockito.mock;
+
+public class ViewsUtils {
     static List<String> indicesOf(List<SearchRequest> clientRequest) {
         return clientRequest.stream()
                 .map(request -> String.join(",", request.indices()))
                 .collect(Collectors.toList());
+    }
+
+    public static OSGeneratedQueryContext.Factory createTestContextFactory(FieldTypesLookup fieldTypesLookup) {
+        return (elasticsearchBackend, ssb, errors, timezone) -> new OSGeneratedQueryContext(elasticsearchBackend, ssb, errors, timezone, fieldTypesLookup);
+    }
+
+    public static OSGeneratedQueryContext.Factory createTestContextFactory() {
+        return createTestContextFactory(mock(FieldTypesLookup.class));
+    }
+
+    public static OSGeneratedQueryContext createTestContext(OpenSearchBackend backend) {
+        return new OSGeneratedQueryContext(backend, new SearchSourceBuilder(), Collections.emptyList(), DateTimeZone.UTC, mock(FieldTypesLookup.class));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -60,6 +60,7 @@ import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -289,7 +290,7 @@ public class AggregationEventProcessor implements EventProcessor {
 
     private void aggregatedSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,
                                   EventConsumer<List<EventWithContext>> eventsConsumer) throws EventProcessorException {
-        final String owner = "event-processor-" + AggregationEventProcessorConfig.TYPE_NAME + "-" + eventDefinition.id();
+        final var owner = new AggregationSearch.User("event-processor-" + AggregationEventProcessorConfig.TYPE_NAME + "-" + eventDefinition.id(), DateTimeZone.UTC);
         final List<SearchType> additionalSearchTypes = eventQueryModifiers.stream()
                 .flatMap(e -> e.additionalSearchTypes(eventDefinition).stream())
                 .toList();

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationSearch.java
@@ -19,14 +19,16 @@ package org.graylog.events.processor.aggregation;
 import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventProcessorException;
 import org.graylog.plugins.views.search.SearchType;
+import org.joda.time.DateTimeZone;
 
 import java.util.List;
 
 public interface AggregationSearch {
+    record User(String name, DateTimeZone timezone) {}
     interface Factory {
         AggregationSearch create(AggregationEventProcessorConfig config,
                                  AggregationEventProcessorParameters parameters,
-                                 String searchOwner,
+                                 User searchOwner,
                                  EventDefinition eventDefinition,
                                  List<SearchType> additionalSearchTypes);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/GeneratedQueryContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/GeneratedQueryContext.java
@@ -17,10 +17,12 @@
 package org.graylog.plugins.views.search.engine;
 
 import org.graylog.plugins.views.search.errors.SearchError;
+import org.joda.time.DateTimeZone;
 
 import java.util.Collection;
 
 public interface GeneratedQueryContext {
+    DateTimeZone timezone();
 
     void addError(SearchError error);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryBackend.java
@@ -30,6 +30,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -49,7 +50,7 @@ public interface QueryBackend<T extends GeneratedQueryContext> {
      * @param query the graylog query structure
      * @return a backend specific generated query
      */
-    T generate(Query query, Set<SearchError> validationErrors);
+    T generate(Query query, Set<SearchError> validationErrors, DateTimeZone timezone);
 
     StatsCollector<QueryExecutionStats> getExecutionStatsCollector();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -18,6 +18,8 @@ package org.graylog.plugins.views.search.engine;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.QueryMetadata;
 import org.graylog.plugins.views.search.QueryMetadataDecorator;
@@ -27,11 +29,9 @@ import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchException;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -73,7 +73,7 @@ public class QueryEngine {
     }
 
     @WithSpan
-    public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors) {
+    public SearchJob execute(SearchJob searchJob, Set<SearchError> validationErrors, DateTimeZone timezone) {
         final Set<Query> validQueries = searchJob.getSearch().queries()
                 .stream()
                 .filter(query -> !isQueryWithError(validationErrors, query))
@@ -82,7 +82,7 @@ public class QueryEngine {
         validQueries.forEach(query -> searchJob.addQueryResultFuture(query.id(),
                 // generate and run each query, making sure we never let an exception escape
                 // if need be we default to an empty result with a failed state and the wrapped exception
-                CompletableFuture.supplyAsync(() -> prepareAndRun(searchJob, query, validationErrors), queryPool)
+                CompletableFuture.supplyAsync(() -> prepareAndRun(searchJob, query, validationErrors, timezone), queryPool)
                         .handle((queryResult, throwable) -> {
                             if (throwable != null) {
                                 final Throwable cause = throwable.getCause();
@@ -115,12 +115,12 @@ public class QueryEngine {
         return searchJob.seal();
     }
 
-    private QueryResult prepareAndRun(SearchJob searchJob, Query query, Set<SearchError> validationErrors) {
+    private QueryResult prepareAndRun(SearchJob searchJob, Query query, Set<SearchError> validationErrors, DateTimeZone timezone) {
         LOG.debug("[{}] Using {} to generate query", query.id(), backend);
         // with all the results done, we can execute the current query and eventually complete our own result
         // if any of this throws an exception, the handle in #execute will convert it to an error and return a "failed" result instead
         // if the backend already returns a "failed result" then nothing special happens here
-        final GeneratedQueryContext generatedQueryContext = backend.generate(query, validationErrors);
+        final GeneratedQueryContext generatedQueryContext = backend.generate(query, validationErrors, timezone);
         LOG.trace("[{}] Generated query {}, running it on backend {}", query.id(), generatedQueryContext, backend);
         final QueryResult result = backend.run(searchJob, query, generatedQueryContext);
         LOG.debug("[{}] Query returned {}", query.id(), result);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/SearchExecutor.java
@@ -18,6 +18,9 @@ package org.graylog.plugins.views.search.engine;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchDomain;
 import org.graylog.plugins.views.search.SearchJob;
@@ -27,13 +30,9 @@ import org.graylog.plugins.views.search.engine.validation.SearchValidation;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.rest.ExecutionState;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-
-import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.ws.rs.NotFoundException;
 
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -42,6 +41,7 @@ import java.util.concurrent.TimeoutException;
 
 public class SearchExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(SearchExecutor.class);
+    private static final DateTimeZone DEFAULT_TIMEZONE = DateTimeZone.UTC;
 
     private final SearchDomain searchDomain;
     private final SearchJobService searchJobService;
@@ -80,7 +80,7 @@ public class SearchExecutor {
 
         final Search normalizedSearch = searchNormalization.postValidation(preValidationSearch, searchUser, executionState);
 
-        final SearchJob searchJob = queryEngine.execute(searchJobService.create(normalizedSearch, searchUser.username()), validationErrors);
+        final SearchJob searchJob = queryEngine.execute(searchJobService.create(normalizedSearch, searchUser.username()), validationErrors, searchUser.timeZone().orElse(DEFAULT_TIMEZONE));
 
         validationErrors.forEach(searchJob::addError);
 

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -448,7 +448,7 @@ public class AggregationEventProcessorTest {
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)
         );
-        verify(searchFactory, never()).create(eq(config), eq(parameters), any(String.class), eq(eventDefinitionDto), eq(List.of()));
+        verify(searchFactory, never()).create(eq(config), eq(parameters), any(AggregationSearch.User.class), eq(eventDefinitionDto), eq(List.of()));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -98,7 +98,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 Collections.emptyList(),
                 searchJobService,
@@ -199,7 +199,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 Collections.emptyList(),
                 searchJobService,
@@ -273,7 +273,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 List.of(Pivot.builder()
                         .id("risk-asset-1")
@@ -344,7 +344,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 Collections.emptyList(),
                 searchJobService,
@@ -482,7 +482,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 Collections.emptyList(),
                 searchJobService,
@@ -528,7 +528,7 @@ public class PivotAggregationSearchTest {
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
                 config,
                 parameters,
-                "test",
+                new AggregationSearch.User("test", DateTimeZone.UTC),
                 eventDefinition,
                 List.of(Pivot.builder()
                         .id("risk-asset-1")

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/SearchExecutorTest.java
@@ -98,7 +98,7 @@ public class SearchExecutorTest {
                                 )
                         )
                 )));
-        when(queryEngine.execute(any(), any())).thenAnswer(invocation -> {
+        when(queryEngine.execute(any(), any(), any())).thenAnswer(invocation -> {
             final SearchJob searchJob = invocation.getArgument(0);
             searchJob.addQueryResultFuture("query", CompletableFuture.completedFuture(QueryResult.emptyResult()));
             searchJob.seal();
@@ -151,7 +151,7 @@ public class SearchExecutorTest {
                 .build();
         this.searchExecutor.execute("search1", searchUser, executionState);
 
-        verify(queryEngine, times(1)).execute(searchJobCaptor.capture(), anySet());
+        verify(queryEngine, times(1)).execute(searchJobCaptor.capture(), anySet(), any());
 
         final SearchJob executedJob = searchJobCaptor.getValue();
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -168,7 +168,7 @@ public class SearchResourceExecutionTest {
         searchJob.addQueryResultFuture("query", CompletableFuture.completedFuture(QueryResult.emptyResult()));
         searchJob.seal();
 
-        when(queryEngine.execute(any(), any())).thenReturn(searchJob);
+        when(queryEngine.execute(any(), any(), any())).thenReturn(searchJob);
 
         final Response response = this.searchResource.executeSyncJob(search, 100, searchUser);
 
@@ -207,7 +207,7 @@ public class SearchResourceExecutionTest {
 
         final SearchJob searchJob = makeSearchJob(search.toSearch());
 
-        when(queryEngine.execute(any(), any())).thenReturn(searchJob);
+        when(queryEngine.execute(any(), any(), any())).thenReturn(searchJob);
 
         final Response response = this.searchResource.executeSyncJob(search, 100, searchUser);
 
@@ -293,7 +293,7 @@ public class SearchResourceExecutionTest {
 
         persistSearch(search);
 
-        when(queryEngine.execute(any(), any())).thenAnswer(invocation -> {
+        when(queryEngine.execute(any(), any(), any())).thenAnswer(invocation -> {
             final SearchJob searchJob = invocation.getArgument(0);
             searchJob.addQueryResultFuture("query", CompletableFuture.completedFuture(QueryResult.emptyResult()));
             searchJob.seal();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending `GeneratedQueryContext` and its implementations to hold a timezone the query is executed. During search execution, the timezone of the user executing the search will be used to initialize it. This enables search types to take the current user's timezone into account, e.g. when accessing data from auxiliary databases (like MongoDB).

/prd Graylog2/graylog-plugin-enterprise#6752
/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.