### PR TITLE
Backport: Add optional ignoreExtraFieldNames parameter to csv_to_map pipeline function

### DIFF
--- a/changelog/unreleased/pr-19865.toml
+++ b/changelog/unreleased/pr-19865.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Add optional ignoreExtraFieldNames parameter to csv_to_map pipeline function"
+
+pulls = ["19865"]

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1593,6 +1593,16 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("test99_k2")).isEqualTo("v,2");
         assertThat(message.getField("test99_k3")).isEqualTo("v3");
 
+        // When too many fieldNames specified, fields should not be parsed.
+        assertThat(message.getField("should_not_exist_k1")).isNull();
+        assertThat(message.getField("should_not_exist_k2")).isNull();
+        assertThat(message.getField("should_not_exist_k3")).isNull();
+
+        // When extra field names are ignored, values should be parsed.
+        assertThat(message.getField("ignore_extra_field_names_k1")).isEqualTo("v1");
+        assertThat(message.getField("ignore_extra_field_names_k2")).isEqualTo("v2");
+        assertThat(message.getField("ignore_extra_field_names_k3")).isEqualTo("v3");
+        assertThat(message.getField("ignore_extra_field_names_k4")).isNull();
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/csvMap.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/csvMap.txt
@@ -50,5 +50,27 @@ then
     );
     set_fields(fields: map, prefix: "test99_");
 
+    let csv = "v1,v2,v3";
+    let map =  csv_to_map(
+        value: csv,
+        fieldNames: "k1,k2,k3,k4"
+    );
+    set_fields(fields: map, prefix: "should_not_exist_");
+
+    let csv = "v1,v2,v3,v4";
+    let map =  csv_to_map(
+        value: csv,
+        fieldNames: "k1,k2,k3",
+        ignoreExtraFieldNames: true
+    );
+    set_fields(fields: map, prefix: "should_not_exist_");
+
+    let csv = "v1,v2,v3";
+        let map =  csv_to_map(
+            value: csv,
+            fieldNames: "k1,k2,k3,k4",
+            ignoreExtraFieldNames: true
+        );
+    set_fields(fields: map, prefix: "ignore_extra_field_names_");
 
 end


### PR DESCRIPTION
Backport #19865 to the `6.0` branch. 