### PR TITLE
fix: Removed custom style on MD Preview

### DIFF
--- a/graylog2-web-interface/src/components/common/MarkdownEditor/Preview.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/Preview.tsx
@@ -61,37 +61,6 @@ const MarkdownStyles = styled.div`
       margin-bottom: 8px;
     }
 
-    & > hr {
-      margin: 16px 0;
-      border: none;
-      border-bottom: 1px solid ${({ theme }) => theme.colors.brand.tertiary};
-    }
-
-    & > h1 {
-      font-size: 5cqw;
-      font-weight: bold;
-    }
-
-    & > h2 {
-      font-size: 4cqw;
-      font-weight: normal;
-    }
-
-    & > h3 {
-      font-size: 3.5cqw;
-      font-weight: bold;
-    }
-
-    & > h4 {
-      font-size: 3.5cqw;
-      font-weight: normal;
-    }
-
-    & > h5, & > h6 {
-      font-size: 3cqw;
-      font-weight: normal;
-    }
-
     & ul, & ol {
       padding-left: 1.5rem;
       margin: 8px 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Small CSS fix to fix issue with too big titles on remediation steps

/nocl

## Description
<!--- Describe your changes in detail -->
MD Preview component had custom font styling. This PR removes the custom styling, so the component uses the app styles instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

