### PR TITLE
Check for plugin presence in Stream-details page

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingDestinations.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingDestinations.tsx
@@ -35,7 +35,7 @@ const StreamDataRoutingDestinations = ({ stream }: Props) => {
   return (
     <>
       {isSuccess && <DestinationIndexSetSection indexSet={indexSet} stream={stream} />}
-      <StreamDataWarehouseComponent />
+      {StreamDataWarehouseComponent && <StreamDataWarehouseComponent />}
     </>
   );
 };

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDetails.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDetails.tsx
@@ -153,7 +153,7 @@ const StreamDetails = ({ stream }: Props) => {
 
   return (
     <>
-      <DataWarehouseJobComponent />
+      {DataWarehouseJobComponent && <DataWarehouseJobComponent />}
       <Container>
         <Header>
           <LeftCol>


### PR DESCRIPTION
This fix stream details page is not loading when the Plugin is not present because it is disabled.


/nocl
/jpd Graylog2/graylog-plugin-enterprise#7623

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

