### PR TITLE
Reimplement active state styling for buttons.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -159,12 +159,11 @@ type Props = React.PropsWithChildren<{
 const Button = React.forwardRef<HTMLButtonElement, Props>(
   ({
     'aria-label': ariaLabel, bsStyle, bsSize, className, 'data-testid': dataTestId, id, onClick, disabled, href,
-    title, form, target, type, rel, role, name, tabIndex, children,
+    title, form, target, type, rel, role, name, tabIndex, children, active,
   }, ref) => {
     const theme = useTheme();
     const style = mapStyle(bsStyle);
     const color = style === 'link' ? 'transparent' : theme.colors.button[style].background;
-
     const sharedProps = {
       id,
       'aria-label': ariaLabel,
@@ -172,6 +171,7 @@ const Button = React.forwardRef<HTMLButtonElement, Props>(
       ...stylesProps(style),
       $bsStyle: style,
       $bsSize: bsSize,
+      variant: active ? 'outline' : 'filled',
       color,
       'data-testid': dataTestId,
       disabled,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are reimplementing the `active` state styling for the button component.
This styling got lost, while implementing the mantine button.

Before we were using the `:active` styling for the active element.
It is currently not easily possible to also use the styling of the pseudo class when the `active` prop is true.

Now we are just using a different variant instead.

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/de3208ce-eba0-4a6a-85fc-a2cb5605bcfe)


Fixes https://github.com/Graylog2/graylog2-server/issues/18360
/nocl