### PR TITLE
Removing ability to look up entity by class name.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesCatalog.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/dbcatalog/DbEntitiesCatalog.java
@@ -29,11 +29,9 @@ public class DbEntitiesCatalog {
     private static final Logger LOG = LoggerFactory.getLogger(DbEntitiesCatalog.class);
 
     private final Map<String, DbEntityCatalogEntry> entitiesByCollectionName;
-    private final Map<Class<?>, DbEntityCatalogEntry> entitiesByClass;
 
     public DbEntitiesCatalog(final Collection<DbEntityCatalogEntry> entries) {
         entitiesByCollectionName = new HashMap<>(entries.size());
-        entitiesByClass = new HashMap<>(entries.size());
 
         entries.forEach(this::add);
     }
@@ -45,11 +43,6 @@ public class DbEntitiesCatalog {
             LOG.error(errorMsg);
             throw new IllegalStateException(errorMsg);
         }
-        entitiesByClass.put(entry.modelClass(), entry);
-    }
-
-    public Optional<DbEntityCatalogEntry> getByModelClass(final Class<?> modelClass) {
-        return Optional.ofNullable(entitiesByClass.get(modelClass));
     }
 
     public Optional<DbEntityCatalogEntry> getByCollectionName(final String collection) {

--- a/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesCatalogTest.java
@@ -32,7 +32,6 @@ class DbEntitiesCatalogTest {
         DbEntitiesCatalog catalog = new DbEntitiesCatalog(List.of());
 
         assertThat(catalog.getByCollectionName("Guadalajara")).isEmpty();
-        assertThat(catalog.getByModelClass(Object.class)).isEmpty();
     }
 
     @Test
@@ -40,7 +39,6 @@ class DbEntitiesCatalogTest {
         DbEntitiesCatalog catalog = new DbEntitiesCatalog(List.of(new DbEntityCatalogEntry("streams", "title", StreamImpl.class, "streams:read")));
 
         assertThat(catalog.getByCollectionName("Guadalajara")).isEmpty();
-        assertThat(catalog.getByModelClass(Object.class)).isEmpty();
     }
 
     @Test
@@ -48,11 +46,6 @@ class DbEntitiesCatalogTest {
         DbEntitiesCatalog catalog = new DbEntitiesCatalog(List.of(new DbEntityCatalogEntry("streams", "title", StreamImpl.class, "streams:read")));
 
         assertThat(catalog.getByCollectionName("streams"))
-                .isEqualTo(Optional.of(
-                        new DbEntityCatalogEntry("streams", "title", StreamImpl.class, "streams:read")
-                        )
-                );
-        assertThat(catalog.getByModelClass(StreamImpl.class))
                 .isEqualTo(Optional.of(
                         new DbEntityCatalogEntry("streams", "title", StreamImpl.class, "streams:read")
                         )

--- a/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/dbcatalog/DbEntitiesScannerTest.java
@@ -29,19 +29,14 @@ import static org.graylog2.shared.security.RestPermissions.INDEXSETS_READ;
 import static org.graylog2.shared.security.RestPermissions.USERS_READ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 class DbEntitiesScannerTest {
-
     @Test
     void testScansEntitiesWithDefaultTitleFieldProperly() {
         DbEntitiesScanner scanner = new DbEntitiesScanner(new String[]{"org.graylog2.indexer.indexset"}, new String[]{});
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName("index_sets").get();
-        final DbEntityCatalogEntry entryByModelClass = dbEntitiesCatalog.getByModelClass(IndexSetConfig.class).get();
-
-        assertSame(entryByCollectionName, entryByModelClass);
 
         assertEquals(new DbEntityCatalogEntry("index_sets", "title", IndexSetConfig.class, INDEXSETS_READ), entryByCollectionName);
     }
@@ -55,11 +50,8 @@ class DbEntitiesScannerTest {
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final Optional<DbEntityCatalogEntry> entryByCollectionName = dbEntitiesCatalog.getByCollectionName("index_sets");
-        final Optional<DbEntityCatalogEntry> entryByModelClass = dbEntitiesCatalog.getByModelClass(IndexSetConfig.class);
 
         assertFalse(entryByCollectionName.isPresent());
-        assertFalse(entryByModelClass.isPresent());
-
     }
 
     @Test
@@ -68,9 +60,6 @@ class DbEntitiesScannerTest {
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName("nodes").get();
-        final DbEntityCatalogEntry entryByModelClass = dbEntitiesCatalog.getByModelClass(ServerNodeEntity.class).get();
-
-        assertSame(entryByCollectionName, entryByModelClass);
 
         assertEquals(new DbEntityCatalogEntry("nodes", "node_id", ServerNodeEntity.class, NOBODY_ALLOWED), entryByCollectionName);
     }
@@ -81,12 +70,7 @@ class DbEntitiesScannerTest {
         final DbEntitiesCatalog dbEntitiesCatalog = scanner.get();
 
         final DbEntityCatalogEntry entryByCollectionName = dbEntitiesCatalog.getByCollectionName(UserImpl.COLLECTION_NAME).get();
-        final DbEntityCatalogEntry entryByModelClass = dbEntitiesCatalog.getByModelClass(UserImpl.class).get();
-
-        assertSame(entryByCollectionName, entryByModelClass);
 
         assertEquals(new DbEntityCatalogEntry(UserImpl.COLLECTION_NAME, UserImpl.USERNAME, UserImpl.class, USERS_READ), entryByCollectionName);
     }
-
-
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up to #19761, removing the unused `getByModelClass` method and references to it in tests. Referencing entities by class name is not a good pattern, as it uses implementation details. In this case, the major drawback is that it is not working with multiple `@DbEntity` annotations. Fortunately, this method was not used outside of tests anyway, so it gets removed with this PR.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.