### PR TITLE
Add interface methods for audit logging without license

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,6 +42,8 @@ The following REST API changes have been made.
 | `DELETE licenses/{licenseId}`        | When called with a contract ID it will delete the contract and all associated licenses |
 | `GET licenses/traffic-remaining` | Get the time series data for remaining provisioned traffic                             |
 | `GET licenses/metrics` | Get the stats for consumed and remaining provisioned traffic                                                                                       |
+| `GET licenses/traffic-threshold`                 | Get info about license traffic threshold warning                                                                                |
+| `PUT licenses/traffic-threshold/acknowledgement` | Acknowledge current traffic threshold warning
 
 ## Deprecated Inputs
 

--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventSender.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.audit;
 
+import java.util.Collections;
 import java.util.Map;
 
 public interface AuditEventSender {
@@ -26,6 +27,8 @@ public interface AuditEventSender {
     void failure(AuditActor actor, AuditEventType type);
 
     void failure(AuditActor actor, AuditEventType type, Map<String, Object> context);
+
+    void successIgnoreLicense(AuditActor actor, AuditEventType type, Map<String, Object> context);
 
     // Some convenience default methods which an audit event type of "String".
 
@@ -43,5 +46,13 @@ public interface AuditEventSender {
 
     default void failure(AuditActor actor, String type, Map<String, Object> context) {
         failure(actor, AuditEventType.create(type), context);
+    }
+
+    default void successIgnoreLicense(AuditActor actor, String type, Map<String, Object> context) {
+        successIgnoreLicense(actor, AuditEventType.create(type), context);
+    }
+
+    default void successIgnoreLicense(AuditActor actor, String type) {
+        successIgnoreLicense(actor, AuditEventType.create(type), Collections.emptyMap());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/audit/NullAuditEventSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/NullAuditEventSender.java
@@ -34,4 +34,8 @@ public class NullAuditEventSender implements AuditEventSender {
     @Override
     public void failure(AuditActor actor, AuditEventType type, Map<String, Object> context) {
     }
+
+    @Override
+    public void successIgnoreLicense(AuditActor actor, AuditEventType type, Map<String, Object> context) {
+    }
 }

--- a/graylog2-web-interface/src/util/DocsHelper.ts
+++ b/graylog2-web-interface/src/util/DocsHelper.ts
@@ -37,6 +37,7 @@ const docsHelper = {
     INDEXER_FAILURES: 'indexer-failures',
     INDEX_MODEL: 'index-model',
     LICENSE: 'license',
+    LICENSE_MANAGEMENT: 'license-management',
     LOAD_BALANCERS: 'load-balancers',
     LOOKUPTABLES: 'lookuptables',
     OPERATIONS_CHANGELOG: 'changelog-graylog',


### PR DESCRIPTION
/nocl unreleased feature

/jpd Graylog2/graylog-plugin-enterprise#8123

Add interface methods for audit logging without license. This is required to create audit logs for license violation / expiration, when no valid license is available.