### PR TITLE
Implement table rows border color with more contrast. (6.0)

### DIFF
--- a/changelog/unreleased/pr-20001.toml
+++ b/changelog/unreleased/pr-20001.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Implement table border color with more contrast."
+
+pulls = ["20001"]

--- a/graylog2-web-interface/src/components/bootstrap/Table.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.jsx
@@ -84,7 +84,7 @@ const tableCss = css(({ theme }) => css`
     > tfoot > tr {
       > th,
       > td {
-        border-top-color: ${theme.colors.table.row.backgroundAlt};
+        border-top-color: ${theme.colors.table.row.border};
       }
     }
 
@@ -100,7 +100,7 @@ const tableCss = css(({ theme }) => css`
     }
 
     > tbody + tbody {
-      border-top-color: ${theme.colors.table.row.backgroundAlt};
+      border-top-color: ${theme.colors.table.row.border};
     }
 
     .table {
@@ -109,14 +109,14 @@ const tableCss = css(({ theme }) => css`
   }
 
   &.table-bordered {
-    border-color: ${theme.colors.table.row.backgroundAlt};
+    border-color: ${theme.colors.table.row.border};
 
     > thead > tr,
     > tfoot > tr,
     > tbody > tr {
       > td,
       > th {
-        border-color: ${theme.colors.table.row.backgroundAlt};
+        border-color: ${theme.colors.table.row.border};
       }
     }
   }

--- a/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/TableHeaderCell.tsx
@@ -20,7 +20,7 @@ const TableHeaderCell = styled.th<{ $isNumeric?: boolean, $borderedHeader?: bool
   && {
     background-color: ${theme.colors.table.head.background};
     min-width: 50px;
-    border: ${$borderedHeader ? `1px solid ${theme.colors.table.row.backgroundAlt}` : '0'};
+    border: ${$borderedHeader ? `1px solid ${theme.colors.table.row.border}` : '0'};
     padding: 0 5px;
     vertical-align: middle;
     white-space: nowrap;


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/20001 for `6.0`
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before:
![image](https://github.com/user-attachments/assets/0dbea682-6c9f-47c6-a326-c7979cd43fac)

After:
![image](https://github.com/user-attachments/assets/dc398280-2e5f-4f9e-bcb2-91aaebd01187)


/nocl

