### PR TITLE
Remove unit field from searches via migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -31,6 +31,7 @@ import org.graylog.plugins.views.migrations.V20191204000000_RemoveLegacyViewsPer
 import org.graylog.plugins.views.migrations.V20200204122000_MigrateUntypedViewsToDashboards.V20200204122000_MigrateUntypedViewsToDashboards;
 import org.graylog.plugins.views.migrations.V20200409083200_RemoveRootQueriesFromMigratedDashboards;
 import org.graylog.plugins.views.migrations.V20200730000000_AddGl2MessageIdFieldAliasForEvents;
+import org.graylog.plugins.views.migrations.V20240605120000_RemoveUnitFieldFromSearchDocuments;
 import org.graylog.plugins.views.providers.ExportBackendProvider;
 import org.graylog.plugins.views.providers.QuerySuggestionsProvider;
 import org.graylog.plugins.views.search.SearchRequirements;
@@ -237,6 +238,7 @@ public class ViewsBindings extends ViewsModule {
         addMigration(V20200204122000_MigrateUntypedViewsToDashboards.class);
         addMigration(V20200409083200_RemoveRootQueriesFromMigratedDashboards.class);
         addMigration(V20200730000000_AddGl2MessageIdFieldAliasForEvents.class);
+        addMigration(V20240605120000_RemoveUnitFieldFromSearchDocuments.class);
 
         addAuditEventTypes(ViewsAuditEventTypes.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20240605120000_RemoveUnitFieldFromSearchDocuments.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20240605120000_RemoveUnitFieldFromSearchDocuments.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.migrations;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
+import jakarta.inject.Inject;
+import org.graylog.plugins.views.search.Search;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.migrations.Migration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class V20240605120000_RemoveUnitFieldFromSearchDocuments extends Migration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(V20240605120000_RemoveUnitFieldFromSearchDocuments.class);
+
+    private final MongoCollection<Search> searchesCollection;
+
+    @Inject
+    public V20240605120000_RemoveUnitFieldFromSearchDocuments(final MongoCollections mongoCollections) {
+        this.searchesCollection = mongoCollections.collection("searches", Search.class);
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2024-06-05T12:00:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final UpdateResult updateResult = searchesCollection.updateMany(
+                Filters.exists("queries.search_types.series.unit"),
+                Updates.unset("queries.$[query].search_types.$[type].series.$[elem].unit"),
+                new UpdateOptions().arrayFilters(List.of(
+                        Filters.exists("query.search_types"),
+                        Filters.exists("type.series"),
+                        Filters.exists("elem.unit")
+                ))
+        );
+        if (updateResult.getModifiedCount() > 0) {
+            LOG.info("Removed outdated unit field from " + updateResult.getModifiedCount() + " searches");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Remove unit field from searches via migration.
/nocl

## Motivation and Context
Alternative solution to https://github.com/Graylog2/graylog2-server/pull/19534.
Fixes https://github.com/Graylog2/graylog2-server/issues/19512

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

