### PR TITLE
Fix data node metrics data stream generation

### DIFF
--- a/changelog/unreleased/pr-19241.toml
+++ b/changelog/unreleased/pr-19241.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix data stream replicas and creation on single/multi-node data node setups."
+
+issues = ["18830,19010"]
+pulls = ["19241"]

--- a/changelog/unreleased/pr-19241.toml
+++ b/changelog/unreleased/pr-19241.toml
@@ -1,5 +1,5 @@
 type = "fixed"
 message = "Fix data stream replicas and creation on single/multi-node data node setups."
 
-issues = ["18830,19010"]
+issues = ["18830", "19010"]
 pulls = ["19241"]

--- a/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
+++ b/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
@@ -74,7 +74,7 @@ public class ConfigureMetricsIndexSettings implements StateMachineTracer {
 
     @Override
     public void transition(OpensearchEvent trigger, OpensearchState source, OpensearchState destination) {
-        if (destination == OpensearchState.AVAILABLE && source == OpensearchState.STARTING) {
+        if (destination == OpensearchState.AVAILABLE && source == OpensearchState.STARTING && process.isManagerNode()) {
             process.openSearchClient().ifPresent(client -> {
                 final IsmApi ismApi = new IsmApi(client, objectMapper);
                 int replicas = nodeService.allActive().size() == 1 ? 0 : 1;

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/OpensearchProcess.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/OpensearchProcess.java
@@ -45,4 +45,6 @@ public interface OpensearchProcess extends ManagableProcess<OpensearchConfigurat
 
     void onReset();
 
+    boolean isManagerNode();
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes generation of data stream system indices with a wrong number of replicas on single-node setups (fixes #19010) 
and generation of metrics data stream and ism settings only from the leader node (fixes #18830)

## Motivation and Context
fixes #18830
fixes #19010

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

