### PR TITLE
Set ignoreSignaturesOfMissingClasses for forbiddenapis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,6 +730,7 @@
                     <!-- if the used Java version is too new, don't fail, just do nothing: -->
                     <failOnUnsupportedJava>false</failOnUnsupportedJava>
                     <failOnViolation>true</failOnViolation>
+                    <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                     <bundledSignatures>
                         <!-- We want to allow String#formatted without charset. -->
                         <bundledSignature>jdk-unsafe-14</bundledSignature>


### PR DESCRIPTION
This allows us to keep singatures for classes that are not present on the classpath. Keeping the signatures is useful if the class should come back at some point.

/nocl Code quality tooling change.