### PR TITLE
Fix display tooltip for help icons in disabled menu items. `6.0`

### DIFF
--- a/changelog/unreleased/issue-19092.toml
+++ b/changelog/unreleased/issue-19092.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fix display tooltip for help icons in disabled menu items."
+
+issues=["19092"]
+pulls=["19093"]

--- a/graylog2-web-interface/src/components/common/HoverForHelp.tsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.tsx
@@ -45,6 +45,7 @@ const StyledIcon = styled(Icon)<{ $type: Type, $displayLeftMargin: boolean }>(({
   color: ${$type === 'error' ? theme.colors.variant.danger : 'inherit'};
   margin: 0;
   margin-left: ${$displayLeftMargin ? '0.3em' : 0};
+  pointer-events: auto !important;
 `);
 
 const iconName = (type: Type) => {


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/19093 for `6.0`.

## Description
<!--- Describe your changes in detail -->

This PR is fixing the problem described in https://github.com/Graylog2/graylog2-server/issues/19092

Fixes https://github.com/Graylog2/graylog2-server/issues/19092