### PR TITLE
Backport: Support caused_by field in task errors during remote reindex migration

### DIFF
--- a/changelog/unreleased/pr-18907.toml
+++ b/changelog/unreleased/pr-18907.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix unknown field caused_by in remote reindex migration task class"
+
+pulls = ["18907"]

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -226,7 +226,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
     @Nullable
     private String getErrors(GetTaskResponse task) {
         if (task.error() != null) {
-            return task.error().type() + ": " + task.error().reason();
+            return task.toString();
         } else if (task.task().status().hasFailures()) {
             return String.join(";", task.task().status().failures());
         }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/TaskError.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/TaskError.java
@@ -16,7 +16,23 @@
  */
 package org.graylog.storage.opensearch2;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record TaskError(@JsonProperty("type") String type, @JsonProperty("reason") String reason) {
+import javax.annotation.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TaskError(@JsonProperty("type") String type, @JsonProperty("reason") String reason,
+                        @Nullable @JsonProperty("caused_by") String causedBy) {
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("type='").append(type).append('\'');
+        sb.append(", reason='").append(reason).append('\'');
+        if (causedBy != null) {
+            sb.append(", causedBy='").append(causedBy).append('\'');
+        }
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
Support caused_by field in task errors during remote reindex migration

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

