### PR TITLE
Reopen closed local indices for remote reindex migration

### DIFF
--- a/changelog/unreleased/issue-20208.toml
+++ b/changelog/unreleased/issue-20208.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Reopen target index for remote reindex migration if this is closed."
+
+issues=["20208"]
+pulls=["20220"]

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -24,6 +24,7 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.Streams;
+import org.apache.commons.io.IOUtils;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
@@ -31,6 +32,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.cluster.
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
@@ -64,15 +66,19 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.Search
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog.testing.elasticsearch.BulkIndexRequest;
 import org.graylog.testing.elasticsearch.Client;
+import org.graylog.testing.elasticsearch.IndexState;
 import org.graylog2.indexer.indices.Template;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -460,5 +466,23 @@ public class ClientES7 implements Client {
     @Override
     public void putFieldMapping(String index, String field, String type) {
         updateMapping(index, Collections.singletonMap("properties", Collections.singletonMap(field, Collections.singletonMap("type", type))));
+    }
+
+    @Override
+    public IndexState getStatus(String indexName) {
+        return client.execute((restHighLevelClient, requestOptions) -> {
+            final Response statusResponse = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "_cat/indices/" + indexName + "/?h=status"));
+            try (final InputStream is = statusResponse.getEntity().getContent()) {
+                String result = IOUtils.toString(is, StandardCharsets.UTF_8);
+                return IndexState.valueOf(result.trim().toUpperCase(Locale.ROOT));
+            }
+        });
+    }
+
+
+    @Override
+    public void openIndex(String indexName) {
+        final OpenIndexRequest openIndexRequest = new OpenIndexRequest(indexName);
+        client.execute((c, requestOptions) -> c.indices().open(openIndexRequest, requestOptions));
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/RemoteReindexingMigrationAdapterOS2.java
@@ -28,13 +28,15 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.DurationFormatUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.graylog.shaded.opensearch2.org.opensearch.OpenSearchException;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.open.OpenIndexRequest;
+import org.graylog.shaded.opensearch2.org.opensearch.client.Request;
 import org.graylog.shaded.opensearch2.org.opensearch.client.RequestOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.client.Response;
 import org.graylog.shaded.opensearch2.org.opensearch.client.ResponseException;
@@ -81,6 +83,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -401,7 +405,19 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
         final String indexName = index.indexName();
 
         try (XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint()) {
-            final boolean closeAfterMigration = openIndexIfNeeded(migration, uri, username, password, indexName);
+
+            List<Runnable> postMigrationActions = new ArrayList<>();
+
+            if(getRemoteIndexState(uri, username, password, indexName) == IndexState.CLOSE) {
+                openRemoteIndex(migration, uri, username, password, indexName);
+                postMigrationActions.add(() -> closeRemoteIndex(migration, uri, username, password, indexName));
+            }
+
+            if(getLocalIndexState(indexName) == IndexState.CLOSE) {
+                openLocalIndex(migration, indexName);
+                postMigrationActions.add(() -> closeLocalIndex(migration, indexName));
+            }
+
             final BytesReference query = BytesReference.bytes(matchAllQuery().toXContent(builder, ToXContent.EMPTY_PARAMS));
             logInfo(migration, "Executing async reindex for " + indexName);
             final TaskSubmissionResponse task = client.execute((c, requestOptions) -> {
@@ -412,51 +428,53 @@ public class RemoteReindexingMigrationAdapterOS2 implements RemoteReindexingMigr
             });
             reindexMigrationService.assignTask(migration.id(), indexName, task.getTask());
             waitForTaskCompleted(migration, indexName, task.getTask());
-            if(closeAfterMigration) {
-                closeMigratedIndex(migration, uri, username, password, indexName);
-            }
+
+            postMigrationActions.forEach(Runnable::run);
+
         } catch (Exception e) {
             final String message = "Could not reindex index: " + indexName + " - " + e.getMessage();
             logError(migration, message, e);
         }
     }
 
