### PR TITLE
fix remote reindex progress calculation

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -252,7 +252,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
     }
 
     private IndexMigrationProgress toProgress(TaskStatus status) {
-        return new IndexMigrationProgress(status.total(), status.created(), status.updated(), status.deleted());
+        return new IndexMigrationProgress(status.total(), status.created(), status.updated(), status.deleted(), status.versionConflicts(), status.noops());
     }
 
     @Nullable
@@ -506,7 +506,10 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
     }
 
     private void onTaskSuccess(MigrationConfiguration migration, String index, TaskStatus taskStatus, Duration duration) {
-        final String message = String.format(Locale.ROOT, "Index %s finished migration after %s. Total %d documents, updated %d, created %d, deleted %d.", index, humanReadable(duration), taskStatus.total(), taskStatus.updated(), taskStatus.created(), taskStatus.deleted());
+        String message = String.format(Locale.ROOT, "Index %s finished migration after %s. Total %d documents, updated %d, created %d, deleted %d.", index, humanReadable(duration), taskStatus.total(), taskStatus.updated(), taskStatus.created(), taskStatus.deleted());
+        if (taskStatus.noops() > 0 || taskStatus.versionConflicts() > 0) {
+            message += String.format(Locale.ROOT, " %d documents were not migrated (%d version conflicts, %d ignored)", taskStatus.versionConflicts() + taskStatus.noops(), taskStatus.versionConflicts(), taskStatus.noops());
+        }
         logInfo(migration, message);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/IndexMigrationProgress.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/IndexMigrationProgress.java
@@ -16,13 +16,15 @@
  */
 package org.graylog2.indexer.migration;
 
-public record IndexMigrationProgress(long total, long created, long updated, long deleted) {
+public record IndexMigrationProgress(long total, long created, long updated, long deleted, long versionConflicts,
+                                     long noops) {
+
     public int progressPercent() {
 
         if(total == 0) { // avoid division by zero
             return 100;
         }
 
-        return (int) Math.min((100.0 / total) * (created + updated + deleted), 100);
+        return (int) Math.min((100.0 / total) * (created + updated + deleted + versionConflicts + noops), 100);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/migration/IndexMigrationProgressTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/migration/IndexMigrationProgressTest.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.api.Test;
 class IndexMigrationProgressTest {
     @Test
     void testProgressPercent() {
-        Assertions.assertThat(new IndexMigrationProgress(100, 30, 10, 10).progressPercent()).isEqualTo(50);
-        Assertions.assertThat(new IndexMigrationProgress(100, 0, 0, 0).progressPercent()).isEqualTo(0);
-        Assertions.assertThat(new IndexMigrationProgress(100, 100, 0, 0).progressPercent()).isEqualTo(100);
-        Assertions.assertThat(new IndexMigrationProgress(0, 0, 0, 0).progressPercent()).isEqualTo(100);
+        Assertions.assertThat(new IndexMigrationProgress(100, 20, 10, 10, 5, 5).progressPercent()).isEqualTo(50);
+        Assertions.assertThat(new IndexMigrationProgress(100, 0, 0, 0, 0, 0).progressPercent()).isEqualTo(0);
+        Assertions.assertThat(new IndexMigrationProgress(100, 100, 0, 0, 0, 0).progressPercent()).isEqualTo(100);
+        Assertions.assertThat(new IndexMigrationProgress(0, 0, 0, 0, 0, 0).progressPercent()).isEqualTo(100);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/migration/RemoteReindexMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/migration/RemoteReindexMigrationTest.java
@@ -23,7 +23,6 @@ import jakarta.annotation.Nonnull;
 import org.assertj.core.api.Assertions;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import jakarta.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -48,9 +47,9 @@ class RemoteReindexMigrationTest {
     private static RemoteReindexIndex index(String indexName, RemoteReindexingMigrationAdapter.Status status) {
 
         final IndexMigrationProgress progress = switch (status) {
-            case FINISHED -> new IndexMigrationProgress(100, 100, 0, 0);
-            case ERROR -> new IndexMigrationProgress(100, 100, 0, 0);
-            default -> new IndexMigrationProgress(100, 0, 0, 0);
+            case FINISHED -> new IndexMigrationProgress(100, 100, 0, 0, 0, 0);
+            case ERROR -> new IndexMigrationProgress(100, 100, 0, 0, 0, 0);
+            default -> new IndexMigrationProgress(100, 0, 0, 0, 0, 0);
         };
         return new RemoteReindexIndex(indexName, status, null, null, progress, null);
     }


### PR DESCRIPTION
## Description
Includes noops and version_conflicts documents in remote reindexing progress calculation.
Also adds these numbers to the logs (only if they occur)

/nocl

## Motivation and Context
possible fix for #19875 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

