### PR TITLE
Extend mock for `IntersectionObserver` with `disconnect` method.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-IntersectionObserver.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-IntersectionObserver.js
@@ -14,10 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-const observe = jest.fn();
-const unobserve = jest.fn();
-
 window.IntersectionObserver = jest.fn(() => ({
-  observe,
-  unobserve,
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
 }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This this PR we are extending the `IntersectionObserver` mock with the `disconnect` method. This is required for testing the `Carousel` component.

/nocl