### PR TITLE
Configure `action.destructive_requires_name` in data node

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -76,6 +76,10 @@ Not affected by this change are the following templates using Freemarker:
 | `disabled_retention_strategies`  | **added** | Disables the specified retention strategies. By default, strategies `none` and `close` are now disabled in new installations.<br/>Strategies can be re-enabled simply by removing from this list.<br/>**Do not extend this list on existing installs!** |
 | `field_value_suggestion_mode`    | **added** | Allows controlling field value suggestions, turning them on, off, or allowing them only for textual fields.                                                                                                                                             |
 
+## OpenSearch Configuration Changes
+
+- Due to a bug in the OpenSearch client, it is recommended to explicitly set `action.destructive_requires_name=true`
+  at cluster level to avoid problems. If you are using Graylog Data Node, this is automatically set for you.
 
 ## Asset Import Changes
 

--- a/changelog/unreleased/pr-18647.toml
+++ b/changelog/unreleased/pr-18647.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Explicitly set `action.destructive_requires_name` in data node."
+
+pulls = ["18647"]
+issues = ["18619"]

--- a/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
@@ -50,6 +50,7 @@ public record OpensearchConfiguration(
         Map<String, String> config = new LinkedHashMap<>();
 
         config.put("action.auto_create_index", "false");
+        config.put("action.destructive_requires_name", "true"); // set to default value due to https://github.com/opensearch-project/opensearch-java/issues/894
 
         // currently, startup fails on macOS without disabling this filter.
         // for a description of the filter (although it's for ES), see https://www.elastic.co/guide/en/elasticsearch/reference/7.17/_system_call_filter_check.html


### PR DESCRIPTION
## Description
Due to a bug in the Opensearch client (https://github.com/opensearch-project/opensearch-java/issues/894) our OS client will throw an exception when calling the nodes info endpoint when `action.auto_create_index` is set but `action.destructive_requires_name` (which should have a default value) is not.

In the data node, we can set the configuration accordingly to avoid that.

For users not using data node, a release not has been added.

## Motivation and Context
see #18619

## How Has This Been Tested?
Start data node without parameter set -> exception will be thrown

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

