### PR TITLE
Add new date time format `YYYY-MM-DD HH:mm` for `DateTime` utils.

### DIFF
--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -33,6 +33,7 @@ export const DATE_TIME_FORMATS = {
   internalIndexer: 'YYYY-MM-DDTHH:mm:ss.SSS[Z]', // ISO 8601, used for ES search queries, when a timestamp has to be reformatted
   date: 'YYYY-MM-DD',
   hourAndMinute: 'HH:mm',
+  dateHourAndMinute: 'YYYY-MM-DD HH:mm',
 };
 
 const DEFAULT_OUTPUT_TZ = 'UTC';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a new date time format `YYYY-MM-DD HH:mm` for the `DateTime` utils. `YYYY-MM-DD HH:mm:ss` is the default format in the Ui and we try to limit the amount of date time formats we display, but in some cases the seconds are not that relevant and not displaying them looks cleaner.

/nocl