### PR TITLE
Add associated_assets field to Events

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/event/Event.java
+++ b/graylog2-server/src/main/java/org/graylog/events/event/Event.java
@@ -25,6 +25,7 @@ import org.joda.time.DateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalDouble;
+import java.util.Set;
 
 public interface Event extends Indexable {
     @Override
@@ -105,6 +106,8 @@ public interface Event extends Indexable {
     OptionalDouble getScore(String name);
 
     void setScore(String name, double riskScore);
+
+    void addAssociatedAssets(Set<String> associatedAssets);
 
     EventDto toDto();
 

--- a/graylog2-server/src/main/java/org/graylog/events/event/EventDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/event/EventDto.java
@@ -51,6 +51,7 @@ public abstract class EventDto {
     public static final String FIELD_KEY = "key";
     public static final String FIELD_PRIORITY = "priority";
     public static final String FIELD_SCORES = "scores";
+    public static final String FIELD_ASSOCIATED_ASSETS = "associated_assets";
     public static final String FIELD_FIELDS = "fields";
     private static final String FIELD_GROUP_BY_FIELDS = "group_by_fields";
     public static final String FIELD_REPLAY_INFO = "replay_info";
@@ -104,6 +105,9 @@ public abstract class EventDto {
     @JsonProperty(FIELD_SCORES)
     public abstract Map<String, Double> scores();
 
+    @JsonProperty(FIELD_ASSOCIATED_ASSETS)
+    public abstract Set<String> associatedAssets();
+
     @JsonProperty(FIELD_ALERT)
     public abstract boolean alert();
 
@@ -131,7 +135,8 @@ public abstract class EventDto {
             return new AutoValue_EventDto.Builder()
                     .sourceStreams(ImmutableSet.of())
                     .groupByFields(ImmutableMap.of())
-                    .scores(ImmutableMap.of());
+                    .scores(ImmutableMap.of())
+                    .associatedAssets(ImmutableSet.of());
         }
 
         @JsonProperty(FIELD_ID)
@@ -185,6 +190,9 @@ public abstract class EventDto {
 
         @JsonProperty(FIELD_SCORES)
         public abstract Builder scores(Map<String, Double> scores);
+
+        @JsonProperty(FIELD_ASSOCIATED_ASSETS)
+        public abstract Builder associatedAssets(Set<String> associatedAssets);
 
         @JsonProperty(FIELD_ALERT)
         public abstract Builder alert(boolean alert);

--- a/graylog2-server/src/main/java/org/graylog/events/event/EventImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/events/event/EventImpl.java
@@ -29,10 +29,12 @@ import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalDouble;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -60,6 +62,7 @@ public class EventImpl implements Event {
     private Map<String, FieldValue> fields = new HashMap<>();
     private Map<String, FieldValue> groupByFields = new HashMap<>();
     private final Map<String, Double> scores = new HashMap<>();
+    private final Set<String> associatedAssets = new HashSet<>();
     private EventReplayInfo replayInfo;
 
     EventImpl(String eventId,
@@ -256,6 +259,11 @@ public class EventImpl implements Event {
     }
 
     @Override
+    public void addAssociatedAssets(Set<String> associatedAssets) {
+        this.associatedAssets.addAll(associatedAssets);
+    }
+
+    @Override
     public boolean getAlert() {
         return alert;
     }
@@ -334,6 +342,7 @@ public class EventImpl implements Event {
                 .key(String.join("|", getKeyTuple()))
                 .priority(getPriority())
                 .scores(ImmutableMap.copyOf(scores))
+                .associatedAssets(ImmutableSet.copyOf(associatedAssets))
                 .alert(getAlert())
                 .fields(ImmutableMap.copyOf(fields))
                 .groupByFields(ImmutableMap.copyOf(groupByFields))
@@ -391,6 +400,7 @@ public class EventImpl implements Event {
                 Objects.equals(fields, event.fields) &&
                 Objects.equals(groupByFields, event.groupByFields) &&
                 Objects.equals(scores, event.scores) &&
+                Objects.equals(associatedAssets, event.associatedAssets) &&
                 Objects.equals(replayInfo, event.replayInfo);
     }
 
@@ -423,6 +433,7 @@ public class EventImpl implements Event {
                 .add("groupByFields", groupByFields)
                 .add("replayInfo", replayInfo)
                 .add("scores", scores)
+                .add("associatedAssets", associatedAssets)
                 .toString();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -23,6 +23,8 @@ import org.graylog2.indexer.indices.Template;
 
 import java.util.Map;
 
+import static org.graylog.schema.SecurityFields.FIELD_ASSOCIATED_ASSETS;
+
 public abstract class EventsIndexMapping implements IndexMappingTemplate {
     @Override
     public Template toTemplate(IndexSetMappingTemplate indexSetConfig, Long order) {
@@ -197,6 +199,9 @@ public abstract class EventsIndexMapping implements IndexMappingTemplate {
                 .put("scores", map()
                         .put("type", "object")
                         .put("dynamic", true)
+                        .build())
+                .put(FIELD_ASSOCIATED_ASSETS, map()
+                        .put("type", "keyword")
                         .build())
                 /* TODO: Enable the typed fields once we decided if that's the way to go
                 .put("fields_typed", map()

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -108,5 +108,7 @@ public class EventsIndexMappingTest {
         at.jsonPathAsString("$.properties.fields.type").isEqualTo("object");
         at.jsonPathAsBoolean("$.properties.fields.dynamic").isTrue();
         at.jsonPathAsString("$.properties.triggered_jobs.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.properties.associated_assets.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.properties.scores.type").isEqualTo("object");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for the `associated_assets` (string id array) field to Events. Also updates the event mapping accordingly. This field needs to be present at the top-level of the Event, since (similar to the `Message` object), it must be an array in order to support effective/efficient search filtering. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Server changes needed for https://github.com/Graylog2/graylog-plugin-enterprise/issues/7475

Corresponding Enterprise PR: https://github.com/Graylog2/graylog-plugin-enterprise/pull/7603

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified that the new events mapping is applied successfully when the Graylog Events index is rotated. Subsequent events index successfully. See additional testing notes in corresponding PR.

/nocl 
