### PR TITLE
Add support for Data Node in search version checking API endpoints and component

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SearchVersionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SearchVersionResource.java
@@ -57,7 +57,7 @@ public class SearchVersionResource extends RestResource implements PluginRestRes
     private static final String SUPPORTED_SEARCH_VERSIONS =
             Arrays.stream(SearchVersion.Distribution.values())
                     .map(Enum::toString)
-                    .map(String::toLowerCase)
+                    .map(s -> s.toLowerCase(Locale.ENGLISH))
                     .collect(Collectors.joining(", "));
     final private ElasticsearchVersionProvider versionProvider;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SearchVersionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SearchVersionResource.java
@@ -25,6 +25,14 @@ import com.google.auto.value.AutoValue;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.configuration.validators.SearchVersionRange;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -35,17 +43,9 @@ import org.graylog2.storage.providers.ElasticsearchVersionProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.inject.Inject;
-
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
-
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 @Api(value = "System/SearchVersion", description = "Checks system search version requirements")
 @Path("/system/searchVersion")
@@ -54,6 +54,11 @@ import java.util.Locale;
 public class SearchVersionResource extends RestResource implements PluginRestResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(SearchVersionResource.class);
+    private static final String SUPPORTED_SEARCH_VERSIONS =
+            Arrays.stream(SearchVersion.Distribution.values())
+                    .map(Enum::toString)
+                    .map(String::toLowerCase)
+                    .collect(Collectors.joining(", "));
     final private ElasticsearchVersionProvider versionProvider;
 
     @Inject
@@ -76,9 +81,9 @@ public class SearchVersionResource extends RestResource implements PluginRestRes
         try {
             requiredDistribution = SearchVersion.Distribution.valueOf(distribution.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException e) {
-            LOG.error("Unsupported distribution {}. Valid values are [opensearch, elasticsearch].", distribution);
+            LOG.error("Unsupported distribution {}. Valid values are [" + SUPPORTED_SEARCH_VERSIONS + "].", distribution);
             throw new InternalServerErrorException(StringUtils.f(
-                    "Unsupported distribution %s. Valid values are [opensearch, elasticsearch].", distribution));
+                    "Unsupported distribution %s. Valid values are [" + SUPPORTED_SEARCH_VERSIONS + "].", distribution));
         }
 
         final SearchVersion currentVersion = versionProvider.get();

--- a/graylog2-web-interface/src/hooks/useSearchVersionCheck.ts
+++ b/graylog2-web-interface/src/hooks/useSearchVersionCheck.ts
@@ -38,7 +38,7 @@ export const fetchSearchVersionCheck = async ({ queryKey }) => {
   }
 };
 
-const useSearchVersionCheck = (distribution: 'opensearch' | 'elasticsearch', version?: string) => {
+const useSearchVersionCheck = (distribution: 'opensearch' | 'elasticsearch' | 'datanode', version?: string) => {
   const MAIN_KEY = 'SearchVersionQuery';
   const queryKey = version ? [MAIN_KEY, { distribution, version }] : [MAIN_KEY, { distribution, version: null }];
   const { data, isLoading, error } = useQuery<VersionCheckType, Error>(queryKey, fetchSearchVersionCheck);


### PR DESCRIPTION
Update the supported search values in the `/system/searchVersion` API endpoint error messages to use supported enum values instead of hard-coded values. Recently, the `DATANODE` search version was added but was not added to the error messages in the SearchVersionResource. This change should future-proof the error messages by using the actual enum values.

Also add `datanode` as supported argument in the `useSearchVersionCheck` component.

/nocl