### PR TITLE
fix(6811): Add condition to navigation items to check for license

### DIFF
--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -160,8 +160,6 @@ const pluginLicenseValid = (navigationItems: Array<PluginNavigation>, descriptio
   if (!navigationItems?.length) return false;
   const menuItem = navigationItems.find((value) => value.description?.toLowerCase() === description.toLowerCase());
 
-  console.log(menuItem);
-
   return menuItem && Object.keys(menuItem).includes('useIsValidLicense') ? menuItem.useIsValidLicense() : true;
 };
 

--- a/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
@@ -151,7 +151,7 @@ const TeaserPageLayout = ({ children }: PropsWithChildren) => {
                 <BoldText>Security Demo</BoldText>
                 <span>For more information and booking a full demo of the product visit Graylog website.</span>
               </LeftItems>
-              <Button bsStyle="primary" role="link" target="_blank" href="https://graylog.org/products/security">
+              <Button bsStyle="primary" role="link" target="_blank" href="https://graylog.org/explore-security/">
                 Graylog Security <Icon name="open_in_new" />
               </Button>
             </Banner>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds security license check for security drop-down nav items. In this way the application mounts the list of security features that have available a teaser page.

/nocl

/jenkis-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/6938

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

