### PR TITLE
Fix RunsWithDatanode injection for insecure datanodes instances

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/RunsWithDataNodeDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/RunsWithDataNodeDiscoveryProvider.java
@@ -17,36 +17,23 @@
 package org.graylog2.configuration;
 
 import com.google.common.base.Suppliers;
-import org.graylog2.bootstrap.preflight.PreflightConfigResult;
-import org.graylog2.bootstrap.preflight.PreflightConfigService;
-import org.graylog2.cluster.Node;
-import org.graylog2.cluster.nodes.DataNodeDto;
-import org.graylog2.cluster.nodes.NodeService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.NodeService;
 
-import java.net.URI;
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 
 public class RunsWithDataNodeDiscoveryProvider implements Provider<Boolean> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RunsWithDataNodeDiscoveryProvider.class);
-    private final PreflightConfigService preflightConfigService;
     private final NodeService<DataNodeDto> nodeService;
 
     private final Supplier<Boolean> resultsCachingSupplier;
 
     @Inject
     public RunsWithDataNodeDiscoveryProvider(
-            PreflightConfigService preflightConfigService,
             NodeService<DataNodeDto> nodeService) {
-        this.preflightConfigService = preflightConfigService;
         this.nodeService = nodeService;
         this.resultsCachingSupplier = Suppliers.memoize(this::doGet);
     }
@@ -57,24 +44,6 @@ public class RunsWithDataNodeDiscoveryProvider implements Provider<Boolean> {
     }
 
     private Boolean doGet() {
-        final PreflightConfigResult preflightResult = preflightConfigService.getPreflightConfigResult();
-
-        // if preflight is finished, we assume that there will be some datanode registered via node-service.
-        if (preflightResult == PreflightConfigResult.FINISHED) {
-            final List<URI> discovered = discover();
-            if (!discovered.isEmpty()) {
-                LOG.debug("Running with DataNode(s).");
-                return Boolean.TRUE;
-            }
-        }
-        LOG.debug("Not running with DataNode(s).");
-        return Boolean.FALSE;
-    }
-
-    private List<URI> discover() {
-        return nodeService.allActive().values().stream()
-                .map(Node::getTransportAddress)
-                .map(URI::create)
-                .collect(Collectors.toList());
+        return !nodeService.allActive().isEmpty();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/RunsWithDataNodeDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/RunsWithDataNodeDiscoveryProvider.java
@@ -20,6 +20,7 @@ import com.google.common.base.Suppliers;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodeStatus;
 import org.graylog2.cluster.nodes.NodeService;
 
 import java.util.function.Supplier;
@@ -44,6 +45,6 @@ public class RunsWithDataNodeDiscoveryProvider implements Provider<Boolean> {
     }
 
     private Boolean doGet() {
-        return !nodeService.allActive().isEmpty();
+        return nodeService.allActive().values().stream().anyMatch(node -> DataNodeStatus.AVAILABLE == node.getDataNodeStatus());
     }
 }


### PR DESCRIPTION
/nocl

## Description
The preflight finished flag will be never configured if the datanode is configured in insecure mode and a graylog server starts against such datanode. This then blocks other features depending on the datanode detection.

To discussion:

- What happens if a datanode appears but it's not used as indexer?
- Is the caching there making the functionality better or worse?
- What happens if the datanode server starts after the graylog server?

The only really reliable solution would be to extend VersionProbe in a way that guarantees that we are using the datanode as the indexer. But there is nothing, except changeable cluster name, that we could use to detect this. Maybe matching the indexer url with datanodes collection in mongodb and know that if the url matches and we get back opensearch version, it's actually a datanode?

## Motivation and Context
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6835


## How Has This Been Tested?
Existing set of integration tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

