### PR TITLE
Fixing wrong audit type namespace usage for Graylog CA

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/audit/CaAuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/audit/CaAuditEventTypes.java
@@ -22,10 +22,10 @@ import org.graylog2.audit.PluginAuditEventTypes;
 import java.util.Set;
 
 public class CaAuditEventTypes implements PluginAuditEventTypes {
-    private static final String NAMESPACE = "ca:";
+    private static final String NAMESPACE = "graylog_ca:";
 
-    public static final String CA_CREATE = NAMESPACE + "create";
-    public static final String CA_UPLOAD = NAMESPACE + "upload";
+    public static final String CA_CREATE = NAMESPACE + "ca:create";
+    public static final String CA_UPLOAD = NAMESPACE + "ca:upload";
     public static final String CLIENTCERT_CREATE = NAMESPACE + "clientcert:create";
     public static final String CLIENTCERT_DELETE = NAMESPACE + "clientcert:delete";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix for the following error:

```
2024-03-14 10:14:44,562 ERROR: org.graylog.plugins.auditlog.jersey.AuditLogFilter - Error building audit event from REST request: POST http://localhost:8080/api/ca/create
java.lang.IllegalArgumentException: Type string needs to be in the following format: <namespace>:<object>:<action> - given string: ca:create
	at org.graylog2.audit.AuditEventType.create(AuditEventType.java:95) ~[classes/:?]
```

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

