### PR TITLE
Always set stream description on edit

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -323,9 +323,7 @@ public class StreamResource extends RestResource {
             stream.setTitle(cr.title().strip());
         }
 
-        if (!Strings.isNullOrEmpty(cr.description())) {
-            stream.setDescription(cr.description());
-        }
+        stream.setDescription(cr.description());
 
         if (cr.matchingType() != null) {
             try {


### PR DESCRIPTION
/nocl
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I think the small code change is self explanatory.

## Motivation and Context
Fixes #18856 
Before it was not possible to change the (optional) description of a Stream to an empty string.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I cherry picked the change to the 5.2 branch and updated the corresponding .jar file on my server. Subsequently, I successfully modified the description to an empty string.
I also made a second test, where I removed the description field from the body of the http request.

It's worth noting that I haven't yet verified these modifications on the master branch. 
With the jar from the master branch it did not start on my server, which is running 5.2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

