### PR TITLE
Fix several search export client issues

### DIFF
--- a/changelog/unreleased/pr-18787.toml
+++ b/changelog/unreleased/pr-18787.toml
@@ -1,0 +1,6 @@
+type = "c"
+message = "Report partial shard failures and fix sort order for search export."
+
+issues = [""]
+pulls = ["18787"]
+

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.storage.elasticsearch7.views.export;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.export.ExportBackend;
@@ -31,25 +33,17 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuil
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.TermsQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.SearchHit;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.SortOrder;
 import org.graylog.storage.elasticsearch7.TimeRangeQueryFactory;
 import org.graylog2.plugin.Message;
-import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
@@ -58,7 +52,6 @@ import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.Qu
 import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_FORMATTER;
 
 @SuppressWarnings("rawtypes")
 public class ElasticsearchExportBackend implements ExportBackend {
@@ -131,8 +124,7 @@ public class ElasticsearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize())
-                .sort(Message.FIELD_TIMESTAMP, SortOrder.ASC);
+                .size(command.chunkSize());
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
@@ -16,7 +16,9 @@
  */
 package org.graylog.storage.elasticsearch7.views.export;
 
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.export.ExportException;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.ShardOperationFailedException;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RequestOptions;
@@ -25,9 +27,9 @@ import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.storage.elasticsearch7.ThrowingBiFunction;
 import org.graylog2.indexer.ElasticsearchException;
 
