### PR TITLE
Restore `ClipboardButton` to work in non-secure contexts.

### DIFF
--- a/changelog/unreleased/issue-19643.toml
+++ b/changelog/unreleased/issue-19643.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Restore ClipboardButton to work in non-secure contexts."
+
+issues=["19643"]
+pulls=["19654"]

--- a/changelog/unreleased/issue-19643.toml
+++ b/changelog/unreleased/issue-19643.toml
@@ -1,5 +1,5 @@
 type="f"
-message="Restore ClipboardButton to work in non-secure contexts."
+message="Fixing copying to clipboard in non-secure contexts."
 
 issues=["19643"]
 pulls=["19654"]

--- a/graylog2-web-interface/src/components/common/ClipboardButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.tsx
@@ -14,12 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
-import { CopyButton, Tooltip } from '@mantine/core';
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+import { Tooltip } from '@mantine/core';
+import { useTimeout } from '@mantine/hooks';
 
 import { Button } from 'components/bootstrap';
 import type { BsSize } from 'components/bootstrap/types';
 import type { StyleProps } from 'components/bootstrap/Button';
+import copyToClipboard from 'util/copyToClipboard';
 
 /**
  * Component that renders a button to copy some text in the clipboard when pressed.
@@ -36,6 +39,24 @@ type Props = {
   text: string,
   title: React.ReactNode,
 }
+
+type Args = {
+  copied: boolean,
+  copy: () => void,
+}
+type CopyButtonProps = {
+  value: string,
+  timeout: number,
+  children: (args: Args) => React.ReactElement,
+};
+
+const CopyButton = ({ children, value, timeout }: CopyButtonProps) => {
+  const [copied, setCopied] = useState(false);
+  const { start } = useTimeout(() => setCopied(false), timeout);
+  const copy = useCallback(() => copyToClipboard(value).then(() => { setCopied(true); start(); }), [start, value]);
+
+  return children({ copied, copy });
+};
 
 const ClipboardButton = ({ bsSize, bsStyle, buttonTitle, className, disabled, onSuccess, text, title }: Props) => {
   const button = (copy: () => void) => (

--- a/graylog2-web-interface/src/components/common/ClipboardButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.tsx
@@ -16,13 +16,13 @@
  */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import { Tooltip } from '@mantine/core';
 import { useTimeout } from '@mantine/hooks';
 
 import { Button } from 'components/bootstrap';
 import type { BsSize } from 'components/bootstrap/types';
 import type { StyleProps } from 'components/bootstrap/Button';
 import copyToClipboard from 'util/copyToClipboard';
+import Tooltip from 'components/common/Tooltip';
 
 /**
  * Component that renders a button to copy some text in the clipboard when pressed.


### PR DESCRIPTION
**Note:** This needs a backport to `6.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is restoring `ClipboardButton`'s functionality to work in non-secure context. In a previous refactoring (#17472), the component was made to use `CopyButton` from Mantine, which works only in secure contexts (+ `localhost`), unfortunately. This PR is now restoring it by removing the usage of Mantine's `CopyButton` and implements an own component for this, which uses our own `copyToClipboard` abstraction, which falls back to a legacy approach in non-secure contexts.

Fixes #19643.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.