### PR TITLE
Check permission for rules create button for read-only stream

### DIFF
--- a/graylog2-web-interface/src/components/streamrules/CreateStreamRuleButton.tsx
+++ b/graylog2-web-interface/src/components/streamrules/CreateStreamRuleButton.tsx
@@ -25,6 +25,7 @@ import type { StyleProps } from 'components/bootstrap/Button';
 import type { StreamRule } from 'stores/streams/StreamsStore';
 import { StreamRulesStore } from 'stores/streams/StreamRulesStore';
 import UserNotification from 'util/UserNotification';
+import { IfPermitted } from 'components/common';
 
 import StreamRuleModal from './StreamRuleModal';
 
@@ -33,10 +34,11 @@ type Props = {
   bsStyle?: StyleProps,
   buttonText?: string,
   className?: string,
+  disabled?: boolean,
   streamId: string,
 }
 
-const CreateStreamRuleButton = ({ bsSize, bsStyle, buttonText, className, streamId }: Props) => {
+const CreateStreamRuleButton = ({ bsSize, bsStyle, buttonText, className, disabled, streamId }: Props) => {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const queryClient = useQueryClient();
   const toggleCreateModal = useCallback(() => setShowCreateModal((cur) => !cur), []);
@@ -47,9 +49,10 @@ const CreateStreamRuleButton = ({ bsSize, bsStyle, buttonText, className, stream
   }), [streamId, queryClient]);
 
   return (
-    <>
+    <IfPermitted permissions={`streams:edit:${streamId}`}>
       <Button bsSize={bsSize}
               bsStyle={bsStyle}
+              disabled={disabled}
               className={className}
               onClick={toggleCreateModal}>
         {buttonText}
@@ -62,8 +65,8 @@ const CreateStreamRuleButton = ({ bsSize, bsStyle, buttonText, className, stream
                          onSubmit={onSaveStreamRule} />
 
       )}
-      {}
-    </>
+
+    </IfPermitted>
   );
 };
 
@@ -80,6 +83,7 @@ CreateStreamRuleButton.defaultProps = {
   bsSize: undefined,
   bsStyle: undefined,
   className: undefined,
+  disabled: false,
   streamId: undefined,
 };
 

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
@@ -34,15 +34,18 @@ export const Headline = styled.h2(({ theme }) => css`
 
 const StreamDataRoutingInstake = ({ stream }: Props) => {
   const hasStreamRules = !!stream.rules?.length;
+  const isDefaultStream = stream.is_default;
+  const isNotEditable = !stream.is_editable;
 
   return (
     <Section title="Stream rules"
              actions={(
-               <IfPermitted permissions="streams:create">
+               <IfPermitted permissions={`streams:edit:${stream.id}`}>
                  <CreateStreamRuleButton bsStyle="success"
+                                         disabled={isDefaultStream || isNotEditable}
                                          streamId={stream.id} />
                </IfPermitted>
-             )}>
+               )}>
       <Table condensed striped hover>
         <thead>
           <tr>
@@ -57,9 +60,9 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
           ))}
 
           {!hasStreamRules && (
-          <tr>
-            <td>No rules defined.</td>
-          </tr>
+            <tr>
+              <td>No rules defined.</td>
+            </tr>
           )}
         </tbody>
       </Table>


### PR DESCRIPTION
This PR disables the create rule button when the user does not have permission, or the Stream is read-only.

fix #20024 
/nocl
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

