### PR TITLE
Optimize byte-size-based output batch handling

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/ImmutableMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/ImmutableMessage.java
@@ -16,12 +16,11 @@
  */
 package org.graylog2.indexer.messages;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.plugin.Message;
 import org.graylog2.shared.messageq.Acknowledgeable;
-
-import java.util.Map;
-import java.util.Set;
 
 /**
  * The purpose of this interface is to provide access to certain properties of a {@link Message} while ensuring that
@@ -44,9 +43,9 @@ public interface ImmutableMessage extends Indexable, Acknowledgeable {
     @Override
     String getId();
 
-    Set<IndexSet> getIndexSets();
+    ImmutableSet<IndexSet> getIndexSets();
 
-    Map<String, Object> getFields();
+    ImmutableMap<String, Object> getFields();
 
     String getMessage();
 
@@ -54,5 +53,5 @@ public interface ImmutableMessage extends Indexable, Acknowledgeable {
 
     String getSource();
 
-    Set<String> getStreamIds();
+    ImmutableSet<String> getStreamIds();
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/SerializationMemoizingMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/SerializationMemoizingMessage.java
@@ -18,6 +18,8 @@ package org.graylog2.indexer.messages;
 
 import com.codahale.metrics.Meter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import jakarta.annotation.Nonnull;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.plugin.Message;
@@ -30,7 +32,6 @@ import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Wraps a {@link Message} by making it immutable and caching the result of {@link #serialize(SerializationContext)}
@@ -150,13 +151,13 @@ public class SerializationMemoizingMessage implements ImmutableMessage {
     }
 
     @Override
-    public Set<IndexSet> getIndexSets() {
-        return delegate.getIndexSets();
+    public ImmutableSet<IndexSet> getIndexSets() {
+        return ImmutableSet.copyOf(delegate.getIndexSets());
     }
 
     @Override
-    public Map<String, Object> getFields() {
-        return delegate.getFields();
+    public ImmutableMap<String, Object> getFields() {
+        return ImmutableMap.copyOf(delegate.getFields());
     }
 
     @Override
@@ -175,8 +176,8 @@ public class SerializationMemoizingMessage implements ImmutableMessage {
     }
 
     @Override
-    public Set<String> getStreamIds() {
-        return delegate.getStreamIds();
+    public ImmutableSet<String> getStreamIds() {
+        return ImmutableSet.copyOf(delegate.getStreamIds());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/outputs/IndexSetAwareMessageOutputBuffer.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/IndexSetAwareMessageOutputBuffer.java
@@ -102,7 +102,10 @@ public class IndexSetAwareMessageOutputBuffer {
             // See class the class documentation for the reasoning behind the bufferLength calculation.
             buffer.add(filteredMessage);
             bufferLength += Math.max(filteredMessage.message().getIndexSets().size(), 1);
-            bufferSizeBytes += estimateOsBulkRequestSize(filteredMessage.message(), objectMapper);
+            // for optimization, only calculate batch size in bytes, if we are actually restricting by size in bytes
+            if (maxBufferSizeBytes != 0L) {
+                bufferSizeBytes += estimateOsBulkRequestSize(filteredMessage.message(), objectMapper);
+            }
 
             if ((maxBufferSizeBytes != 0L && bufferSizeBytes >= maxBufferSizeBytes) ||
                     maxBufferSizeCount != 0 && bufferLength >= maxBufferSizeCount) {

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
@@ -88,7 +88,7 @@ class BatchedMessageFilterOutputTest {
     void setUp(MessageFactory messageFactory) {
         this.messageFactory = messageFactory;
         this.objectMapper = new ObjectMapperProvider().get();
-        when(indexSet.getWriteIndexAlias()).thenReturn("graylog_deflector");
+        lenient().when(indexSet.getWriteIndexAlias()).thenReturn("graylog_deflector");
         lenient().when(defaultStream.getIndexSet()).thenReturn(indexSet);
     }
 


### PR DESCRIPTION
Implements two parts of #20071:
- Don't serialize messages early if count-based batch size is configured
- Make collection types explicitly immutable.

Part of #20071

/nocl internal refactoring