### PR TITLE
Small refactoring for `SegmentedControl` component.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/SegmentedControl.md
+++ b/graylog2-web-interface/src/components/bootstrap/SegmentedControl.md
@@ -1,13 +1,31 @@
 #### Default
 
 ```tsx
-<SegmentedControl data={['Aloho', 'Mora', 'Lumos']}/>
+<SegmentedControl data={[
+  {
+    value: 'aloho',
+    label: 'Aloho',
+  },
+  {
+    value: 'lumos',
+    label: 'Lumos',
+  }
+]}/>
 ```
 
 #### Disabled
 
 ```tsx
-<SegmentedControl data={['Aloho', 'Mora', 'Lumos']} disabled/>
+<SegmentedControl data={[
+  {
+    value: 'aloho',
+    label: 'Aloho',
+  },
+  {
+    value: 'lumos',
+    label: 'Lumos',
+  }
+]} disabled />
 ```
 
 #### Single option disabled
@@ -27,6 +45,6 @@
     value: 'lumos',
     label: 'Lumos',
   }
-]}/>
+]} />
 ```
 

--- a/graylog2-web-interface/src/components/bootstrap/SegmentedControl.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/SegmentedControl.tsx
@@ -15,20 +15,19 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { Dispatch, SetStateAction } from 'react';
 import { SegmentedControl as MantineSegmentedControl } from '@mantine/core';
 import { useTheme } from 'styled-components';
 import type { SegmentedControlItem } from '@mantine/core';
 
-type Props = {
-  data: Array<string> | Array<SegmentedControlItem>,
+type Props<OptionValue> = {
+  data: Array<SegmentedControlItem & { value: OptionValue }>,
   defaultValue?: string,
   disabled?: boolean,
-  handleChange?: (value: string) => void | Dispatch<SetStateAction<string>>,
-  value?: string,
+  onChange?: (value: OptionValue) => void,
+  value?: OptionValue,
 }
 
-const SegmentedControl = ({ data, defaultValue, disabled, handleChange, value }: Props) => {
+const SegmentedControl = <OptionValue extends string>({ data, defaultValue, disabled, onChange, value }: Props<OptionValue>) => {
   const theme = useTheme();
 
   return (
@@ -37,7 +36,7 @@ const SegmentedControl = ({ data, defaultValue, disabled, handleChange, value }:
                              defaultValue={defaultValue}
                              disabled={disabled}
                              value={value}
-                             onChange={handleChange}
+                             onChange={onChange}
                              styles={{ label: { marginBottom: 0 } }} />
   );
 };
@@ -45,7 +44,7 @@ const SegmentedControl = ({ data, defaultValue, disabled, handleChange, value }:
 SegmentedControl.defaultProps = {
   defaultValue: undefined,
   disabled: false,
-  handleChange: undefined,
+  onChange: undefined,
   value: undefined,
 };
 

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useState, useCallback } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { Formik, Form, Field } from 'formik';
@@ -338,9 +337,9 @@ const IndexSetConfigurationForm = ({
                 ) : (
                   <>
                     <ConfigSegmentsTitle>Rotation and Retention</ConfigSegmentsTitle>
-                    <SegmentedControl data={retentionConfigSegments}
-                                      value={selectedRetentionSegment}
-                                      handleChange={setSelectedRetentionSegment as Dispatch<SetStateAction<string>>} />
+                    <SegmentedControl<RetentionConfigSegment> data={retentionConfigSegments}
+                                                              value={selectedRetentionSegment}
+                                                              onChange={setSelectedRetentionSegment} />
 
                     {selectedRetentionSegment === 'data_tiering' ? (
                       <ConfigSegment>


### PR DESCRIPTION
Please note: This PR is required for https://github.com/Graylog2/graylog-plugin-enterprise/pull/7240

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR contains a small refactoring for the `SegmentedControl` component. We are:

- renaming the `handleChange` prop to `onChange` to follow our naming convention and we are simplifying the related type.
- implementing a generic type for the value options, to avoid the need to use `as` when providing the `onChange` function
- removing the `Array<string>` for the `data` prop. It is being supported by the mantine `SegmentedControl` component, but having a look at the `Select` component, future maintenance will be easier if we allow only one format for these options.


/nocl
