### PR TITLE
update built-in indexset template title/description

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,9 +26,9 @@ The following Java Code API changes have been made.
 
 The following REST API changes have been made.
 
-| Endpoint                 | Description                                      |
-|--------------------------|--------------------------------------------------|
-| `tbd`                    | tbd                                              |
+| Endpoint                                 | Description                                                                                                                     |
+|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `PUT /system/indices/index_set_defaults` | This endpoint now expects an index set template id as payload. The values of the index set template are used as default values. |
 
 ## Deprecated Inputs
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexTemplate.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V202211021200_CreateDefaultIndexTemplate.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  */
 public class V202211021200_CreateDefaultIndexTemplate extends Migration {
     private static final Logger LOG = LoggerFactory.getLogger(V202211021200_CreateDefaultIndexTemplate.class);
-    public static final String TEMPLATE_DESCRIPTION = "Generated template that is used for index sets which are created automatically.";
+    public static final String TEMPLATE_DESCRIPTION = "A generated template used for index sets that are created automatically, such as by Illuminate packs.";
 
     private final ClusterConfigService clusterConfigService;
     private final IndexSetDefaultTemplateConfigFactory factory;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -30,6 +30,7 @@ import org.graylog2.validation.ValidObjectId;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 @JsonAutoDetect
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -49,6 +50,11 @@ public record IndexSetUpdateRequest(@JsonProperty(FIELD_TITLE) @NotBlank String 
                                     @JsonProperty(FIELD_DATA_TIERING) @Nullable DataTieringConfig dataTieringConfig,
                                     @JsonProperty(FIELD_USE_LEGACY_ROTATION) @Nullable Boolean useLegacyRotation) implements SimpleIndexSetConfig {
 
+
+    @Override
+    public Boolean useLegacyRotation() {
+        return Objects.isNull(useLegacyRotation) || useLegacyRotation;
+    }
 
     public static IndexSetUpdateRequest fromIndexSetConfig(final IndexSetConfig indexSet) {
         return new IndexSetUpdateRequest(

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -51,7 +51,6 @@ public record IndexSetUpdateRequest(@JsonProperty(FIELD_TITLE) @NotBlank String 
                                     @JsonProperty(FIELD_USE_LEGACY_ROTATION) @Nullable Boolean useLegacyRotation) implements SimpleIndexSetConfig {
 
 
-    @Override
     public Boolean useLegacyRotation() {
         return Objects.isNull(useLegacyRotation) || useLegacyRotation;
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -74,7 +74,7 @@ public abstract class IndexSetSummary implements SimpleIndexSetConfig {
         return new AutoValue_IndexSetSummary(shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass,
                 retentionStrategy, dataTiering, id, title, description, isDefault, canBeDefault, isWritable, indexPrefix,
                 creationDate, indexAnalyzer, indexOptimizationMaxNumSegments, indexOptimizationDisabled, fieldTypeRefreshInterval,
-                Optional.ofNullable(templateType), fieldTypeProfile, useLegacyRotation);
+                Optional.ofNullable(templateType), fieldTypeProfile, Objects.isNull(useLegacyRotation) || useLegacyRotation);
     }
 
     public static IndexSetSummary fromIndexSetConfig(IndexSetConfig indexSet, boolean isDefault) {

--- a/graylog2-server/src/main/resources/org/graylog2/indexer/indexset/template/on_prem_templates.json
+++ b/graylog2-server/src/main/resources/org/graylog2/indexer/indexset/template/on_prem_templates.json
@@ -1,7 +1,7 @@
 [
   {
-    "title": "7 Days Hot - Minimal Historical Searches",
-    "description": "This configuration maintains a minimum of 7 days of logs in the Hot Tier for fast access. Logs older than this will graduate to the Warm tier, where they will kept until at least 90 days old. This configuration is good choice for minimising database overhead and Hot Tier storage provision, and suitable for data that is normally only relavent for a few days.",
+    "title": "7 Days Hot, 90 Days Total",
+    "description": "Use case: rare historical searches. This configuration is good choice for minimising database overhead and Hot Tier storage provision, and suitable for data that is normally only relavent for a few days.",
     "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",
@@ -23,8 +23,8 @@
     }
   },
   {
-    "title": "14 Days Hot - Infrequent or Shallow Historical Searches",
-    "description": "This configuration maintains a minimum of 14 days of logs in the Hot Tier for fast access. Logs older than this will graduate to the Warm tier, and will be kept until at least 90 days old. This configuration is a good balance for faster deep searches, while still keeping database overhead and Hot Tier storage requirement moderate.",
+    "title": "14 Days Hot, 90 Days Total.",
+    "description": "Use Case: Infrequent historical Searches. This configuration offers faster deep historical searches, balanced against higher Hot Tier storage requirement and resource overhead.",
     "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",
@@ -46,8 +46,8 @@
     }
   },
   {
-    "title": "30 days Hot - Frequent or Deep Historical Searches",
-    "description": "This configuration maintains a minimum of 30 days of logs in the Hot Tier for fast access. Logs older than this will graduate to the Warm tier, and will be kept until at least 90 days old. This configuration maximizes deep historical search performance, but the 30 day Hot Tier requires a significant storage provision and resource overhead.",  "built_in": true,
+    "title": "30 days Hot, 90 Days Total",
+    "description": "Use case: Frequent Historical Searches. This configuration maximizes deep historical search performance, but the 30 day Hot Tier requires a significant Hot Tier storage provision and resource overhead.",  "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",
       "shards": 1,
@@ -68,8 +68,8 @@
     }
   },
   {
-    "title": "7 Days Hot - Minimal Historical Searches",
-    "description": "This configuration maintains a minimum of 7 days of logs in the Hot Tier. Logs will be searchable for a maximum of 9 days. This configuration suitable for data that is normally only relavent for a few days.",
+    "title": "7 Days Hot",
+    "description": "This configuration maintains a minimum of 7 days of logs in the Hot Tier. Logs will be searchable for a maximum of 9 days.",
     "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",
@@ -87,8 +87,8 @@
     }
   },
   {
-    "title": "14 Days Hot - Infrequent Historical Searches",
-    "description": "This configuration maintains a minimum of 14 days of logs in the Hot Tier. Logs will be searchable for a maximum of 18 days. This configuration is a balance between enabling deeper searches and moderate storage requirements.",
+    "title": "14 Days Hot",
+    "description": "This configuration maintains a minimum of 14 days of logs in the Hot Tier. Logs will be searchable for a maximum of 18 days.",
     "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",
@@ -106,8 +106,8 @@
     }
   },
   {
-    "title": "30 Days Hot - frequent Historical Searches",
-    "description": "This configuration maintains a minimum of 30 days of logs in the Hot Tier. Logs will be searchable for a maximum of 40 days. This configuration enables deep historical searches, but entails greater storage provision and resource overhead.",
+    "title": "30 Days Hot",
+    "description": "This configuration maintains a minimum of 30 days of logs in the Hot Tier. Logs will be searchable for a maximum of 40 days.",
     "built_in": true,
     "index_set_config": {
       "index_analyzer": "standard",


### PR DESCRIPTION
changed:

- update built-in indexset template title/description (like discussed in Slack#index-templates)
- update default indexset template description (like discussed in Slack#index-templates)
- update Ugrading.md
- make useLegacyRotation optional to not break API

/nocl

