### PR TITLE
Implement table rows border color with more contrast.

### DIFF
--- a/changelog/unreleased/pr-20001.toml
+++ b/changelog/unreleased/pr-20001.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Implement table rows border color with more contrast."
+
+pulls = ["20001"]

--- a/graylog2-web-interface/src/components/bootstrap/Table.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.jsx
@@ -84,7 +84,7 @@ const tableCss = css(({ theme }) => css`
     > tfoot > tr {
       > th,
       > td {
-        border-top-color: ${theme.colors.table.row.backgroundStriped};
+        border-top-color: ${theme.colors.table.row.divider};
       }
     }
 
@@ -100,7 +100,7 @@ const tableCss = css(({ theme }) => css`
     }
 
     > tbody + tbody {
-      border-top-color: ${theme.colors.table.row.backgroundStriped};
+      border-top-color: ${theme.colors.table.row.divider};
     }
 
     .table {
@@ -109,14 +109,14 @@ const tableCss = css(({ theme }) => css`
   }
 
   &.table-bordered {
-    border-color: ${theme.colors.table.row.backgroundStriped};
+    border-color: ${theme.colors.table.row.divider};
 
     > thead > tr,
     > tfoot > tr,
     > tbody > tr {
       > td,
       > th {
-        border-color: ${theme.colors.table.row.backgroundStriped};
+        border-color: ${theme.colors.table.row.divider};
       }
     }
   }

--- a/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
@@ -20,7 +20,7 @@ const TableHeaderCell = styled.th<{ $isNumeric?: boolean, $borderedHeader?: bool
   && {
     background-color: ${theme.colors.table.head.background};
     min-width: 50px;
-    border: ${$borderedHeader ? `1px solid ${theme.colors.table.row.backgroundStriped}` : '0'};
+    border: ${$borderedHeader ? `1px solid ${theme.colors.table.row.divider}` : '0'};
     padding: 0 5px;
     vertical-align: middle;
     white-space: nowrap;


### PR DESCRIPTION
Please note, this PR needs a backport for 6.0 and 5.2

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before:
![image](https://github.com/user-attachments/assets/18905831-a3d3-4e50-bc91-9070766ceb45)


After:
![image](https://github.com/user-attachments/assets/aecb80dd-761e-42a3-ad06-9c980166b5aa)

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/6685