### PR TITLE
Display field value suggestions when field name is in the middle of the search query.

### DIFF
--- a/changelog/unreleased/issue-18288.toml
+++ b/changelog/unreleased/issue-18288.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Display field value suggestions when field name is in the middle of the search query."
+
+issues = ["18288"]
+pulls = ["18952"]

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.test.ts
@@ -129,6 +129,41 @@ describe('FieldValueCompletion', () => {
       expect(suggestions).toEqual(expectedSuggestions);
     });
 
+    it('returns suggestions for field name which is in the middle of the query', async () => {
+      const currentToken = createCurrentToken('keyword', 'http_method:', 2, 8);
+      const prevToken = {
+        type: 'text',
+        value: ' ',
+      };
+
+      const completer = new FieldValueCompletion();
+
+      const suggestions = await completer.getCompletions({
+        ...requestDefaults,
+        currentToken,
+        prevToken,
+        tokens: [
+          {
+            type: 'term',
+            value: 'example',
+          },
+          prevToken,
+          currentToken,
+          {
+            type: 'text',
+            value: ' ',
+          },
+          {
+            type: 'term',
+            value: 'query',
+          },
+        ],
+        currentTokenIdx: 2,
+      });
+
+      expect(suggestions).toEqual(expectedSuggestions);
+    });
+
     it('returns suggestions, field value is a quoted string', async () => {
       const currentToken = createCurrentToken('string', '"P"', 1, 12);
       const prevToken = {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -71,7 +71,7 @@ const getFieldNameAndInput = ({
 }) => {
   const nextToken = tokens[currentTokenIdx + 1] ?? null;
 
-  if (isCompleteFieldName(currentToken) && !nextToken) {
+  if (isCompleteFieldName(currentToken) && (!nextToken || isSpace(nextToken))) {
     return {
       fieldName: removeFinalColon(currentToken.value),
       input: '',
@@ -79,7 +79,7 @@ const getFieldNameAndInput = ({
     };
   }
 
-  if ((isTypeTerm(currentToken) || isTypeString(currentToken) || isKeywordOperator(currentToken)) && isCompleteFieldName(prevToken)) {
+  if ((isTypeTerm(currentToken) || isTypeString(currentToken) || isKeywordOperator(currentToken) || isTypeNumber(currentToken)) && isCompleteFieldName(prevToken)) {
     return {
       fieldName: removeFinalColon(prevToken.value),
       input: formatValue(currentToken.value, currentToken.type),


### PR DESCRIPTION
Please note: This PR needs a backport for `5.2` and `6.0`.

## Description
<!--- Describe your changes in detail -->

As described in https://github.com/Graylog2/graylog2-server/issues/18288 the field value suggestions are currently not being displayed when the field name is in the middle of a query. This PR is fixing this problem.

Fixes #18288