-    private void closeMigratedIndex(MigrationConfiguration migration, URI uri, String username, String password, String indexName) {
-        closeRemoteIndex(uri, username, password, indexName);
+    private void closeLocalIndex(MigrationConfiguration migration, String indexName) {
+        logInfo(migration, "Target index " + indexName + " is being closed after index migration");
         client.execute((restHighLevelClient, requestOptions) -> restHighLevelClient.indices().close(new CloseIndexRequest(indexName), requestOptions));
-        logInfo(migration, "Restoring original index state, both source and target index " + indexName + " closed after migration");
     }
 
-    private boolean openIndexIfNeeded(MigrationConfiguration migration, URI uri, String username, String password, String indexName) {
-        final IndexState indexState = getIndexState(uri, username, password, indexName);
-
-        boolean closeAfterMigration = false;
-
-        if(indexState == IndexState.CLOSE) {
-            logInfo(migration, "Source index " + indexName + " is closed, reopening for the migration");
-            closeAfterMigration = true;
-            openRemoteIndex(uri, username, password, indexName);
-        }
-        return closeAfterMigration;
+    private void openLocalIndex(MigrationConfiguration migration, String indexName) {
+        logInfo(migration, "Target index " + indexName + " is closed, reopening for the migration");
+        client.execute((restHighLevelClient, requestOptions) -> restHighLevelClient.indices().open(new OpenIndexRequest(indexName), requestOptions));
     }
 
-    private void openRemoteIndex(URI uri, String username, String password, String indexName) {
+    private void openRemoteIndex(MigrationConfiguration migration, URI uri, String username, String password, String indexName) {
+        logInfo(migration, "Source index " + indexName + " is closed, reopening for the migration");
         datanodeRestApiProxy.remoteInterface(DatanodeResolver.ANY_NODE_KEYWORD, DatanodeRemoteIndexStateResource.class, datanodeRemoteIndexStateResource -> datanodeRemoteIndexStateResource.changeState(new IndexStateChangeRequest(
                 indexName, IndexState.OPEN, uri.toString(), username, password
         )));
     }
 
-    private void closeRemoteIndex(URI uri, String username, String password, String indexName) {
+    private void closeRemoteIndex(MigrationConfiguration migration, URI uri, String username, String password, String indexName) {
+        logInfo(migration, "Source index " + indexName + " is being closed after index migration");
         datanodeRestApiProxy.remoteInterface(DatanodeResolver.ANY_NODE_KEYWORD, DatanodeRemoteIndexStateResource.class, datanodeRemoteIndexStateResource -> datanodeRemoteIndexStateResource.changeState(new IndexStateChangeRequest(
                 indexName, IndexState.CLOSE, uri.toString(), username, password
         )));
     }
 
-    private IndexState getIndexState(URI uri, String username, String password, String indexName) {
-        final IndexState indexState = datanodeRestApiProxy.remoteInterface(DatanodeResolver.ANY_NODE_KEYWORD, DatanodeRemoteIndexStateResource.class, resource -> resource.readState(new IndexStateGetRequest(
+    private IndexState getRemoteIndexState(URI uri, String username, String password, String indexName) {
+        return datanodeRestApiProxy.remoteInterface(DatanodeResolver.ANY_NODE_KEYWORD, DatanodeRemoteIndexStateResource.class, resource -> resource.readState(new IndexStateGetRequest(
                 indexName, uri.toString(), username, password
         ))).values().iterator().next();
-        return indexState;
+    }
+
+    private IndexState getLocalIndexState(String indexName) {
+        return client.execute((restHighLevelClient, requestOptions) -> {
+            final Response statusResponse = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "_cat/indices/" + indexName + "/?h=status"));
+            try (final InputStream is = statusResponse.getEntity().getContent()) {
+                String result = IOUtils.toString(is, StandardCharsets.UTF_8);
+                return IndexState.valueOf(result.toUpperCase(Locale.ROOT));
+            }
+        });
     }
 
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -80,4 +80,8 @@ public interface Client {
     String getClusterSetting(String setting);
 
     void putFieldMapping(final String index, final String field, final String type);
+
+    IndexState getStatus(String indexName);
+
+    void openIndex(String indexName);
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/IndexState.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/IndexState.java
@@ -1,0 +1,5 @@
+package org.graylog.testing.elasticsearch;
+
+public enum IndexState {
+    OPEN,CLOSE
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/IndexState.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/IndexState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.testing.elasticsearch;
 
 public enum IndexState {


### PR DESCRIPTION
During the remote reindex migration we check if the source index is closed. If yes, we'll reopen it, migrate the data and close it again, together with closing the target index as well. But when somebody runs the migration for the second time (retry) it may happen that also the target index is already existing and is closed. Then we need to reopen it as well. 

## Motivation and Context
Fixes [#20208](https://github.com/Graylog2/graylog2-server/issues/20208)

## How Has This Been Tested?
Extended integration test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

