### PR TITLE
Remove no longer needed search feature flags.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -16,18 +16,17 @@
  */
 package org.graylog.plugins.views;
 
-import au.com.bytecode.opencsv.CSVParser;
+import  au.com.bytecode.opencsv.CSVParser;
 import io.restassured.http.Header;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.ValidatableResponse;
-import org.graylog.plugins.views.search.rest.scriptingapi.ScriptingApiModule;
+import jakarta.ws.rs.core.MediaType;
 import org.graylog.testing.completebackend.apis.GraylogApiResponse;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.completebackend.apis.Sharing;
 import org.graylog.testing.completebackend.apis.SharingRequest;
 import org.graylog.testing.completebackend.apis.Streams;
 import org.graylog.testing.completebackend.apis.Users;
-import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.containermatrix.SearchServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
@@ -37,8 +36,6 @@ import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-
-import jakarta.ws.rs.core.MediaType;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -58,8 +55,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasEntry;
 
 @ContainerMatrixTestsConfiguration(serverLifecycle = CLASS,
-                                   searchVersions = {SearchServer.ES7, SearchServer.OS2},
-                                   enabledFeatureFlags = ScriptingApiModule.FEATURE_FLAG)
+                                   searchVersions = {SearchServer.ES7, SearchServer.OS2})
 public class ScriptingApiResourceIT {
 
     public static final String DEFAULT_STREAM = "000000000000000000000001";

--- a/full-backend-tests/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMappingsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMappingsIT.java
@@ -19,7 +19,6 @@ package org.graylog2.indexer.fieldtypes;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.completebackend.apis.Streams;
-import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
@@ -31,9 +30,8 @@ import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.graylog2.indexer.Constants.FIELD_TYPES_MANAGEMENT_FEATURE;
 
-@ContainerMatrixTestsConfiguration(enabledFeatureFlags = FIELD_TYPES_MANAGEMENT_FEATURE)
+@ContainerMatrixTestsConfiguration()
 public class FieldTypeMappingsIT {
     private static final String INDEX_PREFIX = "custom-mappings";
     private final GraylogApis api;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
@@ -23,29 +23,17 @@ import org.graylog.plugins.views.search.rest.scriptingapi.response.decorators.Id
 import org.graylog.plugins.views.search.rest.scriptingapi.response.decorators.NodeTitleDecorator;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.decorators.TitleDecorator;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.writers.TabularResponseWriter;
-import org.graylog2.featureflag.FeatureFlags;
 
 public class ScriptingApiModule extends ViewsModule {
-
-    public static final String FEATURE_FLAG = "scripting_api_preview";
-    private final FeatureFlags featureFlags;
-
-    public ScriptingApiModule(final FeatureFlags featureFlags) {
-        this.featureFlags = featureFlags;
-    }
-
     @Override
     protected void configure() {
-        if (featureFlags.isOn(FEATURE_FLAG)) {
-            addSystemRestResource(ScriptingApiResource.class);
-            jerseyAdditionalComponentsBinder().addBinding().toInstance(TabularResponseWriter.class);
+        addSystemRestResource(ScriptingApiResource.class);
+        jerseyAdditionalComponentsBinder().addBinding().toInstance(TabularResponseWriter.class);
 
-            final Multibinder<FieldDecorator> fieldDecoratorBinder = Multibinder.newSetBinder(binder(), FieldDecorator.class);
+        final Multibinder<FieldDecorator> fieldDecoratorBinder = Multibinder.newSetBinder(binder(), FieldDecorator.class);
 
-            fieldDecoratorBinder.addBinding().to(TitleDecorator.class);
-            fieldDecoratorBinder.addBinding().to(NodeTitleDecorator.class);
-            fieldDecoratorBinder.addBinding().to(IdDecorator.class);
-
-        }
+        fieldDecoratorBinder.addBinding().to(TitleDecorator.class);
+        fieldDecoratorBinder.addBinding().to(NodeTitleDecorator.class);
+        fieldDecoratorBinder.addBinding().to(IdDecorator.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -122,7 +122,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.graylog2.audit.AuditEventTypes.NODE_SHUTDOWN_INITIATE;
-import static org.graylog2.indexer.Constants.FIELD_TYPES_MANAGEMENT_FEATURE;
 import static org.graylog2.plugin.ServerStatus.Capability.CLOUD;
 import static org.graylog2.plugin.ServerStatus.Capability.MASTER;
 import static org.graylog2.plugin.ServerStatus.Capability.SERVER;
@@ -216,9 +215,8 @@ public class Server extends ServerBootstrap {
                 new CaModule()
         );
 
-        if (featureFlags.isOn(FIELD_TYPES_MANAGEMENT_FEATURE)) {
-            modules.add(new FieldTypeManagementModule());
-        }
+        modules.add(new FieldTypeManagementModule());
+
         return modules.build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -208,7 +208,7 @@ public class Server extends ServerBootstrap {
                 new MapWidgetModule(),
                 new SearchFiltersModule(),
                 new ScopedEntitiesModule(),
-                new ScriptingApiModule(featureFlags),
+                new ScriptingApiModule(),
                 new StreamsModule(),
                 new TracingModule(),
                 new DataTieringModule(),

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Constants.java
@@ -18,6 +18,5 @@ package org.graylog2.indexer;
 
 public interface Constants {
     String COMPOSABLE_INDEX_TEMPLATES_FEATURE = "composable_index_templates";
-    String FIELD_TYPES_MANAGEMENT_FEATURE = "field_types_management";
     String ES_DATE_FORMAT = "8yyyy-MM-dd HH:mm:ss.SSS";
 }

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -55,9 +55,6 @@
 # This flag enable the usage of the legacy AggregationControls in place of the new AggregationWizard.
 # It can be enabled with 'legacy-aggregation-wizard=on', the flag is disabled by default.
 
-# Enabling field types change
-field_types_management=on
-
 # Enabling inputs in cloud environment
 cloud_inputs=on
 

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -55,8 +55,6 @@
 # This flag enable the usage of the legacy AggregationControls in place of the new AggregationWizard.
 # It can be enabled with 'legacy-aggregation-wizard=on', the flag is disabled by default.
 
-# Enabling search filters per default now for everybody
-search_filter=on
 scripting_api_preview=on
 
 # Enabling field types change

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -74,9 +74,6 @@ instant_archiving=off
 # Composable Index Templates
 composable_index_templates=off
 
-# Enable keyboard shortcuts in the graylog web interface
-frontend_hotkeys=on
-
 # Enable data tiering
 data_tiering_cloud=off
 

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -55,8 +55,6 @@
 # This flag enable the usage of the legacy AggregationControls in place of the new AggregationWizard.
 # It can be enabled with 'legacy-aggregation-wizard=on', the flag is disabled by default.
 
-scripting_api_preview=on
-
 # Enabling field types change
 field_types_management=on
 

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
@@ -31,7 +31,7 @@ class ContainerMatrixTestsDescriptorTest {
 
     @Test
     void createKey() {
-        final String key = ContainerMatrixTestsDescriptor.createKey(Lifecycle.CLASS, "mavenDir", "jarDir", SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.2.3")), MongodbServer.MONGO5, true, true, Map.of("p1", "v1"), List.of(ScriptingApiModule.FEATURE_FLAG));
+        final String key = ContainerMatrixTestsDescriptor.createKey(Lifecycle.CLASS, "mavenDir", "jarDir", SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.2.3")), MongodbServer.MONGO5, true, true, Map.of("p1", "v1"), List.of());
         Assertions.assertThat(key).isEqualTo("Lifecycle: CLASS, MavenProjectDirProvider: mavenDir, PluginJarsProvider: jarDir, Search: OpenSearch:1.2.3, MongoDB: 5.0, Mailserver: enabled, Webhookserver: enabled, p1: v1, Featureflags: scripting_api_preview");
     }
 }

--- a/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/junit/jupiter/engine/descriptor/ContainerMatrixTestsDescriptorTest.java
@@ -18,7 +18,6 @@ package org.junit.jupiter.engine.descriptor;
 
 import com.github.zafarkhaja.semver.Version;
 import org.assertj.core.api.Assertions;
-import org.graylog.plugins.views.search.rest.scriptingapi.ScriptingApiModule;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.containermatrix.MongodbServer;
 import org.graylog2.storage.SearchVersion;
@@ -32,6 +31,6 @@ class ContainerMatrixTestsDescriptorTest {
     @Test
     void createKey() {
         final String key = ContainerMatrixTestsDescriptor.createKey(Lifecycle.CLASS, "mavenDir", "jarDir", SearchVersion.create(SearchVersion.Distribution.OPENSEARCH, Version.valueOf("1.2.3")), MongodbServer.MONGO5, true, true, Map.of("p1", "v1"), List.of());
-        Assertions.assertThat(key).isEqualTo("Lifecycle: CLASS, MavenProjectDirProvider: mavenDir, PluginJarsProvider: jarDir, Search: OpenSearch:1.2.3, MongoDB: 5.0, Mailserver: enabled, Webhookserver: enabled, p1: v1, Featureflags: scripting_api_preview");
+        Assertions.assertThat(key).isEqualTo("Lifecycle: CLASS, MavenProjectDirProvider: mavenDir, PluginJarsProvider: jarDir, Search: OpenSearch:1.2.3, MongoDB: 5.0, Mailserver: enabled, Webhookserver: enabled, p1: v1");
     }
 }

--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.test.tsx
@@ -31,6 +31,7 @@ import TimeRangePresetForm from './TimeRangePresetForm';
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
 jest.mock('lodash/debounce', () => jest.fn());
 jest.mock('logic/generateId', () => jest.fn(() => 'tr-id-3'));
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 const mockOnUpdate = jest.fn();
 

--- a/graylog2-web-interface/src/components/hotkeys/HotkeysContianerModal.test.tsx
+++ b/graylog2-web-interface/src/components/hotkeys/HotkeysContianerModal.test.tsx
@@ -21,8 +21,6 @@ import userEvent from '@testing-library/user-event';
 import HotkeysModalContainer from 'components/hotkeys/HotkeysModalContainer';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
-
 describe('HotkeysModalContainer', () => {
   it('should render hotkeys modal after pressing keyboard shortcut', async () => {
     render(

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
@@ -33,7 +33,6 @@ jest.mock('./ScratchpadToggle', () => mockComponent('ScratchpadToggle'));
 jest.mock('hooks/useCurrentUser');
 jest.mock('./DevelopmentHeaderBadge', () => () => <span />);
 jest.mock('routing/withLocation', () => (x) => x);
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
 jest.mock('routing/useLocation', () => jest.fn(() => ({ pathname: '' })));
 
 describe('Navigation', () => {

--- a/graylog2-web-interface/src/components/scratchpad/Scratchpad.test.tsx
+++ b/graylog2-web-interface/src/components/scratchpad/Scratchpad.test.tsx
@@ -21,6 +21,8 @@ import { ScratchpadContext } from 'contexts/ScratchpadProvider';
 
 import Scratchpad from './Scratchpad';
 
+jest.mock('hooks/useHotkey', () => jest.fn());
+
 const setScratchpadVisibility = jest.fn();
 document.execCommand = jest.fn();
 

--- a/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
+++ b/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
@@ -25,7 +25,6 @@ import Immutable from 'immutable';
 
 import type { ScopeName, ActiveHotkeys, HotkeyCollections, Options } from 'contexts/HotkeysContext';
 import HotkeysContext from 'contexts/HotkeysContext';
-import useFeature from 'hooks/useFeature';
 
 const viewActions = {
   undo: { keys: 'mod+shift+z', description: 'Undo last action' },
@@ -121,20 +120,12 @@ type Props = {
   children: React.ReactElement,
 }
 
-const HotkeysProvider = ({ children }: Props) => {
-  const hasHotkeysFeatureFlag = useFeature('frontend_hotkeys');
-
-  if (!hasHotkeysFeatureFlag) {
-    return children;
-  }
-
-  return (
-    <OriginalHotkeysProvider>
-      <CustomHotkeysProvider>
-        {children}
-      </CustomHotkeysProvider>
-    </OriginalHotkeysProvider>
-  );
-};
+const HotkeysProvider = ({ children }: Props) => (
+  <OriginalHotkeysProvider>
+    <CustomHotkeysProvider>
+      {children}
+    </CustomHotkeysProvider>
+  </OriginalHotkeysProvider>
+);
 
 export default HotkeysProvider;

--- a/graylog2-web-interface/src/hooks/useHotkey.tsx
+++ b/graylog2-web-interface/src/hooks/useHotkey.tsx
@@ -21,7 +21,6 @@ import { useEffect, useMemo, useCallback } from 'react';
 
 import type { ScopeName, HotkeyCollections, Options, HotkeysEvent } from 'contexts/HotkeysContext';
 import useHotkeysContext from 'hooks/useHotkeysContext';
-import useFeature from 'hooks/useFeature';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -70,34 +69,23 @@ const useHotkey = <T extends HTMLElement>({
   dependencies,
   telemetryAppPathname,
 }: HotkeysProps) => {
-  const hasHotkeysFeatureFlag = useFeature('frontend_hotkeys');
-
-  if (!hasHotkeysFeatureFlag) {
-    return null;
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const location = useLocation();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const sendTelemetry = useSendTelemetry();
 
   const {
     hotKeysCollections,
     addActiveHotkey,
     removeActiveHotkey,
-    // eslint-disable-next-line react-hooks/rules-of-hooks
   } = useHotkeysContext();
 
   catchErrors(hotKeysCollections, actionKey, scope);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const mergedOptions = useMemo(() => ({
     ...defaultOptions,
     ...options,
     scopes: scope,
   }), [options, scope]);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const callbackWithTelemetry = useCallback((event: KeyboardEvent, handler: HotkeysEvent) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.SHORTCUT_TYPED, {
       app_pathname: telemetryAppPathname ?? getPathnameWithoutId(location.pathname),
@@ -107,7 +95,6 @@ const useHotkey = <T extends HTMLElement>({
     callback(event, handler);
   }, [actionKey, callback, hotKeysCollections, location.pathname, scope, sendTelemetry, telemetryAppPathname]);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     addActiveHotkey({
       scope,

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -43,7 +43,6 @@ jest.mock('components/errors/RouterErrorBoundary', () => mockComponent('RouterEr
 jest.mock('pages/StartPage', () => () => <>This is the start page</>);
 jest.mock('hooks/usePluginEntities');
 jest.mock('contexts/GlobalContextProviders', () => jest.fn(({ children }: React.PropsWithChildren<{}>) => children));
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
 
 jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -101,7 +101,6 @@ import CreateEventDefinition from 'views/logic/valueactions/createEventDefinitio
 import ChangeFieldType, {
   ChangeFieldTypeHelp,
   isChangeFieldTypeEnabled,
-  isChangeFieldTypeHidden,
 } from 'views/logic/fieldactions/ChangeFieldType/ChangeFieldType';
 import AddEventsWidgetActionHandler, { CreateEventsWidget } from 'views/logic/widgets/events/AddEventsWidgetActionHandler';
 import EventsListConfigGenerator from 'views/logic/searchtypes/events/EventsListConfigGenerator';
@@ -322,7 +321,6 @@ const exports: PluginExports = {
       type: 'change-field-type',
       title: 'Change field type',
       isEnabled: isChangeFieldTypeEnabled,
-      isHidden: isChangeFieldTypeHidden,
       resetFocus: false,
       component: ChangeFieldType,
       help: ChangeFieldTypeHelp,

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -39,7 +39,6 @@ import DashboardActionsMenu from './DashboardActionsMenu';
 jest.mock('views/logic/views/OnSaveViewAction', () => jest.fn(() => () => {}));
 jest.mock('views/hooks/useSaveViewFormControls');
 jest.mock('hooks/useCurrentUser');
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
 
 jest.mock('bson-objectid', () => jest.fn(() => ({
   toString: jest.fn(() => 'new-dashboard-id'),

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.pluggableControls.test.tsx
@@ -33,6 +33,7 @@ import OriginalDashboardSearchBar from './DashboardSearchBar';
 
 const testTimeout = applyTimeoutMultiplier(30000);
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('views/components/DashboardActionsMenu', () => () => <span>View Actions</span>);
 jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -28,6 +28,7 @@ import { execute, setGlobalOverride } from 'views/logic/slices/searchExecutionSl
 
 import OriginalDashboardSearchBar from './DashboardSearchBar';
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/components/searchbar/queryinput/QueryInput');
 jest.mock('views/components/DashboardActionsMenu', () => () => <span>View Actions</span>);
 

--- a/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.dashboard.test.tsx
@@ -35,6 +35,7 @@ import OriginalSearch from './Search';
 import WidgetFocusProvider from './contexts/WidgetFocusProvider';
 import WidgetFocusContext from './contexts/WidgetFocusContext';
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 

--- a/graylog2-web-interface/src/views/components/Search.test.tsx
+++ b/graylog2-web-interface/src/views/components/Search.test.tsx
@@ -39,6 +39,7 @@ jest.mock('views/components/SearchResult', () => mockComponent('SearchResult'));
 jest.mock('views/stores/StreamsStore');
 jest.mock('views/components/common/WindowLeaveMessage', () => jest.fn(mockComponent('WindowLeaveMessage')));
 jest.mock('views/components/SearchBar', () => mockComponent('SearchBar'));
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 const mockRefreshSearch = jest.fn();
 

--- a/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
@@ -38,8 +38,6 @@ import OriginalSearchBar from './SearchBar';
 
 const testTimeout = applyTimeoutMultiplier(30000);
 
-jest.mock('hooks/useFeature', () => (key: string) => key === 'search_filter');
-
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 
 jest.mock('views/hooks/useAutoRefresh', () => () => ({

--- a/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.pluggableControls.test.tsx
@@ -38,6 +38,7 @@ import OriginalSearchBar from './SearchBar';
 
 const testTimeout = applyTimeoutMultiplier(30000);
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 
 jest.mock('views/hooks/useAutoRefresh', () => () => ({

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -31,6 +31,7 @@ import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
 import OriginalSearchBar from './SearchBar';
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 
 jest.mock('stores/streams/StreamsStore', () => MockStore(

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -39,8 +39,6 @@ const testTimeout = applyTimeoutMultiplier(30000);
 
 jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mockComponent('QueryValidation'));
 
-jest.mock('hooks/useFeature', () => (key: string) => key === 'search_filter');
-
 jest.mock('views/components/searchbar/queryinput/QueryInput');
 jest.mock('views/components/searchbar/queryinput/BasicQueryInput');
 

--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.test.tsx
@@ -24,7 +24,6 @@ import usePluginEntities from 'hooks/usePluginEntities';
 import PluggableSearchBarControls from './PluggableSearchBarControls';
 
 jest.mock('hooks/usePluginEntities');
-jest.mock('hooks/useFeature', () => (key) => key === 'search_filter');
 
 jest.mock('logic/local-storage/Store', () => ({
   get: jest.fn(),

--- a/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/PluggableSearchBarControls.tsx
@@ -22,7 +22,6 @@ import usePluginEntities from 'hooks/usePluginEntities';
 import SearchFilterBanner from 'views/components/searchbar/SearchFilterBanner';
 import type { SearchBarControl } from 'views/types';
 import Store from 'logic/local-storage/Store';
-import useFeature from 'hooks/useFeature';
 import { SEARCH_BAR_GAP } from 'views/components/searchbar/SearchBarLayout';
 
 export const PLUGGABLE_CONTROLS_HIDDEN_KEY = 'pluggableSearchBarControlsAreHidden';
@@ -53,7 +52,6 @@ const componentHasContent = ({
   showLeftControls,
   showRightControls,
   hasPluggableControls,
-  hasSearchFilterFeatureFlag,
   hasLeftColFallback,
   hasRightColFallback,
 }:{
@@ -61,7 +59,6 @@ const componentHasContent = ({
   showLeftControls: boolean,
   showRightControls: boolean,
   hasPluggableControls: boolean,
-  hasSearchFilterFeatureFlag: boolean,
   hasLeftColFallback?: boolean,
   hasRightColFallback?: boolean
 }) => {
@@ -73,7 +70,7 @@ const componentHasContent = ({
     return false;
   }
 
-  const shouldShowLeftCol = showLeftControls && hasLeftColFallback && hasSearchFilterFeatureFlag;
+  const shouldShowLeftCol = showLeftControls && hasLeftColFallback;
   const shouldShowRightCol = showRightControls && !!hasRightColFallback;
 
   return shouldShowLeftCol || shouldShowRightCol;
@@ -87,7 +84,6 @@ type Props = {
 const PluggableSearchBarControls = ({ showLeftControls, showRightControls }: Props) => {
   const [hidePluggableControlsPreview, setHidePluggableControlsPreview] = useState(() => !!Store.get(PLUGGABLE_CONTROLS_HIDDEN_KEY));
   const { leftControls, rightControls } = usePluggableControls();
-  const hasSearchFilterFeatureFlag = useFeature('search_filter');
   const hasPluggableControls = !!(leftControls?.length || rightControls?.length);
 
   const onHidePluggableControlsPreview = useCallback(() => {
@@ -102,7 +98,6 @@ const PluggableSearchBarControls = ({ showLeftControls, showRightControls }: Pro
     showLeftControls,
     showRightControls,
     hasPluggableControls,
-    hasSearchFilterFeatureFlag,
     hasLeftColFallback: !!leftColFallback,
   });
 
@@ -111,7 +106,7 @@ const PluggableSearchBarControls = ({ showLeftControls, showRightControls }: Pro
   return (
     <Container>
       <div>
-        {hasSearchFilterFeatureFlag && showLeftControls && (
+        {showLeftControls && (
           <>
             {renderControls(leftControls)}
             {leftColFallback}

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.test.tsx
@@ -26,6 +26,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import QueryInput from './QueryInput';
 
 jest.mock('views/logic/fieldtypes/useFieldTypes');
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 jest.mock('views/actions/QueryValidationActions', () => ({
   displayValidationErrors: jest.fn(),

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
@@ -50,7 +50,6 @@ jest.mock('views/hooks/useSaveViewFormControls');
 jest.mock('routing/useHistory');
 jest.mock('hooks/useCurrentUser');
 jest.mock('views/logic/views/OnSaveViewAction', () => jest.fn(() => () => {}));
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
 
 jest.mock('bson-objectid', () => jest.fn(() => ({
   toString: jest.fn(() => 'new-search-id'),

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -34,6 +34,7 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
 }));
 
 jest.mock('hooks/useCurrentUser');
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 describe('TimeRangeFilter', () => {
   beforeEach(() => {

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.relativeTimeRange.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import OriginalTimeRangePicker from './TimeRangePicker';
 
 jest.mock('stores/tools/ToolsStore', () => ({}));
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 describe('TimeRangePicker relative time range', () => {
   const defaultProps = {

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -28,6 +28,7 @@ import { adminUser } from 'fixtures/users';
 import OriginalTimeRangePicker from './TimeRangePicker';
 
 jest.mock('hooks/useCurrentUser');
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
 
 jest.mock('stores/tools/ToolsStore', () => ({

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -39,6 +39,7 @@ jest.mock('util/AppConfig', () => ({
   isFeatureEnabled: jest.fn(() => false),
 }));
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/hooks/useViewType');
 jest.mock('views/hooks/useActiveQueryId');
 jest.mock('views/hooks/useViewTitle');

--- a/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.test.tsx
@@ -36,8 +36,6 @@ jest.mock('views/logic/slices/undoRedoActions', () => ({
   redo: jest.fn(() => () => Promise.resolve()),
 }));
 
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
-
 describe('<RedoNavItem />', () => {
   const RedoNavItemComponent = () => (
     <TestStoreProvider undoRedoState={undoRedoTestStore}>

--- a/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.test.tsx
@@ -30,7 +30,6 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 
 jest.mock('stores/useAppDispatch');
-jest.mock('hooks/useFeature', () => (featureFlag: string) => featureFlag === 'frontend_hotkeys');
 
 jest.mock('views/logic/slices/undoRedoActions', () => ({
   ...jest.requireActual('views/logic/slices/undoRedoActions'),

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -31,6 +31,7 @@ import EditWidgetFrame from './EditWidgetFrame';
 import WidgetContext from '../contexts/WidgetContext';
 
 jest.mock('views/logic/fieldtypes/useFieldTypes');
+jest.mock('hooks/useHotkey', () => jest.fn());
 
 jest.mock('views/stores/StreamsStore', () => ({
   StreamsStore: MockStore(['getInitialState', () => ({

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -47,6 +47,7 @@ import FieldTypesContext from '../contexts/FieldTypesContext';
 const testTimeout = applyTimeoutMultiplier(60000);
 const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
 
+jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
 jest.mock('views/logic/fieldtypes/useFieldTypes');

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
@@ -20,7 +20,6 @@ import type { ActionComponentProps, ActionHandlerArguments } from 'views/compone
 import ChangeFieldTypeModal from 'views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal';
 import { isFunction } from 'views/logic/aggregationbuilder/Series';
 import type User from 'logic/users/User';
-import AppConfig from 'util/AppConfig';
 import isReservedField from 'views/logic/IsReservedField';
 import useInitialSelection from 'views/logic/fieldactions/ChangeFieldType/hooks/useInitialSelection';
 import { isPermitted } from 'util/PermissionsMixin';
@@ -52,8 +51,6 @@ export const isChangeFieldTypeEnabled = ({ field, type, contexts }: ActionHandle
 
   return (!isFunction(field) && !type.isDecorated() && !isReservedField(field) && hasMappingPermission(currentUser));
 };
-
-export const isChangeFieldTypeHidden = () => !AppConfig.isFeatureEnabled('field_types_management');
 
 export const ChangeFieldTypeHelp = ({ contexts }: ActionHandlerArguments) => {
   const { currentUser } = contexts;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we are removing some no longer needed search related feature flags (`frontend_hotkeys`, `search_filter`, `scripting_api_preview` and `field_types_management`). All related features have been enabled by default a while ago.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7106

/nocl