### PR TITLE
Decouple keyword time range validation from keyword time range preview in time range picker. `6.0`

### DIFF
--- a/changelog/unreleased/issue-18809.toml
+++ b/changelog/unreleased/issue-18809.toml
@@ -1,0 +1,11 @@
+type = "f"
+message = "Fixing several smaller bugs with keyword time range tab."
+
+issues = ["18809"]
+pulls = ["18879"]
+
+details.user = """
+Before this change the time range picker submit button could be disabled after switching between the keyword tab and other tabs without any further changes.
+Just opening the keyword tab and saving the keyword time range resulted in an error.
+When opening the keyword tab, with the default time range, the time range preview was not shown.
+"""

--- a/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBarForm.tsx
@@ -49,7 +49,7 @@ type Props = {
 const _isFunction = (children: Props['children']): children is (props: FormikProps<DashboardFormValues>) => React.ReactElement => isFunction(children);
 
 const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQueryString, children }: Props) => {
-  const { formatTime } = useUserDateTime();
+  const { formatTime, userTimezone } = useUserDateTime();
   const { setFieldWarning } = useContext(FormWarningsContext);
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
 
@@ -63,8 +63,16 @@ const DashboardSearchForm = ({ initialValues, limitDuration, onSubmit, validateQ
   const { enableReinitialize, onSubmit: _onSubmit } = useSearchBarSubmit(_initialValues, onSubmit);
 
   const handlerContext = useHandlerContext();
-  const _validate = useCallback((values: DashboardFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext),
-    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext]);
+  const _validate = useCallback((values: DashboardFormValues) => validate(
+    values,
+    limitDuration,
+    setFieldWarning,
+    validateQueryString,
+    pluggableSearchBarControls,
+    formatTime,
+    handlerContext,
+    userTimezone,
+  ), [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext, userTimezone]);
 
   return (
     <Formik<DashboardFormValues> initialValues={_initialValues}

--- a/graylog2-web-interface/src/views/components/TimeRangeValidation.test.ts
+++ b/graylog2-web-interface/src/views/components/TimeRangeValidation.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import asMock from 'helpers/mocking/AsMock';
+import TimeRangeValidation from 'views/components/TimeRangeValidation';
+import ToolsStore from 'stores/tools/ToolsStore';
+import { adjustFormat } from 'util/DateTime';
+
+jest.mock('stores/tools/ToolsStore', () => ({
+  testNaturalDate: jest.fn(),
+}));
+
+describe('TimeRangeValidation', () => {
+  describe('keyword', () => {
+    beforeEach(() => {
+      asMock(ToolsStore.testNaturalDate).mockImplementation(() => Promise.resolve({
+        type: 'absolute',
+        from: '2018-11-14 13:52:38',
+        to: '2018-11-14 13:57:38',
+        timezone: 'Europe/Berlin',
+      }));
+    });
+
+    it('should error on empty keyword', async () => {
+      const errors = await TimeRangeValidation(
+        { type: 'keyword', keyword: '   ' },
+        0,
+        (value) => String(value),
+        'Europe/Berlin',
+      );
+
+      expect(errors).toEqual({ keyword: 'Keyword must not be empty!' });
+    });
+
+    it('should error when keyword is not valid', async () => {
+      asMock(ToolsStore.testNaturalDate).mockImplementation(() => Promise.reject());
+
+      const errors = await TimeRangeValidation(
+        { type: 'keyword', keyword: 'Last five minutes' },
+        0,
+        (value) => String(value),
+        'Europe/Berlin',
+      );
+
+      expect(errors).toEqual({ keyword: 'Unable to parse keyword' });
+    });
+
+    it('should error when keyword exceeds limit', async () => {
+      asMock(ToolsStore.testNaturalDate).mockImplementation(() => Promise.resolve({
+        type: 'absolute',
+        from: '2018-11-14 13:52:38',
+        to: '2018-11-14 13:57:38',
+        timezone: 'Europe/Berlin',
+      }));
+
+      const errors = await TimeRangeValidation(
+        { type: 'keyword', keyword: 'Last ten days' },
+        86400,
+        (value) => adjustFormat(value),
+        'Europe/Berlin',
+      );
+
+      expect(errors).toEqual({ keyword: 'Range is outside limit duration.' });
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.tsx
@@ -45,7 +45,7 @@ type Props = {
 const _isFunction = (children: Props['children']): children is FormRenderer => isFunction(children);
 
 const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, validateOnMount, formRef, validateQueryString }: Props) => {
-  const { formatTime } = useUserDateTime();
+  const { formatTime, userTimezone } = useUserDateTime();
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const { setFieldWarning } = useContext(FormWarningsContext);
   const _initialValues = useMemo(() => {
@@ -60,8 +60,15 @@ const SearchBarForm = ({ initialValues, limitDuration, onSubmit, children, valid
   const { enableReinitialize, onSubmit: _onSubmit } = useSearchBarSubmit(_initialValues, onSubmit);
 
   const handlerContext = useHandlerContext();
-  const _validate = useCallback((values: SearchBarFormValues) => validate(values, limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext),
-    [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext]);
+  const _validate = useCallback((values: SearchBarFormValues) => validate(values,
+    limitDuration,
+    setFieldWarning,
+    validateQueryString,
+    pluggableSearchBarControls,
+    formatTime,
+    handlerContext,
+    userTimezone,
+  ), [limitDuration, setFieldWarning, validateQueryString, pluggableSearchBarControls, formatTime, handlerContext, userTimezone]);
 
   return (
     <Formik<SearchBarFormValues> initialValues={_initialValues}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -92,7 +92,9 @@ describe('TimeRangeFilter', () => {
     });
     fireEvent.change(fromValue, { target: { value: 30 } });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Update time range' }));
+    const submitButton = await screen.findByRole('button', { name: 'Update time range' });
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    fireEvent.click(submitButton);
 
     await waitFor(() => expect(onChange).toHaveBeenCalledWith({
       from: 1800,

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.tsx
@@ -15,25 +15,21 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import trim from 'lodash/trim';
-import isEqual from 'lodash/isEqual';
 import { Field, useField } from 'formik';
+import { useQuery } from '@tanstack/react-query';
+import trim from 'lodash/trim';
 
 import { Col, FormControl, FormGroup, Panel, Row } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import ToolsStore from 'stores/tools/ToolsStore';
-import type { KeywordTimeRange } from 'views/logic/queries/Query';
 import useUserDateTime from 'hooks/useUserDateTime';
-import { InputDescription } from 'components/common';
+import { InputDescription, Timestamp } from 'components/common';
 import debounceWithPromise from 'views/logic/debounceWithPromise';
 
 import { EMPTY_RANGE } from '../TimeRangeDisplay';
-
-type KeywordPreview = { from: string, to: string, timezone: string }
 
 const Headline = styled.h3`
   margin-bottom: 5px;
@@ -52,169 +48,115 @@ const EffectiveTimeRangeTable = styled.table`
   }
 `;
 
-const _parseKeywordPreview = (data: Pick<KeywordTimeRange, 'from' | 'to' | 'timezone'>, formatTime: (dateTime: string, format: string) => string) => {
-  const { timezone } = data;
-
-  return {
-    from: formatTime(data.from, 'complete'),
-    to: formatTime(data.to, 'complete'),
-    timezone,
-  };
-};
-
-type Props = {
-  defaultValue: string,
-  disabled: boolean,
-  setValidatingKeyword: (isValidating: boolean) => void
-};
-
 const debouncedTestNaturalDate = debounceWithPromise((
   keyword: string,
   userTZ: string,
-  mounted: React.RefObject<boolean>,
-  setSuccessfulPreview: (response: KeywordPreview) => void,
-  setFailedPreview: () => void,
-) => ToolsStore.testNaturalDate(keyword, userTZ).then((response) => {
-  if (mounted.current) {
-    setSuccessfulPreview(response);
+) => ToolsStore.testNaturalDate(keyword, userTZ), 350);
+
+const TimePreview = ({ dateTime, isLoading }: { dateTime: string, isLoading: boolean }) => {
+  if (!dateTime || isLoading) {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <>{EMPTY_RANGE}</>;
   }
-}).catch(() => {
-  setFailedPreview();
 
-  return 'Unable to parse keyword.';
-}), 350);
+  return <Timestamp dateTime={dateTime} format="complete" />;
+};
 
-const TabKeywordTimeRange = ({ defaultValue, disabled, setValidatingKeyword }: Props) => {
-  const { formatTime, userTimezone } = useUserDateTime();
-  const [nextRangeProps, , nextRangeHelpers] = useField('timeRangeTabs.keyword');
-  const mounted = useRef(true);
-  const keywordRef = useRef<string>();
-  const [keywordPreview, setKeywordPreview] = useState<KeywordPreview>({ from: '', to: '', timezone: '' });
+const useKeywordPreview = (keyword: string, userTZ: string) => {
+  const { data, isFetching } = useQuery(['time-range', 'validation', 'keyword', keyword], () => debouncedTestNaturalDate(keyword, userTZ), {
+    retry: 0,
+    enabled: !!trim(keyword),
+  });
 
-  const _setSuccessfulPreview = useCallback((response: KeywordPreview) => {
-    setValidatingKeyword(false);
+  return { data, isFetching };
+};
 
-    setKeywordPreview(_parseKeywordPreview(response, formatTime));
-  },
-  [setValidatingKeyword, formatTime]);
-
-  const _setFailedPreview = useCallback(() => {
-    setKeywordPreview({ from: EMPTY_RANGE, to: EMPTY_RANGE, timezone: userTimezone });
-  }, [userTimezone]);
-
-  const _validateKeyword = useCallback((keyword: string) => {
-    if (keyword === undefined) {
-      return undefined;
-    }
-
-    if (keywordRef.current !== keyword) {
-      keywordRef.current = keyword;
-
-      setValidatingKeyword(true);
-
-      return trim(keyword) === ''
-        ? Promise.resolve('Keyword must not be empty!')
-        : debouncedTestNaturalDate(keyword, userTimezone, mounted, _setSuccessfulPreview, _setFailedPreview);
-    }
-
-    return undefined;
-  }, [_setFailedPreview, _setSuccessfulPreview, setValidatingKeyword, userTimezone]);
-
-  useEffect(() => () => {
-    mounted.current = false;
-  }, []);
-
-  useEffect(() => {
-    _validateKeyword(keywordRef.current);
-  }, [_validateKeyword]);
-
-  useEffect(() => {
-    if (nextRangeProps?.value) {
-      const { type, keyword, ...restPreview } = nextRangeProps.value;
-
-      if (!isEqual(restPreview, keywordPreview)) {
-        nextRangeHelpers.setValue({
-          type,
-          keyword,
-          ...restPreview,
-          ...keywordPreview,
-        }, false);
-      }
-    }
-  }, [nextRangeProps.value, keywordPreview, nextRangeHelpers]);
+const KeywordTimeRangePreview = () => {
+  const [{ value: { keyword } }] = useField('timeRangeTabs.keyword');
+  const { userTimezone } = useUserDateTime();
+  const { data, isFetching } = useKeywordPreview(keyword, userTimezone);
 
   return (
-    <Row className="no-bm">
-      <Col sm={5}>
-        <Headline>Time range:</Headline>
-        <Field name="timeRangeTabs.keyword.keyword" validate={_validateKeyword}>
-          {({ field: { name, value, onChange }, meta: { error } }) => (
-            <FormGroup controlId="form-inline-keyword"
-                       style={{ marginRight: 5, width: '100%', marginBottom: 0 }}
-                       validationState={error ? 'error' : null}>
-              <KeywordInput type="text"
-                            className="input-sm mousetrap"
-                            name={name}
-                            disabled={disabled}
-                            placeholder="Last week"
-                            title="Keyword input"
-                            aria-label="Keyword input"
-                            onChange={onChange}
-                            required
-                            value={value || defaultValue} />
-
-              <InputDescription error={error} help="Specify the time frame for the search in natural language." />
-            </FormGroup>
-          )}
-        </Field>
-
-        <b>Preview</b>
-        <EffectiveTimeRangeTable>
-          <tbody>
-            <tr>
-              <td>From</td>
-              <td>{keywordPreview.from}</td>
-            </tr>
-            <tr>
-              <td>To</td>
-              <td>{keywordPreview.to}</td>
-            </tr>
-          </tbody>
-        </EffectiveTimeRangeTable>
-      </Col>
-
-      <Col sm={7}>
-        <Panel>
-          <Panel.Body>
-            <p><code>last month</code> searches between one month ago and now</p>
-
-            <p><code>4 hours ago</code> searches between four hours ago and now</p>
-
-            <p><code>1st of april to 2 days ago</code> searches between 1st of April and 2 days ago</p>
-
-            <p><code>yesterday midnight +0200 to today midnight +0200</code> searches between yesterday midnight and today midnight in timezone +0200 - will be 22:00 in UTC</p>
-
-            <p>Please consult the <DocumentationLink page={DocsHelper.PAGES.TIME_FRAME_SELECTOR}
-                                                     title="Keyword Time Range Documentation"
-                                                     text="documentation" /> for more details.
-            </p>
-          </Panel.Body>
-        </Panel>
-      </Col>
-    </Row>
+    <EffectiveTimeRangeTable>
+      <tbody>
+        <tr>
+          <td>From</td>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+          <td>
+            <TimePreview dateTime={data?.from} isLoading={isFetching} />
+          </td>
+        </tr>
+        <tr>
+          <td>To</td>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+          <td>
+            <TimePreview dateTime={data?.to} isLoading={isFetching} />
+          </td>
+        </tr>
+      </tbody>
+    </EffectiveTimeRangeTable>
   );
 };
 
+type Props = {
+  disabled: boolean,
+};
+
+const TabKeywordTimeRange = ({ disabled }: Props) => (
+  <Row className="no-bm">
+    <Col sm={5}>
+      <Headline>Time range:</Headline>
+      <Field name="timeRangeTabs.keyword.keyword">
+        {({ field: { name, value, onChange }, meta: { error } }) => (
+          <FormGroup controlId="form-inline-keyword"
+                     style={{ marginRight: 5, width: '100%', marginBottom: 0 }}
+                     validationState={error ? 'error' : null}>
+            <KeywordInput type="text"
+                          className="input-sm mousetrap"
+                          name={name}
+                          disabled={disabled}
+                          placeholder="Last week"
+                          title="Keyword input"
+                          aria-label="Keyword input"
+                          onChange={onChange}
+                          required
+                          value={value} />
+            <InputDescription error={error} help="Specify the time frame for the search in natural language." />
+          </FormGroup>
+        )}
+      </Field>
+
+      <b>Preview</b>
+      <KeywordTimeRangePreview />
+    </Col>
+
+    <Col sm={7}>
+      <Panel>
+        <Panel.Body>
+          <p><code>last month</code> searches between one month ago and now</p>
+
+          <p><code>4 hours ago</code> searches between four hours ago and now</p>
+
+          <p><code>1st of april to 2 days ago</code> searches between 1st of April and 2 days ago</p>
+
+          <p><code>yesterday midnight +0200 to today midnight +0200</code> searches between yesterday midnight and today midnight in timezone +0200 - will be 22:00 in UTC</p>
+
+          <p>Please consult the <DocumentationLink page={DocsHelper.PAGES.TIME_FRAME_SELECTOR}
+                                                   title="Keyword Time Range Documentation"
+                                                   text="documentation" /> for more details.
+          </p>
+        </Panel.Body>
+      </Panel>
+    </Col>
+  </Row>
+);
+
 TabKeywordTimeRange.propTypes = {
-  defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
-  setValidatingKeyword: PropTypes.func,
 };
 
 TabKeywordTimeRange.defaultProps = {
-  defaultValue: '',
   disabled: false,
-  setValidatingKeyword: () => {},
 };
 
 export default TabKeywordTimeRange;

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.relativeTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.relativeTimeRange.test.tsx
@@ -104,6 +104,8 @@ describe('TimeRangePicker relative time range', () => {
 
     await userEvent.type(fromRangeValueInput, '{backspace}7');
     await userEvent.type(toRangeValueInput, '{backspace}6');
+
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
     await userEvent.click(submitButton);
 
     await waitFor(() => expect(setCurrentTimeRangeStub).toHaveBeenCalledTimes(1));

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.test.tsx
@@ -88,6 +88,9 @@ describe('TimeRangePicker', () => {
     render(<TimeRangePicker {...defaultProps} />);
 
     const applyButton = screen.getByRole('button', { name: /update time range/i });
+
+    await waitFor(() => expect(applyButton).not.toBeDisabled());
+
     fireEvent.click(applyButton);
 
     await waitFor(() => expect(defaultProps.setCurrentTimeRange).toHaveBeenCalled());

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePickerTabs.tsx
@@ -57,7 +57,6 @@ export const timeRangePickerTabs = {
 type TimeRangeTabsArguments = {
   activeTab: SupportedTimeRangeType,
   limitDuration: number,
-  setValidatingKeyword: (status: boolean) => void,
   tabs: Array<SupportedTimeRangeType>,
 }
 
@@ -69,7 +68,6 @@ const StyledTabs = styled(Tabs)`
 const timeRangeTypeTabs = ({
   activeTab,
   limitDuration,
-  setValidatingKeyword,
   tabs,
 }: TimeRangeTabsArguments) => availableTimeRangeTypes
   .filter(({ type }) => tabs.includes(type))
@@ -82,8 +80,7 @@ const timeRangeTypeTabs = ({
            eventKey={type}>
         {type === activeTab && (
           <TimeRangeTypeTab disabled={false}
-                            limitDuration={limitDuration}
-                            setValidatingKeyword={type === 'keyword' ? setValidatingKeyword : undefined} />
+                            limitDuration={limitDuration} />
         )}
       </Tab>
     );
@@ -114,7 +111,6 @@ const createDefaultRanges = (formatTime: (time: DateTime, format: DateTimeFormat
 type Props = {
   limitDuration: number,
   validTypes: Array<'absolute' | 'relative' | 'keyword'>,
-  setValidatingKeyword: (validating: boolean) => void,
 };
 
 const newTabTimeRange = ({
@@ -123,19 +119,26 @@ const newTabTimeRange = ({
   timeRangeTabs,
   formatTime,
   defaultRanges,
+  userTimezone,
 }: {
   activeTab: TimeRangePickerFormValues['activeTab'],
   nextTab: TimeRangePickerFormValues['activeTab'],
   timeRangeTabs: TimeRangePickerFormValues['timeRangeTabs'],
   formatTime: (time: DateTime, format: DateTimeFormats) => string,
   defaultRanges: ReturnType<typeof createDefaultRanges>,
+  userTimezone: string
 }) => {
   if (timeRangeTabs[nextTab]) {
     return timeRangeTabs[nextTab];
   }
 
   if (isTimeRange(timeRangeTabs[activeTab])) {
-    return migrateTimeRangeToNewType(timeRangeTabs[activeTab], nextTab, formatTime);
+    return migrateTimeRangeToNewType({
+      oldTimeRange: timeRangeTabs[activeTab],
+      type: nextTab,
+      formatTime,
+      userTimezone,
+    });
   }
 
   return defaultRanges[nextTab];
@@ -144,11 +147,10 @@ const newTabTimeRange = ({
 const TimeRangeTabs = ({
   limitDuration,
   validTypes,
-  setValidatingKeyword,
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const location = useLocation();
-  const { formatTime } = useUserDateTime();
+  const { formatTime, userTimezone } = useUserDateTime();
   const { setValues, values: { activeTab, timeRangeTabs } } = useFormikContext<TimeRangePickerFormValues>();
   const defaultRanges = useMemo(() => createDefaultRanges(formatTime), [formatTime]);
 
@@ -162,6 +164,7 @@ const TimeRangeTabs = ({
           timeRangeTabs,
           formatTime,
           defaultRanges,
+          userTimezone,
         }),
       },
       activeTab: nextTab,
@@ -175,14 +178,13 @@ const TimeRangeTabs = ({
         tab: nextTab,
       },
     });
-  }, [activeTab, defaultRanges, formatTime, location.pathname, sendTelemetry, setValues, timeRangeTabs]);
+  }, [activeTab, defaultRanges, formatTime, location.pathname, sendTelemetry, setValues, timeRangeTabs, userTimezone]);
 
   const tabs = useMemo(() => timeRangeTypeTabs({
     activeTab,
     limitDuration,
-    setValidatingKeyword,
     tabs: validTypes,
-  }), [activeTab, limitDuration, setValidatingKeyword, validTypes]);
+  }), [activeTab, limitDuration, validTypes]);
 
   return (
     <StyledTabs id="dateTimeTypes"

--- a/graylog2-web-interface/src/views/components/searchbar/validate.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/validate.ts
@@ -36,11 +36,12 @@ const validate = async <T extends FormValues>(
   pluggableSearchBarControls: Array<() => SearchBarControl>,
   formatTime: (dateTime: DateTime, format: string) => string,
   context: HandlerContext,
+  userTimezone: string,
 ) => {
   const { timerange: nextTimeRange } = values;
   let errors = {};
 
-  const timeRangeErrors = validateTimeRange(nextTimeRange, limitDuration, formatTime);
+  const timeRangeErrors = await validateTimeRange(nextTimeRange, limitDuration, formatTime, userTimezone, false);
 
   if (!isEmpty(timeRangeErrors)) {
     errors = { ...errors, timerange: timeRangeErrors };

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -219,6 +219,7 @@ describe('Aggregation Widget', () => {
       await userEvent.click(absoluteTabButton);
 
       const applyTimeRangeChangesButton = await screen.findByRole('button', { name: 'Update time range' });
+      await waitFor(() => expect(applyTimeRangeChangesButton).not.toBeDisabled());
       await userEvent.click(applyTimeRangeChangesButton);
 
       const timeRangeDisplay = await screen.findByLabelText('Search Time Range, Opens Time Range Selector On Click');


### PR DESCRIPTION
**Please note:** This is a backport of https://github.com/Graylog2/graylog2-server/pull/18879 for `6.0`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are separating the time range validation from time range preview in time keyword tab of the range picker.

This approach has multiple advantages
- We are no longer using the `validate` prop of the keyword formik field and have all the validation in the form validate function
- We no longer need to maintain the `validatingKeyword` state to disable the submit button while the keyword is being validated
- The keyword preview and validation logic is a lot simpler and less error-prone

The main disadvantage:
- we are currently doing two requests to test the keyword time range in the date time picker, on change. One for the validation and one for the preview.

This restructuring is fixing three bugs:
- the problem described in https://github.com/Graylog2/graylog2-server/issues/18809. We are now always including the user time zone when defining a keyword time range.
- before it often happened that the submit button stayed disabled after switching between the keyword tab and the other tabs
- before this change the keyword time range preview was empty when opening the keyword tab while it contained the default keyword time range.

Fixes https://github.com/Graylog2/graylog2-server/issues/18809

