### PR TITLE
Remove no longer needed usage of tooltip component.

### DIFF
--- a/graylog2-web-interface/src/components/common/PageHeader.tsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.tsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
 import styled, { css } from 'styled-components';
 
-import { Col, Label, Tooltip } from 'components/bootstrap';
+import { Col, Label } from 'components/bootstrap';
 import { OverlayTrigger } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import ContentHeadRow from 'components/common/ContentHeadRow';
@@ -87,11 +87,10 @@ const LifecycleIndicator = ({
 
   const label = upperFirst(lifecycle);
   const defaultMessage = lifecycle === 'experimental' ? LIFECYCLE_DEFAULT_MESSAGES.experimental : LIFECYCLE_DEFAULT_MESSAGES.legacy;
-  const tooltip = <Tooltip id={lifecycle}>{lifecycleMessage || defaultMessage}</Tooltip>;
 
   return (
     <LifecycleIndicatorContainer>
-      <OverlayTrigger placement="bottom" overlay={tooltip}>
+      <OverlayTrigger placement="bottom" overlay={lifecycleMessage || defaultMessage}>
         <Label bsStyle="primary">{label}</Label>
       </OverlayTrigger>
     </LifecycleIndicatorContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up for https://github.com/Graylog2/graylog-plugin-enterprise/pull/7283. It removes the no longer needed usage of the `Tooltip` component when used in combination with the `OverlayTrigger`.
 
 /nocl
 