### PR TITLE
Change default TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE

### DIFF
--- a/changelog/unreleased/pr-18609.toml
+++ b/changelog/unreleased/pr-18609.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Modified default values for min and max shard size for Time-Size-Optimizing rotation strategy to better match typical node resourcing."
+
+pulls = ["18609"]
+issues = ["Graylog2/graylog-plugin-enterprise/issues/6611"]

--- a/changelog/unreleased/pr-18609.toml
+++ b/changelog/unreleased/pr-18609.toml
@@ -2,4 +2,4 @@ type = "c"
 message = "Modified default values for min and max shard size for Time-Size-Optimizing rotation strategy to better match typical node resourcing."
 
 pulls = ["18609"]
-issues = ["Graylog2/graylog-plugin-enterprise/issues/6611"]
+issues = ["Graylog2/graylog-plugin-enterprise#6611"]

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -127,7 +127,7 @@ public class ElasticsearchConfiguration {
     private Size timeSizeOptimizingRotationMinShardSize = Size.gigabytes(20);
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE)
-    private Size timeSizeOptimizingRotationMaxShardSize = Size.gigabytes(50);
+    private Size timeSizeOptimizingRotationMaxShardSize = Size.gigabytes(20);
 
     @Parameter(value = TIME_SIZE_OPTIMIZING_RETENTION_MIN_LIFETIME)
     private Period timeSizeOptimizingRetentionMinLifeTime = IndexLifetimeConfig.DEFAULT_LIFETIME_MIN;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedSizeOptimizingStrategyTest.java
@@ -120,10 +120,13 @@ class TimeBasedSizeOptimizingStrategyTest {
     void shouldRotateWhenRightSizedAndOverRotationPeriod(String startDate) {
         setClockTo(startDate);
 
-        final DateTime creationDate = clock.nowUTC().minus(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod());
-        when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
         final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize();
         when(indices.getStoreSizeInBytes("index_0")).thenReturn(Optional.of(timeSizeOptimizingRotationMinSize.toBytes() + 10));
+        final Size timeSizeOptimizingRotationMaxSize = Size.bytes(timeSizeOptimizingRotationMinSize.toBytes() * 2);
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxShardSize()).thenReturn(timeSizeOptimizingRotationMaxSize);
+        final DateTime creationDate = clock.nowUTC().minus(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod());
+        when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
+        timeBasedSizeOptimizingStrategy = createStrategy();
 
         final Result result = timeBasedSizeOptimizingStrategy.shouldRotate("index_0", indexSet);
 
@@ -156,14 +159,15 @@ class TimeBasedSizeOptimizingStrategyTest {
     void shouldRotateWhenRightSizedAndOverCustomRotationPeriod(String startDate) {
         setClockTo(startDate);
 
-        final Period customRotationPeriod = Period.hours(12);
-        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(customRotationPeriod);
-        timeBasedSizeOptimizingStrategy = createStrategy();
-
-        final DateTime creationDate = clock.nowUTC().minus(customRotationPeriod);
-        when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
         final Size timeSizeOptimizingRotationMinSize = elasticsearchConfiguration.getTimeSizeOptimizingRotationMinShardSize();
         when(indices.getStoreSizeInBytes("index_0")).thenReturn(Optional.of(timeSizeOptimizingRotationMinSize.toBytes() + 10));
+        final Size timeSizeOptimizingRotationMaxSize = Size.bytes(timeSizeOptimizingRotationMinSize.toBytes() * 2);
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationMaxShardSize()).thenReturn(timeSizeOptimizingRotationMaxSize);
+        final Period customRotationPeriod = Period.hours(12);
+        when(elasticsearchConfiguration.getTimeSizeOptimizingRotationPeriod()).thenReturn(customRotationPeriod);
+        final DateTime creationDate = clock.nowUTC().minus(customRotationPeriod);
+        when(indices.indexCreationDate("index_0")).thenReturn(Optional.of(creationDate));
+        timeBasedSizeOptimizingStrategy = createStrategy();
 
         final Result result = timeBasedSizeOptimizingStrategy.shouldRotate("index_0", indexSet);
 

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.tsx
@@ -214,7 +214,7 @@ const IndexMaintenanceStrategiesConfiguration = ({
   const shouldShowNormalRetentionForm = (!isTimeBasedSizeOptimizing || (name === 'retention' && (!retentionIsNotNoop || !isArchiveRetention)));
   const helpText = isTimeBasedSizeOptimizing && name === 'rotation'
     ? 'The Time Based Size Optimizing Rotation Strategy tries to rotate the index daily.'
-    + ' It can however skip the rotation to achieve optimal sized indices by keeping the shard size between 20 and 50 GB.'
+    + ' It can however skip the rotation to achieve optimal sized indices by keeping the shard size within an acceptable range.'
     + ' The optimization can delay the rotation within the range of the configured retention min/max lifetime.'
     + ' If an index is older than the range between min/max, it will be rotated regardless of its current size.'
     : null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change default value for `TIME_SIZE_OPTIMIZING_ROTATION_MAX_SHARD_SIZE` to 20GB
See linked issue for discussion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Graylog2/graylog-plugin-enterprise#6611

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Cloud has been operating with min==max shard size for some time.
