### PR TITLE
Wrong check for execution completion fixed

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -119,7 +119,7 @@ public class SearchJob implements ParameterProvider {
 
     @JsonProperty("execution")
     public ExecutionInfo execution() {
-        final boolean isDone = (searchEngineTaskFuture != null && searchEngineTaskFuture.isDone()) || (resultFuture != null && resultFuture.isDone());
+        final boolean isDone = (resultFuture == null || resultFuture.isDone()) && (searchEngineTaskFuture == null || searchEngineTaskFuture.isDone());
         final boolean isCancelled = (searchEngineTaskFuture != null && searchEngineTaskFuture.isCancelled()) || (resultFuture != null && resultFuture.isCancelled());
         return new ExecutionInfo(isDone, isCancelled, !errors.isEmpty());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -119,7 +119,7 @@ public class SearchJob implements ParameterProvider {
 
     @JsonProperty("execution")
     public ExecutionInfo execution() {
-        final boolean isDone = searchEngineTaskFuture != null && searchEngineTaskFuture.isDone() && resultFuture != null && resultFuture.isDone();
+        final boolean isDone = (searchEngineTaskFuture != null && searchEngineTaskFuture.isDone()) || (resultFuture != null && resultFuture.isDone());
         final boolean isCancelled = (searchEngineTaskFuture != null && searchEngineTaskFuture.isCancelled()) || (resultFuture != null && resultFuture.isCancelled());
         return new ExecutionInfo(isDone, isCancelled, !errors.isEmpty());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -37,11 +37,12 @@ public record SearchJobDTO(
 
 
     public static SearchJobDTO fromSearchJob(final SearchJob searchJob) {
+        final ExecutionInfo executionInfo = searchJob.execution();
         return new SearchJobDTO(
                 searchJob.getSearchJobIdentifier(),
                 searchJob.getErrors(),
                 searchJob.results(),
-                searchJob.execution());
+                executionInfo);
     }
 
 }


### PR DESCRIPTION
## Description
Wrong check for execution completion fixed.
It was implemented properly for "cancel" status, improperly for "done" status.
/nocl

## Motivation and Context
This error caused executions on empty search types (i.e. with fresh new Dashboards, Dashboard pages with no widgets) to never return "Done" status. Because of that, FE was asking for status infinitely.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

