### PR TITLE
Fix "Expected value reference of type STRING but got PARAMETER" Exception when using a parameter for a stream title

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
@@ -144,7 +144,7 @@ public class StreamReferenceFacade extends StreamFacade {
 
     private Optional<NativeEntity<Stream>> findExisting(EntityV1 entity, Map<String, ValueReference> parameters) {
         final StreamReferenceEntity streamEntity = objectMapper.convertValue(entity.data(), StreamReferenceEntity.class);
-        final List<Stream> streams = streamService.loadAllByTitle(streamEntity.title().asString());
+        final List<Stream> streams = streamService.loadAllByTitle(streamEntity.title().asString(parameters));
         if (streams.size() == 1) {
             final Stream stream = streams.get(0);
             return Optional.of(NativeEntity.create(entity.id(), stream.getId(), ModelTypes.STREAM_V1, stream.getTitle(), stream));


### PR DESCRIPTION
StreamReferenceFacade uses asString() without parameter mapping when retrieving the stream title from a content pack. This leads to the aforementioned exception, while installing a content pack containing a stream title with attached parameter.

## Description
Use the asString() variant that supports parameter lookups.

## Motivation and Context
We want to use content packs containing adjustable stream titles. This is blocking us. 

## How Has This Been Tested?
Untested.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

