### PR TITLE
fix duplicate startup of data node

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -192,6 +192,8 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
                     }
 
                     restClient = Optional.of(createRestClient(config));
+                    openSearchClient = restClient.map(c -> new OpenSearchClient(c, objectMapper));
+
                 }),
                 () -> {throw new IllegalArgumentException("Opensearch configuration required but not supplied!");}
         );

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -17,7 +17,6 @@
 package org.graylog.datanode.management;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.oxo42.stateless4j.StateMachine;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.http.client.utils.URIBuilder;
@@ -180,7 +179,18 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
                     trustManager.refresh();
                     // refresh the seed hosts
                     writeSeedHostsList();
+
+                    boolean startedPreviously = Objects.nonNull(commandLineProcess) && commandLineProcess.processInfo().alive();
+                    if (startedPreviously) {
+                        stop();
+                    }
+
                     commandLineProcess = new OpensearchCommandLineProcess(config, this);
+
+                    if (startedPreviously) {
+                        commandLineProcess.start();
+                    }
+
                     restClient = Optional.of(createRestClient(config));
                 }),
                 () -> {throw new IllegalArgumentException("Opensearch configuration required but not supplied!");}
@@ -199,14 +209,16 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
     }
     @Override
     public synchronized void start() {
-        opensearchConfiguration.ifPresentOrElse(
-                (config -> {
-                    commandLineProcess.start();
-                    restClient = Optional.of(createRestClient(config));
-                    openSearchClient = restClient.map(c -> new OpenSearchClient(c, objectMapper));
-                }),
-                () -> {throw new IllegalArgumentException("Opensearch configuration required but not supplied!");}
-        );
+        if (Objects.isNull(commandLineProcess) || !commandLineProcess.processInfo().alive()) {
+            opensearchConfiguration.ifPresentOrElse(
+                    (config -> {
+                        commandLineProcess.start();
+                        restClient = Optional.of(createRestClient(config));
+                        openSearchClient = restClient.map(c -> new OpenSearchClient(c, objectMapper));
+                    }),
+                    () -> {throw new IllegalArgumentException("Opensearch configuration required but not supplied!");}
+            );
+        }
     }
 
     @Override

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
@@ -34,12 +34,10 @@ import org.graylog2.cluster.nodes.NodeService;
 import org.graylog2.cluster.preflight.DataNodeProvisioningConfig;
 import org.graylog2.cluster.preflight.DataNodeProvisioningService;
 import org.graylog2.cluster.preflight.DataNodeProvisioningStateChangeEvent;
-import org.graylog2.configuration.IndexSetsDefaultConfiguration;
 import org.graylog2.datanode.DataNodeLifecycleEvent;
 import org.graylog2.datanode.RemoteReindexAllowlistEvent;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypesService;
-import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.security.CustomCAX509TrustManager;
@@ -126,7 +124,7 @@ public class OpensearchProcessService extends AbstractIdleService implements Pro
     @SuppressWarnings("unused")
     public void handlePreflightConfigEvent(DataNodeProvisioningStateChangeEvent event) {
         switch (event.state()) {
-            case STARTUP_REQUESTED -> startUp();
+            case STARTUP_REQUESTED -> this.process.start();
             case STORED -> {
                 configure();
                 dataNodeProvisioningService.changeState(event.nodeId(), DataNodeProvisioningConfig.State.STARTUP_PREPARED);

--- a/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
+++ b/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
@@ -76,15 +76,13 @@ public class ConfigureMetricsIndexSettings implements StateMachineTracer {
     public void transition(ProcessEvent trigger, ProcessState source, ProcessState destination) {
         if (destination == ProcessState.AVAILABLE && source == ProcessState.STARTING) {
             process.openSearchClient().ifPresent(client -> {
-                if (dataStreamService == null) {
-                    final IsmApi ismApi = new IsmApi(client, objectMapper);
-                    int replicas = nodeService.allActive().size() == 1 ? 0 : 1;
-                    dataStreamService = new DataStreamServiceImpl(
-                            new DataStreamAdapterOS2(client, objectMapper, ismApi),
-                            indexFieldTypesService,
-                            replicas
-                    );
-                }
+                final IsmApi ismApi = new IsmApi(client, objectMapper);
+                int replicas = nodeService.allActive().size() == 1 ? 0 : 1;
+                dataStreamService = new DataStreamServiceImpl(
+                        new DataStreamAdapterOS2(client, objectMapper, ismApi),
+                        indexFieldTypesService,
+                        replicas
+                );
                 dataStreamService.createDataStream(configuration.getMetricsStream(),
                         configuration.getMetricsTimestamp(),
                         createMappings(),


### PR DESCRIPTION
## Description
This is a workaround to not startup up a second instance/gracefully shutting down the running instance of OpenSearch in the data node.

Data node configuration change handling needs to be reworked and worked into the state machine to properly address this in the future (see #18013 )

/nocl

## Motivation and Context
On configuration change (e.g. cert renewal), the existing OS instance didn't get shutdown properly, leading to a second instance being started with error.

## How Has This Been Tested?
- renew data node certificate

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

