### PR TITLE
Pinning `typescript` to `5.5.2` and fixing type fallout.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -176,6 +176,7 @@
   },
   "resolutions": {
     "@types/react": "18.0.28",
-    "nth-check": "2.0.1"
+    "nth-check": "2.0.1",
+    "typescript": "5.5.2"
   }
 }

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
@@ -31,6 +31,7 @@ describe('ConfigurationForm', () => {
         <ConfigurationForm submitAction={submitAction}
                            title="Edit entity"
                            titleValue="Entity title"
+                           ref={formRef}
                            submitButtonText="Update entity"
                            typeName="placeholder"
                            cancelAction={() => {}}

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
@@ -31,9 +31,10 @@ describe('ConfigurationForm', () => {
         <ConfigurationForm submitAction={submitAction}
                            title="Edit entity"
                            titleValue="Entity title"
-                           ref={formRef}
                            submitButtonText="Update entity"
-                           typeName="placeholder" />
+                           typeName="placeholder"
+                           cancelAction={() => {}}
+                           values={{}} />
         <button type="button" onClick={openForm}>Open modal</button>
       </>
     );

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
@@ -16,6 +16,7 @@
  */
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import type { ForwardedRef } from 'react';
 import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
@@ -25,26 +26,31 @@ import { FIELD_TYPES_WITH_ENCRYPTION_SUPPORT } from './types';
 import type { ConfigurationFormData, ConfigurationField, ConfigurationFieldValue, EncryptedFieldValue, FieldValue, ConfigurationFieldWithEncryption } from './types';
 
 type Props<Configuration extends object> = {
-  cancelAction: () => void,
+  cancelAction?: () => void,
   configFields?: {
     [key: string]: ConfigurationField,
   },
   children?: React.ReactNode,
   titleHelpText?: string,
-  includeTitleField: boolean,
+  includeTitleField?: boolean,
   submitAction: (data: ConfigurationFormData<Configuration>) => void,
   title: string | React.ReactNode | null,
-  titleValue: string,
+  titleValue?: string,
   typeName?: string,
-  values: { [key:string]: any },
-  wrapperComponent: React.ComponentType<React.PropsWithChildren<{
+  values?: { [key:string]: any },
+  wrapperComponent?: React.ComponentType<React.PropsWithChildren<{
     show: boolean,
     title: string | React.ReactNode | null,
     onCancel: () => void,
     onSubmitForm: () => void,
     submitButtonText: string
   }>>,
-  submitButtonText: string,
+  submitButtonText?: string,
+}
+
+type RefType<Configuration extends object> = {
+  open: () => void,
+  getValue: () => ConfigurationFormData<Configuration>,
 }
 
 const ConfigurationForm = forwardRef(<Configuration extends object>({
@@ -60,7 +66,7 @@ const ConfigurationForm = forwardRef(<Configuration extends object>({
   values: initialValues,
   wrapperComponent: WrapperComponent,
   submitButtonText,
-} : Props<Configuration>, ref: typeof ConfigurationForm) => {
+} : Props<Configuration>, ref: React.ForwardedRef<RefType<Configuration>>) => {
   const [showConfigurationModal, setShowConfigurationModal] = useState(false);
   const [titleValue, setTitleValue] = useState(undefined);
   const [values, setValues] = useState<{[key:string]: any} | undefined>(undefined);
@@ -243,16 +249,16 @@ const ConfigurationForm = forwardRef(<Configuration extends object>({
 
 ConfigurationForm.propTypes = {
   cancelAction: PropTypes.func,
-  configFields: PropTypes.object,
-  children: PropTypes.node,
+  configFields: PropTypes.any,
+  children: PropTypes.any,
   titleHelpText: PropTypes.string,
   includeTitleField: PropTypes.bool,
   submitAction: PropTypes.func.isRequired,
-  title: PropTypes.node,
+  title: PropTypes.any,
   titleValue: PropTypes.string,
   typeName: PropTypes.string,
   values: PropTypes.object,
-  wrapperComponent: PropTypes.elementType,
+  wrapperComponent: PropTypes.any,
   submitButtonText: PropTypes.string.isRequired,
 };
 
@@ -263,10 +269,13 @@ ConfigurationForm.defaultProps = {
   titleHelpText: '',
   title: null,
   includeTitleField: true,
+  submitButtonText: undefined,
   titleValue: '',
   typeName: undefined,
   values: {},
-  wrapperComponent: BootstrapModalForm,
+  wrapperComponent: BootstrapModalForm as unknown as Props<{ }>['wrapperComponent'],
 };
 
-export default ConfigurationForm;
+export default ConfigurationForm as <T extends object>(
+  props: Props<T> & { ref?: ForwardedRef<RefType<T>> },
+) => ReturnType<typeof ConfigurationForm>;

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
@@ -259,7 +259,7 @@ ConfigurationForm.propTypes = {
   typeName: PropTypes.string,
   values: PropTypes.object,
   wrapperComponent: PropTypes.any,
-  submitButtonText: PropTypes.string.isRequired,
+  submitButtonText: PropTypes.string,
 };
 
 ConfigurationForm.defaultProps = {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.tsx
@@ -131,7 +131,7 @@ class AddDecoratorButton extends React.Component<Props, State> {
                                                 title={`Create new ${typeDefinition.name}`}
                                                 typeName={typeName}
                                                 includeTitleField={false}
-                                                wrapperComponent={wrapperComponent}
+                                                wrapperComponent={wrapperComponent as React.ComponentProps<typeof ConfigurationForm>['wrapperComponent']}
                                                 submitAction={this._handleSubmit}
                                                 cancelAction={this._handleCancel} />
       ) : null);

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.tsx
@@ -153,7 +153,7 @@ class DecoratorSummary extends React.Component<Props, State> {
                                                 includeTitleField={false}
                                                 submitAction={this._handleSubmit}
                                                 cancelAction={this._closeEditForm}
-                                                wrapperComponent={wrapperComponent}
+                                                wrapperComponent={wrapperComponent as React.ComponentProps<typeof ConfigurationForm>['wrapperComponent']}
                                                 values={decorator.config} />
       )
       : (

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.tsx
@@ -20,7 +20,8 @@ import { Button } from 'components/bootstrap';
 
 type Props = {
   children: React.ReactElement,
-  disabled: boolean,
+  // eslint-disable-next-line react/require-default-props
+  disabled?: boolean,
   onCancel: () => void,
   onSubmitForm: (arg: any) => void,
 };

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "lib": [
       "dom",
       "dom.iterable",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -7209,7 +7209,7 @@ eslint-config-airbnb@19.0.4:
     eslint-config-airbnb "19.0.4"
     eslint-import-resolver-webpack "0.13.8"
     eslint-plugin-compat "4.2.0"
-    eslint-plugin-graylog "file:packages/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-cd3e5455-9c1b-4ed4-a067-f0139ce5da99-1719229843003/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.25.3"
     eslint-plugin-jest "28.6.0"
     eslint-plugin-jest-dom "5.4.0"
@@ -8677,13 +8677,13 @@ graphemer@^1.4.0:
     "@types/create-react-class" "15.6.8"
     "@types/jquery" "3.5.30"
     "@types/react" "18.3.3"
-    babel-preset-graylog "file:packages/babel-preset-graylog"
+    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.1.0-SNAPSHOT-8ccb003a-cd29-4767-b827-62bfc41e4141-1719229842892/node_modules/babel-preset-graylog"
     create-react-class "15.7.0"
-    eslint-config-graylog "file:packages/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.1.0-SNAPSHOT-8ccb003a-cd29-4767-b827-62bfc41e4141-1719229842892/node_modules/eslint-config-graylog"
     formik "2.4.6"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:packages/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.1.0-SNAPSHOT-8ccb003a-cd29-4767-b827-62bfc41e4141-1719229842892/node_modules/jest-preset-graylog"
     jquery "3.7.1"
     moment "2.30.1"
     moment-timezone "0.5.45"
@@ -14640,16 +14640,7 @@ string-split-by@^1.0.0:
   dependencies:
     parenthesis "^3.1.5"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14826,14 +14817,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14914,21 +14898,21 @@ styled-components@6.1.1:
   dependencies:
     postcss-styled-syntax "0.6.4"
     stylelint "16.6.1"
-    stylelint-config-recommended "14.0.0"
-    stylelint-config-standard "36.0.0"
+    stylelint-config-recommended "14.0.1"
+    stylelint-config-standard "36.0.1"
     stylelint-config-styled-components "0.1.1"
 
-stylelint-config-recommended@14.0.0, stylelint-config-recommended@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz#b395c7014838d2aaca1755eebd914d0bb5274994"
-  integrity sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==
+stylelint-config-recommended@14.0.1, stylelint-config-recommended@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz#d25e86409aaf79ee6c6085c2c14b33c7e23c90c6"
+  integrity sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==
 
-stylelint-config-standard@36.0.0:
-  version "36.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-36.0.0.tgz#6704c044d611edc12692d4a5e37b039a441604d4"
-  integrity sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==
+stylelint-config-standard@36.0.1:
+  version "36.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz#727cbb2a1ef3e210f5ce8329cde531129f156609"
+  integrity sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==
   dependencies:
-    stylelint-config-recommended "^14.0.0"
+    stylelint-config-recommended "^14.0.1"
 
 stylelint-config-styled-components@0.1.1:
   version "0.1.1"
@@ -15621,15 +15605,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@5.5.2:
+typescript@5.5.2, typescript@^5.3.3:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
-
-typescript@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 ultimate-pagination@1.0.0:
   version "1.0.0"
@@ -16394,16 +16373,7 @@ world-calendars@^1.0.3:
   dependencies:
     object-assign "^4.1.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the `postcss-styled-syntax` was shadowing our own `typescript` dependency, causing in being stuck on 5.3.x. This PR is now pinning our desired version and fixes the typing fallout.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.