### PR TITLE
Check inputs for cloud compatibility when installing content pack

### DIFF
--- a/changelog/unreleased/pr-18769.toml
+++ b/changelog/unreleased/pr-18769.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "When installing a content pack in cloud, ignore any inputs that are not cloud-compatible."
+
+pulls = ["18688", "Graylog2/graylog-plugin-enterprise#6854"]
+issues = ["Graylog2/graylog-plugin-enterprise#5997"]

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -18,14 +18,13 @@ package org.graylog.aws.inputs.cloudtrail;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
+import jakarta.inject.Inject;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
-
-import jakarta.inject.Inject;
 
 public class CloudTrailInput extends MessageInput {
     private static final String NAME = "AWS CloudTrail";
@@ -67,13 +66,11 @@ public class CloudTrailInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        @Override
-        public boolean isCloudCompatible() {
+        public static boolean isCloudCompatible() {
             return true;
         }
 
-        @Override
-        public boolean isForwarderCompatible() {
+        public static boolean isForwarderCompatible() {
             return false;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
@@ -18,6 +18,7 @@ package org.graylog.integrations.aws.inputs;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
+import jakarta.inject.Inject;
 import org.graylog.integrations.aws.codecs.AWSCodec;
 import org.graylog.integrations.aws.service.AWSService;
 import org.graylog.integrations.aws.transports.AWSTransport;
@@ -34,8 +35,6 @@ import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import software.amazon.awssdk.regions.Region;
-
-import jakarta.inject.Inject;
 
 /**
  * General AWS input for all types of supported AWS logs.
@@ -90,8 +89,7 @@ public class AWSInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        @Override
-        public boolean isCloudCompatible() {
+        public static boolean isCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -110,8 +110,8 @@ public class ContentPackService {
                                                       Map<String, ValueReference> parameters,
                                                       String comment,
                                                       String user) {
-        if (contentPack instanceof ContentPackV1) {
-            return installContentPack((ContentPackV1) contentPack, parameters, comment, user);
+        if (contentPack instanceof ContentPackV1 contentPackV1) {
+            return installContentPack(contentPackV1, parameters, comment, user);
         } else {
             throw new IllegalArgumentException("Unsupported content pack version: " + contentPack.version());
         }
@@ -235,8 +235,8 @@ public class ContentPackService {
     }
 
     public ContentPackUninstallDetails getUninstallDetails(ContentPack contentPack, ContentPackInstallation installation) {
-        if (contentPack instanceof ContentPackV1) {
-            return getUninstallDetails((ContentPackV1) contentPack, installation);
+        if (contentPack instanceof ContentPackV1 contentPackV1) {
+            return getUninstallDetails(contentPackV1, installation);
         } else {
             throw new IllegalArgumentException("Unsupported content pack version: " + contentPack.version());
         }
@@ -328,7 +328,7 @@ public class ContentPackService {
                                 nativeEntityDescriptor);
                     } else if (nativeEntityOptional.isPresent()) {
                         final Object nativeEntity = nativeEntityOptional.get();
-                        LOG.trace("Removing existing native entity for {} ({})", nativeEntityDescriptor);
+                        LOG.trace("Removing existing native entity for {}", nativeEntityDescriptor);
                         try {
                             // The EntityFacade#delete() method expects the actual entity object
                             //noinspection unchecked
@@ -340,7 +340,7 @@ public class ContentPackService {
                             failedEntities.add(nativeEntityDescriptor);
                         }
                     } else {
-                        LOG.trace("Couldn't find existing native entity for {} ({})", nativeEntityDescriptor);
+                        LOG.trace("Couldn't find existing native entity for {}", nativeEntityDescriptor);
                     }
                 }
             }
@@ -477,8 +477,8 @@ public class ContentPackService {
     }
 
     public Set<ConstraintCheckResult> checkConstraints(ContentPack contentPack) {
-        if (contentPack instanceof ContentPackV1) {
-            return checkConstraintsV1((ContentPackV1) contentPack);
+        if (contentPack instanceof ContentPackV1 contentPackV1) {
+            return checkConstraintsV1(contentPackV1);
         } else if (contentPack instanceof LegacyContentPack) {
             return Collections.emptySet();
         } else {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -91,7 +91,7 @@ public class ContentPackService {
     private final Set<ConstraintChecker> constraintCheckers;
     private final Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades;
     private final ObjectMapper objectMapper;
-    private boolean isCloud = false;
+    private final Configuration configuration;
 
     @Inject
     public ContentPackService(ContentPackInstallationPersistenceService contentPackInstallationPersistenceService,
@@ -99,18 +99,11 @@ public class ContentPackService {
                               Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades,
                               ObjectMapper objectMapper,
                               Configuration configuration) {
-        this(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, objectMapper);
-        isCloud = configuration.isCloud();
-    }
-
-    public ContentPackService(ContentPackInstallationPersistenceService contentPackInstallationPersistenceService,
-                              Set<ConstraintChecker> constraintCheckers,
-                              Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades,
-                              ObjectMapper objectMapper) {
         this.contentPackInstallationPersistenceService = contentPackInstallationPersistenceService;
         this.constraintCheckers = constraintCheckers;
         this.entityFacades = entityFacades;
         this.objectMapper = objectMapper;
+        this.configuration = configuration;
     }
 
     public ContentPackInstallation installContentPack(ContentPack contentPack,
@@ -151,10 +144,7 @@ public class ContentPackService {
                 final EntityDescriptor entityDescriptor = entity.toEntityDescriptor();
                 final EntityWithExcerptFacade facade = entityFacades.getOrDefault(entity.type(), UnsupportedEntityFacade.INSTANCE);
 
-                //TODO remove this
-                isCloud = true;
-
-                if (isCloud && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
+                if (configuration.isCloud() && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
                     boolean isCloudCompatible = true;
                     final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
                     try {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -19,6 +19,7 @@ package org.graylog2.inputs.misc.jsonpath;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import jakarta.inject.Inject;
 import org.graylog2.inputs.codecs.JsonPathCodec;
 import org.graylog2.inputs.transports.HttpPollTransport;
 import org.graylog2.plugin.DocsHelper;
@@ -27,8 +28,6 @@ import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.inputs.MessageInput;
-
-import jakarta.inject.Inject;
 
 import static org.graylog2.inputs.transports.HttpPollTransport.CK_CONTENT_TYPE;
 import static org.graylog2.inputs.transports.HttpPollTransport.CK_HTTP_BODY;
@@ -70,8 +69,7 @@ public class JsonPathInput extends MessageInput {
             super(NAME, false, DocsHelper.PAGE_SENDING_JSONPATH.toString());
         }
 
-        @Override
-        public boolean isCloudCompatible() {
+        public static boolean isCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
@@ -19,14 +19,13 @@ package org.graylog2.inputs.random;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import jakarta.inject.Inject;
 import org.graylog2.inputs.codecs.RandomHttpMessageCodec;
 import org.graylog2.inputs.transports.RandomMessageTransport;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.MessageInput;
-
-import jakarta.inject.Inject;
 
 public class FakeHttpMessageInput extends MessageInput {
 
@@ -61,8 +60,7 @@ public class FakeHttpMessageInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        @Override
-        public boolean isCloudCompatible() {
+        public static boolean isCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -418,12 +418,12 @@ public abstract class MessageInput implements Stoppable {
         this.nodeId = nodeId;
     }
 
-    public boolean isCloudCompatible() {
-        return descriptor.isCloudCompatible();
+    public static boolean isCloudCompatible() {
+        return Descriptor.isCloudCompatible();
     }
 
-    public boolean isForwarderCompatible() {
-        return descriptor.isForwarderCompatible();
+    public static boolean isForwarderCompatible() {
+        return Descriptor.isForwarderCompatible();
     }
 
     public interface Factory<M> {
@@ -472,11 +472,11 @@ public abstract class MessageInput implements Stoppable {
             super(name, exclusive, linkToDocs);
         }
 
-        public boolean isCloudCompatible() {
+        public static boolean isCloudCompatible() {
             return false;
         }
 
-        public boolean isForwarderCompatible() {
+        public static boolean isForwarderCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -418,11 +418,11 @@ public abstract class MessageInput implements Stoppable {
         this.nodeId = nodeId;
     }
 
-    public static boolean isCloudCompatible() {
+    public boolean isCloudCompatible() {
         return Descriptor.isCloudCompatible();
     }
 
-    public static boolean isForwarderCompatible() {
+    public boolean isForwarderCompatible() {
         return Descriptor.isForwarderCompatible();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -57,7 +57,6 @@ public abstract class MessageInput implements Stoppable {
     public static final String FIELD_CONFIGURATION = "configuration";
     public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
     public static final String FIELD_CREATED_AT = "created_at";
-    public static final String FIELD_STARTED_AT = "started_at";
     public static final String FIELD_ATTRIBUTES = "attributes";
     public static final String FIELD_STATIC_FIELDS = "static_fields";
     public static final String FIELD_GLOBAL = "global";
@@ -101,7 +100,7 @@ public abstract class MessageInput implements Stoppable {
     private String nodeId;
     private MetricSet transportMetrics;
 
-    public MessageInput(MetricRegistry metricRegistry,
+    protected MessageInput(MetricRegistry metricRegistry,
                         Configuration configuration,
                         Transport transport,
                         LocalMetricRegistry localRegistry, Codec codec, Config config, Descriptor descriptor, ServerStatus serverStatus) {
@@ -289,7 +288,7 @@ public abstract class MessageInput implements Stoppable {
                 || newDesiredState.equals(IOState.Type.STOPPED)) {
             desiredState = newDesiredState;
         } else {
-            LOG.error("Ignoring unexpected desired state " + newDesiredState + " for input " + title);
+            LOG.error("Ignoring unexpected desired state {} for input {}", newDesiredState, title);
         }
     }
 
@@ -338,7 +337,7 @@ public abstract class MessageInput implements Stoppable {
             map.put(FIELD_STATIC_FIELDS, getStaticFields());
         }
 
-        if (!isGlobal()) {
+        if (Boolean.FALSE.equals(isGlobal())) {
             map.put(FIELD_NODE_ID, getNodeId());
         }
 
@@ -368,8 +367,7 @@ public abstract class MessageInput implements Stoppable {
 
     @Override
     public boolean equals(final Object obj) {
-        if (obj instanceof MessageInput) {
-            final MessageInput input = (MessageInput) obj;
+        if (obj instanceof MessageInput input) {
             return this.getPersistId().equals(input.getPersistId());
         } else {
             return false;
@@ -463,8 +461,8 @@ public abstract class MessageInput implements Stoppable {
         }
     }
 
-    public static abstract class Descriptor extends AbstractDescriptor {
-        public Descriptor() {
+    public abstract static class Descriptor extends AbstractDescriptor {
+        protected Descriptor() {
             super();
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -183,7 +183,7 @@ public class ContentPackServiceTest {
                 ModelTypes.EVENT_DEFINITION_V1, new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService)
                 );
 
-        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades);
+        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper());
 
         Map<String, String> entityData = new HashMap<>(2);
         entityData.put("name", "NAME");

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -50,10 +50,12 @@ import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewSummaryService;
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
 import org.graylog.scheduler.DBJobDefinitionService;
+import org.graylog2.Configuration;
 import org.graylog2.contentpacks.constraints.ConstraintChecker;
 import org.graylog2.contentpacks.constraints.GraylogVersionConstraintChecker;
 import org.graylog2.contentpacks.facades.EntityWithExcerptFacade;
 import org.graylog2.contentpacks.facades.GrokPatternFacade;
+import org.graylog2.contentpacks.facades.InputFacade;
 import org.graylog2.contentpacks.facades.OutputFacade;
 import org.graylog2.contentpacks.facades.SearchFacade;
 import org.graylog2.contentpacks.facades.StreamFacade;
@@ -67,18 +69,27 @@ import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.contentpacks.model.entities.InputEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.QueryEntity;
 import org.graylog2.contentpacks.model.entities.SearchEntity;
 import org.graylog2.contentpacks.model.entities.ViewEntity;
 import org.graylog2.contentpacks.model.entities.ViewStateEntity;
 import org.graylog2.contentpacks.model.entities.WidgetEntity;
+import org.graylog2.contentpacks.model.entities.references.ReferenceMap;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternService;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.inputs.Input;
+import org.graylog2.inputs.InputService;
+import org.graylog2.inputs.converters.ConverterFactory;
+import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.inputs.gelf.udp.GELFUDPInput;
+import org.graylog2.lookup.db.DBLookupTableService;
 import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.plugin.outputs.MessageOutput;
@@ -87,6 +98,8 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.inputs.InputRegistry;
+import org.graylog2.shared.inputs.MessageInputFactory;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.OutputImpl;
 import org.graylog2.streams.OutputService;
@@ -101,12 +114,14 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -116,6 +131,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ContentPackServiceTest {
@@ -156,6 +172,25 @@ public class ContentPackServiceTest {
     @Mock
     private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
 
+    @Mock
+    InputService inputService;
+    @Mock
+    InputRegistry inputRegistry;
+    @Mock
+    DBLookupTableService lookupTableService;
+    @Mock
+    GrokPatternService grokPatternService;
+    @Mock
+    MessageInputFactory messageInputFactory;
+    @Mock
+    ExtractorFactory extractorFactory;
+    @Mock
+    ConverterFactory converterFactory;
+    @Mock
+    ServerStatus serverStatus;
+    @Mock
+    Configuration configuration;
+
     private ContentPackService contentPackService;
     private Set<PluginMetaData> pluginMetaData;
     private Map<String, MessageOutput.Factory<? extends MessageOutput>> outputFactories;
@@ -180,10 +215,11 @@ public class ContentPackServiceTest {
                 ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, legacyAlertConditionMigration, indexSetService, userService),
                 ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2),
                 ModelTypes.SEARCH_V1, new SearchFacade(objectMapper, searchDbService, viewService, viewSummaryService, userService),
-                ModelTypes.EVENT_DEFINITION_V1, new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService)
+                ModelTypes.EVENT_DEFINITION_V1, new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService),
+                ModelTypes.INPUT_V1, new InputFacade(objectMapper, inputService, inputRegistry, lookupTableService, grokPatternService, messageInputFactory,
+                        extractorFactory, converterFactory, serverStatus, pluginMetaData, new HashMap<>())
                 );
-
-        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper());
+        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper(), configuration);
 
         Map<String, String> entityData = new HashMap<>(2);
         entityData.put("name", "NAME");
@@ -248,6 +284,39 @@ public class ContentPackServiceTest {
         when(eventDefinitionHandler.create(any(), any())).thenReturn(createTestEventDefinitionDto());
 
         contentPackService.installContentPack(contentPack, Collections.emptyMap(), "", TEST_USER);
+    }
+
+    @Test
+    public void installContentPackWithCloudCheck() throws Exception {
+        ImmutableSet<Entity> entities = ImmutableSet.of(createTestGelfUDPEntity());
+        ContentPackV1 contentPack = ContentPackV1.builder()
+                .description("test")
+                .entities(entities)
+                .name("test")
+                .revision(1)
+                .summary("")
+                .vendor("")
+                .url(URI.create("http://graylog.com"))
+                .id(ModelId.of("dead-beef"))
+                .build();
+
+        Input input = mock(Input.class);
+        GELFUDPInput gelfUDPInput = mock(GELFUDPInput.class);
+        when(messageInputFactory.create(any(), any())).thenReturn(gelfUDPInput);
+        when(inputService.find(any())).thenReturn(input);
+        when(input.getId()).thenReturn("id1");
+        when(input.getTitle()).thenReturn("myGelfUDP");
+
+        ArgumentCaptor<ContentPackInstallation> captor = ArgumentCaptor.forClass(ContentPackInstallation.class);
+        when(contentPackInstallService.insert(captor.capture())).thenReturn(null);
+
+        when(configuration.isCloud()).thenReturn(false);
+        contentPackService.installContentPack(contentPack, Collections.emptyMap(), "", TEST_USER);
+        assertThat(captor.getValue().entities().size()).isEqualTo(1);
+
+        when(configuration.isCloud()).thenReturn(true);
+        contentPackService.installContentPack(contentPack, Collections.emptyMap(), "", TEST_USER);
+        assertThat(captor.getValue().entities().size()).isEqualTo(0);
     }
 
     @Test
@@ -469,6 +538,22 @@ public class ContentPackServiceTest {
         return EntityV1.builder()
                 .id(ModelId.of("1"))
                 .type(ModelTypes.SEARCH_V1)
+                .data(objectMapper.convertValue(entity, JsonNode.class))
+                .constraints(ImmutableSet.of())
+                .build();
+    }
+
+    private Entity createTestGelfUDPEntity() {
+        final InputEntity entity = InputEntity.create(
+                ValueReference.of("myGelfUDP"),
+                new ReferenceMap(),
+                ImmutableMap.of(),
+                ValueReference.of("org.graylog2.inputs.gelf.udp.GELFUDPInput"),
+                ValueReference.of(true),
+                new ArrayList<>());
+        return EntityV1.builder()
+                .id(ModelId.of("1"))
+                .type(ModelTypes.INPUT_V1)
                 .data(objectMapper.convertValue(entity, JsonNode.class))
                 .constraints(ImmutableSet.of())
                 .build();

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -312,11 +312,11 @@ public class ContentPackServiceTest {
 
         when(configuration.isCloud()).thenReturn(false);
         contentPackService.installContentPack(contentPack, Collections.emptyMap(), "", TEST_USER);
-        assertThat(captor.getValue().entities().size()).isEqualTo(1);
+        assertThat(captor.getValue().entities()).hasSize(1);
 
         when(configuration.isCloud()).thenReturn(true);
         contentPackService.installContentPack(contentPack, Collections.emptyMap(), "", TEST_USER);
-        assertThat(captor.getValue().entities().size()).isEqualTo(0);
+        assertThat(captor.getValue().entities()).isEmpty();
     }
 
     @Test
@@ -429,7 +429,7 @@ public class ContentPackServiceTest {
     }
 
     @Test
-    public void getUninstallDetails() throws NotFoundException {
+    public void getUninstallDetails() {
         /* Test will be uninstalled */
         when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 1);
         ContentPackUninstallDetails expect = ContentPackUninstallDetails.create(nativeEntityDescriptors);
@@ -489,7 +489,7 @@ public class ContentPackServiceTest {
                 .build();
     }
 
-    private EntityV1 createTestViewEntity() throws Exception {
+    private EntityV1 createTestViewEntity() {
         final QueryEntity query = QueryEntity.builder()
                 .id("dead-beef")
                 .timerange(KeywordRange.create("last 5 minutes", "Etc/UTC"))

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
@@ -72,7 +72,7 @@ class V20230601104500_AddSourcesPageV2Test {
 
     static class TestContentPackService extends ContentPackService {
         public TestContentPackService() {
-            super(null, null, Map.of(), null);
+            super(null, null, Map.of(), null, null);
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
@@ -72,7 +72,7 @@ class V20230601104500_AddSourcesPageV2Test {
 
     static class TestContentPackService extends ContentPackService {
         public TestContentPackService() {
-            super(null, null, Map.of());
+            super(null, null, Map.of(), null);
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 import org.graylog.plugins.views.search.rest.TestSearchUser;
+import org.graylog2.Configuration;
 import org.graylog2.contentpacks.ContentPackInstallationPersistenceService;
 import org.graylog2.contentpacks.ContentPackService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -70,7 +71,7 @@ public class CatalogResourceTest {
                 mock(ContentPackInstallationPersistenceService.class);
         final Set<ConstraintChecker> constraintCheckers = Collections.emptySet();
         final Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades = Collections.singletonMap(ModelType.of("test", "1"), mockEntityFacade);
-        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper());
+        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper(), mock(Configuration.class));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.resources.system.contentpacks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableSet;
@@ -69,7 +70,7 @@ public class CatalogResourceTest {
                 mock(ContentPackInstallationPersistenceService.class);
         final Set<ConstraintChecker> constraintCheckers = Collections.emptySet();
         final Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades = Collections.singletonMap(ModelType.of("test", "1"), mockEntityFacade);
-        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades);
+        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper());
     }
 
     @Test


### PR DESCRIPTION
/prd Graylog2/graylog-plugin-enterprise#6854
<!--- Provide a general summary of your changes in the Title above -->
When installing a contentpack in cloud environment, ignore any inputs that are not cloud-compatible.

## Description
<!--- Describe your changes in detail -->
Method `MessageInput.Descriptor:isCloudCompatible()` is changed to be a static method. We can then use reflection prior to instantiating the class to validate that the class is cloud-compatible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See Graylog2/graylog-plugin-enterprise#5997

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing and unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

