### PR TITLE
fix functional component triggering on page render

### DIFF
--- a/changelog/unreleased/issue-18633.toml
+++ b/changelog/unreleased/issue-18633.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed automatic pop-up triggering for clearing notifications on the events definition overview page."
+
+issues = ["18633"]
+pulls = ["18646"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/SchedulingCell.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/SchedulingCell.tsx
@@ -80,7 +80,7 @@ const detailsPopover = (scheduler: Scheduler, clearNotifications: () => void) =>
     <DetailTitle>Queued notifications:</DetailTitle>
     <DetailValue>{scheduler.queued_notifications}
       {scheduler.queued_notifications > 0 && (
-        <Button bsStyle="link" bsSize="xsmall" onClick={clearNotifications}>
+        <Button bsStyle="link" bsSize="xsmall" onClick={() => clearNotifications()}>
           clear
         </Button>
       )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixing #18633 
Fix when having queued events, while fixing the event definition  overview page, the clearNotifications page gets triggered automatically after page render.


