### PR TITLE
Tieing events widget to configured time range. `6.0`

### DIFF
--- a/changelog/unreleased/pull-18954.toml
+++ b/changelog/unreleased/pull-18954.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Tieing events widget to configured time range."
+
+issues=["18914"]
+pulls=["18954"]

--- a/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
@@ -20,7 +20,6 @@ import Widget from 'views/logic/widgets/Widget';
 import type { WidgetState } from 'views/logic/widgets/Widget';
 import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
-import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 
 import EventsWidgetConfig from './EventsWidgetConfig';
 
@@ -31,8 +30,8 @@ export default class EventsWidget extends Widget {
       EventsWidget.type,
       config,
       undefined,
-      { range: 0, type: 'relative' },
-      createElasticsearchQueryString('*'),
+      undefined,
+      undefined,
       [],
     );
   }
@@ -40,11 +39,6 @@ export default class EventsWidget extends Widget {
   static type = 'events';
 
   static defaultTitle = 'Untitled Events Overview';
-
-  // eslint-disable-next-line class-methods-use-this
-  get hasFixedFilters() {
-    return true;
-  }
 
   static fromJSON(value: WidgetState) {
     const { id, config } = value;


### PR DESCRIPTION
**Note:** This is a backport of https://github.com/Graylog2/graylog2-server/pull/18954 for `6.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is reverting an implementation detail where we configured an explicit "All Time" timerange for the events widget, which lead to problems and confusion. With this PR, it is consistent with the search/widget's configured time range.

Fixes #18914.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.