### PR TITLE
Fix parsing of opensearch allowlist

### DIFF
--- a/changelog/unreleased/pr-19947.toml
+++ b/changelog/unreleased/pr-19947.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix parsing of opensearch allowlist during remote reindex migration"
+
+pulls = ["19947"]

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexAllowlist.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexAllowlist.java
@@ -25,10 +25,10 @@ import org.graylog.shaded.opensearch2.org.opensearch.common.regex.Regex;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class RemoteReindexAllowlist {
 
@@ -98,7 +98,9 @@ public class RemoteReindexAllowlist {
                 .map(v -> StringUtils.removeStart(v, "["))
                 .map(v -> StringUtils.removeEnd(v, "]"))
                 .map(v -> v.split(","))
-                .map(v -> new HashSet<>(Arrays.asList(v)))
-                .orElseGet(HashSet::new);
+                .stream()
+                .flatMap(Arrays::stream)
+                .map(String::trim)
+                .collect(Collectors.toSet());
     }
 }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/RemoteReindexAllowlistTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/RemoteReindexAllowlistTest.java
@@ -25,13 +25,13 @@ class RemoteReindexAllowlistTest {
 
     @Test
     void testMultipleAllowlistValues() {
-        final RemoteReindexAllowlist allowlist = new RemoteReindexAllowlist(URI.create("http://10.0.1.28:9200"), "10.0.1.28:9200,10.0.1.49:9200,10.0.1.134:9200,10.0.1.148:9200");
+        final RemoteReindexAllowlist allowlist = new RemoteReindexAllowlist(URI.create("http://10.0.1.28:9200"), "10.0.1.28:9200, 10.0.1.49:9200,10.0.1.134:9200,10.0.1.148:9200");
         Assertions.assertThat(allowlist.value())
                 .hasSize(4)
                 .contains("10.0.1.28:9200", "10.0.1.49:9200", "10.0.1.134:9200", "10.0.1.148:9200");
 
         Assertions.assertThat(allowlist.isClusterSettingMatching("")).isFalse();
-        Assertions.assertThat(allowlist.isClusterSettingMatching("10.0.1.28:9200,10.0.1.49:9200,10.0.1.134:9200,10.0.1.148:9200")).isTrue();
+        Assertions.assertThat(allowlist.isClusterSettingMatching("10.0.1.28:9200, 10.0.1.49:9200, 10.0.1.134:9200, 10.0.1.148:9200")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Fix parsing of opensearch allowlist value for remote reindex migrations. The server config value contains spaces that needs to be trimmed. 

## How Has This Been Tested?
Added unit test


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

