### PR TITLE
Fix conflicting static import of ImmutableSet#of

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -51,7 +51,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.toSet;
 
@@ -154,7 +153,7 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
     public abstract Builder toBuilder();
 
     public static Builder builder() {
-        return Builder.create().parameters(of()).queries(ImmutableSet.<Query>builder().build());
+        return Builder.create().parameters(ImmutableSet.of()).queries(ImmutableSet.<Query>builder().build());
     }
 
     public Set<String> usedStreamIds() {
@@ -222,7 +221,7 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
             return new AutoValue_Search.Builder()
                     .requires(Collections.emptyMap())
                     .createdAt(DateTime.now(DateTimeZone.UTC))
-                    .parameters(of());
+                    .parameters(ImmutableSet.of());
         }
 
         public Search build() {


### PR DESCRIPTION
There a was name conflict between `ImmutableSet#of` and `ParameterProvider#of`. Even though the compiler appears to have coped with it, Intellij Idea was complaining about it.

![image](https://github.com/Graylog2/graylog2-server/assets/886541/ab29872a-0cbb-4341-8b9d-d8b86fc8a7f3)

/nocl
