### PR TITLE
Set readPreference=primary for reading back write results

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyInsertManyResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyInsertManyResult.java
@@ -17,6 +17,7 @@
 package org.graylog2.database.jackson.legacy;
 
 import com.mongodb.MongoException;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.result.InsertManyResult;
 import org.bson.BsonValue;
 import org.mongojack.JacksonMongoCollection;
@@ -35,7 +36,7 @@ public class LegacyInsertManyResult<T, K> implements WriteResult<T, K> {
 
     public LegacyInsertManyResult(JacksonMongoCollection<T> collection, InsertManyResult insertManyResult,
                                   Class<K> idType) {
-        this.collection = collection;
+        this.collection = collection.withReadPreference(ReadPreference.primary());
         this.insertOneResult = insertManyResult;
         this.idType = idType;
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyInsertOneResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyInsertOneResult.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.database.jackson.legacy;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.client.result.InsertOneResult;
 import org.bson.BsonValue;
 import org.mongojack.JacksonMongoCollection;
@@ -34,7 +35,7 @@ public class LegacyInsertOneResult<T, K> implements WriteResult<T, K> {
 
     public LegacyInsertOneResult(JacksonMongoCollection<T> collection, InsertOneResult insertOneResult,
                                  Class<K> idType) {
-        this.collection = collection;
+        this.collection = collection.withReadPreference(ReadPreference.primary());
         this.insertOneResult = insertOneResult;
         this.idType = idType;
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyUpdateOneResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/jackson/legacy/LegacyUpdateOneResult.java
@@ -18,6 +18,7 @@ package org.graylog2.database.jackson.legacy;
 
 import com.google.common.primitives.Ints;
 import com.mongodb.MongoException;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.BsonValue;
 import org.bson.codecs.CollectibleCodec;
@@ -38,7 +39,7 @@ public class LegacyUpdateOneResult<T, K> implements WriteResult<T, K> {
     private final Class<K> idType;
 
     public LegacyUpdateOneResult(JacksonMongoCollection<T> collection, T object, UpdateResult updateResult, Class<T> valueType, Class<K> idType) {
-        this.collection = collection;
+        this.collection = collection.withReadPreference(ReadPreference.primary());
         this.object = object;
         this.updateResult = updateResult;
         this.valueType = valueType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We added a compatibility layer to emulate the deprecated Mongojack 2.x API. Under the hood, it reads back written documents right after writing to return them when a user calls `org.mongojack.WriteResult#getSavedObject`.

As a safety net to prevent this from failing if users configure a non-default MongoDB read preference, we force the fetch operations to be executed with read preference `primary`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even though it's not supported, users might have configured a non-default [read preference](https://www.mongodb.com/docs/manual/core/read-preference/) in their MongoDB connection string. A read preference of `secondaryPreferred` or `secondary` will probably have caused issues in Graylog before, but it might have worked well enough for users to tolerate.

With the move away from Mongojack 2 in 6.0 the chances for things to break with a read preference other than `primary` are much higher because, in our compatibility layer, we read back documents right after writing them in a couple of scenarios.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created a small test program and ran that against a replica set of three nodes:
```java
package org.graylog2.database;

import com.fasterxml.jackson.annotation.JsonCreator;
import com.fasterxml.jackson.annotation.JsonProperty;
import com.google.auto.value.AutoValue;
import com.mongodb.MongoClientOptions;
import com.mongodb.MongoClientURI;
import jakarta.annotation.Nullable;
import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
import org.mongojack.Id;
import org.mongojack.JacksonDBCollection;

import java.util.ArrayList;
import java.util.List;

public class ReplicationSetTest {

    @AutoValue
    public static abstract class Dto {
        @JsonProperty("id")
        @Nullable
        @Id
        public abstract String id();

        @JsonProperty("i")
        public abstract int i();

        @JsonCreator
        public static Dto create(@JsonProperty("id") @Nullable String id, @JsonProperty("i") int i) {
            return new AutoValue_ReplicationSetTest_Dto(id, i);
        }
    }

    public static void main(String... args) throws Exception {

        final MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder().connectionsPerHost(10);
        final MongoClientURI mongoClientURI = new MongoClientURI("mongodb://mongo-1:27017,mongo-2:27018,mongo-3:27019/bugdb?replicationSet=rs0&readPreference=secondaryPreferred", mongoClientOptionsBuilder);
        final MongoConnectionImpl mongoConnection = new MongoConnectionImpl(mongoClientURI);
        mongoConnection.connect();

        final JacksonDBCollection<Dto, String> collection =
                JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection("repltest"), Dto.class, String.class, new MongoJackObjectMapperProvider(new ObjectMapperProvider().get()).get());

        collection.drop();

        final List<Dto> savedDocs = new ArrayList<>();
        for (int i = 0; i < 1000; i++) {
            var doc = collection.save(Dto.create(null, i)).getSavedObject();
            if (doc == null) {
                throw new RuntimeException("OUCH, didn't get saved object on attempt " + i);
            }
            savedDocs.add(doc);
        }

        savedDocs.forEach(doc -> {
            var newI = doc.i() + 1;
            var saved = collection.save(Dto.create(doc.id(), newI)).getSavedObject();
            if (saved.i() != newI) {
                throw new RuntimeException("OUCH, saved object has i = %d, expected %d".formatted(saved.i(), newI));
            }
        });
    }
}

```

Needs to be backported to 6.0!

/nocl
