### PR TITLE
Fixing `chroma-js` imports.

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { scales } from 'plotly.js/src/components/colorscale';
-import * as chroma from 'chroma-js';
+import chroma from 'chroma-js';
 
 const plotlyScaleToChroma = (plotlyScale: Array<[domain: number, color: string]>) => {
   const domains = plotlyScale.map(([domain]) => domain);

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type * as chroma from 'chroma-js';
+import type chroma from 'chroma-js';
 
 import scaleForGradient from 'views/components/sidebar/highlighting/Scale';
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing imports for `chroma-js` from a wildcard import to a generic default import. This fixes warnings with webpack starting with `chroma-js` 2.6.0.

/nocl

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.