### PR TITLE
Escape quotes in Custom HTTP Notification JSON payload strings

### DIFF
--- a/changelog/unreleased/pr-19951.toml
+++ b/changelog/unreleased/pr-19951.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fixed issue where unescaped quotes in Custom HTTP notification JSON payloads breaks the notifications."
+
+pulls = ["19951"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.floreysoft.jmte.Engine;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import jakarta.inject.Inject;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -48,13 +49,12 @@ import org.graylog2.system.urlwhitelist.UrlWhitelistService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.inject.Inject;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -225,7 +225,15 @@ public class HTTPEventNotificationV2 extends HTTPNotification implements EventNo
                         })
                         .collect(Collectors.joining("&"));
             } else {
-                body = templateEngine.transform(bodyTemplate, modelMap);
+                Map<String, Object> escapedModelMap = new HashMap<>();
+                modelMap.forEach((k, v) -> {
+                    if (v instanceof String str) {
+                        escapedModelMap.put(k, str.replace("\"", "\\\""));
+                    } else {
+                        escapedModelMap.put(k, v);
+                    }
+                });
+                body = templateEngine.transform(bodyTemplate, escapedModelMap);
             }
         } else {
             if (config.contentType().equals(HTTPEventNotificationConfigV2.ContentType.FORM_DATA)) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Custom HTTP Notifications with JSON formatted payloads do not currently send strings with escaped double quote chars. This leads to improperly formatted JSON if any fields contain them and breaks the notification. Escaping double quote chars on strings containing them resolves this issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

