### PR TITLE
New configuration `license_manager_url`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,10 @@ The `default_message_output_class` setting changed from
 org.graylog2.outputs.BatchedMessageFilterOutput` as part of an internal
 refactoring. Regular users should not change the setting.
 
+## New Configuration Settings
+
+`license_manager_url` specifies the base path of the new License Manager component.
+
 ## Java API Changes
 
 The following Java Code API changes have been made.

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -763,3 +763,6 @@ mongodb_max_connections = 1000
 #   event-processor-execution-v1
 #   notification-execution-v1
 #job_scheduler_concurrency_limits = event-processor-execution-v1:2,notification-execution-v1:2
+
+# License Manager configuration
+#license_manager_url = "http://localhost:9998"


### PR DESCRIPTION
/nocl CL in related Enterprise PR

<!--- Provide a general summary of your changes in the Title above -->
Document a new configuration setting available to Enterprise users.

## Description
This is purely documentation. The configuration is implemented in the corresponding PR Graylog2/graylog-plugin-enterprise#8100
