### PR TITLE
DataNode: fix for path_repo / support Lists etc. in opensearch.yml generation

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/OpensearchConfigurationProvider.java
@@ -97,7 +97,7 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
                 .findFirst();
 
         try {
-            ImmutableMap.Builder<String, String> opensearchProperties = ImmutableMap.builder();
+            ImmutableMap.Builder<String, Object> opensearchProperties = ImmutableMap.builder();
 
             if (localConfiguration.getInitialClusterManagerNodes() != null && !localConfiguration.getInitialClusterManagerNodes().isBlank()) {
                 opensearchProperties.put("cluster.initial_cluster_manager_nodes", localConfiguration.getInitialClusterManagerNodes());
@@ -136,8 +136,8 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
         }
     }
 
-    private ImmutableMap<String, String> commonOpensearchConfig(final Configuration localConfiguration) {
-        final ImmutableMap.Builder<String, String> config = ImmutableMap.builder();
+    private ImmutableMap<String, Object> commonOpensearchConfig(final Configuration localConfiguration) {
+        final ImmutableMap.Builder<String, Object> config = ImmutableMap.builder();
         localConfiguration.getOpensearchNetworkHost().ifPresent(
                 networkHost -> config.put("network.host", networkHost));
         config.put("path.data", datanodeConfiguration.datanodeDirectories().getDataTargetDir().toString());
@@ -147,7 +147,7 @@ public class OpensearchConfigurationProvider implements Provider<OpensearchConfi
 
         // https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/#shared-file-system
         if(localConfiguration.getPathRepo() != null && !localConfiguration.getPathRepo().isEmpty()) {
-            config.put("path.repo", String.join(",", localConfiguration.getPathRepo()));
+            config.put("path.repo", localConfiguration.getPathRepo());
         }
 
         //config.put("network.publish_host", Tools.getLocalCanonicalHostname());

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchCommandLineProcess.java
@@ -115,8 +115,8 @@ public class OpensearchCommandLineProcess implements Closeable {
         opensearchCli.keystore().add("s3.client.default.secret_key", config.s3RepositoryConfiguration().getS3ClientDefaultSecretKey());
     }
 
-    private static Map<String, String> getOpensearchConfigurationArguments(OpensearchConfiguration config) {
-        Map<String, String> allArguments = new LinkedHashMap<>(config.asMap());
+    private static Map<String, Object> getOpensearchConfigurationArguments(OpensearchConfiguration config) {
+        Map<String, Object> allArguments = new LinkedHashMap<>(config.asMap());
 
         // now copy all the environment values to the configuration arguments. Opensearch won't do it for us,
         // because we are using tar distriburion and opensearch does this only for docker dist. See opensearch-env script

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessService.java
@@ -168,7 +168,7 @@ public class OpensearchProcessService extends AbstractIdleService implements Pro
     private void configure(Map<String, String> additionalConfig) {
         final OpensearchConfiguration original = configurationProvider.get();
 
-        final var finalAdditionalConfig = new HashMap<String, String>();
+        final var finalAdditionalConfig = new HashMap<String, Object>();
         finalAdditionalConfig.putAll(original.additionalConfiguration());
         finalAdditionalConfig.putAll(additionalConfig);
 

--- a/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
@@ -43,11 +43,11 @@ public record OpensearchConfiguration(
         S3RepositoryConfiguration s3RepositoryConfiguration,
 
         String nodeSearchCacheSize,
-        Map<String, String> additionalConfiguration
+        Map<String, Object> additionalConfiguration
 ) {
-    public Map<String, String> asMap() {
+    public Map<String, Object> asMap() {
 
-        Map<String, String> config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
 
         config.put("action.auto_create_index", "false");
 
@@ -78,7 +78,7 @@ public record OpensearchConfiguration(
         config.put("discovery.seed_providers", "file");
 
         config.put("node.search.cache.size", nodeSearchCacheSize);
-        if(s3RepositoryConfiguration.isRepositoryEnabled()) {
+        if (s3RepositoryConfiguration.isRepositoryEnabled()) {
             config.putAll(s3RepositoryConfiguration.toOpensearchProperties());
         }
 
@@ -97,12 +97,12 @@ public record OpensearchConfiguration(
     }
 
     public HttpHost getRestBaseUrl() {
-        final boolean sslEnabled = Boolean.parseBoolean(asMap().getOrDefault("plugins.security.ssl.http.enabled", "false"));
+        final boolean sslEnabled = Boolean.parseBoolean(asMap().getOrDefault("plugins.security.ssl.http.enabled", "false").toString());
         return new HttpHost(hostname(), httpPort(), sslEnabled ? "https" : "http");
     }
 
     public HttpHost getClusterBaseUrl() {
-        final boolean sslEnabled = Boolean.parseBoolean(asMap().getOrDefault("plugins.security.ssl.http.enabled", "false"));
+        final boolean sslEnabled = Boolean.parseBoolean(asMap().getOrDefault("plugins.security.ssl.http.enabled", "false").toString());
         return new HttpHost(hostname(), transportPort(), sslEnabled ? "https" : "http");
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

to support structured objects (lists etc.) in `opensearch.yml` config generation, we have to change the map values from String to Object

Has been manually tested with `path_repo` setting:

`path_repo = /tmp/dir1,/tmp/dir2` was converted to 
```
path.repo:
- /tmp/dir1
- /tmp/dir2
```

and OpenSearch started successfully

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

