### PR TITLE
Ensure that search dialog for saved search is remounted.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -210,7 +210,8 @@ const SearchActionsMenu = () => {
 
   return (
     <Container aria-label="Search Meta Buttons">
-      <SavedSearchForm show={showForm}
+      <SavedSearchForm key={currentTitle}
+                       show={showForm}
                        saveSearch={saveSearch}
                        saveAsSearch={saveAsSearch}
                        isCreateNew={isNew || !isAllowedToEdit}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the current title of the saved search is memoized in the `SavedSearchForm` component's state. Due to a refactoring around popovers, we are not remounting the component anymore when the saved search changes. Due to this, this PR is now forcing a remount (through changing the component's `key`) when the title changes.

Fixes #18832.

/nocl Regression was introduced after last release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.