### PR TITLE
Do not listen for keyboard shortcuts in inputs, by default.

### DIFF
--- a/graylog2-web-interface/src/hooks/useHotkey.tsx
+++ b/graylog2-web-interface/src/hooks/useHotkey.tsx
@@ -32,7 +32,6 @@ export const DEFAULT_COMBINATION_KEY = '+';
 const defaultOptions: ReactHotKeysHookOptions & Options = {
   preventDefault: true,
   enabled: true,
-  enableOnFormTags: true,
   enableOnContentEditable: false,
   combinationKey: DEFAULT_COMBINATION_KEY,
   splitKey: DEFAULT_SPLIT_KEY,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


Currently you can't enter a `?` in an input, because it will open the shortcuts overview.

I remember enabling this feature to be able to trigger keyboard shortcuts while the search query input is focused. Now where we use the `react-ace` commands to listen for the keyboard shortcuts this is no longer necessary.

it is still possible to overwrite this behaviour for an individual shortcut.

Fixes https://github.com/Graylog2/graylog2-server/issues/18699
/nocl
