### PR TITLE
Specify permissions for datanode proxy resources, rename request paths

### DIFF
--- a/changelog/unreleased/pr-18688.toml
+++ b/changelog/unreleased/pr-18688.toml
@@ -1,0 +1,15 @@
+type = "c"
+message = "Rename datanode opensearch proxy paths"
+
+pulls = ["18688"]
+
+details.user = """
+Opensearch proxy path is now containing /opensearch/ path instead of /request/:
+
+Before:
+* /api/datanodes/{hostname}/request/{path: .*}
+
+After:
+* /api/datanodes/{hostname}/opensearch/{path: .*}
+
+"""

--- a/full-backend-tests/src/test/java/org/graylog/datanode/DatanodeOpensearchProxyDisabledAllowlistIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/datanode/DatanodeOpensearchProxyDisabledAllowlistIT.java
@@ -38,7 +38,7 @@ public class DatanodeOpensearchProxyDisabledAllowlistIT {
     void testProtectedPath() {
         // this requests the /_search of the underlying opensearch. By default, it's disabled and should return HTTP 400
         // only if we disable the allowlist it should be accessible
-        apis.get("/datanodes/any/request/_search", 200)
+        apis.get("/datanodes/any/opensearch/_search", 200)
                 .assertThat().body("_shards.successful", Matchers.greaterThanOrEqualTo(1));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
@@ -40,6 +40,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.graylog2.shared.security.RestPermissions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,8 +53,8 @@ import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 @Api(value = "DataNodes/API", description = "Proxy direct access to Data Node's API")
 @Produces(MediaType.APPLICATION_JSON)
 @Timed
-@Path("/datanodes/{hostname}/request/{path: .*}")
-@RequiresPermissions("*")
+@Path("/datanodes/{hostname}/opensearch/{path: .*}")
+@RequiresPermissions(RestPermissions.DATANODE_OPENSEARCH_PROXY)
 public class DataNodeApiProxyResource extends RestResource {
     private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
             request -> request.path().startsWith("_cluster"),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
@@ -38,6 +38,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.indexer.datanode.ProxyRequestAdapter;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,7 +52,7 @@ import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 @Path("/datanodes/{hostname}/rest/{path: .*}")
 @Produces(MediaType.APPLICATION_JSON)
 @Timed
-@RequiresPermissions("*")
+@RequiresPermissions(RestPermissions.DATANODE_REST_PROXY)
 public class DataNodeRestApiProxyResource extends RestResource {
     private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
             request -> request.path().startsWith("indices-directory") && "GET".equals(request.method())

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -173,6 +173,9 @@ public class RestPermissions implements PluginPermissions {
     public static final String DATANODE_START = "datanode:start";
     public static final String DATANODE_MIGRATION = "datanode:migration";
 
+    public static final String DATANODE_OPENSEARCH_PROXY = "datanode:opensearchproxy";
+    public static final String DATANODE_REST_PROXY = "datanode:opensearchproxy";
+
     // This is a special permission that ONLY works with GRNs as ID/target
     // TODO does this belong here?
     public static final String ENTITY_OWN = "entity:own";
@@ -205,6 +208,8 @@ public class RestPermissions implements PluginPermissions {
             .add(create(DATANODE_STOP, ""))
             .add(create(DATANODE_START, ""))
             .add(create(DATANODE_MIGRATION, ""))
+            .add(create(DATANODE_OPENSEARCH_PROXY, ""))
+            .add(create(DATANODE_REST_PROXY, ""))
             .add(create(DECORATORS_CREATE, ""))
             .add(create(DECORATORS_EDIT, ""))
             .add(create(DECORATORS_READ, ""))

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -174,7 +174,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String DATANODE_MIGRATION = "datanode:migration";
 
     public static final String DATANODE_OPENSEARCH_PROXY = "datanode:opensearchproxy";
-    public static final String DATANODE_REST_PROXY = "datanode:opensearchproxy";
+    public static final String DATANODE_REST_PROXY = "datanode:restproxy";
 
     // This is a special permission that ONLY works with GRNs as ID/target
     // TODO does this belong here?


### PR DESCRIPTION
Specify rest permissions for datanode proxies. Rename opensearch proxy path from 

`/datanodes/{hostname}/request/{path: .*}` to `/datanodes/{hostname}/opensearch/{path: .*}`


## Description
Add explicit REST permissions for the proxy endpoints. Rename paths from /request/ to /opensearch/, to avoid any confusion. 

Fixes partially https://github.com/Graylog2/graylog2-server/issues/18687

## How Has This Been Tested?
Existing and new integration tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

