### PR TITLE
Add missing exception handling for IpInfo*Resolver

### DIFF
--- a/changelog/unreleased/pr-19750.toml
+++ b/changelog/unreleased/pr-19750.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix processing failures due to lookup failures in the IPInfo geolocation database."
+
+issues = ["Graylog2/graylog-plugin-enterprise#7602"]
+pulls = ["19750"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpAsnResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoIpAsnResolver.java
@@ -23,7 +23,6 @@ import com.maxmind.geoip2.exception.AddressNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Locale;
 import java.util.Optional;
@@ -50,7 +49,7 @@ public class IpInfoIpAsnResolver extends IpInfoIpResolver<GeoAsnInformation> {
         try (Timer.Context ignored = resolveTime.time()) {
             final IPinfoASN ipInfoASN = adapter.ipInfoASN(address);
             info = GeoAsnInformation.create(ipInfoASN.name(), ipInfoASN.type(), ipInfoASN.asn());
-        } catch (IOException | AddressNotFoundException | UnsupportedOperationException e) {
+        } catch (Exception e) {
             info = null;
             if (!(e instanceof AddressNotFoundException)) {
                 String error = String.format(Locale.US, "Error getting ASN for IP Address '%s'. %s", address, e.getMessage());

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/IpInfoLocationResolver.java
@@ -23,7 +23,6 @@ import com.maxmind.geoip2.exception.AddressNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Locale;
 import java.util.Optional;
@@ -52,7 +51,7 @@ public class IpInfoLocationResolver extends IpInfoIpResolver<GeoLocationInformat
             info = GeoLocationInformation.create(loc.latitude(), loc.longitude(), loc.country(), "N/A",
                     loc.city(), loc.region(), loc.timezone());
 
-        } catch (NullPointerException | IOException | AddressNotFoundException | UnsupportedOperationException e) {
+        } catch (Exception e) {
             info = null;
             if (!(e instanceof AddressNotFoundException)) {
                 String error = String.format(Locale.US, "Error getting IP location info for '%s'. %s", address, e.getMessage());


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-enterprise#7602

<!--- Provide a general summary of your changes in the Title above -->
`IpInfo*Resolver` classes only handle a specific set of exception types. Unknown exceptions bubble up, leading to processing failure.
Extend exception handling to cover all types of exceptions. 

## Description
<!--- Describe your changes in detail -->
When an IP address cannot be resolved against the IPInfo DB, we may receive a `com.maxmind.db.DeserializationException` from `IPinfoIPLocationDatabaseAdapter`. 
This may occur in 2 places:
- `MaxmindDataAdapter`: this class handles any exceptions in lookup.
- `IpInfoIpAsnResolver` and `IpInfoLocationResolver`: these classes only handle a subset of exception types, resulting in an unexpected exception and failure to process messages when an unknown exception is encountered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This affects all versions that support IPInfo DBs, i.e. 5.1 and up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

