### PR TITLE
DataNode: Fixing line breaks in cert for UI

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/csr/ClientCertGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/csr/ClientCertGenerator.java
@@ -83,7 +83,7 @@ public class ClientCertGenerator {
         this.dataDir = dataDir;
     }
 
-    private Path certFilePath( final String role, final String principal) {
+    private Path certFilePath(final String role, final String principal) {
         var certfile = Base64.getEncoder().encodeToString((role + ":" + principal).getBytes(StandardCharsets.UTF_8));
         return dataDir.resolve(Path.of(certfile + ".cert"));
     }
@@ -93,12 +93,12 @@ public class ClientCertGenerator {
         try (JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(writer)) {
             jcaPEMWriter.writeObject(o);
         }
-        return writer.toString().replace("\n", "");
+        return writer.toString();
     }
 
     public ClientCert generateClientCert(final String principal,
-                                     final String role,
-                                     final char[] privateKeyPassword) throws ClientCertGenerationException {
+                                         final String role,
+                                         final char[] privateKeyPassword) throws ClientCertGenerationException {
         try {
             var renewalPolicy = this.clusterConfigService.get(RenewalPolicy.class);
             var privateKeyEncryptedStorage = new PrivateKeyEncryptedFileStorage(certFilePath(role, principal));
@@ -123,7 +123,7 @@ public class ClientCertGenerator {
 
     public void removeCertFor(final String role, final String principal) throws IOException {
         var certFile = certFilePath(role, principal);
-        if(Files.exists(certFile)) {
+        if (Files.exists(certFile)) {
             Files.delete(certFile);
             securityAdapter.removeUserFromRoleMapping(role, principal);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The cert should be copy/pasteable from the UI, so I keep the linebreaks in the response which means it works from the UI but not from the API response via copy/paste 

fixes https://github.com/Graylog2/graylog2-server/issues/18781
/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

