### PR TITLE
New configuration option for AI Investigation Reports (abandoned solution)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -240,6 +240,9 @@ public class Configuration extends CaConfiguration {
     @Parameter(value = "minimum_auto_refresh_interval", required = true)
     private Period minimumAutoRefreshInterval = Period.seconds(1);
 
+    @Parameter(value = "ai_investigation_reports_enabled")
+    private boolean aiInvestigationReports = false;
+
     /**
      * Classes considered safe to load by name. A set of prefixes matched against the fully qualified class name.
      */
@@ -497,6 +500,10 @@ public class Configuration extends CaConfiguration {
 
     public FieldValueSuggestionMode getFieldValueSuggestionMode() {
         return fieldValueSuggestionMode;
+    }
+
+    public boolean aiInvestigationReportsEnabled() {
+        return aiInvestigationReports;
     }
 
     /**

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -763,3 +763,6 @@ mongodb_max_connections = 1000
 #   event-processor-execution-v1
 #   notification-execution-v1
 #job_scheduler_concurrency_limits = event-processor-execution-v1:2,notification-execution-v1:2
+
+# Flag used to switch on and off "AI Investigation Reports" functionality.
+ai_investigation_reports_enabled = false


### PR DESCRIPTION
## Description
New configuration option for AI Investigation Reports.
Set by default to false, so that no admin gets surprised that their users are sending stuff to our AI proxy.
Proper enterprise PR will follow this PR to make use of this flag.
/nocl


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

