### PR TITLE
Block field type changes in Illuminate index sets

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexTemplateProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexTemplateProvider.java
@@ -23,6 +23,9 @@ import javax.annotation.Nonnull;
 
 public interface IndexTemplateProvider<T extends IndexMappingTemplate> {
 
+    String FAILURE_TEMPLATE_TYPE = "failures";
+    String ILLUMINATE_INDEX_TEMPLATE_TYPE = "illuminate_content";
+
     @Nonnull
     T create(@Nonnull SearchVersion searchVersion, @Nonnull IndexSetConfig indexSetConfig)
             throws IgnoreIndexTemplate;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -42,6 +42,7 @@ import org.mongojack.ObjectId;
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.graylog2.indexer.EventIndexTemplateProvider.EVENT_TEMPLATE_TYPE;
@@ -60,6 +61,12 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig>, Simp
     public static final String FIELD_INDEX_WILDCARD = "index_wildcard";
     public static final String FIELD_INDEX_TEMPLATE_NAME = "index_template_name";
     public static final String FIELD_CUSTOM_FIELD_MAPPINGS = "custom_field_mappings";
+
+    private static final Set<String> TEMPLATE_TYPES_FOR_INDEX_SETS_WITH_IMMUTABLE_FIELD_TYPES = Set.of(
+            EVENT_TEMPLATE_TYPE,
+            IndexTemplateProvider.FAILURE_TEMPLATE_TYPE,
+            IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE
+    );
 
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
@@ -255,26 +262,12 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig>, Simp
 
     @JsonIgnore
     public boolean canHaveCustomFieldMappings() {
-        final String indexTemplateType = this.indexTemplateType().orElse(null);
-        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) ||
-                IndexTemplateProvider.FAILURE_TEMPLATE_TYPE.equals(indexTemplateType) ||
-                IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE.equals(indexTemplateType)
-
-        ) {
-            return false;
-        }
-        return true;
+        return !this.indexTemplateType().map(TEMPLATE_TYPES_FOR_INDEX_SETS_WITH_IMMUTABLE_FIELD_TYPES::contains).orElse(false);
     }
 
     @JsonIgnore
     public boolean canHaveProfile() {
-        final String indexTemplateType = this.indexTemplateType().orElse(null);
-        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) ||
-                IndexTemplateProvider.FAILURE_TEMPLATE_TYPE.equals(indexTemplateType) ||
-                IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE.equals(indexTemplateType)) {
-            return false;
-        }
-        return true;
+        return !this.indexTemplateType().map(TEMPLATE_TYPES_FOR_INDEX_SETS_WITH_IMMUTABLE_FIELD_TYPES::contains).orElse(false);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -29,6 +29,7 @@ import jakarta.validation.constraints.Pattern;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.database.DbEntity;
 import org.graylog2.datatiering.DataTieringConfig;
+import org.graylog2.indexer.IndexTemplateProvider;
 import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
@@ -255,7 +256,11 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig>, Simp
     @JsonIgnore
     public boolean canHaveCustomFieldMappings() {
         final String indexTemplateType = this.indexTemplateType().orElse(null);
-        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) || "failures".equals(indexTemplateType)) {
+        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) ||
+                IndexTemplateProvider.FAILURE_TEMPLATE_TYPE.equals(indexTemplateType) ||
+                IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE.equals(indexTemplateType)
+
+        ) {
             return false;
         }
         return true;
@@ -264,7 +269,9 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig>, Simp
     @JsonIgnore
     public boolean canHaveProfile() {
         final String indexTemplateType = this.indexTemplateType().orElse(null);
-        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) || "failures".equals(indexTemplateType)) {
+        if (EVENT_TEMPLATE_TYPE.equals(indexTemplateType) ||
+                IndexTemplateProvider.FAILURE_TEMPLATE_TYPE.equals(indexTemplateType) ||
+                IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE.equals(indexTemplateType)) {
             return false;
         }
         return true;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.indexset;
 
+import org.graylog2.indexer.IndexTemplateProvider;
 import org.graylog2.indexer.MessageIndexTemplateProvider;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
@@ -299,14 +300,28 @@ public class IndexSetConfigTest {
 
     @Test
     public void testFailureIndexWithProfileSetIsIllegal() {
-        assertFalse(testIndexSetConfig("failures",
+        assertFalse(testIndexSetConfig(IndexTemplateProvider.FAILURE_TEMPLATE_TYPE,
                 null,
                 "profile").canHaveProfile());
     }
 
     @Test
     public void testFailureIndexWithChangedFieldMappingsIsIllegal() {
-        assertFalse(testIndexSetConfig("failures",
+        assertFalse(testIndexSetConfig(IndexTemplateProvider.FAILURE_TEMPLATE_TYPE,
+                new CustomFieldMappings(List.of(new CustomFieldMapping("john", "long"))),
+                null).canHaveCustomFieldMappings());
+    }
+
+    @Test
+    public void testIlluminateIndexWithProfileSetIsIllegal() {
+        assertFalse(testIndexSetConfig(IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE,
+                null,
+                "profile").canHaveProfile());
+    }
+
+    @Test
+    public void testIlluminateIndexWithChangedFieldMappingsIsIllegal() {
+        assertFalse(testIndexSetConfig(IndexTemplateProvider.ILLUMINATE_INDEX_TEMPLATE_TYPE,
                 new CustomFieldMappings(List.of(new CustomFieldMapping("john", "long"))),
                 null).canHaveCustomFieldMappings());
     }


### PR DESCRIPTION
## Description
Block field type and profile changes in Illuminate index sets.
/nocl

## Motivation and Context
Field type and profile changes in Illuminate do not take place anyway, are silently ignored.
We want to explicitly block them, so that no one is surprised by that.
Partially solves https://github.com/Graylog2/graylog2-server/issues/19766, but some FE blocks would make the solution even nicer.

## How Has This Been Tested?
Manually and with new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

