### PR TITLE
Use filter when searching DB for event definitions

### DIFF
--- a/changelog/unreleased/issue-19007.toml
+++ b/changelog/unreleased/issue-19007.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fixed user permission-based filtering on Event Definitions."
+
+issues=["19007"]
+pulls=["19262"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Returns to using `PaginatedDBService.findPaginatedWithQueryFilterAndSort` when searching event definitions. Event definition configs are then repopulated with any associated Search Filters after the filter has been applied. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #19007 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local dev testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

