### PR TITLE
DataNode: on insecure startup, always assume that preflight is finished

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
@@ -76,13 +76,6 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
         this.s3RepositoryConfiguration = s3RepositoryConfiguration;
     }
 
-    private boolean isPreflight() {
-        final PreflightConfigResult preflightResult = preflightConfigService.getPreflightConfigResult();
-
-        // if preflight is finished, we assume that there will be some datanode registered via node-service.
-        return preflightResult != PreflightConfigResult.FINISHED;
-    }
-
     @Override
     public OpensearchConfiguration get() {
         //TODO: at some point bind the whole list, for now there is too much experiments with order and prerequisites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In several places, we rely on `Preflight.FINISHED` so we have to make sure that it has been written during an insecure startup. Because in that case we don't do a preflight.

This is only a temp fix that should be replaced in the future.


/nocl

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6835

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

