### PR TITLE
Refactor static cloud compatibility check for inputs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -66,12 +66,17 @@ public class CloudTrailInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isForwarderCompatible() {
+            return false;
+        }
+
+        public boolean isCloudCompatible() {
             return true;
         }
 
-        public static boolean isForwarderCompatible() {
-            return false;
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
+            return true;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
@@ -89,7 +89,12 @@ public class AWSInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -145,14 +145,14 @@ public class ContentPackService {
                 final EntityWithExcerptFacade facade = entityFacades.getOrDefault(entity.type(), UnsupportedEntityFacade.INSTANCE);
 
                 if (configuration.isCloud() && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
-                    boolean isCloudCompatible = true;
+                    boolean isCloudCompatible = false;
                     final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
                     try {
                         final Method isCloudCompatibleMethod =
-                                Class.forName(inputEntity.type().asString() + "$Descriptor").getMethod("isCloudCompatible");
+                                Class.forName(inputEntity.type().asString() + "$Descriptor").getMethod("isStaticCloudCompatible");
                         isCloudCompatible = (boolean) isCloudCompatibleMethod.invoke(null);
                     } catch (Exception e) {
-                        LOG.info("Failed to invoke Descriptor.isCloudCompatible() for {}", inputEntity.type().asString());
+                        LOG.info("Failed to invoke Descriptor.isStaticCloudCompatible() for {}", inputEntity.type().asString());
                     }
                     if (!isCloudCompatible) {
                         LOG.warn("Ignoring incompatible input {} in cloud", inputEntity.type().asString());

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -69,7 +69,12 @@ public class JsonPathInput extends MessageInput {
             super(NAME, false, DocsHelper.PAGE_SENDING_JSONPATH.toString());
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
@@ -60,7 +60,12 @@ public class FakeHttpMessageInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -417,11 +417,11 @@ public abstract class MessageInput implements Stoppable {
     }
 
     public boolean isCloudCompatible() {
-        return Descriptor.isCloudCompatible();
+        return descriptor.isCloudCompatible();
     }
 
     public boolean isForwarderCompatible() {
-        return Descriptor.isForwarderCompatible();
+        return descriptor.isForwarderCompatible();
     }
 
     public interface Factory<M> {
@@ -470,11 +470,11 @@ public abstract class MessageInput implements Stoppable {
             super(name, exclusive, linkToDocs);
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
             return false;
         }
 
-        public static boolean isForwarderCompatible() {
+        public boolean isForwarderCompatible() {
             return true;
         }
     }


### PR DESCRIPTION
/nocl (bug in unreleased change)
/prd Graylog2/graylog-plugin-enterprise#7044

Relates to Graylog2/graylog-plugin-enterprise#7019

Graylog2/graylog2-server#18769 changed the signature of `MessageInput.Descriptor` methods to be static, to support pre-install compatibility checks for content packs. However, other parts of the code rely on dynamic overriding of these methods. 

To support both use cases, we revert back to the original state and instead introduce a static check method, specifically for content pack imports in Cloud. All `MessageInput` subclasses that want to be cloud-compatible need to define this new static method in `MessageInput.Descriptor`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Can create inputs in Cloud and on-prem
- Cloud only shows cloud-compatible inputs; on-prem shows all
- Cloud-incompatible inputs are ignored when importing a content pack in Cloud

Note: an exception is thrown when uninstalling a content pack. It is related to audit logging and is not relevant to this issue, since it reproduces on `master`. We should fix that separately (Graylog2/graylog2-server#19034).

> 2024-04-12 12:25:04,859 WARN : org.graylog.plugins.auditlog.jersey.AuditLogFilter - Couldn't capture response entity
> java.lang.IllegalArgumentException: No serializer found for class 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
