### PR TITLE
Fixing "unknown format" error on sidecar overview page `6.0`.

### DIFF
--- a/changelog/unreleased/issue-19012.toml
+++ b/changelog/unreleased/issue-19012.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing 'unknown format' error on sidecar overview page."
+
+issues = ["19012"]
+pulls = ["19128"]

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -30,12 +30,8 @@ import recentMessagesTimeRange from 'util/TimeRangeHelper';
 import style from './SidecarRow.css';
 
 const SidecarTR = styled.tr(({ inactive, theme }) => css`
-  color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.row.background, 'AA') : 'currentColor'};
-  opacity: ${inactive ? 0.9 : 1};
-
-  &:nth-of-type(2n+1) {
-    color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.row.backgroundAlt, 'AA') : 'currentColor'};
-  }
+  color: ${inactive ? theme.utils.contrastingColor(theme.colors.global.contentBackground, 'AA') : 'currentColor'};
+  opacity: ${inactive ? 0.8 : 1};
 
   td:not(:last-child) {
     font-style: ${inactive ? 'italic' : 'normal'};

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -30,11 +30,11 @@ import recentMessagesTimeRange from 'util/TimeRangeHelper';
 import style from './SidecarRow.css';
 
 const SidecarTR = styled.tr(({ inactive, theme }) => css`
-  color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.background, 'AA') : 'currentColor'};
+  color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.row.background, 'AA') : 'currentColor'};
   opacity: ${inactive ? 0.9 : 1};
 
   &:nth-of-type(2n+1) {
-    color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.backgroundAlt, 'AA') : 'currentColor'};
+    color: ${inactive ? theme.utils.contrastingColor(theme.colors.table.row.backgroundAlt, 'AA') : 'currentColor'};
   }
 
   td:not(:last-child) {

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -31,7 +31,7 @@ import style from './SidecarRow.css';
 
 const SidecarTR = styled.tr(({ inactive, theme }) => css`
   color: ${inactive ? theme.utils.contrastingColor(theme.colors.global.contentBackground, 'AA') : 'currentColor'};
-  opacity: ${inactive ? 0.8 : 1};
+  opacity: ${inactive ? 0.9 : 1};
 
   td:not(:last-child) {
     font-style: ${inactive ? 'italic' : 'normal'};


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/19128 for `6.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an error which has been introduced with https://github.com/Graylog2/graylog2-server/pull/18558 when renaming theme variables. It occurred when the overview contains inactive sidecars.


