### PR TITLE
Linking reporting binaries into the TestContainer

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -177,14 +177,6 @@ public class NodeContainerFactory {
             LOG.info("Container debug port: " + container.getMappedPort(DEBUG_PORT));
         }
 
-        config.mavenProjectDirProvider.getFilesToAddToBinDir().forEach(filename -> {
-            final Path originalPath = fileCopyBaseDir.resolve(filename);
-            final String containerPath = GRAYLOG_HOME + "/bin/" + originalPath.getFileName();
-            if (!containerFileExists(container, containerPath)) {
-                LOG.error("Mandatory file {} does not exist in container at {}", filename, containerPath);
-            }
-        });
-
         return container;
     }
 

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -163,6 +163,12 @@ public class NodeContainerFactory {
             }
         });
 
+        config.mavenProjectDirProvider.getFilesToAddToBinDir().forEach(filename -> {
+            final Path originalPath = fileCopyBaseDir.resolve(filename);
+            final String containerPath = GRAYLOG_HOME + "/bin/" + originalPath.getFileName();
+            container.addFileSystemBind(originalPath.toString(), containerPath.toString(), BindMode.READ_ONLY);
+        });
+
         addEnabledFeatureFlagsToContainerEnv(config, container);
 
         container.start();
@@ -174,7 +180,6 @@ public class NodeContainerFactory {
         config.mavenProjectDirProvider.getFilesToAddToBinDir().forEach(filename -> {
             final Path originalPath = fileCopyBaseDir.resolve(filename);
             final String containerPath = GRAYLOG_HOME + "/bin/" + originalPath.getFileName();
-            container.copyFileToContainer(MountableFile.forHostPath(originalPath), containerPath);
             if (!containerFileExists(container, containerPath)) {
                 LOG.error("Mandatory file {} does not exist in container at {}", filename, containerPath);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding a preflight check for the reporting binaries so that we fail more early than during report generation needs linking the binaries instead of copying them after container start. see https://github.com/Graylog2/graylog-plugin-enterprise/pull/6988

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

