### PR TITLE
Add datanode information to support bundle

### DIFF
--- a/changelog/unreleased/pr-20090.toml
+++ b/changelog/unreleased/pr-20090.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add data node information to support bundle."
+
+pulls = ["20090"]
+issues = ["graylog-plugin-enterprise#7966"]

--- a/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeDirectories.java
+++ b/data-node/src/main/java/org/graylog/datanode/configuration/DatanodeDirectories.java
@@ -16,9 +16,10 @@
  */
 package org.graylog.datanode.configuration;
 
+import jakarta.annotation.Nonnull;
+import org.apache.commons.io.FileUtils;
 import org.graylog.datanode.Configuration;
 import org.graylog2.plugin.system.NodeId;
-import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,12 +91,20 @@ public class DatanodeDirectories {
         return dataTargetDir.toAbsolutePath();
     }
 
+    public String getDataTargetDirSpace() {
+        return FileUtils.byteCountToDisplaySize(dataTargetDir.toFile().getFreeSpace());
+    }
+
     /**
      * This directory is used by the managed opensearch to store its logs in it.
      * Read-write permissions required.
      */
     public Path getLogsTargetDir() {
         return logsTargetDir.toAbsolutePath();
+    }
+
+    public String getLogsTargetDirSpace() {
+        return FileUtils.byteCountToDisplaySize(logsTargetDir.toFile().getFreeSpace());
     }
 
 
@@ -125,6 +134,10 @@ public class DatanodeDirectories {
      */
     public Path getConfigurationTargetDir() {
         return configurationTargetDir.toAbsolutePath();
+    }
+
+    public String getConfigurationTargetDirSpace() {
+        return FileUtils.byteCountToDisplaySize(configurationTargetDir.toFile().getFreeSpace());
     }
 
     public Path createConfigurationFile(Path relativePath) throws IOException {

--- a/data-node/src/main/java/org/graylog/datanode/rest/DataNodeStatus.java
+++ b/data-node/src/main/java/org/graylog/datanode/rest/DataNodeStatus.java
@@ -21,12 +21,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog.datanode.configuration.DatanodeDirectories;
 import org.graylog2.plugin.Version;
 
-import java.util.List;
+public record DataNodeStatus(@JsonIgnore Version appVersion, SystemInfo operatingSystem, StatusResponse opensearch,
+                             DatanodeDirectories datanodeDirectories) {
 
-public record DataNodeStatus(@JsonIgnore Version appVersion, StatusResponse opensearch, DatanodeDirectories datanodeDirectories) {
+    DataNodeStatus(Version appVersion, StatusResponse opensearch, DatanodeDirectories datanodeDirectories) {
+        this(appVersion, new SystemInfo(), opensearch, datanodeDirectories);
+    }
 
     @JsonProperty
     public String dataNodeVersion() {
         return this.appVersion.toString();
     }
+
+    record SystemInfo(String osName, String osVersion, String javaVersion, String userName) {
+        public SystemInfo() {
+            this(System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("java.version"), System.getProperty("user.name"));
+        }
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/RemoteDataNodeStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/RemoteDataNodeStatusResource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.resources.system;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface RemoteDataNodeStatusResource {
+
+    @GET("/")
+    Call<JsonNode> status();
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds initial information about data nodes to the support bundle.
Information from the data nodes as stored in mongodb are provided in `datanodes.configured` and status information from the status endpoint of running data nodes is provided in `datanodes.running` in the generated `cluster.json`

Additionally, the status endpoint now return information about the operating system, java version and user running the data node as well as free disk space available for the configured data node directories.

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/7966

## How Has This Been Tested?
manually by creating a support bundle in System/Logging

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

