### PR TITLE
fix(7370): Updated home nav icon to open active perspective welcome page

### DIFF
--- a/changelog/unreleased/issue-7370.toml
+++ b/changelog/unreleased/issue-7370.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Fixed routing of home nav icon to open the active perspective welcome page."
 
 issues = ["Graylog2/graylog-plugin-enterprise#7370"]
-pulls = [""]
+pulls = ["19673"]

--- a/changelog/unreleased/issue-7370.toml
+++ b/changelog/unreleased/issue-7370.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed routing of home nav icon to open the active perspective welcome page."
+
+issues = ["Graylog2/graylog-plugin-enterprise#7370"]
+pulls = [""]

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -26,6 +26,7 @@ import { Icon } from 'components/common';
 import PerspectivesSwitcher from 'components/perspectives/PerspectivesSwitcher';
 import usePluginEntities from 'hooks/usePluginEntities';
 import MainNavbar from 'components/navigation/MainNavbar';
+import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 
 import UserMenu from './UserMenu';
 import HelpMenu from './HelpMenu';
@@ -41,6 +42,7 @@ type Props = {
 
 const Navigation = React.memo(({ pathname }: Props) => {
   const pluginItems = usePluginEntities('navigationItems');
+  const { activePerspective } = useActivePerspective();
 
   return (
     <StyledNavbar fluid fixedTop collapseOnSelect>
@@ -74,7 +76,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
 
           <HelpMenu />
 
-          <LinkContainer relativeActive to={Routes.WELCOME}>
+          <LinkContainer relativeActive to={activePerspective.welcomeRoute}>
             <NavItem id="welcome-nav-link">
               <Icon size="lg" title="Welcome" name="home" />
             </NavItem>

--- a/graylog2-web-interface/src/routing/AppRouter.test.tsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.tsx
@@ -30,7 +30,7 @@ import usePluginEntities from 'hooks/usePluginEntities';
 import AppConfig from 'util/AppConfig';
 import GlobalContextProviders from 'contexts/GlobalContextProviders';
 import HotkeysProvider from 'contexts/HotkeysProvider';
-import { defaultPerspective } from 'fixtures/perspectives';
+import { defaultPerspective as mockDefaultPerspective } from 'fixtures/perspectives';
 
 import AppRouter from './AppRouter';
 
@@ -55,6 +55,13 @@ jest.mock('util/AppConfig', () => ({
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   createBrowserRouter: jest.fn(),
+}));
+
+jest.mock('components/perspectives/hooks/useActivePerspective', () => ({
+  __esModule: true,
+  default: () => ({
+    activePerspective: mockDefaultPerspective,
+  }),
 }));
 
 const AppRouterWithContext = () => (
@@ -86,7 +93,7 @@ const mockRoutes = (routes: PluginExports['routes']) => {
 
 describe('AppRouter', () => {
   const defaultPlugins = {
-    perspectives: [defaultPerspective],
+    perspectives: [mockDefaultPerspective],
   };
 
   beforeEach(() => {

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.it.tsx
@@ -29,6 +29,7 @@ import CurrentUserProvider from 'contexts/CurrentUserProvider';
 import StreamsContext from 'contexts/StreamsContext';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
+import { defaultPerspective as mockDefaultPerspective } from 'fixtures/perspectives';
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import type { Stream } from 'logic/streams/types';
 
@@ -98,6 +99,13 @@ jest.mock('hooks/useSearchConfiguration', () => () => ({
     default_auto_refresh_option: 'PT5S',
   },
   refresh: jest.fn(),
+}));
+
+jest.mock('components/perspectives/hooks/useActivePerspective', () => ({
+  __esModule: true,
+  default: () => ({
+    activePerspective: mockDefaultPerspective,
+  }),
 }));
 
 jest.mock('react-router-dom', () => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make home nav icon navigate to the active perspective Welcome page.

closes: Graylog2/graylog-plugin-enterprise#7370

## Description
<!--- Describe your changes in detail -->
Before the icon was navigating to the General UI welcome page since the route was hard-coded. With this PR we use the useActivePerspective hook to get the active perspective Welcome page URL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated unit test to account for the hook

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

