### PR TITLE
Show system notification while remote reindexing

### DIFF
--- a/changelog/unreleased/pr-20123.toml
+++ b/changelog/unreleased/pr-20123.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Show system notification while remote reindexing during the data node migration."
+
+pulls = ["20123"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActions.java
@@ -66,4 +66,6 @@ public interface MigrationActions {
     void getElasticsearchHosts();
 
     void stopDatanodes();
+
+    void finishRemoteReindexMigration();
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/actions/MigrationActionsImpl.java
@@ -33,6 +33,8 @@ import org.graylog2.datanode.DataNodeCommandService;
 import org.graylog2.datanode.DatanodeStartType;
 import org.graylog2.indexer.datanode.RemoteReindexRequest;
 import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.GlobalMetricNames;
 import org.graylog2.plugin.Version;
 import org.graylog2.plugin.certificates.RenewalPolicy;
@@ -76,6 +78,7 @@ public class MigrationActionsImpl implements MigrationActions {
     private final List<URI> elasticsearchHosts;
 
     private final Version graylogVersion = Version.CURRENT_CLASSPATH;
+    private final NotificationService notificationService;
 
     @Inject
     public MigrationActionsImpl(@Assisted MigrationStateMachineContext stateMachineContext,
@@ -87,7 +90,8 @@ public class MigrationActionsImpl implements MigrationActions {
                                 final MetricRegistry metricRegistry,
                                 final DatanodeRestApiProxy datanodeProxy,
                                 ElasticsearchVersionProvider searchVersionProvider,
-                                @Named("elasticsearch_hosts") List<URI> elasticsearchHosts) {
+                                @Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
+                                NotificationService notificationService) {
         this.stateMachineContext = stateMachineContext;
         this.clusterConfigService = clusterConfigService;
         this.nodeService = nodeService;
@@ -100,6 +104,7 @@ public class MigrationActionsImpl implements MigrationActions {
         this.datanodeProxy = datanodeProxy;
         this.searchVersionProvider = searchVersionProvider;
         this.elasticsearchHosts = elasticsearchHosts;
+        this.notificationService = notificationService;
     }
 
 
@@ -318,5 +323,10 @@ public class MigrationActionsImpl implements MigrationActions {
                         // we don't care, we tried and hope for the best
                     }
                 });
+    }
+
+    @Override
+    public void finishRemoteReindexMigration() {
+        notificationService.destroyAllByType(Notification.Type.REMOTE_REINDEX_FINISHED);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilder.java
@@ -93,7 +93,7 @@ public class MigrationStateMachineBuilder {
                 .permitIf(MigrationStep.SHOW_ASK_TO_SHUTDOWN_OLD_CLUSTER, MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER, migrationActions::isRemoteReindexingFinished);
 
         config.configure(MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER)
-                .permitIf(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED, MigrationState.FINISHED, migrationActions::isOldClusterStopped);
+                .permitIf(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED, MigrationState.FINISHED, migrationActions::isOldClusterStopped, migrationActions::finishRemoteReindexMigration);
 
         // in place / rolling upgrade branch of the migration
         config.configure(MigrationState.ROLLING_UPGRADE_MIGRATION_WELCOME_PAGE)

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -95,7 +95,9 @@ public interface Notification extends Persisted {
         SIDECAR_STATUS_UNKNOWN,
         CERTIFICATE_NEEDS_RENEWAL,
         EVENT_LIMIT_REACHED,
-        DRAWDOWN_LICENSE_ERROR
+        DRAWDOWN_LICENSE_ERROR,
+        REMOTE_REINDEX_RUNNING,
+        REMOTE_REINDEX_FINISHED
     }
 
     enum Severity {

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/remote_reindex_finished.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/remote_reindex_finished.ftl
@@ -1,0 +1,8 @@
+<#if _title>Remote Reindex Migration has finished</#if>
+
+<#if _description><span>
+    Remote reindexing your existing data into the Graylog data node has finished <#if status == 'FINISHED'>sucessfully<#else>with errors</#if>.<br />
+    <#if DATA_NODE_MIGRATION_WIZARD?has_content>
+        Please visit the <a href="${DATA_NODE_MIGRATION_WIZARD}" target="_blank" rel="noreferrer">data node migration wizard</a> to finalize the migration.
+    </#if>
+    </#if>

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/remote_reindex_running.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/remote_reindex_running.ftl
@@ -1,0 +1,8 @@
+<#if _title>Remote Reindex Migration is running</#if>
+
+<#if _description><span>
+    Remote reindexing your existing data into the Graylog data node is running.<br />
+    <#if DATA_NODE_MIGRATION_WIZARD?has_content>
+        Please visit the <a href="${DATA_NODE_MIGRATION_WIZARD}" target="_blank" rel="noreferrer">data node migration wizard</a> to see the current progress.
+    </#if>
+    </#if>

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/remote_reindex_finished.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/remote_reindex_finished.ftl
@@ -1,0 +1,6 @@
+<#if _title>Remote Reindex Migration has finished</#if>
+
+<#if _description><span>
+    Remote reindexing your existing data into the Graylog data node has finished <#if status == 'FINISHED'>sucessfully<#else>with errors</#if>.
+    Please visit the data node migration wizard to finalize the migration.
+</#if>

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/remote_reindex_running.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/remote_reindex_running.ftl
@@ -1,0 +1,6 @@
+<#if _title>Remote Reindex Migration is running</#if>
+
+<#if _description><span>
+    Remote reindexing your existing data into the Graylog data node is running.
+    Please visit the data node migration wizard to see the current progress.
+</#if>

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationActionsAdapter.java
@@ -66,6 +66,10 @@ public class MigrationActionsAdapter implements MigrationActions {
     }
 
     @Override
+    public void finishRemoteReindexMigration() {
+    }
+
+    @Override
     public void runDirectoryCompatibilityCheck() {
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineBuilderTest.java
@@ -309,6 +309,7 @@ public class MigrationStateMachineBuilderTest {
         StateMachine<MigrationState, MigrationStep> stateMachine = getStateMachine(MigrationState.ASK_TO_SHUTDOWN_OLD_CLUSTER);
         when(migrationActions.isOldClusterStopped()).thenReturn(true);
         stateMachine.fire(MigrationStep.CONFIRM_OLD_CLUSTER_STOPPED);
+        verify(migrationActions, times(1)).finishRemoteReindexMigration();
         assertThat(stateMachine.getState()).isEqualTo(MigrationState.FINISHED);
     }
 

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.tsx
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.tsx
@@ -45,7 +45,7 @@ class NotificationsFactory {
       case 'data_node_needs_provisioning':
         return {
           values: {
-            DATA_NODE_CONFIGURATION: Routes.SYSTEM.configurationsSection('Data Node'),
+            DATA_NODE_CONFIGURATION: Routes.SYSTEM.DATANODES.CONFIGURATION,
           },
         };
 

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.tsx
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.tsx
@@ -49,6 +49,14 @@ class NotificationsFactory {
           },
         };
 
+      case 'remote_reindex_running':
+      case 'remote_reindex_finished':
+        return {
+          values: {
+            DATA_NODE_MIGRATION_WIZARD: Routes.SYSTEM.DATANODES.MIGRATION,
+          },
+        };
+
       default:
         return undefined;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a system notification that indicates that the remote reindexing migration is still going on. This is replaced by another notification showing the success status after remote reindexing has finished, pointing the user to finalize the migration in the wizard. This second notification will be cleared after finishing the migration wizard.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Feedback from testers

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
perform remote reindex migration

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

