### PR TITLE
Add guard for matching graylog/datanode version in migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
@@ -41,6 +41,8 @@ public interface MigrationActions {
     boolean renewalPolicyDoesNotExist();
     boolean caAndRenewalPolicyExist();
 
+    boolean compatibleDatanodesRunning();
+
     void provisionDataNodes();
 
     void provisionAndStartDataNodes();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
@@ -37,6 +37,7 @@ import org.graylog2.indexer.datanode.ProxyRequestAdapter;
 import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.plugin.GlobalMetricNames;
+import org.graylog2.plugin.Version;
 import org.graylog2.plugin.certificates.RenewalPolicy;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.resources.datanodes.DatanodeRestApiProxy;
@@ -76,6 +77,8 @@ public class MigrationActionsImpl implements MigrationActions {
     private final ElasticsearchVersionProvider searchVersionProvider;
     private final List<URI> elasticsearchHosts;
     private final ObjectMapper objectMapper;
+
+    private final Version graylogVersion = Version.CURRENT_CLASSPATH;
 
     @Inject
     public MigrationActionsImpl(final ClusterConfigService clusterConfigService, NodeService<DataNodeDto> nodeService,
@@ -175,6 +178,13 @@ public class MigrationActionsImpl implements MigrationActions {
     @Override
     public boolean caAndRenewalPolicyExist() {
         return !caDoesNotExist() && !renewalPolicyDoesNotExist();
+    }
+
+    @Override
+    public boolean compatibleDatanodesRunning() {
+        Map<String, DataNodeDto> nodes = nodeService.allActive();
+        return !nodes.isEmpty() && nodes.values().stream()
+                .allMatch(node -> Objects.equals(node.getDatanodeVersion(), graylogVersion.toString()));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
@@ -67,7 +67,7 @@ public class MigrationStateMachineBuilder {
         // remote reindexing branch of the migration
         config.configure(MigrationState.REMOTE_REINDEX_WELCOME_PAGE)
                 .onEntry(migrationActions::reindexUpgradeSelected)
-                .permitIf(MigrationStep.PROVISION_DATANODE_CERTIFICATES, MigrationState.PROVISION_DATANODE_CERTIFICATES_RUNNING, () -> !migrationActions.dataNodeStartupFinished(), migrationActions::provisionAndStartDataNodes)
+                .permitIf(MigrationStep.PROVISION_DATANODE_CERTIFICATES, MigrationState.PROVISION_DATANODE_CERTIFICATES_RUNNING, () -> !migrationActions.dataNodeStartupFinished() && migrationActions.compatibleDatanodesRunning(), migrationActions::provisionAndStartDataNodes)
                 .permitIf(MigrationStep.SHOW_DATA_MIGRATION_QUESTION, MigrationState.EXISTING_DATA_MIGRATION_QUESTION_PAGE, migrationActions::dataNodeStartupFinished);
 
         // This page should contain the "Please restart Graylog to continue with data migration"
@@ -98,7 +98,7 @@ public class MigrationStateMachineBuilder {
         // in place / rolling upgrade branch of the migration
         config.configure(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME_PAGE)
                 .onEntry(migrationActions::rollingUpgradeSelected)
-                .permit(MigrationStep.RUN_DIRECTORY_COMPATIBILITY_CHECK, MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE, migrationActions::runDirectoryCompatibilityCheck);
+                .permitIf(MigrationStep.RUN_DIRECTORY_COMPATIBILITY_CHECK, MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE, migrationActions::compatibleDatanodesRunning, migrationActions::runDirectoryCompatibilityCheck);
 
         config.configure(MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE)
                 .permitReentryIf(MigrationStep.RUN_DIRECTORY_COMPATIBILITY_CHECK, () -> !migrationActions.directoryCompatibilityCheckOk(), migrationActions::runDirectoryCompatibilityCheck)

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
@@ -125,6 +125,11 @@ public class MigrationActionsAdapter implements MigrationActions {
     }
 
     @Override
+    public boolean compatibleDatanodesRunning() {
+        return false;
+    }
+
+    @Override
     public void provisionDataNodes() {
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
@@ -146,6 +146,7 @@ public class MigrationStateMachineBuilderTest {
     @Test
     public void testRemoteReindexWelcomePage() {
         StateMachine<MigrationState, MigrationStep> stateMachine = getStateMachine(MigrationState.MIGRATION_SELECTION_PAGE);
+        when(migrationActions.compatibleDatanodesRunning()).thenReturn(true);
         stateMachine.fire(MigrationStep.SELECT_REMOTE_REINDEX_MIGRATION);
         assertThat(stateMachine.getState()).isEqualTo(MigrationState.REMOTE_REINDEX_WELCOME_PAGE);
         verify(migrationActions).reindexUpgradeSelected();
@@ -161,6 +162,7 @@ public class MigrationStateMachineBuilderTest {
     @Test
     public void testProvisionDatanodeCertificatesRunning() {
         StateMachine<MigrationState, MigrationStep> stateMachine = getStateMachine(MigrationState.REMOTE_REINDEX_WELCOME_PAGE);
+        when(migrationActions.compatibleDatanodesRunning()).thenReturn(true);
         stateMachine.fire(MigrationStep.PROVISION_DATANODE_CERTIFICATES);
         verify(migrationActions, times(1)).dataNodeStartupFinished();
         verify(migrationActions, times(1)).provisionAndStartDataNodes();
@@ -202,6 +204,7 @@ public class MigrationStateMachineBuilderTest {
     @Test
     public void testRollingUpgradeMigrationWelcomePage() {
         StateMachine<MigrationState, MigrationStep> stateMachine = getStateMachine(MigrationState.MIGRATION_SELECTION_PAGE);
+        when(migrationActions.compatibleDatanodesRunning()).thenReturn(true);
         when(migrationActions.isCompatibleInPlaceMigrationVersion()).thenReturn(true);
         stateMachine.fire(MigrationStep.SELECT_ROLLING_UPGRADE_MIGRATION);
         assertThat(stateMachine.getState()).isEqualTo(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME_PAGE);
@@ -213,6 +216,7 @@ public class MigrationStateMachineBuilderTest {
     @Test
     public void testDirectoryCompatibilityCheckPage() {
         StateMachine<MigrationState, MigrationStep> stateMachine = getStateMachine(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME_PAGE);
+        when(migrationActions.compatibleDatanodesRunning()).thenReturn(true);
         stateMachine.fire(MigrationStep.RUN_DIRECTORY_COMPATIBILITY_CHECK);
         assertThat(stateMachine.getState()).isEqualTo(MigrationState.DIRECTORY_COMPATIBILITY_CHECK_PAGE);
         assertThat(stateMachine.getPermittedTriggers()).containsOnly(MigrationStep.RUN_DIRECTORY_COMPATIBILITY_CHECK);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a guard for disallowing next steps after welcome pages of in-place and remote reindexing if there are datanodes running with version not matching the graylog version. 

## Motivation and Context
extending #19680 , making it impossible to perform migrations with incompatible versions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

