### PR TITLE
Backport 6.0: Conditionally set authentication cookie sameSite for training instances

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/HttpConfiguration.java
@@ -86,6 +86,12 @@ public class HttpConfiguration {
     @Parameter(value = "http_allow_embedding")
     private boolean httpAllowEmbedding = false;
 
+    @Parameter(value = "http_cookie_secure_override")
+    private boolean httpCookieSecureOverride = false;
+
+    @Parameter(value = "http_cookie_same_site_strict")
+    private boolean httpCookieSameSiteStrict = true;
+
     public HostAndPort getHttpBindAddress() {
         return httpBindAddress
                 .requireBracketsForIPv6()
@@ -212,6 +218,14 @@ public class HttpConfiguration {
 
     public String getHttpTlsKeyPassword() {
         return httpTlsKeyPassword;
+    }
+
+    public boolean getHttpCookieSameSiteStrict() {
+        return httpCookieSameSiteStrict;
+    }
+
+    public boolean getHttpCookieSecureOverride() {
+        return httpCookieSecureOverride;
     }
 
     public URI getHttpExternalUri() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/CookieFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/CookieFactory.java
@@ -40,10 +40,14 @@ public class CookieFactory {
     private static final String HEADER_X_FORWARDED_PROTO = "X-Forwarded-Proto";
     private static final CharMatcher PATH_MATCHER = ascii().and(isNot(';')).and(javaIsoControl().negate());
     private final URI httpExternalUri;
+    private final boolean httpCookieSecureOverride;
+    private final boolean httpCookieSameSiteStrict;
 
     @Inject
     public CookieFactory(HttpConfiguration httpConfiguration) {
         httpExternalUri = httpConfiguration.getHttpExternalUri();
+        httpCookieSecureOverride = httpConfiguration.getHttpCookieSecureOverride();
+        httpCookieSameSiteStrict = httpConfiguration.getHttpCookieSameSiteStrict();
     }
 
     NewCookie createAuthenticationCookie(SessionResponse token, ContainerRequestContext requestContext) {
@@ -70,9 +74,9 @@ public class CookieFactory {
                 .path(basePath)
                 .maxAge(maxAge)
                 .expiry(validUntil)
-                .secure(isSecure)
+                .secure(isSecure || httpCookieSecureOverride)
                 .httpOnly(true)
-                .sameSite(NewCookie.SameSite.STRICT)
+                .sameSite(httpCookieSameSiteStrict ? NewCookie.SameSite.STRICT : NewCookie.SameSite.NONE)
                 .build();
     }
 


### PR DESCRIPTION
* Conditionally set authentication cookie sameSite value based on config values

backport #19356 to 6.0 so Training/ProServe can have it in a stable build.
/nocl
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

