### PR TITLE
use legacy default rotation/retention config for existing installations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfiguration.java
@@ -58,6 +58,8 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
     public static final String RETENTION_STRATEGY_CONFIG = "retention_strategy_config";
     public static final String RETENTION_STRATEGY = "retention_strategy"; // alias for retention_strategy_config
 
+    public static final String FIELD_USE_LEGACY_ROTATION = "use_legacy_rotation";
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -126,6 +128,9 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
     @JsonProperty(FIELD_DATA_TIERING)
     public abstract DataTieringConfig dataTiering();
 
+    @JsonProperty(value = FIELD_USE_LEGACY_ROTATION)
+    public abstract Boolean useLegacyRotation();
+
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
@@ -134,6 +139,7 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
         @JsonCreator
         public static Builder create() {
             return new AutoValue_IndexSetsDefaultConfiguration.Builder()
+                    .useLegacyRotation(true)
                     .dataTiering(new PlaceholderDataTieringConfig());
         }
 
@@ -184,6 +190,9 @@ public abstract class IndexSetsDefaultConfiguration implements PluginConfigBean 
 
         @JsonProperty(FIELD_DATA_TIERING)
         public abstract Builder dataTiering(DataTieringConfig dataTiering);
+
+        @JsonProperty(FIELD_USE_LEGACY_ROTATION)
+        public abstract Builder useLegacyRotation(boolean useLegacyRotation);
 
         public abstract IndexSetsDefaultConfiguration build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfigurationFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexSetsDefaultConfigurationFactory.java
