### PR TITLE
Disable world map interactions in non-interactive mode.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.tsx
@@ -219,18 +219,24 @@ class MapVisualization extends React.Component<MapVisualizationProps> {
         {(interactive) => (
           <div className={locked ? style.mapLocked : ''} style={{ position: 'relative', zIndex: 0 }}>
             {locked && <div className={style.overlay} style={{ height, width }} />}
-            <MapContainer center={viewport.center}
-                          boundsOptions={{ maxZoom: 19, animate: interactive }}
-                          zoom={viewport.zoom}
+            <MapContainer boundsOptions={{ maxZoom: 19, animate: interactive }}
+                          center={viewport.center}
                           className={style.map}
+                          closePopupOnClick={interactive}
+                          doubleClickZoom={interactive}
+                          dragging={interactive}
                           fadeAnimation={interactive}
-                          key={`visualization-${id}-${width}-${height}`}
                           id={`visualization-${id}`}
+                          key={`visualization-${id}-${width}-${height}`}
                           markerZoomAnimation={interactive}
-                          scrollWheelZoom
+                          scrollWheelZoom={interactive}
                           style={{ height, width }}
+                          touchZoom={interactive}
+                          trackResize={interactive}
                           whenReady={this._handleMapReady}
-                          zoomAnimation={interactive}>
+                          zoom={viewport.zoom}
+                          zoomAnimation={interactive}
+                          zoomControl={interactive}>
               <MapEvents onViewportChanged={onChange} />
               <TileLayer url={url} attribution={attribution} eventHandlers={{ load: this._handleTilesReady }} />
               {markers}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There are some cases like the dashboard "full screen" mode where widgets are being displayed in a non-interactive mode.

With this PR we are also displaying the world map widget non-interactive in these cases.

Before in non-interactive-mode:
![image](https://github.com/user-attachments/assets/2ec6befb-a095-4504-95ec-4037bcaf78c3)


After in non-interactive-mode:
![image](https://github.com/user-attachments/assets/b0b228a2-61f7-48bf-9770-cd56d64eeca6)


Fixes 
