### PR TITLE
Unify table header border style for search widgets.

### DIFF
--- a/changelog/unreleased/pr-19950.toml
+++ b/changelog/unreleased/pr-19950.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Unify table header border style for search widgets, fix scrolling behaviour."
+
+pulls = ["19950"]

--- a/graylog2-web-interface/src/components/bootstrap/Table.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.jsx
@@ -84,7 +84,7 @@ const tableCss = css(({ theme }) => css`
     > tfoot > tr {
       > th,
       > td {
-        border-top-color: ${theme.colors.table.row.backgroundStriped};
+        border-top-color: ${theme.colors.table.row.divider};
       }
     }
 
@@ -100,7 +100,7 @@ const tableCss = css(({ theme }) => css`
     }
 
     > tbody + tbody {
-      border-top-color: ${theme.colors.table.row.backgroundStriped};
+      border-top-color: ${theme.colors.table.row.divider};
     }
 
     .table {

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -47,7 +47,6 @@ import { makeVisualization, retrieveChartData } from '../aggregationbuilder/Aggr
 
 type Props = VisualizationComponentProps & {
   bordered?: boolean,
-  borderedHeader?: boolean,
   condensed?: boolean,
   data: { [key: string]: Rows } & { events?: Events },
   setLoadingState: (loading: boolean) => void
@@ -124,7 +123,6 @@ const _extractColumnPivotValues = (rows): Array<Array<string>> => {
 
 const DataTable = ({
   bordered,
-  borderedHeader,
   condensed,
   config,
   data,
@@ -269,7 +267,6 @@ const DataTable = ({
                        condensed={condensed}>
           <THead $stickyLeftMarginsByColumnIndex={stickyLeftMarginsByColumnIndex}>
             <Headers actualColumnPivotFields={actualColumnPivotFields}
-                     borderedHeader={borderedHeader}
                      columnPivots={columnPivots}
                      fields={fields}
                      rollup={rollup}
@@ -296,7 +293,6 @@ DataTable.defaultProps = {
   striped: true,
   bordered: false,
   stickyHeader: true,
-  borderedHeader: true,
 };
 
 const ConnectedDataTable = makeVisualization(DataTable, 'table');

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.tsx
@@ -66,7 +66,6 @@ describe('Headers', () => {
         <Headers columnPivots={columnPivots}
                  rowPivots={rowPivots}
                  series={series}
-                 borderedHeader={false}
                  rollup={rollup}
                  actualColumnPivotFields={actualColumnPivotFields}
                  fields={Immutable.List(fields)}

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -61,7 +61,6 @@ const PinIcon = styled.button(({ theme }) => css`
 
 type HeaderFilterProps = {
   activeQuery: string;
-  borderedHeader: boolean,
   fields: (FieldTypeMappingsList | Array<FieldTypeMapping>);
   field: string;
   prefix?: (string | number);
@@ -80,7 +79,6 @@ type HeaderFilterProps = {
 
 const HeaderField = ({
   activeQuery,
-  borderedHeader,
   fields,
   field,
   prefix = '',
@@ -113,8 +111,7 @@ const HeaderField = ({
     <TableHeaderCell ref={thRef}
                      key={`${prefix}${field}`}
                      colSpan={span}
-                     $isNumeric={type.isNumeric()}
-                     $borderedHeader={borderedHeader}>
+                     $isNumeric={type.isNumeric()}>
       <Field name={field} queryId={activeQuery} type={type}>{title}</Field>
       {showPinIcon && <PinIcon data-testid={`pin-${prefix}${field}`} type="button" onClick={_togglePin} className={isPinned ? 'active' : ''}><Icon name="push_pin" /></PinIcon>}
       {sortable && sortType && (
@@ -139,17 +136,15 @@ HeaderField.defaultProps = {
 };
 
 type HeaderFieldForValueProps = {
-  borderedHeader: boolean,
   field: string,
   value: any,
   span?: number,
   prefix?: string,
   type: FieldType,
 };
-const HeaderFieldForValue = ({ field, value, span = 1, prefix = '', type, borderedHeader }: HeaderFieldForValueProps) => (
+const HeaderFieldForValue = ({ field, value, span = 1, prefix = '', type }: HeaderFieldForValueProps) => (
   <CenteredTh key={`${prefix}${field}-${value}`}
-              colSpan={span}
-              $borderedHeader={borderedHeader}>
+              colSpan={span}>
     <Value field={field} value={value} type={type} />
   </CenteredTh>
 );
@@ -162,7 +157,6 @@ HeaderFieldForValue.defaultProps = {
 const Spacer = ({ span }: { span: number }) => <th aria-label="spacer" colSpan={span} />;
 
 type ColumnHeadersProps = {
-  borderedHeader: boolean,
   fields: (FieldTypeMappingsList | Array<FieldTypeMapping>);
   pivots: string[],
   values: any[][],
@@ -170,7 +164,7 @@ type ColumnHeadersProps = {
   offset?: number,
 };
 
-const ColumnPivotFieldsHeaders = ({ fields, pivots, values, series, offset = 1, borderedHeader }: ColumnHeadersProps) => {
+const ColumnPivotFieldsHeaders = ({ fields, pivots, values, series, offset = 1 }: ColumnHeadersProps) => {
   const headerRows = pivots.map((columnPivot, idx) => {
     const actualValues = values.map((key) => ({ path: key.slice(0, idx).join('-'), key: key[idx] || '', count: 1 }));
     const actualValuesWithoutDuplicates = actualValues.reduce((prev, cur) => {
@@ -195,7 +189,6 @@ const ColumnPivotFieldsHeaders = ({ fields, pivots, values, series, offset = 1, 
         {offset > 0 && <Spacer span={offset} />}
         {actualValuesWithoutDuplicates.map((value) => (
           <HeaderFieldForValue key={`header-field-value-${value.path}-${value.key}`}
-                               borderedHeader={borderedHeader}
                                field={columnPivot}
                                value={value.key}
                                span={value.count * series.length}
@@ -215,7 +208,6 @@ ColumnPivotFieldsHeaders.defaultProps = {
 };
 
 type Props = {
-  borderedHeader: boolean,
   columnPivots: Array<Pivot>,
   rowPivots: Array<Pivot>,
   series: Array<Series>,
@@ -231,7 +223,6 @@ type Props = {
 };
 
 const Headers = ({
-  borderedHeader,
   columnPivots,
   fields,
   rowPivots,
@@ -252,7 +243,6 @@ const Headers = ({
 
   const headerField = ({ field, prefix = '', span = 1, title = field, sortable = false, sortType = undefined, showPinIcon = false }) => (
     <HeaderField activeQuery={activeQuery}
-                 borderedHeader={borderedHeader}
                  key={`${prefix}${field}`}
                  fields={fields}
                  field={field}
@@ -277,8 +267,7 @@ const Headers = ({
 
   return (
     <>
-      <ColumnPivotFieldsHeaders borderedHeader={borderedHeader}
-                                fields={fields}
+      <ColumnPivotFieldsHeaders fields={fields}
                                 pivots={columnFieldNames}
                                 values={actualColumnPivotFields}
                                 series={series}

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
@@ -28,7 +28,7 @@ const StyledTable = styled(Table)<{ $stickyHeader: boolean }>(({ theme, $stickyH
   position: relative;
   font-size: ${theme.fonts.size.small};
   margin: 0;
-  border-collapse: collapse;
+  border-collapse: separate; // without this the th border are not sticky
   width: 100%;
   word-break: break-all;
   

--- a/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
@@ -16,17 +16,21 @@
  */
 import styled, { css } from 'styled-components';
 
-const TableHeaderCell = styled.th<{ $isNumeric?: boolean, $borderedHeader?: boolean }>(({ $isNumeric, $borderedHeader, theme }) => css`
+const TableHeaderCell = styled.th<{ $isNumeric?: boolean }>(({ $isNumeric, theme }) => css`
   && {
     background-color: ${theme.colors.table.head.background};
     min-width: 50px;
-    border: ${$borderedHeader ? `1px solid ${theme.colors.table.row.backgroundStriped}` : '0'};
+    border-bottom: 1px solid ${theme.colors.table.row.divider};
     padding: 0 5px;
     vertical-align: middle;
     white-space: nowrap;
     font-weight: normal;
     font-size: ${theme.fonts.size.small};
-    ${$isNumeric ? 'text-align: right' : ''}
+    ${$isNumeric ? 'text-align: right;' : ''}
+
+    &:not(:last-child) {
+      border-right: 1px solid ${theme.colors.table.row.divider};
+    }
   }
 `);
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.tsx
@@ -39,7 +39,7 @@ const Table = styled.table(({ theme }) => css`
   position: relative;
   font-size: ${theme.fonts.size.small};
   margin: 0;
-  border-collapse: collapse;
+  border-collapse: separate;
   width: 100%;
   word-break: break-all;
 

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
@@ -30,6 +30,10 @@ import type Direction from 'views/logic/aggregationbuilder/Direction';
 
 import AttributeSortIcon from '../../overview-configuration/AttributeSortIcon';
 
+const Table = styled.table`
+  border-collapse: separate;
+`;
+
 const TableWrapper = styled.div`
   overflow: auto;
 `;
@@ -56,7 +60,7 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
 
   return (
     <TableWrapper>
-      <table className="table table-condensed">
+      <Table className="table table-condensed">
         <TableHead>
           <tr>
             {config.fields.toArray().map((field) => {
@@ -88,7 +92,7 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
                             fields={config.fields} />
           ))}
         </tbody>
-      </table>
+      </Table>
     </TableWrapper>
   );
 };


### PR DESCRIPTION
**Please note**, this PR requires a backport.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR unifies and fixes the styling table header border displayed in search widgets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6685

