### PR TITLE
Skip index retention if its remote-reindex migration is currently run…

### DIFF
--- a/changelog/unreleased/pr-20121.toml
+++ b/changelog/unreleased/pr-20121.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Stop index retention during remote reindex migration"
+
+pulls = ["20121"]
+issues = ["graylog-plugin-enterprise#8097"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/UnsupportedRemoteReindexingMigrationAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/UnsupportedRemoteReindexingMigrationAdapterES7.java
@@ -18,6 +18,7 @@ package org.graylog.storage.elasticsearch7;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
@@ -29,6 +30,11 @@ import java.util.Optional;
 public class UnsupportedRemoteReindexingMigrationAdapterES7 implements RemoteReindexingMigrationAdapter {
 
     public static final String UNSUPPORTED_MESSAGE = "This operation should never be called. We remote-reindex into the DataNode that contains OpenSearch. This adapter only exists for API completeness";
+
+    @Override
+    public boolean isMigrationRunning(IndexSet indexSet) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
 
     @Override
     public String start(RemoteReindexRequest request) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/UnsupportedRemoteReindexingMigrationAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/UnsupportedRemoteReindexingMigrationAdapterES7.java
@@ -33,7 +33,7 @@ public class UnsupportedRemoteReindexingMigrationAdapterES7 implements RemoteRei
 
     @Override
     public boolean isMigrationRunning(IndexSet indexSet) {
-        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+        return false; // we'll never run a remote reindex migration against elasticsearch target. It's always OS in datanode.
     }
 
     @Override
@@ -53,6 +53,6 @@ public class UnsupportedRemoteReindexingMigrationAdapterES7 implements RemoteRei
 
     @Override
     public Optional<String> getLatestMigrationId() {
-        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+        return Optional.empty();
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -69,7 +69,6 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Tools;
 import org.graylog2.rest.resources.datanodes.DatanodeResolver;
 import org.graylog2.rest.resources.datanodes.DatanodeRestApiProxy;
-import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -142,7 +141,7 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
                 .orElse(false);
     }
 
-    @NotNull
+    @Nonnull
     private Boolean isIndexSetCurrentlyMigrated(IndexSet indexSet, RemoteReindexMigration mig) {
         if (mig.status() == Status.NOT_STARTED || mig.status() == Status.RUNNING) {
             final Set<String> runningIndices = mig.indices().stream()

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.datanode;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.migration.IndexerConnectionCheckResult;
 import org.graylog2.indexer.migration.RemoteReindexMigration;
 
@@ -25,6 +26,8 @@ import java.net.URI;
 import java.util.Optional;
 
 public interface RemoteReindexingMigrationAdapter {
+    boolean isMigrationRunning(IndexSet indexSet);
+
     enum Status {
         NOT_STARTED, RUNNING, ERROR, FINISHED
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -21,6 +21,7 @@ import org.graylog2.datatiering.DataTieringOrchestrator;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
@@ -48,6 +49,8 @@ public class IndexRetentionThread extends Periodical {
     private final Map<String, Provider<RetentionStrategy>> retentionStrategyMap;
     private final DataTieringOrchestrator dataTieringOrchestrator;
 
+    private final RemoteReindexingMigrationAdapter migrationService;
+
     @Inject
     public IndexRetentionThread(ElasticsearchConfiguration configuration,
                                 IndexSetRegistry indexSetRegistry,
@@ -55,7 +58,7 @@ public class IndexRetentionThread extends Periodical {
                                 NodeId nodeId,
                                 NotificationService notificationService,
                                 Map<String, Provider<RetentionStrategy>> retentionStrategyMap,
-                                DataTieringOrchestrator dataTieringOrchestrator) {
+                                DataTieringOrchestrator dataTieringOrchestrator, RemoteReindexingMigrationAdapter migrationService) {
         this.configuration = configuration;
         this.indexSetRegistry = indexSetRegistry;
         this.cluster = cluster;
@@ -63,6 +66,7 @@ public class IndexRetentionThread extends Periodical {
         this.notificationService = notificationService;
         this.retentionStrategyMap = retentionStrategyMap;
         this.dataTieringOrchestrator = dataTieringOrchestrator;
+        this.migrationService = migrationService;
     }
 
     @Override
@@ -81,6 +85,12 @@ public class IndexRetentionThread extends Periodical {
                 LOG.debug("Skipping non-writable index set <{}> ({})", indexSet.getConfig().id(), indexSet.getConfig().title());
                 continue;
             }
+
+            if(isCurrentlyMigrated(indexSet)) {
+                LOG.info("Index set <{}> is currently being migrated, skipping retention", indexSet.getConfig().title());
+                continue;
+            }
+
             final IndexSetConfig config = indexSet.getConfig();
             if (config.dataTieringConfig() != null) {
                 dataTieringOrchestrator.retain(indexSet);
@@ -97,6 +107,10 @@ public class IndexRetentionThread extends Periodical {
                 retentionStrategyProvider.get().retain(indexSet);
             }
         }
+    }
+
+    private boolean isCurrentlyMigrated(IndexSet indexSet) {
+        return migrationService.isMigrationRunning(indexSet);
     }
 
     private void retentionProblemNotification(String title, String description) {


### PR DESCRIPTION
Index retention may delete our freshly created indices during remote reindex migration. The migration itself starts with a switch from old open/elastic cluster to the new empty datanode cluster. Then we create an empty preconfigured index for each index that will be migrated. Afterwards the actual migration starts, copying content of indices in batches. If the retention tasks starts during the migration, it may delete some of these newly created and prepared indices even before the migration reaches them. The remote reindex task will fail afterwards, as it has no target index to copy data into. 

This PR is pausing retention for index sets that are being migrated to prevent such problems.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/8097

## How Has This Been Tested?
Manually, configuring aggressive retention policy and running the retention task every minute. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

