### PR TITLE
Lookup cache: bubble up error results without modifying (#19670)

### DIFF
--- a/changelog/unreleased/issue-19159.toml
+++ b/changelog/unreleased/issue-19159.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fixes handling of error results in the lookup cache."
+
+issues=["19159"]
+pulls=["19670"]

--- a/changelog/unreleased/issue-19159.toml
+++ b/changelog/unreleased/issue-19159.toml
@@ -2,4 +2,4 @@ type="f"
 message="Fixes handling of error results in the lookup cache."
 
 issues=["19159"]
-pulls=["19670"]
+pulls=["20167", "19670"]

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
@@ -49,11 +49,11 @@ public abstract class LookupResult {
     // Cache erroneous results with a shorter TTL
     private static final long ERROR_CACHE_TTL = Duration.ofSeconds(5).toMillis();
 
-    private static final LookupResult EMPTY_LOOKUP_RESULT = builder()
+    public static final LookupResult EMPTY_LOOKUP_RESULT = builder()
             .cacheTTL(NO_TTL)
             .build();
 
-    private static final LookupResult DEFAULT_ERROR_LOOKUP_RESULT = builder()
+    public static final LookupResult DEFAULT_ERROR_LOOKUP_RESULT = builder()
             .cacheTTL(ERROR_CACHE_TTL)
             .hasError(true)
             .build();

--- a/graylog2-server/src/test/java/org/graylog2/lookup/CaffeineLookupCacheTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/CaffeineLookupCacheTest.java
@@ -36,6 +36,8 @@ import org.mockito.junit.MockitoRule;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static org.graylog2.plugin.lookup.LookupResult.DEFAULT_ERROR_LOOKUP_RESULT;
+import static org.graylog2.plugin.lookup.LookupResult.EMPTY_LOOKUP_RESULT;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -113,6 +115,27 @@ public class CaffeineLookupCacheTest {
         ticker.advance(10, TimeUnit.SECONDS);
         LookupResult value3 = cache.get(LookupCacheKey.createFromJSON("x", "y"), loader);
         Assertions.assertThat(value3.singleValue()).isEqualTo("x");
+    }
+
+    @Test
+    public void ttlError() throws Exception {
+        LookupCache cache = buildCache(false);
+        LookupResult lr1 = LookupResult.empty();
+        LookupResult lr2 = LookupResult.withError();
+        LookupResult lr3 = LookupResult.withError(999);
+        when(loader.call()).thenReturn(lr1).thenReturn(lr2).thenReturn(lr3);
+
+        LookupResult value1 = cache.get(LookupCacheKey.createFromJSON("x1", "y"), loader);
+        Assertions.assertThat(value1.singleValue()).isNull();
+        Assertions.assertThat(value1.cacheTTL()).isEqualTo(EMPTY_LOOKUP_RESULT.cacheTTL());
+
+        LookupResult value2 = cache.get(LookupCacheKey.createFromJSON("x2", "y"), loader);
+        Assertions.assertThat(value2.singleValue()).isNull();
+        Assertions.assertThat(value2.cacheTTL()).isEqualTo(DEFAULT_ERROR_LOOKUP_RESULT.cacheTTL());
+
+        LookupResult value3 = cache.get(LookupCacheKey.createFromJSON("x3", "y"), loader);
+        Assertions.assertThat(value3.singleValue()).isNull();
+        Assertions.assertThat(value3.cacheTTL()).isEqualTo(999);
     }
 
     private LookupCache buildCache(boolean ignoreNull) {


### PR DESCRIPTION
Unmodified backport of #19670 

* bubble up lookup failures
* add unit test
* CL

---------

Co-authored-by: Tomas Dvorak <tomas.dvorak@graylog.com>
(cherry picked from commit ab31c69147f27363fb68e9d134fcb80bba81502a)
