### PR TITLE
Sorting of custom field types is null safe

### DIFF
--- a/changelog/unreleased/issue-19694.toml
+++ b/changelog/unreleased/issue-19694.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Sorting custom field mappings has been fixed, it does not fail on null values anymore."
+
+issues = ["19694"]
+pulls = ["19960"]
+

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldType.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldType.java
@@ -98,10 +98,13 @@ public record IndexSetFieldType(@JsonProperty(FIELD_NAME) String fieldName,
     public static Comparator<IndexSetFieldType> getComparator(final String sort,
                                                               final Sorting.Direction order) {
         final Comparator<IndexSetFieldType> comparator = switch (sort) {
-            case TYPE -> Comparator.comparing(IndexSetFieldType::type);
-            case IS_RESERVED -> Comparator.comparing(IndexSetFieldType::isReserved);
-            case ORIGIN -> Comparator.comparing(IndexSetFieldType::origin);
-            default -> Comparator.comparing(IndexSetFieldType::fieldName);
+            case TYPE -> Comparator.comparing(IndexSetFieldType::type, Comparator.nullsLast(Comparator.naturalOrder()));
+            case IS_RESERVED ->
+                    Comparator.comparing(IndexSetFieldType::isReserved, Comparator.nullsLast(Comparator.naturalOrder()));
+            case ORIGIN ->
+                    Comparator.comparing(IndexSetFieldType::origin, Comparator.nullsLast(Comparator.naturalOrder()));
+            default ->
+                    Comparator.comparing(IndexSetFieldType::fieldName, Comparator.nullsLast(Comparator.naturalOrder()));
         };
 
         if (order == Sorting.Direction.DESC) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
@@ -89,5 +89,14 @@ class IndexSetFieldTypeTest {
                 new IndexSetFieldType("buhaha", "text", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
         ));
+
+        assertTrue(0 > fieldTypeComparator.compare(
+                new IndexSetFieldType("buhaha", "long", INDEX, false),
+                new IndexSetFieldType("buhaha", null, INDEX, false)
+        ));
+        assertTrue(0 < reversedFieldTypeComparator.compare(
+                new IndexSetFieldType("buhaha", "long", INDEX, false),
+                new IndexSetFieldType("buhaha", null, INDEX, false)
+        ));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
@@ -21,11 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.rest.resources.system.indexer.responses.FieldTypeOrigin.INDEX;
 import static org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType.FIELD_NAME;
 import static org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType.TYPE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IndexSetFieldTypeTest {
 
@@ -34,30 +33,30 @@ class IndexSetFieldTypeTest {
 
         final Comparator<IndexSetFieldType> fieldNameComparator = IndexSetFieldType.getComparator(FIELD_NAME, Sorting.Direction.ASC);
         final Comparator<IndexSetFieldType> reversedFieldNameComparator = IndexSetFieldType.getComparator(FIELD_NAME, Sorting.Direction.DESC);
-        assertEquals(0, fieldNameComparator.compare(
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "string", INDEX, false)
-        ));
-        assertEquals(0, reversedFieldNameComparator.compare(
+        )).isZero();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "string", INDEX, false)
-        ));
-        assertTrue(0 > fieldNameComparator.compare(
+        )).isZero();
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < reversedFieldNameComparator.compare(
+        )).isNegative();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < fieldNameComparator.compare(
+        )).isPositive();
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
-        assertTrue(0 > reversedFieldNameComparator.compare(
+        )).isPositive();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
+        )).isNegative();
     }
 
     @Test
@@ -65,38 +64,38 @@ class IndexSetFieldTypeTest {
 
         final Comparator<IndexSetFieldType> fieldTypeComparator = IndexSetFieldType.getComparator(TYPE, Sorting.Direction.ASC);
         final Comparator<IndexSetFieldType> reversedFieldTypeComparator = IndexSetFieldType.getComparator(TYPE, Sorting.Direction.DESC);
-        assertEquals(0, fieldTypeComparator.compare(
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "long", INDEX, false)
-        ));
-        assertEquals(0, reversedFieldTypeComparator.compare(
+        )).isZero();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "long", INDEX, false)
-        ));
-        assertTrue(0 > fieldTypeComparator.compare(
+        )).isZero();
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < reversedFieldTypeComparator.compare(
+        )).isNegative();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < fieldTypeComparator.compare(
+        )).isPositive();
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "text", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
-        assertTrue(0 > reversedFieldTypeComparator.compare(
+        )).isPositive();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "text", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
+        )).isNegative();
 
-        assertTrue(0 > fieldTypeComparator.compare(
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", null, INDEX, false)
-        ));
-        assertTrue(0 < reversedFieldTypeComparator.compare(
+        )).isNegative();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", null, INDEX, false)
-        ));
+        )).isPositive();
     }
 }


### PR DESCRIPTION
## Description
Sorting of custom field types is null safe.
Fixes #19694

## Motivation and Context
See #19694

## How Has This Been Tested?
Manually and with new unit tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

