### PR TITLE
Ignore unknown properties on series that used to contain units during…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Average.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Average.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -63,6 +64,7 @@ public abstract class Average implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Average, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Latest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Latest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -58,6 +59,7 @@ public abstract class Latest implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Latest, Latest.Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Max.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Max.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -58,6 +59,7 @@ public abstract class Max implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Max, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Min.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Min.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -59,6 +60,7 @@ public abstract class Min implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Min, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentage.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -70,6 +71,7 @@ public abstract class Percentage implements SeriesSpec, HasOptionalField {
 
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Percentage, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -61,6 +62,7 @@ public abstract class Percentile implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Percentile, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/StdDev.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/StdDev.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -64,6 +65,7 @@ public abstract class StdDev implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<StdDev, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Sum.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Sum.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -59,6 +60,7 @@ public abstract class Sum implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Sum, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SumOfSquares.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/SumOfSquares.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -64,6 +65,7 @@ public abstract class SumOfSquares implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<SumOfSquares, Builder> {
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Variance.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Variance.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -64,6 +65,7 @@ public abstract class Variance implements SeriesSpec, HasField {
     }
 
     @AutoValue.Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends SeriesSpecBuilder<Variance, Builder> {
         @JsonCreator
         public static Builder create() {


### PR DESCRIPTION
… development


## Description
Ignore unknown properties on series that used to contain units during development.
Fixes https://github.com/Graylog2/graylog2-server/issues/19512
/nocl

## Motivation and Context
For a short period of time it was possible to store units on certain series/metrics objects.
Units have been moved to views instead. 
While the first approach has never been released, it is possible that it was used on our internal/development systems and can now cause errors like in #19512.

Ignoring unknown properties solves that. This approach has been chosen over creating a migration, as the related code has never been released.




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

