### PR TITLE
Endpoint for JSON/CSV export of aggregation widget data (a.k.a pivot …

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -75,6 +75,8 @@ import org.graylog.plugins.views.search.rest.contexts.SearchUserBinder;
 import org.graylog.plugins.views.search.rest.exceptionmappers.IllegalTimeRangeExceptionMapper;
 import org.graylog.plugins.views.search.rest.exceptionmappers.MissingCapabilitiesExceptionMapper;
 import org.graylog.plugins.views.search.rest.exceptionmappers.PermissionExceptionMapper;
+import org.graylog.plugins.views.search.rest.export.AggregationWidgetExportResource;
+import org.graylog.plugins.views.search.rest.export.response.AggregationWidgetExportResponseWriter;
 import org.graylog.plugins.views.search.rest.remote.SearchJobsStatusResource;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.events.EventList;
@@ -145,6 +147,7 @@ public class ViewsBindings extends ViewsModule {
     protected void configure() {
         registerExportBackendProvider();
 
+        addSystemRestResource(AggregationWidgetExportResource.class);
         addSystemRestResource(DashboardsResource.class);
         addSystemRestResource(StartPageResource.class);
         addSystemRestResource(FavoritesResource.class);
@@ -254,6 +257,8 @@ public class ViewsBindings extends ViewsModule {
 
         addExportFormat(() -> MoreMediaTypes.TEXT_CSV_TYPE);
 
+
+        jerseyAdditionalComponentsBinder().addBinding().toInstance(AggregationWidgetExportResponseWriter.class);
         jerseyAdditionalComponentsBinder().addBinding().toInstance(SimpleMessageChunkCsvWriter.class);
         jerseyAdditionalComponentsBinder().addBinding().toInstance(MessageExportFormatFilter.class);
         jerseyAdditionalComponentsBinder().addBinding().toInstance(SearchUserBinder.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.export;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.plugins.views.search.rest.export.response.AggregationWidgetExportResponse;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
+
+@Api(value = "Search/Pivot/Export", tags = {CLOUD_VISIBLE})
+@Path("/views/search/pivot/export")
+@RequiresAuthentication
+@Produces({MoreMediaTypes.TEXT_CSV, MediaType.APPLICATION_JSON})
+public class AggregationWidgetExportResource extends RestResource {
+
+    @ApiOperation(value = "Export widget data")
+    @POST
+    @NoAuditEvent("") //TODO: do we need an audit event for widget data export???
+    public AggregationWidgetExportResponse export(@ApiParam @Valid PivotResult pivotResult) {
+        return AggregationWidgetExportResponse.fromPivotResult(pivotResult);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
@@ -20,15 +20,20 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.search.rest.export.response.AggregationWidgetExportResponse;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.rest.RestTools;
 import org.graylog2.shared.rest.resources.RestResource;
 
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
@@ -36,13 +41,21 @@ import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_V
 @Api(value = "Search/Pivot/Export", tags = {CLOUD_VISIBLE})
 @Path("/views/search/pivot/export")
 @RequiresAuthentication
-@Produces({MoreMediaTypes.TEXT_CSV, MediaType.APPLICATION_JSON})
+@Consumes(MediaType.APPLICATION_JSON)
 public class AggregationWidgetExportResource extends RestResource {
 
     @ApiOperation(value = "Export widget data")
     @POST
     @NoAuditEvent("") //TODO: do we need an audit event for widget data export???
-    public AggregationWidgetExportResponse exportData(@ApiParam @Valid PivotResult pivotResult) {
-        return AggregationWidgetExportResponse.fromPivotResult(pivotResult);
+    @Produces({MoreMediaTypes.TEXT_CSV, MediaType.APPLICATION_JSON})
+    @Path("/{filename}")
+    public Response exportData(@ApiParam @Valid PivotResult pivotResult,
+                               @HeaderParam("Accept") String mediaType,
+                               @ApiParam("filename") @PathParam("filename") String filename) {
+        return RestTools.respondWithFile(
+                        filename,
+                        AggregationWidgetExportResponse.fromPivotResult(pivotResult),
+                        MediaType.valueOf(mediaType))
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
@@ -42,7 +42,7 @@ public class AggregationWidgetExportResource extends RestResource {
     @ApiOperation(value = "Export widget data")
     @POST
     @NoAuditEvent("") //TODO: do we need an audit event for widget data export???
-    public AggregationWidgetExportResponse export(@ApiParam @Valid PivotResult pivotResult) {
+    public AggregationWidgetExportResponse exportData(@ApiParam @Valid PivotResult pivotResult) {
         return AggregationWidgetExportResponse.fromPivotResult(pivotResult);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/AggregationWidgetExportResource.java
@@ -46,7 +46,7 @@ public class AggregationWidgetExportResource extends RestResource {
 
     @ApiOperation(value = "Export widget data")
     @POST
-    @NoAuditEvent("") //TODO: do we need an audit event for widget data export???
+    @NoAuditEvent("Exporting widget data does not need audit event")
     @Produces({MoreMediaTypes.TEXT_CSV, MediaType.APPLICATION_JSON})
     @Path("/{filename}")
     public Response exportData(@ApiParam @Valid PivotResult pivotResult,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponse.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.export.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog.plugins.views.search.util.ListOfStringsComparator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public record AggregationWidgetExportResponse(@JsonProperty List<String> header,
+                                              @JsonProperty List<List<String>> dataRows) {
+
+    public static AggregationWidgetExportResponse fromPivotResult(final PivotResult pivotResult) {
+
+        final Collection<PivotResult.Row> rows = pivotResult.rows();
+
+        final int longestRowKey = rows.stream()
+                .mapToInt(row -> row.key().size())
+                .max()
+                .orElse(0);
+
+        final List<ImmutableList<String>> columns = rows.stream()
+                .flatMap(row -> row.values()
+                        .stream()
+                        .map(PivotResult.Value::key)
+                )
+                .distinct()
+                .sorted(new ListOfStringsComparator())
+                .toList();
+
+        final List<String> header = new ArrayList<>(longestRowKey + columns.size());
+        header.addAll(Collections.nCopies(longestRowKey, ""));
+        columns.forEach(column -> header.add(column.toString()));
+
+        final List<List<String>> dataRows = rows.stream()
+                .filter(row -> "leaf".equals(row.source()))
+                .map(row -> {
+                    final ImmutableList<String> key = row.key();
+                    final List<String> values = columns.stream()
+                            .map(metric -> row.values()
+                                    .stream()
+                                    .filter(value -> value.key().equals(metric))
+                                    .filter(value -> value.value() != null)
+                                    .findFirst()
+                                    .map(value -> value.value().toString())
+                                    .orElse("")
+                            ).toList();
+
+                    List<String> dataRow = new ArrayList<>();
+                    dataRow.addAll(key);
+                    dataRow.addAll(values);
+                    return dataRow;
+                })
+                .toList();
+
+        return new AggregationWidgetExportResponse(header, dataRows);
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseWriter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseWriter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.export.response;
+
+import au.com.bytecode.opencsv.CSVWriter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import org.graylog2.rest.MoreMediaTypes;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Provider
+@Produces({MoreMediaTypes.TEXT_CSV, MediaType.APPLICATION_JSON})
+public class AggregationWidgetExportResponseWriter implements MessageBodyWriter<AggregationWidgetExportResponse> {
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public AggregationWidgetExportResponseWriter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+
+    @Override
+    public boolean isWriteable(Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType) {
+        return aClass.equals(AggregationWidgetExportResponse.class);
+    }
+
+    @Override
+    public void writeTo(AggregationWidgetExportResponse widgetExportResponse, Class<?> aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
+        switch (mediaType.toString()) {
+            case MoreMediaTypes.TEXT_CSV -> writeCsv(widgetExportResponse, outputStream);
+            case MediaType.APPLICATION_JSON -> objectMapper.writeValue(outputStream, widgetExportResponse);
+            default -> throw new IllegalArgumentException("Media type " + mediaType + " not supported");
+        }
+    }
+
+    private void writeCsv(final AggregationWidgetExportResponse widgetExportResponse,
+                          final OutputStream outputStream) throws IOException {
+        try (final CSVWriter csvWriter = new CSVWriter(new PrintWriter(outputStream, true, StandardCharsets.UTF_8))) {
+
+            csvWriter.writeNext(widgetExportResponse.header().toArray(new String[0]));
+            for (List<String> row : widgetExportResponse.dataRows()) {
+                csvWriter.writeNext(row.toArray(new String[0]));
+            }
+
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PivotResult.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/PivotResult.java
@@ -120,6 +120,11 @@ public abstract class PivotResult implements SearchType.Result {
         @AutoValue.Builder
         public abstract static class Builder {
 
+            @JsonCreator
+            public static PivotResult.Row.Builder create() {
+                return new AutoValue_PivotResult_Row.Builder();
+            }
+
             @JsonProperty
             public abstract Builder key(ImmutableList<String> key);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/util/ListOfStringsComparator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/util/ListOfStringsComparator.java
@@ -22,7 +22,8 @@ import java.util.List;
 /**
  * Comparator of lists of strings, with following features:
  * - shorter lists always come before longer lists,
- * - if lists have the same sizes, the first non-equal element decides which list goes first.
+ * - if lists have the same sizes, the first non-equal element decides which list goes first,
+ * - comparison of elements is case-insensitive.
  */
 public class ListOfStringsComparator implements Comparator<List<String>> {
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/util/ListOfStringsComparator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/util/ListOfStringsComparator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.util;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Comparator of lists of strings, with following features:
+ * - shorter lists always come before longer lists,
+ * - if lists have the same sizes, the first non-equal element decides which list goes first.
+ */
+public class ListOfStringsComparator implements Comparator<List<String>> {
+
+    @Override
+    public int compare(final List<String> o1, final List<String> o2) {
+
+        if (o1.size() < o2.size()) {
+            return -1;
+        } else if (o1.size() > o2.size()) {
+            return 1;
+        } else {
+            int index = 0;
+            while (index < o1.size()) {
+                String item1 = o1.get(index);
+                String item2 = o2.get(index++);
+                final int comparisonResult = item1.compareToIgnoreCase(item2);
+                if (comparisonResult != 0) {
+                    return comparisonResult;
+                }
+            }
+            return 0;
+        }
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.rest.export.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AggregationWidgetExportResponseTest {
+
+    @Test
+    void testCreationFromPivotResult() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final byte[] bytes = Resources.toByteArray(Resources.getResource("org/graylog/plugins/views/search/rest/export/response/sample_pivot_result.json"));
+        final PivotResult pivotResult = objectMapper.readValue(bytes, PivotResult.class);
+        final AggregationWidgetExportResponse response = AggregationWidgetExportResponse.fromPivotResult(pivotResult);
+
+        final AggregationWidgetExportResponse expectedResponse = new AggregationWidgetExportResponse(
+                List.of("", "[count()]", "[max(http_response_code)]", "[DELETE, count()]", "[DELETE, max(http_response_code)]", "[GET, count()]", "[GET, max(http_response_code)]", "[POST, count()]", "[POST, max(http_response_code)]", "[PUT, count()]", "[PUT, max(http_response_code)]"),
+                List.of(
+                        List.of("index", "1507337", "504", "75322", "504", "1296526", "504", "75163", "504", "60326", "504"),
+                        List.of("show", "444038", "504", "22229", "504", "381846", "504", "22271", "504", "17692", "504"),
+                        List.of("login", "377715", "504", "18773", "204", "325040", "200", "18761", "504", "15141", "504"),
+                        List.of("edit", "68699", "504", "3540", "504", "58912", "504", "3488", "504", "2759", "504")
+                )
+        );
+
+        assertEquals(expectedResponse, response);
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/util/ListOfStringsComparatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/util/ListOfStringsComparatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ListOfStringsComparatorTest {
+
+    ListOfStringsComparator toTest;
+
+    @BeforeEach
+    void setUp() {
+        toTest = new ListOfStringsComparator();
+    }
+
+    @Test
+    void testEmptyListsAreEqual() {
+        assertEquals(0, toTest.compare(List.of(), List.of()));
+    }
+
+    @Test
+    void testListsWithTheSameElementsAreEqual() {
+        assertEquals(0, toTest.compare(List.of("mum"), List.of("mum")));
+        assertEquals(0, toTest.compare(List.of("mum", "dad"), List.of("mum", "dad")));
+    }
+
+    @Test
+    void testListsWithSameElementsIgnoringCaseAreEqual() {
+        assertEquals(0, toTest.compare(List.of("Mum"), List.of("mum")));
+        assertEquals(0, toTest.compare(List.of("mum", "Dad"), List.of("mum", "dad")));
+    }
+
+    @Test
+    void testEmptyListIsSmallerThanListWithElements() {
+        assertTrue(toTest.compare(List.of(), List.of("mum")) < 0);
+        assertTrue(toTest.compare(List.of("mum", "Dad"), List.of()) > 0);
+    }
+
+    @Test
+    void testShorterListIsSmaller() {
+        assertTrue(toTest.compare(List.of("max(carramba)"), List.of("GET", "max(carramba)")) < 0);
+    }
+
+    @Test
+    void testListOfSameSizeAreOrderedBasedOnTheirFirstNonEqualElement() {
+        assertTrue(toTest.compare(List.of("mum", "dad"), List.of("mum", "plumber")) < 0); //last elem decides
+        assertTrue(toTest.compare(List.of("mummy", "dad", ""), List.of("mum", "dad", "whatever")) > 0); //first elem decides
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/search/rest/export/response/sample_pivot_result.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/search/rest/export/response/sample_pivot_result.json
@@ -1,0 +1,419 @@
+{
+  "name": "chart",
+  "id": "1031c586-2eb1-4459-8c2c-2a91dec5dd72",
+  "rows": [
+    {
+      "key": [
+        "index"
+      ],
+      "values": [
+        {
+          "key": [
+            "count()"
+          ],
+          "value": 1507337,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "count()"
+          ],
+          "value": 1296526,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "count()"
+          ],
+          "value": 75322,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "count()"
+          ],
+          "value": 75163,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "count()"
+          ],
+          "value": 60326,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        }
+      ],
+      "source": "leaf"
+    },
+    {
+      "key": [
+        "show"
+      ],
+      "values": [
+        {
+          "key": [
+            "count()"
+          ],
+          "value": 444038,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "count()"
+          ],
+          "value": 381846,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "count()"
+          ],
+          "value": 22271,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "count()"
+          ],
+          "value": 22229,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "count()"
+          ],
+          "value": 17692,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        }
+      ],
+      "source": "leaf"
+    },
+    {
+      "key": [
+        "login"
+      ],
+      "values": [
+        {
+          "key": [
+            "count()"
+          ],
+          "value": 377715,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "count()"
+          ],
+          "value": 325040,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "max(http_response_code)"
+          ],
+          "value": 200,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "count()"
+          ],
+          "value": 18773,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "max(http_response_code)"
+          ],
+          "value": 204,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "count()"
+          ],
+          "value": 18761,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "count()"
+          ],
+          "value": 15141,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        }
+      ],
+      "source": "leaf"
+    },
+    {
+      "key": [
+        "edit"
+      ],
+      "values": [
+        {
+          "key": [
+            "count()"
+          ],
+          "value": 68699,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": true,
+          "source": "row-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "count()"
+          ],
+          "value": 58912,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "GET",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "count()"
+          ],
+          "value": 3540,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "DELETE",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "count()"
+          ],
+          "value": 3488,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "POST",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "count()"
+          ],
+          "value": 2759,
+          "rollup": false,
+          "source": "col-leaf"
+        },
+        {
+          "key": [
+            "PUT",
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": false,
+          "source": "col-leaf"
+        }
+      ],
+      "source": "leaf"
+    },
+    {
+      "key": [],
+      "values": [
+        {
+          "key": [
+            "count()"
+          ],
+          "value": 2397789,
+          "rollup": true,
+          "source": "row-inner"
+        },
+        {
+          "key": [
+            "max(http_response_code)"
+          ],
+          "value": 504,
+          "rollup": true,
+          "source": "row-inner"
+        }
+      ],
+      "source": "non-leaf"
+    }
+  ],
+  "total": 2397789,
+  "type": "pivot",
+  "effective_timerange": {
+    "from": "2024-04-11T11:06:00.186Z",
+    "to": "2024-04-16T11:06:00.186Z",
+    "type": "absolute"
+  }
+}


### PR DESCRIPTION
…resuts)

## Description
Endpoint for JSON/CSV export of aggregation widget data.
Provides only 2 basic formats, so that FE can provide simple tool to make basic export visible and team can discuss further steps.
/nocl

## Motivation and Context
FE needs an endpoint to export pivot results (aggregation widget data) to a file.

## How Has This Been Tested?
Manually and with new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

