### PR TITLE
Supporting plain `Bson` for view retrieval filter.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DashboardService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DashboardService.java
@@ -17,9 +17,9 @@
 package org.graylog.plugins.views.search.views;
 
 import jakarta.inject.Inject;
+import org.bson.BsonDocument;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.rest.models.SortOrder;
-import org.graylog2.search.SearchQuery;
 
 public class DashboardService {
     private final ViewService viewService;
@@ -30,7 +30,7 @@ public class DashboardService {
     }
 
     public long count() {
-        final PaginatedList<ViewDTO> result = viewService.searchPaginatedByType(ViewDTO.Type.DASHBOARD, new SearchQuery(""), dashboard -> true, SortOrder.ASCENDING, ViewDTO.FIELD_ID, 1, 0);
+        final PaginatedList<ViewDTO> result = viewService.searchPaginatedByType(ViewDTO.Type.DASHBOARD, new BsonDocument(), dashboard -> true, SortOrder.ASCENDING, ViewDTO.FIELD_ID, 1, 0);
         return result.grandTotal().orElseThrow(() -> new IllegalStateException("Missing grand total in response when counting dashboards!"));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -146,7 +146,7 @@ public class ViewService implements ViewUtils<ViewDTO> {
     }
 
     public PaginatedList<ViewDTO> searchPaginatedByType(ViewDTO.Type type,
-                                                        SearchQuery query,
+                                                        Bson query,
                                                         Predicate<ViewDTO> filter,
                                                         SortOrder order,
                                                         String sortField,
@@ -156,7 +156,7 @@ public class ViewService implements ViewUtils<ViewDTO> {
         return searchPaginatedWithGrandTotal(
                 Filters.and(
                         Filters.or(Filters.eq(ViewDTO.FIELD_TYPE, type), Filters.not(Filters.exists(ViewDTO.FIELD_TYPE))),
-                        query.toBson()
+                        query
                 ),
                 filter,
                 order,

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
@@ -29,6 +29,7 @@ import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.database.filtering.DbQueryCreator;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.system.SimpleNodeId;
 import org.graylog2.rest.models.SortOrder;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +58,7 @@ public class ViewServiceTest {
 
     private SearchUser searchUser;
     private MongoDBTestService mongodb;
+    private final DbQueryCreator dbQueryCreator = new DbQueryCreator(ViewDTO.FIELD_TITLE, List.of());
 
     @BeforeEach
     public void setUp(MongoDBTestService mongodb, ObjectMapper objectMapper) throws Exception {
@@ -249,11 +252,9 @@ public class ViewServiceTest {
         dbService.save(ViewDTO.builder().type(ViewDTO.Type.SEARCH).title("View D").searchId("abc123").state(Collections.emptyMap()).owner("franz").build());
         dbService.save(ViewDTO.builder().type(ViewDTO.Type.SEARCH).title("View E").searchId("abc123").state(Collections.emptyMap()).owner("franz").build());
 
-        final SearchQueryParser queryParser = new SearchQueryParser(ViewDTO.FIELD_TITLE, searchFieldMapping);
-
         final PaginatedList<ViewDTO> result1 = dbService.searchPaginatedByType(
                 ViewDTO.Type.DASHBOARD,
-                queryParser.parse("A B D"),
+                dbQueryCreator.createDbQuery(List.of(), "A B D"),
                 view -> true, SortOrder.DESCENDING,
                 "title",
                 1,
@@ -269,7 +270,7 @@ public class ViewServiceTest {
 
         final PaginatedList<ViewDTO> result2 = dbService.searchPaginatedByType(
                 ViewDTO.Type.DASHBOARD,
-                queryParser.parse("A B D"),
+                dbQueryCreator.createDbQuery(List.of(), "A B D"),
                 view -> view.title().contains("B") || view.title().contains("D"), SortOrder.DESCENDING,
                 "title",
                 1,
@@ -285,7 +286,7 @@ public class ViewServiceTest {
 
         final PaginatedList<ViewDTO> result3 = dbService.searchPaginatedByType(
                 ViewDTO.Type.SEARCH,
-                queryParser.parse(""),
+                dbQueryCreator.createDbQuery(List.of(), ""),
                 view -> true, SortOrder.ASCENDING,
                 "title",
                 1,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is refactoring the view filter type to be plain `Bson`, so results from a `DBQueryCreator` instance can be used too.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.