### PR TITLE
ObjectMappers' config unification

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponse.java
@@ -30,7 +30,7 @@ import java.util.List;
 public record AggregationWidgetExportResponse(@JsonProperty List<String> header,
                                               @JsonProperty @JacksonXmlElementWrapper(useWrapping = false) List<DataRow> dataRows) {
 
-    public record DataRow(@JacksonXmlElementWrapper(useWrapping = false) List<String> row) {
+    public record DataRow(@JacksonXmlElementWrapper(useWrapping = false) List<Object> row) {
 
     }
 
@@ -60,17 +60,17 @@ public record AggregationWidgetExportResponse(@JsonProperty List<String> header,
                 .filter(row -> "leaf".equals(row.source()))
                 .map(row -> {
                     final ImmutableList<String> key = row.key();
-                    final List<String> values = columns.stream()
+                    final List<Object> values = columns.stream()
                             .map(metric -> row.values()
                                     .stream()
                                     .filter(value -> value.key().equals(metric))
                                     .filter(value -> value.value() != null)
                                     .findFirst()
-                                    .map(value -> value.value().toString())
-                                    .orElse("")
+                                    .map(value -> value.value())
+                                    .orElse(null)
                             ).toList();
 
-                    List<String> dataRow = new ArrayList<>();
+                    List<Object> dataRow = new ArrayList<>();
                     dataRow.addAll(key);
                     dataRow.addAll(values);
                     return new DataRow(dataRow);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseWriter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseWriter.java
@@ -80,7 +80,7 @@ public class AggregationWidgetExportResponseWriter implements MessageBodyWriter<
 
             csvWriter.writeNext(widgetExportResponse.header().toArray(new String[0]));
             for (AggregationWidgetExportResponse.DataRow row : widgetExportResponse.dataRows()) {
-                csvWriter.writeNext(row.row().toArray(new String[0]));
+                csvWriter.writeNext(row.row().stream().map(obj -> obj == null ? "" : obj.toString()).toList().toArray(new String[0]));
             }
 
         }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -16,58 +16,21 @@
  */
 package org.graylog2.shared.bindings.providers;
 
-import com.codahale.metrics.json.MetricsModule;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.zafarkhaja.semver.Version;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.vdurmont.semver4j.Requirement;
-import com.vdurmont.semver4j.Semver;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
-import org.graylog.grn.GRN;
-import org.graylog.grn.GRNDeserializer;
-import org.graylog.grn.GRNKeyDeserializer;
 import org.graylog.grn.GRNRegistry;
-import org.graylog2.database.ObjectIdSerializer;
-import org.graylog2.jackson.AutoValueSubtypeResolver;
-import org.graylog2.jackson.DeserializationProblemHandlerModule;
 import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
-import org.graylog2.jackson.JacksonModelValidator;
-import org.graylog2.jackson.JodaDurationCompatSerializer;
-import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
-import org.graylog2.jackson.SemverDeserializer;
-import org.graylog2.jackson.SemverRequirementDeserializer;
-import org.graylog2.jackson.SemverRequirementSerializer;
-import org.graylog2.jackson.SemverSerializer;
-import org.graylog2.jackson.VersionDeserializer;
-import org.graylog2.jackson.VersionSerializer;
 import org.graylog2.plugin.inject.JacksonSubTypes;
-import org.graylog2.security.encryption.EncryptedValue;
-import org.graylog2.security.encryption.EncryptedValueDeserializer;
-import org.graylog2.security.encryption.EncryptedValueSerializer;
 import org.graylog2.security.encryption.EncryptedValueService;
-import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.bindings.providers.config.ObjectMapperConfiguration;
 import org.graylog2.shared.plugins.GraylogClassLoader;
-import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
-import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +38,6 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class ObjectMapperProvider implements Provider<ObjectMapper> {
@@ -114,56 +76,17 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
     @Inject
     public ObjectMapperProvider(@GraylogClassLoader final ClassLoader classLoader,
-                                @JacksonSubTypes Set<NamedType> subtypes,
-                                EncryptedValueService encryptedValueService,
-                                GRNRegistry grnRegistry,
-                                InputConfigurationBeanDeserializerModifier inputConfigurationBeanDeserializerModifier) {
+                                @JacksonSubTypes final Set<NamedType> subtypes,
+                                final EncryptedValueService encryptedValueService,
+                                final GRNRegistry grnRegistry,
+                                final InputConfigurationBeanDeserializerModifier inputConfigurationBeanDeserializerModifier) {
         final ObjectMapper mapper = new ObjectMapper();
-        final TypeFactory typeFactory = mapper.getTypeFactory().withClassLoader(classLoader);
-        final AutoValueSubtypeResolver subtypeResolver = new AutoValueSubtypeResolver();
-
-        this.objectMapper = mapper
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
-                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
-                .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
-                // Starting from Jackson 2.16, the default for INCLUDE_SOURCE_IN_LOCATION was changed to `disabled`.
-                // We are explicitly enabling it again to get verbose output that helps with troubleshooting.
-                .enable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION)
-                .setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy())
-                .setSubtypeResolver(subtypeResolver)
-                .setTypeFactory(typeFactory)
-                .setDateFormat(new StdDateFormat().withColonInTimeZone(false))
-                .registerModule(new GuavaModule())
-                .registerModule(new JodaModule())
-                .registerModule(new Jdk8Module())
-                .registerModule(new JavaTimeModule())
-                .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
-                .registerModule(new DeserializationProblemHandlerModule())
-                .registerModule(new SimpleModule("Graylog")
-                        .addKeyDeserializer(Period.class, new JodaTimePeriodKeyDeserializer())
-                        .addKeyDeserializer(GRN.class, new GRNKeyDeserializer(grnRegistry))
-                        .addSerializer(new RangeJsonSerializer())
-                        .addSerializer(new SizeSerializer())
-                        .addSerializer(new ObjectIdSerializer())
-                        .addSerializer(new VersionSerializer())
-                        .addSerializer(new SemverSerializer())
-                        .addSerializer(new SemverRequirementSerializer())
-                        .addSerializer(Duration.class, new JodaDurationCompatSerializer())
-                        .addSerializer(GRN.class, new ToStringSerializer())
-                        .addSerializer(EncryptedValue.class, new EncryptedValueSerializer())
-                        .addDeserializer(Version.class, new VersionDeserializer())
-                        .addDeserializer(Semver.class, new SemverDeserializer())
-                        .addDeserializer(Requirement.class, new SemverRequirementDeserializer())
-                        .addDeserializer(GRN.class, new GRNDeserializer(grnRegistry))
-                        .addDeserializer(EncryptedValue.class, new EncryptedValueDeserializer(encryptedValueService))
-                        .setDeserializerModifier(inputConfigurationBeanDeserializerModifier)
-                        .setSerializerModifier(JacksonModelValidator.getBeanSerializerModifier())
-                );
-
-        if (subtypes != null) {
-            objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
-        }
+        this.objectMapper = ObjectMapperConfiguration.configureMapper(mapper,
+                classLoader,
+                subtypes,
+                encryptedValueService,
+                grnRegistry,
+                inputConfigurationBeanDeserializerModifier);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/XmlMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/XmlMapperProvider.java
@@ -16,17 +16,39 @@
  */
 package org.graylog2.shared.bindings.providers;
 
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import org.graylog.grn.GRNRegistry;
+import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
+import org.graylog2.plugin.inject.JacksonSubTypes;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.config.ObjectMapperConfiguration;
+import org.graylog2.shared.plugins.GraylogClassLoader;
+
+import java.util.Set;
 
 public class XmlMapperProvider implements Provider<XmlMapper> {
 
     private final XmlMapper objectMapper;
 
-    public XmlMapperProvider() {
-        this.objectMapper = new XmlMapper.Builder(new XmlMapper())
+    @Inject
+    public XmlMapperProvider(@GraylogClassLoader final ClassLoader classLoader,
+                             @JacksonSubTypes final Set<NamedType> subtypes,
+                             final EncryptedValueService encryptedValueService,
+                             final GRNRegistry grnRegistry,
+                             final InputConfigurationBeanDeserializerModifier inputConfigurationBeanDeserializerModifier) {
+        final XmlMapper mapper = new XmlMapper.Builder(new XmlMapper())
                 .defaultUseWrapper(true)
                 .build();
+
+        this.objectMapper = ObjectMapperConfiguration.configureMapper(mapper,
+                classLoader,
+                subtypes,
+                encryptedValueService,
+                grnRegistry,
+                inputConfigurationBeanDeserializerModifier);
 
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/YamlMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/YamlMapperProvider.java
@@ -16,15 +16,36 @@
  */
 package org.graylog2.shared.bindings.providers;
 
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import org.graylog.grn.GRNRegistry;
+import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
+import org.graylog2.plugin.inject.JacksonSubTypes;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.config.ObjectMapperConfiguration;
+import org.graylog2.shared.plugins.GraylogClassLoader;
+
+import java.util.Set;
 
 public class YamlMapperProvider implements Provider<YAMLMapper> {
 
     private final YAMLMapper objectMapper;
 
-    public YamlMapperProvider() {
-        this.objectMapper = new YAMLMapper();
+    @Inject
+    public YamlMapperProvider(@GraylogClassLoader final ClassLoader classLoader,
+                              @JacksonSubTypes final Set<NamedType> subtypes,
+                              final EncryptedValueService encryptedValueService,
+                              final GRNRegistry grnRegistry,
+                              final InputConfigurationBeanDeserializerModifier inputConfigurationBeanDeserializerModifier) {
+        YAMLMapper mapper = new YAMLMapper();
+        this.objectMapper = ObjectMapperConfiguration.configureMapper(mapper,
+                classLoader,
+                subtypes,
+                encryptedValueService,
+                grnRegistry,
+                inputConfigurationBeanDeserializerModifier);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/config/ObjectMapperConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/config/ObjectMapperConfiguration.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.bindings.providers.config;
+
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.zafarkhaja.semver.Version;
+import com.vdurmont.semver4j.Requirement;
+import com.vdurmont.semver4j.Semver;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNDeserializer;
+import org.graylog.grn.GRNKeyDeserializer;
+import org.graylog.grn.GRNRegistry;
+import org.graylog2.database.ObjectIdSerializer;
+import org.graylog2.jackson.AutoValueSubtypeResolver;
+import org.graylog2.jackson.DeserializationProblemHandlerModule;
+import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
+import org.graylog2.jackson.JacksonModelValidator;
+import org.graylog2.jackson.JodaDurationCompatSerializer;
+import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
+import org.graylog2.jackson.SemverDeserializer;
+import org.graylog2.jackson.SemverRequirementDeserializer;
+import org.graylog2.jackson.SemverRequirementSerializer;
+import org.graylog2.jackson.SemverSerializer;
+import org.graylog2.jackson.VersionDeserializer;
+import org.graylog2.jackson.VersionSerializer;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueDeserializer;
+import org.graylog2.security.encryption.EncryptedValueSerializer;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.rest.RangeJsonSerializer;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class ObjectMapperConfiguration {
+
+    public static <T extends ObjectMapper> T configureMapper(T mapper,
+                                                             final ClassLoader classLoader,
+                                                             final Set<NamedType> subtypes,
+                                                             final EncryptedValueService encryptedValueService,
+                                                             final GRNRegistry grnRegistry,
+                                                             final InputConfigurationBeanDeserializerModifier inputConfigurationBeanDeserializerModifier) {
+
+        final TypeFactory typeFactory = mapper.getTypeFactory().withClassLoader(classLoader);
+        final AutoValueSubtypeResolver subtypeResolver = new AutoValueSubtypeResolver();
+
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+                // Starting from Jackson 2.16, the default for INCLUDE_SOURCE_IN_LOCATION was changed to `disabled`.
+                // We are explicitly enabling it again to get verbose output that helps with troubleshooting.
+                .enable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION)
+                .setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy())
+                .setSubtypeResolver(subtypeResolver)
+                .setTypeFactory(typeFactory)
+                .setDateFormat(new StdDateFormat().withColonInTimeZone(false))
+                .registerModule(new GuavaModule())
+                .registerModule(new JodaModule())
+                .registerModule(new Jdk8Module())
+                .registerModule(new JavaTimeModule())
+                .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
+                .registerModule(new DeserializationProblemHandlerModule())
+                .registerModule(new SimpleModule("Graylog")
+                        .addKeyDeserializer(Period.class, new JodaTimePeriodKeyDeserializer())
+                        .addKeyDeserializer(GRN.class, new GRNKeyDeserializer(grnRegistry))
+                        .addSerializer(new RangeJsonSerializer())
+                        .addSerializer(new SizeSerializer())
+                        .addSerializer(new ObjectIdSerializer())
+                        .addSerializer(new VersionSerializer())
+                        .addSerializer(new SemverSerializer())
+                        .addSerializer(new SemverRequirementSerializer())
+                        .addSerializer(Duration.class, new JodaDurationCompatSerializer())
+                        .addSerializer(GRN.class, new ToStringSerializer())
+                        .addSerializer(EncryptedValue.class, new EncryptedValueSerializer())
+                        .addDeserializer(Version.class, new VersionDeserializer())
+                        .addDeserializer(Semver.class, new SemverDeserializer())
+                        .addDeserializer(Requirement.class, new SemverRequirementDeserializer())
+                        .addDeserializer(GRN.class, new GRNDeserializer(grnRegistry))
+                        .addDeserializer(EncryptedValue.class, new EncryptedValueDeserializer(encryptedValueService))
+                        .setDeserializerModifier(inputConfigurationBeanDeserializerModifier)
+                        .setSerializerModifier(JacksonModelValidator.getBeanSerializerModifier())
+                );
+
+        if (subtypes != null) {
+            mapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
+        }
+
+        return mapper;
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/export/response/AggregationWidgetExportResponseTest.java
@@ -39,10 +39,10 @@ class AggregationWidgetExportResponseTest {
         final AggregationWidgetExportResponse expectedResponse = new AggregationWidgetExportResponse(
                 List.of("", "[count()]", "[max(http_response_code)]", "[DELETE, count()]", "[DELETE, max(http_response_code)]", "[GET, count()]", "[GET, max(http_response_code)]", "[POST, count()]", "[POST, max(http_response_code)]", "[PUT, count()]", "[PUT, max(http_response_code)]"),
                 List.of(
-                        new DataRow(List.of("index", "1507337", "504", "75322", "504", "1296526", "504", "75163", "504", "60326", "504")),
-                        new DataRow(List.of("show", "444038", "504", "22229", "504", "381846", "504", "22271", "504", "17692", "504")),
-                        new DataRow(List.of("login", "377715", "504", "18773", "204", "325040", "200", "18761", "504", "15141", "504")),
-                        new DataRow(List.of("edit", "68699", "504", "3540", "504", "58912", "504", "3488", "504", "2759", "504"))
+                        new DataRow(List.of("index", 1507337, 504, 75322, 504, 1296526, 504, 75163, 504, 60326, 504)),
+                        new DataRow(List.of("show", 444038, 504, 22229, 504, 381846, 504, 22271, 504, 17692, 504)),
+                        new DataRow(List.of("login", 377715, 504, 18773, 204, 325040, 200, 18761, 504, 15141, 504)),
+                        new DataRow(List.of("edit", 68699, 504, 3540, 504, 58912, 504, 3488, 504, 2759, 504))
                 )
         );
 


### PR DESCRIPTION
## Description
ObjectMappers' config unification - they all get the same settings.
Data is not stored in strings anymore (as was initially done because of csv format), but can be exported in different formats.
/nocl

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

