### PR TITLE
Enable frontend perspectives without feature flag

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -77,9 +77,6 @@ composable_index_templates=off
 # Enable keyboard shortcuts in the graylog web interface
 frontend_hotkeys=on
 
-# Enable the perspectives feature in the graylog web interface
-frontend_perspectives=off
-
 # Enable data tiering
 data_tiering_cloud=off
 

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.test.tsx
@@ -29,7 +29,6 @@ import PerspectivesSwitcher from './PerspectivesSwitcher';
 
 jest.mock('components/perspectives/hooks/usePerspectives', () => jest.fn());
 jest.mock('components/perspectives/hooks/useActivePerspective', () => jest.fn());
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_perspectives');
 jest.mock('routing/useHistory');
 
 describe('PerspectivesSwitcher', () => {

--- a/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
+++ b/graylog2-web-interface/src/components/perspectives/PerspectivesSwitcher.tsx
@@ -20,7 +20,6 @@ import { useCallback } from 'react';
 
 import Menu from 'components/bootstrap/Menu';
 import Icon from 'components/common/Icon';
-import useFeature from 'hooks/useFeature';
 import usePerspectives from 'components/perspectives/hooks/usePerspectives';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 import useHistory from 'routing/useHistory';
@@ -94,9 +93,8 @@ const Switcher = () => {
 
 const PerspectivesSwitcher = () => {
   const perspectives = usePerspectives();
-  const hasPerspectivesFeature = useFeature('frontend_perspectives');
 
-  if (!hasPerspectivesFeature || perspectives.length === 1) {
+  if (perspectives.length === 1) {
     return (
       <ActivePerspectiveBrand className="navbar-brand" />
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In preparation for the `6.0` release and for testing testing, remove the `frontend_perspectives` feature flag and enable perspective switching by default.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify that the perspective switching option is available when additional perspectives are available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

