### PR TITLE
Additional validation - profile and custom mappings changes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -43,6 +43,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.graylog2.indexer.EventIndexTemplateProvider.EVENT_TEMPLATE_TYPE;
 import static org.graylog2.shared.security.RestPermissions.INDEXSETS_READ;
 
 @AutoValue
@@ -295,6 +296,24 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         final String indexTemplate = indexTemplateType().orElse(null);
         return isWritable() && (indexTemplate == null || DEFAULT_INDEX_TEMPLATE_TYPE.equals(indexTemplate) ||
                 isRegular().orElse(false));
+    }
+
+    @JsonIgnore
+    public boolean canHaveCustomFieldMappings() {
+        final String indexTemplateType = this.indexTemplateType().orElse(null);
+        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) || "failures".equals(indexTemplateType)) {
+            return false;
+        }
+        return true;
+    }
+
+    @JsonIgnore
+    public boolean canHaveProfile() {
+        final String indexTemplateType = this.indexTemplateType().orElse(null);
+        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) || "failures".equals(indexTemplateType)) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/mapping/FieldTypeMappingsServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/mapping/FieldTypeMappingsServiceTest.java
@@ -50,6 +50,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -181,6 +182,19 @@ class FieldTypeMappingsServiceTest {
     void testThrowsExceptionWhenTryingToSetUnExistingProfile() {
         assertThrows(NotFoundException.class, () -> toTest.setProfile(Set.of(), "000000000000000000000042", false));
     }
+
+    @Test
+    void testThrowsExceptionOnIndexThatCannotHaveFieldTypeChanged() {
+        IndexSetConfig illegalForFieldTypeChange = mock(IndexSetConfig.class);
+        doReturn(Optional.of(illegalForFieldTypeChange)).when(indexSetService).get("existing_index_set");
+
+        assertThrows(BadRequestException.class, () -> toTest.changeFieldType(newCustomMapping,
+                Set.of("existing_index_set"),
+                false));
+
+        verifyNoInteractions(mongoIndexSetService);
+    }
+
 
     @Test
     void testThrowsExceptionWhenTryingToSetProfileWithReservedFields() {


### PR DESCRIPTION
## Description
Additional validation - profile and custom mappings changes are impossible on `failure` and `event` indices.
This fix is independent, but complementary to FE fix: https://github.com/Graylog2/graylog2-server/pull/18490
/nocl

## Motivation and Context
See #17839.

## How Has This Been Tested?
Manually and with new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

