### PR TITLE
Hide gl2_processing_duration_ms field by default

### DIFF
--- a/graylog2-web-interface/src/views/Constants.ts
+++ b/graylog2-web-interface/src/views/Constants.ts
@@ -47,6 +47,7 @@ export const FILTERED_FIELDS = [
   // Our reserved fields.
   'gl2_accounted_message_size',
   'gl2_processing_timestamp',
+  'gl2_processing_duration_ms',
   'gl2_receive_timestamp',
   'gl2_message_id',
   'gl2_source_node',


### PR DESCRIPTION
/nocl
