### PR TITLE
string_array_add pipeline function: Add handling for null elements argument

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/StringArrayAdd.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/arrays/StringArrayAdd.java
@@ -65,7 +65,7 @@ public class StringArrayAdd extends AbstractFunction<List<String>> {
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
         }
-        return Collections.singletonList(value.toString());
+        return value == null ? Collections.emptyList() : Collections.singletonList(value.toString());
     }
 
     private static String convertValue(Object o) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1694,6 +1694,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("add_array_to_array_empty_value")).isEqualTo(List.of("one", "two"));
             assertThat(message.getField("combined_json_array")).isEqualTo(List.of("Administrator", "Administrator", "Administrator", "Administrator", "user01"));
             assertThat(message.getField("mixed_types_json_array")).isEqualTo(List.of("text"));
+            assertThat(message.getField("add_value_to_null_array")).isEqualTo(List.of("test"));
+            assertThat(message.getField("add_null_to_array")).isEqualTo(List.of("test"));
         }
     }
 

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/stringArrayAdd.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/stringArrayAdd.txt
@@ -14,6 +14,8 @@ then
     set_field("add_array_to_array", string_array_add(["one", "two"], ["three", "four"]));
     set_field("add_array_to_array_empty_source", string_array_add([], ["three", "four"]));
     set_field("add_array_to_array_empty_value", string_array_add(["one", "two"], []));
+    set_field("add_value_to_null_array", string_array_add($message.null_field, ["test"]));
+    set_field("add_null_to_array", string_array_add(["test"], $message.null_field));
 
     let json = parse_json(to_string($message.json_with_arrays));
         let selectedPath = select_jsonpath(json: json,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add handling for condition when the `elements` `string_array_add` pipeline function receives a null value, such as when `$message.field_does_not_exist` is passed to it.

Now, the function correctly returns the supplied `value`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/7262

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To manually test this create a pipeline rule with the following rule (supplying the function a null value), and use the Rule simulator below, to ensure that the correct `[ "test1", "test2" ]` value is returned, and that the error mentioned in the issue does not 

> occur.

```
rule "test"
when
    true
then
    let t = string_array_add (
        elements: $message.null_field,
        value: [ "test1", "test2" ]
        );
        
    set_field ( field: "_test", value: t );
end
```

![image](https://github.com/Graylog2/graylog2-server/assets/3423655/a06f6535-89c8-4b48-914c-36709a756fe2)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

