### PR TITLE
Use Modal confirm when deleting stream and show DWH warning.

### DIFF
--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -187,6 +187,24 @@ interface PluginDataWarehouse {
   StreamDataWarehouse: React.ComponentType<{}>,
   DataWarehouseJobs: React.ComponentType<{}>,
   StreamIndexSetDataWarehouseWarning: React.ComponentType<{streamId: string, isArchivingEnabled: boolean}>,
+  fetchStreamDataWarehouseStatus: (streamId: string) => Promise<{
+    id: string,
+    archive_name: string,
+    enabled: boolean,
+    stream_id: string,
+    retention_time: number,
+  }>,
+  fetchStreamDataWarehouse: (streamId: string) => Promise<{
+    id: string,
+    archive_config_id: string,
+    message_count: number,
+    archive_name: string,
+    timestamp_from: string,
+    timestamp_to: string,
+    restore_history: Array<{id:string}>,
+
+  }>;
+  DataWarehouseStreamDeleteWarning: React.ComponentType<{}>,
   getStreamDataWarehouseTableElements: (permission: Immutable.List<string>) => {
     attributeName: string,
     attributes: Array<{ id: string, title: string }>,

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -22,9 +22,7 @@ import { Button, ButtonToolbar, MenuItem } from 'components/bootstrap';
 import type { Stream, StreamRule } from 'stores/streams/StreamsStore';
 import StreamsStore from 'stores/streams/StreamsStore';
 import Routes from 'routing/Routes';
-import HideOnCloud from 'util/conditional/HideOnCloud';
 import { StartpageStore } from 'stores/users/StartpageStore';
-import UserNotification from 'util/UserNotification';
 import StreamRuleModal from 'components/streamrules/StreamRuleModal';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import { StreamRulesStore } from 'stores/streams/StreamRulesStore';
@@ -35,6 +33,10 @@ import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
 import { MoreActions } from 'components/common/EntityDataTable';
 import { LinkContainer } from 'components/common/router';
+import HideOnCloud from 'util/conditional/HideOnCloud';
+import UserNotification from 'util/UserNotification';
+
+import StreamDeleteModal from './StreamDeleteModal';
 
 import StreamModal from '../StreamModal';
 
@@ -53,6 +55,7 @@ const StreamActions = ({
 }) => {
   const currentUser = useCurrentUser();
   const { deselectEntity } = useSelectedEntities();
+  const [showDeleteModal, setDeleteModal] = useState(false);
   const [showEntityShareModal, setShowEntityShareModal] = useState(false);
   const [showStreamRuleModal, setShowStreamRuleModal] = useState(false);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
@@ -94,6 +97,10 @@ const StreamActions = ({
     setShowEntityShareModal((cur) => !cur);
   }, [sendTelemetry]);
 
+  const toggleDeleteModal = useCallback(() => {
+    setDeleteModal((cur) => !cur);
+  }, []);
+
   const toggleUpdateModal = useCallback(() => {
     setShowUpdateModal((cur) => !cur);
   }, []);
@@ -107,21 +114,19 @@ const StreamActions = ({
   }, []);
 
   const onDelete = useCallback(() => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm('Do you really want to remove this stream?')) {
-      sendTelemetry(TELEMETRY_EVENT_TYPE.STREAMS.STREAM_ITEM_DELETED, {
-        app_pathname: 'streams',
-        app_action_value: 'stream-item-delete',
-      });
+    sendTelemetry(TELEMETRY_EVENT_TYPE.STREAMS.STREAM_ITEM_DELETED, {
+      app_pathname: 'streams',
+      app_action_value: 'stream-item-delete',
+    });
 
-      StreamsStore.remove(stream.id).then(() => {
-        deselectEntity(stream.id);
-        UserNotification.success(`Stream '${stream.title}' was deleted successfully.`, 'Success');
-      }).catch((error) => {
-        UserNotification.error(`An error occurred while deleting the stream. ${error}`);
-      });
-    }
-  }, [deselectEntity, sendTelemetry, stream.id, stream.title]);
+    StreamsStore.remove(stream.id).then(() => {
+      deselectEntity(stream.id);
+      UserNotification.success(`Stream '${stream.title}' was deleted successfully.`, 'Success');
+      toggleDeleteModal();
+    }).catch((error) => {
+      UserNotification.error(`An error occurred while deleting the stream. ${error}`);
+    });
+  }, [deselectEntity, sendTelemetry, stream.id, stream.title, toggleDeleteModal]);
 
   const onSaveStreamRule = useCallback((_streamRuleId: string, streamRule: StreamRule) => StreamRulesStore.create(stream.id, streamRule, () => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.STREAMS.STREAM_ITEM_RULE_SAVED, {
@@ -221,7 +226,7 @@ const StreamActions = ({
         </IfPermitted>
 
         <IfPermitted permissions={`streams:edit:${stream.id}`}>
-          <MenuItem onSelect={onDelete} disabled={isDefaultStream}>
+          <MenuItem onSelect={toggleDeleteModal} disabled={isDefaultStream}>
             Delete this stream {isDefaultStream && <DefaultStreamHelp />}
           </MenuItem>
         </IfPermitted>
@@ -256,6 +261,12 @@ const StreamActions = ({
                           entityTitle={stream.title}
                           description="Search for a User or Team to add as collaborator on this stream."
                           onClose={toggleEntityShareModal} />
+      )}
+      {showDeleteModal && (
+      <StreamDeleteModal streamTitle={stream.title}
+                         streamId={stream.id}
+                         onCancel={toggleDeleteModal}
+                         onDelete={onDelete} />
       )}
     </ButtonToolbar>
   );

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamDeleteModal.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamDeleteModal.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import usePluginEntities from 'hooks/usePluginEntities';
+import { ConfirmDialog } from 'components/common';
+
+type Props = {
+  onDelete: () => void,
+  streamId: string,
+  streamTitle: string,
+  onCancel: () => void,
+};
+
+const useStreamDataWarehouseHasData = (streamId: string, enabled: boolean) => {
+  const { fetchStreamDataWarehouse } = usePluginEntities('dataWarehouse')[0] ?? {};
+  const { data: dataWarehouse, isError, isLoading } = useQuery(['stream', 'data-warehouse', streamId],
+    () => fetchStreamDataWarehouse(streamId),
+    { enabled: fetchStreamDataWarehouse && enabled },
+  );
+
+  return (isLoading || isError) ? undefined : (
+    dataWarehouse?.message_count > 1 || dataWarehouse?.restore_history?.length > 0
+  );
+};
+
+const useIsStreamDataWarehouseEnabled = (streamId: string, enabled: boolean) => {
+  const { fetchStreamDataWarehouseStatus } = usePluginEntities('dataWarehouse')[0] ?? {};
+  const { data: status, isError, isLoading } = useQuery(['data-warehouse-config', streamId, 'enabled'],
+    () => fetchStreamDataWarehouseStatus(streamId),
+    { enabled: fetchStreamDataWarehouseStatus && enabled },
+  );
+
+  return (isLoading || isError) ? undefined : status?.enabled;
+};
+
+const StreamDeleteModal = ({ onDelete, streamId, streamTitle, onCancel }: Props) => {
+  const DataWarehouseStreamDeleteWarning = usePluginEntities('dataWarehouse')?.[0]?.DataWarehouseStreamDeleteWarning;
+  const streamDataWarehouseHasData = useStreamDataWarehouseHasData(streamId, !!DataWarehouseStreamDeleteWarning);
+  const isDataWarehouseEnable = useIsStreamDataWarehouseEnabled(streamId, !!DataWarehouseStreamDeleteWarning);
+
+  const shouldShowWarning = useMemo(() => isDataWarehouseEnable || streamDataWarehouseHasData, [isDataWarehouseEnable, streamDataWarehouseHasData]);
+
+  return (
+    <ConfirmDialog show
+                   onConfirm={onDelete}
+                   btnConfirmDisabled={shouldShowWarning}
+                   onCancel={onCancel}
+                   title="Delete Stream">
+                   {shouldShowWarning ? <DataWarehouseStreamDeleteWarning /> : `Do you really want to remove stream:  ${streamTitle}?`}
+    </ConfirmDialog>
+  );
+};
+
+export default StreamDeleteModal;

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.tsx
@@ -70,7 +70,7 @@ const StreamsOverview = ({ indexSets }: Props) => {
                                   tableLayout={defaultLayout}
                                   fetchEntities={fetchStreams}
                                   keyFn={keyFn}
-                                  actionsCellWidth={180}
+                                  actionsCellWidth={200}
                                   expandedSectionsRenderer={expandedSections}
                                   bulkSelection={{ actions: bulkActions }}
                                   entityAttributesAreCamelCase={false}


### PR DESCRIPTION
Before this PR, deleting a stream was used to show the confirm base and `windows.confirm`  with this change, we are using `ConfirmModal` Component. 
We are also adding the possibility to display a warning when  DWH is enabled or has data on the stream.

/nocl
/jpd Graylog2/graylog-plugin-enterprise#8291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

