### PR TITLE
Support Message size based output_batch_size

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -47,7 +47,7 @@ public abstract class ExposedConfiguration {
     public abstract int outputBufferProcessors();
 
     @JsonProperty("output_batch_size")
-    public abstract int outputBatchSize();
+    public abstract String outputBatchSize();
 
     @JsonProperty("processor_wait_strategy")
     public abstract String processorWaitStrategy();
@@ -132,7 +132,7 @@ public abstract class ExposedConfiguration {
             @JsonProperty("inputbuffer_processors") int inputBufferProcessors,
             @JsonProperty("processbuffer_processors") int processBufferProcessors,
             @JsonProperty("outputbuffer_processors") int outputBufferProcessors,
-            @JsonProperty("output_batch_size") int outputBatchSize,
+            @JsonProperty("output_batch_size") String outputBatchSize,
             @JsonProperty("processor_wait_strategy") String processorWaitStrategy,
             @JsonProperty("inputbuffer_wait_strategy") String inputBufferWaitStrategy,
             @JsonProperty("inputbuffer_ring_size") int inputBufferRingSize,

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -448,12 +448,12 @@ field_value_suggestion_mode = on
 # Default: 1h
 #index_ranges_cleanup_interval = 1h
 
-# Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
+# Batch size for the Elasticsearch output. This is the maximum size of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
 # reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
 # that every outputbuffer processor manages its own batch and performs its own batch write calls.
 # ("outputbuffer_processors" variable)
-output_batch_size = 500
+output_batch_size = 50mb
 
 # Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
 # batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages


### PR DESCRIPTION
The output `output_batch_size` config parameter was always count based.

Limiting the batch size send to OS/ES based on count has the problem that the count might be too small to be efficient for small messages and too big (> 100MB) for huge messages.

So we end up having to customly tune this parameter for each scenario.

Supporting a byte size based limit would auto-tune the batch size instead.

Change our default from `500` messages to message batches of `50mb`. A count based setting is still supported for backwards compatibility.

# TODO
 - Fix unit test
 - Test thoroughly (maybe tweak the size calculation to reflect the actual serialized size of the message)
 - Add changelog
 - 