### PR TITLE
Implement `Messages.search` from `@graylog/server-api` for `useMessage` hook.

### DIFF
--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -117,7 +117,7 @@ const ShowMessagePage = ({ params: { index, messageId } }: Props) => {
   }
 
   const { streams, allStreams } = useStreams();
-  const { data: message } = useMessage(messageId, index);
+  const { data: message } = useMessage(index, messageId);
   const inputs = useInputs(message?.source_input_id, message?.fields.gl2_source_node);
 
   useEffect(() => { NodesActions.list(); }, []);

--- a/graylog2-web-interface/src/views/hooks/useMessage.ts
+++ b/graylog2-web-interface/src/views/hooks/useMessage.ts
@@ -16,13 +16,25 @@
  */
 import { useQuery } from '@tanstack/react-query';
 
-import { MessagesActions } from 'stores/messages/MessagesStore';
 import type { Message } from 'views/components/messagelist/Types';
+import { Messages } from '@graylog/server-api';
+import MessageFormatter from 'logic/message/MessageFormatter';
+import UserNotification from 'preflight/util/UserNotification';
 
-const useMessage = (id: string, index: string, enabled = true): { data: Message | undefined, isInitialLoading: boolean } => {
+const fetchMessage = async (index: string, id: string) => {
+  const message = await Messages.search(index, id);
+
+  return MessageFormatter.formatResultMessage(message);
+};
+
+const useMessage = (index: string, id: string, enabled = true): { data: Message | undefined, isInitialLoading: boolean } => {
   const { data, isInitialLoading } = useQuery({
     queryKey: ['messages', index, id],
-    queryFn: () => MessagesActions.loadMessage(index, id),
+    queryFn: () => fetchMessage(index, id),
+    onError: (error) => {
+      UserNotification.error(`Loading message information failed with status: ${error}`,
+        'Could not load message information');
+    },
     enabled,
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is Implementing `Messages.search` from `@graylog/server-api` for the `useMessage` hook. In a follow-up PR I will replace the remaining usages of `MessagesActions.loadMessage` with the `useMessage` hook.

/nocl
