### PR TITLE
Fix widget time range info when widget has fixed filters and returns all records. `6.0`

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -68,7 +68,7 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions }:
     <WidgetEditApplyAllChangesProvider widget={widget}>
       <DisableSubmissionStateProvider>
         <Container>
-          {(isDashboard && !widget.hasFixedFilters) && (
+          {(isDashboard && !widget.returnsAllRecords) && (
             <QueryControls>
               <QueryEditModeContext.Provider value="widget">
                 <WidgetQueryControls />

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -32,7 +32,7 @@ type Props = {
   widget: Widget,
   activeQuery?: string,
   widgetId?: string,
-  hasFixedFilters?: boolean
+  returnsAllRecords?: boolean
 };
 
 const Wrapper = styled.div(({ theme }) => css`
@@ -50,7 +50,7 @@ const StyledIcon = styled(Icon)(({ theme }) => css`
 `);
 const getEffectiveWidgetTimerange = (result, activeQuery, searchTypeId) => result?.results?.[activeQuery]?.searchTypes[searchTypeId]?.effective_timerange;
 
-const TimerangeInfo = ({ className, widget, activeQuery, widgetId, hasFixedFilters }: Props) => {
+const TimerangeInfo = ({ className, widget, activeQuery, widgetId, returnsAllRecords }: Props) => {
   const { formatTime } = useUserDateTime();
   const { result, widgetMapping } = useSearchResult() ?? {};
   const globalOverride = useGlobalOverride();
@@ -68,12 +68,12 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId, hasFixedFilte
   const currentWidgetMapping = widgetMapping?.get(widgetId);
   const timerange = globalTimerangeString || configuredTimerange;
 
-  if (hasFixedFilters) {
+  if (returnsAllRecords) {
     return (
       <Wrapper className={className}>
-        <StyledIcon name="warning" title="This widget has fixed filters and its results are independent of the current search." />
+        <StyledIcon name="warning" title="The result of this widget is independent of the current search." />
         <TextOverflowEllipsis titleOverride={effectiveTimerangeString}>
-          {timerange}
+          All Time
         </TextOverflowEllipsis>
       </Wrapper>
     );
@@ -82,7 +82,6 @@ const TimerangeInfo = ({ className, widget, activeQuery, widgetId, hasFixedFilte
   return (
     <SearchQueryExecutionInfoHelper currentWidgetMapping={currentWidgetMapping}>
       <Wrapper className={className}>
-        {hasFixedFilters && <StyledIcon name="warning" title="This widget has a fixed time range" />}
         <TextOverflowEllipsis titleOverride={effectiveTimerangeString}>
           {timerange}
         </TextOverflowEllipsis>
@@ -95,7 +94,7 @@ TimerangeInfo.defaultProps = {
   className: undefined,
   activeQuery: undefined,
   widgetId: undefined,
-  hasFixedFilters: undefined,
+  returnsAllRecords: undefined,
 };
 
 export default TimerangeInfo;

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -291,8 +291,8 @@ const Widget = ({ id, editing, widget, title, position, onPositionsChange }: Pro
           </WidgetErrorBoundary>
         </EditWrapper>
         <WidgetFooter>
-          {((widget.hasFixedFilters || isDashboard) && !editing) && (
-            <TimerangeInfo widget={widget} activeQuery={activeQuery} widgetId={id} hasFixedFilters={widget.hasFixedFilters} />
+          {((widget.returnsAllRecords || isDashboard) && !editing) && (
+            <TimerangeInfo widget={widget} activeQuery={activeQuery} widgetId={id} returnsAllRecords={widget.returnsAllRecords} />
           )}
         </WidgetFooter>
       </WidgetFrame>

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -87,7 +87,7 @@ class Widget {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  get hasFixedFilters() {
+  get returnsAllRecords() {
     return false;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR contains changes required for https://github.com/Graylog2/graylog-plugin-enterprise/pull/7003. Before it was possible that a widget had fixed filters and returned all available records, but the widget time range info still referred to the search time range.

/nocl
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7003