### PR TITLE
Cloud compatibility annotation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -66,12 +66,17 @@ public class CloudTrailInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isForwarderCompatible() {
+            return false;
+        }
+
+        public boolean isCloudCompatible() {
             return true;
         }
 
-        public static boolean isForwarderCompatible() {
-            return false;
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
+            return true;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -22,10 +22,12 @@ import jakarta.inject.Inject;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 
+@CloudCompatible
 public class CloudTrailInput extends MessageInput {
     private static final String NAME = "AWS CloudTrail";
 
@@ -71,11 +73,6 @@ public class CloudTrailInput extends MessageInput {
         }
 
         public boolean isCloudCompatible() {
-            return true;
-        }
-
-        // static check for contentpack import
-        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
@@ -31,6 +31,7 @@ import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
 import org.graylog2.plugin.configuration.fields.NumberField;
 import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.regions.Region;
 /**
  * General AWS input for all types of supported AWS logs.
  */
+@CloudCompatible
 public class AWSInput extends MessageInput {
 
     public static final String NAME = "AWS Kinesis/CloudWatch";
@@ -90,11 +92,6 @@ public class AWSInput extends MessageInput {
         }
 
         public boolean isCloudCompatible() {
-            return true;
-        }
-
-        // static check for contentpack import
-        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
@@ -89,7 +89,12 @@ public class AWSInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -145,14 +145,14 @@ public class ContentPackService {
                 final EntityWithExcerptFacade facade = entityFacades.getOrDefault(entity.type(), UnsupportedEntityFacade.INSTANCE);
 
                 if (configuration.isCloud() && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
-                    boolean isCloudCompatible = true;
+                    boolean isCloudCompatible = false;
                     final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
                     try {
                         final Method isCloudCompatibleMethod =
-                                Class.forName(inputEntity.type().asString() + "$Descriptor").getMethod("isCloudCompatible");
+                                Class.forName(inputEntity.type().asString() + "$Descriptor").getMethod("isStaticCloudCompatible");
                         isCloudCompatible = (boolean) isCloudCompatibleMethod.invoke(null);
                     } catch (Exception e) {
-                        LOG.info("Failed to invoke Descriptor.isCloudCompatible() for {}", inputEntity.type().asString());
+                        LOG.info("Failed to invoke Descriptor.isStaticCloudCompatible() for {}", inputEntity.type().asString());
                     }
                     if (!isCloudCompatible) {
                         LOG.warn("Ignoring incompatible input {} in cloud", inputEntity.type().asString());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -62,12 +62,12 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.contentpacks.model.entities.references.ValueType;
 import org.graylog2.contentpacks.model.parameters.Parameter;
+import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.utilities.Graphs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -145,17 +145,11 @@ public class ContentPackService {
                 final EntityWithExcerptFacade facade = entityFacades.getOrDefault(entity.type(), UnsupportedEntityFacade.INSTANCE);
 
                 if (configuration.isCloud() && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
-                    boolean isCloudCompatible = false;
                     final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
-                    try {
-                        final Method isCloudCompatibleMethod =
-                                Class.forName(inputEntity.type().asString() + "$Descriptor").getMethod("isStaticCloudCompatible");
-                        isCloudCompatible = (boolean) isCloudCompatibleMethod.invoke(null);
-                    } catch (Exception e) {
-                        LOG.info("Failed to invoke Descriptor.isStaticCloudCompatible() for {}", inputEntity.type().asString());
-                    }
-                    if (!isCloudCompatible) {
-                        LOG.warn("Ignoring incompatible input {} in cloud", inputEntity.type().asString());
+                    String className = inputEntity.type().asString();
+                    Class inputClass = Class.forName(className);
+                    if (inputClass.getAnnotation(CloudCompatible.class) == null) {
+                        LOG.warn("Ignoring incompatible input {} in cloud", className);
                         continue;
                     }
                 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -27,6 +27,7 @@ import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationException;
+import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.inputs.MessageInput;
 
 import static org.graylog2.inputs.transports.HttpPollTransport.CK_CONTENT_TYPE;
@@ -35,6 +36,7 @@ import static org.graylog2.inputs.transports.HttpPollTransport.CK_HTTP_METHOD;
 import static org.graylog2.inputs.transports.HttpPollTransport.POST;
 import static org.graylog2.inputs.transports.HttpPollTransport.PUT;
 
+@CloudCompatible
 public class JsonPathInput extends MessageInput {
 
     private static final String NAME = "JSON path value from HTTP API";
@@ -70,11 +72,6 @@ public class JsonPathInput extends MessageInput {
         }
 
         public boolean isCloudCompatible() {
-            return true;
-        }
-
-        // static check for contentpack import
-        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -69,7 +69,12 @@ public class JsonPathInput extends MessageInput {
             super(NAME, false, DocsHelper.PAGE_SENDING_JSONPATH.toString());
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
@@ -25,8 +25,10 @@ import org.graylog2.inputs.transports.RandomMessageTransport;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.inputs.MessageInput;
 
+@CloudCompatible
 public class FakeHttpMessageInput extends MessageInput {
 
     private static final String NAME = "Random HTTP message generator";
@@ -61,11 +63,6 @@ public class FakeHttpMessageInput extends MessageInput {
         }
 
         public boolean isCloudCompatible() {
-            return true;
-        }
-
-        // static check for contentpack import
-        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/random/FakeHttpMessageInput.java
@@ -60,7 +60,12 @@ public class FakeHttpMessageInput extends MessageInput {
             super(NAME, false, "");
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
+            return true;
+        }
+
+        // static check for contentpack import
+        public static boolean isStaticCloudCompatible() {
             return true;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/CloudCompatible.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/CloudCompatible.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.inputs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface CloudCompatible {
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -417,11 +417,11 @@ public abstract class MessageInput implements Stoppable {
     }
 
     public boolean isCloudCompatible() {
-        return Descriptor.isCloudCompatible();
+        return descriptor.isCloudCompatible();
     }
 
     public boolean isForwarderCompatible() {
-        return Descriptor.isForwarderCompatible();
+        return descriptor.isForwarderCompatible();
     }
 
     public interface Factory<M> {
@@ -470,11 +470,11 @@ public abstract class MessageInput implements Stoppable {
             super(name, exclusive, linkToDocs);
         }
 
-        public static boolean isCloudCompatible() {
+        public boolean isCloudCompatible() {
             return false;
         }
 
-        public static boolean isForwarderCompatible() {
+        public boolean isForwarderCompatible() {
             return true;
         }
     }


### PR DESCRIPTION
/nocl (bug in unreleased change)
/prd Graylog2/graylog-plugin-enterprise#7054

Relates to Graylog2/graylog-plugin-enterprise#7019

Graylog2/graylog2-server#18769 changed the signature of `MessageInput.Descriptor` methods to be static, to support pre-install compatibility checks for content packs. However, other parts of the code rely on dynamic overriding of these methods. 

Instead we introduce a class annotation `@CloudCompatible` to indicate that an input class is compatible with Cloud.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Can create inputs in Cloud and on-prem
- Cloud only shows cloud-compatible inputs; on-prem shows all
- Cloud-incompatible inputs are ignored when importing a content pack in Cloud

Note: an exception is thrown when uninstalling a content pack. It is related to audit logging and is not relevant to this issue, since it reproduces on `master`. We should fix that separately (Graylog2/graylog2-server#19034).

> 2024-04-12 12:25:04,859 WARN : org.graylog.plugins.auditlog.jersey.AuditLogFilter - Couldn't capture response entity
> java.lang.IllegalArgumentException: No serializer found for class 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
