### PR TITLE
datanode: add possible downtime estimate

### DIFF
--- a/changelog/unreleased/pr-19271.toml
+++ b/changelog/unreleased/pr-19271.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Show maximum available time for restarting Graylog during in-place migration."
+
+issues = ["19270"]
+pulls = ["19271"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/JournalEstimate.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/rest/JournalEstimate.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.rest;
+
+public record JournalEstimate(long bytesPerMinute, long journalSize, long maxDowntimeMinutes) {
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/rest/MigrationStateResourceTest.java
@@ -16,11 +16,12 @@
  */
 package org.graylog.plugins.views.storage.migration.state.rest;
 
+import com.github.joschi.jadconfig.util.Size;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
-import org.assertj.core.api.Assertions;
 import org.graylog.plugins.views.storage.migration.state.InMemoryStateMachinePersistence;
+import org.graylog.plugins.views.storage.migration.state.actions.TrafficSnapshot;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationActionsAdapter;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationState;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
@@ -28,17 +29,25 @@ import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateM
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineContext;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineImpl;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStep;
+import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class MigrationStateResourceTest {
+
+    @Mock
+    KafkaJournalConfiguration journalConfiguration;
 
     @Test
     public void authenticationTokenSetToStateMachineContext() {
@@ -47,7 +56,8 @@ public class MigrationStateResourceTest {
         final String expectedAuthToken = "MyAuthorization";
         new MigrationStateResource(
                 stateMachine,
-                mockHttpHeaders(Pair.of(HttpHeaders.AUTHORIZATION, expectedAuthToken))
+                mockHttpHeaders(Pair.of(HttpHeaders.AUTHORIZATION, expectedAuthToken)),
+                journalConfiguration
         );
 
         assertThat(stateMachine.getContext().getExtendedState(MigrationStateMachineContext.AUTH_TOKEN_KEY)).isEqualTo(expectedAuthToken);
@@ -55,7 +65,7 @@ public class MigrationStateResourceTest {
 
     @Test
     public void requestReturnsSuccessfulResult() {
-        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders());
+        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders(), journalConfiguration);
 
         try (Response response = resource.trigger(new MigrationStepRequest(MigrationStep.SELECT_MIGRATION, Map.of()))) {
             assertThat(response.getStatus()).isEqualTo(200);
@@ -68,7 +78,7 @@ public class MigrationStateResourceTest {
 
     @Test
     public void requestReturns500OnError() {
-        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders());
+        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders(), journalConfiguration);
         // trigger a step that's not allowed in this state. That should cause and propagate an error
         try (Response response = resource.trigger(new MigrationStepRequest(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED, Map.of()))) {
             assertThat(response.getStatus()).isEqualTo(500);
@@ -83,16 +93,28 @@ public class MigrationStateResourceTest {
 
     @Test
     void testReset() {
-        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders());
+        final MigrationStateResource resource = new MigrationStateResource(createStateMachine(), mockHttpHeaders(), journalConfiguration);
         resource.trigger(new MigrationStepRequest(MigrationStep.SELECT_MIGRATION, Map.of()));
         assertThat(resource.status().state()).isEqualTo(MigrationState.MIGRATION_WELCOME_PAGE);
         resource.resetState();
         assertThat(resource.status().state()).isEqualTo(MigrationState.NEW);
     }
 
+    @Test
+    void testJournalEstimate() {
+        MigrationStateMachine stateMachine = createStateMachine();
+        final MigrationStateResource resource = new MigrationStateResource(stateMachine, mockHttpHeaders(), journalConfiguration);
+        when(journalConfiguration.getMessageJournalMaxSize()).thenReturn(Size.bytes(10000));
+        JournalEstimate journalEstimate = resource.getJournalEstimate();
+        assertThat(journalEstimate.journalSize()).isEqualTo(10000L);
+        assertThat(journalEstimate.maxDowntimeMinutes()).isEqualTo(10000L);
+        stateMachine.getContext().addExtendedState(TrafficSnapshot.ESTIMATED_TRAFFIC_PER_MINUTE, 3000L);
+        assertThat(resource.getJournalEstimate().maxDowntimeMinutes()).isEqualTo(3L);
+    }
+
     @SafeVarargs
     private HttpHeaders mockHttpHeaders(Pair<String, String>... headers) {
-        final HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+        final HttpHeaders httpHeaders = mock(HttpHeaders.class);
         Arrays.stream(headers).forEach(pair -> when(httpHeaders.getRequestHeader(pair.getKey())).thenReturn(List.of(pair.getValue())));
         return httpHeaders;
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
calculate estimated possible downtime based on journal size and current throughput

## Motivation and Context
backend for #19270 

## How Has This Been Tested?
in-place migration / endpoint

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

