### PR TITLE
Disable sigma event definition duplicate and delete options

### DIFF
--- a/changelog/unreleased/pr-19404.toml
+++ b/changelog/unreleased/pr-19404.toml
@@ -1,0 +1,8 @@
+type = "f"
+message = "Removed `Delete` and `Duplicate` options for Sigma event definitions."
+
+pulls = ["19404"]
+
+details.user = """
+Sigma event definitions are automatically deleted or duplicated when their parent Sigma rule is deleted or duplicated.
+"""

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -98,6 +98,18 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
 
   const isSigmaEventDefinition = (): boolean => eventDefinition?.config?.type === 'sigma-v1';
 
+  const getDeleteActionTitle = () => {
+    if (isSystemEventDefinition()) {
+      return 'System Event Definition cannot be deleted';
+    }
+
+    if (isSigmaEventDefinition()) {
+      return 'Sigma Rules must be deleted from the Sigma Rules page';
+    }
+
+    return undefined;
+  };
+
   const pluggableSigmaModal = usePluginEntities('eventDefinitions.components.editSigmaModal')
     .find((entity: { key: string }) => entity.key === 'coreSigmaModal');
 
@@ -260,9 +272,7 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
             <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
               <MenuItem divider />
               <MenuItem disabled={isSystemEventDefinition() || isSigmaEventDefinition()}
-                        title={isSystemEventDefinition() ? 'System Event Definition cannot be deleted'
-                          : isSigmaEventDefinition() ? 'Sigma Rules must be deleted from the Sigma Rules page'
-                            : undefined}
+                        title={getDeleteActionTitle()}
                         onClick={isSystemEventDefinition() || isSigmaEventDefinition() ? undefined : () => handleAction(DIALOG_TYPES.DELETE, eventDefinition)}
                         data-testid="delete-button">Delete
               </MenuItem>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -96,6 +96,8 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
 
   const isAggregationEventDefinition = (): boolean => eventDefinition?.config?.type === 'aggregation-v1';
 
+  const isSigmaEventDefinition = (): boolean => eventDefinition?.config?.type === 'sigma-v1';
+
   const pluggableSigmaModal = usePluginEntities('eventDefinitions.components.editSigmaModal')
     .find((entity: { key: string }) => entity.key === 'coreSigmaModal');
 
@@ -217,7 +219,7 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
   };
 
   const onEditEventDefinition = () => {
-    if (eventDefinition.config.type === 'sigma-v1') {
+    if (isSigmaEventDefinition()) {
       setShowSigmaModal(true);
     } else {
       navigate(Routes.ALERTS.DEFINITIONS.edit(eventDefinition.id));
@@ -244,7 +246,7 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
               Edit
             </MenuItem>
           </IfPermitted>
-          {!isSystemEventDefinition() && (
+          {!isSystemEventDefinition() && !isSigmaEventDefinition() && (
             <MenuItem onClick={() => handleAction(DIALOG_TYPES.COPY, eventDefinition)}>Duplicate</MenuItem>
           )}
           <MenuItem divider />
@@ -257,9 +259,11 @@ const EventDefinitionActions = ({ eventDefinition, refetchEventDefinitions }: Pr
           {showActions() && (
             <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
               <MenuItem divider />
-              <MenuItem disabled={isSystemEventDefinition()}
-                        title={isSystemEventDefinition() ? 'System Event Definition cannot be deleted' : undefined}
-                        onClick={isSystemEventDefinition() ? undefined : () => handleAction(DIALOG_TYPES.DELETE, eventDefinition)}
+              <MenuItem disabled={isSystemEventDefinition() || isSigmaEventDefinition()}
+                        title={isSystemEventDefinition() ? 'System Event Definition cannot be deleted'
+                          : isSigmaEventDefinition() ? 'Sigma Rules must be deleted from the Sigma Rules page'
+                            : undefined}
+                        onClick={isSystemEventDefinition() || isSigmaEventDefinition() ? undefined : () => handleAction(DIALOG_TYPES.DELETE, eventDefinition)}
                         data-testid="delete-button">Delete
               </MenuItem>
             </IfPermitted>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes `Duplicate` and disables `Delete` action menu options for sigma event definitions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Deleting or duplicating a sigma event definition from the event definition UI does not delete or copy the parent sigma rule, causing confusion and unexpected results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

