### PR TITLE
Drop `dashboards` collection if migration if it exists.

### DIFF
--- a/changelog/unreleased/pr-19921.toml
+++ b/changelog/unreleased/pr-19921.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Dropping legacy `dashboards` collection in migration."
+
+issues = ["19912"]
+pulls = ["19921"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On setups which were already running Graylog before Views were introduced in `3.2.0`, a `dashboards` collection already exists. For these, we need to drop the collection before creating the `dashboards` view based on the `views` collection.

The `dashboards` collection was not dropped before, because it seemed to be safer to keep it in case the migration (from `dashboards` to `views`) contains errors. This is now roughly 5 years ago, so dropping it now should be safe™.

Fixes #19912.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.