### PR TITLE
Fixing text color for unqualified fields in field select.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -58,7 +58,7 @@ type Props = {
 const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
 
 const UnqualifiedOption = styled.span(({ theme }) => css`
-  color: ${theme.colors.variant.light.default};
+  color: ${theme.colors.gray[70]};
 `);
 
 type OptionRendererProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**Before**
light mode:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/c582a27c-8b4a-43c8-86e5-4cd4a4a7dfbe)

dark mode:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/ebbe3353-5c07-4228-a4ea-b6c439d45c75)



**After**
light mode:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/d1942e4f-b587-4a69-b0f8-845ea35afad9)


dark mode:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/6795fb30-367a-4a69-8316-c4b60f0d7b9b)

Fixes #18975

