### PR TITLE
Allow disabling dragging for carousel.

### DIFF
--- a/graylog2-web-interface/src/components/common/Carousel/CarouselProvider.tsx
+++ b/graylog2-web-interface/src/components/common/Carousel/CarouselProvider.tsx
@@ -26,6 +26,7 @@ type Props = React.PropsWithChildren<{
     align: 'start',
     slidesToScroll: number,
     inViewThreshold: number,
+    watchDrag: boolean
   }>
 }>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Disabling dragging is required for use cases when it is important that text inside slides can be copied.

/nocl
