### PR TITLE
monkey patch `NodeInfoAction` to not require destructiveRequiresName

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/opensearch/client/opensearch/nodes/info/NodeInfoAction.java
+++ b/graylog-storage-opensearch2/src/main/java/org/opensearch/client/opensearch/nodes/info/NodeInfoAction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.opensearch.client.opensearch.nodes.info;
+
+import jakarta.json.stream.JsonGenerator;
+import org.opensearch.client.json.JsonpDeserializable;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.JsonpSerializable;
+import org.opensearch.client.json.ObjectBuilderDeserializer;
+import org.opensearch.client.json.ObjectDeserializer;
+import org.opensearch.client.util.ApiTypeHelper;
+import org.opensearch.client.util.MissingRequiredPropertyException;
+import org.opensearch.client.util.ObjectBuilder;
+import org.opensearch.client.util.ObjectBuilderBase;
+
+import java.util.function.Function;
+
+// typedef: nodes.info.NodeInfoAction
+
+@JsonpDeserializable
+public class NodeInfoAction implements JsonpSerializable {
+    private final String destructiveRequiresName;
+
+    // ---------------------------------------------------------------------------------------------
+
+    private NodeInfoAction(Builder builder) {
+
+        String destructiveRequiresNameSetting;
+        try {
+            destructiveRequiresNameSetting = ApiTypeHelper.requireNonNull(builder.destructiveRequiresName, this, "destructiveRequiresName");
+        } catch (MissingRequiredPropertyException e) {
+            destructiveRequiresNameSetting = "true";
+        }
+        this.destructiveRequiresName = destructiveRequiresNameSetting;
+
+    }
+
+    public static NodeInfoAction of(Function<Builder, ObjectBuilder<NodeInfoAction>> fn) {
+        return fn.apply(new Builder()).build();
+    }
+
+    /**
+     * Required - API name: {@code destructive_requires_name}
+     */
+    public final String destructiveRequiresName() {
+        return this.destructiveRequiresName;
+    }
+
+    /**
+     * Serialize this object to JSON.
+     */
+    public void serialize(JsonGenerator generator, JsonpMapper mapper) {
+        generator.writeStartObject();
+        serializeInternal(generator, mapper);
+        generator.writeEnd();
+    }
+
+    protected void serializeInternal(JsonGenerator generator, JsonpMapper mapper) {
+
+        generator.writeKey("destructive_requires_name");
+        generator.write(this.destructiveRequiresName);
+
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Builder for {@link NodeInfoAction}.
+     */
+
+    public static class Builder extends ObjectBuilderBase implements ObjectBuilder<NodeInfoAction> {
+        private String destructiveRequiresName;
+
+        /**
+         * Required - API name: {@code destructive_requires_name}
+         */
+        public final Builder destructiveRequiresName(String value) {
+            this.destructiveRequiresName = value;
+            return this;
+        }
+
+        /**
+         * Builds a {@link NodeInfoAction}.
+         *
+         * @throws NullPointerException if some of the required fields are null.
+         */
+        public NodeInfoAction build() {
+            _checkSingleUse();
+
+            return new NodeInfoAction(this);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Json deserializer for {@link NodeInfoAction}
+     */
+    public static final JsonpDeserializer<NodeInfoAction> _DESERIALIZER = ObjectBuilderDeserializer.lazy(
+            Builder::new,
+            NodeInfoAction::setupNodeInfoActionDeserializer
+    );
+
+    protected static void setupNodeInfoActionDeserializer(ObjectDeserializer<NodeInfoAction.Builder> op) {
+
+        op.add(Builder::destructiveRequiresName, JsonpDeserializer.stringDeserializer(), "destructive_requires_name");
+
+    }
+
+}


### PR DESCRIPTION
## Description
Due to a bug in the OS client (https://github.com/opensearch-project/opensearch-java/issues/894), deserialization of the `NodeInfoAction` fails if `action.destructive_requires_name` hasn't been set but another `action.*` property has. 

This change should be reverted after the original bug has been fixed. 

To make sure it is included in the jar, this should be merged after the pr containing https://github.com/Graylog2/graylog2-server/pull/18648/commits/41e70ab6e414f1ec3d16bdc64bbc4ba85a172e25 has been merged.

/nocl

## Motivation and Context
fixes #18619 

## How Has This Been Tested?
start graylog connected to OS without the change, call telemetry endpoint -> exception
start graylog with the change -> no exception

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

