### PR TITLE
Do not show confirm dialog when saving event notification. `6.0`

### DIFF
--- a/changelog/unreleased/issue-19014.toml
+++ b/changelog/unreleased/issue-19014.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Do not show confirm dialog when saving event notification."
+
+issues = ["19014"]
+pulls = ["19073"]

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -99,6 +99,8 @@ class EventNotificationFormContainer extends React.Component {
     const { action, embedded, onSubmit, history } = this.props;
     const { notification } = this.state;
 
+    this.setState({ isDirty: false });
+
     let promise;
 
     if (action === 'create') {
@@ -106,11 +108,9 @@ class EventNotificationFormContainer extends React.Component {
 
       promise.then(
         () => {
-          this.setState({ isDirty: false }, () => {
-            if (!embedded) {
-              history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
-            }
-          });
+          if (!embedded) {
+            history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
+          }
         },
         (errorResponse) => {
           const { body } = errorResponse.additional;
@@ -126,11 +126,9 @@ class EventNotificationFormContainer extends React.Component {
 
       promise.then(
         () => {
-          this.setState({ isDirty: false }, () => {
-            if (!embedded) {
-              history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
-            }
-          });
+          if (!embedded) {
+            history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
+          }
         },
         (errorResponse) => {
           const { body } = errorResponse.additional;


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/19073 for `6.0`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, when you create or update an event notification, you will see the following confirm dialog on submit. 

![image](https://github.com/Graylog2/graylog2-server/assets/46300478/11c3a650-d1e8-4804-ba90-b497a5de7fb7)

This PR is fixing the bug by implementing a fix similar to https://github.com/Graylog2/graylog2-server/pull/18880

Please keep in mind while testing, that the confirm dialog is not showing up in development mode, by default.

