### PR TITLE
Add option for `useSlidesInView` to memorize which slides have been visible already.

### DIFF
--- a/graylog2-web-interface/src/components/common/Carousel/CarouselProvider.tsx
+++ b/graylog2-web-interface/src/components/common/Carousel/CarouselProvider.tsx
@@ -22,7 +22,11 @@ import CarouselContext from './CarouselContext';
 
 type Props = React.PropsWithChildren<{
   carouselId: string,
-  options?: Partial<{ align: 'start', slidesToScroll: number }>
+  options?: Partial<{
+    align: 'start',
+    slidesToScroll: number,
+    inViewThreshold: number,
+  }>
 }>
 
 const CarouselProvider = ({ carouselId, children, options } : Props) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR extends the `Carousel` `useSlidesInView` hook. The hook can now be used to receive the slides which are currently visible or all slides which have been visible at least once.

/nocl
