### PR TITLE
Wait for opensearch process termination

### DIFF
--- a/changelog/unreleased/pr-19056.toml
+++ b/changelog/unreleased/pr-19056.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Actively wait for opensearch process termination in the datanode."
+
+pulls = ["19056"]


### PR DESCRIPTION
## Description
Actively wait for opensearch process termination in the datanode

## Motivation and Context
Sometimes during certificate provisioning and/or data migrations we encountered an opensearch process that has not been properly terminated, but we have already started a new one. This leads to occupied ports and everything falls apart. Let's rather actively wait for the termination, count and log all attempts and only then continue.

## How Has This Been Tested?
Existing set of integration tests
:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

