### PR TITLE
Implement table rows border color with more contrast. (5.2)

### DIFF
--- a/changelog/unreleased/pr-20001.toml
+++ b/changelog/unreleased/pr-20001.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Implement table rows border color with more contrast."
+
+pulls = ["20001"]

--- a/graylog2-web-interface/src/components/bootstrap/Table.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.jsx
@@ -84,7 +84,7 @@ const tableCss = css(({ theme }) => css`
     > tfoot > tr {
       > th,
       > td {
-        border-top-color: ${theme.colors.table.backgroundAlt};
+        border-top-color: ${theme.colors.gray[80]};
       }
     }
 
@@ -99,7 +99,7 @@ const tableCss = css(({ theme }) => css`
     }
 
     > tbody + tbody {
-      border-top-color: ${theme.colors.table.backgroundAlt};
+      border-top-color: ${theme.colors.gray[80]};
     }
 
     .table {
@@ -108,14 +108,14 @@ const tableCss = css(({ theme }) => css`
   }
 
   &.table-bordered {
-    border-color: ${theme.colors.table.backgroundAlt};
+    border-color: ${theme.colors.gray[80]};
 
     > thead > tr,
     > tfoot > tr,
     > tbody > tr {
       > td,
       > th {
-        border-color: ${theme.colors.table.backgroundAlt};
+        border-color: ${theme.colors.gray[80]};
       }
     }
   }

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.tsx
@@ -55,7 +55,7 @@ const StyledTable = styled(Table)<{ $stickyHeader: boolean, $borderedHeader: boo
     background-color: ${theme.colors.gray[90]};
     color: ${theme.utils.readableColor(theme.colors.gray[90])};
     white-space: nowrap;
-    ${$borderedHeader ? `border: 1px solid ${theme.colors.table.backgroundAlt}` : ''}
+    ${$borderedHeader ? `border: 1px solid ${theme.colors.gray[80]}` : ''}
   }
 
   > tbody td {


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/20001 for `5.2`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before:
![image](https://github.com/user-attachments/assets/1990acd1-4b95-4f1e-a8bc-61450c3df776)


After:
![image](https://github.com/user-attachments/assets/f9993528-7760-49db-8a44-59cca980a959)


/nocl

