### PR TITLE
Add container for `Spinner` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Spinner.tsx
+++ b/graylog2-web-interface/src/components/common/Spinner.tsx
@@ -23,8 +23,13 @@ import type { IconName } from 'components/common/Icon';
 import Icon from './Icon';
 import Delayed from './Delayed';
 
+const Container = styled.div`
+  display: inline-flex;
+  align-items: center;
+  vertical-align: baseline;
+`;
+
 const StyledIcon = styled(Icon)<{ $displayMargin: boolean }>(({ $displayMargin }) => css`
-  vertical-align: bottom;
   ${$displayMargin ? 'margin-right: 6px;' : ''}
 `);
 
@@ -39,7 +44,9 @@ type Props = {
  */
 const Spinner = ({ name, text, delay, ...rest }: Props) => (
   <Delayed delay={delay}>
-    <StyledIcon {...rest} name={name} $displayMargin={!!text?.trim()} spin />{text}
+    <Container>
+      <StyledIcon {...rest} name={name} $displayMargin={!!text?.trim()} spin />{text}
+    </Container>
   </Delayed>
 );
 

--- a/graylog2-web-interface/src/components/common/Spinner.tsx
+++ b/graylog2-web-interface/src/components/common/Spinner.tsx
@@ -23,7 +23,7 @@ import type { IconName } from 'components/common/Icon';
 import Icon from './Icon';
 import Delayed from './Delayed';
 
-const Container = styled.div`
+const Container = styled.span`
   display: inline-flex;
   align-items: center;
   vertical-align: baseline;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a container for the `Spinner` component. This makes the component a bit more independent of the parent element styling.

I noticed one case which previously looked like this, because of the parent element styling:
![spinner](https://github.com/Graylog2/graylog2-server/assets/46300478/72351465-8fef-4eb6-b3fc-2673ba1dc0d5)

Now it looks like this:
<img width="138" alt="image" src="https://github.com/Graylog2/graylog2-server/assets/46300478/d69ec962-4863-4a12-93d0-30414be3f585">


/nocl
