### PR TITLE
Event list can accept ex. state with limit instead of page/perpage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -119,6 +119,11 @@ public abstract class EventList implements SearchType {
             state.page().ifPresent(builder::page);
             state.perPage().ifPresent(builder::perPage);
             return builder.build();
+        } else if (state.limit().isPresent() && (state.offset().isEmpty()) || state.offset().get().equals(0)) {
+            final var builder = toBuilder();
+            builder.page(1);
+            builder.perPage(state.limit().get());
+            return builder.build();
         }
 
         return this;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -119,7 +119,9 @@ public abstract class EventList implements SearchType {
             state.page().ifPresent(builder::page);
             state.perPage().ifPresent(builder::perPage);
             return builder.build();
-        } else if (state.limit().isPresent() && (state.offset().isEmpty()) || state.offset().get().equals(0)) {
+        } else if (state.limit().isPresent() &&
+                (state.offset().isEmpty() || state.offset().get().equals(0))
+        ) {
             final var builder = toBuilder();
             builder.page(1);
             builder.perPage(state.limit().get());


### PR DESCRIPTION
## Description
Event list can accept ex. state with limit instead of page/perpage.
/nocl

## Motivation and Context
Currently, when we want to get some number of top elements for different document-based search types (messages, events, investigation lists), we have to express that need with different execution state objects for each of them.

So, request like "give me first 42 documents" translates to this execution state object in case of messages

```
		"search_types" :
		{
			"9602cdb3-528d-4f1f-852c-5a0021c92dfd" : {
					"limit" : 42
			}
		}
```

and this in case of events:

```
		"search_types" :
		{
			"9602cdb3-528d-4f1f-852c-5a0021c92dfd" : {
					"page": 1,
					"per_page": 42
			}
		}
```

I'd like to avoid a need to make this choice and be able to use `limit` everywhere for this use case.

If this gets accepted, similar change will be made for investigation list in enterprise.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

