### PR TITLE
Add optional support for sorting Events by unmapped fields

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -32,6 +32,8 @@ import org.graylog.shaded.opensearch2.org.opensearch.core.xcontent.ToXContent;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.sort.FieldSortBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.sort.SortOrder;
 import org.graylog2.indexer.results.ChunkedResult;
 import org.graylog2.indexer.results.MultiChunkResultRetriever;
 import org.graylog2.indexer.results.ResultChunk;
@@ -104,12 +106,17 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
             filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
         }
 
+        final SortOrder order = sortOrderMapper.fromSorting(sorting);
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
                 .query(filter)
                 .from((page - 1) * perPage)
                 .size(perPage)
-                .sort(sorting.getField(), sortOrderMapper.fromSorting(sorting))
                 .trackTotalHits(true);
+        final FieldSortBuilder sortBuilder = new FieldSortBuilder(sorting.getField()).order(order);
+        sorting.getUnmappedType().ifPresent(unmappedType -> sortBuilder
+                        .unmappedType(unmappedType)
+                        .missing(order.equals(SortOrder.ASC) ? "_first" : "_last"));
+        searchSourceBuilder.sort(sortBuilder);
 
         final Set<String> indices = affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices;
         final SearchRequest searchRequest = new SearchRequest(indices.toArray(new String[0]))

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
@@ -26,6 +26,8 @@ import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersExc
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import java.util.Optional;
+
 @AutoValue
 @JsonAutoDetect
 @JsonDeserialize(builder = EventsSearchParameters.Builder.class)
@@ -37,6 +39,7 @@ public abstract class EventsSearchParameters {
     private static final String FIELD_FILTER = "filter";
     private static final String FIELD_SORT_BY = "sort_by";
     private static final String FIELD_SORT_DIRECTION = "sort_direction";
+    private static final String FIELD_SORT_UNMAPPED_TYPE = "sort_unmapped_type";
 
     public enum SortDirection {
         @JsonProperty("asc")
@@ -65,6 +68,9 @@ public abstract class EventsSearchParameters {
 
     @JsonProperty(FIELD_SORT_DIRECTION)
     public abstract SortDirection sortDirection();
+
+    @JsonProperty(FIELD_SORT_UNMAPPED_TYPE)
+    public abstract Optional<String> sortUnmappedType();
 
     public static Builder builder() {
         return Builder.create();
@@ -116,6 +122,9 @@ public abstract class EventsSearchParameters {
 
         @JsonProperty(FIELD_SORT_DIRECTION)
         public abstract Builder sortDirection(SortDirection sortDirection);
+
+        @JsonProperty(FIELD_SORT_UNMAPPED_TYPE)
+        public abstract Builder sortUnmappedType(String sortUnmappedType);
 
         public abstract EventsSearchParameters build();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -85,7 +85,9 @@ public class MoreSearch {
         checkArgument(forbiddenSourceStreams != null, "forbiddenSourceStreams cannot be null");
 
         final Sorting.Direction sortDirection = parameters.sortDirection() == EventsSearchParameters.SortDirection.ASC ? Sorting.Direction.ASC : Sorting.Direction.DESC;
-        final Sorting sorting = new Sorting(parameters.sortBy(), sortDirection);
+        final Sorting sorting = parameters.sortUnmappedType().isPresent() ?
+                new Sorting(parameters.sortBy(), sortDirection, parameters.sortUnmappedType().get())
+                : new Sorting(parameters.sortBy(), sortDirection);
         final String queryString = parameters.query().trim();
         final Set<String> affectedIndices = getAffectedIndices(eventStreams, parameters.timerange());
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
@@ -19,6 +19,7 @@ package org.graylog2.indexer.searches;
 import org.graylog2.plugin.Message;
 
 import java.util.Locale;
+import java.util.Optional;
 
 public class Sorting {
 
@@ -31,17 +32,35 @@ public class Sorting {
 
     private final String field;
     private final Direction direction;
+    /**
+     * Specifying an unmappedType can be used to allow sorting by unmapped fields, which is not supported by default.
+     * See https://opensearch.org/docs/2.2/opensearch/search/sort/#ignoring-unmapped-fields.
+     */
+    private final String unmappedType;
+
+    public Sorting(String field, Direction direction, String unmappedType) {
+        this.field = field;
+        this.direction = direction;
+        this.unmappedType = unmappedType;
+    }
 
     public Sorting(String field, Direction direction) {
         this.field = field;
         this.direction = direction;
+        this.unmappedType = null;
     }
 
     public String getField() {
         return field;
     }
 
-    public Direction getDirection() { return this.direction; }
+    public Direction getDirection() {
+        return this.direction;
+    }
+
+    public Optional<String> getUnmappedType() {
+        return Optional.ofNullable(this.unmappedType);
+    }
 
     public static Sorting fromApiParam(String param) {
         if (param == null || !param.contains(":")) {


### PR DESCRIPTION
Add optional support for sorting Events by unmapped fields. For example, individual event.scores values.

/nocl
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/Graylog2/graylog-plugin-enterprise/pull/6893

Adds similar capability as was added for Events List widget in https://github.com/Graylog2/graylog2-server/pull/18826.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

