### PR TITLE
Add exception stacktrace to unsupported search version error

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -585,7 +585,7 @@ public abstract class CmdLineTool implements CliCommand {
                 System.exit(-2);
             } else if (rootCause instanceof UnsupportedSearchException) {
                 final SearchVersion search = ((UnsupportedSearchException) rootCause).getSearchMajorVersion();
-                LOG.error(UI.wallString("Unsupported search version: " + search, DocsHelper.PAGE_ES_VERSIONS.toString()));
+                LOG.error(UI.wallString("Unsupported search version: " + search, DocsHelper.PAGE_ES_VERSIONS.toString()), rootCause);
                 System.exit(-3);
             } else if (rootCause instanceof ElasticsearchProbeException) {
                 LOG.error(UI.wallString(rootCause.getMessage(), DocsHelper.PAGE_ES_CONFIGURATION.toString()));


### PR DESCRIPTION
Adding this temporary PR that adds the exception stack trace to the `unsupported search version` error to help debug build issue in https://github.com/Graylog2/graylog-plugin-enterprise/pull/6756.

This PR will be closed/unmerged after.