### PR TITLE
Import scatterpolar from plotly.

### DIFF
--- a/graylog2-web-interface/src/views/custom-plotly.ts
+++ b/graylog2-web-interface/src/views/custom-plotly.ts
@@ -19,6 +19,7 @@ import Bar from 'plotly.js/lib/bar';
 import Pie from 'plotly.js/lib/pie';
 import Heatmap from 'plotly.js/lib/heatmap';
 import Scatter from 'plotly.js/lib/scatter';
+import Scatterpolar from 'plotly.js/lib/scatterpolar';
 
 // @ts-ignore
 Plotly.register([
@@ -26,6 +27,7 @@ Plotly.register([
   Pie,
   Scatter,
   Heatmap,
+  Scatterpolar,
 ]);
 
 export default Plotly;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With this PR we import another plotly visualization, the scatterpolar. This allows using the visualization type when rendering a plotly chart.

/nocl

