### PR TITLE
DataNode: Added OpenSearch heap setting

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -114,9 +114,12 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "initial_cluster_manager_nodes")
     private String initialClusterManagerNodes;
 
+    // Initial and maxmium heap must be identical for OpenSearch, otherwise the boot fails. So it's only one config option
+    @Parameter(value = "opensearch_heap")
+    private String opensearchHeap = "1g";
+
     @Parameter(value = "opensearch_http_port", converter = IntegerConverter.class)
     private int opensearchHttpPort = 9200;
-
 
     @Parameter(value = "opensearch_transport_port", converter = IntegerConverter.class)
     private int opensearchTransportPort = 9300;
@@ -687,5 +690,9 @@ public class Configuration extends BaseConfiguration {
 
     public List<String> getNodeRoles() {
         return nodeRoles;
+    }
+
+    public String getOpensearchHeap() {
+        return opensearchHeap;
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfiguration.java
@@ -27,6 +27,7 @@ public record DatanodeConfiguration(
         OpensearchDistributionProvider opensearchDistributionProvider,
         DatanodeDirectories datanodeDirectories,
         int processLogsBufferSize,
+        String opensearchHeap,
         IndexerJwtAuthTokenProvider indexerJwtAuthTokenProvider
 ) {
 }

--- a/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfigurationProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeConfigurationProvider.java
@@ -40,6 +40,7 @@ public class DatanodeConfigurationProvider implements Provider<DatanodeConfigura
                 opensearchDistributionProvider,
                 DatanodeDirectories.fromConfiguration(localConfiguration, nodeId),
                 localConfiguration.getProcessLogsBufferSize(),
+                localConfiguration.getOpensearchHeap(),
                 jwtTokenProvider
         );
     }

--- a/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
@@ -56,6 +56,7 @@ public class OpensearchSecurityConfiguration {
     private final KeystoreInformation transportCertificate;
     private final KeystoreInformation httpCertificate;
     private KeystoreInformation truststore;
+    private String opensearchHeap;
 
     public OpensearchSecurityConfiguration(KeystoreInformation transportCertificate, KeystoreInformation httpCertificate) {
         this.transportCertificate = transportCertificate;
@@ -114,7 +115,7 @@ public class OpensearchSecurityConfiguration {
             config.put("plugins.security.ssl.http.enabled", "true");
 
             config.put("plugins.security.ssl.http.keystore_type", KEYSTORE_FORMAT);
-            config.put("plugins.security.ssl.http.keystore_filepath",  httpCertificate.location().getFileName().toString());  // todo: this should be computed as a relative path
+            config.put("plugins.security.ssl.http.keystore_filepath", httpCertificate.location().getFileName().toString());  // todo: this should be computed as a relative path
             config.put("plugins.security.ssl.http.keystore_password", httpCertificate.passwordAsString());
             config.put("plugins.security.ssl.http.keystore_alias", CertConstants.DATANODE_KEY_ALIAS);
 
@@ -133,8 +134,8 @@ public class OpensearchSecurityConfiguration {
 
     private Map<String, Object> filterConfigurationMap(final Map<String, Object> map, final String... keys) {
         Map<String, Object> result = map;
-        for(final String key: List.of(keys)) {
-            result = (Map<String, Object>)result.get(key);
+        for (final String key : List.of(keys)) {
+            result = (Map<String, Object>) result.get(key);
         }
         return result;
     }
@@ -191,9 +192,9 @@ public class OpensearchSecurityConfiguration {
         try (final FileInputStream is = new FileInputStream(keystore.location().toFile())) {
             instance.load(is, keystore.password());
             final Enumeration<String> aliases = instance.aliases();
-            while(aliases.hasMoreElements()) {
+            while (aliases.hasMoreElements()) {
                 final Certificate cert = instance.getCertificate(aliases.nextElement());
-                if(cert instanceof X509Certificate x509Certificate) {
+                if (cert instanceof X509Certificate x509Certificate) {
                     final String alternativeNames = x509Certificate.getSubjectAlternativeNames()
                             .stream()
                             .map(san -> san.get(1))
@@ -203,5 +204,9 @@ public class OpensearchSecurityConfiguration {
                 }
             }
         }
+    }
+
+    public String getOpensearchHeap() {
+        return opensearchHeap;
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
@@ -75,6 +75,7 @@ public class OpensearchSecurityConfiguration {
      * truststore.
      */
     public OpensearchSecurityConfiguration configure(DatanodeConfiguration datanodeConfiguration, byte[] signingKey) throws GeneralSecurityException, IOException {
+        opensearchHeap = datanodeConfiguration.opensearchHeap();
         if (securityEnabled()) {
 
             logCertificateInformation("transport certificate", transportCertificate);
@@ -94,7 +95,6 @@ public class OpensearchSecurityConfiguration {
             System.setProperty("javax.net.ssl.trustStorePassword", truststorePassword);
 
             enableJwtAuthenticationInConfig(opensearchConfigDir, signingKey);
-            opensearchHeap = datanodeConfiguration.opensearchHeap();
         }
         return this;
     }

--- a/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/variants/OpensearchSecurityConfiguration.java
@@ -94,6 +94,7 @@ public class OpensearchSecurityConfiguration {
             System.setProperty("javax.net.ssl.trustStorePassword", truststorePassword);
 
             enableJwtAuthenticationInConfig(opensearchConfigDir, signingKey);
+            opensearchHeap = datanodeConfiguration.opensearchHeap();
         }
         return this;
     }

--- a/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/process/OpensearchConfiguration.java
@@ -92,6 +92,7 @@ public record OpensearchConfiguration(
 
     public Environment getEnv() {
         final Environment env = new Environment(System.getenv());
+        env.put("OPENSEARCH_JAVA_OPTS", "-Xms%s -Xmx%s".formatted(opensearchSecurityConfiguration.getOpensearchHeap(), opensearchSecurityConfiguration.getOpensearchHeap()));
         env.put("OPENSEARCH_PATH_CONF", datanodeDirectories.getOpensearchProcessConfigurationDir().toString());
         return env;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

You can specify the Java heap setting for OpenSearch now. It's only one config setting as both (initial and max) have to be the same size otherwise the OpenSearch boot fails.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

