### PR TITLE
Lazy configuration processing, printing all errors at once

### DIFF
--- a/changelog/unreleased/issue-19207.toml
+++ b/changelog/unreleased/issue-19207.toml
@@ -1,0 +1,5 @@
+type="c"
+message="Lazy configuration processing for datanode, collecting all errors in one go."
+
+issues=["19207"]
+pulls=["19801"]

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/CmdLineTool.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/CmdLineTool.java
@@ -269,8 +269,6 @@ public abstract class CmdLineTool implements CliCommand {
 
         coreConfigInjector = setupCoreConfigInjector();
 
-        processConfiguration(jadConfig);
-
         if (isDumpConfig()) {
             dumpCurrentConfigAndExit();
         }
@@ -421,7 +419,7 @@ public abstract class CmdLineTool implements CliCommand {
 
     protected void processConfiguration(JadConfig jadConfig) {
         try {
-            jadConfig.process();
+            jadConfig.processFailingLazily();
         } catch (RepositoryException e) {
             LOG.error("Couldn't load configuration: {}", e.getMessage());
             System.exit(1);


### PR DESCRIPTION
This PR changes the way how we handle configuration errors during startup. The original logic stopped on first encountered error, forcing user to fix it and try again, which could repeat several times and leads to tiresome process. The new logic discovers and reports all problems at once, making it easy to fix in one go.  

Removed duplicated configuration processing during the datanode startup, which I assume, was a copy-paste error.

## Description
See https://github.com/Graylog2/JadConfig/pull/127

## Motivation and Context
Fixes https://github.com/Graylog2/graylog2-server/issues/19207

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

Before, stopping at the first error:

```
2024-07-02 09:19:25,504 ERROR: org.graylog.datanode.bootstrap.CmdLineTool - Invalid configuration
com.github.joschi.jadconfig.ParameterException: Required parameter "opensearch_data_location" not found.
	at com.github.joschi.jadconfig.JadConfig.processClassField(JadConfig.java:173) ~[jadconfig-0.15.0.jar:?]
	at com.github.joschi.jadconfig.JadConfig.processClassFields(JadConfig.java:143) ~[jadconfig-0.15.0.jar:?]
	at com.github.joschi.jadconfig.JadConfig.process(JadConfig.java:103) ~[jadconfig-0.15.0.jar:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.processConfiguration(CmdLineTool.java:422) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.parseAndGetConfiguration(CmdLineTool.java:310) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.doRun(CmdLineTool.java:266) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.run(CmdLineTool.java:246) [classes/:?]
	at org.graylog.datanode.bootstrap.Main.main(Main.java:57) [classes/:?]
```

After, collecting all errors and then failing:

```
2024-07-02 09:21:06,927 ERROR: org.graylog.datanode.bootstrap.CmdLineTool - Invalid configuration
com.github.joschi.jadconfig.LazyValidationException: Following errors ocurred during configuration processing:
Required parameter "opensearch_data_location" not found.
Required parameter "opensearch_config_location" not found.
Required parameter "opensearch_logs_location" not found.
	at com.github.joschi.jadconfig.JadConfig.processFailingLazily(JadConfig.java:118) ~[jadconfig-0.15.0.jar:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.processConfiguration(CmdLineTool.java:422) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.parseAndGetConfiguration(CmdLineTool.java:310) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.doRun(CmdLineTool.java:266) [classes/:?]
	at org.graylog.datanode.bootstrap.CmdLineTool.run(CmdLineTool.java:246) [classes/:?]
	at org.graylog.datanode.bootstrap.Main.main(Main.java:57) [classes/:?]

```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

