### PR TITLE
Remove empty indexer tranport addresses in IndexerDiscoveryProvider

### DIFF
--- a/changelog/unreleased/pr-18802.toml
+++ b/changelog/unreleased/pr-18802.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Remove not yet configured datanodes (empty transport address) from indexer discovery"
+
+pulls = ["18802"]

--- a/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/management/OpensearchProcessImpl.java
@@ -123,7 +123,7 @@ class OpensearchProcessImpl implements OpensearchProcess, ProcessListener {
                         .setHost(httpHost.getHostName())
                         .setPort(httpHost.getPort())
                         .setScheme(httpHost.getSchemeName()).toString())
-                .orElse(""); // TODO: will this cause problems in the nodeservice?
+                .orElse(""); // Empty address will cause problems for opensearch clients. Has to be filtered out in IndexerDiscoveryProvider
         return URI.create(baseUrl);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
@@ -130,6 +130,7 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
     private List<URI> discover() {
         return nodeService.allActive().values().stream()
                 .map(Node::getTransportAddress)
+                .filter(address -> address != null && !address.isBlank())
                 .map(URI::create)
                 .collect(Collectors.toList());
     }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/IndexerDiscoveryProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/IndexerDiscoveryProviderTest.java
@@ -57,6 +57,23 @@ class IndexerDiscoveryProviderTest {
 
 
     @Test
+    void testAutomaticDiscoveryOneUnconfigured() {
+        final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
+                Collections.emptyList(),
+                1,
+                Duration.seconds(1),
+                preflightConfig(PreflightConfigResult.FINISHED),
+                nodes("http://localhost:9200", "") // the second node is not configured yet, has no transport address
+        );
+
+        Assertions.assertThat(provider.get())
+                .hasSize(1)
+                .extracting(URI::toString)
+                .contains("http://localhost:9200");
+    }
+
+
+    @Test
     void testPreconfiguredIndexers() {
         final IndexerDiscoveryProvider provider = new IndexerDiscoveryProvider(
                 List.of(URI.create("http://my-host:9200")),


### PR DESCRIPTION
When there are several datanodes available, one configured and one not yet configured, the IndexerDiscoveryProvider will see both, one with valid transport address and one with empty. We have to filter out the empty one, otherwise it will break opensearch clients. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

