### PR TITLE
Fix missing field types problem on message details page.

### DIFF
--- a/changelog/unreleased/pr-19600.toml
+++ b/changelog/unreleased/pr-19600.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix problem with missing field types on message details page."
+
+pulls = ["19600"]

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -35,6 +35,7 @@ import View from 'views/logic/views/View';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import SingleMessageFieldTypesProvider from 'views/components/fieldtypes/SingleMessageFieldTypesProvider';
 import StreamsContext from 'contexts/StreamsContext';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
 type Props = {
   params: {
@@ -100,14 +101,18 @@ const ShowMessagePage = ({ params: { index, messageId } }: Props) => {
             <Col md={12}>
               <WindowDimensionsContextProvider>
                 <SingleMessageFieldTypesProvider streams={fieldTypesStreams} timestamp={timestamp}>
-                  <InteractiveContext.Provider value={false}>
-                    <MessageDetail fields={Immutable.List()}
-                                   streams={streamsMap}
-                                   allStreams={streamsList}
-                                   disableSurroundingSearch
-                                   inputs={inputs}
-                                   message={message} />
-                  </InteractiveContext.Provider>
+                  <FieldTypesContext.Consumer>
+                    {({ all }) => (
+                      <InteractiveContext.Provider value={false}>
+                        <MessageDetail fields={all}
+                                       streams={streamsMap}
+                                       allStreams={streamsList}
+                                       disableSurroundingSearch
+                                       inputs={inputs}
+                                       message={message} />
+                      </InteractiveContext.Provider>
+                    )}
+                  </FieldTypesContext.Consumer>
                 </SingleMessageFieldTypesProvider>
               </WindowDimensionsContextProvider>
             </Col>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the field types were missing for the message fields on the message details page (`/messages/index-set-id/message-id`).
This is just a simple fix. The proper way to provide field types for these components requires a bigger refactoring https://github.com/Graylog2/graylog2-server/issues/16308.


Before (date is just a string and does not consider user time zone):
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/210066d4-0e32-48f3-be6c-fd6689b68741)


After:
![image](https://github.com/Graylog2/graylog2-server/assets/46300478/08e2715c-4866-4bc6-baec-920d1f63918c)
