### PR TITLE
add addonAfter for FormikInput

### DIFF
--- a/graylog2-web-interface/src/components/common/FormikInput.tsx
+++ b/graylog2-web-interface/src/components/common/FormikInput.tsx
@@ -23,6 +23,7 @@ import { Input } from 'components/bootstrap';
 
 type BaseProps = {
   autoComplete?: string,
+  addonAfter?: React.ReactElement | string,
   bsSize?: 'large' | 'small' | 'xsmall',
   buttonAfter?: React.ReactElement | string,
   children?: React.ReactNode,
@@ -93,6 +94,7 @@ const FormikInput = ({ name, type, help, validate, onChange: propagateOnChange, 
 
 FormikInput.propTypes = {
   autoComplete: PropTypes.string,
+  addonAfter: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   bsSize: PropTypes.string,
   buttonAfter: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   children: PropTypes.oneOfType([
@@ -121,6 +123,7 @@ FormikInput.propTypes = {
 
 FormikInput.defaultProps = {
   autoComplete: undefined,
+  addonAfter: undefined,
   bsSize: undefined,
   buttonAfter: undefined,
   children: null,


### PR DESCRIPTION
Input supports addonAfter, but the FormikInput didn't expose it in its properties. This Pr is adding that.
/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

