### PR TITLE
Add new banDynamicVersions enforcer rule to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -698,6 +698,13 @@
                                     </excludes>
                                 </bannedDependencies>
                                 <banDuplicatePomDependencyVersions/>
+                                <banDynamicVersions>
+                                    <ignores>
+                                        <ignore>org.graylog2</ignore>
+                                        <ignore>org.graylog</ignore>
+                                        <ignore>org.graylog.plugins</ignore>
+                                    </ignores>
+                                </banDynamicVersions>
                                 <requireMavenVersion>
                                     <!-- Enforce the same version we define in the maven wrapper -->
                                     <version>[3.9.6]</version>


### PR DESCRIPTION
This prevents the accidental inclusion of `SNAPSHOT` dependencies.