### PR TITLE
Convert pipeline parser tests to Junit 5

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -172,12 +172,11 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -195,8 +194,6 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -211,8 +208,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class FunctionsSnippetsTest extends BaseParserTest {
-    @org.junit.Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     public static final DateTime GRAYLOG_EPOCH = DateTime.parse("2010-07-30T16:03:25Z");
     private static final EventBus eventBus = new EventBus();
@@ -227,7 +222,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     private static Logger loggerMock;
     private static MessageFactory messageFactory = new TestMessageFactory();
 
-    @BeforeClass
+    @BeforeAll
     @SuppressForbidden("Allow using default thread factory")
     public static void registerFunctions() {
         final Map<String, Function<?>> functions = commonFunctions();
@@ -423,7 +418,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void stringConcat() {
+    void stringConcat() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule, messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC()));
 
@@ -432,7 +427,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void jsonpath() {
+    void jsonpath() {
         final String json = "{\n" +
                 "    \"store\": {\n" +
                 "        \"book\": [\n" +
@@ -482,7 +477,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void jsonpathFromMessageField() {
+    void jsonpathFromMessageField() {
         final String json = "{\n" +
                 "    \"store\": {\n" +
                 "        \"book\": [\n" +
@@ -531,7 +526,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void json() {
+    void json() {
         final String flatJson = "{\"str\":\"foobar\",\"int\":42,\"float\":2.5,\"bool\":true,\"array\":[1,2,3]}";
         final String nestedJson = "{\n" +
                 "    \"store\": {\n" +
@@ -568,7 +563,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void flattenJson() {
+    void flattenJson() {
         final String nestedJson = "{\n" +
                 "    \"store\": {\n" +
                 "        \"book\": {\n" +
@@ -603,7 +598,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void substring() {
+    void substring() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -611,7 +606,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void dates() {
+    void dates() {
         final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
         DateTimeUtils.setCurrentMillisProvider(clock);
 
@@ -653,7 +648,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void datesUnixTimestamps() {
+    void datesUnixTimestamps() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -661,7 +656,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void digests() {
+    void digests() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -669,7 +664,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void grok_exists() {
+    void grok_exists() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -677,7 +672,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void grok_exists_not() {
+    void grok_exists_not() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -685,7 +680,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void encodings() {
+    void encodings() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 
@@ -693,24 +688,24 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void regexMatch() {
+    void regexMatch() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
-        assertNotNull(message);
-        assertTrue(message.hasField("matched_regex"));
-        assertTrue(message.hasField("group_1"));
+        Assertions.assertNotNull(message);
+        Assertions.assertTrue(message.hasField("matched_regex"));
+        Assertions.assertTrue(message.hasField("group_1"));
         assertThat((String) message.getField("named_group")).isEqualTo("cd.e");
     }
 
     @Test
-    public void regexReplace() {
+    void regexReplace() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
         assertThat(actionsTriggered.get()).isTrue();
     }
 
     @Test
-    public void strings() {
+    void strings() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -723,7 +718,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void stringLength() {
+    void stringLength() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -735,7 +730,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void split() {
+    void split() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -756,7 +751,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void ipMatching() {
+    void ipMatching() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message in = messageFactory.createMessage("test", "test", Tools.nowUTC());
         in.addField("ip", "192.168.1.20");
@@ -769,7 +764,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void evalErrorSuppressed() {
+    void evalErrorSuppressed() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
@@ -782,7 +777,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void newlyCreatedMessage() {
+    void newlyCreatedMessage() {
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         message.addField("foo", "bar");
         message.addStream(mock(Stream.class));
@@ -804,7 +799,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void clonedMessage() {
+    void clonedMessage() {
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         message.addField("foo", "bar");
         message.addStream(mock(Stream.class));
@@ -832,7 +827,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void clonedMessageWithInvalidTimestamp() {
+    void clonedMessageWithInvalidTimestamp() {
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         message.addField("timestamp", "foobar");
         final Rule rule = parser.parseRule(ruleForTest(), false);
@@ -853,7 +848,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void grok() {
+    void grok() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -870,7 +865,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void urls() {
+    void urls() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -892,7 +887,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void syslog() {
+    void syslog() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
 
@@ -944,7 +939,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void ipMatchingIssue28() {
+    void ipMatchingIssue28() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message in = messageFactory.createMessage("some message", "somehost.graylog.org", Tools.nowUTC());
         evaluateRule(rule, in);
@@ -953,7 +948,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void fieldRenaming() {
+    void fieldRenaming() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 
         final Message in = messageFactory.createMessage("some message", "somehost.graylog.org", Tools.nowUTC());
@@ -968,7 +963,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void normalizeFields() {
+    void normalizeFields() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 
         final Message in = messageFactory.createMessage("some message", "somehost.graylog.org", Tools.nowUTC());
@@ -990,7 +985,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void debug() {
+    void debug() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message in = messageFactory.createMessage("some message", "somehost.graylog.org", Tools.nowUTC());
         in.addField("somefield", "somevalue");
@@ -1006,7 +1001,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void comparisons() {
+    void comparisons() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final EvaluationContext context = contextForRuleEval(rule, messageFactory.createMessage("", "", Tools.nowUTC()));
         assertThat(context.hasEvaluationErrors()).isFalse();
@@ -1015,7 +1010,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void conversions() {
+    void conversions() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 
         final EvaluationContext context = contextForRuleEval(rule, messageFactory.createMessage("test", "test", Tools.nowUTC()));
@@ -1023,7 +1018,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(context.evaluationErrors()).isEmpty();
         final Message message = context.currentMessage();
 
-        assertNotNull(message);
+        Assertions.assertNotNull(message);
         assertThat(message.getField("string_1")).isEqualTo("1");
         assertThat(message.getField("string_2")).isEqualTo("2");
         // special case, Message doesn't allow adding fields with empty string values
@@ -1080,7 +1075,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void fieldPrefixSuffix() {
+    void fieldPrefixSuffix() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
 
         final Message message = evaluateRule(rule);
@@ -1100,7 +1095,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void keyValue() {
+    void keyValue() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
 
         final EvaluationContext context = contextForRuleEval(rule, messageFactory.createMessage("", "", Tools.nowUTC()));
@@ -1153,7 +1148,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void keyValueFailure() {
+    void keyValueFailure() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final EvaluationContext context = contextForRuleEval(rule, messageFactory.createMessage("", "", Tools.nowUTC()));
 
@@ -1161,7 +1156,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void timezones() {
+    void timezones() {
         final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
         DateTimeUtils.setCurrentMillisProvider(clock);
         try {
@@ -1175,7 +1170,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void dateArithmetic() {
+    void dateArithmetic() {
         final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
         DateTimeUtils.setCurrentMillisProvider(clock);
         try {
@@ -1207,7 +1202,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void routeToStream() {
+    void routeToStream() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule);
 
@@ -1221,7 +1216,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void routeToStreamRemoveDefault() {
+    void routeToStreamRemoveDefault() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule);
 
@@ -1235,7 +1230,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeFromStream() {
+    void removeFromStream() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule, msg -> msg.addStream(otherStream));
 
@@ -1244,7 +1239,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeFromStreamRetainDefault() {
+    void removeFromStreamRetainDefault() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule, msg -> msg.addStream(otherStream));
 
@@ -1253,7 +1248,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void int2ipv4() {
+    void int2ipv4() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         evaluateRule(rule);
 
@@ -1261,7 +1256,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void accountingSize() {
+    void accountingSize() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule);
 
@@ -1270,7 +1265,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void metricCounter() {
+    void metricCounter() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         evaluateRule(rule);
 
@@ -1278,7 +1273,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupSetValue() {
+    void lookupSetValue() {
         doReturn(LookupResult.single(123)).when(lookupTable).setValue(any(), any());
 
         final Rule rule = parser.parseRule(ruleForTest(), true);
@@ -1291,7 +1286,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupSetValueWithTtl() {
+    void lookupSetValueWithTtl() {
         doReturn(LookupResult.single(123)).when(lookupTable).setValueWithTtl(any(), any(), any());
 
         final Rule rule = parser.parseRule(ruleForTest(), true);
@@ -1304,7 +1299,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupClearKey() {
+    void lookupClearKey() {
         // Stub method call to avoid having verifyNoMoreInteractions() fail
         doNothing().when(lookupTable).clearKey(any());
 
@@ -1316,7 +1311,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupSetStringList() {
+    void lookupSetStringList() {
         final ImmutableList<String> testList = ImmutableList.of("foo", "bar");
 
         doReturn(LookupResult.withoutTTL().stringListValue(testList).build()).when(lookupTable).setStringList(any(), any());
@@ -1331,7 +1326,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupSetStringListWithTtl() {
+    void lookupSetStringListWithTtl() {
         final ImmutableList<String> testList = ImmutableList.of("foo", "bar");
 
         doReturn(LookupResult.withoutTTL().stringListValue(testList).build()).when(lookupTable).setStringListWithTtl(any(), any(), any());
@@ -1346,7 +1341,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupAddStringList() {
+    void lookupAddStringList() {
         final ImmutableList<String> testList = ImmutableList.of("foo", "bar");
         doReturn(LookupResult.withoutTTL().stringListValue(testList).build()).when(lookupTable).addStringList(any(), any(), anyBoolean());
 
@@ -1360,7 +1355,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupRemoveStringList() {
+    void lookupRemoveStringList() {
         final ImmutableList<String> testList = ImmutableList.of("foo", "bar");
         final ImmutableList<String> result = ImmutableList.of("bonk");
         doReturn(LookupResult.withoutTTL().stringListValue(result).build()).when(lookupTable).removeStringList(any(), any());
@@ -1375,7 +1370,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupHasValue() {
+    void lookupHasValue() {
         doReturn(null).when(lookupTable).lookup(any());
         doReturn(LookupResult.withoutTTL().single("present").build()).when(lookupTable).lookup("present");
         doReturn(LookupResult.withoutTTL().build()).when(lookupTable).lookup("empty");
@@ -1392,7 +1387,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupAssignTtl() {
+    void lookupAssignTtl() {
         doReturn(LookupResult.single(123L)).when(lookupTable).assignTtl(any(), any());
 
         final Rule rule = parser.parseRule(ruleForTest(), true);
@@ -1405,7 +1400,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void lookupAll() throws IOException {
+    void lookupAll() throws IOException {
         doReturn(LookupResult.single("val1")).when(lookupTable).lookup("one");
         doReturn(LookupResult.single("val2")).when(lookupTable).lookup("two");
         doReturn(LookupResult.single("val3")).when(lookupTable).lookup("three");
@@ -1432,7 +1427,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void firstNonNull() {
+    void firstNonNull() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = evaluateRule(rule);
 
@@ -1446,7 +1441,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void stringEntropy() {
+    void stringEntropy() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
         assertThat(actionsTriggered.get()).isTrue();
@@ -1456,7 +1451,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void notExpressionTypeCheck() {
+    void notExpressionTypeCheck() {
         try {
             Rule rule = parser.parseRule(ruleForTest(), true);
             Message in = messageFactory.createMessage("test", "source", Tools.nowUTC());
@@ -1470,7 +1465,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void dateConversion() {
+    void dateConversion() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1482,7 +1477,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void mapSet() {
+    void mapSet() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1492,7 +1487,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void mapGet() {
+    void mapGet() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1503,7 +1498,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void mapRemove() {
+    void mapRemove() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1512,7 +1507,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void listGet() {
+    void listGet() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1522,7 +1517,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void ipAnonymize() {
+    void ipAnonymize() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1531,7 +1526,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void listCount() {
+    void listCount() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1540,7 +1535,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void csvMap() {
+    void csvMap() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         Message message = messageFactory.createMessage("test", "source", DateTime.parse("2010-01-01T10:00:00Z"));
         evaluateRule(rule, message);
@@ -1558,7 +1553,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeField() {
+    void removeField() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
@@ -1571,7 +1566,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeSingleField() {
+    void removeSingleField() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
@@ -1583,7 +1578,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeFieldsByName() {
+    void removeFieldsByName() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
@@ -1595,7 +1590,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void removeFieldsByRegex() {
+    void removeFieldsByRegex() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
@@ -1607,7 +1602,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void setField() {
+    void setField() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         evaluateRule(rule, message);
@@ -1620,7 +1615,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void setFields() {
+    void setFields() {
         final Rule rule = parser.parseRule(ruleForTest(), true);
         final Message message = messageFactory.createMessage("test", "test", Tools.nowUTC());
         message.addField("json_field_map", "{ " +
@@ -1645,7 +1640,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void arrayContains() throws IOException {
+    void arrayContains() throws IOException {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = messageFactory.createMessage("message", "source", DateTime.now(DateTimeZone.UTC));
         try (InputStream inputStream = getClass().getResourceAsStream("with-arrays.json")) {
@@ -1677,7 +1672,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void stringArrayAdd() throws IOException {
+    void stringArrayAdd() throws IOException {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = messageFactory.createMessage("hello test", "source", DateTime.now(DateTimeZone.UTC));
         try (InputStream inputStream = getClass().getResourceAsStream("with-arrays.json")) {
@@ -1703,7 +1698,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
-    public void arrayRemove() {
+    void arrayRemove() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = evaluateRule(rule);
         assertThat(actionsTriggered.get()).isTrue();

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
@@ -48,8 +48,8 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
 import org.graylog2.streams.StreamService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -57,7 +57,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -65,13 +65,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class MessageCreationLoopPreventionTest extends BaseParserTest {
+class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     private MessageFactory messageFactory = new TestMessageFactory();
     final CloneMessage cloneMessage = spy(new CloneMessage(messageFactory));
     PipelineInterpreter pipelineInterpreter;
 
-    @Before
+    @BeforeEach
     @SuppressForbidden("Allow using default thread factory")
     public void createPipelineInterpreter() {
         // load rule from resource file
@@ -147,7 +147,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // make sure a naive call to clone_message() will not cause a loop
     @Test
-    public void loopPreventionBasic() {
+    void loopPreventionBasic() {
         Message msg = messageInDefaultStream();
         final Messages processed = pipelineInterpreter.process(msg);
 
@@ -158,7 +158,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // make sure a call to clone_message() with 'preventLoops' set will stop after cloning once
     @Test
-    public void loopPreventionParam() {
+    void loopPreventionParam() {
         Message msg = messageInDefaultStream();
         final Messages processed = pipelineInterpreter.process(msg);
 
@@ -169,7 +169,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // make sure possible existing workarounds for loop prevention will still work
     @Test
-    public void loopPreventionWorkaround1() {
+    void loopPreventionWorkaround1() {
         Message msg = messageInDefaultStream();
         final Messages processed = pipelineInterpreter.process(msg);
 
@@ -180,7 +180,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // make sure possible existing workarounds for loop prevention will still work
     @Test
-    public void loopPreventionWorkaround2() {
+    void loopPreventionWorkaround2() {
         Message msg = messageInDefaultStream();
         final Messages processed = pipelineInterpreter.process(msg);
 
@@ -191,7 +191,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // make sure possible existing recursive calls of clone message will still work
     @Test
-    public void loopPreventionRecursive() {
+    void loopPreventionRecursive() {
         Message msg = messageInDefaultStream();
         msg.addField("cycle", 5);
         final Messages processed = pipelineInterpreter.process(msg);
@@ -203,7 +203,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // possible existing recursive calls which exceed MAX_CLONES will stop creating clones with an error
     @Test
-    public void loopPreventionRecursiveFail() {
+    void loopPreventionRecursiveFail() {
         Message msg = messageInDefaultStream();
         msg.addField("cycle", 110);
         final Messages processed = pipelineInterpreter.process(msg);
@@ -215,7 +215,7 @@ public class MessageCreationLoopPreventionTest extends BaseParserTest {
 
     // recursive calls of clone message can exceed MAX_CLONES if preventLoops is explicitly set to 'false'
     @Test
-    public void loopPreventionRecursiveParam() {
+    void loopPreventionRecursiveParam() {
         Message msg = messageInDefaultStream();
         msg.addField("cycle", 110);
         final Messages processed = pipelineInterpreter.process(msg);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -64,10 +64,9 @@ import jakarta.annotation.Nonnull;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -77,17 +76,17 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.graylog.plugins.pipelineprocessor.functions.FunctionsSnippetsTest.GRAYLOG_EPOCH;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipelineRuleParserTest extends BaseParserTest {
+class PipelineRuleParserTest extends BaseParserTest {
     private MessageFactory messageFactory = new TestMessageFactory();
 
-    @BeforeClass
+    @BeforeAll
     public static void registerFunctions() {
         final Map<String, Function<?>> functions = commonFunctions();
         functions.put("nein", new NeinFunction());
@@ -123,7 +122,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
         functionRegistry = new FunctionRegistry(functions);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         parser = null;
     }
@@ -133,51 +132,48 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void basicRule() throws Exception {
+    void basicRule() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
-        Assert.assertNotNull("rule should be successfully parsed", rule);
+        assertNotNull(rule, "rule should be successfully parsed");
     }
 
     @Test
-    public void undeclaredIdentifier() throws Exception {
+    void undeclaredIdentifier() throws Exception {
         try {
             parseRuleWithOptionalCodegen();
             fail("should throw error: undeclared variable x");
         } catch (ParseException e) {
-            assertEquals(2,
-                    e.getErrors().size()); // undeclared var and incompatible type, but we only care about the undeclared one here
-            assertTrue("Should find error UndeclaredVariable",
-                    e.getErrors().stream().anyMatch(error -> error instanceof UndeclaredVariable));
+            assertEquals(2, e.getErrors().size()); // undeclared var and incompatible type, but we only care about the undeclared one here
+            assertTrue(e.getErrors().stream().anyMatch(error -> error instanceof UndeclaredVariable), "Should find error UndeclaredVariable");
         }
     }
 
     @Test
-    public void declaredFunction() throws Exception {
-        assertNotNull("Should not fail to resolve function 'false'", parseRuleWithOptionalCodegen());
+    void declaredFunction() throws Exception {
+        assertNotNull(parseRuleWithOptionalCodegen(), "Should not fail to resolve function 'false'");
     }
 
     @Test
-    public void undeclaredFunction() throws Exception {
+    void undeclaredFunction() throws Exception {
         try {
             parseRuleWithOptionalCodegen();
             fail("should throw error: undeclared function 'unknown'");
         } catch (ParseException e) {
-            assertTrue("Should find error UndeclaredFunction",
-                    e.getErrors().stream().anyMatch(input -> input instanceof UndeclaredFunction));
+            assertTrue(e.getErrors().stream().anyMatch(input -> input instanceof UndeclaredFunction), "Should find error UndeclaredFunction");
         }
     }
 
     @Test
-    public void singleArgFunction() throws Exception {
+    void singleArgFunction() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         final Message message = evaluateRule(rule);
 
         assertNotNull(message);
-        assertTrue("actions should have triggered", actionsTriggered.get());
+        assertTrue(actionsTriggered.get(), "actions should have triggered");
     }
 
     @Test
-    public void positionalArguments() throws Exception {
+    void positionalArguments() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
 
@@ -185,33 +181,32 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void inferVariableType() throws Exception {
+    void inferVariableType() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
     }
 
     @Test
-    public void invalidArgType() throws Exception {
+    void invalidArgType() throws Exception {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
         } catch (ParseException e) {
             assertEquals(2, e.getErrors().size());
-            assertTrue("Should only find IncompatibleArgumentType errors",
-                    e.getErrors().stream().allMatch(input -> input instanceof IncompatibleArgumentType));
+            assertTrue(e.getErrors().stream().allMatch(input -> input instanceof IncompatibleArgumentType), "Should only find IncompatibleArgumentType errors");
         }
     }
 
     @Test
-    public void booleanValuedFunctionAsCondition() throws Exception {
+    void booleanValuedFunctionAsCondition() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
 
         evaluateRule(rule);
-        assertTrue("actions should have triggered", actionsTriggered.get());
+        assertTrue(actionsTriggered.get(), "actions should have triggered");
     }
 
     @Test
-    public void messageRef() throws Exception {
+    void messageRef() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         Message message = messageFactory.createMessage("hello test", "source", DateTime.now(DateTimeZone.UTC));
         message.addField("responseCode", 500);
@@ -222,7 +217,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void messageRefQuotedField() throws Exception {
+    void messageRefQuotedField() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         Message message = messageFactory.createMessage("hello test", "source", DateTime.now(DateTimeZone.UTC));
         message.addField("@specialfieldname", "string");
@@ -232,7 +227,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void optionalArguments() throws Exception {
+    void optionalArguments() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
 
         Message message = messageFactory.createMessage("hello test", "source", DateTime.now(DateTimeZone.UTC));
@@ -241,7 +236,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void optionalParamsMustBeNamed() throws Exception {
+    void optionalParamsMustBeNamed() throws Exception {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -253,7 +248,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void requiredParameter() {
+    void requiredParameter() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -264,7 +259,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void mapArrayLiteral() {
+    void mapArrayLiteral() {
         final Rule rule = parseRuleWithOptionalCodegen();
         Message message = messageFactory.createMessage("hello test", "source", DateTime.now(DateTimeZone.UTC));
         evaluateRule(rule, message);
@@ -272,21 +267,21 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void typedFieldAccess() throws Exception {
+    void typedFieldAccess() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule, messageFactory.createMessage("hallo", "test", DateTime.now(DateTimeZone.UTC)));
-        assertTrue("condition should be true", actionsTriggered.get());
+        assertTrue(actionsTriggered.get(), "condition should be true");
     }
 
     @Test
-    public void nestedFieldAccess() throws Exception {
+    void nestedFieldAccess() throws Exception {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule, messageFactory.createMessage("hello", "world", DateTime.now(DateTimeZone.UTC)));
-        assertTrue("condition should be true", actionsTriggered.get());
+        assertTrue(actionsTriggered.get(), "condition should be true");
     }
 
     @Test
-    public void pipelineDeclaration() throws Exception {
+    void pipelineDeclaration() throws Exception {
         final List<Pipeline> pipelines = parser.parsePipelines(ruleForTest());
         assertEquals(1, pipelines.size());
         final Pipeline pipeline = Iterables.getOnlyElement(pipelines);
@@ -301,20 +296,19 @@ public class PipelineRuleParserTest extends BaseParserTest {
 
         assertEquals(Stage.Match.EITHER, stage2.match());
         assertEquals(2, stage2.stage());
-        assertArrayEquals(new Object[]{"parse_cisco_time", "extract_src_dest", "normalize_src_dest", "lookup_ips", "resolve_ips"},
-                stage2.ruleReferences().toArray());
+        assertArrayEquals(new Object[]{"parse_cisco_time", "extract_src_dest", "normalize_src_dest", "lookup_ips", "resolve_ips"}, stage2.ruleReferences().toArray());
     }
 
     @Test
-    public void indexedAccess() {
+    void indexedAccess() {
         final Rule rule = parseRuleWithOptionalCodegen();
 
         evaluateRule(rule, messageFactory.createMessage("hallo", "test", DateTime.now(DateTimeZone.UTC)));
-        assertTrue("condition should be true", actionsTriggered.get());
+        assertTrue(actionsTriggered.get(), "condition should be true");
     }
 
     @Test
-    public void indexedAccessWrongType() {
+    void indexedAccessWrongType() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -325,7 +319,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void indexedAccessWrongIndexType() {
+    void indexedAccessWrongIndexType() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -336,7 +330,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void arithmetic() {
+    void arithmetic() {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
 
@@ -344,7 +338,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void mismatchedNumericTypes() {
+    void mismatchedNumericTypes() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -355,7 +349,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void booleanNot() {
+    void booleanNot() {
         final Rule rule = parseRuleWithOptionalCodegen();
         evaluateRule(rule);
 
@@ -363,7 +357,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void dateArithmetic() {
+    void dateArithmetic() {
         final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
         DateTimeUtils.setCurrentMillisProvider(clock);
         try {
@@ -378,7 +372,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void invalidDateAddition() {
+    void invalidDateAddition() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -389,7 +383,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void issue185() {
+    void issue185() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");
@@ -400,7 +394,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
     }
 
     @Test
-    public void invalidIdentifier() {
+    void invalidIdentifier() {
         try {
             parseRuleWithOptionalCodegen();
             fail("Should have thrown parse exception");

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PrecedenceTest.java
@@ -31,17 +31,18 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.TestMessageFactory;
 import org.graylog2.plugin.Tools;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class PrecedenceTest extends BaseParserTest {
+class PrecedenceTest extends BaseParserTest {
     private MessageFactory messageFactory = new TestMessageFactory();
 
-    @BeforeClass
+    @BeforeAll
     public static void registerFunctions() {
         final Map<String, Function<?>> functions = commonFunctions();
 
@@ -113,9 +114,11 @@ public class PrecedenceTest extends BaseParserTest {
         assertThat(and.right()).isInstanceOf(BooleanExpression.class);
     }
 
-    @Test(expected = ParseException.class)
+    @Test
     public void literalsMustBeQuotedInFieldref() {
-        final Rule rule = parseRule("rule \"test\" when to_string($message.true) == to_string($message.false) then end");
+        assertThatThrownBy(() ->
+                parseRule("rule \"test\" when to_string($message.true) == to_string($message.false) then end")).
+                isInstanceOf(ParseException.class);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20220522125200_AddSetGrokToFieldsExtractorFragmentsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20220522125200_AddSetGrokToFieldsExtractorFragmentsTest.java
@@ -34,8 +34,8 @@ import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.TestMessageFactory;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.SuppressForbidden;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Set;
@@ -45,12 +45,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class V20220522125200_AddSetGrokToFieldsExtractorFragmentsTest extends BaseFragmentTest {
+class V20220522125200_AddSetGrokToFieldsExtractorFragmentsTest extends BaseFragmentTest {
 
     V20220522125200_AddSetGrokToFieldsExtractorFragments migration;
     private final MessageFactory messageFactory = new TestMessageFactory();
 
-    @BeforeClass
+    @BeforeAll
     @SuppressForbidden("Allow using default thread factory")
     public static void initialize() {
         final Map<String, Function<?>> functions = commonFunctions();
@@ -71,7 +71,7 @@ public class V20220522125200_AddSetGrokToFieldsExtractorFragmentsTest extends Ba
 
 
     @Test
-    public void testGrokExtract() {
+    void testGrokExtract() {
         final RuleFragment fragment = V20220522125200_AddSetGrokToFieldsExtractorFragments.createSetGrokToFieldsFragment();
 
         Rule testRule = createFragmentSource(fragment, Map.of(

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230720161500_AddExtractorFragmentsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230720161500_AddExtractorFragmentsTest.java
@@ -35,8 +35,8 @@ import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.TestMessageFactory;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.lookup.LookupResult;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest {
+class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest {
 
 
     private static LookupTableService lookupTableService;
@@ -54,7 +54,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
     private static LookupTable lookupTable;
     private final MessageFactory messageFactory = new TestMessageFactory();
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         final Map<String, Function<?>> functions = commonFunctions();
         functions.put(GetField.NAME, new GetField());
@@ -80,7 +80,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
 
 
     @Test
-    public void testCopyField() {
+    void testCopyField() {
         RuleFragment fragment = V20230720161500_AddExtractorFragments.createCopyFieldExtractor();
         Map<String, Object> params = Map.of("field", "message", "newField", "copyfield");
         Rule rule = super.createFragmentSource(fragment, params);
@@ -89,7 +89,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
     }
 
     @Test
-    public void testRegex() {
+    void testRegex() {
         RuleFragment fragment = V20230720161500_AddExtractorFragments.createRegexExtractor();
         Map<String, Object> params = Map.of("field", "message", "pattern", "^.*(doo...).*$", "newField", "copyfield");
         Rule rule = super.createFragmentSource(fragment, params);
@@ -98,7 +98,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
     }
 
     @Test
-    public void testRegexReplacement() {
+    void testRegexReplacement() {
         RuleFragment fragment = V20230720161500_AddExtractorFragments.createRegexReplacementExtractor();
         Map<String, Object> params = Map.of(
                 "field", "message",
@@ -123,7 +123,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
     }
 
     @Test
-    public void testSplitIndex() {
+    void testSplitIndex() {
         RuleFragment fragment = V20230720161500_AddExtractorFragments.createSplitIndexExtractor();
         Map<String, Object> params = Map.of(
                 "field", "message",
@@ -137,7 +137,7 @@ public class V20230720161500_AddExtractorFragmentsTest extends BaseFragmentTest 
     }
 
     @Test
-    public void testLookup() {
+    void testLookup() {
         RuleFragment fragment = V20230720161500_AddExtractorFragments.createLookupExtractor();
         Map<String, Object> params = Map.of(
                 "field", "message",

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230724092100_AddFieldConditionsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230724092100_AddFieldConditionsTest.java
@@ -63,12 +63,10 @@ import org.graylog2.plugin.TestMessageFactory;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.SuppressForbidden;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -80,15 +78,14 @@ import java.util.concurrent.Executors;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
-public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
+class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
 
     V20230724092100_AddFieldConditions migration;
     private final MessageFactory messageFactory = new TestMessageFactory();
     @Mock
     private RuleFragmentService ruleFragmentService;
 
-    @BeforeClass
+    @BeforeAll
     @SuppressForbidden("Allow using default thread factory")
     public static void initialize() {
         final Map<String, Function<?>> functions = commonFunctions();
@@ -133,13 +130,13 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
         functionRegistry = new FunctionRegistry(functions);
     }
 
-    @Before
+    @BeforeEach
     public void initializeMigration() {
         migration = new V20230724092100_AddFieldConditions(ruleFragmentService);
     }
 
     @Test
-    public void testFieldBoolean() {
+    void testFieldBoolean() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         message.addField("bool", true);
         final RuleFragment fragment = migration.createCheckFieldType("bool");
@@ -162,7 +159,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldCollection() {
+    void testFieldCollection() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("collection");
 
@@ -176,7 +173,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldDouble() {
+    void testFieldDouble() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("double");
 
@@ -196,7 +193,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldDate() {
+    void testFieldDate() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckDateField();
 
@@ -214,7 +211,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldList() {
+    void testFieldList() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("list");
 
@@ -228,7 +225,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldIp() {
+    void testFieldIp() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("ip");
 
@@ -248,7 +245,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldLong() {
+    void testFieldLong() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("long");
 
@@ -268,7 +265,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldMap() {
+    void testFieldMap() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("map");
 
@@ -282,7 +279,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldNotNull() {
+    void testFieldNotNull() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("not_null");
 
@@ -295,7 +292,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldNull() {
+    void testFieldNull() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("null");
 
@@ -308,7 +305,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldNumber() {
+    void testFieldNumber() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("number");
 
@@ -322,7 +319,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldString() {
+    void testFieldString() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("string");
 
@@ -336,7 +333,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldPeriod() {
+    void testFieldPeriod() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldTypeNoConversion("period");
 
@@ -350,7 +347,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldUrl() throws MalformedURLException {
+    void testFieldUrl() throws MalformedURLException {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCheckFieldType("url");
 
@@ -370,7 +367,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldCidr() throws MalformedURLException {
+    void testFieldCidr() throws MalformedURLException {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createCIDRMatchField();
 
@@ -385,7 +382,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldContains() {
+    void testFieldContains() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createStringContainsField();
 
@@ -401,7 +398,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldStartsWith() {
+    void testFieldStartsWith() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createStringStartsWithField();
 
@@ -417,7 +414,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldEndsWith() {
+    void testFieldEndsWith() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createStringEndsWithField();
 
@@ -433,7 +430,7 @@ public class V20230724092100_AddFieldConditionsTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testFieldGrokMatches() {
+    void testFieldGrokMatches() {
         Message message = messageFactory.createMessage("Dummy Message", "test", Tools.nowUTC());
         final RuleFragment fragment = migration.createGrokMatchesField();
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230915095200_AddSimpleRegexTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/db/migrations/V20230915095200_AddSimpleRegexTest.java
@@ -21,14 +21,14 @@ import org.graylog.plugins.pipelineprocessor.functions.strings.RegexMatch;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.parser.BaseFragmentTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class V20230915095200_AddSimpleRegexTest extends BaseFragmentTest {
+class V20230915095200_AddSimpleRegexTest extends BaseFragmentTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void initialize() {
         final Map<String, Function<?>> functions = commonFunctions();
         functions.put(RegexMatch.NAME, new RegexMatch());
@@ -36,7 +36,7 @@ public class V20230915095200_AddSimpleRegexTest extends BaseFragmentTest {
     }
 
     @Test
-    public void testSimpleRegex() {
+    void testSimpleRegex() {
         RuleFragment fragment = V20230915095200_AddSimpleRegex.createSimpleRegex();
         Map<String, Object> params = Map.of("pattern", "^([a-zA-z]+)\\\\s(\\\\d+)$", "value", "Answer 42");
         createFragmentSource(fragment, params);

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/BaseFragmentTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/BaseFragmentTest.java
@@ -26,7 +26,7 @@ import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.plugin.Message;
 import org.graylog2.shared.utilities.StringUtils;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,7 @@ public class BaseFragmentTest extends BaseParserTest {
     private static final Logger log = LoggerFactory.getLogger(BaseFragmentTest.class);
     Configuration configuration;
 
-    @Before
+    @BeforeEach
     public void initializeFreemarkerConfig() {
         SecureFreemarkerConfigProvider secureFreemarkerConfigProvider = new SecureFreemarkerConfigProvider();
         this.configuration = secureFreemarkerConfigProvider.get();


### PR DESCRIPTION
I was experimenting with tests in another PR so I thought I could as well convert the existing tests to Junit 5 while I'm at it.

/nocl
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7270