@@ -55,6 +55,7 @@ public class IndexSetsDefaultConfigurationFactory {
                 .rotationStrategyConfig(rotationConfig.right)
                 .retentionStrategyClass(retentionConfig.left)
                 .retentionStrategyConfig(retentionConfig.right)
+                .useLegacyRotation(false)
                 .dataTiering(maintenanceStrategiesHelper.defaultDataTieringConfig())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfigFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfigFactory.java
@@ -20,6 +20,7 @@ import jakarta.inject.Inject;
 import org.graylog2.configuration.IndexSetsDefaultConfiguration;
 import org.graylog2.configuration.IndexSetsDefaultConfigurationFactory;
 import org.graylog2.datatiering.DataTieringChecker;
+import org.graylog2.datatiering.DataTieringConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -47,6 +48,10 @@ public class IndexSetConfigFactory {
         return ZonedDateTime.now(ZoneOffset.UTC);
     }
 
+    private static DataTieringConfig getDataTieringConfig(IndexSetsDefaultConfiguration defaultConfig) {
+        return defaultConfig.useLegacyRotation() ? null : defaultConfig.dataTiering();
+    }
+
     public IndexSetConfig.Builder createDefault() {
         IndexSetsDefaultConfiguration defaultConfig = clusterConfigService.get(IndexSetsDefaultConfiguration.class);
         if (defaultConfig == null) {
@@ -68,6 +73,6 @@ public class IndexSetConfigFactory {
                 .rotationStrategy(defaultConfig.rotationStrategyConfig())
                 .retentionStrategyClass(defaultConfig.retentionStrategyClass())
                 .retentionStrategy(defaultConfig.retentionStrategyConfig())
-                .dataTiering(dataTieringChecker.isEnabled() ? defaultConfig.dataTiering() : null);
+                .dataTiering(dataTieringChecker.isEnabled() ? getDataTieringConfig(defaultConfig) : null);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MaintenanceStrategiesHelper.java
@@ -17,7 +17,6 @@
 package org.graylog2.migrations;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.datatiering.hotonly.HotOnlyDataTieringConfig;
@@ -34,29 +33,18 @@ import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedSizeOptimizingStrategyConfig;
 import org.graylog2.indexer.rotation.tso.IndexLifetimeConfig;
-import org.graylog2.plugin.cluster.ClusterConfigService;
-import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
-import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 public class MaintenanceStrategiesHelper {
     private static final Logger LOG = LoggerFactory.getLogger(MaintenanceStrategiesHelper.class);
-    private final Map<String, Provider<RotationStrategy>> rotationStrategies;
-    private final Map<String, Provider<RetentionStrategy>> retentionStrategies;
-    private final ClusterConfigService clusterConfigService;
     private final ElasticsearchConfiguration elasticsearchConfiguration;
 
 
     @Inject
-    public MaintenanceStrategiesHelper(Map<String, Provider<RotationStrategy>> rotationStrategies, Map<String, Provider<RetentionStrategy>> retentionStrategies, ClusterConfigService clusterConfigService, ElasticsearchConfiguration elasticsearchConfiguration) {
-        this.rotationStrategies = rotationStrategies;
-        this.retentionStrategies = retentionStrategies;
-        this.clusterConfigService = clusterConfigService;
+    public MaintenanceStrategiesHelper(ElasticsearchConfiguration elasticsearchConfiguration) {
         this.elasticsearchConfiguration = elasticsearchConfiguration;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetDefaultsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetDefaultsResource.java
@@ -108,6 +108,13 @@ public class IndexSetDefaultsResource extends RestResource {
             throw new BadRequestException(buildFieldError(IndexSetConfig.FIELD_DATA_TIERING, violation.message()));
         }
 
+        // Any change to the default config can only have been performed without data tiering because there is no UI yet.
+        // Thus we need to switch back to legacy mode, to make the users' changes effective.
+        // TODO remove this once we build a UI for data tiering defaults.
+        config = config.toBuilder().useLegacyRotation(true).build();
+
+        clusterConfigService.write(config);
+
         clusterConfigService.write(config);
         return Response.ok(config).build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.migrations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexDefaultsConfigTest.java
@@ -1,0 +1,146 @@
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.configuration.IndexSetsDefaultConfiguration;
+import org.graylog2.configuration.IndexSetsDefaultConfigurationFactory;
+import org.graylog2.datatiering.hotonly.HotOnlyDataTieringConfig;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
+import org.graylog2.indexer.rotation.tso.IndexLifetimeConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class V202211021200_CreateDefaultIndexDefaultsConfigTest {
+
+    private final static String DEFAULT_CONFIG = """
+            {
+                "index_analyzer": "standard",
+                "shards": 4,
+                "replicas": 0,
+                "index_optimization_max_num_segments": 1,
+                "index_optimization_disabled": false,
+                "field_type_refresh_interval": 5,
+                "field_type_refresh_interval_unit": "SECONDS",
+                "rotation_strategy_class": "org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy",
+                "rotation_strategy_config": {
+                  "type": "org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig",
+                  "max_docs_per_index": 10000000
+                },
+                "retention_strategy_class": "org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy",
+                "retention_strategy_config": {
+                  "type": "org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig",
+                  "max_number_of_indices": 5
+                },
+                %s
+                "retention_strategy": {
+                  "type": "org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig",
+                  "max_number_of_indices": 5
+                },
+                "rotation_strategy": {
+                  "type": "org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig",
+                  "max_docs_per_index": 10000000
+                }
+              }
+            """;
+    private final static String DATA_TIERING_CONFIG = """
+            "data_tiering": {
+                  "type": "hot_only",
+                  "index_lifetime_min": "P30D",
+                  "index_lifetime_max": "P40D"
+                },
+            """;
+    final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    @Mock
+    private ElasticsearchConfiguration elasticsearchConfiguration;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    private IndexSetsDefaultConfigurationFactory defaultConfigurationFactory;
+    private V202211021200_CreateDefaultIndexDefaultsConfig underTest;
+
+
+    @BeforeEach
+    void setUp() {
+        defaultConfigurationFactory = new IndexSetsDefaultConfigurationFactory(
+                elasticsearchConfiguration, new MaintenanceStrategiesHelper(elasticsearchConfiguration));
+        underTest = new V202211021200_CreateDefaultIndexDefaultsConfig(
+                clusterConfigService,
+                defaultConfigurationFactory);
+    }
+
+    @Test
+    void testNoDefaultConfigurationExists() {
+        mockElasticConfig();
+
+        underTest.upgrade();
+        IndexSetsDefaultConfiguration defaultConfiguration = defaultConfigurationFactory.create();
+
+        verify(clusterConfigService).write(defaultConfiguration);
+        assertThat(defaultConfiguration.useLegacyRotation()).isFalse();
+    }
+
+    @Test
+    void testDefaultConfigWithoutDataTiering() throws JsonProcessingException {
+        IndexSetsDefaultConfiguration defaultConfiguration = readConfig(DEFAULT_CONFIG.formatted(""));
+        when(clusterConfigService.get(IndexSetsDefaultConfiguration.class)).thenReturn(defaultConfiguration);
+
+        underTest.upgrade();
+
+        IndexSetsDefaultConfiguration expected = defaultConfiguration.toBuilder()
+                .dataTiering(HotOnlyDataTieringConfig.builder()
+                        .indexLifetimeMin(IndexLifetimeConfig.DEFAULT_LIFETIME_MIN)
+                        .indexLifetimeMax(IndexLifetimeConfig.DEFAULT_LIFETIME_MAX)
+                        .build())
+                .build();
+        verify(clusterConfigService).write(expected);
+        assertThat(expected.useLegacyRotation()).isTrue();
+    }
+
+    @Test
+    void testDefaultConfigWithDataTiering() throws JsonProcessingException {
+        IndexSetsDefaultConfiguration defaultConfiguration = readConfig(DEFAULT_CONFIG.formatted(DATA_TIERING_CONFIG));
+        when(clusterConfigService.get(IndexSetsDefaultConfiguration.class)).thenReturn(defaultConfiguration);
+
+        underTest.upgrade();
+
+        verify(clusterConfigService, never()).write(any());
+        assertThat(defaultConfiguration.useLegacyRotation()).isTrue();
+    }
+
+    @Test
+    void testDefaultConfigWithDataTieringAndUseLegacyRotation() throws JsonProcessingException {
+        IndexSetsDefaultConfiguration defaultConfiguration = readConfig(DEFAULT_CONFIG.formatted(DATA_TIERING_CONFIG +
+                """
+                        "use_legacy_rotation": false,"""));
+        when(clusterConfigService.get(IndexSetsDefaultConfiguration.class)).thenReturn(defaultConfiguration);
+
+        underTest.upgrade();
+
+        verify(clusterConfigService, never()).write(any());
+        assertThat(defaultConfiguration.useLegacyRotation()).isFalse();
+    }
+
+    private IndexSetsDefaultConfiguration readConfig(String json) throws JsonProcessingException {
+        return objectMapper.readValue(json, IndexSetsDefaultConfiguration.class);
+    }
+
+    private void mockElasticConfig() {
+        when(elasticsearchConfiguration.getRotationStrategy()).thenReturn(SizeBasedRotationStrategy.NAME);
+        when(elasticsearchConfiguration.getRetentionStrategy()).thenReturn(DeletionRetentionStrategy.NAME);
+        when(elasticsearchConfiguration.getAnalyzer()).thenReturn("analyzer");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For existing Graylog installations the legacy rotation and retention default configuration is used if configured. Otherwise the data tiering default configuration will be used. This is important for index sets created by Illuminate.

fixes Graylog2/graylog-plugin-enterprise#6889
/nocl
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

