### PR TITLE
Fix selecting option in more results select on pipeline simulator page. (`6.0`)

### DIFF
--- a/changelog/unreleased/issue-18932.toml
+++ b/changelog/unreleased/issue-18932.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fix selecting option in more results select on pipeline simulator page."
+
+issues=["18932"]
+pulls=["19413"]

--- a/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
@@ -66,7 +66,7 @@ class SimulationResults extends React.Component {
     const { viewOption } = this.state;
 
     return (
-      <MenuItem key={option} eventKey={option} active={viewOption === option}>
+      <MenuItem key={option} onSelect={() => this._changeViewOptions(option)} active={viewOption === option}>
         {text}
       </MenuItem>
     );
@@ -148,7 +148,6 @@ class SimulationResults extends React.Component {
           <div className="pull-right">
             <DropdownButton id="simulation-view-options"
                             title="More results"
-                            onSelect={this._changeViewOptions}
                             bsStyle="default"
                             bsSize="small"
                             pullRight>


### PR DESCRIPTION
Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/19413 for `6.0`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is fixing the problem described in https://github.com/Graylog2/graylog2-server/issues/18932.

The issue is related to the refactoring we did for the `Menu` component. The `Menu` no longer supports the `onSelect` prop. This is the only case where we made use of it.