### PR TITLE
Backport 5.2: New pipeline functions remove_single_field and remove_multiple_fields

### DIFF
--- a/changelog/unreleased/issue-19098.toml
+++ b/changelog/unreleased/issue-19098.toml
@@ -1,0 +1,16 @@
+type="a"
+message="Introduce new pipeline functions `remove_single_field` and `remove_multiple_fields` to (eventually) replace `remove_field`."
+
+details.user="""
+GL 5.1 added regex-matching to the pipeline function `remove_field`. This breaks existing pipeline rules that call
+`remove_field` with a field name containing a regex reserved character, notably `.`. Performance of existing rules
+may also be degraded.
+Both issues are addressed by introducing alternate, more specific functions:
+`remove_single_field` removes just a single field specified by name. It is simple and fast.
+`remove_multiple_fields` removes fields matching a regex pattern and/or list of names. Depending on the
+complexity of the matching it is slower.
+'remove_field' will be deprecated and removed in the next major version. Do not use it.
+"""
+
+issues=["19098"]
+pulls=["19268"]

--- a/changelog/unreleased/issue-19098.toml
+++ b/changelog/unreleased/issue-19098.toml
@@ -13,4 +13,4 @@ complexity of the matching it is slower.
 """
 
 issues=["19098"]
-pulls=["19268"]
+pulls=["19300"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -109,6 +109,8 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.NormalizeFields;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveFromStream;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveMultipleFields;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveSingleField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
@@ -179,6 +181,8 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(SetFields.NAME, SetFields.class);
         addMessageProcessorFunction(RenameField.NAME, RenameField.class);
         addMessageProcessorFunction(RemoveField.NAME, RemoveField.class);
+        addMessageProcessorFunction(RemoveSingleField.NAME, RemoveSingleField.class);
+        addMessageProcessorFunction(RemoveMultipleFields.NAME, RemoveMultipleFields.class);
         addMessageProcessorFunction(NormalizeFields.NAME, NormalizeFields.class);
 
         addMessageProcessorFunction(DropMessage.NAME, DropMessage.class);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1569,7 +1569,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     @Test
     public void removeSingleField() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
-        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        final Message message = new Message("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
 
         assertThat(message.getField("a.1")).isNull();
@@ -1581,7 +1581,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     @Test
     public void removeFieldsByName() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
-        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        final Message message = new Message("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
 
         assertThat(message.getField("a.1")).isNull();
@@ -1593,7 +1593,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     @Test
     public void removeFieldsByRegex() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
-        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        final Message message = new Message("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
 
         assertThat(message.getField("a.1")).isNull();

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -112,6 +112,8 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.NormalizeFields;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveFromStream;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveMultipleFields;
+import org.graylog.plugins.pipelineprocessor.functions.messages.RemoveSingleField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RenameField;
 import org.graylog.plugins.pipelineprocessor.functions.messages.RouteToStream;
 import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
@@ -219,7 +221,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     private static LookupTableService lookupTableService;
     private static LookupTableService.Function lookupServiceFunction;
     private static LookupTable lookupTable;
-    private static Map aMap;
 
     private static Logger loggerMock;
 
@@ -240,6 +241,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(SetFields.NAME, new SetFields());
         functions.put(RenameField.NAME, new RenameField());
         functions.put(RemoveField.NAME, new RemoveField());
+        functions.put(RemoveSingleField.NAME, new RemoveSingleField());
+        functions.put(RemoveMultipleFields.NAME, new RemoveMultipleFields());
         functions.put(NormalizeFields.NAME, new NormalizeFields());
 
         functions.put(DropMessage.NAME, new DropMessage());
@@ -1561,6 +1564,42 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("i2")).isNull();
         assertThat(message.getField("f2")).isEqualTo("f2");
         assertThat(message.getField("f3")).isEqualTo("f3");
+    }
+
+    @Test
+    public void removeSingleField() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("f1")).isNull();
+        assertThat(message.getField("a_1")).isEqualTo("a_1");
+        assertThat(message.getField("f2")).isEqualTo("f2");
+    }
+
+    @Test
+    public void removeFieldsByName() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("f1")).isNull();
+        assertThat(message.getField("a_1")).isEqualTo("a_1");
+        assertThat(message.getField("f2")).isEqualTo("f2");
+    }
+
+    @Test
+    public void removeFieldsByRegex() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("a.1")).isNull();
+        assertThat(message.getField("a_1")).isNull();
+        assertThat(message.getField("f2")).isNull();
+        assertThat(message.getField("f1")).isEqualTo("f1");
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldsByName.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldsByName.txt
@@ -1,0 +1,15 @@
+rule "remove_fields_by_name"
+when true
+then
+  set_field(field: "a.1", value: "a.1");
+  set_field(field: "a_1", value: "a_1");
+  set_field(field: "f1", value: "f1");
+  set_field(field: "f2", value: "f2");
+
+  remove_multiple_fields(names:["a.1", "f1"]);
+
+  // invalid - should be NOOP
+  remove_multiple_fields(names:["dummy"]);
+  remove_multiple_fields(names:[]);
+  remove_multiple_fields();
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldsByRegex.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeFieldsByRegex.txt
@@ -1,0 +1,10 @@
+rule "remove_fields_by_regex_and_name)"
+when true
+then
+  set_field(field: "a.1", value: "a.1");
+  set_field(field: "a_1", value: "a_1");
+  set_field(field: "f1", value: "f1");
+  set_field(field: "f2", value: "f2");
+
+  remove_multiple_fields(pattern:"a.1", names:["f2"]);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeSingleField.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/removeSingleField.txt
@@ -1,0 +1,15 @@
+rule "remove_single_field"
+when true
+then
+  set_field(field: "a.1", value: "a.1");
+  set_field(field: "a_1", value: "a_1");
+  set_field(field: "f1", value: "f1");
+  set_field(field: "f2", value: "f2");
+
+  remove_single_field(field:"a.1");
+  remove_single_field(field:"f1");
+
+  // invalid - should be NO-OP
+  remove_single_field(field:"f.");
+  remove_single_field(field:"dummy");
+end


### PR DESCRIPTION
5.2 backport of #19268

* new pipeline functions remove_single_field and remove_multiple_fields

* CL

* improve rulebuilder descriptions

* compile regex and other feedback changes

* pre-compile pattern

* UI string improvements

(cherry picked from commit https://github.com/Graylog2/graylog2-server/commit/4a1cbb4dcb8563a6686e0709040dea75ed831359)

