### PR TITLE
show datanode version in telemetry

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/telemetry/rest/TelemetryServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/telemetry/rest/TelemetryServiceTest.java
@@ -199,7 +199,8 @@ public class TelemetryServiceTest {
                 eventBus,
                 telemetryClusterService,
                 "unknown",
-                nodeService);
+                nodeService,
+                false);
     }
 
     private void mockUserTelemetryEnabled(boolean isTelemetryEnabled) {

--- a/graylog2-server/src/test/java/org/graylog2/telemetry/rest/TelemetryServiceWithDbTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/telemetry/rest/TelemetryServiceWithDbTest.java
@@ -117,7 +117,8 @@ public class TelemetryServiceWithDbTest {
                 eventBus,
                 telemetryClusterService,
                 "unknown",
-                nodeService);
+                nodeService,
+                false);
     }
 
     @Test


### PR DESCRIPTION
## Description
If running against data node, the `search_cluster_version` property in Posthog is replaced by `DataNode:<version>`

/nocl internal

## Motivation and Context
resolves #https://github.com/Graylog2/graylog-plugin-enterprise/issues/6970

## How Has This Been Tested?
run Graylog configured with datanode, check Posthog entries

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b11bec80-ab9f-49c7-b2aa-0ea14ded0954)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

