### PR TITLE
Skip cleaning of node_modules in plugins on `-Dskip.web.build=true`

### DIFF
--- a/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
+++ b/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
@@ -41,6 +41,21 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${basedir}</directory>
+                                    <includes>
+                                        <include>node_modules/**/*</include>
+                                    </includes>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
                         <configuration>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -91,23 +91,6 @@
 
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}</directory>
-                            <includes>
-                                <include>node_modules/**/*</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-
-            <plugin>
                 <artifactId>jdeb</artifactId>
                 <groupId>org.vafer</groupId>
                 <configuration>


### PR DESCRIPTION
As a backend developer I sometimes need to rebuild the backend code but I would like to skip rebuilding the frontend code. I can do this with providing `-Dskip.web.build=true` to the maven command, like so:

```
./mvnw clean test-compile -Dskip.web.build=true -Dmaven.javadoc.skip=true -Dforbiddenapis.skip=true
```

However, this will also clean the node modules from the plugins without rebuilding them. So after executing the command, the development web server won't work anymore until I trigger installing the modules again.

With this change, the `maven-clean-plugin` will only clean the node modules from plugins, if the web build is *not* skipped. That's in line with how this was already handled for graylog2-server.

This allows me to cleanly rebuild the backend without breaking my frontend dev server.

/nocl not a user-facing change
