### PR TITLE
Backport: Bump com.fasterxml.jackson:jackson-bom from 2.17.0 to 2.17.1 (#19256)

### DIFF
--- a/changelog/unreleased/pr-19629.toml
+++ b/changelog/unreleased/pr-19629.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Update \"Jackson\" to version 2.17.1 to prevent potential memory issues."
+
+pulls = ["19629"]

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <hk2.version>3.1.0</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.17.0</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <jadconfig.version>0.14.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
Backport of #19256

Several projects reported memory issues related to Jackson version 2.17.0. See e.g. [here](https://github.com/opensearch-project/OpenSearch/issues/13927) and [here](https://github.com/trinodb/trino/issues/21356).
The issue has been [fixed in Jackson version 2.17.1](https://github.com/FasterXML/jackson-core/issues/1256).

We haven't received any reports of Graylog being affected, but as a safety measure, we are backporting the Jackson update to the fixed version.

Bumps [com.fasterxml.jackson:jackson-bom](https://github.com/FasterXML/jackson-bom) from 2.17.0 to 2.17.1.
