### PR TITLE
Only fetch event definitions in events widget, when user has required permissions `6.0`

### DIFF
--- a/changelog/unreleased/issue-18949.toml
+++ b/changelog/unreleased/issue-18949.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Fix event definitions handling in events widget."
+message = "Fix permissions handling in events widget."
 
 issues = ["18949"]
 pulls = ["18953"]

--- a/changelog/unreleased/issue-18949.toml
+++ b/changelog/unreleased/issue-18949.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix event definitions handling in events widget."
+
+issues = ["18949"]
+pulls = ["18953"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionLink.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionLink.tsx
@@ -37,7 +37,8 @@ const EventDefinitionLink = ({ event, eventDefinitionContext }: Props) => {
   return isPermitted(currentUser.permissions,
     `eventdefinitions:edit:${eventDefinitionContext.id}`)
     ? <Link to={Routes.ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>{eventDefinitionContext.title}</Link>
-    : <>eventDefinitionContext.title</>;
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    : <>{eventDefinitionContext.title}</>;
 };
 
 export default EventDefinitionLink;

--- a/graylog2-web-interface/src/components/events/events/hooks/useEventDefinition.tsx
+++ b/graylog2-web-interface/src/components/events/events/hooks/useEventDefinition.tsx
@@ -25,7 +25,7 @@ export const fetchEventDefinitionDetails = async (eventDefinitionId: string): Pr
   fetch('GET', qualifyUrl(`/events/definitions/${eventDefinitionId}`))
 );
 
-const useEventDefinition = (eventDefId: string) => {
+const useEventDefinition = (eventDefId: string, enabled = true) => {
   const { data, isFetching } = useQuery({
     queryKey: ['get-event-definition-details', eventDefId],
     queryFn: () => fetchEventDefinitionDetails(eventDefId),
@@ -34,7 +34,7 @@ const useEventDefinition = (eventDefId: string) => {
     },
     retry: 0,
     keepPreviousData: true,
-    enabled: !!eventDefId,
+    enabled: !!eventDefId && enabled,
   });
 
   return { data, isFetching };

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { adminUser, alice } from 'fixtures/users';
+import usePluginEntities from 'hooks/usePluginEntities';
+import useEventById from 'hooks/useEventById';
+import { mockEventData } from 'helpers/mocking/EventAndEventDefinitions_mock';
+import useEventDefinition from 'components/events/events/hooks/useEventDefinition';
+
+import EventDetails from './EventDetails';
+
+jest.mock('hooks/useEventById');
+jest.mock('hooks/useCurrentUser');
+jest.mock('hooks/usePluginEntities');
+jest.mock('components/events/events/hooks/useEventDefinition');
+
+describe('EventDetails', () => {
+  beforeEach(() => {
+    asMock(usePluginEntities).mockReturnValue([]);
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+    asMock(useEventDefinition).mockReturnValue({ data: undefined, isFetching: false });
+
+    asMock(useEventById).mockImplementation(() => ({
+      data: mockEventData.event,
+      isLoading: false,
+      isFetched: true,
+      refetch: () => {},
+    }));
+  });
+
+  it('should render pluggable event details', async () => {
+    asMock(usePluginEntities).mockImplementation((entityKey) => ({
+      'views.components.widgets.events.detailsComponent': [{
+        component: () => <div>Pluggable details component</div>,
+        useCondition: () => true,
+        key: 'details-component',
+      }],
+    }[entityKey]));
+
+    render(<EventDetails eventId="event-id" />);
+
+    await screen.findByText('Pluggable details component');
+  });
+
+  it('should render default event details', async () => {
+    render(<EventDetails eventId="event-id" />);
+
+    await waitFor(() => expect(useEventDefinition).toHaveBeenCalledWith('event-definition-id-1', true));
+    await screen.findByText('Additional Fields');
+  });
+
+  it('should not fetch event definition when user does not have required permissions', async () => {
+    asMock(useCurrentUser).mockReturnValue(alice);
+    render(<EventDetails eventId="event-id" />);
+
+    await waitFor(() => expect(useEventDefinition).toHaveBeenCalledWith('event-definition-id-1', false));
+    await screen.findByText('Additional Fields');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
@@ -37,7 +37,7 @@ export const usePluggableEventDetails = (eventId: string) => {
   );
 };
 
-export const EventDetails = ({ eventId }: { eventId: string }) => {
+export const DefaultDetailsWrapper = ({ eventId }: { eventId: string }) => {
   const { data: event, isLoading } = useEventById(eventId);
   const currentUser = useCurrentUser();
   const canViewDefinition = isPermitted(currentUser.permissions, `eventdefinitions:read:${event?.event_definition_id}`);
@@ -62,7 +62,7 @@ const EventDetailsWrapper = ({ eventId }: { eventId: string }) => {
     return <>{puggableEventDetails}</>;
   }
 
-  return <EventDetails eventId={eventId} />;
+  return <DefaultDetailsWrapper eventId={eventId} />;
 };
 
 export default EventDetailsWrapper;

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
@@ -35,7 +35,7 @@ export const usePluggableEventDetails = (eventId: string) => {
   );
 };
 
-const DefaultDetailsWrapper = ({ eventId }: { eventId: string }) => {
+export const EventDetails = ({ eventId }: { eventId: string }) => {
   const { data: event, isLoading } = useEventById(eventId);
   const { data: eventDefinition, isFetching } = useEventDefinition(event?.event_definition_id);
 
@@ -50,7 +50,7 @@ const DefaultDetailsWrapper = ({ eventId }: { eventId: string }) => {
   return <DefaultDetails event={event} eventDefinitionContext={eventDefinition} />;
 };
 
-const EventDetails = ({ eventId }: { eventId: string }) => {
+const EventDetailsWrapper = ({ eventId }: { eventId: string }) => {
   const puggableEventDetails = usePluggableEventDetails(eventId);
 
   if (puggableEventDetails?.length) {
@@ -58,7 +58,7 @@ const EventDetails = ({ eventId }: { eventId: string }) => {
     return <>{puggableEventDetails}</>;
   }
 
-  return <DefaultDetailsWrapper eventId={eventId} />;
+  return <EventDetails eventId={eventId} />;
 };
 
-export default EventDetails;
+export default EventDetailsWrapper;

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.tsx
@@ -22,6 +22,8 @@ import useEventById from 'hooks/useEventById';
 import useEventDefinition from 'components/events/events/hooks/useEventDefinition';
 import { Spinner } from 'components/common';
 import DefaultDetails from 'components/events/events/EventDetails';
+import { isPermitted } from 'util/PermissionsMixin';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 export const usePluggableEventDetails = (eventId: string) => {
   const pluggableEventDetails = usePluginEntities('views.components.widgets.events.detailsComponent');
@@ -37,7 +39,9 @@ export const usePluggableEventDetails = (eventId: string) => {
 
 export const EventDetails = ({ eventId }: { eventId: string }) => {
   const { data: event, isLoading } = useEventById(eventId);
-  const { data: eventDefinition, isFetching } = useEventDefinition(event?.event_definition_id);
+  const currentUser = useCurrentUser();
+  const canViewDefinition = isPermitted(currentUser.permissions, `eventdefinitions:read:${event?.event_definition_id}`);
+  const { data: eventDefinition, isFetching } = useEventDefinition(event?.event_definition_id, canViewDefinition);
 
   if (isFetching) {
     return <Spinner />;

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
@@ -27,7 +27,6 @@ import EventsWidgetSortConfig from 'views/logic/widgets/events/EventsWidgetSortC
 import useEventAttributes from 'views/components/widgets/events/hooks/useEventAttributes';
 import UnknownAttributeTitle from 'views/components/widgets/events/UnknownAttributeTitle';
 import type Direction from 'views/logic/aggregationbuilder/Direction';
-import { IfPermitted } from 'components/common';
 
 import AttributeSortIcon from '../../overview-configuration/AttributeSortIcon';
 
@@ -78,9 +77,7 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
               );
             })}
             <IfInteractive>
-              <IfPermitted permissions={['eventdefinitions:read']}>
-                <ActionsHeader />
-              </IfPermitted>
+              <ActionsHeader />
             </IfInteractive>
           </tr>
         </TableHead>

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
@@ -27,6 +27,7 @@ import EventsWidgetSortConfig from 'views/logic/widgets/events/EventsWidgetSortC
 import useEventAttributes from 'views/components/widgets/events/hooks/useEventAttributes';
 import UnknownAttributeTitle from 'views/components/widgets/events/UnknownAttributeTitle';
 import type Direction from 'views/logic/aggregationbuilder/Direction';
+import { IfPermitted } from 'components/common';
 
 import AttributeSortIcon from '../../overview-configuration/AttributeSortIcon';
 
@@ -77,7 +78,9 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
               );
             })}
             <IfInteractive>
-              <ActionsHeader />
+              <IfPermitted permissions={['eventdefinitions:read']}>
+                <ActionsHeader />
+              </IfPermitted>
             </IfInteractive>
           </tr>
         </TableHead>

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
@@ -17,8 +17,15 @@
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
+import userEvent from '@testing-library/user-event';
+
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { alice, adminUser } from 'fixtures/users';
 
 import EventsTableRow from './EventsTableRow';
+
+jest.mock('hooks/useCurrentUser');
 
 const event = {
   id: 'event-id-1',
@@ -30,11 +37,23 @@ const event = {
   updated_at: '2024-02-26T15:32:24.666Z',
   priority: null,
   archived: false,
-  replay_info: null,
+  replay_info: {
+    timerange_start: '2024-04-09T14:29:36.644Z',
+    timerange_end: '2024-04-09T14:29:39.644Z',
+    query: '',
+    streams: [
+      '000000000000000000000001',
+    ],
+    filters: [],
+  },
 };
 
-describe('EventsList', () => {
-  it('should render list of events', async () => {
+describe('EventsTableRow', () => {
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
+  it('should render event', async () => {
     render(
       <table>
         <tbody>
@@ -45,5 +64,35 @@ describe('EventsList', () => {
     );
 
     await screen.findByText('Event 1');
+  });
+
+  it('should render replay search action', async () => {
+    render(
+      <table>
+        <tbody>
+          <EventsTableRow event={event}
+                          fields={Immutable.OrderedSet(['name'])} />
+        </tbody>
+      </table>,
+    );
+
+    userEvent.click(await screen.findByRole('button', { name: /toggle event actions/i }));
+
+    await screen.findByRole('menuitem', { name: /replay search/i });
+  });
+
+  it('should not render more action menu when user does not have required permissions', async () => {
+    asMock(useCurrentUser).mockReturnValue(alice);
+
+    render(
+      <table>
+        <tbody>
+          <EventsTableRow event={event}
+                          fields={Immutable.OrderedSet(['name'])} />
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByRole('button', { name: /toggle event actions/i })).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
@@ -22,6 +22,7 @@ import EventsTableRow from './EventsTableRow';
 
 const event = {
   id: 'event-id-1',
+  event_definition_id: 'event-definition-id-1',
   name: 'Event 1',
   status: null,
   assigned_to: null,

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.tsx
@@ -22,6 +22,7 @@ import IfInteractive from 'views/components/dashboard/IfInteractive';
 import type { EventListItem } from 'views/components/widgets/events/types';
 import RowActions from 'views/components/widgets/events/EventsList/RowActions';
 import useEventAttributes from 'views/components/widgets/events/hooks/useEventAttributes';
+import { IfPermitted } from 'components/common';
 
 const Td = styled.td(({ theme }) => css`
   && {
@@ -52,9 +53,11 @@ const EventsTableRow = ({ event, fields }: Props) => {
         );
       })}
       <IfInteractive>
-        <Td>
-          <RowActions eventId={event.id} hasReplayInfo={!!event.replay_info} />
-        </Td>
+        <IfPermitted permissions={['eventdefinitions:read']}>
+          <Td>
+            <RowActions eventId={event.id} hasReplayInfo={!!event.replay_info} />
+          </Td>
+        </IfPermitted>
       </IfInteractive>
     </tr>
   );

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.tsx
@@ -22,7 +22,6 @@ import IfInteractive from 'views/components/dashboard/IfInteractive';
 import type { EventListItem } from 'views/components/widgets/events/types';
 import RowActions from 'views/components/widgets/events/EventsList/RowActions';
 import useEventAttributes from 'views/components/widgets/events/hooks/useEventAttributes';
-import { IfPermitted } from 'components/common';
 
 const Td = styled.td(({ theme }) => css`
   && {
@@ -53,11 +52,9 @@ const EventsTableRow = ({ event, fields }: Props) => {
         );
       })}
       <IfInteractive>
-        <IfPermitted permissions={['eventdefinitions:read']}>
-          <Td>
-            <RowActions eventId={event.id} hasReplayInfo={!!event.replay_info} />
-          </Td>
-        </IfPermitted>
+        <Td>
+          <RowActions eventId={event.id} eventDefinitionId={event.event_definition_id} hasReplayInfo={!!event.replay_info} />
+        </Td>
       </IfInteractive>
     </tr>
   );

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
@@ -21,6 +21,8 @@ import { IconButton, ModalSubmit } from 'components/common';
 import { ButtonToolbar, Modal, Menu, MenuItem } from 'components/bootstrap';
 import usePluginEntities from 'hooks/usePluginEntities';
 import Routes from 'routing/Routes';
+import { isPermitted } from 'util/PermissionsMixin';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import EventDetails from './EventDetails';
 
@@ -49,16 +51,18 @@ const usePluggableDashboardActions = (eventId: string) => {
 
 type Props = {
   eventId: string,
-  hasReplayInfo: boolean
+  hasReplayInfo: boolean,
+  eventDefinitionId: string,
 }
 
-const RowActions = ({ eventId, hasReplayInfo }: Props) => {
+const RowActions = ({ eventId, hasReplayInfo, eventDefinitionId }: Props) => {
+  const user = useCurrentUser();
   const [showDetailsModal, setShowDetailsModal] = useState(false);
   const toggleDetailsModal = () => setShowDetailsModal((cur) => !cur);
   const { actions: pluggableActions, actionModals: pluggableActionModals } = usePluggableDashboardActions(eventId);
 
   const moreActions = [
-    hasReplayInfo ? (
+    (hasReplayInfo && isPermitted(user.permissions, `eventdefinitions:read:${eventDefinitionId}`)) ? (
       <MenuItem href={Routes.ALERTS.replay_search(eventId)} target="_blank" key="replay-search">
         Replay search
       </MenuItem>

--- a/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
@@ -30,15 +30,15 @@ type Props = {
 
 const EventDefinitionName = ({ eventDefinitionId, displayAsLink }: Props) => {
   const currentUser = useCurrentUser();
-  const canViewDefinitions = isPermitted(currentUser.permissions, ['eventdefinitions:read']);
-  const { data: eventDefinition, isFetching } = useEventDefinition(eventDefinitionId, canViewDefinitions);
+  const canViewDefinition = isPermitted(currentUser.permissions, `eventdefinitions:read:${eventDefinitionId}`);
+  const { data: eventDefinition, isFetching } = useEventDefinition(eventDefinitionId, canViewDefinition);
   const title = eventDefinition?.title ?? eventDefinitionId;
 
   if (isFetching) {
     return <Spinner />;
   }
 
-  if (!displayAsLink || !canViewDefinitions) {
+  if (!displayAsLink || !canViewDefinition) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{title}</>;
   }

--- a/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
@@ -20,6 +20,8 @@ import { Spinner } from 'components/common';
 import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
 import useEventDefinition from 'components/events/events/hooks/useEventDefinition';
+import { isPermitted } from 'util/PermissionsMixin';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 type Props = {
   eventDefinitionId: string,
@@ -27,21 +29,24 @@ type Props = {
 }
 
 const EventDefinitionName = ({ eventDefinitionId, displayAsLink }: Props) => {
-  const { data: eventDefinition, isFetching } = useEventDefinition(eventDefinitionId);
+  const currentUser = useCurrentUser();
+  const canViewDefinitions = isPermitted(currentUser.permissions, ['eventdefinitions:read']);
+  const { data: eventDefinition, isFetching } = useEventDefinition(eventDefinitionId, canViewDefinitions);
+  const title = eventDefinition?.title ?? eventDefinitionId;
 
   if (isFetching) {
     return <Spinner />;
   }
 
-  if (!displayAsLink) {
+  if (!displayAsLink || !canViewDefinitions) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
-    return <>{eventDefinition.title}</>;
+    return <>{title}</>;
   }
 
   if (eventDefinition) {
     return (
       <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)} target="_blank">
-        {eventDefinition.title}
+        {title}
       </Link>
     );
   }

--- a/graylog2-web-interface/src/views/components/widgets/events/types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/events/types.ts
@@ -20,6 +20,7 @@ export type EventListItem = {
   archived: boolean,
   assigned_to: string | null,
   created_at: string,
+  event_definition_id: string,
   id: string,
   name: string,
   priority: number,

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -58,7 +58,7 @@ export const mockEventData = {
     key_tuple: [],
     key: null,
     priority: 2,
-    fields: [{}],
+    fields: [],
     replay_info: {
       timerange_start: '2023-03-02T13:42:21.266Z',
       timerange_end: '2023-03-02T13:43:21.266Z',


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/18953 for `6.0`

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are fixing the permissions checks for the events widget. We are now:

- Only displaying the event definitions name in the events widget, when the user has the required permissions.
- Only showing the replay search action when the user has the required permissions for the related event definition
- Only fetching the event definition for the event details when the user has the required permissions

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7004

Fixes https://github.com/Graylog2/graylog2-server/issues/18949
