### PR TITLE
Search Cleanup Job: Fix interval checking, skip static referenced searches

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -270,6 +270,10 @@ public class ViewsBindings extends ViewsModule {
 
         bind(LastUsedQueryStringsService.class).to(MongoLastUsedQueryStringsService.class);
         addSystemRestResource(QueryStringsResource.class);
+
+        // The Set<StaticReferencedSearch> binder must be explicitly initialized to avoid an initialization error when
+        // no values are bound.
+        staticReferencedSearchBinder();
     }
 
     private void registerExportBackendProvider() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchDbService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchDbService.java
@@ -173,9 +173,9 @@ public class SearchDbService {
         return Streams.stream((Iterable<SearchSummary>) summarydb.find());
     }
 
-    public Set<String> getExpiredSearches(final Set<String> neverDeleteIds, final Instant mustNotBeOlderThan) {
+    public Set<String> getExpiredSearches(final Set<String> neverDeleteIds, final Instant mustBeOlderThan) {
         return this.findSummaries()
-                .filter(search -> !neverDeleteIds.contains(search.id()) && search.createdAt().isBefore(mustNotBeOlderThan))
+                .filter(search -> !neverDeleteIds.contains(search.id()) && search.createdAt().isBefore(mustBeOlderThan))
                 .map(search -> search.id())
                 .collect(Collectors.toSet());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticReferencedSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticReferencedSearch.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.db;
+
+/**
+ * Represents a persisted search database entity that should not be deleted by the
+ * {@link SearchesCleanUpJob}, since it is directly referenced by a static dashboard in the
+ * application.
+ *
+ * @param id The Search id.
+ */
+public record StaticReferencedSearch(String id) {
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticSearchLoader.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticSearchLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.db;
 
 import org.graylog.plugins.views.search.rest.SearchDTO;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticSearchLoader.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/StaticSearchLoader.java
@@ -1,0 +1,20 @@
+package org.graylog.plugins.views.search.db;
+
+import org.graylog.plugins.views.search.rest.SearchDTO;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Provides ability to load search records from resources during server startup.
+ */
+public class StaticSearchLoader {
+    public static SearchDTO loadSearchResource(URL fileUrl) {
+        try {
+            return new ObjectMapperProvider().get().readValue(fileUrl, SearchDTO.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load search.", e);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -35,6 +35,7 @@ import org.graylog.events.processor.modifier.EventModifier;
 import org.graylog.events.processor.storage.EventStorageHandler;
 import org.graylog.grn.GRNDescriptorProvider;
 import org.graylog.grn.GRNType;
+import org.graylog.plugins.views.search.db.StaticReferencedSearch;
 import org.graylog.plugins.views.search.export.ExportFormat;
 import org.graylog.scheduler.Job;
 import org.graylog.scheduler.JobDefinitionConfig;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -28,6 +28,7 @@ import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Names;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.realm.AuthorizingRealm;
+import org.graylog.plugins.views.search.db.StaticReferencedSearch;
 import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.AuditEventType;
@@ -522,5 +523,13 @@ public abstract class Graylog2Module extends AbstractModule {
     protected void installViewResolver(String name,
                                        Class<? extends ViewResolver> resolverClass) {
         viewResolverBinder().addBinding(name).to(resolverClass).asEagerSingleton();
+    }
+
+    protected void addStaticReferencedSearch(StaticReferencedSearch referencedSearch) {
+        staticReferencedSearchBinder().addBinding().toInstance(referencedSearch);
+    }
+
+    protected Multibinder<StaticReferencedSearch> staticReferencedSearchBinder() {
+        return Multibinder.newSetBinder(binder(), StaticReferencedSearch.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.when;
 public class SearchesCleanUpJobTest {
     public static final String IN_USE_SEARCH_ID = "This search is in use";
     public static final String IN_USE_RESOLVER_SEARCH_ID = "in-use-resolver-search-id";
+    private static final String IN_USE_STATIC_SEARCH_ID = "static-search-id";
 
     @Mock
     private ViewSummaryService viewService;
@@ -69,7 +70,8 @@ public class SearchesCleanUpJobTest {
 
     @BeforeEach
     public void setup() {
-        this.searchesCleanUpJob = new SearchesCleanUpJob(viewService, searchDbService, Duration.standardDays(4), testViewResolvers());
+        this.searchesCleanUpJob = new SearchesCleanUpJob(viewService, searchDbService, Duration.standardDays(4),
+                testViewResolvers(), Collections.singleton(new StaticReferencedSearch(IN_USE_STATIC_SEARCH_ID)));
     }
 
     @Test
@@ -136,6 +138,7 @@ public class SearchesCleanUpJobTest {
         verify(searchDbService, times(1)).getExpiredSearches(searchIdsCaptor.capture(), any());
         assertThat(searchIdsCaptor.getValue().contains(IN_USE_SEARCH_ID)).isTrue();
         assertThat(searchIdsCaptor.getValue().contains(IN_USE_RESOLVER_SEARCH_ID)).isTrue();
+        assertThat(searchIdsCaptor.getValue().contains(IN_USE_STATIC_SEARCH_ID)).isTrue();
 
         verify(searchDbService, never()).delete(any());
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,7 +88,7 @@ public class SearchesCleanUpJobWithDBServicesTest {
                 )
         );
         this.searchesCleanUpJob = new SearchesCleanUpJob(viewService, searchDbService, Duration.standardDays(4),
-                new HashMap<>());
+                new HashMap<>(), new HashSet<>());
     }
 
     @After


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `SearchCleanupJob` previously used a fixed previous duration (set at in constructor at injection time), which resulted in the periodical only ever cleaning up expired searches once at server startup time (thanks to @ryan-carroll-graylog  for noticing this). The migration is intended to perform the cleanup once per hour. This PR fixes that, so that the expired reports threshold `mustBeOlderThan` is recalculated on each run, which allows newly expired non-referenced searches to be deleted each time the job runs.

Also adds support for not deleting static referenced search ids. See https://github.com/Graylog2/graylog-plugin-enterprise/pull/7107 for context.

/nocl fixes/adjusts backend process that does not affect visible user functionality

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing by overriding the initial delay and run intervals in the migration to get it to execute quicker. Verifying that appropriate static IDs are skipped, unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

