### PR TITLE
ensure all data nodes are properly stopped in DataNodeClusterIT

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
+++ b/data-node/src/test/java/org/graylog/datanode/integration/DatanodeClusterIT.java
@@ -18,6 +18,7 @@ package org.graylog.datanode.integration;
 
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.rholder.retry.RetryException;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.graylog.datanode.configuration.variants.KeystoreInformation;
 import org.graylog.datanode.restoperations.DatanodeOpensearchWait;
@@ -39,8 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -59,6 +58,7 @@ public class DatanodeClusterIT {
 
     private DatanodeContainerizedBackend nodeA;
     private DatanodeContainerizedBackend nodeB;
+    private DatanodeContainerizedBackend nodeC;
 
     @TempDir
     static Path tempDir;
@@ -119,6 +119,9 @@ public class DatanodeClusterIT {
         if (nodeA != null) {
             nodeA.stop();
         }
+        if (nodeC != null) {
+            nodeC.stop();
+        }
         mongoDBTestService.close();
         network.close();
     }
@@ -135,7 +138,7 @@ public class DatanodeClusterIT {
         final KeystoreInformation transportNodeC = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, hostnameNodeC);
         final KeystoreInformation httpNodeC = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, hostnameNodeC);
 
-        final DatanodeContainerizedBackend nodeC = createDatanodeContainer(
+        nodeC = createDatanodeContainer(
                 network, mongoDBTestService,
                 hostnameNodeC,
                 transportNodeC,
@@ -155,7 +158,7 @@ public class DatanodeClusterIT {
         final KeystoreInformation transportNodeC = DatanodeSecurityTestUtils.generateTransportCert(tempDir, ca, hostnameNodeC);
         final KeystoreInformation httpNodeC = DatanodeSecurityTestUtils.generateHttpCert(tempDir, ca, hostnameNodeC);
 
-        final DatanodeContainerizedBackend nodeC = createDatanodeContainer(
+        nodeC = createDatanodeContainer(
                 network, mongoDBTestService,
                 hostnameNodeC,
                 transportNodeC,
@@ -269,8 +272,11 @@ public class DatanodeClusterIT {
                     .waitForNodesCount(countOfNodes);
 
         } catch (Exception retryException) {
-            LOG.error("DataNode Container logs from nodeA follow:\n" + nodeA.getLogs());
+            LOG.error("DataNode Container logs from node A follow:\n" + nodeA.getLogs());
             LOG.error("DataNode Container logs from node B follow:\n" + nodeB.getLogs());
+            if (nodeC != null) {
+                LOG.error("DataNode Container logs from node C follow:\n" + nodeC.getLogs());
+            }
             throw retryException;
         }
     }


### PR DESCRIPTION
## Description
`nodeC` was not properly stopped in `testRemovingNodeReallocatesShards()`, which caused the node's container to remain after the test, consuming 2GB of memory.
Locally, this could cause the docker daemon to run out of memory in certain cases.
This PR ensures all data nodes in the test are stopped after each test.

## Motivation and Context
can cause failing tests

## How Has This Been Tested?
Rerun ITs consecutively multiple times

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

