### PR TITLE
Clarify invalid message field error on event definition fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -175,7 +175,8 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
             final String fieldName = fieldSpecEntry.getKey();
             if (!Message.validKey(fieldName)) {
                 validation.addError(FIELD_FIELD_SPEC,
-                        "Event Definition field_spec contains invalid message field \"" + fieldName + "\"");
+                        "Event Definition field_spec contains invalid message field \"" + fieldName + "\"." +
+                                " Valid message field characters are: a-z, A-Z, 0-9, ., -, and @. No spaces are allowed.");
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clarify invalid message field error on event definition fields by adding accepted characters and spaces aren't allowed.

/nocl just clarifying an error message
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #13974 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

