### PR TITLE
Allow supplying fetch options for paginated entity fetcher.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -30,7 +30,7 @@ import EntityFilters from 'components/common/EntityFilters';
 import useUrlQueryFilters from 'components/common/EntityFilters/hooks/useUrlQueryFilters';
 import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
 import TableFetchContextProvider from 'components/common/PaginatedEntityTable/TableFetchContextProvider';
-import type { PaginatedResponse } from 'components/common/PaginatedEntityTable/useFetchEntities';
+import type { PaginatedResponse, FetchOptions } from 'components/common/PaginatedEntityTable/useFetchEntities';
 import useFetchEntities from 'components/common/PaginatedEntityTable/useFetchEntities';
 
 const SearchRow = styled.div`
@@ -53,6 +53,7 @@ type Props<T> = {
   entityAttributesAreCamelCase: boolean,
   expandedSectionsRenderer?: EntityDataTableProps['expandedSectionsRenderer'],
   fetchEntities: (options: SearchParams) => Promise<PaginatedResponse<T>>,
+  fetchOptions?: FetchOptions,
   filterValueRenderers?: React.ComponentProps<typeof EntityFilters>['filterValueRenderers'],
   humanName: string,
   keyFn: (options: SearchParams) => Array<unknown>,
@@ -78,7 +79,7 @@ const PaginatedEntityTable = <T extends EntityBase>({
   actionsCellWidth, columnsOrder, entityActions, tableLayout, fetchEntities, keyFn,
   humanName, columnRenderers, queryHelpComponent, filterValueRenderers,
   expandedSectionsRenderer, bulkSelection, additionalAttributes,
-  entityAttributesAreCamelCase, topRightCol, searchPlaceholder,
+  entityAttributesAreCamelCase, topRightCol, searchPlaceholder, fetchOptions: reactQueryOptions,
 }: Props<T>) => {
   const [urlQueryFilters, setUrlQueryFilters] = useUrlQueryFilters();
   const [query, setQuery] = useQueryParam('query', StringParam);
@@ -98,7 +99,7 @@ const PaginatedEntityTable = <T extends EntityBase>({
     data: paginatedEntities = INITIAL_DATA,
     isInitialLoading: isLoadingEntities,
     refetch,
-  } = useFetchEntities<T>({ fetchKey, searchParams: fetchOptions, enabled: !isLoadingLayoutPreferences, fetchEntities, humanName });
+  } = useFetchEntities<T>({ fetchKey, searchParams: fetchOptions, enabled: !isLoadingLayoutPreferences, fetchEntities, humanName, fetchOptions: reactQueryOptions });
 
   const onChangeFilters = useCallback((newUrlQueryFilters: UrlQueryFilters) => {
     paginationQueryParameter.resetPage();
@@ -184,6 +185,7 @@ PaginatedEntityTable.defaultProps = {
   queryHelpComponent: undefined,
   topRightCol: undefined,
   searchPlaceholder: undefined,
+  fetchOptions: undefined,
 };
 
 export default PaginatedEntityTable;

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFetchEntities.ts
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFetchEntities.ts
@@ -29,18 +29,24 @@ export type PaginatedResponse<T> = {
   attributes: Array<Attribute>,
 }
 
+export type FetchOptions = {
+  refetchInterval?: number,
+};
+
 const useFetchEntities = <T>({
   fetchKey,
   searchParams,
   fetchEntities,
   enabled,
   humanName,
+  fetchOptions = {},
 }: {
   fetchKey: Array<unknown>,
   searchParams: SearchParams,
   fetchEntities: (searchParams: SearchParams) => Promise<PaginatedResponse<T>>
   enabled: boolean,
   humanName: string
+  fetchOptions?: FetchOptions,
 }): {
   isInitialLoading: boolean,
   data: PaginatedResponse<T>,
@@ -55,6 +61,7 @@ const useFetchEntities = <T>({
         UserNotification.error(`Fetching ${humanName} failed with status: ${error}`, `Could not retrieve ${humanName}`);
       },
       keepPreviousData: true,
+      ...fetchOptions,
     },
   );
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows supplying fetch options for paginated entity tables. A use case right now is specifying a `refetchInterval` to refetch entities periodically.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.