### PR TITLE
Mark unmanaged indices for remote reindexing

### DIFF
--- a/changelog/unreleased/pr-19976.toml
+++ b/changelog/unreleased/pr-19976.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Indices not managed by Graylog are now marked and not selected by default in data node's remote reindex migration."
+
+pulls = ["19976"]
+issues = ["19974"]

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -59,6 +59,7 @@ import org.graylog2.indexer.migration.IndexMigrationProgress;
 import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
 import org.graylog2.indexer.migration.LogEntry;
 import org.graylog2.indexer.migration.LogLevel;
+import org.graylog2.indexer.migration.RemoteIndex;
 import org.graylog2.indexer.migration.RemoteReindexIndex;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 import org.graylog2.indexer.migration.TaskStatus;
@@ -229,10 +230,13 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
             final RemoteReindexAllowlist reindexAllowlist = new RemoteReindexAllowlist(remoteHost, allowlist);
             reindexAllowlist.validate();
             final AggregatedConnectionResponse results = getAllIndicesFrom(remoteHost, username, password, trustUnknownCerts);
+            final List<RemoteIndex> indices = results.indices().stream()
+                    .map(i -> new RemoteIndex(i, indexSetRegistry.isManagedIndex(i)))
+                    .toList();
             if (results.error() != null && !results.error().isEmpty()) {
                 return IndexerConnectionCheckResult.failure(results.error());
             } else {
-                return IndexerConnectionCheckResult.success(results.indices());
+                return IndexerConnectionCheckResult.success(indices);
             }
         } catch (Exception e) {
             return IndexerConnectionCheckResult.failure(e);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -232,6 +232,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
             final AggregatedConnectionResponse results = getAllIndicesFrom(remoteHost, username, password, trustUnknownCerts);
             final List<RemoteIndex> indices = results.indices().stream()
                     .map(i -> new RemoteIndex(i, indexSetRegistry.isManagedIndex(i)))
+                    .distinct()
                     .toList();
             if (results.error() != null && !results.error().isEmpty()) {
                 return IndexerConnectionCheckResult.failure(results.error());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteIndex.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/migration/RemoteIndex.java
@@ -16,20 +16,5 @@
  */
 package org.graylog2.indexer.migration;
 
-import java.util.Collections;
-import java.util.List;
-
-public record IndexerConnectionCheckResult(List<RemoteIndex> indices, String error) {
-
-    public static IndexerConnectionCheckResult success(List<RemoteIndex> indexNames) {
-        return new IndexerConnectionCheckResult(indexNames, null);
-    }
-
-    public static IndexerConnectionCheckResult failure(Exception e) {
-        return new IndexerConnectionCheckResult(Collections.emptyList(), e.getMessage());
-    }
-
-    public static IndexerConnectionCheckResult failure(String errorMessage) {
-        return new IndexerConnectionCheckResult(Collections.emptyList(), errorMessage);
-    }
+public record RemoteIndex(String name, boolean managed) {
 }


### PR DESCRIPTION
## Description
In the remote reindexing migration for data node, the connection check which retrieves the index list now also adds the information if the index is managed by Graylog in an index set.

If  not, this index is not selected by default in the migration and a warning with an appropriate tooltip will be displayed.

## Motivation and Context
helps users to understand that some migrated indices will not be visible in Graylog
#19974 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/06edcb32-db36-4ec2-95c9-3e5636e33e32)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

