### PR TITLE
Add pipeline rule output destination filter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -146,6 +146,7 @@ import org.graylog.plugins.pipelineprocessor.functions.urls.IsUrl;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlDecode;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlEncode;
+import org.graylog.plugins.pipelineprocessor.parser.InternalPipelineFunctions;
 import org.graylog2.plugin.PluginModule;
 
 public class ProcessorFunctionsModule extends PluginModule {
@@ -323,12 +324,23 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(binder(), name, functionClass);
     }
 
+    protected void addInternalMessageProcessorFunction(String name, Class<? extends Function<?>> functionClass) {
+        addInternalMessageProcessorFunction(binder(), name, functionClass);
+    }
+
     public static MapBinder<String, Function<?>> processorFunctionBinder(Binder binder) {
         return MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), new TypeLiteral<>() {});
     }
 
+    public static MapBinder<String, Function<?>> processorInternalFunctionBinder(Binder binder) {
+        return MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), new TypeLiteral<>() {}, InternalPipelineFunctions.class);
+    }
+
     public static void addMessageProcessorFunction(Binder binder, String name, Class<? extends Function<?>> functionClass) {
         processorFunctionBinder(binder).addBinding(name).to(functionClass);
+    }
 
+    public static void addInternalMessageProcessorFunction(Binder binder, String name, Class<? extends Function<?>> functionClass) {
+        processorInternalFunctionBinder(binder).addBinding(name).to(functionClass);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/FunctionRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/FunctionRegistry.java
@@ -16,26 +16,32 @@
  */
 package org.graylog.plugins.pipelineprocessor.parser;
 
-import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
-
 import jakarta.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FunctionRegistry {
 
     private final Map<String, Function<?>> functions;
+    private final Map<String, Function<?>> internalFunctions;
 
     @Inject
-    public FunctionRegistry(Map<String, Function<?>> functions) {
+    public FunctionRegistry(Map<String, Function<?>> functions,
+                            @InternalPipelineFunctions Map<String, Function<?>> internalFunctions) {
         this.functions = functions;
+        this.internalFunctions = internalFunctions;
     }
 
+    public FunctionRegistry(Map<String, Function<?>> functions) {
+        this(functions, Map.of());
+    }
 
     public Function<?> resolve(String name) {
-        return functions.get(name);
+        return functions.getOrDefault(name, internalFunctions.get(name));
     }
 
     public Function<?> resolveOrError(String name) {
@@ -46,9 +52,24 @@ public class FunctionRegistry {
         return function;
     }
 
+    /**
+     * Returns all registered public functions.
+     *
+     * @return a collection of functions
+     */
     public Collection<Function<?>> all() {
         return functions.values().stream().collect(Collectors.toList());
     }
 
+    /**
+     * Returns all registered public and internal functions.
+     *
+     * @return a collection of functions
+     */
+    public Collection<Function<?>> allWithInternal() {
+        return Stream.of(functions.values(), internalFunctions.values())
+                .flatMap(Collection::stream)
+                .toList();
+    }
 }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/InternalPipelineFunctions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/InternalPipelineFunctions.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.parser;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for internal pipeline rule functions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Qualifier
+public @interface InternalPipelineFunctions {
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/RuleBuilderRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/RuleBuilderRegistry.java
@@ -17,11 +17,10 @@
 package org.graylog.plugins.pipelineprocessor.rulebuilder;
 
 import com.google.common.collect.Streams;
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragmentService;
-
-import jakarta.inject.Inject;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -40,7 +39,7 @@ public class RuleBuilderRegistry {
     }
 
     public Map<String, RuleFragment> conditions() {
-        final Stream<RuleFragment> functionConditions = functionRegistry.all()
+        final Stream<RuleFragment> functionConditions = functionRegistry.allWithInternal()
                 .stream()
                 .filter(f -> f.descriptor().ruleBuilderEnabled()
                         && f.descriptor().returnType().equals(Boolean.class))
@@ -55,7 +54,7 @@ public class RuleBuilderRegistry {
     }
 
     public Map<String, RuleFragment> actions() {
-        final Stream<RuleFragment> functions = functionRegistry.all()
+        final Stream<RuleFragment> functions = functionRegistry.allWithInternal()
                 .stream()
                 .filter(f -> f.descriptor().ruleBuilderEnabled()
                         && !f.descriptor().returnType().equals(Boolean.class))

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/ActionParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/ActionParser.java
@@ -17,14 +17,13 @@
 package org.graylog.plugins.pipelineprocessor.rulebuilder.parser;
 
 import freemarker.template.Configuration;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderRegistry;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderStep;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ public class ActionParser {
 
     @Inject
     public ActionParser(RuleBuilderRegistry ruleBuilderRegistry, SecureFreemarkerConfigProvider secureFreemarkerConfigProvider) {
-        this.actions = ruleBuilderRegistry.actions();
+        this.actions = ruleBuilderRegistry.actionsWithInternal();
         this.freemarkerConfiguration = ParserUtil.initializeFragmentTemplates(secureFreemarkerConfigProvider, actions);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/ConditionParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/ConditionParser.java
@@ -17,15 +17,14 @@
 package org.graylog.plugins.pipelineprocessor.rulebuilder.parser;
 
 import freemarker.template.Configuration;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderRegistry;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderStep;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,7 @@ public class ConditionParser {
 
     @Inject
     public ConditionParser(RuleBuilderRegistry ruleBuilderRegistry, SecureFreemarkerConfigProvider secureFreemarkerConfigProvider) {
-        this.conditions = ruleBuilderRegistry.conditions();
+        this.conditions = ruleBuilderRegistry.conditionsWithInternal();
         freemarkerConfiguration = ParserUtil.initializeFragmentTemplates(secureFreemarkerConfigProvider, conditions);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidAction.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidAction.java
@@ -32,7 +32,7 @@ public class ValidAction implements Validator {
 
     @Inject
     public ValidAction(RuleBuilderRegistry ruleBuilderRegistry) {
-        this.actions = ruleBuilderRegistry.actions();
+        this.actions = ruleBuilderRegistry.actionsWithInternal();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNegation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNegation.java
@@ -29,7 +29,7 @@ public class ValidNegation implements Validator {
     private final Map<String, RuleFragment> actions;
 
     public ValidNegation(RuleBuilderRegistry ruleBuilderRegistry) {
-        this.actions = ruleBuilderRegistry.actions();
+        this.actions = ruleBuilderRegistry.actionsWithInternal();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNewMessageField.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNewMessageField.java
@@ -38,7 +38,7 @@ public class ValidNewMessageField implements Validator {
 
     @Inject
     public ValidNewMessageField(RuleBuilderRegistry ruleBuilderRegistry) {
-        this.actions = ruleBuilderRegistry.actions();
+        this.actions = ruleBuilderRegistry.actionsWithInternal();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariables.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariables.java
@@ -41,7 +41,7 @@ public class ValidVariables implements Validator {
 
     @Inject
     public ValidVariables(RuleBuilderRegistry ruleBuilderRegistry) {
-        this.actions = ruleBuilderRegistry.actions();
+        this.actions = ruleBuilderRegistry.actionsWithInternal();
         this.variables = new HashMap<>();
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/condition/ValidCondition.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/condition/ValidCondition.java
@@ -16,13 +16,12 @@
  */
 package org.graylog.plugins.pipelineprocessor.rulebuilder.parser.validation.condition;
 
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderRegistry;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderStep;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.db.RuleFragment;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.parser.validation.ValidationResult;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.parser.validation.Validator;
-
-import jakarta.inject.Inject;
 
 import java.util.Map;
 import java.util.Objects;
@@ -33,7 +32,7 @@ public class ValidCondition implements Validator {
 
     @Inject
     public ValidCondition(RuleBuilderRegistry ruleBuilderRegistry) {
-        this.conditions = ruleBuilderRegistry.conditions();
+        this.conditions = ruleBuilderRegistry.conditionsWithInternal();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -19,7 +19,6 @@ package org.graylog2.outputs;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.ImmutableMultimap;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.graylog2.indexer.messages.IndexingResults;
@@ -38,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -90,12 +90,7 @@ public class ElasticSearchOutput implements MessageOutput, FilteredMessageOutput
         if (LOG.isTraceEnabled()) {
             LOG.trace("Writing message id to [{}]: <{}>", NAME, message.getId());
         }
-        writeMessageEntries(List.of(new DefaultFilteredMessage(
-                message,
-                ImmutableMultimap.<String, Stream>builder()
-                        .putAll(FILTER_KEY, message.getStreams())
-                        .build()
-        )));
+        writeMessageEntries(List.of(DefaultFilteredMessage.forDestinationKeys(message, Set.of(FILTER_KEY))));
     }
 
     @Override
@@ -104,12 +99,7 @@ public class ElasticSearchOutput implements MessageOutput, FilteredMessageOutput
             LOG.trace("Writing {} messages to [{}]", messageList.size(), NAME);
         }
         writeMessageEntries(messageList.stream()
-                .map(message -> new DefaultFilteredMessage(
-                        message,
-                        ImmutableMultimap.<String, Stream>builder()
-                                .putAll(FILTER_KEY, message.getStreams())
-                                .build()
-                ))
+                .map(message -> DefaultFilteredMessage.forDestinationKeys(message, Set.of(FILTER_KEY)))
                 .collect(Collectors.toList()));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/AllOutputsFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/AllOutputsFilter.java
@@ -38,6 +38,6 @@ public class AllOutputsFilter implements OutputFilter {
 
     @Override
     public FilteredMessage apply(Message msg) {
-        return new DefaultFilteredMessage(msg, outputNames);
+        return DefaultFilteredMessage.forDestinationKeys(msg, outputNames);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/FilteredMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/FilteredMessage.java
@@ -16,12 +16,12 @@
  */
 package org.graylog2.outputs.filter;
 
+import com.google.common.collect.Multimap;
 import org.graylog2.plugin.Message;
-
-import java.util.Set;
+import org.graylog2.plugin.streams.Stream;
 
 /**
- * A filtered message that contains output target information.
+ * A filtered message that contains output destination information.
  */
 public interface FilteredMessage {
     /**
@@ -32,11 +32,11 @@ public interface FilteredMessage {
     Message message();
 
     /**
-     * A set of output targets names.
+     * A multimap of destination streams.
      *
-     * @return set of output targets
+     * @return multimap of destination streams
      */
-    Set<String> outputs();
+    Multimap<String, Stream> destinations();
 
     /**
      * Whether the message has been indexed or not.

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/OutputFilterModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/OutputFilterModule.java
@@ -16,12 +16,19 @@
  */
 package org.graylog2.outputs.filter;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
+import org.graylog2.outputs.filter.functions.RemoveFromStreamDestination;
 
-public class OutputFilterModule extends AbstractModule {
+public class OutputFilterModule extends ProcessorFunctionsModule {
     @Override
     protected void configure() {
-        bind(OutputFilter.class).to(AllOutputsFilter.class).in(Scopes.SINGLETON);
+        bind(OutputFilter.class).to(PipelineRuleOutputFilter.class).in(Scopes.SINGLETON);
+
+        bind(PipelineRuleOutputFilterStateUpdater.class).in(Scopes.SINGLETON);
+        install(new FactoryModuleBuilder().build(PipelineRuleOutputFilterState.Factory.class));
+
+        addInternalMessageProcessorFunction(RemoveFromStreamDestination.NAME, RemoveFromStreamDestination.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilter.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog.plugins.pipelineprocessor.processors.listeners.NoopInterpreterListener;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.shared.messageq.noop.NoopMessageQueueAcknowledger;
+import org.graylog2.streams.filters.StreamDestinationFilterDeletedEvent;
+import org.graylog2.streams.filters.StreamDestinationFilterUpdatedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+/**
+ * An {@link OutputFilter} that filters messages with pipeline processor rules based on stream destination filters.
+ *
+ * @see org.graylog2.streams.filters.StreamDestinationFilterService
+ */
+@Singleton
+public class PipelineRuleOutputFilter implements OutputFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineRuleOutputFilter.class);
+    private static final NoopInterpreterListener NOOP_INTERPRETER_LISTENER = new NoopInterpreterListener();
+    public static final String METADATA_KEY = PipelineRuleOutputFilter.class.getCanonicalName();
+
+    private final PipelineRuleOutputFilterStateUpdater stateUpdater;
+    private final ScheduledExecutorService scheduler;
+    private final AtomicReference<PipelineRuleOutputFilterState> activeState = new AtomicReference<>();
+    private final PipelineInterpreter pipelineInterpreter;
+    private final Timer executionTime;
+
+    @Inject
+    public PipelineRuleOutputFilter(PipelineRuleOutputFilterStateUpdater stateUpdater,
+                                    @Named("daemonScheduler") ScheduledExecutorService scheduler,
+                                    MetricRegistry metricRegistry,
+                                    EventBus eventBus) {
+        this.stateUpdater = stateUpdater;
+        this.scheduler = scheduler;
+
+        // TODO: We probably want to extract the actual pipeline interpreter out of the PipelineInterpreter which
+        //       is actually a MessageProcessor. That would make it more reusable.
+        // We can pass a null value for the stateUpdater because we don't use functions that use it.
+        this.pipelineInterpreter = new PipelineInterpreter(new NoopMessageQueueAcknowledger(), new MetricRegistry(), null);
+
+        this.executionTime = metricRegistry.timer(name(getClass(), "executionTime"));
+
+        eventBus.register(this);
+        stateUpdater.init(activeState); // This blocks to ensure we have a config before we start processing
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    private void handleFilterUpdate(StreamDestinationFilterUpdatedEvent event) {
+        LOG.info("Handling filter update: {}", event);
+        scheduler.execute(() -> stateUpdater.reloadForUpdate(activeState, event.ids()));
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe
+    private void handleFilterDelete(StreamDestinationFilterDeletedEvent event) {
+        LOG.info("Handling filter deletion: {}", event);
+        scheduler.execute(() -> stateUpdater.reloadForDelete(activeState, event.ids()));
+    }
+
+    @Override
+    public FilteredMessage apply(Message msg) {
+        try (var ignored = executionTime.time()) {
+            return doApply(msg);
+        }
+    }
+
+    public record Metadata(Multimap<String, Stream> destinations) {
+        public static Metadata forDestinationsAndStreams(Set<String> destinations, Set<Stream> streams) {
+            final Multimap<String, Stream> destinationsBuilder = MultimapBuilder.hashKeys().hashSetValues().build();
+
+            // Populate each destination with all message streams
+            destinations.forEach(destination -> destinationsBuilder.putAll(destination, streams));
+
+            return new Metadata(destinationsBuilder);
+        }
+    }
+
+    private DefaultFilteredMessage doApply(Message msg) {
+        final var state = activeState.get();
+        if (state == null) {
+            throw new IllegalStateException("Active state has not been initialized");
+        }
+
+        final var newMetadata = Metadata.forDestinationsAndStreams(state.getDestinations(), msg.getStreams());
+
+        if (state.isEmpty()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("No active filter - returning early");
+            }
+            return new DefaultFilteredMessage(msg, newMetadata.destinations());
+        }
+
+        // Add metadata to message, so we can modify it from the filter rules
+        msg.setMetadata(METADATA_KEY, newMetadata);
+
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Message metadata before running filter: {} (message-id={})", newMetadata, msg.getId());
+        }
+
+        final var pipelinesToRun = state.getPipelinesForMessage(msg);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Running {} pipelines for message <{}>: {}", pipelinesToRun.size(), msg.getId(), pipelinesToRun);
+        }
+        pipelineInterpreter.processForResolvedPipelines(
+                msg,
+                msg.getId(),
+                pipelinesToRun,
+                NOOP_INTERPRETER_LISTENER,
+                activeState.get()
+        );
+
+        if (msg.getMetadataValue(METADATA_KEY) instanceof Metadata metadata) {
+            msg.removeMetadata(METADATA_KEY); // Free up metadata early since we don't need it anymore
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Message metadata after running filter: {} (message-id={})", metadata, msg.getId());
+            }
+            return new DefaultFilteredMessage(msg, metadata.destinations());
+        }
+        // Since we set the metadata before we pass the message into the interpreter, it's a bug if it doesn't exist.
+        throw new IllegalStateException(f("No metadata found for message <%s> - this should not happen!", msg.getId()));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterState.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterState.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.inject.assistedinject.Assisted;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.db.RuleMetricsConfigDto;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
+import org.graylog2.plugin.Message;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class PipelineRuleOutputFilterState extends PipelineInterpreter.State {
+    public interface Factory {
+        PipelineRuleOutputFilterState newState(@Assisted("pipelines") ImmutableMap<String, Pipeline> pipelines,
+                                               @Assisted("destinations") ImmutableSet<String> destinations,
+                                               @Assisted("activeStreams") ImmutableSet<String> activeStreams);
+    }
+
+    private final ImmutableSet<String> destinations;
+    private final ImmutableSet<String> activeStreams;
+
+    @Inject
+    public PipelineRuleOutputFilterState(@Assisted("pipelines") ImmutableMap<String, Pipeline> pipelines,
+                                         @Assisted("destinations") ImmutableSet<String> destinations,
+                                         @Assisted("activeStreams") ImmutableSet<String> activeStreams,
+                                         MetricRegistry metricRegistry,
+                                         @Named("processbuffer_processors") int processorCount,
+                                         @Named("cached_stageiterators") boolean cachedIterators) {
+        super(
+                pipelines,
+                ImmutableSetMultimap.of(),
+                RuleMetricsConfigDto.createDefault(),
+                metricRegistry,
+                processorCount,
+                cachedIterators
+        );
+        this.destinations = destinations;
+        this.activeStreams = activeStreams;
+    }
+
+    public boolean isEmpty() {
+        return getCurrentPipelines().isEmpty();
+    }
+
+    public ImmutableSet<String> getDestinations() {
+        return destinations;
+    }
+
+    public ImmutableSet<String> getActiveStreams() {
+        return activeStreams;
+    }
+
+    public Set<Pipeline> getPipelinesForMessage(Message msg) {
+        // The current pipelines are keyed by stream
+        return msg.getStreamIds().stream()
+                .map(id -> getCurrentPipelines().get(id))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    protected String getStageCacheMetricName() {
+        return name(PipelineRuleOutputFilter.class, STAGE_CACHE_METRIC_SUFFIX);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterStateUpdater.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterStateUpdater.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
+import org.graylog.plugins.pipelineprocessor.db.RuleDao;
+import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineMetricRegistry;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolver;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolverConfig;
+import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderStep;
+import org.graylog.plugins.pipelineprocessor.rulebuilder.parser.RuleBuilderService;
+import org.graylog2.outputs.filter.functions.RemoveFromStreamDestination;
+import org.graylog2.plugin.outputs.FilteredMessageOutput;
+import org.graylog2.streams.filters.StreamDestinationFilterRuleDTO;
+import org.graylog2.streams.filters.StreamDestinationFilterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+/**
+ * State updater for the {@link PipelineRuleOutputFilter}.
+ */
+@Singleton
+public class PipelineRuleOutputFilterStateUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineRuleOutputFilterStateUpdater.class);
+
+    private final StreamDestinationFilterService filterService;
+    private final PipelineRuleOutputFilterState.Factory stateFactory;
+    private final Map<String, FilteredMessageOutput> filteredOutputs;
+    private final RuleBuilderService ruleBuilderService;
+    private final PipelineResolver.Factory resolverFactory;
+    private final PipelineRuleParser pipelineRuleParser;
+    private final PipelineMetricRegistry pipelineMetricRegistry;
+
+    @Inject
+    public PipelineRuleOutputFilterStateUpdater(StreamDestinationFilterService filterService,
+                                                PipelineRuleOutputFilterState.Factory stateFactory,
+                                                Map<String, FilteredMessageOutput> filteredOutputs,
+                                                RuleBuilderService ruleBuilderService,
+                                                PipelineResolver.Factory resolverFactory,
+                                                PipelineRuleParser pipelineRuleParser,
+                                                MetricRegistry metricRegistry) {
+        this.filterService = filterService;
+        this.stateFactory = stateFactory;
+        this.filteredOutputs = filteredOutputs;
+        this.ruleBuilderService = ruleBuilderService;
+        this.resolverFactory = resolverFactory;
+        this.pipelineRuleParser = pipelineRuleParser;
+
+        this.pipelineMetricRegistry = PipelineMetricRegistry.create(
+                metricRegistry,
+                name(PipelineRuleOutputFilter.class, "pipelines"),
+                name(PipelineRuleOutputFilter.class, "rules")
+        );
+    }
+
+    public void init(AtomicReference<PipelineRuleOutputFilterState> activeState) {
+        reload(activeState, ReloadTrigger.empty());
+    }
+
+    public void reloadForUpdate(AtomicReference<PipelineRuleOutputFilterState> activeState,
+                                Set<String> updatedFilterRuleIds) {
+        reload(activeState, ReloadTrigger.updatedIds(updatedFilterRuleIds));
+    }
+
+    public void reloadForDelete(AtomicReference<PipelineRuleOutputFilterState> activeState,
+                                Set<String> deletedFilterRuleIds) {
+        reload(activeState, ReloadTrigger.deletedIds(deletedFilterRuleIds));
+    }
+
+    private synchronized void reload(AtomicReference<PipelineRuleOutputFilterState> activeState,
+                                     ReloadTrigger reloadTrigger) {
+        LOG.info("Reloading filter rules: {}", reloadTrigger);
+
+        final var streamPipelines = new HashMap<String, Pipeline>();
+        final var allRules = new ArrayList<RuleDao>();
+        // We track active and previously active stream IDs, so we can clean up the metrics.
+        final var activeStreams = new HashSet<String>();
+        final var previouslyActiveStreams = getPreviouslyActiveStreams(activeState);
+
+        // TODO: Only load rules where the stream still exists and is active!
+        filterService.forEachEnabledFilterGroupedByStream(streamGroup -> {
+            LOG.info("Processing stream group: {}", streamGroup);
+
+            final var streamId = streamGroup.streamId();
+            final var ruleList = streamGroup.filters()
+                    .stream()
+                    .map(this::streamDestinationFilterToRuleDao)
+                    .toList();
+
+            final var filterPipeline = Pipeline.builder()
+                    // We use the stream ID as pipeline ID, so we can easily select the pipelines we need to
+                    // run for a message.
+                    .id(streamId)
+                    .name("Stream Destination Filter: " + streamId)
+                    .stages(ImmutableSortedSet.of(
+                            Stage.builder()
+                                    .stage(0)
+                                    .match(Stage.Match.EITHER)
+                                    .ruleReferences(ruleList.stream().map(RuleDao::title).toList())
+                                    .build()
+                    ))
+                    .build();
+
+            streamPipelines.put(streamId, filterPipeline);
+            allRules.addAll(ruleList);
+            activeStreams.add(streamId);
+        });
+
+        LOG.info("Stream pipelines: {}", streamPipelines);
+        LOG.info("Rule list: {}", allRules);
+        LOG.info("Active streams: {}", activeStreams);
+
+        final var resolver = resolverFactory.create(
+                PipelineResolverConfig.of(allRules::stream, java.util.stream.Stream::of),
+                pipelineRuleParser
+        );
+
+        // This activates the new state! Only do cleanup after this statement.
+        activeState.set(stateFactory.newState(
+                resolver.resolveFunctions(streamPipelines.values(), pipelineMetricRegistry),
+                ImmutableSet.copyOf(filteredOutputs.keySet()),
+                ImmutableSet.copyOf(activeStreams)
+        ));
+
+        // Cleanup metrics for old pipeline and rule IDs to avoid stale entries in the metric registry.
+        reloadTrigger.deletedIds().forEach(ruleId -> {
+            LOG.info("Removing rule metrics for: {}", ruleId);
+            pipelineMetricRegistry.removeRuleMetrics(ruleId);
+        });
+        Sets.difference(previouslyActiveStreams, activeStreams).forEach(pipelineId -> {
+            LOG.info("Removing pipeline metrics for: {}", pipelineId);
+            pipelineMetricRegistry.removePipelineMetrics(pipelineId);
+        });
+    }
+
+    private RuleDao streamDestinationFilterToRuleDao(StreamDestinationFilterRuleDTO dto) {
+        // The filter rules are exclude rules. For each matching rule we remove the filter rule's stream from the
+        // destination.
+        final var removalAction = RuleBuilderStep.builder()
+                .id(UUID.randomUUID().toString())
+                .title(UUID.randomUUID().toString())
+                .function(RemoveFromStreamDestination.NAME)
+                .parameters(Map.of(
+                        RemoveFromStreamDestination.STREAM_ID_PARAM, dto.streamId(),
+                        RemoveFromStreamDestination.DESTINATION_TYPE_PARAM, dto.destinationType()
+                ))
+                .build();
+
+        // The removal action must be added to the rule, so it's executed when the rule condition matches.
+        final var ruleWithRemovalAction = dto.rule().toBuilder().actions(List.of(removalAction)).build();
+
+        // The uniqueness of the dto.title() is no guaranteed.
+        final var title = f("[%s] %s", dto.id(), dto.title());
+        return RuleDao.builder()
+                .id(dto.id())
+                .title(title)
+                .source(ruleBuilderService.generateRuleSource(title, ruleWithRemovalAction, false))
+                .build();
+    }
+
+    private Set<String> getPreviouslyActiveStreams(AtomicReference<PipelineRuleOutputFilterState> activeState) {
+        return activeState.get() != null ? activeState.get().getActiveStreams() : Set.of();
+    }
+
+    private record ReloadTrigger(Set<String> updatedIds, Set<String> deletedIds) {
+        public static ReloadTrigger empty() {
+            return new ReloadTrigger(Set.of(), Set.of());
+        }
+
+        public static ReloadTrigger updatedIds(Set<String> updatedIds) {
+            return new ReloadTrigger(updatedIds, Set.of());
+        }
+
+        public static ReloadTrigger deletedIds(Set<String> deletedIds) {
+            return new ReloadTrigger(Set.of(), deletedIds);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/outputs/filter/functions/RemoveFromStreamDestination.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/filter/functions/RemoveFromStreamDestination.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter.functions;
+
+import com.google.common.collect.ImmutableList;
+import jakarta.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
+import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderFunctionGroup;
+import org.graylog2.outputs.filter.PipelineRuleOutputFilter;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
+
+/**
+ * An internal function that is used for the pipeline processing rule {@link org.graylog2.outputs.filter.OutputFilter}
+ * implementation.
+ *
+ * @see PipelineRuleOutputFilter
+ */
+public class RemoveFromStreamDestination extends AbstractFunction<Void> {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveFromStreamDestination.class);
+    private static final Logger RATE_LIMITED_LOG = RateLimitedLogFactory.createRateLimitedLog(LOG, 1, Duration.ofSeconds(15));
+
+    public static final String NAME = "__remove_from_stream_destination__";
+    public static final String STREAM_ID_PARAM = "stream_id";
+    public static final String DESTINATION_TYPE_PARAM = "destination_type";
+
+    private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<String, String> streamIdParam;
+    private final ParameterDescriptor<String, String> destinationTypeParam;
+
+    private final StreamCacheService streamCacheService;
+
+    @Inject
+    public RemoveFromStreamDestination(StreamCacheService streamCacheService) {
+        this.streamCacheService = streamCacheService;
+        this.messageParam = type("message", Message.class).optional().description("The message to use, defaults to '$message'.").build();
+        this.streamIdParam = string(STREAM_ID_PARAM).optional().description("The stream to remove the message from.").build();
+        this.destinationTypeParam = string(DESTINATION_TYPE_PARAM).optional().description("The destination type to remove the message from.").build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        final var streamId = streamIdParam.required(args, context);
+        final var destinationType = destinationTypeParam.required(args, context);
+        final var message = messageParam.optional(args, context).orElse(context.currentMessage());
+
+        if (message.getMetadataValue(PipelineRuleOutputFilter.METADATA_KEY) instanceof PipelineRuleOutputFilter.Metadata metadata) {
+            final var stream = streamCacheService.getById(streamId);
+            if (stream != null) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Removing stream <{}/{}> from destination <{}> for message: {}", stream.getId(), stream.getTitle(), destinationType, message);
+                }
+                metadata.destinations().remove(destinationType, stream);
+            } else {
+                RATE_LIMITED_LOG.warn("Couldn't find stream for stream ID <{}> in cache", streamId);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
+                .name(NAME)
+                .returnType(Void.class)
+                .params(ImmutableList.of(streamIdParam, destinationTypeParam, messageParam))
+                .description("[INTERNAL] Removes a message from a stream target.")
+                .ruleBuilderEnabled()
+                .ruleBuilderName(NAME)
+                .ruleBuilderTitle("[INTERNAL] Removes a message from a stream target.")
+                .ruleBuilderFunctionGroup(RuleBuilderFunctionGroup.OTHER)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -16,10 +16,8 @@
  */
 package org.graylog2.streams;
 
-import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.inject.Graylog2Module;
-import org.graylog2.streams.filters.StreamDestinationFilterService;
 import org.graylog2.streams.input.StreamRuleInputsProvider;
 import org.graylog2.streams.input.StreamRuleServerInputsProvider;
 
@@ -29,8 +27,6 @@ public class StreamsModule extends Graylog2Module {
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
         bind(StreamService.class).to(StreamServiceImpl.class);
-
-        bind(StreamDestinationFilterService.class).in(Scopes.SINGLETON);
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);
         uriBinder.addBinding().to(StreamRuleServerInputsProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -16,8 +16,10 @@
  */
 package org.graylog2.streams;
 
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.inject.Graylog2Module;
+import org.graylog2.streams.filters.StreamDestinationFilterService;
 import org.graylog2.streams.input.StreamRuleInputsProvider;
 import org.graylog2.streams.input.StreamRuleServerInputsProvider;
 
@@ -27,6 +29,8 @@ public class StreamsModule extends Graylog2Module {
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
         bind(StreamService.class).to(StreamServiceImpl.class);
+
+        bind(StreamDestinationFilterService.class).in(Scopes.SINGLETON);
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);
         uriBinder.addBinding().to(StreamRuleServerInputsProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterDeletedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterDeletedEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.streams.filters;
+
+import java.util.Set;
+
+public record StreamDestinationFilterDeletedEvent(Set<String> ids) {
+    public static StreamDestinationFilterDeletedEvent of(String id) {
+        return new StreamDestinationFilterDeletedEvent(Set.of(id));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
@@ -151,7 +151,7 @@ public class StreamDestinationFilterService {
                 .orElseThrow(() -> new IllegalArgumentException(f("Couldn't find document with ID <%s> for deletion", id)));
 
         if (collection.deleteOne(and(eq(FIELD_STREAM_ID, streamId), idEq(id))).getDeletedCount() > 0) {
-            clusterEventBus.post(StreamDestinationFilterUpdatedEvent.of(id));
+            clusterEventBus.post(StreamDestinationFilterDeletedEvent.of(id));
         }
 
         return dto;

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
@@ -23,7 +23,6 @@ import com.mongodb.client.model.Accumulators;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Indexes;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.bson.conversions.Bson;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
@@ -53,7 +52,6 @@ import static org.graylog2.streams.filters.StreamDestinationFilterRuleDTO.FIELD_
 import static org.graylog2.streams.filters.StreamDestinationFilterRuleDTO.FIELD_STREAM_ID;
 import static org.graylog2.streams.filters.StreamDestinationFilterRuleDTO.FIELD_TITLE;
 
-@Singleton
 public class StreamDestinationFilterService {
     static final String COLLECTION = "stream_destination_filters";
 

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterUpdatedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterUpdatedEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.streams.filters;
+
+import java.util.Set;
+
+public record StreamDestinationFilterUpdatedEvent(Set<String> ids) {
+    public static StreamDestinationFilterUpdatedEvent of(String id) {
+        return new StreamDestinationFilterUpdatedEvent(Set.of(id));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidActionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidActionTest.java
@@ -52,7 +52,7 @@ class ValidActionTest {
         RuleFragment ruleFragment = FunctionUtil.testCondition(TEST_ACTION, "fragment", optional);
         actions.put(TEST_ACTION, ruleFragment);
 
-        when(ruleBuilderRegistry.actions()).thenReturn(actions);
+        when(ruleBuilderRegistry.actionsWithInternal()).thenReturn(actions);
 
         classUnderTest = new ValidAction(ruleBuilderRegistry);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNegationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNegationTest.java
@@ -67,7 +67,7 @@ class ValidNegationTest {
                 .descriptor(fragmentFunction.descriptor())
                 .build());
 
-        when(ruleBuilderRegistry.actions()).thenReturn(actions);
+        when(ruleBuilderRegistry.actionsWithInternal()).thenReturn(actions);
 
         classUnderTest = new ValidNegation(ruleBuilderRegistry);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNewMessageFieldTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidNewMessageFieldTest.java
@@ -65,7 +65,7 @@ class ValidNewMessageFieldTest {
                 .descriptor(setFieldFunction.descriptor())
                 .build());
 
-        when(ruleBuilderRegistry.actions()).thenReturn(actions);
+        when(ruleBuilderRegistry.actionsWithInternal()).thenReturn(actions);
 
         classUnderTest = new ValidNewMessageField(ruleBuilderRegistry);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariablesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/action/ValidVariablesTest.java
@@ -68,7 +68,7 @@ class ValidVariablesTest {
         actions.put(INTEGER_FUNCTION, RuleFragment.builder().descriptor(integerFunction.descriptor()).build());
         actions.put(VOID_FUNCTION, RuleFragment.builder().descriptor(voidFunction.descriptor()).build());
 
-        when(ruleBuilderRegistry.actions()).thenReturn(actions);
+        when(ruleBuilderRegistry.actionsWithInternal()).thenReturn(actions);
 
         classUnderTest = new ValidVariables(ruleBuilderRegistry);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/condition/ValidConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/rulebuilder/parser/validation/condition/ValidConditionTest.java
@@ -52,7 +52,7 @@ class ValidConditionTest {
         RuleFragment ruleFragment = FunctionUtil.testCondition(TEST_CONDITION, "fragment", optional);
         conditions.put(TEST_CONDITION, ruleFragment);
 
-        when(ruleBuilderRegistry.conditions()).thenReturn(conditions);
+        when(ruleBuilderRegistry.conditionsWithInternal()).thenReturn(conditions);
 
         classUnderTest = new ValidCondition(ruleBuilderRegistry);
     }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -194,8 +195,8 @@ class BatchedMessageFilterOutputTest {
 
     private List<FilteredMessage> messagesWithOutput(List<Message> messages) {
         return messages.stream()
-                .map(message -> (FilteredMessage) new DefaultFilteredMessage(message, Set.of(ElasticSearchOutput.FILTER_KEY)))
-                .toList();
+                .map(message -> DefaultFilteredMessage.forDestinationKeys(message, Set.of(ElasticSearchOutput.FILTER_KEY)))
+                .collect(Collectors.toList());
     }
 
     private List<Message> buildMessages(final int count) {

--- a/graylog2-server/src/test/java/org/graylog2/outputs/ElasticSearchOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/ElasticSearchOutputTest.java
@@ -163,8 +163,8 @@ public class ElasticSearchOutputTest {
 
         output.writeFiltered(List.of(
                 // The first message should not be written to the output because the output's filter key is not included.
-                new DefaultFilteredMessage(messageList.get(0), Set.of("foo")),
-                new DefaultFilteredMessage(messageList.get(1), Set.of("foo", ElasticSearchOutput.FILTER_KEY))
+                DefaultFilteredMessage.forDestinationKeys(messageList.get(0), Set.of("foo")),
+                DefaultFilteredMessage.forDestinationKeys(messageList.get(1), Set.of("foo", ElasticSearchOutput.FILTER_KEY))
         ));
 
         verify(messages, times(1)).bulkIndex(eq(List.of(
@@ -182,8 +182,8 @@ public class ElasticSearchOutputTest {
 
         output.writeFiltered(List.of(
                 // The first message should not be written to the output because the output's filter key is not included.
-                new DefaultFilteredMessage(messageList.get(0), Set.of("foo")),
-                new DefaultFilteredMessage(messageList.get(1), Set.of("foo", ElasticSearchOutput.FILTER_KEY))
+                DefaultFilteredMessage.forDestinationKeys(messageList.get(0), Set.of("foo")),
+                DefaultFilteredMessage.forDestinationKeys(messageList.get(1), Set.of("foo", ElasticSearchOutput.FILTER_KEY))
         ));
 
         verify(messages, times(1)).bulkIndex(argThat(argument -> {

--- a/graylog2-server/src/test/java/org/graylog2/outputs/IndexSetAwareMessageOutputBufferTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/IndexSetAwareMessageOutputBufferTest.java
@@ -115,6 +115,6 @@ class IndexSetAwareMessageOutputBufferTest {
     }
 
     private FilteredMessage createMessage(String message, Set<String> outputs) {
-        return new DefaultFilteredMessage(messageFactory.createMessage(message, "source", Tools.nowUTC()), outputs);
+        return DefaultFilteredMessage.forDestinationKeys(messageFactory.createMessage(message, "source", Tools.nowUTC()), outputs);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterStateUpdaterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterStateUpdaterTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog.plugins.pipelineprocessor.db.RuleDao;
+import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
+import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
+import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolver;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolverConfig;
+import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilder;
+import org.graylog.plugins.pipelineprocessor.rulebuilder.parser.RuleBuilderService;
+import org.graylog.testing.messages.MessagesExtension;
+import org.graylog2.outputs.filter.functions.RemoveFromStreamDestination;
+import org.graylog2.plugin.MessageFactory;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.outputs.FilteredMessageOutput;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.filters.StreamDestinationFilterRuleDTO;
+import org.graylog2.streams.filters.StreamDestinationFilterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.shared.utilities.StringUtils.f;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(MessagesExtension.class)
+class PipelineRuleOutputFilterStateUpdaterTest {
+
+    @Mock
+    private StreamDestinationFilterService filterService;
+    @Mock
+    private RuleBuilderService ruleBuilderService;
+    @Mock
+    private PipelineResolver.Factory resolverFactory;
+    @Mock
+    private PipelineRuleParser ruleParser;
+    @Mock
+    private StreamCacheService streamCacheService;
+    @Mock
+    private Stream defaultStream;
+    @Mock
+    private Stream testStream;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(defaultStream.getId()).thenReturn("000000000000000000000001");
+        lenient().when(testStream.getId()).thenReturn("668cff9ed9f9636b4b629c37");
+    }
+
+    private String ruleTitle(StreamDestinationFilterRuleDTO dto) {
+        return f("[%s] %s", dto.id(), dto.title());
+    }
+
+    @Test
+    void init(MessageFactory messageFactory) {
+        final var defaultStreamDestinationFilter = StreamDestinationFilterRuleDTO.builder()
+                .id("54e3deadbeefdeadbeef0001")
+                .title("Test 1")
+                .streamId(defaultStream.getId())
+                .destinationType("indexer")
+                .rule(RuleBuilder.builder().build()) // Not needed because we mock the RuleBuilderService
+                .build();
+        final var testStreamDestinationFilter = StreamDestinationFilterRuleDTO.builder()
+                .id("54e3deadbeefdeadbeef0002")
+                .title("Test 2")
+                .streamId(testStream.getId())
+                .destinationType("indexer")
+                .rule(RuleBuilder.builder().build()) // Not needed because we mock the RuleBuilderService
+                .build();
+        final var defaultStreamRuleDao = RuleDao.builder()
+                .id(defaultStreamDestinationFilter.id())
+                .title("does-not-matter")
+                .source("""
+                        rule "%s"
+                        when has_field(field : "source")
+                        then
+                          __remove_from_stream_destination__(stream_id : "%s", destination_type : "indexer");
+                        end
+                        """.formatted(ruleTitle(defaultStreamDestinationFilter), defaultStream.getId()))
+                .build();
+        final var testStreamRuleDao = RuleDao.builder()
+                .id(testStreamDestinationFilter.id())
+                .title("does-not-matter")
+                .source("""
+                        rule "%s"
+                        when has_field(field : "source")
+                        then
+                          __remove_from_stream_destination__(stream_id : "%s", destination_type : "indexer");
+                        end
+                        """.formatted(ruleTitle(testStreamDestinationFilter), testStream.getId()))
+                .build();
+
+        doAnswer((Answer<Void>) invocation -> {
+            final Consumer<StreamDestinationFilterService.GroupByStreamResult> consumer = invocation.getArgument(0);
+            // The consumer must be called once for each stream group
+            consumer.accept(new StreamDestinationFilterService.GroupByStreamResult(defaultStream.getId(), Set.of(defaultStreamDestinationFilter)));
+            consumer.accept(new StreamDestinationFilterService.GroupByStreamResult(testStream.getId(), Set.of(testStreamDestinationFilter)));
+            return null;
+        }).when(filterService).forEachEnabledFilterGroupedByStream(any());
+
+        when(resolverFactory.create(any(), any())).thenReturn(createResolver(List.of(defaultStreamRuleDao, testStreamRuleDao)));
+
+        // Mock each rule source generator call to return the correct source for the given rule
+        when(ruleBuilderService.generateRuleSource(eq(ruleTitle(defaultStreamDestinationFilter)), any(RuleBuilder.class), anyBoolean()))
+                .thenReturn(defaultStreamRuleDao.source());
+        when(ruleBuilderService.generateRuleSource(eq(ruleTitle(testStreamDestinationFilter)), any(RuleBuilder.class), anyBoolean()))
+                .thenReturn(testStreamRuleDao.source());
+
+        final var stateUpdater = new PipelineRuleOutputFilterStateUpdater(
+                filterService,
+                (pipelines, destinations, activeStreams) -> new PipelineRuleOutputFilterState(
+                        pipelines,
+                        destinations,
+                        activeStreams,
+                        new MetricRegistry(),
+                        1,
+                        true
+                ),
+                Map.of("indexer", mock(FilteredMessageOutput.class)),
+                ruleBuilderService,
+                resolverFactory,
+                ruleParser,
+                new MetricRegistry()
+        );
+
+        final var activeState = new AtomicReference<PipelineRuleOutputFilterState>();
+        stateUpdater.init(activeState);
+
+        assertThat(activeState.get()).isNotNull().satisfies(state -> {
+            assertThat(state.isEmpty()).isFalse();
+            assertThat(state.getCurrentPipelines().keySet()).containsExactlyInAnyOrder(defaultStream.getId(), testStream.getId());
+            assertThat(state.getDestinations()).containsExactlyInAnyOrder("indexer");
+            assertThat(state.getActiveStreams()).containsExactlyInAnyOrder(defaultStream.getId(), testStream.getId());
+
+            // Asser default stream pipeline
+            assertThat(state.getCurrentPipelines().get(defaultStream.getId())).isNotNull().satisfies(pipeline -> {
+                assertThat(pipeline.id()).isEqualTo(defaultStream.getId());
+                assertThat(pipeline.name()).isEqualTo("Stream Destination Filter: " + defaultStream.getId());
+                assertThat(pipeline.stages()).hasSize(1);
+                assertThat(pipeline.stages().first()).satisfies(stage -> {
+                    assertThat(stage.stage()).isEqualTo(0);
+                    assertThat(stage.getRules()).hasSize(1).first().satisfies(rule -> {
+                        assertThat(rule.id()).isEqualTo(defaultStreamDestinationFilter.id());
+                        assertThat(rule.name()).isEqualTo(ruleTitle(defaultStreamDestinationFilter));
+                    });
+                    assertThat(stage.ruleReferences())
+                            .containsExactlyInAnyOrder(ruleTitle(defaultStreamDestinationFilter));
+                });
+            });
+
+            // Asser test stream pipeline
+            assertThat(state.getCurrentPipelines().get(testStream.getId())).isNotNull().satisfies(pipeline -> {
+                assertThat(pipeline.id()).isEqualTo(testStream.getId());
+                assertThat(pipeline.name()).isEqualTo("Stream Destination Filter: " + testStream.getId());
+                assertThat(pipeline.stages()).hasSize(1);
+                assertThat(pipeline.stages().first()).satisfies(stage -> {
+                    assertThat(stage.stage()).isEqualTo(0);
+                    assertThat(stage.getRules()).hasSize(1).first().satisfies(rule -> {
+                        assertThat(rule.id()).isEqualTo(testStreamDestinationFilter.id());
+                        assertThat(rule.name()).isEqualTo(ruleTitle(testStreamDestinationFilter));
+                    });
+                    assertThat(stage.ruleReferences())
+                            .containsExactlyInAnyOrder(ruleTitle(testStreamDestinationFilter));
+                });
+            });
+
+            final var message = messageFactory.createMessage("message", "source", Tools.nowUTC());
+
+            // The message doesn't have a stream, so we shouldn't get any pipelines
+            assertThat(state.getPipelinesForMessage(message)).isEmpty();
+
+            // Add the default stream to test that we get the default stream pipeline
+            message.addStream(defaultStream);
+            assertThat(state.getPipelinesForMessage(message))
+                    .hasSize(1)
+                    .containsExactlyInAnyOrder(state.getCurrentPipelines().get(defaultStream.getId()));
+
+            // Add the test stream to test that we now get both pipelines
+            message.addStream(testStream);
+            assertThat(state.getPipelinesForMessage(message))
+                    .hasSize(2)
+                    .containsAll(state.getCurrentPipelines().values());
+
+            // Remove default stream to test that we now only get the test stream pipeline
+            message.removeStream(defaultStream);
+            assertThat(state.getPipelinesForMessage(message))
+                    .hasSize(1)
+                    .containsExactlyInAnyOrder(state.getCurrentPipelines().get(testStream.getId()));
+        });
+    }
+
+    private PipelineResolver createResolver(List<RuleDao> rules) {
+        final var ruleParser = new PipelineRuleParser(new FunctionRegistry(
+                Map.of(HasField.NAME, new HasField()),
+                Map.of(RemoveFromStreamDestination.NAME, new RemoveFromStreamDestination(streamCacheService))
+        ));
+
+        return new PipelineResolver(ruleParser, PipelineResolverConfig.of(rules::stream, java.util.stream.Stream::of));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.outputs.filter;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.eventbus.EventBus;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
+import org.graylog.plugins.pipelineprocessor.db.RuleDao;
+import org.graylog.plugins.pipelineprocessor.functions.messages.HasField;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
+import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
+import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineMetricRegistry;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolver;
+import org.graylog.plugins.pipelineprocessor.processors.PipelineResolverConfig;
+import org.graylog.testing.messages.MessagesExtension;
+import org.graylog2.outputs.filter.functions.RemoveFromStreamDestination;
+import org.graylog2.plugin.MessageFactory;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.streams.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(MessagesExtension.class)
+class PipelineRuleOutputFilterTest {
+
+    @Mock
+    private PipelineRuleOutputFilterStateUpdater stateUpdater;
+    @Mock
+    private Stream defaultStream;
+    @Mock
+    private StreamCacheService streamCacheService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(defaultStream.getId()).thenReturn("000000000000000000000001");
+        lenient().when(streamCacheService.getById("000000000000000000000001")).thenReturn(defaultStream);
+    }
+
+    @Test
+    void applyWithNoFilterAndOneDestination(MessageFactory messageFactory) {
+        final var filter = createFilter(Map.of(), Set.of("indexer"));
+        final var message = messageFactory.createMessage("msg", "src", Tools.nowUTC());
+        message.addStream(defaultStream);
+
+        final var filteredMessage = filter.apply(message);
+
+        assertThat(filteredMessage.message()).isEqualTo(message);
+        assertThat(filteredMessage.destinations().keySet()).containsExactlyInAnyOrder("indexer");
+        assertThat(filteredMessage.destinations().get("indexer")).containsExactlyInAnyOrder(defaultStream);
+    }
+
+    @Test
+    void applyWithNoFilterAndTwoDestinations(MessageFactory messageFactory) {
+        final var filter = createFilter(Map.of(), Set.of("indexer", "other"));
+        final var message = messageFactory.createMessage("msg", "src", Tools.nowUTC());
+        message.addStream(defaultStream);
+
+        final var filteredMessage = filter.apply(message);
+
+        assertThat(filteredMessage.message()).isEqualTo(message);
+        assertThat(filteredMessage.destinations().keySet()).containsExactlyInAnyOrder("indexer", "other");
+        assertThat(filteredMessage.destinations().get("indexer")).containsExactlyInAnyOrder(defaultStream);
+        assertThat(filteredMessage.destinations().get("other")).containsExactlyInAnyOrder(defaultStream);
+    }
+
+    @Test
+    void applyWithFilter(MessageFactory messageFactory) {
+        final var filterRules = List.of(
+                RuleDao.builder()
+                        .id("668cff8ed9f9636b4b629c29")
+                        .title("[668cff8ed9f9636b4b629c29] Test Filter 1")
+                        .source("""
+                                rule "[668cff8ed9f9636b4b629c29] Test Filter 1"
+                                when has_field(field : "source")
+                                then
+                                  __remove_from_stream_destination__(stream_id : "000000000000000000000001", destination_type : "indexer");
+                                end
+                                """)
+                        .build()
+        );
+
+        final var pipeline = Pipeline.builder()
+                .id(defaultStream.getId()) // Must be the stream ID to make PipelineRuleOutputFilterState#getPipelinesForMessage work
+                .name("Test")
+                .stages(ImmutableSortedSet.of(
+                        Stage.builder()
+                                .stage(0)
+                                .match(Stage.Match.EITHER)
+                                .ruleReferences(filterRules.stream().map(RuleDao::title).toList())
+                                .build()
+                ))
+                .build();
+
+        final var resolver = createResolver(filterRules);
+        final var pipelines = resolver.resolveFunctions(Set.of(pipeline), PipelineMetricRegistry.create(new MetricRegistry(), "P", "R"));
+
+        final var filter = createFilter(pipelines, Set.of("indexer", "other"));
+        final var message = messageFactory.createMessage("msg", "src", Tools.nowUTC());
+        message.addStream(defaultStream);
+
+        final var filteredMessage = filter.apply(message);
+
+        assertThat(filteredMessage.message()).isEqualTo(message);
+        // The filter rules removes the default stream from the indexer destination, so it shouldn't be in the
+        // destinations after running the filter.
+        assertThat(filteredMessage.destinations().keySet()).containsExactlyInAnyOrder("other");
+        assertThat(filteredMessage.destinations().get("indexer")).isEmpty();
+        assertThat(filteredMessage.destinations().get("other")).containsExactlyInAnyOrder(defaultStream);
+    }
+
+    private PipelineRuleOutputFilter createFilter(Map<String, Pipeline> pipelines, Set<String> destinations) {
+        doAnswer((Answer<Void>) invocation -> {
+            final AtomicReference<PipelineRuleOutputFilterState> state = invocation.getArgument(0);
+            state.set(new PipelineRuleOutputFilterState(
+                    ImmutableMap.copyOf(pipelines),
+                    ImmutableSet.copyOf(destinations),
+                    ImmutableSet.of(),
+                    new MetricRegistry(),
+                    1,
+                    true
+            ));
+            return null;
+        }).when(stateUpdater).init(any());
+
+        return new PipelineRuleOutputFilter(
+                stateUpdater,
+                Executors.newSingleThreadScheduledExecutor(),
+                new MetricRegistry(),
+                new EventBus()
+        );
+    }
+
+    private PipelineResolver createResolver(List<RuleDao> rules) {
+        final var ruleParser = new PipelineRuleParser(new FunctionRegistry(
+                Map.of(HasField.NAME, new HasField()),
+                Map.of(RemoveFromStreamDestination.NAME, new RemoveFromStreamDestination(streamCacheService))
+        ));
+
+        return new PipelineResolver(ruleParser, PipelineResolverConfig.of(rules::stream, java.util.stream.Stream::of));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/filter/PipelineRuleOutputFilterTest.java
@@ -36,6 +36,7 @@ import org.graylog2.outputs.filter.functions.RemoveFromStreamDestination;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.shared.SuppressForbidden;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -143,6 +144,7 @@ class PipelineRuleOutputFilterTest {
         assertThat(filteredMessage.destinations().get("other")).containsExactlyInAnyOrder(defaultStream);
     }
 
+    @SuppressForbidden("Executors.newSingleThreadScheduledExecutor is okay in tests")
     private PipelineRuleOutputFilter createFilter(Map<String, Pipeline> pipelines, Set<String> destinations) {
         doAnswer((Answer<Void>) invocation -> {
             final AtomicReference<PipelineRuleOutputFilterState> state = invocation.getArgument(0);

--- a/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
@@ -17,12 +17,14 @@
 package org.graylog2.streams.filters;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.mongodb.client.model.Sorts;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilder;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilderStep;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog2.database.MongoCollections;
+import org.graylog2.events.ClusterEventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +42,7 @@ class StreamDestinationFilterServiceTest {
 
     @BeforeEach
     void setUp(MongoCollections mongoCollections) {
-        this.service = new StreamDestinationFilterService(mongoCollections);
+        this.service = new StreamDestinationFilterService(mongoCollections, new ClusterEventBus(MoreExecutors.directExecutor()));
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/streams/filters/StreamDestinationFilterServiceTest-2024-07-01-1.json
+++ b/graylog2-server/src/test/resources/org/graylog2/streams/filters/StreamDestinationFilterServiceTest-2024-07-01-1.json
@@ -81,6 +81,30 @@
           }
         ]
       }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0003"
+      },
+      "stream_id": "54e3deadbeefdeadbeef2000",
+      "destination_type": "something-else",
+      "title": "Test Filter 4",
+      "status": "enabled",
+      "rule": {
+        "operator": "AND",
+        "conditions": [
+          {
+            "id": {
+              "$oid": "54e3deadbeefdeadbeef0001"
+            },
+            "function": "has_field",
+            "params": {
+              "field": "is_debug",
+              "negate": false
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR implements a processing pipeline based output filter.

Additional required changes:

- Extend `FunctionRegistry` to hold internal functions which aren't exposed to users.
- Allow binding of internal pipeline functions.
- Add `PipelineResolver#resolveFunctions` to allow function resolving on a programmatically created `Pipeline` object.
- Change the `FilteredMessage` interface to hold a destination to streams mapping instead of a simple set of destinations.
- Extend `StreamDestinationFilterService` to publish events when destination filters are updated or deleted.

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/7210

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/7691
/nocl Part of the bigger DWH feature.