### PR TITLE
Sorting of custom field types is null safe (#19960)

### DIFF
--- a/changelog/unreleased/issue-19694.toml
+++ b/changelog/unreleased/issue-19694.toml
@@ -1,0 +1,6 @@
+type = "fixed"
+message = "Sorting custom field mappings has been fixed, it does not fail on null values anymore."
+
+issues = ["19694"]
+pulls = ["19960"]
+

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldType.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldType.java
@@ -98,10 +98,13 @@ public record IndexSetFieldType(@JsonProperty(FIELD_NAME) String fieldName,
     public static Comparator<IndexSetFieldType> getComparator(final String sort,
                                                               final Sorting.Direction order) {
         final Comparator<IndexSetFieldType> comparator = switch (sort) {
-            case TYPE -> Comparator.comparing(IndexSetFieldType::type);
-            case IS_RESERVED -> Comparator.comparing(IndexSetFieldType::isReserved);
-            case ORIGIN -> Comparator.comparing(IndexSetFieldType::origin);
-            default -> Comparator.comparing(IndexSetFieldType::fieldName);
+            case TYPE -> Comparator.comparing(IndexSetFieldType::type, Comparator.nullsLast(Comparator.naturalOrder()));
+            case IS_RESERVED ->
+                    Comparator.comparing(IndexSetFieldType::isReserved, Comparator.nullsLast(Comparator.naturalOrder()));
+            case ORIGIN ->
+                    Comparator.comparing(IndexSetFieldType::origin, Comparator.nullsLast(Comparator.naturalOrder()));
+            default ->
+                    Comparator.comparing(IndexSetFieldType::fieldName, Comparator.nullsLast(Comparator.naturalOrder()));
         };
 
         if (order == Sorting.Direction.DESC) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetFieldTypeTest.java
@@ -21,11 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.rest.resources.system.indexer.responses.FieldTypeOrigin.INDEX;
 import static org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType.FIELD_NAME;
 import static org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType.TYPE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IndexSetFieldTypeTest {
 
@@ -34,30 +33,30 @@ class IndexSetFieldTypeTest {
 
         final Comparator<IndexSetFieldType> fieldNameComparator = IndexSetFieldType.getComparator(FIELD_NAME, Sorting.Direction.ASC);
         final Comparator<IndexSetFieldType> reversedFieldNameComparator = IndexSetFieldType.getComparator(FIELD_NAME, Sorting.Direction.DESC);
-        assertEquals(0, fieldNameComparator.compare(
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "string", INDEX, false)
-        ));
-        assertEquals(0, reversedFieldNameComparator.compare(
+        )).isZero();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "string", INDEX, false)
-        ));
-        assertTrue(0 > fieldNameComparator.compare(
+        )).isZero();
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < reversedFieldNameComparator.compare(
+        )).isNegative();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < fieldNameComparator.compare(
+        )).isPositive();
+        assertThat(fieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
-        assertTrue(0 > reversedFieldNameComparator.compare(
+        )).isPositive();
+        assertThat(reversedFieldNameComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
+        )).isNegative();
     }
 
     @Test
@@ -65,29 +64,38 @@ class IndexSetFieldTypeTest {
 
         final Comparator<IndexSetFieldType> fieldTypeComparator = IndexSetFieldType.getComparator(TYPE, Sorting.Direction.ASC);
         final Comparator<IndexSetFieldType> reversedFieldTypeComparator = IndexSetFieldType.getComparator(TYPE, Sorting.Direction.DESC);
-        assertEquals(0, fieldTypeComparator.compare(
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "long", INDEX, false)
-        ));
-        assertEquals(0, reversedFieldTypeComparator.compare(
+        )).isZero();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("buhaha", "long", INDEX, false)
-        ));
-        assertTrue(0 > fieldTypeComparator.compare(
+        )).isZero();
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < reversedFieldTypeComparator.compare(
+        )).isNegative();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "long", INDEX, false),
                 new IndexSetFieldType("chiquita", "string", INDEX, false)
-        ));
-        assertTrue(0 < fieldTypeComparator.compare(
+        )).isPositive();
+        assertThat(fieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "text", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
-        assertTrue(0 > reversedFieldTypeComparator.compare(
+        )).isPositive();
+        assertThat(reversedFieldTypeComparator.compare(
                 new IndexSetFieldType("buhaha", "text", INDEX, false),
                 new IndexSetFieldType("arizona", "string", INDEX, false)
-        ));
+        )).isNegative();
+
+        assertThat(fieldTypeComparator.compare(
+                new IndexSetFieldType("buhaha", "long", INDEX, false),
+                new IndexSetFieldType("buhaha", null, INDEX, false)
+        )).isNegative();
+        assertThat(reversedFieldTypeComparator.compare(
+                new IndexSetFieldType("buhaha", "long", INDEX, false),
+                new IndexSetFieldType("buhaha", null, INDEX, false)
+        )).isPositive();
     }
 }


### PR DESCRIPTION
## Description
Sorting of custom field types is null safe.
Fixes https://github.com/Graylog2/graylog2-server/issues/19694
Backported to 6.0, based on PR: https://github.com/Graylog2/graylog2-server/pull/19960

## Motivation and Context
See https://github.com/Graylog2/graylog2-server/issues/19694




