### PR TITLE
Refactor remote reindex migration to use tasks

### DIFF
--- a/changelog/unreleased/pr-18825.toml
+++ b/changelog/unreleased/pr-18825.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Remote reindex migration in datanode now uses async opensearch tasks."
+
+pulls = ["18825"]
+issues=["Graylog2/graylog-plugin-enterprise#6844"]

--- a/full-backend-tests/src/test/java/org/graylog/datanode/RemoteReindexingMigrationIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/datanode/RemoteReindexingMigrationIT.java
@@ -69,37 +69,6 @@ public class RemoteReindexingMigrationIT {
         this.openSearchInstance.close();
     }
 
-    @ContainerMatrixTest
-    void testRemoteReindexingSync() throws ExecutionException, RetryException {
-        final String indexName = createRandomIndex();
-        final String indexName2 = createRandomIndex();
-        final String messageContent = ingestRandomMessage(indexName);
-        final String messageContent2 = ingestRandomMessage(indexName2);
-
-        // flush the newly created document
-        openSearchInstance.client().refreshNode();
-
-        final String request = """
-                {
-                    "hostname": "%s",
-                    "indices": ["%s", "%s"],
-                    "synchronous": true
-                }
-                """.formatted(openSearchInstance.internalUri(), indexName, indexName2);
-
-
-        LOG.info("Requesting remote reindex: " + request);
-
-        final ValidatableResponse migrationResponse = apis.post("/remote-reindex-migration/remoteReindex", request, 200);
-
-        // one document migrated
-        migrationResponse.assertThat().body("indices", Matchers.hasSize(2));
-        migrationResponse.assertThat().body("indices[0].status", Matchers.equalTo("FINISHED"));
-        migrationResponse.assertThat().body("indices[1].status", Matchers.equalTo("FINISHED"));
-
-        Assertions.assertThat(waitForMessage(indexName, messageContent)).containsEntry("message", messageContent);
-        Assertions.assertThat(waitForMessage(indexName2, messageContent2)).containsEntry("message", messageContent2);
-    }
 
     @ContainerMatrixTest
     void testRemoteAsyncReindexing() throws ExecutionException, RetryException {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RemoteReindexingMigrationAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RemoteReindexingMigrationAdapterES7.java
@@ -16,20 +16,19 @@
  */
 package org.graylog.storage.elasticsearch7;
 
+import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.List;
 
 public class RemoteReindexingMigrationAdapterES7 implements RemoteReindexingMigrationAdapter {
 
     public static final String UNSUPPORTED_MESSAGE = "This operation should never be called. We remote-reindex into the DataNode that contains OpenSearch. This adapter only exists for API completeness";
 
     @Override
-    public RemoteReindexMigration start(URI uri, String username, String password, List<String> indices, boolean synchronous) {
+    public RemoteReindexMigration start(RemoteReindexRequest request) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexNotAllowedException.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexNotAllowedException.java
@@ -1,0 +1,7 @@
+package org.graylog.storage.opensearch2;
+
+public class RemoteReindexNotAllowedException extends IllegalStateException {
+    public RemoteReindexNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -307,7 +307,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         } catch (IOException e) {
             final String message = "Could not reindex index: " + indexName + " - " + e.getMessage();
             logError(migration, message, e);
-            migration.indexByName(indexName).ifPresent(r -> r.onError(duration, message));
+            migration.indexByName(indexName).ifPresent(r -> r.onError(Duration.ZERO, TaskStatus.failure(message)));
         }
         waitForTaskCompleted(migration, index);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -16,10 +16,13 @@
  */
 package org.graylog.storage.opensearch2;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.validation.constraints.NotNull;
@@ -28,12 +31,13 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.client.tasks.GetTaskRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.client.tasks.GetTaskResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.client.tasks.TaskSubmissionResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.common.xcontent.json.JsonXContent;
-import org.graylog.shaded.opensearch2.org.opensearch.core.action.ActionListener;
 import org.graylog.shaded.opensearch2.org.opensearch.core.common.bytes.BytesReference;
 import org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ToXContent;
 import org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.XContentBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.index.reindex.BulkByScrollResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.index.reindex.ReindexRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.index.reindex.RemoteInfo;
 import org.graylog2.cluster.nodes.DataNodeDto;
@@ -43,11 +47,14 @@ import org.graylog2.cluster.nodes.NodeService;
 import org.graylog2.datanode.RemoteReindexAllowlistEvent;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
 import org.graylog2.indexer.migration.RemoteReindexIndex;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
+import org.graylog2.indexer.migration.TaskStatus;
+import org.graylog2.plugin.Tools;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +70,8 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -74,6 +83,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
 
     private static final int CONNECTION_ATTEMPTS = 40;
     private static final int WAIT_BETWEEN_CONNECTION_ATTEMPTS = 3;
+    public static final int TASK_UPDATE_INTERVAL_MILLIS = 1000;
 
     private final OpenSearchClient client;
     private final OkHttpClient httpClient;
@@ -81,6 +91,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
     private final Indices indices;
     private final IndexSetRegistry indexSetRegistry;
     private final ClusterEventBus eventBus;
+    private final ObjectMapper objectMapper;
 
     // TODO: this should be mongodb-persisted to ensure that any node in the cluster sees the same values. Other approach
     // would be to use regular graylog job. Then the migration ID would be the job ID
@@ -96,44 +107,43 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
                                                final NodeService<DataNodeDto> nodeService,
                                                final Indices indices,
                                                final IndexSetRegistry indexSetRegistry,
-                                               final ClusterEventBus eventBus) {
+                                               final ClusterEventBus eventBus,
+                                               final ObjectMapper objectMapper) {
         this.client = client;
         this.httpClient = httpClient;
         this.nodeService = nodeService;
         this.indices = indices;
         this.indexSetRegistry = indexSetRegistry;
         this.eventBus = eventBus;
+        this.objectMapper = objectMapper;
     }
 
     @Override
-    public RemoteReindexMigration start(final URI uri, final String username, final String password, final List<String> indices, final boolean synchronous) {
+    public RemoteReindexMigration start(RemoteReindexRequest request) {
         final RemoteReindexMigration migration = new RemoteReindexMigration();
         JOBS.put(migration.id(), migration);
         try {
-            migration.setIndices(collectIndices(uri, username, password, indices));
-            // finish can happen very late, in async code, so we need to handle it as a callback
-            // but the async nature causes problems with closed connections :-/
-            // migration.setFinishCallback(() -> removeAllowlist(uri.getHost() + ":" + uri.getPort()));
-            doStartMigration(uri, username, password, synchronous, migration);
+            migration.setIndices(collectIndices(request));
+            doStartMigration(migration, request);
         } catch (MalformedURLException e) {
             migration.error("Failed to collect indices for migration: " + e.getMessage());
         }
         return migration;
     }
 
-    private List<RemoteReindexIndex> collectIndices(URI uri, String username, String password, List<String> indices) throws MalformedURLException {
-        final List<String> toReindex = isAllIndices(indices) ? getAllIndicesFrom(uri, username, password) : indices;
+    private List<RemoteReindexIndex> collectIndices(RemoteReindexRequest request) throws MalformedURLException {
+        final List<String> toReindex = isAllIndices(request.indices()) ? getAllIndicesFrom(request.uri(), request.username(), request.password()) : request.indices();
         return toReindex.stream().map(indexName -> new RemoteReindexIndex(indexName, Status.NOT_STARTED)).collect(Collectors.toList());
     }
 
-    private void doStartMigration(URI uri, String username, String password, boolean synchronous, RemoteReindexMigration migration) {
-        prepareCluster(uri);
-        migration.status(Status.RUNNING);
-        createIndicesInNewCluster(migration);
-        if (synchronous) {
-            reindexSynchronously(migration, uri, username, password);
-        } else {
-            reindexNextAvailableAsync(migration, uri, username, password);
+    private void doStartMigration(RemoteReindexMigration migration, RemoteReindexRequest request) {
+        try {
+            prepareCluster(request.uri());
+            createIndicesInNewCluster(migration);
+            startAsyncTasks(migration, request);
+        } catch (Exception e) {
+            LOG.error("Failed to start remote reindex migration", e);
+            migration.error(e.getMessage());
         }
     }
 
@@ -150,8 +160,16 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
     private void prepareCluster(URI uri) {
         final var activeNodes = getAllActiveNodeIDs();
         final String reindexSourceAddress = uri.getHost() + ":" + uri.getPort();
-        allowReindexingFrom(reindexSourceAddress);
-        waitForClusterRestart(activeNodes);
+        try {
+            verifyRemoteReindexAllowlistSetting(reindexSourceAddress);
+        } catch (RemoteReindexNotAllowedException e) {
+            // this is expected state for fresh datanode cluster - there is no value configured in the reindex.remote.allowlist
+            // we have to add it to the configuration and wait till the whole cluster restarts
+            allowReindexingFrom(reindexSourceAddress);
+            waitForClusterRestart(activeNodes);
+        }
+
+        // verify again, just to be sure that all the configuration is in place and vali
         verifyRemoteReindexAllowlistSetting(reindexSourceAddress);
     }
 
@@ -160,23 +178,8 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         reindexRequest
                 .setRemoteInfo(new RemoteInfo(uri.getScheme(), uri.getHost(), uri.getPort(), uri.getPath(), query, username, password, Map.of(), RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT))
                 .setSourceIndices(index).setDestIndex(index);
+
         return reindexRequest;
-    }
-
-    private void reindexSynchronously(final RemoteReindexMigration migration, URI uri, String username, String password) {
-        migration.indices().forEach(index -> reindexSync(index, uri, username, password));
-        migration.finish();
-    }
-
-    private void reindexSync(RemoteReindexIndex index, URI uri, String username, String password) {
-        try (XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint()) {
-            final BytesReference query = BytesReference.bytes(matchAllQuery().toXContent(builder, ToXContent.EMPTY_PARAMS));
-            final var response = client.execute((c, requestOptions) -> c.reindex(createReindexRequest(index.getName(), query, uri, username, password), requestOptions));
-            index.onFinished(new Duration(response.getTotal()), response.getBatches());
-        } catch (IOException e) {
-            LOG.error("Could not reindex index: {} - {}", index, e.getMessage(), e);
-            index.onError(e.getMessage());
-        }
     }
 
     @Override
@@ -194,7 +197,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         }
     }
 
-    public void verifyRemoteReindexAllowlistSetting(String reindexSourceAddress) {
+    public void verifyRemoteReindexAllowlistSetting(String reindexSourceAddress) throws RemoteReindexNotAllowedException {
         final String allowlistSetttingValue = client.execute((restHighLevelClient, requestOptions) -> {
             final ClusterGetSettingsRequest request = new ClusterGetSettingsRequest();
             request.includeDefaults(true);
@@ -204,10 +207,11 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
 
         // the value is not proper json, just something like [localhost:9201]. It should be safe to simply use String.contains,
         // but there is maybe a chance for mismatches and then we'd have to parse the value
-        if (!allowlistSetttingValue.contains(reindexSourceAddress)) {
+        final boolean isRemoteReindexAllowed = !allowlistSetttingValue.contains(reindexSourceAddress);
+        if (isRemoteReindexAllowed) {
             final String message = "Failed to configure reindex.remote.allowlist setting in the datanode cluster. Current setting value: " + allowlistSetttingValue;
             LOG.error(message);
-            throw new IllegalStateException(message);
+            throw new RemoteReindexNotAllowedException(message);
         }
     }
 
@@ -250,10 +254,6 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         }
     }
 
-    void removeAllowlist(final String host) {
-        eventBus.post(new RemoteReindexAllowlistEvent(host, RemoteReindexAllowlistEvent.ACTION.REMOVE));
-    }
-
     void allowReindexingFrom(final String host) {
         eventBus.post(new RemoteReindexAllowlistEvent(host, RemoteReindexAllowlistEvent.ACTION.ADD));
     }
@@ -277,42 +277,66 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         return indices == null || indices.isEmpty() || (indices.size() == 1 && "*".equals(indices.get(0)));
     }
 
-    private void reindexNextAvailableAsync(final RemoteReindexMigration migration, URI uri, String username, String password) {
+    private void startAsyncTasks(RemoteReindexMigration migration, RemoteReindexRequest request) {
+        final int threadsCount = Math.max(1, Math.min(request.threadsCount(), migration.indices().size()));
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadsCount, new ThreadFactoryBuilder()
+                .setNameFormat("remote-reindex-migration-backend-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(new Tools.LogUncaughtExceptionHandler(LOG))
+                .build());
+
         migration.indices().stream()
                 .filter(i -> i.getStatus() == Status.NOT_STARTED)
-                .findFirst()
-                .ifPresentOrElse(
-                        index -> executeReindexAsync(migration, uri, username, password, index),
-                        migration::finish); // nothing more to reindex, stop recursion here
+                .forEach(index -> executorService.submit(() -> executeReindexAsync(migration, request.uri(), request.username(), request.password(), index)));
     }
-
 
     private void executeReindexAsync(RemoteReindexMigration migration, URI uri, String username, String password, RemoteReindexIndex index) {
         final String indexName = index.getName();
         try (XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint()) {
             final BytesReference query = BytesReference.bytes(matchAllQuery().toXContent(builder, ToXContent.EMPTY_PARAMS));
             LOG.info("Executing reindexAsync for " + indexName);
-            client.execute((c, requestOptions) -> c.reindexAsync(createReindexRequest(indexName, query, uri, username, password), requestOptions, new ActionListener<>() {
-                @Override
-                public void onResponse(BulkByScrollResponse response) {
-                    migration.indexByName(indexName).ifPresent(r -> r.onFinished(new Duration(response.getTotal()), response.getBatches()));
-                    // one done, continue with other indices available
-                    reindexNextAvailableAsync(migration, uri, username, password);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    LOG.warn("Failed to remotely reindex " + indexName, e);
-                    migration.indexByName(indexName).ifPresent(r -> r.onError("Can't migrate index " + indexName + ", " + e.getMessage()));
-                    // one failed, continue with other indices available
-                    reindexNextAvailableAsync(migration, uri, username, password);
-                }
-            }));
+            final TaskSubmissionResponse task = client.execute((c, requestOptions) -> c.submitReindexTask(createReindexRequest(indexName, query, uri, username, password), requestOptions));
+            migration.indexByName(indexName).ifPresent(i -> i.setTask(task.getTask()));
 
         } catch (IOException e) {
             LOG.error("Could not reindex index: {} - {}", indexName, e.getMessage(), e);
             migration.indexByName(indexName).ifPresent(r -> r.onError("Can't migrate index " + indexName + ", " + e.getMessage()));
-            // TODO: what about all other indices? Should we stop here?
+        }
+        waitForTaskCompleted(index);
+    }
+
+    private void waitForTaskCompleted(RemoteReindexIndex index) {
+        while (index.getStatus() != Status.FINISHED && index.getStatus() != Status.ERROR) {
+            updateTaskStatus(index);
+            sleep();
+        }
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(TASK_UPDATE_INTERVAL_MILLIS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void updateTaskStatus(RemoteReindexIndex index) {
+        final String[] parts = index.getTaskID().split(":");
+        client.execute((restHighLevelClient, requestOptions) -> restHighLevelClient.tasks().get(new GetTaskRequest(parts[0], Long.parseLong(parts[1])), requestOptions))
+                .ifPresentOrElse(response -> {
+                    if (response.isCompleted()) {
+                        final long durationInSec = TimeUnit.SECONDS.convert(response.getTaskInfo().getRunningTimeNanos(), TimeUnit.NANOSECONDS);
+                        index.onFinished(Duration.standardSeconds(durationInSec), getTaskStatus(response));
+                    }
+                }, () -> LOG.warn("Task for reindexing of {} not found!", index.getName()));
+    }
+
+    private TaskStatus getTaskStatus(GetTaskResponse response) {
+        try {
+            return objectMapper.readValue(response.getTaskInfo().getStatus().toString(), TaskStatus.class);
+        } catch (JsonProcessingException e) {
+            LOG.error("Failed to convert TaskStatus", e);
+            return TaskStatus.unknown();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexParams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexParams.java
@@ -19,6 +19,6 @@ package org.graylog.plugins.views.storage.migration;
 import java.net.URI;
 import java.util.List;
 
-public record RemoteReindexRequest(URI hostname, String user, String password, List<String> indices,
-                                   boolean synchronous) {
+public record RemoteReindexParams(URI hostname, String user, String password, List<String> indices,
+                                  boolean synchronous, int threadsCount) {
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/RemoteReindexResource.java
@@ -32,6 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 import org.graylog2.shared.security.RestPermissions;
@@ -54,8 +55,9 @@ public class RemoteReindexResource {
     @NoAuditEvent("No Audit Event needed")
     @RequiresPermissions(RestPermissions.DATANODE_MIGRATION)
     @ApiOperation(value = "by remote reindexing", notes = "configure the host/credentials you want to use to migrate data from")
-    public RemoteReindexMigration migrate(@ApiParam(name = "remote configuration") @NotNull @Valid RemoteReindexRequest request) {
-        return migrationService.start(request.hostname(), request.user(), request.password(), request.indices(), request.synchronous());
+    public RemoteReindexMigration migrate(@ApiParam(name = "remote configuration") @NotNull @Valid RemoteReindexParams params) {
+        final RemoteReindexRequest req = new RemoteReindexRequest(params.hostname(), params.user(), params.password(), params.indices(), params.threadsCount());
+        return migrationService.start(req);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
@@ -30,6 +30,7 @@ import org.graylog2.cluster.nodes.DataNodeStatus;
 import org.graylog2.cluster.nodes.NodeService;
 import org.graylog2.cluster.preflight.DataNodeProvisioningConfig;
 import org.graylog2.cluster.preflight.DataNodeProvisioningService;
+import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 import org.graylog2.plugin.GlobalMetricNames;
@@ -199,7 +200,8 @@ public class MigrationActionsImpl implements MigrationActions {
         final String user = getStateMachineContext().getActionArgumentOpt("user", String.class).orElse(null);
         final String password = getStateMachineContext().getActionArgumentOpt("password", String.class).orElse(null);
         final List<String> indices = getStateMachineContext().getActionArgumentOpt("indices", List.class).orElse(Collections.emptyList()); // todo: generics!
-        final RemoteReindexMigration migration = migrationService.start(hostname, user, password, indices, false);
+        final int threadsCount = getStateMachineContext().getActionArgumentOpt("threads", Integer.class).orElse(4);
+        final RemoteReindexMigration migration = migrationService.start(new RemoteReindexRequest(hostname, user, password, indices, threadsCount));
         final String migrationID = migration.id();
         getStateMachineContext().addExtendedState(MigrationStateMachineContext.KEY_MIGRATION_ID, migrationID);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexRequest.java
@@ -1,0 +1,7 @@
+package org.graylog2.indexer.datanode;
+
+import java.net.URI;
+import java.util.List;
+
+public record RemoteReindexRequest(URI uri, String username, String password, List<String> indices, int threadsCount) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.indexer.datanode;
 
 import java.net.URI;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
@@ -21,14 +21,13 @@ import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 
 import java.net.URI;
-import java.util.List;
 
 public interface RemoteReindexingMigrationAdapter {
     enum Status {
         NOT_STARTED, STARTING, RUNNING, ERROR, FINISHED
     }
 
-    RemoteReindexMigration start(URI uri, String username, String password, List<String> indices, boolean synchronous);
+    RemoteReindexMigration start(RemoteReindexRequest request);
 
     RemoteReindexMigration status(@NotNull String migrationID);
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/LogEntry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/LogEntry.java
@@ -14,10 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.storage.opensearch2;
+package org.graylog2.indexer.migration;
 
-public class RemoteReindexNotAllowedException extends IllegalStateException {
-    public RemoteReindexNotAllowedException(String message) {
-        super(message);
+import org.joda.time.DateTime;
+
+import java.util.Locale;
+
+public record LogEntry(DateTime timestamp, LogLevel logLevel, String message) {
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "%s %s : %s", timestamp.toLocalDateTime(), logLevel, message);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/LogLevel.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/LogLevel.java
@@ -14,10 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.storage.opensearch2;
+package org.graylog2.indexer.migration;
 
-public class RemoteReindexNotAllowedException extends IllegalStateException {
-    public RemoteReindexNotAllowedException(String message) {
-        super(message);
-    }
+public enum LogLevel {
+    INFO,
+    WARN,
+    ERROR
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexIndex.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexIndex.java
@@ -28,8 +28,9 @@ public class RemoteReindexIndex {
     private Status status;
     private final DateTime created;
     private Duration took;
-    private Integer batches;
+    private TaskStatus taskStatus;
     private String errorMsg;
+    private String taskID;
 
     public RemoteReindexIndex(final String name, final Status status) {
         this.name = name;
@@ -55,8 +56,8 @@ public class RemoteReindexIndex {
     }
 
 
-    public Integer getBatches() {
-        return batches;
+     public TaskStatus getTaskStatus() {
+        return taskStatus;
     }
 
 
@@ -69,10 +70,15 @@ public class RemoteReindexIndex {
         this.errorMsg = errorMsg;
     }
 
-    public void onFinished(Duration duration, int batches) {
+    public void onFinished(Duration duration, TaskStatus taskStatus) {
         this.status = Status.FINISHED;
         this.took = duration;
-        this.batches = batches;
+        this.taskStatus = taskStatus;
+    }
+
+    public void setTask(String taskID) {
+        this.status = Status.RUNNING;
+        this.taskID = taskID;
     }
 
     @Override
@@ -81,5 +87,9 @@ public class RemoteReindexIndex {
                 "name='" + name + '\'' +
                 ", status=" + status +
                 '}';
+    }
+
+    public String getTaskID() {
+        return taskID;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexIndex.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexIndex.java
@@ -22,6 +22,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RemoteReindexIndex {
     private final String name;
@@ -62,12 +65,16 @@ public class RemoteReindexIndex {
 
 
     public String getErrorMsg() {
-        return errorMsg;
+        return Optional.ofNullable(taskStatus)
+                .map(TaskStatus::failures)
+                .map(failures -> String.join(";", failures))
+                .orElse(null);
     }
 
-    public void onError(String errorMsg) {
+    public void onError(Duration duration, TaskStatus taskStatus) {
         this.status = Status.ERROR;
-        this.errorMsg = errorMsg;
+        this.took = duration;
+        this.taskStatus = taskStatus;
     }
 
     public void onFinished(Duration duration, TaskStatus taskStatus) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteReindexMigration.java
@@ -16,16 +16,17 @@
  */
 package org.graylog2.indexer.migration;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter.Status;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.UUID;
 
 /**
@@ -37,6 +38,8 @@ public class RemoteReindexMigration {
     @JsonProperty("id")
     private final String id;
     private List<RemoteReindexIndex> indices = new ArrayList<>();
+
+    private final Queue<LogEntry> logs = new CircularFifoQueue<>(50);
 
     @JsonProperty("error")
     private String error;
@@ -104,5 +107,13 @@ public class RemoteReindexMigration {
         final int done = (int) indices.stream().map(RemoteReindexIndex::getStatus).filter(i -> i == Status.FINISHED || i == Status.ERROR).count();
         float percent = (100.0f / countOfIndices) * done;
         return (int) Math.ceil(percent);
+    }
+
+    public void log(LogEntry log) {
+        this.logs.offer(log);
+    }
+
+    public List<LogEntry> getLogs() {
+        return logs.stream().toList();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
@@ -43,4 +43,8 @@ public record TaskStatus(
     public static TaskStatus failure(String failure) {
         return new TaskStatus(-1, -1, -1, -1, -1, -1, -1, Collections.singletonList(failure));
     }
+
+    public boolean  hasFailures() {
+        return failures() != null && !failures().isEmpty();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
@@ -39,4 +39,8 @@ public record TaskStatus(
     public static TaskStatus unknown() {
         return new TaskStatus(-1, -1, -1, -1, -1, -1, -1, Collections.emptyList());
     }
+
+    public static TaskStatus failure(String failure) {
+        return new TaskStatus(-1, -1, -1, -1, -1, -1, -1, Collections.singletonList(failure));
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
@@ -1,0 +1,26 @@
+package org.graylog2.indexer.migration;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TaskStatus(
+        @JsonProperty("total") long total,
+        @JsonProperty("updated") long updated,
+        @JsonProperty("created") long created,
+        @JsonProperty("deleted") long deleted,
+        @JsonProperty("batches") long batches,
+        @JsonProperty("version_conflicts") long versionConflicts,
+        @JsonProperty("noops") long noops,
+        @JsonProperty("failures") List<String> failures
+
+) {
+
+    public static TaskStatus unknown() {
+        return new TaskStatus(-1, -1, -1, -1, -1, -1, -1, Collections.emptyList());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/TaskStatus.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.indexer.migration;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;


### PR DESCRIPTION
Changes in this PR:

- The remote reindex migration now supports only async reindex, sync removed
- Migration is task based, we submit tasks and monitor them regularly
- There is now `threads` (int) param, which  configures how many tasks are running in parallel (uses Executors.newFixedThreadPool)
- The overall status of the migration is now computed from states of indices => single source of truth
- We have more information about finished index migrations. How many batches and documents, duration, problems... We can display this
- Support for logs view - latest 50 logs from migration. With log level, timestamp and message. For advanced view like in installation wizards.

![image](https://github.com/Graylog2/graylog2-server/assets/4102775/01d384da-2b61-47e6-b684-46cded18557c)
 

## Motivation and Context
Solve timeouts problems during the long running migration, increase stability, add users more control over performance.


## How Has This Been Tested?
Manually and with existing integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

