### PR TITLE
Require `title` for `IconButton`.

### DIFF
--- a/graylog2-web-interface/src/components/common/IconButton.tsx
+++ b/graylog2-web-interface/src/components/common/IconButton.tsx
@@ -44,7 +44,7 @@ const Wrapper = styled.button<{ disabled: boolean }>(({ theme, disabled }) => cs
 
 type Props = {
   focusable?: boolean,
-  title?: string,
+  title: string,
   onClick?: () => void,
   className?: string,
   name: IconName,
@@ -54,7 +54,7 @@ type Props = {
   'data-testid'?: string
 };
 
-const handleClick = (onClick) => {
+const handleClick = (onClick: () => void | undefined) => {
   if (typeof onClick === 'function') {
     onClick();
   }
@@ -74,6 +74,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
            tabIndex={focusable ? 0 : -1}
            data-testid={dataTestId}
            title={title}
+           aria-label={title}
            onClick={() => handleClick(onClick)}
            className={className}
            type="button"
@@ -84,7 +85,6 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
 
 IconButton.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.string,
   onClick: PropTypes.func,
   name: PropTypes.any,
 };
@@ -93,7 +93,6 @@ IconButton.defaultProps = {
   className: undefined,
   focusable: true,
   onClick: undefined,
-  title: undefined,
   name: undefined,
   disabled: false,
   rotation: undefined,

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
@@ -297,6 +297,7 @@ const CollectorsAdministration = ({
             {(configAssignments.length > 0)
               && (
               <IconButton name="edit_square"
+                          title="Edit configuration"
                           onClick={() => {
                             setSelected([collectorId]);
                             setShowConfigurationModal(true);

--- a/graylog2-web-interface/src/views/components/searchbar/QueryHistoryButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryHistoryButton.tsx
@@ -71,7 +71,7 @@ const QueryHistoryButton = ({ editorRef }: Props) => {
 
   return (
     <ButtonContainer>
-      <IconButton name="history" onClick={showQueryHistory} />
+      <IconButton name="history" onClick={showQueryHistory} title="Open query history" />
     </ButtonContainer>
   );
 };

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.tsx
@@ -72,7 +72,12 @@ const HighlightingRules = () => {
         Any field value can be highlighted by clicking on the value and selecting &quot;Highlight this value&quot;.
         If a term or a value has more than one rule, the first matching rule is used.
       </SectionInfo>
-      <SectionSubheadline>Active highlights <IconButton className="pull-right" name="add" onClick={() => setShowForm(!showForm)} /> </SectionSubheadline>
+      <SectionSubheadline>
+        Active highlights <IconButton className="pull-right"
+                                      name="add"
+                                      onClick={() => setShowForm(!showForm)}
+                                      title="Add highlighting rule" />
+      </SectionSubheadline>
       {showForm && <HighlightForm onClose={() => setShowForm(false)} />}
       <Container $displayBorder={!!rulesWithId?.length}>
         <ColorPreview color={DEFAULT_HIGHLIGHT_COLOR} />

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { asElement, render } from 'wrappedTestingLibrary';
+import { asElement, render, screen } from 'wrappedTestingLibrary';
 
 import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
@@ -29,36 +29,36 @@ type OptionalOverrides = {
 };
 
 describe('ReplaySearchButton', () => {
-  it('renders play button', () => {
-    const { getByTitle } = render(<ReplaySearchButton />);
+  it('renders play button', async () => {
+    render(<ReplaySearchButton />);
 
-    expect(getByTitle('Replay search')).not.toBeNull();
+    await screen.findByRole('link', { name: /replay search/i });
   });
 
   describe('generates link', () => {
-    const renderWithContext = ({ query, timerange, streams }: OptionalOverrides = {}) => {
-      const { getByTitle } = render(<ReplaySearchButton queryString={query?.query_string}
-                                                        timerange={timerange}
-                                                        streams={streams} />);
+    const renderWithContext = async ({ query, timerange, streams }: OptionalOverrides = {}) => {
+      render(<ReplaySearchButton queryString={query?.query_string}
+                                 timerange={timerange}
+                                 streams={streams} />);
 
-      return asElement(getByTitle('Replay search'), HTMLAnchorElement);
+      return asElement(await screen.findByRole('link', { name: /replay search/i }), HTMLAnchorElement);
     };
 
-    it('opening in a new page', () => {
-      const button = renderWithContext();
+    it('opening in a new page', async () => {
+      const button = await renderWithContext();
 
       expect(button.target).toEqual('_blank');
       expect(button.rel).toEqual('noopener noreferrer');
     });
 
-    it('including query string', () => {
-      const button = renderWithContext({ query: createElasticsearchQueryString('_exists_:nf_version') });
+    it('including query string', async () => {
+      const button = await renderWithContext({ query: createElasticsearchQueryString('_exists_:nf_version') });
 
       expect(button.href).toContain('q=_exists_%3Anf_version');
     });
 
-    it('including timerange', () => {
-      const button = renderWithContext({
+    it('including timerange', async () => {
+      const button = await renderWithContext({
         timerange: {
           type: 'absolute',
           from: '2020-01-10T13:23:42.000Z',
@@ -69,8 +69,8 @@ describe('ReplaySearchButton', () => {
       expect(button.href).toContain('rangetype=absolute&from=2020-01-10T13%3A23%3A42.000Z&to=2020-01-10T14%3A23%3A42.000Z');
     });
 
-    it('including streams', () => {
-      const button = renderWithContext({ streams: ['stream1', 'stream2', 'someotherstream'] });
+    it('including streams', async () => {
+      const button = await renderWithContext({ streams: ['stream1', 'stream2', 'someotherstream'] });
 
       expect(button.href).toContain('streams=stream1%2Cstream2%2Csomeotherstream');
     });

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -66,13 +66,17 @@ const buildSearchLink = (
   return searchLink;
 };
 
-export const ReplaySearchButtonComponent = ({ searchLink, children, onClick }: { children?: React.ReactNode, searchLink: string, onClick?: () => void }) => (
-  <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search" onClick={onClick}>
-    {children
-      ? <>{children} <StyledIcon name="play_arrow" /></>
-      : <IconButton name="play_arrow" focusable={false} />}
-  </NeutralLink>
-);
+export const ReplaySearchButtonComponent = ({ searchLink, children, onClick }: { children?: React.ReactNode, searchLink: string, onClick?: () => void }) => {
+  const title = 'Replay search';
+
+  return (
+    <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
+      {children
+        ? <>{children} <StyledIcon name="play_arrow" /></>
+        : <IconButton name="play_arrow" focusable={false} title={title} />}
+    </NeutralLink>
+  );
+};
 
 type Props = {
   queryString?: string | undefined,
@@ -93,7 +97,11 @@ const ReplaySearchButton = ({ queryString, timerange, streams, parameters, child
     }
   }, [sessionId, parameters, parameterBindings]);
 
-  return <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch}>{children}</ReplaySearchButtonComponent>;
+  return (
+    <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch}>
+      {children}
+    </ReplaySearchButtonComponent>
+  );
 };
 
 ReplaySearchButton.defaultProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are requiring the `title` prop for the `IconButton` component. The component just renders a button with an icon and should always have a title. I only found one case where it is wrapped with a link, which already has a title. In this case the `IconButton` does not need a title, but in my opinion it still makes sense to require the title in general.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7376
/nocl