### PR TITLE
Implement `useViewsPlugin` in all suitable tests.

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.test.tsx
@@ -20,7 +20,7 @@ import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 
 import asMock from 'helpers/mocking/AsMock';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import CreateProfile from 'components/indices/IndexSetFieldTypeProfiles/CreateProfile';
@@ -47,9 +47,7 @@ describe('CreateProfile', () => {
   const editMock = jest.fn(() => Promise.resolve());
   const deleteMock = jest.fn(() => Promise.resolve());
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.test.tsx
@@ -20,7 +20,7 @@ import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
 
 import asMock from 'helpers/mocking/AsMock';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import EditProfile from 'components/indices/IndexSetFieldTypeProfiles/EditProfile';
@@ -50,9 +50,7 @@ describe('EditProfile', () => {
   const editMock = jest.fn(() => Promise.resolve());
   const deleteMock = jest.fn(() => Promise.resolve());
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfileForm.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfileForm.test.tsx
@@ -19,7 +19,7 @@ import { render, screen, fireEvent, waitFor } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 
 import asMock from 'helpers/mocking/AsMock';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import ProfileForm from 'components/indices/IndexSetFieldTypeProfiles/ProfileForm';
@@ -42,9 +42,7 @@ const selectItem = async (select: HTMLElement, option: string | RegExp) => {
 };
 
 describe('IndexSetFieldTypesList', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfilesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfilesList.test.tsx
@@ -23,7 +23,7 @@ import asMock from 'helpers/mocking/AsMock';
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import { profile1, attributes, profile2 } from 'fixtures/indexSetFieldTypeProfiles';
 import ProfilesList from 'components/indices/IndexSetFieldTypeProfiles/ProfilesList';
@@ -55,9 +55,7 @@ jest.mock('views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappin
 jest.mock('components/common/EntityDataTable/hooks/useUserLayoutPreferences');
 
 describe('IndexSetFieldTypesList', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useUserLayoutPreferences).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.test.tsx
@@ -20,7 +20,7 @@ import { render, screen, fireEvent } from 'wrappedTestingLibrary';
 import { MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import IndexSetCustomFieldTypeRemoveModal from 'components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal';
 import useRemoveCustomFieldTypeMutation from 'components/indices/IndexSetFieldTypes/hooks/useRemoveCustomFieldTypeMutation';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
@@ -52,9 +52,7 @@ jest.mock('components/indices/IndexSetFieldTypes/hooks/useIndexProfileWithMappin
 describe('IndexSetFieldTypesList', () => {
   const mockedRemoveCustomFieldTypeMutation = jest.fn(() => Promise.resolve());
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useSelectedEntities).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
@@ -26,7 +26,7 @@ import useIndexSetFieldTypes from 'components/indices/IndexSetFieldTypes/hooks/u
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import IndexSetFieldTypesList from 'components/indices/IndexSetFieldTypes/IndexSetFieldTypesList';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import {
@@ -86,9 +86,7 @@ jest.mock('use-query-params', () => ({
 }));
 
 describe('IndexSetFieldTypesList', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useParams).mockImplementation(() => ({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/hooks/useIndexProfileWithMappingsByField.test.ts
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/hooks/useIndexProfileWithMappingsByField.test.ts
@@ -18,7 +18,7 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 
 import asMock from 'helpers/mocking/AsMock';
 import { MockStore } from 'helpers/mocking';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import useProfile from 'components/indices/IndexSetFieldTypeProfiles/hooks/useProfile';
 import useIndexProfileWithMappingsByField
@@ -41,9 +41,7 @@ jest.mock('components/indices/IndexSetFieldTypeProfiles/hooks/useProfile', () =>
 const renderUseIndexProfileWithMappingsByField = () => renderHook(() => useIndexProfileWithMappingsByField());
 
 describe('useRemoveCustomFieldTypeMutation', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
@@ -25,7 +25,7 @@ import useIndexSetFieldTypes from 'components/indices/IndexSetFieldTypes/hooks/u
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import IndexSetFieldTypesPage from 'pages/IndexSetFieldTypesPage';
 import useFieldTypesForMappings from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypesForMappings';
 import { overriddenIndexField, defaultField, attributes } from 'fixtures/indexSetFieldTypes';
@@ -72,9 +72,7 @@ jest.mock('stores/indices/IndexSetsStore', () => ({
 }));
 
 describe('IndexSetFieldTypesList', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useUserLayoutPreferences).mockReturnValue({

--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.tsx
@@ -20,7 +20,7 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import { StoreMock as MockStore, asMock } from 'helpers/mocking';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import StreamsStore from 'stores/streams/StreamsStore';
 import { InputsActions } from 'stores/inputs/InputsStore';
 
@@ -80,11 +80,9 @@ describe('ShowMessagePage', () => {
     forwarder: [{ isLocalNode }],
   });
 
-  beforeAll(loadViewsPlugin);
+  useViewsPlugin();
 
   beforeAll(() => PluginStore.register(testForwarderPlugin));
-
-  afterAll(unloadViewsPlugin);
 
   afterAll(() => PluginStore.unregister(testForwarderPlugin));
 

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -22,7 +22,7 @@ import userEvent from '@testing-library/user-event';
 
 import type { TitlesMap } from 'views/stores/TitleTypes';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useCurrentQueryId from 'views/logic/queries/useCurrentQueryId';
 import { asMock } from 'helpers/mocking';
 
@@ -90,13 +90,11 @@ describe('AdaptableQueryTabs', () => {
     });
   };
 
-  beforeAll(loadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useCurrentQueryId).mockReturnValue('query-id-1');
   });
-
-  afterAll(unloadViewsPlugin);
 
   describe('renders main tabs and more tabs dropdown based on container width', () => {
     // Defaults widths: Container width = 500px, create tab button + more tabs dropdown button with = 215px, width of one main tab = 100px

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -22,7 +22,7 @@ import userEvent from '@testing-library/user-event';
 
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { setQueriesOrder, mergeQueryTitles } from 'views/logic/slices/viewSlice';
 
 jest.mock('views/logic/slices/viewSlice', () => ({
@@ -44,9 +44,7 @@ describe('AdaptableQueryTabsConfiguration', () => {
     window.confirm = oldConfirm;
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   const renderConfiguration = () => render((
     <TestStoreProvider>

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -29,7 +29,7 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useCurrentUser from 'hooks/useCurrentUser';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
@@ -84,9 +84,7 @@ describe('DashboardActionsMenu', () => {
     view: mockView,
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   const submitDashboardSaveForm = async () => {
     const saveDashboardModal = await screen.findByTestId('modal-form');

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -23,7 +23,7 @@ import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
 import type { WidgetEditingState, WidgetFocusingState } from 'views/components/contexts/WidgetFocusContext';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { execute, setGlobalOverride } from 'views/logic/slices/searchExecutionSlice';
 
 import OriginalDashboardSearchBar from './DashboardSearchBar';
@@ -69,9 +69,7 @@ describe('DashboardSearchBar', () => {
     jest.clearAllMocks();
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should render the DashboardSearchBar', async () => {
     render(<DashboardSearchBar />);

--- a/graylog2-web-interface/src/views/components/Query.test.tsx
+++ b/graylog2-web-interface/src/views/components/Query.test.tsx
@@ -19,7 +19,7 @@ import { render, screen } from 'wrappedTestingLibrary';
 
 import View from 'views/logic/views/View';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createViewWithWidgets, createSearch } from 'fixtures/searches';
 
 import OriginalQuery from './Query';
@@ -36,9 +36,7 @@ const Query = (props: Partial<React.ComponentProps<typeof TestStoreProvider>>) =
 );
 
 describe('Query', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('renders dashboard widget creation explanation on the dashboard page, if no widget is defined', async () => {
     const dashboard = createSearch().toBuilder().type(View.Type.Dashboard).build();

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -24,7 +24,7 @@ import DashboardPageContext from 'views/components/contexts/DashboardPageContext
 import useQueryIds from 'views/hooks/useQueryIds';
 import useQueryTitles from 'views/hooks/useQueryTitles';
 import useViewMetadata from 'views/hooks/useViewMetadata';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useAppDispatch from 'stores/useAppDispatch';
 import { selectQuery, removeQuery } from 'views/logic/slices/viewSlice';
@@ -67,9 +67,7 @@ const QueryBar = () => (
 describe('QueryBar', () => {
   let oldWindowConfirm;
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     oldWindowConfirm = window.confirm;

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -29,7 +29,7 @@ import useQueryIds from 'views/hooks/useQueryIds';
 import useQueryTitles from 'views/hooks/useQueryTitles';
 import { createSearch } from 'fixtures/searches';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 
 import OriginalSearch from './Search';
 import WidgetFocusProvider from './contexts/WidgetFocusProvider';
@@ -105,9 +105,7 @@ describe('Dashboard Search', () => {
     asMock(useQueryTitles).mockReturnValue(mockedQueryTitles);
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should list tabs for dashboard pages', async () => {
     render(<Search />);

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -24,7 +24,7 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import validateQuery from 'views/components/searchbar/queryvalidation/validateQuery';
 import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useAppDispatch from 'stores/useAppDispatch';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
@@ -72,9 +72,7 @@ const SearchBar = () => (
 );
 
 describe('SearchBar', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useSearchConfiguration).mockReturnValue({ config: mockSearchesClusterConfig, refresh: () => {} });

--- a/graylog2-web-interface/src/views/components/Value.test.tsx
+++ b/graylog2-web-interface/src/views/components/Value.test.tsx
@@ -20,7 +20,7 @@ import userEvent from '@testing-library/user-event';
 
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useExternalValueActions from 'views/hooks/useExternalValueActions';
 import asMock from 'helpers/mocking/AsMock';
 
@@ -48,9 +48,7 @@ describe('Value', () => {
     });
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   describe('actions menu title', () => {
     it('renders without type information but no children', async () => {

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -24,7 +24,7 @@ import _Widget from 'views/logic/widgets/Widget';
 import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import type View from 'views/logic/views/View';
 import { createViewWithWidgets } from 'fixtures/searches';
 
@@ -51,9 +51,7 @@ SimpleWidgetGrid.defaultProps = {
 };
 
 describe('<WidgetGrid />', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should render with minimal props', () => {
     const wrapper = mount(<SimpleWidgetGrid />);

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -20,7 +20,7 @@ import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import Widget from 'views/logic/widgets/Widget';
 import mockComponent from 'helpers/mocking/MockComponent';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { asMock } from 'helpers/mocking';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
@@ -50,9 +50,7 @@ describe('WidgetQueryControls', () => {
     asMock(useGlobalOverride).mockReturnValue(GlobalOverride.empty());
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   const config = {
     relative_timerange_options: { P1D: 'Search in last day', PT0S: 'Search in all messages' },

--- a/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
+++ b/graylog2-web-interface/src/views/components/__tests__/MigrateFieldCharts.test.tsx
@@ -25,7 +25,7 @@ import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import Store from 'logic/local-storage/Store';
 import type ViewState from 'views/logic/views/ViewState';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { execute } from 'views/logic/slices/searchExecutionSlice';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
@@ -102,9 +102,7 @@ const renderAndMigrate = async () => {
 };
 
 describe('MigrateFieldCharts', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(createSearch).mockImplementation(async (s) => s);

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.test.tsx
@@ -19,7 +19,7 @@ import { render } from 'wrappedTestingLibrary';
 
 import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 
 import type { DashboardPageContextType } from './DashboardPageContext';
@@ -44,9 +44,7 @@ const emptyLocation = {
 };
 
 describe('DashboardPageContextProvider', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useLocation).mockReturnValue(emptyLocation);

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -27,7 +27,7 @@ import Query, { filtersForQuery } from 'views/logic/queries/Query';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import type { SearchExecutionResult } from 'views/types';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useAppDispatch from 'stores/useAppDispatch';
 import executeSearch from 'views/logic/slices/executeSearch';
 import generateId from 'logic/generateId';
@@ -57,9 +57,7 @@ describe('DefaultFieldTypesProvider', () => {
     return consume;
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('provides no field types with empty store', () => {
     asMock(useCurrentQuery).mockReturnValue(Query.builder().id('foobar').build());

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.tsx
@@ -22,7 +22,7 @@ import { StaticColor } from 'views/logic/views/formatting/highlighting/Highlight
 import ViewState from 'views/logic/views/ViewState';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import type View from 'views/logic/views/View';
 import { createSearch } from 'fixtures/searches';
 
@@ -46,9 +46,7 @@ describe('HighlightingRulesProvider', () => {
     return consume;
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('provides no data when highlighting rules store is empty', () => {
     const consume = renderSUT();

--- a/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.test.tsx
@@ -24,7 +24,7 @@ import { renderHook } from 'wrappedTestingLibrary/hooks';
 import { asMock, StoreMock as MockStore } from 'helpers/mocking';
 import fetch from 'logic/rest/FetchProvider';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExplainContextProvider from 'views/components/contexts/SearchExplainContextProvider';
 import SearchExplainContext from 'views/components/contexts/SearchExplainContext';
 
@@ -108,9 +108,7 @@ const mockData = {
 };
 
 describe('SearchExplainContextProvider', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPagePreferencesProvider.test.tsx
@@ -29,7 +29,7 @@ import { PreferencesActions } from 'stores/users/PreferencesStore';
 import type User from 'logic/users/User';
 import useCurrentUser from 'hooks/useCurrentUser';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import View from 'views/logic/views/View';
 
@@ -53,9 +53,7 @@ jest.mock('logic/local-storage/Store', () => ({
 }));
 
 describe('SearchPagePreferencesProvider', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useCurrentUser).mockReturnValue(defaultUser);

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -22,7 +22,7 @@ import { asMock } from 'helpers/mocking';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import type { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { allMessagesTable } from 'views/logic/Widgets';
 import { createViewWithWidgets } from 'fixtures/searches';
@@ -62,9 +62,7 @@ jest.mock('views/logic/slices/searchExecutionSlice', () => ({
 }));
 
 describe('WidgetFocusProvider', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     const dispatch = jest.fn();

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
@@ -21,7 +21,7 @@ import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import type { QueryId } from 'views/logic/queries/Query';
 import Query from 'views/logic/queries/Query';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { asMock } from 'helpers/mocking';
 import useAppDispatch from 'stores/useAppDispatch';
@@ -55,9 +55,7 @@ describe('CycleQueryTab', () => {
   ]).build();
   const view = View.create().toBuilder().search(search).build();
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     jest.useFakeTimers();

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.tsx
@@ -34,7 +34,7 @@ import Direction from 'views/logic/aggregationbuilder/Direction';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
 import type WidgetConfig from 'views/logic/widgets/WidgetConfig';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import { createViewWithWidgets } from 'fixtures/searches';
 import { updateWidgetConfig } from 'views/logic/slices/widgetActions';
@@ -146,9 +146,7 @@ describe('DataTable', () => {
     );
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should render with empty data', () => {
     const config = AggregationWidgetConfig.builder()

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
@@ -19,7 +19,7 @@ import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { asMock } from 'helpers/mocking';
 import createSearch from 'views/logic/slices/createSearch';
 import useAppSelector from 'stores/useAppSelector';
@@ -70,9 +70,7 @@ describe('QueryTitle', () => {
     </TestStoreProvider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   describe('duplicate action', () => {
     it('triggers duplication of query', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 import QueryValidationActions from 'views/actions/QueryValidationActions';
 import { validationError } from 'fixtures/queryValidationState';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 
 import QueryInput from './QueryInput';
 
@@ -56,9 +56,7 @@ describe('QueryInput', () => {
     </TestStoreProvider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
@@ -37,7 +37,7 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import useView from 'views/hooks/useView';
 import useIsDirty from 'views/hooks/useIsDirty';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useIsNew from 'views/hooks/useIsNew';
 import useHistory from 'routing/useHistory';
 import mockHistory from 'helpers/mocking/mockHistory';
@@ -132,9 +132,7 @@ describe('SearchActionsMenu', () => {
     asMock(useIsNew).mockReturnValue(false);
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   describe('Button handling', () => {
     let history;

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -25,7 +25,7 @@ import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import useViewTitle from 'views/hooks/useViewTitle';
 import useViewMetadata from 'views/hooks/useViewMetadata';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 
@@ -85,9 +85,7 @@ describe('<Sidebar />', () => {
     </TestStoreProvider>,
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useViewType).mockReturnValue(View.Type.Search);

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -27,7 +27,7 @@ import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { updateHighlightingRule } from 'views/logic/slices/highlightActions';
 
 jest.mock('views/logic/slices/highlightActions', () => ({
@@ -67,9 +67,7 @@ describe('HighlightForm', () => {
     fireEvent.click(elem);
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should render for edit', async () => {
     const { findByText } = render(<HighlightFormWithContext onClose={() => {}} rule={rule} />);

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -20,7 +20,7 @@ import userEvent from '@testing-library/user-event';
 
 import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { asMock } from 'helpers/mocking';
 import useAppDispatch from 'stores/useAppDispatch';
 import mockDispatch from 'views/test/mockDispatch';
@@ -38,9 +38,7 @@ jest.mock('views/logic/slices/highlightActions', () => ({
 }));
 
 describe('HighlightingRule', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   const rule = Rule.create('response_time', '250', undefined, StaticColor.create('#f44242'));
   const view = createSearch();

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.tsx
@@ -20,7 +20,7 @@ import { render, screen } from 'wrappedTestingLibrary';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
 import HighlightingRulesProvider from 'views/components/contexts/HighlightingRulesProvider';
@@ -49,9 +49,7 @@ HighlightingRules.defaultProps = {
 };
 
 describe('HighlightingRules', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('renders search term legend even when rules are empty', async () => {
     render(<HighlightingRules />);

--- a/graylog2-web-interface/src/views/components/views/ViewHeader.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewHeader.test.tsx
@@ -20,7 +20,7 @@ import userEvent from '@testing-library/user-event';
 
 import OriginalViewHeader from 'views/components/views/ViewHeader';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import View from 'views/logic/views/View';
 import onSaveView from 'views/logic/views/OnSaveViewAction';
@@ -56,9 +56,7 @@ describe('ViewHeader', () => {
     asMock(onSaveView).mockReturnValue(async () => {});
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('Render view type and title', async () => {
     render(<ViewHeader />);

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -30,7 +30,7 @@ import useViewType from 'views/hooks/useViewType';
 import View from 'views/logic/views/View';
 import useCurrentQueryId from 'views/logic/queries/useCurrentQueryId';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import { setTimerange } from 'views/logic/slices/viewSlice';
 
@@ -77,9 +77,7 @@ describe('XYPlot', () => {
     currentQuery: defaultCurrentQuery,
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useCurrentQuery).mockReturnValue(defaultCurrentQuery);

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -23,7 +23,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
@@ -49,9 +49,7 @@ const AreaVisualization = (props: React.ComponentProps<typeof OriginalAreaVisual
 );
 
 describe('AreaVisualization', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('generates correct props for plot component', () => {
     const config = AggregationWidgetConfig.builder()

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -25,7 +25,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
@@ -44,9 +44,7 @@ const WrappedHeatMap = (props: React.ComponentProps<typeof HeatmapVisualization>
 );
 
 describe('HeatmapVisualization', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('generates correct props for plot component', () => {
     const columnPivot = Pivot.createValues(['http_status']);

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.tsx
@@ -26,7 +26,7 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { CurrentViewType } from 'views/components/CustomPropTypes';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 
 import NumberVisualization from './NumberVisualization';
 
@@ -83,9 +83,7 @@ describe('NumberVisualization', () => {
     </TestStoreProvider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should render a number visualization', () => {
     const wrapper = mount(<SimplifiedNumberVisualization />);

--- a/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
@@ -23,7 +23,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Series from 'views/logic/aggregationbuilder/Series';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useExternalValueActions from 'views/hooks/useExternalValueActions';
@@ -57,9 +57,7 @@ describe('PieVisualization', () => {
     await screen.findByRole('menu');
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useExternalValueActions).mockReturnValue({

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -22,7 +22,7 @@ import MockStore from 'helpers/mocking/StoreMock';
 import Widget from 'views/logic/widgets/Widget';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { execute } from 'views/logic/slices/searchExecutionSlice';
 import { updateWidget } from 'views/logic/slices/widgetActions';
 
@@ -77,9 +77,7 @@ describe('EditWidgetFrame', () => {
       </TestStoreProvider>
     ));
 
-    beforeAll(loadViewsPlugin);
-
-    afterAll(unloadViewsPlugin);
+    useViewsPlugin();
 
     it('refreshes search after clicking on search button, when there are no changes', async () => {
       renderSUT();

--- a/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraWidgetActions.test.tsx
@@ -22,7 +22,7 @@ import asMock from 'helpers/mocking/AsMock';
 import OriginalExtraWidgetActions from 'views/components/widgets/ExtraWidgetActions';
 import Widget from 'views/logic/widgets/Widget';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useWidgetActions from 'views/components/widgets/useWidgetActions';
 import wrapWithMenu from 'helpers/components/wrapWithMenu';
 
@@ -56,9 +56,7 @@ describe('ExtraWidgetActions', () => {
     disabled: jest.fn(() => true),
   };
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('does not render menu items, when no action is configured', () => {
     asMock(useWidgetActions).mockReturnValue([]);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -35,7 +35,7 @@ import SearchResult from 'views/logic/SearchResult';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
 import type { SearchErrorResponse } from 'views/logic/SearchError';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
 
 import type { MessageListResult } from './MessageList';
@@ -97,17 +97,15 @@ describe('MessageList', () => {
     total: 1,
   };
 
-  beforeAll(() => {
-    loadViewsPlugin();
+  useViewsPlugin();
 
+  beforeAll(() => {
     asMock(useAutoRefresh).mockReturnValue({
       refreshConfig: null,
       startAutoRefresh: () => {},
       stopAutoRefresh: () => {},
     });
   });
-
-  afterAll(unloadViewsPlugin);
 
   beforeEach(() => {
     asMock(useActiveQueryId).mockReturnValue('somequery');

--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.test.tsx
@@ -24,7 +24,7 @@ import Widget from 'views/logic/widgets/Widget';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import { ALL_MESSAGES_TIMERANGE } from 'views/Constants';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useSearchResult from 'views/hooks/useSearchResult';
 import type { SearchExecutionResult } from 'views/types';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
@@ -77,9 +77,7 @@ const TimerangeInfo = (props: React.ComponentProps<typeof OriginalTimerangeInfo>
 describe('TimerangeInfo', () => {
   const widget = Widget.empty();
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useSearchResult).mockReturnValue(mockSearchStoreState());

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -34,7 +34,7 @@ import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visuali
 import { asMock } from 'helpers/mocking';
 import useViewType from 'views/hooks/useViewType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { updateWidget } from 'views/logic/slices/widgetActions';
 
 import Widget from './Widget';
@@ -77,9 +77,7 @@ jest.mock('views/logic/slices/widgetActions', () => ({
 const selectEventConfig = { container: document.body };
 
 describe('Aggregation Widget', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   const dataTableWidget = WidgetModel.builder().newId()
     .type('AGGREGATION')

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -35,7 +35,7 @@ import { loadDashboard } from 'views/logic/views/Actions';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useDashboards from 'views/components/dashboard/hooks/useDashboards';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import createSearch from 'views/logic/slices/createSearch';
 import { duplicateWidget, removeWidget } from 'views/logic/slices/widgetActions';
 import useViewType from 'views/hooks/useViewType';
@@ -144,9 +144,7 @@ describe('<WidgetActionsMenu />', () => {
     </TestStoreProvider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/graylog2-web-interface/src/views/hooks/useQueryIds.test.tsx
+++ b/graylog2-web-interface/src/views/hooks/useQueryIds.test.tsx
@@ -23,7 +23,7 @@ import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 import useQueryIds from 'views/hooks/useQueryIds';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 
 const createView = (queryIds: Array<string>) => View.builder()
   .search(Search.builder()
@@ -47,9 +47,7 @@ describe('useQueryIds', () => {
     jest.clearAllMocks();
   });
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('tracks query updates', async () => {
     const { result } = renderHook(() => useQueryIds(), { wrapper: createWrapper(['foo']) });

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.test.ts
@@ -24,16 +24,14 @@ import { updateWidgets } from 'views/logic/slices/widgetActions';
 import mockDispatch from 'views/test/mockDispatch';
 import { createViewWithWidgets } from 'fixtures/searches';
 import type { RootState } from 'views/types';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 
 jest.mock('views/logic/slices/widgetActions', () => ({
   updateWidgets: jest.fn(),
 }));
 
 describe('AddToAllTablesActionHandler', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   it('should add a field to all message widgets', async () => {
     const messageWidgetConfig = MessageWidgetConfig.builder()

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.test.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.test.tsx
@@ -20,7 +20,7 @@ import { render, screen } from 'wrappedTestingLibrary';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import ChangeFieldType from 'views/logic/fieldactions/ChangeFieldType/ChangeFieldType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useInitialSelection from 'views/logic/fieldactions/ChangeFieldType/hooks/useInitialSelection';
 import asMock from 'helpers/mocking/AsMock';
 import useFieldTypeUsages from 'views/logic/fieldactions/ChangeFieldType/hooks/useFieldTypeUsages';
@@ -55,13 +55,12 @@ const renderChangeTypeAction = ({
 );
 
 describe('ChangeFieldType', () => {
+  useViewsPlugin();
+
   beforeAll(() => {
-    loadViewsPlugin();
     asMock(useInitialSelection).mockReturnValue(['id-1', 'id-2']);
     asMock(useFieldTypeUsages).mockReturnValue(paginatedFieldUsage);
   });
-
-  afterAll(unloadViewsPlugin);
 
   it('Shows modal', async () => {
     renderChangeTypeAction({});

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.test.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.test.tsx
@@ -24,7 +24,7 @@ import useFieldTypeUsages from 'views/logic/fieldactions/ChangeFieldType/hooks/u
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import ChangeFieldTypeModal from 'views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal';
 import type { Attributes } from 'stores/PaginationTypes';
 import suppressConsole from 'helpers/suppressConsole';
@@ -119,9 +119,7 @@ jest.mock('components/common/EntityDataTable/hooks/useUserLayoutPreferences');
 describe('ChangeFieldTypeModal', () => {
   const putFieldTypeMutationMock = jest.fn(() => Promise.resolve());
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/EventDefinitionReplaySearchPage.test.tsx
@@ -24,7 +24,7 @@ import StreamsContext from 'contexts/StreamsContext';
 import UseCreateViewForEventDefinition from 'views/logic/views/UseCreateViewForEventDefinition';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import { createSearch } from 'fixtures/searches';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import EventDefinitionReplaySearchPage, { onErrorHandler } from 'views/pages/EventDefinitionReplaySearchPage';
 import useEventDefinition from 'hooks/useEventDefinition';
@@ -72,9 +72,7 @@ describe('EventDefinitionReplaySearchPage', () => {
     </StreamsContext.Provider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useParams).mockReturnValue({ definitionId: mockEventDefinitionTwoAggregations.id });

--- a/graylog2-web-interface/src/views/pages/EventReplaySearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/EventReplaySearchPage.test.tsx
@@ -24,7 +24,7 @@ import StreamsContext from 'contexts/StreamsContext';
 import UseCreateViewForEvent from 'views/logic/views/UseCreateViewForEvent';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import { createSearch } from 'fixtures/searches';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import EventReplaySearchPage, { onErrorHandler } from 'views/pages/EventReplaySearchPage';
 import useEventById from 'hooks/useEventById';
@@ -74,9 +74,7 @@ describe('EventReplaySearchPage', () => {
     </StreamsContext.Provider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useParams).mockReturnValue({ alertId: mockEventData.event.id });

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.tsx
@@ -25,7 +25,7 @@ import View from 'views/logic/views/View';
 import useQuery from 'routing/useQuery';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import StreamsContext from 'contexts/StreamsContext';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import useCreateSearch from 'views/hooks/useCreateSearch';
 
@@ -52,9 +52,7 @@ describe('NewDashboardPage', () => {
     hash: '',
   } as Location;
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useLocation).mockReturnValue(mockLocation);

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -27,7 +27,7 @@ import useQuery from 'routing/useQuery';
 import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import { createSearch } from 'fixtures/searches';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import useCreateSearch from 'views/hooks/useCreateSearch';
 import type View from 'views/logic/views/View';
@@ -56,9 +56,7 @@ describe('NewSearchPage', () => {
     </StreamsContext.Provider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useQuery).mockReturnValue(query);

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.test.tsx
@@ -20,7 +20,7 @@ import { render, waitFor } from 'wrappedTestingLibrary';
 import View from 'views/logic/views/View';
 import OriginalShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import { asMock } from 'helpers/mocking';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
@@ -51,12 +51,11 @@ describe('ShowDashboardInBigDisplayMode', () => {
     stopAutoRefresh: () => {},
   };
 
+  useViewsPlugin();
+
   beforeAll(() => {
     asMock(useQuery).mockReturnValue({ interval: '30', refresh: '10' });
-    loadViewsPlugin();
   });
-
-  afterAll(unloadViewsPlugin);
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.tsx
@@ -26,7 +26,7 @@ import useFetchView from 'views/hooks/useFetchView';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 
 import ShowViewPage from './ShowViewPage';
@@ -66,9 +66,7 @@ describe('ShowViewPage', () => {
     </StreamsContext.Provider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useQuery).mockReturnValue({});

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -26,7 +26,7 @@ import { loadNewViewForStream, loadView } from 'views/logic/views/Actions';
 import useParams from 'routing/useParams';
 import useQuery from 'routing/useQuery';
 import useCreateSavedSearch from 'views/logic/views/UseCreateSavedSearch';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import { createSearch } from 'fixtures/searches';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
@@ -60,9 +60,7 @@ describe('StreamSearchPage', () => {
     </StreamsContext.Provider>
   );
 
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useQuery).mockReturnValue({});

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
@@ -27,7 +27,7 @@ import Routes from 'routing/Routes';
 import AppRouter from 'routing/AppRouter';
 import CurrentUserProvider from 'contexts/CurrentUserProvider';
 import StreamsContext from 'contexts/StreamsContext';
-import { loadViewsPlugin, unloadViewsPlugin } from 'views/test/testViewsPlugin';
+import useViewsPlugin from 'views/test/testViewsPlugin';
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 
@@ -110,9 +110,7 @@ const testTimeout = applyTimeoutMultiplier(30000);
 const setInitialUrl = (url: string) => asMock(createBrowserRouter).mockImplementation((routes) => createMemoryRouter(routes, { initialEntries: [url] }));
 
 describe('Create a new dashboard', () => {
-  beforeAll(loadViewsPlugin);
-
-  afterAll(unloadViewsPlugin);
+  useViewsPlugin();
 
   beforeEach(() => {
     asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });

--- a/graylog2-web-interface/src/views/test/testViewsPlugin.ts
+++ b/graylog2-web-interface/src/views/test/testViewsPlugin.ts
@@ -20,8 +20,8 @@ import viewsBindings from 'views/bindings';
 
 const testViewsPlugin = new PluginManifest({}, viewsBindings);
 
-export const loadViewsPlugin = () => PluginStore.register(testViewsPlugin);
-export const unloadViewsPlugin = () => PluginStore.unregister(testViewsPlugin);
+const loadViewsPlugin = () => PluginStore.register(testViewsPlugin);
+const unloadViewsPlugin = () => PluginStore.unregister(testViewsPlugin);
 
 const useViewsPlugin = () => {
   beforeAll(loadViewsPlugin);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The function `useViewsPlugin` is taking care of loading and unloading the views plugin in tests. With this We implement it in all suitable tests.

/prd Graylog2/graylog-plugin-enterprise#7046
/nocl