### PR TITLE
Display archive before deletion checkbox independent of warm tier config

### DIFF
--- a/graylog2-web-interface/src/components/indices/data-tiering/DataTieringConfiguration.tsx
+++ b/graylog2-web-interface/src/components/indices/data-tiering/DataTieringConfiguration.tsx
@@ -20,11 +20,12 @@ import { useFormikContext } from 'formik';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import type { IndexSet, IndexSetFormValues } from 'stores/indices/IndexSetsStore';
-import { FormikFormGroup } from 'components/common';
+import { FormikFormGroup, FormikInput } from 'components/common';
+import { Input } from 'components/bootstrap';
 import { DATA_TIERING_TYPE } from 'components/indices/data-tiering';
 
 const dayFields = ['index_lifetime_max', 'index_lifetime_min', 'index_hot_lifetime_min'];
-const hotWarmOnlyFormFields = ['index_hot_lifetime_min', 'warm_tier_enabled', 'archive_before_deletion', 'warm_tier_repository_name'];
+const hotWarmOnlyFormFields = ['index_hot_lifetime_min', 'warm_tier_enabled', 'warm_tier_repository_name'];
 
 export const durationToRoundedDays = (duration: string) => Math.round(moment.duration(duration).asDays());
 
@@ -46,9 +47,12 @@ export const prepareDataTieringInitialValues = (values: IndexSet) : IndexSetForm
 export const prepareDataTieringConfig = (values: IndexSetFormValues, pluginStore) : IndexSet => {
   if (!values.data_tiering) return values as unknown as IndexSet;
 
+  const hotOnlyDefaults = {
+    archive_before_deletion: false,
+  };
+
   const hotWarmDefaultValues = {
     warm_tier_enabled: false,
-    archive_before_deletion: false,
     warm_tier_repository_name: null,
   };
 
@@ -56,6 +60,8 @@ export const prepareDataTieringConfig = (values: IndexSetFormValues, pluginStore
   const dataTieringType = dataTieringPlugin?.type ?? DATA_TIERING_TYPE.HOT_ONLY;
 
   let { data_tiering } = values;
+
+  data_tiering = { ...hotOnlyDefaults, ...data_tiering };
 
   if (dataTieringType === DATA_TIERING_TYPE.HOT_WARM) {
     data_tiering = { ...hotWarmDefaultValues, ...data_tiering };
@@ -130,7 +136,22 @@ const DataTieringConfiguration = () => {
                        validate={validateMinDaysInStorage}
                        help="How many days at minumum your data should be stored."
                        required />
-      {dataTieringPlugin && <dataTieringPlugin.TiersConfigurationFields />}
+
+      {dataTieringPlugin && (
+        <>
+          <Input id="roles-selector-input"
+                 labelClassName="col-sm-3"
+                 wrapperClassName="col-sm-9"
+                 label="Archiving">
+            <FormikInput type="checkbox"
+                         id="data_tiering.archive_before_deletion"
+                         label="Archive before deletion"
+                         name="data_tiering.archive_before_deletion"
+                         help="Archive this index before it is deleted?" />
+          </Input>
+          <dataTieringPlugin.TiersConfigurationFields />
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Part of https://github.com/Graylog2/graylog-plugin-enterprise/issues/6916

/nocl
/jpd Graylog2/graylog-plugin-enterprise#6933

## Description
Move the _Archive before Deletion_ checkbox out of the warm tiering config.
This should be configurable when the enterprise plugin is installed, even if the warm tier is not ready to be configured.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

