### PR TITLE
IT Test fix: setting the timeout after setting the waiting strategy

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -145,10 +145,9 @@ public class NodeContainerFactory {
 
                 .withEnv("GRAYLOG_ENABLE_DEBUG_RESOURCES", "true") // see RestResourcesModule#addDebugResources
                 .withEnv(config.configParams)
-                .withExposedPorts(config.portsToExpose())
-                .withStartupTimeout(Duration.of(600, SECONDS));
+                .withExposedPorts(config.portsToExpose());
 
-        container.waitingFor(getWaitStrategy(container.getEnvMap()));
+        container.waitingFor(getWaitStrategy(container.getEnvMap())).withStartupTimeout(Duration.of(600, SECONDS));
 
         if (!includeFrontend) {
             container.withEnv("DEVELOPMENT", "true");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`container.withStartupTimeout()` works (according to the code) by retrieving the waiting strategy and setting the timeout on the resulting object. If we set another waiting strategy  later (as we do before this fix), I am of the opinion, that the timeout falls back to the default - which is probably 30sec and makes sometimes fail the startup.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

