### PR TITLE
Manage org.json:json dependency to ensure consistent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <jmte.version>7.0.3</jmte.version>
         <joda-time.version>2.12.7</joda-time.version>
         <jool.version>0.9.15</jool.version>
+        <json-org.version>20240303</json-org.version>
         <json-path.version>2.9.0</json-path.version>
         <kafka.version>3.8.0</kafka.version>
         <kafka09.version>0.9.0.1-7</kafka09.version>
@@ -343,6 +344,11 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json-org.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
Earlier versions include a DoS vulnerability, so we want to ensure we
are using a fixed version.

Refs https://github.com/Graylog2/graylog2-server/security/dependabot/131

/nocl No user-visible change.