### PR TITLE
fix(8075): Added definitionId optional prop to FilterAggregationSummary

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.tsx
@@ -39,7 +39,7 @@ import styles from './FilterAggregationSummary.css';
 
 import LinkToReplaySearch from '../replay-search/LinkToReplaySearch';
 
-const StreamOrId = ({ streamOrId } : { streamOrId: Stream | string }) => {
+const StreamOrId = ({ streamOrId }: { streamOrId: Stream | string }) => {
   if (typeof streamOrId === 'string') {
     return <span key={streamOrId}><em>{streamOrId}</em></span>;
   }
@@ -55,8 +55,8 @@ const getConditionType = (config: EventDefinition['config']) => {
   const { group_by: groupBy, series, conditions } = config;
 
   return (isEmpty(groupBy)
-  && (!conditions || isEmpty(conditions) || conditions.expression === null)
-  && isEmpty(series)
+    && (!conditions || isEmpty(conditions) || conditions.expression === null)
+    && isEmpty(series)
     ? 'filter' : 'aggregation');
 };
 
@@ -80,9 +80,10 @@ type Props = {
   streams: Array<Stream>,
   config: EventDefinition['config'],
   currentUser: User,
+  definitionId?: string,
 }
 
-const SearchFilters = ({ filters }: { filters: EventDefinition['config']['filters']}) => {
+const SearchFilters = ({ filters }: { filters: EventDefinition['config']['filters'] }) => {
   if (!filters || filters.length === 0) {
     return <dd>No filters configured</dd>;
   }
@@ -126,7 +127,7 @@ const Streams = ({ streams, streamIds, streamIdsWithMissingPermission }: Streams
   );
 };
 
-const FilterAggregationSummary = ({ config, currentUser }: Props) => {
+const FilterAggregationSummary = ({ config, currentUser, definitionId }: Props) => {
   const streams = useContext(StreamsContext);
   const {
     query,
@@ -197,33 +198,37 @@ const FilterAggregationSummary = ({ config, currentUser }: Props) => {
       <dt>Enable scheduling</dt>
       <dd>{isScheduled ? 'yes' : 'no'}</dd>
       {conditionType === 'filter' && (
-      <>
-        <dt>Event limit</dt>
-        <dd>{event_limit}</dd>
-      </>
+        <>
+          <dt>Event limit</dt>
+          <dd>{event_limit}</dd>
+        </>
       )}
       {conditionType === 'aggregation' && (
-      <>
-        <dt>Group by Field(s)</dt>
-        <dd>{groupBy && groupBy.length > 0 ? groupBy.join(', ') : 'No Group by configured'}</dd>
-        <dt>Create Events if</dt>
-        <dd>
-          {validationResults.isValid
-            ? <AggregationConditionSummary series={series} conditions={conditions} />
-            : (
-              <Alert bsStyle="danger">
-                Condition is not valid: {validationResults.errors.join(', ')}
-              </Alert>
-            )}
-        </dd>
-      </>
+        <>
+          <dt>Group by Field(s)</dt>
+          <dd>{groupBy && groupBy.length > 0 ? groupBy.join(', ') : 'No Group by configured'}</dd>
+          <dt>Create Events if</dt>
+          <dd>
+            {validationResults.isValid
+              ? <AggregationConditionSummary series={series} conditions={conditions} />
+              : (
+                <Alert bsStyle="danger">
+                  Condition is not valid: {validationResults.errors.join(', ')}
+                </Alert>
+              )}
+          </dd>
+        </>
       )}
       <dt>Actions</dt>
       <dd>
-        <LinkToReplaySearch />
+        <LinkToReplaySearch id={definitionId} />
       </dd>
     </dl>
   );
+};
+
+FilterAggregationSummary.defaultProps = {
+  definitionId: undefined,
 };
 
 export default FilterAggregationSummary;

--- a/graylog2-web-interface/src/components/event-definitions/types.d.ts
+++ b/graylog2-web-interface/src/components/event-definitions/types.d.ts
@@ -37,6 +37,7 @@ interface EventDefinitionType {
   summaryComponent: React.ComponentType<{
     currentUser: User,
     config: EventDefinition['config'],
+    definitionId?: string,
   }>
 }
 declare module 'graylog-web-plugin/plugin' {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added `definitionId` to FilterAggregationSummary to fix issue with replay search button

closes: graylog2/graylog-plugin-enterprise#8075

/nocl

## Description
<!--- Describe your changes in detail -->
The implementation of LinkToReplaySearch component changed. It uses URL params to get the event definition ID when the user tries to replay the search of an event definition.

This PR adds an optional property to the component to be able to pass the ID when the component is used in a view that doesn't have the definition ID as a parameter in the URL. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

