### PR TITLE
Fix shutdown process of the job scheduler

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobExecutionEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobExecutionEngine.java
@@ -166,7 +166,6 @@ public class JobExecutionEngine {
      * Signal shutdown to the engine.
      */
     public void shutdown() {
-        // TODO this should indicate that running jobs have been aborted
         isRunning.set(false);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/worker/JobWorkerPool.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/worker/JobWorkerPool.java
@@ -22,13 +22,11 @@ import com.codahale.metrics.InstrumentedThreadFactory;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
-import org.graylog2.system.shutdown.GracefulShutdownHook;
-import org.graylog2.system.shutdown.GracefulShutdownService;
+import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.inject.Inject;
-
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -44,9 +42,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * Worker pool to execute jobs.
  */
-public class JobWorkerPool implements GracefulShutdownHook {
+public class JobWorkerPool {
     public interface Factory {
-        JobWorkerPool create(String name, int poolSize, Runnable shutdownCallback);
+        JobWorkerPool create(String name, int poolSize);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(JobWorkerPool.class);
@@ -57,15 +55,11 @@ public class JobWorkerPool implements GracefulShutdownHook {
     private final int poolSize;
     private final ExecutorService executor;
     private final Semaphore slots;
-    private final Runnable shutdownCallback;
 
     @Inject
     public JobWorkerPool(@Assisted String name,
                          @Assisted int poolSize,
-                         @Assisted Runnable shutdownCallback,
-                         GracefulShutdownService gracefulShutdownService,
                          MetricRegistry metricRegistry) {
-        this.shutdownCallback = shutdownCallback;
         this.poolSize = poolSize;
         checkArgument(NAME_PATTERN.matcher(name).matches(), "Pool name must match %s", NAME_PATTERN);
 
@@ -73,7 +67,6 @@ public class JobWorkerPool implements GracefulShutdownHook {
         this.slots = new Semaphore(poolSize, true);
 
         registerMetrics(metricRegistry, poolSize);
-        gracefulShutdownService.register(this);
     }
 
     /**
@@ -134,13 +127,10 @@ public class JobWorkerPool implements GracefulShutdownHook {
         }
     }
 
-    @Override
-    public void doGracefulShutdown() throws Exception {
+    public void shutdown(Duration timeout) throws InterruptedException {
         executor.shutdown();
-        if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-            LOG.warn("Timeout shutting down worker pool after 60 seconds");
-        } else {
-            shutdownCallback.run();
+        if (!executor.awaitTermination(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            LOG.warn("Timeout shutting down worker pool after {} ms", timeout.toMillis());
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
@@ -71,13 +71,10 @@ class JobSchedulerServiceIT {
     @Mock
     private ServerStatus serverStatus;
 
-    private NodeId nodeId = new SimpleNodeId("dummy-node");
+    private final NodeId nodeId = new SimpleNodeId("dummy-node");
 
     @Mock
     SchedulerCapabilitiesService schedulerCapabilitiesService;
-
-    @Mock
-    private GracefulShutdownService gracefulShutdownService;
 
     private DBJobTriggerService jobTriggerService;
     private DBCustomJobDefinitionService customJobDefinitionService;
@@ -147,12 +144,12 @@ class JobSchedulerServiceIT {
                 metricRegistry,
                 200);
 
-        final JobWorkerPool.Factory workerPoolFactory = (name, poolSize, shutdownCallback) ->
-                new JobWorkerPool(name, poolSize, shutdownCallback, gracefulShutdownService, metricRegistry);
+        final JobWorkerPool.Factory workerPoolFactory = (name, poolSize) ->
+                new JobWorkerPool(name, poolSize, metricRegistry);
 
         final Duration loopSleepDuration = Duration.milliseconds(200);
 
-        jobSchedulerService = new JobSchedulerService(engineFactory, workerPoolFactory, schedulerConfig, clock, eventBus, serverStatus, loopSleepDuration);
+        jobSchedulerService = new JobSchedulerService(engineFactory, workerPoolFactory, schedulerConfig, clock, eventBus, serverStatus, new GracefulShutdownService(), 30_000, loopSleepDuration);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/scheduler/worker/JobWorkerPoolTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/worker/JobWorkerPoolTest.java
@@ -19,29 +19,23 @@ package org.graylog.scheduler.worker;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.assertj.core.api.AbstractThrowableAssert;
-import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class JobWorkerPoolTest {
 
-    @Mock
-    Runnable shutdownCallback;
-
     @Test
     public void testExecute() throws Exception {
-        final JobWorkerPool pool = new JobWorkerPool("test", 2, shutdownCallback, new GracefulShutdownService(), new MetricRegistry());
+        final JobWorkerPool pool = new JobWorkerPool("test", 2, new MetricRegistry());
 
         final CountDownLatch latch1 = new CountDownLatch(1);
         final CountDownLatch latch2 = new CountDownLatch(1);
@@ -83,9 +77,8 @@ public class JobWorkerPoolTest {
         task2Latch.countDown();
         assertThat(latch2.await(60, TimeUnit.SECONDS)).isTrue();
 
-        pool.doGracefulShutdown();
+        pool.shutdown(Duration.ofSeconds(30));
         assertThat(pool.anySlotsUsed()).isFalse();
-        verify(shutdownCallback, times(1)).run();
     }
 
     @Test
@@ -102,6 +95,6 @@ public class JobWorkerPoolTest {
     }
 
     private AbstractThrowableAssert<?, ? extends Throwable> assertName(String name) {
-        return assertThatCode(() -> new JobWorkerPool(name, 1, shutdownCallback, new GracefulShutdownService(), new MetricRegistry()));
+        return assertThatCode(() -> new JobWorkerPool(name, 1, new MetricRegistry()));
     }
 }


### PR DESCRIPTION
Let the JobSchedulerService register with the GracefulShutdownService to ensure a correct shutdown order of the job scheduler components.

Previously, only the JobWorkerPool was registered in the GracefulShutdownService. That caused the JobWorkerPool to be stopped *before* the JobSchedulerService.

The JobExecutionContext#isShuttingDown method only returned true when the JobSchedulerService was shut down. So jobs would only cancel their execution when the scheduler service is in shutdown mode.

When the jobs are not cancelled, the JobWorkerPool shutdown didn't finish and ran into a 60 second timeout. The JobSchedulerService was only shutdown after the JobWorkerPool timeout.

/nocl No user-visible change