### PR TITLE
Reuse http client for all preflight connection checks

### DIFF
--- a/changelog/unreleased/issue-19272.toml
+++ b/changelog/unreleased/issue-19272.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Reuse http client for datanode connection checks during preflight configuration."
+
+issues=["19272"]
+pulls=["19273"]

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogCertificateProvisioningPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/preflight/GraylogCertificateProvisioningPeriodical.java
@@ -24,6 +24,7 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -50,7 +51,6 @@ import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.security.CustomCAX509TrustManager;
 import org.graylog2.security.IndexerJwtAuthTokenProvider;
-import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +99,6 @@ public class GraylogCertificateProvisioningPeriodical extends Periodical {
     private final String passwordSecret;
     private final Supplier<OkHttpClient> okHttpClient;
     private final PreflightConfigService preflightConfigService;
-    private final IndexerJwtAuthTokenProvider indexerJwtAuthTokenProvider;
     private final NotificationService notificationService;
     private final ExecutorService executor;
 
@@ -127,19 +126,24 @@ public class GraylogCertificateProvisioningPeriodical extends Periodical {
         this.csrSigner = csrSigner;
         this.clusterConfigService = clusterConfigService;
         this.preflightConfigService = preflightConfigService;
-        this.indexerJwtAuthTokenProvider = indexerJwtAuthTokenProvider;
         this.notificationService = notificationService;
         this.executor = Executors.newFixedThreadPool(THREADPOOL_THREADS, new ThreadFactoryBuilder().setNameFormat("provisioning-connectivity-check-task").build());
-        this.okHttpClient = Suppliers.memoize(() -> buildConnectivityCheckOkHttpClient(trustManager));
+        this.okHttpClient = Suppliers.memoize(() -> buildConnectivityCheckOkHttpClient(trustManager, indexerJwtAuthTokenProvider));
     }
 
     // building a httpclient to check the connectivity to OpenSearch - TODO: maybe replace it with a VersionProbe already?
-    private static OkHttpClient buildConnectivityCheckOkHttpClient(final X509TrustManager trustManager) {
+    private static OkHttpClient buildConnectivityCheckOkHttpClient(final X509TrustManager trustManager, IndexerJwtAuthTokenProvider indexerJwtAuthTokenProvider) {
         try {
             final var clientBuilder = new OkHttpClient.Builder();
             final var sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{trustManager}, new SecureRandom());
             clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+
+            clientBuilder.authenticator((route, response) -> response.request()
+                    .newBuilder()
+                    .header("Authorization", indexerJwtAuthTokenProvider.get())
+                    .build());
+
             return clientBuilder.build();
         } catch (NoSuchAlgorithmException | KeyManagementException ex) {
             LOG.error("Could not set Graylog CA trust manager: {}", ex.getMessage(), ex);
@@ -264,15 +268,11 @@ public class GraylogCertificateProvisioningPeriodical extends Periodical {
                 .retryIfResult(response -> !response.isSuccessful())
                 .retryIfException()
                 .build();
+
         final Callable<Response> callable = () -> {
             final var node = nodeService.byNodeId(nodeId);
             final var request = new Request.Builder().url(node.getTransportAddress()).build();
-            final var builder = okHttpClient.get().newBuilder()
-                    .authenticator((route, response) -> response.request()
-                            .newBuilder()
-                            .header("Authorization", indexerJwtAuthTokenProvider.get())
-                            .build());
-            final var call = builder.build().newCall(request);
+            final var call = okHttpClient.get().newCall(request);
             return call.execute();
         };
         try (Response response = retryer.call(callable)) {


### PR DESCRIPTION
This PR removes http client per datanode for preflight connections checks. Instead, it reuses one shared client, which is created only when needed. Additionally we don't propagate the http response through the whole retryer logic, as we can't guarantee that it will be closed. So we rather extract the needed information during each call, close the response and propagate only a record with status and message. 


## Motivation and Context
Fixes https://github.com/Graylog2/graylog2-server/issues/19272


## How Has This Been Tested?
Existing provisioning integration test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

