### PR TITLE
fix: Small styles fix

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.styles.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.styles.tsx
@@ -36,8 +36,8 @@ const StyledNavbar = styled(Navbar)(({ theme }) => css`
       align-items: center;
     }
 
-    .navbar-nav > li {
-      > a {
+    .navbar-nav > li, .navbar-nav > span {
+      > * {
         font-family: ${theme.fonts.family.navigation};
         font-size: ${theme.fonts.size.navigation};
 
@@ -47,7 +47,7 @@ const StyledNavbar = styled(Navbar)(({ theme }) => css`
       }
 
       &.active {
-        > a {
+        > * {
           ${activeIndicatorStyles(theme)}
           &:hover,
           &:focus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the navigation items alignment.

/nocl

## Description
<!--- Describe your changes in detail -->
The issue with the alignment was caused by the way the styling was applied. In the nav links there are 2 different HTML elements. The regular elements are `li` and plugin links are `span`. Specific styling was being applied to only `li` elements leaving the `span` links with the default style.

By making the css selector broader, the style now is correctly applied to all element in the main navigation bar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

