### PR TITLE
Revert default behavior of `remove_field` to not perform regex-matching

### DIFF
--- a/changelog/unreleased/issue-19098.toml
+++ b/changelog/unreleased/issue-19098.toml
@@ -2,7 +2,7 @@ type="f"
 message="Fix performance and functional regression in pipeline function `remove_field` by introducing optional parameter `is_regex`."
 
 details.user="""
-GL 6.0 added regex-matching to the pipeline function `remove_field`. This breaks existing pipeline rules that call
+GL 5.1 added regex-matching to the pipeline function `remove_field`. This breaks existing pipeline rules that call
 `remove_field` with a field name containing a regex reserved character, notably `.`. Performance of existing rules
 may also be degraded.
 Both issues are addressed by introducing a new optional parameter `is_regex`, which is `false` by default; thus reverting
@@ -11,4 +11,4 @@ If regex-matching is desired, the `remove_field` must now be called with paramet
 """
 
 issues=["19098"]
-pulls=[""]
+pulls=["19259"]

--- a/changelog/unreleased/issue-19098.toml
+++ b/changelog/unreleased/issue-19098.toml
@@ -1,0 +1,14 @@
+type="f"
+message="Fix performance and functional regression in pipeline function `remove_field` by introducing optional parameter `is_regex`."
+
+details.user="""
+GL 6.0 added regex-matching to the pipeline function `remove_field`. This breaks existing pipeline rules that call
+`remove_field` with a field name containing a regex reserved character, notably `.`. Performance of existing rules
+may also be degraded.
+Both issues are addressed by introducing a new optional parameter `is_regex`, which is `false` by default; thus reverting
+to the old behavior.
+If regex-matching is desired, the `remove_field` must now be called with parameter `is_regex:true`.
+"""
+
+issues=["19098"]
+pulls=[""]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RemoveField.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/RemoveField.java
@@ -62,7 +62,7 @@ public class RemoveField extends AbstractFunction<Void> {
         } else {
             if (Boolean.TRUE.equals(invert)) {
                 message.getFieldNames().stream()
-                        .filter(f -> f.equals(fieldOrPattern))
+                        .filter(f -> !f.equals(fieldOrPattern))
                         .toList() // required to avoid ConcurrentModificationException
                         .forEach(message::removeField);
             } else {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1555,19 +1555,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeField() {
-        final Rule rule = parser.parseRule(ruleForTest(), true);
-        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
-        evaluateRule(rule, message);
-
-        assertThat(message.getField("f1")).isNull();
-        assertThat(message.getField("i1")).isNull();
-        assertThat(message.getField("i2")).isNull();
-        assertThat(message.getField("f2")).isEqualTo("f2");
-        assertThat(message.getField("f3")).isEqualTo("f3");
-    }
-
-    @Test
     public void setField() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
@@ -1674,5 +1661,42 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("remove_missing")).isEqualTo(Arrays.asList(1L, 2L, 3L));
         assertThat(message.getField("remove_only_one")).isEqualTo(Arrays.asList(1L, 2L));
         assertThat(message.getField("remove_all")).isEqualTo(List.of(1L));
+    }
+
+    @Test
+    public void removeField() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("f1")).isNull();
+        assertThat(message.getField("f2")).isEqualTo("f2");
+        assertThat(message.getField("i1")).isEqualTo("i1");
+    }
+
+    @Test
+    public void removeFieldRegex() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("f1")).isNull();
+        assertThat(message.getField("i1")).isNull();
+        assertThat(message.getField("i2")).isNull();
+        assertThat(message.getField("a.1")).isEqualTo("a.1");
+        assertThat(message.getField("f2")).isEqualTo("f2");
+    }
+
+    @Test
+    public void removeFieldInvert() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("i1")).isNull();
+        assertThat(message.getField("f1")).isEqualTo("f1");
+        assertThat(message.getField("f2")).isEqualTo("f2");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1697,6 +1697,18 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("a.1")).isNull();
         assertThat(message.getField("i1")).isNull();
         assertThat(message.getField("f1")).isEqualTo("f1");
+        assertThat(message.getField("f2")).isNull();
+    }
+
+    @Test
+    public void removeFieldInvertRegex() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("i1")).isNull();
+        assertThat(message.getField("f1")).isEqualTo("f1");
         assertThat(message.getField("f2")).isEqualTo("f2");
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldInvert.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldInvert.txt
@@ -1,4 +1,4 @@
-rule "remove_field"
+rule "remove_field_invert"
 when true
 then
   set_field(field: "a.1", value: "a.1");
@@ -6,6 +6,5 @@ then
   set_field(field: "f2", value: "f2");
   set_field(field: "i1", value: "i1");
 
-  remove_field(field:"f1");
-  remove_field(field:"a.1");
+  remove_field(field:"f.", is_regex:true, invert:true);
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldInvertRegex.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldInvertRegex.txt
@@ -6,5 +6,5 @@ then
   set_field(field: "f2", value: "f2");
   set_field(field: "i1", value: "i1");
 
-  remove_field(field:"f1", invert:true);
+  remove_field(field:"f.", is_regex:true, invert:true);
 end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldRegex.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldRegex.txt
@@ -1,11 +1,12 @@
-rule "remove_field"
+rule "remove_field_regex"
 when true
 then
   set_field(field: "a.1", value: "a.1");
   set_field(field: "f1", value: "f1");
   set_field(field: "f2", value: "f2");
   set_field(field: "i1", value: "i1");
+  set_field(field: "i2", value: "i2");
 
-  remove_field(field:"f1");
-  remove_field(field:"a.1");
+  remove_field(field:"f1", is_regex:true);
+  remove_field(field:"i.", is_regex:true);
 end


### PR DESCRIPTION
Resolves #19098 
Resolves #16047 

Fix performance and functional regression in pipeline function `remove_field` by introducing optional parameter `is_regex`.

## Description
GL 5.1 added regex-matching to the pipeline function `remove_field`. This breaks existing pipeline rules that call
`remove_field` with a field name containing a regex reserved character, notably `.`. Performance of existing rules
may also be degraded.
Both issues are addressed by introducing a new optional parameter `is_regex`, which is `false` by default; thus reverting
to the old behavior.
If regex-matching is desired, the `remove_field` must now be called with parameter `is_regex:true`.

This is a **breaking change** for users that have started using the 5.1 regex capability. They will need to add `is_regex:true` (or revert the pattern to a previous non-regex field name, if they had changed it after upgrading).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See discussion in linked issue.

## How Has This Been Tested?
- unit test
- performed perf testing using metric `org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter.executionTime`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

