### PR TITLE
Reset events widget pagination when executing search.

### DIFF
--- a/changelog/unreleased/issue-18915.toml
+++ b/changelog/unreleased/issue-18915.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Reset events widget pagination when executing search."
+
+issues = ["18915"]
+pulls = ["18945"]

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
+import * as Immutable from 'immutable';
+import userEvent from '@testing-library/user-event';
+
+import asMock from 'helpers/mocking/AsMock';
+import useAppDispatch from 'stores/useAppDispatch';
+import { finishedLoading } from 'views/logic/slices/searchExecutionSlice';
+import SearchResult from 'views/logic/SearchResult';
+import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
+import type { SearchErrorResponse } from 'views/logic/SearchError';
+import TestStoreProvider from 'views/test/TestStoreProvider';
+import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useAutoRefresh from 'views/hooks/useAutoRefresh';
+import EventsWidgetConfig from 'views/logic/widgets/events/EventsWidgetConfig';
+
+import EventsList from './EventsList';
+
+jest.mock('views/hooks/useAutoRefresh');
+
+const dummySearchJobResults = {
+  errors: [],
+  execution: { cancelled: false, completed_exceptionally: false, done: true },
+  id: 'foo',
+  owner: 'me',
+  search_id: 'bar',
+  results: {},
+};
+jest.mock('views/components/widgets/reexecuteSearchTypes');
+jest.mock('stores/useAppDispatch');
+
+describe('EventsList', () => {
+  const config = EventsWidgetConfig.createDefault();
+
+  const data = {
+    id: 'search-type-id',
+    type: 'events' as const,
+    events: [
+      {
+        id: '01HV0YS4GHDMT30E3EMWQVQNK9',
+        streams: [
+          '000000000000000000000001',
+        ],
+        timestamp: '2024-04-09T08:14:49.445Z',
+        message: 'Test Event 1',
+        alert: false,
+        event_definition_id: 'event-definition-1',
+        priority: 2,
+        event_keys: [],
+        replay_info: {
+          timerange_start: '2024-04-09T08:14:46.644Z',
+          timerange_end: '2024-04-09T08:14:49.644Z',
+          query: '',
+          streams: [
+            '000000000000000000000001',
+          ],
+          filters: [],
+        },
+        status: 'NEW',
+        opened_at: '2024-04-09T08:14:49.445Z',
+        closed_at: null,
+        updated_at: null,
+        owner: null,
+        risk_score: 2,
+        archived: false,
+        assigned_to: undefined,
+        created_at: '2024-04-09T08:14:49.445Z',
+        name: undefined,
+      },
+      {
+        id: '01HV0YS4GH0VC7DV6A2VGN1VJ0',
+        streams: [
+          '000000000000000000000001',
+        ],
+        timestamp: '2024-04-09T08:14:49.416Z',
+        message: 'Test Event 2',
+        alert: false,
+        event_definition_id: 'event-definition-2',
+        priority: 2,
+        event_keys: [],
+        replay_info: {
+          timerange_start: '2024-04-09T08:14:46.644Z',
+          timerange_end: '2024-04-09T08:14:49.644Z',
+          query: '',
+          streams: [
+            '000000000000000000000001',
+          ],
+          filters: [],
+        },
+        status: 'NEW',
+        opened_at: '2024-04-09T08:14:49.416Z',
+        closed_at: null,
+        updated_at: null,
+        owner: null,
+        risk_score: 2,
+        archived: false,
+        assigned_to: undefined,
+        created_at: '2024-04-09T08:14:49.445Z',
+        name: undefined,
+      },
+    ],
+    totalResults: 1,
+  };
+
+  beforeAll(() => {
+    loadViewsPlugin();
+
+    asMock(useAutoRefresh).mockReturnValue({
+      refreshConfig: null,
+      startAutoRefresh: () => {},
+      stopAutoRefresh: () => {},
+    });
+  });
+
+  afterAll(unloadViewsPlugin);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const clickNextPageButton = () => {
+    const paginationListItem = screen.getByRole('listitem', { name: /next/i });
+
+    const nextPageButton = within(paginationListItem).getByRole('button');
+    userEvent.click(nextPageButton);
+  };
+
+  const SimpleEventsList = (props: Partial<React.ComponentProps<typeof EventsList>>) => (
+    <TestStoreProvider>
+      <EventsList title="Events List"
+                  editing={false}
+                  filter=""
+                  onConfigChange={() => Promise.resolve()}
+                  type="events"
+                  id="events-list"
+                  queryId="deadbeef"
+                  toggleEdit={() => {}}
+                  setLoadingState={() => {}}
+                  data={props.data}
+                  config={props.config}
+                  fields={props.fields}
+                  {...props} />
+    </TestStoreProvider>
+  );
+
+  SimpleEventsList.defaultProps = {
+    config: config,
+    data: data,
+    fields: Immutable.List([]),
+  };
+
+  it('lists events', async () => {
+    render(<SimpleEventsList data={data} />);
+
+    await screen.findByRole('cell', { name: /test event 1/i });
+  });
+
+  it('reexecute query for search type, when using pagination', async () => {
+    const dispatch = jest.fn().mockResolvedValue(finishedLoading({
+      result: new SearchResult(dummySearchJobResults),
+      widgetMapping: Immutable.Map(),
+    }));
+    asMock(useAppDispatch).mockReturnValue(dispatch);
+    const searchTypePayload = { [data.id]: { page: 1, per_page: 10 } };
+    const secondPageSize = 10;
+
+    render(<SimpleEventsList data={{ ...data, totalResults: 10 + secondPageSize }} />);
+
+    clickNextPageButton();
+
+    await waitFor(() => expect(reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload));
+  });
+
+  it('disables refresh actions, when using pagination', async () => {
+    const stopAutoRefresh = jest.fn();
+
+    asMock(useAutoRefresh).mockReturnValue({
+      refreshConfig: null,
+      startAutoRefresh: () => {},
+      stopAutoRefresh,
+    });
+
+    const dispatch = jest.fn().mockResolvedValue(finishedLoading({
+      result: new SearchResult(dummySearchJobResults),
+      widgetMapping: Immutable.Map(),
+    }));
+    asMock(useAppDispatch).mockReturnValue(dispatch);
+    const secondPageSize = 10;
+
+    render(<SimpleEventsList data={{ ...data, totalResults: 10 + secondPageSize }} />);
+
+    clickNextPageButton();
+
+    await waitFor(() => expect(stopAutoRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it('displays error description, when using pagination throws an error', async () => {
+    const dispatch = jest.fn().mockResolvedValue(finishedLoading({
+      result: new SearchResult({
+        ...dummySearchJobResults,
+        errors: [{
+          description: 'Error description',
+        } as SearchErrorResponse],
+      }),
+      widgetMapping: Immutable.Map(),
+    }));
+    asMock(useAppDispatch).mockReturnValue(dispatch);
+
+    const secondPageSize = 10;
+
+    render(<SimpleEventsList data={{ ...data, totalResults: 10 + secondPageSize }} />);
+
+    clickNextPageButton();
+
+    await screen.findByText('Error description');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
@@ -26,7 +26,7 @@ import SearchResult from 'views/logic/SearchResult';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
 import type { SearchErrorResponse } from 'views/logic/SearchError';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
 import EventsWidgetConfig from 'views/logic/widgets/events/EventsWidgetConfig';
 
@@ -118,20 +118,14 @@ describe('EventsList', () => {
     totalResults: 1,
   };
 
-  beforeAll(() => {
-    loadViewsPlugin();
+  useViewsPlugin();
 
+  beforeEach(() => {
     asMock(useAutoRefresh).mockReturnValue({
       refreshConfig: null,
       startAutoRefresh: () => {},
       stopAutoRefresh: () => {},
     });
-  });
-
-  afterAll(unloadViewsPlugin);
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   const clickNextPageButton = () => {

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
@@ -177,7 +177,7 @@ describe('EventsList', () => {
       widgetMapping: Immutable.Map(),
     }));
     asMock(useAppDispatch).mockReturnValue(dispatch);
-    const searchTypePayload = { [data.id]: { page: 1, per_page: 10 } };
+    const searchTypePayload = { [data.id]: { page: 2, per_page: 10 } };
     const secondPageSize = 10;
 
     render(<SimpleEventsList data={{ ...data, totalResults: 10 + secondPageSize }} />);

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
@@ -75,7 +75,7 @@ const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: bo
     stopAutoRefresh();
     setLoadingState(true);
 
-    dispatch(reexecuteSearchTypes(searchTypePayload)).then((response) => {
+    return dispatch(reexecuteSearchTypes(searchTypePayload)).then((response) => {
       const { result } = response.payload;
       setLoadingState(false);
 

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
@@ -26,10 +26,18 @@ import useAppDispatch from 'stores/useAppDispatch';
 import type EventsWidgetConfig from 'views/logic/widgets/events/EventsWidgetConfig';
 import type { EventsListResult } from 'views/components/widgets/events/types';
 import type EventsWidgetSortConfig from 'views/logic/widgets/events/EventsWidgetSortConfig';
+import useOnSearchExecution from 'views/hooks/useOnSearchExecution';
+import useAutoRefresh from 'views/hooks/useAutoRefresh';
+import ErrorWidget from 'views/components/widgets/ErrorWidget';
 
 import EventsTable from './EventsTable';
 
 import { PAGINATION } from '../Constants';
+
+type Pagination = {
+  pageErrors: Array<{ description: string }>,
+  currentPage: number
+}
 
 const Container = styled.div`
   display: flex;
@@ -39,37 +47,55 @@ const Container = styled.div`
   height: 100%;
 `;
 
-const useRefreshPage = (searchTypeId: string, setLoadingState: React.Dispatch<React.SetStateAction<boolean>>) => {
-  const dispatch = useAppDispatch();
+const useResetPaginationOnSearchExecution = (setPagination: (pagination: Pagination) => void, currentPage) => {
+  const resetPagination = useCallback(() => {
+    if (currentPage !== 1) {
+      setPagination({ currentPage: 1, pageErrors: [] });
+    }
+  }, [currentPage, setPagination]);
+  useOnSearchExecution(resetPagination);
+};
 
-  return useCallback((page: number, perPage: number) => {
+const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: boolean) => void, currentPage: number, setPagination: (pagination: Pagination) => void) => {
+  const dispatch = useAppDispatch();
+  const { stopAutoRefresh } = useAutoRefresh();
+
+  return useCallback((pageNo: number) => {
+    // execute search with new offset
     const searchTypePayload: SearchTypeOptions<{
       page: number,
       per_page: number,
     }> = {
       [searchTypeId]: {
-        page,
-        per_page: perPage,
+        page: currentPage,
+        per_page: PAGINATION.PER_PAGE,
       },
     };
 
+    stopAutoRefresh();
     setLoadingState(true);
 
-    return dispatch(reexecuteSearchTypes(searchTypePayload)).then(() => {
+    dispatch(reexecuteSearchTypes(searchTypePayload)).then((response) => {
+      const { result } = response.payload;
       setLoadingState(false);
+
+      setPagination({
+        pageErrors: result.errors,
+        currentPage: pageNo,
+      });
     });
-  }, [dispatch, searchTypeId, setLoadingState]);
+  }, [currentPage, dispatch, searchTypeId, setLoadingState, setPagination, stopAutoRefresh]);
 };
 
 const EventsList = ({ data, config, onConfigChange, setLoadingState }: WidgetComponentProps<EventsWidgetConfig, EventsListResult>) => {
-  const [currentPage, setCurrentPage] = useState(PAGINATION.INITIAL_PAGE);
-  const refreshPage = useRefreshPage(data.id, setLoadingState);
+  const [{ currentPage, pageErrors }, setPagination] = useState<Pagination>({
+    pageErrors: [],
+    currentPage: PAGINATION.INITIAL_PAGE,
+  });
 
-  const handlePageChange = useCallback((newPage: number, newPageSize: number) => {
-    refreshPage(newPage, newPageSize).then(() => {
-      setCurrentPage(newPage);
-    });
-  }, [refreshPage]);
+  useResetPaginationOnSearchExecution(setPagination, currentPage);
+
+  const handlePageChange = useHandlePageChange(data.id, setLoadingState, currentPage, setPagination);
 
   const onSortChange = useCallback((newSort: EventsWidgetSortConfig) => {
     const newConfig = config.toBuilder().sort(newSort).build();
@@ -85,10 +111,13 @@ const EventsList = ({ data, config, onConfigChange, setLoadingState }: WidgetCom
                      pageSize={PAGINATION.PER_PAGE}
                      showPageSizeSelect={false}
                      totalItems={data.totalResults ?? 0}>
-        <EventsTable config={config}
-                     setLoadingState={setLoadingState}
-                     onSortChange={onSortChange}
-                     events={data.events} />
+        {!pageErrors?.length
+          ? (
+            <EventsTable config={config}
+                         setLoadingState={setLoadingState}
+                         onSortChange={onSortChange}
+                         events={data.events} />
+          ) : <ErrorWidget errors={pageErrors} />}
       </PaginatedList>
     </Container>
   );

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
@@ -56,7 +56,7 @@ const useResetPaginationOnSearchExecution = (setPagination: (pagination: Paginat
   useOnSearchExecution(resetPagination);
 };
 
-const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: boolean) => void, currentPage: number, setPagination: (pagination: Pagination) => void) => {
+const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: boolean) => void, setPagination: (pagination: Pagination) => void) => {
   const dispatch = useAppDispatch();
   const { stopAutoRefresh } = useAutoRefresh();
 
@@ -67,7 +67,7 @@ const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: bo
       per_page: number,
     }> = {
       [searchTypeId]: {
-        page: currentPage,
+        page: pageNo,
         per_page: PAGINATION.PER_PAGE,
       },
     };
@@ -84,7 +84,7 @@ const useHandlePageChange = (searchTypeId: string, setLoadingState: (loading: bo
         currentPage: pageNo,
       });
     });
-  }, [currentPage, dispatch, searchTypeId, setLoadingState, setPagination, stopAutoRefresh]);
+  }, [dispatch, searchTypeId, setLoadingState, setPagination, stopAutoRefresh]);
 };
 
 const EventsList = ({ data, config, onConfigChange, setLoadingState }: WidgetComponentProps<EventsWidgetConfig, EventsListResult>) => {
@@ -95,7 +95,7 @@ const EventsList = ({ data, config, onConfigChange, setLoadingState }: WidgetCom
 
   useResetPaginationOnSearchExecution(setPagination, currentPage);
 
-  const handlePageChange = useHandlePageChange(data.id, setLoadingState, currentPage, setPagination);
+  const handlePageChange = useHandlePageChange(data.id, setLoadingState, setPagination);
 
   const onSortChange = useCallback((newSort: EventsWidgetSortConfig) => {
     const newConfig = config.toBuilder().sort(newSort).build();
@@ -111,13 +111,12 @@ const EventsList = ({ data, config, onConfigChange, setLoadingState }: WidgetCom
                      pageSize={PAGINATION.PER_PAGE}
                      showPageSizeSelect={false}
                      totalItems={data.totalResults ?? 0}>
-        {!pageErrors?.length
-          ? (
-            <EventsTable config={config}
-                         setLoadingState={setLoadingState}
-                         onSortChange={onSortChange}
-                         events={data.events} />
-          ) : <ErrorWidget errors={pageErrors} />}
+        {!pageErrors?.length ? (
+          <EventsTable config={config}
+                       setLoadingState={setLoadingState}
+                       onSortChange={onSortChange}
+                       events={data.events} />
+        ) : <ErrorWidget errors={pageErrors} />}
       </PaginatedList>
     </Container>
   );

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
@@ -59,7 +59,7 @@ const RowActions = ({ eventId, hasReplayInfo }: Props) => {
 
   const moreActions = [
     hasReplayInfo ? (
-      <MenuItem href={Routes.ALERTS.replay_search(eventId)} target="_blank">
+      <MenuItem href={Routes.ALERTS.replay_search(eventId)} target="_blank" key="replay-search">
         Replay search
       </MenuItem>
     ) : null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR contains some improvements for the events widget pagination logic.

We are unifying the behaviour with the message list widget. We are now:
- resetting the pagination when the search is being executed
- stopping the auto refresh when using the pagination
- displaying errors which can occur when reexecuting the search.

Fixes https://github.com/Graylog2/graylog2-server/issues/18915