### PR TITLE
Removed references to leader datanodes in UI

### DIFF
--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeList.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeList.tsx
@@ -49,7 +49,6 @@ const columnDefinitions = [
   { id: 'hostname', title: 'Name', sortable: true, permissions: [] },
   { id: 'transport_address', title: 'Transport address' },
   { id: 'status', title: 'Status', sortable: false },
-  { id: 'is_leader', title: 'Is leader', sortable: true },
   { id: 'cert_valid_until', title: 'Certificate valid until', sortable: false },
 ];
 

--- a/graylog2-web-interface/src/pages/DataNodePage.tsx
+++ b/graylog2-web-interface/src/pages/DataNodePage.tsx
@@ -24,7 +24,6 @@ import DocsHelper from 'util/DocsHelper';
 import { Row, Col, Label } from 'components/bootstrap';
 import { DocumentTitle, NoSearchResult, PageHeader, RelativeTime, Spinner } from 'components/common';
 import { CertRenewalButton } from 'components/datanode/DataNodeConfiguration/CertificateRenewal';
-import Icon from 'components/common/Icon';
 import useDataNode from 'components/datanode/hooks/useDataNode';
 import DataNodeActions from 'components/datanode/DataNodeList/DataNodeActions';
 
@@ -51,12 +50,6 @@ const StatusLabel = styled(Label)`
   justify-content: center;
   gap: 4px;
 `;
-const BooleanIcon = styled(Icon)<{ value: boolean }>(({ theme, value }) => css`
-  color: ${value ? theme.colors.variant.success : theme.colors.variant.danger};
-`);
-const BooleanValue = ({ value }: { value: boolean }) => (
-  <><BooleanIcon name={value ? 'check_circle' : 'cancel'} value={value} /> {value ? 'yes' : 'no'}</>
-);
 
 const ActionsCol = styled(Col)`
   text-align: right;
@@ -103,8 +96,6 @@ const DataNodePage = () => {
                   {datanode.data_node_status || 'N/A'}
                 </StatusLabel>
               </dd>
-              <dt>Is leader:</dt>
-              <dd><BooleanValue value={datanode.is_leader} /></dd>
               <dt>Certificate valid until:</dt>
               <dd><RelativeTime dateTime={datanode.cert_valid_until} /> <CertRenewalButton nodeId={datanode.node_id} status={datanode.status} /></dd>
             </StyledHorizontalDl>


### PR DESCRIPTION
/nocl

## Description
The datanode doesn't use leader flags anymore. It shouldn't be visible anywhere in the UI.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

