### PR TITLE
Units are stored in views

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetConfigDTO.java
@@ -20,4 +20,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 @JsonAutoDetect
 public interface WidgetConfigDTO {
+
+    String UNIT_SETTINGS_PROPERTY = "units";
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/units/WithConfigurableUnits.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/units/WithConfigurableUnits.java
@@ -16,10 +16,16 @@
  */
 package org.graylog.plugins.views.search.views.units;
 
+import org.graylog.plugins.formatting.units.model.UnitId;
+
+import java.util.Map;
+
 /**
- * Marker interface for those implementations of {@link org.graylog.plugins.views.search.views.WidgetConfigDTO},
+ * Interface for those implementations of {@link org.graylog.plugins.views.search.views.WidgetConfigDTO},
  * where customizing/configuring per field unit setting is supported.
  */
 public interface WithConfigurableUnits {
     String UNIT_SETTINGS_PROPERTY = "units";
+
+    Map<String, UnitId> unitSettings();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/units/WithConfigurableUnits.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/units/WithConfigurableUnits.java
@@ -14,11 +14,12 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.plugins.views.search.views;
+package org.graylog.plugins.views.search.views.units;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-
-@JsonAutoDetect
-public interface WidgetConfigDTO {
-
+/**
+ * Marker interface for those implementations of {@link org.graylog.plugins.views.search.views.WidgetConfigDTO},
+ * where customizing/configuring per field unit setting is supported.
+ */
+public interface WithConfigurableUnits {
+    String UNIT_SETTINGS_PROPERTY = "units";
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
@@ -54,6 +54,7 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO, WithConfi
     @JsonProperty(FIELD_ROW_PIVOTS)
     public abstract List<PivotDTO> rowPivots();
 
+    @Override
     @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
@@ -23,11 +23,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SortConfigDTO;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -50,6 +52,9 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
 
     @JsonProperty(FIELD_ROW_PIVOTS)
     public abstract List<PivotDTO> rowPivots();
+
+    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    public abstract Map<String, UnitId> unitSettings();
 
     @JsonProperty(FIELD_COLUMN_PIVOTS)
     public abstract List<PivotDTO> columnPivots();
@@ -109,6 +114,9 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
     public static abstract class Builder {
         @JsonProperty(FIELD_ROW_PIVOTS)
         public abstract Builder rowPivots(List<PivotDTO> rowPivots);
+
+        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
 
         abstract List<PivotDTO> rowPivots();
 
@@ -179,6 +187,7 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
         @JsonCreator
         public static Builder builder() {
             return new AutoValue_AggregationConfigDTO.Builder()
+                    .unitSettings(Map.of())
                     .eventAnnotation(false)
                     .rollup(true);
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
+import org.graylog.plugins.views.search.views.units.WithConfigurableUnits;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SortConfigDTO;
 
 import javax.annotation.Nullable;
@@ -36,7 +37,7 @@ import java.util.OptionalInt;
 @AutoValue
 @JsonTypeName(AggregationConfigDTO.NAME)
 @JsonDeserialize(builder = AggregationConfigDTO.Builder.class)
-public abstract class AggregationConfigDTO implements WidgetConfigDTO {
+public abstract class AggregationConfigDTO implements WidgetConfigDTO, WithConfigurableUnits {
     public static final String NAME = "aggregation";
     private static final String FIELD_ROW_PIVOTS = "row_pivots";
     private static final String FIELD_COLUMN_PIVOTS = "column_pivots";
@@ -53,7 +54,7 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
     @JsonProperty(FIELD_ROW_PIVOTS)
     public abstract List<PivotDTO> rowPivots();
 
-    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 
     @JsonProperty(FIELD_COLUMN_PIVOTS)
@@ -115,7 +116,7 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_ROW_PIVOTS)
         public abstract Builder rowPivots(List<PivotDTO> rowPivots);
 
-        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        @JsonProperty(UNIT_SETTINGS_PROPERTY)
         public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
 
         abstract List<PivotDTO> rowPivots();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
+import org.graylog.plugins.views.search.views.units.WithConfigurableUnits;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,7 @@ import java.util.Set;
 @AutoValue
 @JsonTypeName(EventsWidgetConfigDTO.NAME)
 @JsonDeserialize(builder = EventsWidgetConfigDTO.Builder.class)
-public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
+public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO, WithConfigurableUnits {
     public static final String NAME = "events";
 
     public enum Direction {
@@ -62,7 +63,7 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
     @JsonProperty(FIELD_FIELDS)
     public abstract Set<String> fields();
 
-    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 
     @JsonProperty(FIELD_FILTERS)
@@ -79,7 +80,7 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_FIELDS)
         public abstract Builder fields(Set<String> fields);
 
-        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        @JsonProperty(UNIT_SETTINGS_PROPERTY)
         public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
 
         @JsonProperty(FIELD_FILTERS)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
@@ -21,9 +21,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @AutoValue
@@ -60,6 +62,9 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
     @JsonProperty(FIELD_FIELDS)
     public abstract Set<String> fields();
 
+    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    public abstract Map<String, UnitId> unitSettings();
+
     @JsonProperty(FIELD_FILTERS)
     public abstract List<Filter> filters();
 
@@ -74,6 +79,9 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_FIELDS)
         public abstract Builder fields(Set<String> fields);
 
+        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
+
         @JsonProperty(FIELD_FILTERS)
         public abstract Builder filters(List<Filter> filters);
 
@@ -86,6 +94,7 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO {
         public static Builder builder() {
             return new AutoValue_EventsWidgetConfigDTO.Builder()
                     .mode(Mode.List)
+                    .unitSettings(Map.of())
                     .fields(Set.of())
                     .filters(List.of());
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/events/EventsWidgetConfigDTO.java
@@ -63,6 +63,7 @@ public abstract class EventsWidgetConfigDTO implements WidgetConfigDTO, WithConf
     @JsonProperty(FIELD_FIELDS)
     public abstract Set<String> fields();
 
+    @Override
     @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
+import org.graylog.plugins.views.search.views.units.WithConfigurableUnits;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SortConfigDTO;
 import org.graylog2.decorators.Decorator;
 import org.graylog2.decorators.DecoratorImpl;
@@ -37,7 +38,7 @@ import java.util.Map;
 @AutoValue
 @JsonTypeName(MessageListConfigDTO.NAME)
 @JsonDeserialize(builder = MessageListConfigDTO.Builder.class)
-public abstract class MessageListConfigDTO implements WidgetConfigDTO {
+public abstract class MessageListConfigDTO implements WidgetConfigDTO, WithConfigurableUnits {
     public static final String NAME = "messages";
     private static final String FIELD_FIELDS = "fields";
     private static final String FIELD_SHOW_MESSAGE_ROW = "show_message_row";
@@ -48,7 +49,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
     @JsonProperty(FIELD_FIELDS)
     public abstract ImmutableSet<String> fields();
 
-    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 
     @JsonProperty(FIELD_SHOW_MESSAGE_ROW)
@@ -69,7 +70,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_FIELDS)
         public abstract Builder fields(ImmutableSet<String> fields);
 
-        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        @JsonProperty(UNIT_SETTINGS_PROPERTY)
         public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
 
         @JsonProperty(FIELD_SHOW_MESSAGE_ROW)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
@@ -49,6 +49,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO, WithConfi
     @JsonProperty(FIELD_FIELDS)
     public abstract ImmutableSet<String> fields();
 
+    @Override
     @JsonProperty(UNIT_SETTINGS_PROPERTY)
     public abstract Map<String, UnitId> unitSettings();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/messagelist/MessageListConfigDTO.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.formatting.units.model.UnitId;
 import org.graylog.plugins.views.search.views.WidgetConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SortConfigDTO;
 import org.graylog2.decorators.Decorator;
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @AutoValue
 @JsonTypeName(MessageListConfigDTO.NAME)
@@ -45,6 +47,9 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
 
     @JsonProperty(FIELD_FIELDS)
     public abstract ImmutableSet<String> fields();
+
+    @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+    public abstract Map<String, UnitId> unitSettings();
 
     @JsonProperty(FIELD_SHOW_MESSAGE_ROW)
     public abstract boolean showMessageRow();
@@ -63,6 +68,9 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
     public abstract static class Builder {
         @JsonProperty(FIELD_FIELDS)
         public abstract Builder fields(ImmutableSet<String> fields);
+
+        @JsonProperty(WidgetConfigDTO.UNIT_SETTINGS_PROPERTY)
+        public abstract Builder unitSettings(Map<String, UnitId> unitSettings);
 
         @JsonProperty(FIELD_SHOW_MESSAGE_ROW)
         public abstract Builder showMessageRow(boolean showMessageRow);
@@ -85,6 +93,7 @@ public abstract class MessageListConfigDTO implements WidgetConfigDTO {
         @JsonCreator
         public static Builder builder() {
             return new AutoValue_MessageListConfigDTO.Builder()
+                    .unitSettings(Map.of())
                     .decorators(Collections.emptyList())
                     .sort(Collections.emptyList());
         }


### PR DESCRIPTION
## Description
Units are stored in views.
/jpd Graylog2/graylog-plugin-enterprise#7379
/nocl

## Motivation and Context
It was decided that we do not want to store units in searches, but in views instead. This PR covers that : https://github.com/Graylog2/graylog2-server/pull/19458
It was identified that units are a feature of fields, not metrics.
Even if FE uses units on the metric level, they have to be stored as a field->unit mapping.

![image](https://github.com/Graylog2/graylog2-server/assets/100699120/2577c5c8-c7c4-49ec-90d2-93eef6549246)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

