### PR TITLE
Add util to download binary files

### DIFF
--- a/graylog2-web-interface/src/util/FileDownloadUtils.ts
+++ b/graylog2-web-interface/src/util/FileDownloadUtils.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import { fetchFile } from 'logic/rest/FetchProvider';
+import { fetchBlobFile, fetchFile } from 'logic/rest/FetchProvider';
 import UserNotification from 'preflight/util/UserNotification';
 
 export const createLinkAndDownload = (href: string, fileName: string) => {
@@ -40,8 +40,14 @@ export const downloadBLOB = (contents: BlobPart, metadata: { fileName: string, c
   createLinkAndDownload(href, metadata.fileName);
 };
 
-export const fetchFileWithBlob = async <Body>(method: string, url: string, body: Body | undefined, mimeType: string, fileName: string) => fetchFile(method, url, body, mimeType)
-  .then((result) => downloadBLOB(result, { fileName, contentType: mimeType }))
-  .catch((errorThrown) => {
-    UserNotification.error(`Downloading failed with status: ${errorThrown}`, 'Unable to download');
-  });
+const errorHandler = (errorThrown: Error) => {
+  UserNotification.error(`Downloading failed with status: ${errorThrown}`, 'Unable to download');
+};
+
+export const fetchTextFile = async <Body>(method: string, url: string, body: Body | undefined, mimeType: string, fileName: string) => fetchFile(method, url, body, mimeType)
+  .then((result: string) => downloadBLOB(result, { fileName, contentType: mimeType }))
+  .catch(errorHandler);
+
+export const fetchBinaryFile = async <Body>(method: string, url: string, body: Body | undefined, mimeType: string, fileName: string) => fetchBlobFile(method, url, body, mimeType)
+  .then((result: Blob) => downloadBLOB(result, { fileName, contentType: mimeType }))
+  .catch(errorHandler);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds utils to download binary files. In this case, we are using `response.blob() ` method instead of `response.text()` to represent response data in correct binary format 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/jenkins-pr-deps https://github.com/Graylog2/graylog-plugin-enterprise/pull/7355
/nocl