### PR TITLE
Add banner for security marketing pages.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Alert.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Alert.tsx
@@ -26,6 +26,7 @@ type Props = {
   bsStyle?: ColorVariant,
   children: React.ReactNode,
   className?: string,
+  displayIcon?: boolean,
   onDismiss?: () => void,
   style?: CSSProperties,
   title?: React.ReactNode,
@@ -62,7 +63,7 @@ const iconNameForType = (bsStyle: ColorVariant) => {
   }
 };
 
-const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props) => {
+const Alert = ({ children, bsStyle, title, style, className, onDismiss, displayIcon }: Props) => {
   const displayCloseButton = typeof onDismiss === 'function';
   const iconName = iconNameForType(bsStyle);
 
@@ -73,7 +74,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
                  style={style}
                  onClose={onDismiss}
                  title={title}
-                 icon={<Icon name={iconName} />}
+                 icon={displayIcon && <Icon name={iconName} />}
                  closeButtonLabel={displayCloseButton && 'Close alert'}
                  withCloseButton={displayCloseButton}>
       {children}
@@ -83,6 +84,7 @@ const Alert = ({ children, bsStyle, title, style, className, onDismiss }: Props)
 
 Alert.defaultProps = {
   className: undefined,
+  displayIcon: true,
   onDismiss: undefined,
   style: undefined,
   title: undefined,

--- a/graylog2-web-interface/src/components/security/teaser/Banner.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/Banner.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled from 'styled-components';
+import { useState } from 'react';
+
+import Store from 'logic/local-storage/Store';
+import { Alert, Modal, BootstrapModalWrapper } from 'components/bootstrap';
+import { ExternalLinkButton } from 'components/common';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+
+const SECURITY_TEASER_MODAL_STORAGE_KEY = 'dismissed_security_teaser_modal';
+
+const Container = styled.div`
+  padding: 0 10px;
+`;
+
+const AlertInner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Header = styled.h2`
+  font-weight: bold;
+`;
+
+const LeftCol = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Banner = () => {
+  const [showModal, setShowModal] = useState(() => Store.get(SECURITY_TEASER_MODAL_STORAGE_KEY) !== 'true');
+  const sendTelemetry = useSendTelemetry();
+
+  const dismissModal = () => {
+    setShowModal(false);
+
+    Store.set(SECURITY_TEASER_MODAL_STORAGE_KEY, 'true');
+
+    sendTelemetry(TELEMETRY_EVENT_TYPE.SECURITY_APP.ASSET_CONFIG_PRIORITY_UPDATED, {
+      app_pathname: 'security',
+      app_section: 'teaser-page',
+      app_action_value: 'dismiss-teaser-modal',
+    });
+  };
+
+  return (
+    <Container>
+      <Alert bsStyle="info" displayIcon={false}>
+        <AlertInner>
+          <LeftCol>
+            <Header>Security Demo</Header>
+            For more information and booking a full demo of the product, visit the Graylog web site.
+          </LeftCol>
+          <ExternalLinkButton bsStyle="info" href="https://graylog.org/products/security">
+            Graylog Web Site
+          </ExternalLinkButton>
+        </AlertInner>
+      </Alert>
+      {showModal && (
+        <BootstrapModalWrapper showModal
+                               onHide={dismissModal}
+                               bsSize="lg">
+          <Modal.Header closeButton>
+            <Modal.Title>Welcome to Graylog Security!</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            Graylog Security is designed to revolutionize cybersecurity for IT teams, offering the combined capabilities of SIEM,
+            Security Analytics, Incident Investigation, and Anomaly Detection. By using our platform, you can work more efficiently,
+            tackling critical tasks quicker, and mitigating risk caused by malicious actors and credential-based attacks.
+          </Modal.Body>
+        </BootstrapModalWrapper>
+      )}
+    </Container>
+  );
+};
+
+export default Banner;

--- a/graylog2-web-interface/src/components/security/teaser/TeaserSearch.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/TeaserSearch.tsx
@@ -26,6 +26,7 @@ import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayout
 import type { SearchJobResult } from 'views/logic/SearchResult';
 import type { SearchJson } from 'views/logic/search/Search';
 import StaticSearch from 'views/components/StaticSearch';
+import Banner from 'components/security/teaser/Banner';
 
 type HotspotMeta = {
   positionX: string,
@@ -81,6 +82,7 @@ const TeaserSearch = ({ searchJson, viewJson, searchJobResult, hotspots }: Props
 
   return (
     <SearchPageLayoutProvider value={searchPageLayout}>
+      <Banner />
       <StaticSearch searchJson={searchJson}
                     viewJson={viewJson}
                     searchJobResult={searchJobResult} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are adding a simple banner for the security teaser pages. We are also showing a modal when opening the pages for the first time.

/nocl