### PR TITLE
improve Remote Reindex Migration Indices display UX

### DIFF
--- a/changelog/unreleased/pr-18754.toml
+++ b/changelog/unreleased/pr-18754.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "improve Remote Reindex Migration Indices display UX."
+
+pulls = ["18754"]
+issues=["Graylog2/graylog-plugin-enterprise#6844"]

--- a/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/MigrateExistingData.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/MigrateExistingData.tsx
@@ -28,8 +28,9 @@ import type { MigrationActions, MigrationState, MigrationStepComponentProps, Ste
 import MigrationStepTriggerButtonToolbar from '../common/MigrationStepTriggerButtonToolbar';
 
 const IndicesContainer = styled.div`
-  max-height: 100px;
-  overflow-y: auto;
+  max-height: 300px;
+  overflow-y: scroll;
+  overflow: -moz-scrollbars-vertical;
   margin-top: 5px;
 `;
 
@@ -136,7 +137,7 @@ const MigrateExistingData = ({ currentStep, onTriggerStep }: MigrationStepCompon
                  onChange={(e) => handleChange(e, setFieldValue)} />
           {(availableIndices.length > 0) && (
             <Alert title="Valid connection" bsStyle="success">
-              These are the available indices for the remote reindex migration:
+              These are the available <b>{availableIndices.length}</b> indices for the remote reindex migration:
               <IndicesContainer>
                 {availableIndices.map((index) => (
                   <Input type="checkbox"

--- a/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/MigrateExistingData.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/MigrateExistingData.tsx
@@ -31,6 +31,7 @@ const IndicesContainer = styled.div`
   max-height: 300px;
   overflow-y: scroll;
   overflow: -moz-scrollbars-vertical;
+  -ms-overflow-y: scroll;
   margin-top: 5px;
 `;
 


### PR DESCRIPTION
In this PR we:

- Display the total number of available indices
- Increase the number of indices shown in the valid connection box
- Made scroll-bar always visible

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6844

## Screenshots (if appropriate):
![Screenshot 2024-03-22 at 15 02 59](https://github.com/Graylog2/graylog2-server/assets/106236152/7d289282-3674-4bf6-92a3-9c5995310c47)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

