### PR TITLE
Fetch only fields needed by export

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
@@ -124,7 +124,8 @@ public class ElasticsearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize());
+                .size(command.chunkSize())
+                .fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
@@ -124,8 +124,10 @@ public class ElasticsearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize())
-                .fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
+                .size(command.chunkSize());
+        if (!command.fieldsInOrder().equals(ExportMessagesCommand.ALL_FIELDS)) {
+            ssb = ssb.fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
+        }
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackend.java
@@ -125,7 +125,7 @@ public class ElasticsearchExportBackend implements ExportBackend {
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
                 .size(command.chunkSize());
-        if (!command.fieldsInOrder().equals(ExportMessagesCommand.ALL_FIELDS)) {
+        if (!command.exportAllFields()) {
             ssb = ssb.fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
         }
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/export/ElasticsearchExportBackendIT.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.elasticsearch7.views.export;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.annotation.Nonnull;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.export.ExportException;
@@ -32,7 +33,6 @@ import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import jakarta.annotation.Nonnull;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
@@ -194,11 +194,11 @@ public class ElasticsearchExportBackendIT extends ElasticsearchBaseTest {
     }
 
     @Test
-    public void resultsHaveAllMessageFields() {
+    public void resultsHaveAllMessageFieldsIfFieldsHaveNotBeenExplicitlyChosen() {
         importFixture("messages.json");
 
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams()
-                .fieldsInOrder("timestamp", "message")
+                .fieldsInOrder(ExportMessagesCommand.ALL_FIELDS)
                 .build();
 
         LinkedHashSet<SimpleMessageChunk> allChunks = helper.collectChunksFor(command);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
@@ -124,8 +124,10 @@ public class OpenSearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize())
-                .fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
+                .size(command.chunkSize());
+        if (!command.fieldsInOrder().equals(ExportMessagesCommand.ALL_FIELDS)) {
+            ssb = ssb.fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
+        }
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
@@ -124,7 +124,8 @@ public class OpenSearchExportBackend implements ExportBackend {
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(command.chunkSize());
+                .size(command.chunkSize())
+                .fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
 
         return requestStrategy.configure(ssb);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackend.java
@@ -125,7 +125,7 @@ public class OpenSearchExportBackend implements ExportBackend {
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
                 .size(command.chunkSize());
-        if (!command.fieldsInOrder().equals(ExportMessagesCommand.ALL_FIELDS)) {
+        if (!command.exportAllFields()) {
             ssb = ssb.fetchSource(command.fieldsInOrder().toArray(new String[]{}), null);
         }
 

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackendIT.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/export/OpenSearchExportBackendIT.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.opensearch2.views.export;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.annotation.Nonnull;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.export.ExportException;
@@ -32,7 +33,6 @@ import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import jakarta.annotation.Nonnull;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
@@ -192,11 +192,11 @@ public class OpenSearchExportBackendIT extends ElasticsearchBaseTest {
     }
 
     @Test
-    public void resultsHaveAllMessageFields() {
+    public void resultsHaveAllMessageFieldsIfFieldsHaveNotBeenExplicitlyChosen() {
         importFixture("messages.json");
 
         ExportMessagesCommand command = helper.commandBuilderWithAllTestDefaultStreams()
-                .fieldsInOrder("timestamp", "message")
+                .fieldsInOrder(ExportMessagesCommand.ALL_FIELDS)
                 .build();
 
         LinkedHashSet<SimpleMessageChunk> allChunks = helper.collectChunksFor(command);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -54,6 +54,10 @@ public abstract class ExportMessagesCommand {
         }
     }
 
+    public boolean exportAllFields() {
+        return fieldsInOrder().isEmpty();
+    }
+
     public abstract AbsoluteRange timeRange();
 
     public abstract ElasticsearchQueryString queryString();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -40,6 +40,8 @@ public abstract class ExportMessagesCommand {
     public static final ElasticsearchQueryString DEFAULT_QUERY = ElasticsearchQueryString.empty();
     public static final Set<String> DEFAULT_STREAMS = ImmutableSet.of();
     public static final LinkedHashSet<String> DEFAULT_FIELDS = linkedHashSetOf("timestamp", "source", "message");
+
+    public static final LinkedHashSet<String> ALL_FIELDS = new LinkedHashSet<>();
     public static final int DEFAULT_CHUNK_SIZE = 1000;
     public static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 


### PR DESCRIPTION
Fetch only fields needed by export.
/nocl

## Motivation and Context
Performance - do not get what you don't need from the search engine.
Maybe be useful for future development of [#5616.](https://github.com/Graylog2/graylog-plugin-enterprise/issues/5616)

## How Has This Been Tested?
Manually and with existing tests re-run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

