### PR TITLE
Fix removing of unavailable data nodes

### DIFF
--- a/changelog/unreleased/pr-19981.toml
+++ b/changelog/unreleased/pr-19981.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Remove last data node from list if no more data nodes are running."
+
+issues = ["19980"]
+pulls = ["19981"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -25,6 +25,7 @@ import org.graylog2.events.ClusterEventPeriodical;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerPeriodical;
 import org.graylog2.periodical.ClusterHealthCheckThread;
 import org.graylog2.periodical.ContentPackLoaderPeriodical;
+import org.graylog2.periodical.DataNodeHousekeepingPeriodical;
 import org.graylog2.periodical.ESVersionCheckPeriodical;
 import org.graylog2.periodical.IndexBlockCheck;
 import org.graylog2.periodical.IndexRangesCleanupPeriodical;
@@ -64,5 +65,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(UserSessionTerminationPeriodical.class);
         periodicalBinder.addBinding().to(TelemetryClusterInfoPeriodical.class);
         periodicalBinder.addBinding().to(GraylogCertificateProvisioningPeriodical.class);
+        periodicalBinder.addBinding().to(DataNodeHousekeepingPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodePaginatedService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodePaginatedService.java
@@ -16,28 +16,35 @@
  */
 package org.graylog2.cluster.nodes;
 
-import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
-import org.graylog2.database.MongoConnection;
-import org.graylog2.database.PaginatedDbService;
-import org.graylog2.database.PaginatedList;
-import org.graylog2.search.SearchQuery;
-
+import com.mongodb.client.MongoCollection;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.bson.conversions.Bson;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.database.pagination.MongoPaginationHelper;
+import org.graylog2.search.SearchQuery;
 
 @Singleton
-public class DataNodePaginatedService extends PaginatedDbService<DataNodeDto> {
+public class DataNodePaginatedService {
     private static final String NODE_COLLECTION_NAME = "datanodes";
 
+    private final MongoCollection<DataNodeDto> collection;
+    private final MongoPaginationHelper<DataNodeDto> paginationHelper;
+
     @Inject
-    public DataNodePaginatedService(MongoConnection mongoConnection, MongoJackObjectMapperProvider mapper) {
-        super(mongoConnection, mapper, DataNodeDto.class, NODE_COLLECTION_NAME);
+    public DataNodePaginatedService(MongoCollections mongoCollections) {
+        this.collection = mongoCollections.collection(NODE_COLLECTION_NAME, DataNodeDto.class);
+        this.paginationHelper = mongoCollections.paginationHelper(collection);
     }
 
     public PaginatedList<DataNodeDto> searchPaginated(SearchQuery query,
-                                                      String sortByField, String sortOrder, int page, int perPage) {
-        return findPaginatedWithQueryFilterAndSort(query.toDBQuery(), node -> true,
-                getSortBuilder(sortOrder, sortByField), page, perPage);
+                                                      Bson sort, int page, int perPage) {
+        return paginationHelper
+                .filter(query.toBson())
+                .sort(sort)
+                .perPage(perPage)
+                .page(page);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/NodeDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/NodeDto.java
@@ -18,6 +18,7 @@ package org.graylog2.cluster.nodes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog2.cluster.Node;
+import org.graylog2.database.MongoEntity;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -25,7 +26,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public abstract class NodeDto implements Node {
+public abstract class NodeDto implements Node, MongoEntity {
+
+    @Override
+    public String id() {
+        return getId();
+    }
 
     @JsonProperty("object_id")
     @Nullable

--- a/graylog2-server/src/main/java/org/graylog2/periodical/DataNodeHousekeepingPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/DataNodeHousekeepingPeriodical.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.periodical;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.NodeService;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Data nodes set their status in their own periodical while running. If a data node is stopped/crashed, we want to keep it in the list of data nodes but set their status to `UNAVAILABLE`
+ */
+@Singleton
+public class DataNodeHousekeepingPeriodical extends Periodical {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataNodeHousekeepingPeriodical.class);
+    private final NodeService<DataNodeDto> nodeService;
+
+    @Inject
+    public DataNodeHousekeepingPeriodical(NodeService<DataNodeDto> nodeService) {
+        this.nodeService = nodeService;
+    }
+
+    @Override
+    // This method is "synchronized" because we are also calling it directly in AutomaticLeaderElectionService
+    public synchronized void doRun() {
+        nodeService.dropOutdated();
+    }
+
+    @Override
+    @Nonnull
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return true;
+    }
+
+    @Override
+    public boolean leaderOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 2;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/RestResourcesModule.java
@@ -40,6 +40,7 @@ import org.graylog2.rest.resources.cluster.ClusterSystemShutdownResource;
 import org.graylog2.rest.resources.datanodes.DataNodeApiProxyResource;
 import org.graylog2.rest.resources.datanodes.DataNodeManagementResource;
 import org.graylog2.rest.resources.datanodes.DataNodeRestApiProxyResource;
+import org.graylog2.rest.resources.datanodes.DatanodeResource;
 import org.graylog2.rest.resources.entities.preferences.EntityListPreferencesResource;
 import org.graylog2.rest.resources.messages.MessageResource;
 import org.graylog2.rest.resources.roles.RolesResource;
@@ -161,6 +162,7 @@ public class RestResourcesModule extends Graylog2Module {
         addSystemRestResource(TelemetryResource.class);
         addSystemRestResource(ContentStreamResource.class);
         addSystemRestResource(CertificateRenewalResource.class);
+        addSystemRestResource(DatanodeResource.class);
         addSystemRestResource(DataNodeApiProxyResource.class);
         addSystemRestResource(DataNodeRestApiProxyResource.class);
         addSystemRestResource(DataNodeManagementResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
@@ -57,12 +57,14 @@ public class DatanodeResource extends RestResource {
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
             .put("hostname", SearchQueryField.create("hostname"))
+            .put("datanode_status", SearchQueryField.create("datanode_status"))
             .build();
 
     private static final String DEFAULT_SORT_FIELD = "title";
     private static final String DEFAULT_SORT_DIRECTION = "asc";
     private static final List<EntityAttribute> attributes = List.of(
-            EntityAttribute.builder().id("hostname").title("Name").build()
+            EntityAttribute.builder().id("hostname").title("Name").build(),
+            EntityAttribute.builder().id("datanode_status").title("Status").build()
     );
     private static final EntityDefaults settings = EntityDefaults.builder()
             .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
@@ -64,7 +64,10 @@ public class DatanodeResource extends RestResource {
     private static final String DEFAULT_SORT_DIRECTION = "asc";
     private static final List<EntityAttribute> attributes = List.of(
             EntityAttribute.builder().id("hostname").title("Name").build(),
-            EntityAttribute.builder().id("datanode_status").title("Status").build()
+            EntityAttribute.builder().id("data_node_status").title("Status").build(),
+            EntityAttribute.builder().id("transport_address").title("Transport address").build(),
+            EntityAttribute.builder().id("cert_valid_until").title("Certificate valid until").build(),
+            EntityAttribute.builder().id("datanode_version").title("Datanode version").build()
     );
     private static final EntityDefaults settings = EntityDefaults.builder()
             .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableMap;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodePaginatedService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.rest.models.SortOrder;
+import org.graylog2.rest.models.tools.responses.PageListResponse;
+import org.graylog2.rest.resources.entities.EntityAttribute;
+import org.graylog2.rest.resources.entities.EntityDefaults;
+import org.graylog2.rest.resources.entities.Sorting;
+import org.graylog2.search.SearchQuery;
+import org.graylog2.search.SearchQueryField;
+import org.graylog2.search.SearchQueryParser;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import java.util.List;
+import java.util.Locale;
+
+@Api(value = "System/Datanodes", description = "Data Node discovery")
+@RequiresAuthentication
+@Path("/system/cluster/datanodes")
+@Produces(MediaType.APPLICATION_JSON)
+public class DatanodeResource extends RestResource {
+
+    private final DataNodePaginatedService dataNodePaginatedService;
+    private final SearchQueryParser searchQueryParser;
+
+    private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
+            .put("id", SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
+            .put("hostname", SearchQueryField.create("hostname"))
+            .build();
+
+    private static final String DEFAULT_SORT_FIELD = "title";
+    private static final String DEFAULT_SORT_DIRECTION = "asc";
+    private static final List<EntityAttribute> attributes = List.of(
+            EntityAttribute.builder().id("hostname").title("Name").build()
+    );
+    private static final EntityDefaults settings = EntityDefaults.builder()
+            .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))
+            .build();
+
+    @Inject
+    public DatanodeResource(DataNodePaginatedService dataNodePaginatedService) {
+        this.dataNodePaginatedService = dataNodePaginatedService;
+        this.searchQueryParser = new SearchQueryParser("hostname", SEARCH_FIELD_MAPPING);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get a paginated list of all datanodes in this cluster")
+    public PageListResponse<DataNodeDto> dataNodes(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+                                                   @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+                                                   @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+                                                   @ApiParam(name = "sort",
+                                                             value = "The field to sort the result on",
+                                                             required = true,
+                                                             allowableValues = "title,description,type")
+                                                   @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sort,
+                                                   @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+                                                   @DefaultValue(DEFAULT_SORT_DIRECTION) @QueryParam("order") SortOrder order
+
+    ) {
+        final SearchQuery searchQuery = searchQueryParser.parse(query);
+        final PaginatedList<DataNodeDto> result = dataNodePaginatedService.searchPaginated(searchQuery, order.toBsonSort(sort), page, perPage);
+
+
+        return PageListResponse.create(query, result.pagination(),
+                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -18,50 +18,32 @@ package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;
 import com.eaio.uuid.UUID;
-import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.graylog.security.certutil.CertRenewalService;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
-import org.graylog2.cluster.nodes.DataNodeDto;
-import org.graylog2.cluster.nodes.DataNodePaginatedService;
-import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.cluster.ClusterId;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.rest.models.system.cluster.responses.NodeSummary;
 import org.graylog2.rest.models.system.cluster.responses.NodeSummaryList;
-import org.graylog2.rest.models.tools.responses.PageListResponse;
-import org.graylog2.rest.resources.entities.EntityAttribute;
-import org.graylog2.rest.resources.entities.EntityDefaults;
-import org.graylog2.rest.resources.entities.Sorting;
-import org.graylog2.search.SearchQuery;
-import org.graylog2.search.SearchQueryField;
-import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
-
-import jakarta.inject.Inject;
-
-import jakarta.validation.constraints.NotEmpty;
-
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 @Api(value = "System/Cluster", description = "Node discovery")
@@ -70,36 +52,15 @@ import java.util.Map;
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterResource extends RestResource {
     private final NodeService nodeService;
-    private final DataNodePaginatedService dataNodePaginatedService;
-    private final SearchQueryParser searchQueryParser;
-    private final CertRenewalService certRenewalService;
 
     private final NodeId nodeId;
     private final ClusterId clusterId;
 
-    private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
-            .put("id", SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
-            .put("hostname", SearchQueryField.create("hostname"))
-            .build();
-
-    private static final String DEFAULT_SORT_FIELD = "title";
-    private static final String DEFAULT_SORT_DIRECTION = "asc";
-    private static final List<EntityAttribute> attributes = List.of(
-            EntityAttribute.builder().id("hostname").title("Name").build()
-    );
-    private static final EntityDefaults settings = EntityDefaults.builder()
-            .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))
-            .build();
-
     @Inject
     public ClusterResource(final NodeService nodeService,
-                           final DataNodePaginatedService dataNodePaginatedService,
-                           CertRenewalService certRenewalService, final ClusterConfigService clusterConfigService,
+                           final ClusterConfigService clusterConfigService,
                            final NodeId nodeId) {
         this.nodeService = nodeService;
-        this.dataNodePaginatedService = dataNodePaginatedService;
-        this.certRenewalService = certRenewalService;
-        this.searchQueryParser = new SearchQueryParser("hostname", SEARCH_FIELD_MAPPING);
         this.nodeId = nodeId;
         this.clusterId = clusterConfigService.getOrDefault(ClusterId.class, ClusterId.create(UUID.nilUUID().toString()));
     }
@@ -116,30 +77,6 @@ public class ClusterResource extends RestResource {
         }
 
         return NodeSummaryList.create(nodeList);
-    }
-
-    @GET
-    @Timed
-    @Path("/datanodes")
-    @ApiOperation(value = "Get a paginated list of all datanodes in this cluster")
-    public PageListResponse<DataNodeDto> dataNodes(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
-                                                   @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
-                                                   @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
-                                                   @ApiParam(name = "sort",
-                                                             value = "The field to sort the result on",
-                                                             required = true,
-                                                             allowableValues = "title,description,type")
-                                                   @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sort,
-                                                   @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
-                                                   @DefaultValue(DEFAULT_SORT_DIRECTION) @QueryParam("order") String order
-
-    ) {
-        final SearchQuery searchQuery = searchQueryParser.parse(query);
-        final PaginatedList<DataNodeDto> result = dataNodePaginatedService.searchPaginated(searchQuery, sort, order, page, perPage);
-
-
-        return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
     }
 
     @GET

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeList.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeList.tsx
@@ -33,17 +33,10 @@ const DEFAULT_LAYOUT = {
   entityTableId: 'datanodes',
   defaultPageSize: 10,
   defaultSort: { attributeId: 'hostname', direction: 'asc' } as Sort,
-  defaultDisplayedAttributes: ['hostname', 'transport_address', 'status', 'is_leader', 'cert_valid_until', 'datanode_version'],
+  defaultDisplayedAttributes: ['hostname', 'transport_address', 'data_node_status', 'is_leader', 'cert_valid_until', 'datanode_version'],
 };
 
-const COLUMNS_ORDER = ['hostname', 'transport_address', 'status', 'is_leader', 'cert_valid_until', 'datanode_version'];
-
-const additionalAttributes = [
-  { id: 'transport_address', title: 'Transport address' },
-  { id: 'status', title: 'Status', sortable: false },
-  { id: 'cert_valid_until', title: 'Certificate valid until', sortable: false },
-  { id: 'datanode_version', title: 'Datanode version', sortable: false },
-];
+const COLUMNS_ORDER = ['hostname', 'transport_address', 'data_node_status', 'is_leader', 'cert_valid_until', 'datanode_version'];
 
 const columnRenderers: ColumnRenderers<DataNode> = {
   attributes: {
@@ -54,7 +47,7 @@ const columnRenderers: ColumnRenderers<DataNode> = {
         </Link>
       ),
     },
-    status: {
+    data_node_status: {
       renderCell: (_status: DataNodeStatus, dataNode: DataNode) => <DataNodeStatusCell dataNode={dataNode} />,
     },
     is_leader: {
@@ -73,7 +66,6 @@ const entityActions = (dataNode: DataNode) => (
 const DataNodeList = () => (
   <PaginatedEntityTable<DataNode> humanName="data nodes"
                                   columnsOrder={COLUMNS_ORDER}
-                                  additionalAttributes={additionalAttributes}
                                   queryHelpComponent={(
                                     <QueryHelper entityName="datanode"
                                                  commonFields={['name']}

--- a/graylog2-web-interface/src/components/datanode/hooks/useDataNodes.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useDataNodes.ts
@@ -155,7 +155,7 @@ export type DataNodeResponse = {
 }
 
 const useDataNodes = (searchParams: SearchParams = {
-  query: '',
+  query: '-datanode_status:UNAVAILABLE',
   page: 1,
   pageSize: 0,
   sort: undefined,


### PR DESCRIPTION
## Description
- refactor data node discovery into its own resource, remove usage of PaginatedDbService, add column definitions in backend
- considers UNAVAILABLE data nodes in the migration wizard (e.g. data nodes with stopped OS)
- adds periodical to drop outdated data nodes to remove last remaining data node in cluster after stopping it

## Motivation and Context
fixes #19980
fixes #19433  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

