### PR TITLE
Update handling of Event Definition enable field to prevent errors

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
@@ -299,6 +299,13 @@ const FilterForm = ({
     debouncedParseQuery(query, newConfig);
   };
 
+  const handleEnabledChange = (event) => {
+    const { name } = event.target;
+    const value = FormsUtils.getValueFromInput(event.target);
+    const newConfig = getUpdatedConfig(name, value);
+    handleConfigChange(name, newConfig);
+  };
+
   const hideFiltersPreview = (value) => {
     Store.set(PLUGGABLE_CONTROLS_HIDDEN_KEY, value);
     setSearchFiltersHidden(value);
@@ -492,7 +499,7 @@ const FilterForm = ({
                label="Enable"
                help="Should this event definition be executed automatically?"
                checked={defaultTo(eventDefinition.config._is_scheduled, true)}
-               onChange={handleConfigChange} />
+               onChange={handleEnabledChange} />
       </>
       )}
     </fieldset>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, when creating or editing a Filter & Aggregation event definition, on the Condition page if the "Enable" checkbox is toggled there is a page error. See issue for more details: https://github.com/Graylog2/graylog2-server/issues/18786.

This looks to have been introduced in https://github.com/Graylog2/graylog2-server/pull/18742.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/Graylog2/graylog2-server/issues/18786.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in dev environment.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

