### PR TITLE
Fix client-side routing in `MenuItem` component. (`6.0`)

### DIFF
--- a/changelog/unreleased/pr-19225.toml
+++ b/changelog/unreleased/pr-19225.toml
@@ -1,0 +1,4 @@
+type="f"
+message="Fixing full page refreshes for menu items with href."
+
+pulls=["18954"]

--- a/changelog/unreleased/pr-19276.toml
+++ b/changelog/unreleased/pr-19276.toml
@@ -1,4 +1,4 @@
 type="f"
 message="Fixing full page refreshes for menu items with href."
 
-pulls=["18954"]
+pulls=["19276"]

--- a/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/MenuItem.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
 
 import Icon from 'components/common/Icon';
 
@@ -82,11 +83,7 @@ const CustomMenuItem = <T, >({ children, className, disabled, divider, eventKey,
 
   if (href) {
     return (
-      <StyledMenuItem component="a"
-                      href={href}
-                      target={target}
-                      rel={rel}
-                      {...sharedProps}>
+      <StyledMenuItem component={Link} to={href} rel={rel} target={target} {...sharedProps}>
         {children}
       </StyledMenuItem>
     );


### PR DESCRIPTION
**Note:** This is a backport of #19225 to `6.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the migration of the `MenuItem` component to Mantine, we introduced a regression leading to client-side routing (rendering a new page without a full page refresh) not working when an `href` prop is passed to the `MenuItem` component.

This PR is now fixing this by using the `Link`-component instead of a n `a`-element when the `href` prop is specified, is a relative URL and `target`/`rel` are not specified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.