-import jakarta.inject.Inject;
-
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class ExportClient {
     private final ElasticsearchClient client;
@@ -39,7 +41,19 @@ public class ExportClient {
 
     public SearchResponse search(SearchRequest request, String errorMessage) {
         try {
-            return this.client.search(request, errorMessage);
+            final SearchResponse response = this.client.search(request, errorMessage);
+            if (response.getFailedShards() > 0) {
+                final List<Throwable> shardFailures = Arrays.stream(response.getShardFailures())
+                        .map(ShardOperationFailedException::getCause)
+                        .toList();
+                final List<String> errors = shardFailures
+                        .stream()
+                        .map(Throwable::getMessage)
+                        .distinct()
+                        .toList();
+                throw new ElasticsearchException("Unable to perform export query: ", errors);
+            }
+            return response;
         } catch (Exception e) {
             throw wrapException(e);
         }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
@@ -43,11 +43,8 @@ public class ExportClient {
         try {
             final SearchResponse response = this.client.search(request, errorMessage);
             if (response.getFailedShards() > 0) {
-                final List<Throwable> shardFailures = Arrays.stream(response.getShardFailures())
+                final List<String> errors = Arrays.stream(response.getShardFailures())
                         .map(ShardOperationFailedException::getCause)
-                        .toList();
-                final List<String> errors = shardFailures
-                        .stream()
                         .map(Throwable::getMessage)
                         .distinct()
                         .toList();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/SearchAfter.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/SearchAfter.java
@@ -60,8 +60,8 @@ public class SearchAfter implements RequestStrategy {
     }
 
     private void configureSort(SearchSourceBuilder source) {
-        source.sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC));
-        source.sort(SortBuilders.fieldSort(DEFAULT_TIEBREAKER_FIELD).order(SortOrder.DESC).unmappedType("keyword"));
+        source.sort(SortBuilders.fieldSort("timestamp").order(SortOrder.ASC));
+        source.sort(SortBuilders.fieldSort(DEFAULT_TIEBREAKER_FIELD).order(SortOrder.ASC).unmappedType("keyword"));
     }
 
     private Object[] lastHitSortFrom(List<SearchHit> hits) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
@@ -23,21 +23,30 @@ import org.graylog.plugins.views.search.export.ExportException;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog.plugins.views.search.export.SimpleMessageChunk;
 import org.graylog.plugins.views.search.searchfilters.db.IgnoreSearchFilters;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutMappingRequest;
 import org.graylog.storage.elasticsearch7.testing.ElasticsearchInstanceES7;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 
@@ -47,6 +56,11 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
     private ElasticsearchExportBackend backend;
 
     private ElasticsearchExportITHelper helper;
+
+    @Override
+    public String messageTemplateIndexPattern() {
+        return "graylog_*";
+    }
 
     @Rule
     public final ElasticsearchInstanceES7 elasticsearch = ElasticsearchInstanceES7.create();
@@ -62,6 +76,11 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
         backend = new ElasticsearchExportBackend(indexLookup, requestStrategy(), false, new IgnoreSearchFilters());
         helper = new ElasticsearchExportITHelper(indexLookup, backend);
 
+    }
+
+    @After
+    public void afterEach() {
+        elasticsearch.cleanUp();
     }
 
     private RequestStrategy requestStrategy() {
@@ -93,6 +112,7 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams()
                 .queryString(ElasticsearchQueryString.of("Ha Ho"))
                 .build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
 
         helper.runWithExpectedResultIgnoringSort(command, "timestamp,source,message",
                 "graylog_0, 2015-01-01T04:00:00.000Z, source-2, Ho",
@@ -200,6 +220,7 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
         importFixture("messages.json");
 
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
 
         helper.runWithExpectedResult(command, "timestamp,source,message",
                 "graylog_0, 2015-01-01T01:00:00.000Z, source-1, Ha",
@@ -223,5 +244,92 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
                 "graylog_0, 2015-01-01T14:30:00.000+10:30, source-2, Ho");
     }
 
+    @Test
+    @SkipDefaultIndexTemplate
+    public void canExportWithMissingFieldOnSort() {
+
+        createIndicesWithMapping(mappingWithOutAlias(), "graylog_0");
+        createIndicesWithMapping(mappingWithAlias(), "graylog_1");
+
+        importFixture("messages-with-old-field-types.json");
+
+        ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
+
+        helper.runWithExpectedResult(command, "timestamp,source,message",
+                "graylog_1, 2015-01-01T01:00:00.000Z, source-1, Ha",
+                "graylog_0, 2015-01-01T01:59:59.999Z, source-2, This message has no gl2_second_sort_field alias"
+        );
+    }
+
+    @Test
+    @SkipDefaultIndexTemplate
+    public void reportsShardErrors() {
+        createIndicesWithMapping(mappingWithOutAlias(), "graylog_0");
+        createIndicesWithMapping(mappingWithAlias(), "graylog_1");
+        // no mapping for graylog_2, so we will have a message with the wrong timestamp field type
+
+        importFixture("messages-with-old-field-types.json");
+
+        ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1", "graylog_2");
+
+        assertThatThrownBy(() ->
+                helper.runWithExpectedResult(command, "timestamp,source,message", "ignored, ignored, ignored, ignored"))
+                .isInstanceOf(ExportException.class);
+    }
+
+    @NotNull
+    private static Map<String, Object> mappingWithOutAlias() {
+        return Map.of("properties",
+                Map.of(
+                        Message.FIELD_TIMESTAMP,
+                        Map.of("type", "date",
+                                "format", "uuuu-MM-dd HH:mm:ss.SSS"
+                        )
+                        ,
+                        Message.FIELD_GL2_MESSAGE_ID,
+                        Map.of("type", "keyword"),
+                        Message.FIELD_STREAMS,
+                        Map.of("type", "keyword")
+                )
+        );
+    }
+
+    @NotNull
+    private static Map<String, Object> mappingWithAlias() {
+        return Map.of("properties",
+                Map.of(
+                        Message.FIELD_TIMESTAMP,
+                        Map.of("type", "date",
+                                "format", "uuuu-MM-dd HH:mm:ss.SSS"
+                        )
+                        ,
+                        Message.FIELD_GL2_MESSAGE_ID,
+                        Map.of("type", "keyword")
+                        ,
+                        Message.FIELD_STREAMS,
+                        Map.of("type", "keyword"),
+                        Message.GL2_SECOND_SORT_FIELD,
+                        Map.of("type", "alias",
+                                "path", Message.FIELD_GL2_MESSAGE_ID)
+                )
+        );
+    }
+
+    private void createIndicesWithMapping(Map<String, Object> mapping, String... indices) {
+        for (String index : indices) {
+            client().createIndex(index);
+        }
+
+        final PutMappingRequest putMappingRequest = new PutMappingRequest(indices).source(mapping);
+        final AcknowledgedResponse acknowledgedResponse = elasticsearch.elasticsearchClient()
+                .execute((c, opt) -> c.indices().putMapping(putMappingRequest, opt));
+
+        if (!acknowledgedResponse.isAcknowledged()) {
+            throw new RuntimeException("Failed to add mapping for indices " + Arrays.toString(indices));
+        }
+    }
 
 }

--- a/graylog-storage-elasticsearch7/src/test/resources/org/graylog/storage/elasticsearch7/views/export/messages-with-old-field-types.json
+++ b/graylog-storage-elasticsearch7/src/test/resources/org/graylog/storage/elasticsearch7/views/export/messages-with-old-field-types.json
@@ -1,0 +1,69 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_1",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "gl2_message_id": "0",
+            "source": "source-1",
+            "message": "Ha",
+            "timestamp": "2015-01-01 01:00:00.000",
+            "streams": [
+              "stream-01"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "gl2_message_id": "1",
+            "source": "source-2",
+            "message": "This message has no gl2_second_sort_field alias",
+            "timestamp": "2015-01-01 01:59:59.999",
+            "streams": [
+              "stream-02"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_2",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "data": {
+            "source": "source-3",
+            "message": "This message will be ingested with a wrong timestamp field type to trigger a shard error during export",
+            "timestamp": "2015-01-01 02:00:00.000",
+            "streams": [
+              "stream-03"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
@@ -43,11 +43,8 @@ public class ExportClient {
         try {
             final SearchResponse response = this.client.search(request, errorMessage);
             if (response.getFailedShards() > 0) {
-                final List<Throwable> shardFailures = Arrays.stream(response.getShardFailures())
+                final List<String> errors = Arrays.stream(response.getShardFailures())
                         .map(ShardOperationFailedException::getCause)
-                        .toList();
-                final List<String> errors = shardFailures
-                        .stream()
                         .map(Throwable::getMessage)
                         .distinct()
                         .toList();

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
@@ -16,18 +16,20 @@
  */
 package org.graylog.storage.opensearch2.views.export;
 
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.export.ExportException;
-import org.graylog.storage.opensearch2.OpenSearchClient;
-import org.graylog.storage.opensearch2.ThrowingBiFunction;
-import org.graylog2.indexer.ElasticsearchException;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.client.RequestOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.client.RestHighLevelClient;
-
-import jakarta.inject.Inject;
+import org.graylog.shaded.opensearch2.org.opensearch.core.action.ShardOperationFailedException;
+import org.graylog.storage.opensearch2.OpenSearchClient;
+import org.graylog.storage.opensearch2.ThrowingBiFunction;
+import org.graylog2.indexer.ElasticsearchException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class ExportClient {
     private final OpenSearchClient client;
@@ -39,7 +41,19 @@ public class ExportClient {
 
     public SearchResponse search(SearchRequest request, String errorMessage) {
         try {
-            return this.client.search(request, errorMessage);
+            final SearchResponse response = this.client.search(request, errorMessage);
+            if (response.getFailedShards() > 0) {
+                final List<Throwable> shardFailures = Arrays.stream(response.getShardFailures())
+                        .map(ShardOperationFailedException::getCause)
+                        .toList();
+                final List<String> errors = shardFailures
+                        .stream()
+                        .map(Throwable::getMessage)
+                        .distinct()
+                        .toList();
+                throw new ElasticsearchException("Unable to perform export query: ", errors);
+            }
+            return response;
         } catch (Exception e) {
             throw wrapException(e);
         }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.storage.opensearch2.views.export;
 
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.export.ExportBackend;
@@ -31,15 +33,11 @@ import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.TermsQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHit;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.sort.SortOrder;
 import org.graylog.storage.opensearch2.TimeRangeQueryFactory;
 import org.graylog2.plugin.Message;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -126,8 +124,7 @@ public class OpenSearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize())
-                .sort(Message.FIELD_TIMESTAMP, SortOrder.ASC);
+                .size(command.chunkSize());
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/SearchAfter.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/SearchAfter.java
@@ -60,8 +60,8 @@ public class SearchAfter implements RequestStrategy {
     }
 
     private void configureSort(SearchSourceBuilder source) {
-        source.sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC));
-        source.sort(SortBuilders.fieldSort(DEFAULT_TIEBREAKER_FIELD).order(SortOrder.DESC).unmappedType("keyword"));
+        source.sort(SortBuilders.fieldSort("timestamp").order(SortOrder.ASC));
+        source.sort(SortBuilders.fieldSort(DEFAULT_TIEBREAKER_FIELD).order(SortOrder.ASC).unmappedType("keyword"));
     }
 
     private Object[] lastHitSortFrom(List<SearchHit> hits) {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackendIT.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackendIT.java
@@ -23,21 +23,30 @@ import org.graylog.plugins.views.search.export.ExportException;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog.plugins.views.search.export.SimpleMessageChunk;
 import org.graylog.plugins.views.search.searchfilters.db.IgnoreSearchFilters;
+import org.graylog.shaded.opensearch2.org.opensearch.action.support.master.AcknowledgedResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.client.indices.PutMappingRequest;
 import org.graylog.storage.opensearch2.testing.OpenSearchInstance;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.SearchServerInstance;
+import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 
@@ -46,6 +55,11 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
     private IndexLookup indexLookup;
     private OpenSearchExportBackend backend;
     private OpenSearchExportITHelper helper;
+
+    @Override
+    public String messageTemplateIndexPattern() {
+        return "graylog_*";
+    }
 
     @Rule
     public final OpenSearchInstance openSearchInstance = OpenSearchInstance.create();
@@ -62,7 +76,12 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
         helper = new OpenSearchExportITHelper(indexLookup, backend);
     }
 
-    public RequestStrategy requestStrategy() {
+    @After
+    public void afterEach() {
+        openSearchInstance.cleanUp();
+    }
+
+    private RequestStrategy requestStrategy() {
         final ExportClient exportClient = new ExportClient(openSearchInstance.openSearchClient());
         return new SearchAfter(exportClient);
     }
@@ -91,6 +110,7 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams()
                 .queryString(ElasticsearchQueryString.of("Ha Ho"))
                 .build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
 
         helper.runWithExpectedResultIgnoringSort(command, "timestamp,source,message",
                 "graylog_0, 2015-01-01T04:00:00.000Z, source-2, Ho",
@@ -198,6 +218,7 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
         importFixture("messages.json");
 
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
 
         helper.runWithExpectedResult(command, "timestamp,source,message",
                 "graylog_0, 2015-01-01T01:00:00.000Z, source-1, Ha",
@@ -221,5 +242,92 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
                 "graylog_0, 2015-01-01T14:30:00.000+10:30, source-2, Ho");
     }
 
+    @Test
+    @SkipDefaultIndexTemplate
+    public void canExportWithMissingFieldOnSort() {
+
+        createIndicesWithMapping(mappingWithOutAlias(), "graylog_0");
+        createIndicesWithMapping(mappingWithAlias(), "graylog_1");
+
+        importFixture("messages-with-old-field-types.json");
+
+        ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1");
+
+        helper.runWithExpectedResult(command, "timestamp,source,message",
+                "graylog_1, 2015-01-01T01:00:00.000Z, source-1, Ha",
+                "graylog_0, 2015-01-01T01:59:59.999Z, source-2, This message has no gl2_second_sort_field alias"
+        );
+    }
+
+    @Test
+    @SkipDefaultIndexTemplate
+    public void reportsShardErrors() {
+        createIndicesWithMapping(mappingWithOutAlias(), "graylog_0");
+        createIndicesWithMapping(mappingWithAlias(), "graylog_1");
+        // no mapping for graylog_2 so we will have a message with the wrong timestamp field type
+
+        importFixture("messages-with-old-field-types.json");
+
+        ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams().build();
+
+        helper.mockIndexLookupFor(command, "graylog_0", "graylog_1", "graylog_2");
+
+        assertThatThrownBy(() ->
+                helper.runWithExpectedResult(command, "timestamp,source,message", "ignored, ignored, ignored, ignored"))
+                .isInstanceOf(ExportException.class);
+    }
+
+    @NotNull
+    private static Map<String, Object> mappingWithOutAlias() {
+        return Map.of("properties",
+                Map.of(
+                        Message.FIELD_TIMESTAMP,
+                        Map.of("type", "date",
+                                "format", "uuuu-MM-dd HH:mm:ss.SSS"
+                        )
+                        ,
+                        Message.FIELD_GL2_MESSAGE_ID,
+                        Map.of("type", "keyword"),
+                        Message.FIELD_STREAMS,
+                        Map.of("type", "keyword")
+                )
+        );
+    }
+
+    @NotNull
+    private static Map<String, Object> mappingWithAlias() {
+        return Map.of("properties",
+                Map.of(
+                        Message.FIELD_TIMESTAMP,
+                        Map.of("type", "date",
+                                "format", "uuuu-MM-dd HH:mm:ss.SSS"
+                        )
+                        ,
+                        Message.FIELD_GL2_MESSAGE_ID,
+                        Map.of("type", "keyword")
+                        ,
+                        Message.FIELD_STREAMS,
+                        Map.of("type", "keyword"),
+                        Message.GL2_SECOND_SORT_FIELD,
+                        Map.of("type", "alias",
+                                "path", Message.FIELD_GL2_MESSAGE_ID)
+                )
+        );
+    }
+
+    private void createIndicesWithMapping(Map<String, Object> mapping, String... indices) {
+        for (String index : indices) {
+            client().createIndex(index);
+        }
+
+        final PutMappingRequest putMappingRequest = new PutMappingRequest(indices).source(mapping);
+        final AcknowledgedResponse acknowledgedResponse = openSearchInstance.openSearchClient()
+                .execute((c, opt) -> c.indices().putMapping(putMappingRequest, opt));
+
+        if (!acknowledgedResponse.isAcknowledged()) {
+            throw new RuntimeException("Failed to add mapping for indices " + Arrays.toString(indices));
+        }
+    }
 
 }

--- a/graylog-storage-opensearch2/src/test/resources/org/graylog/storage/opensearch2/views/export/messages-with-old-field-types.json
+++ b/graylog-storage-opensearch2/src/test/resources/org/graylog/storage/opensearch2/views/export/messages-with-old-field-types.json
@@ -1,0 +1,69 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_1",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "gl2_message_id": "0",
+            "source": "source-1",
+            "message": "Ha",
+            "timestamp": "2015-01-01 01:00:00.000",
+            "streams": [
+              "stream-01"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "gl2_message_id": "1",
+            "source": "source-2",
+            "message": "This message has no gl2_second_sort_field alias",
+            "timestamp": "2015-01-01 01:59:59.999",
+            "streams": [
+              "stream-02"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_2",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "data": {
+            "source": "source-3",
+            "message": "This message will be ingested with a wrong timestamp field type to trigger a shard error during export",
+            "timestamp": "2015-01-01 02:00:00.000",
+            "streams": [
+              "stream-03"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -112,7 +112,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_PROCESSING_DURATION_MS, typeInteger())
-                .put(Message.FIELD_GL2_MESSAGE_ID, notAnalyzedString())
+                .put(FIELD_GL2_MESSAGE_ID, notAnalyzedString())
                 .put(Message.GL2_SECOND_SORT_FIELD, aliasTo(FIELD_GL2_MESSAGE_ID))
                 .put(Message.FIELD_STREAMS, notAnalyzedString())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchBaseTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchBaseTest.java
@@ -48,6 +48,8 @@ public abstract class ElasticsearchBaseTest {
     }
 
     public String messageTemplateIndexPattern() {
+        // TODO Check whether we can use graylog_* here.
+        //      This also matches composable ism templates and generates warnings
         return "*";
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchBaseTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchBaseTest.java
@@ -47,13 +47,17 @@ public abstract class ElasticsearchBaseTest {
         }
     }
 
+    public String messageTemplateIndexPattern() {
+        return "*";
+    }
+
     private void addGraylogDefaultIndexTemplate() {
         addIndexTemplates(getGraylogDefaultMessageTemplates(searchServer().version()));
     }
 
-    private static Map<String, Template> getGraylogDefaultMessageTemplates(SearchVersion version) {
+    private Map<String, Template> getGraylogDefaultMessageTemplates(SearchVersion version) {
         var template = new MessageIndexTemplateProvider().create(version, null)
-                .messageTemplate("*", "standard", 100L, null);
+                .messageTemplate(messageTemplateIndexPattern(), "standard", 100L, null);
         return Collections.singletonMap("graylog-test-internal", template);
     }
 


### PR DESCRIPTION
- The export client did not report any errors if only individual shards fail.
    
- The default sort order was wrong.
   We did sort by "timestamp.ASC, timestamp.DESC, gl2_second_sort_field.DESC"
   Change this to: "timestamp.ASC, gl2_second_sort_field.ASC"
    
- The ExportBackendIT tests were producing errors because the templates
  were applied for '*' which included the ism indices and their
  compound templates. Maybe we can use `graylog_*` for all tests, but
  for now make the wildcard configurable for each test.
    
- Add proper cleanup between each ExportBackendIT test
   
- Add missing mocking. some tests were running against all indices
   which is something that never happens in the real world.
    
- Add test for the missing sort field (gl2_second_sort_field) fix
    
- Add test for reporting individual shard failures


/nocl
