### PR TITLE
Fix initial selection of index sets in change field types modal.

### DIFF
--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
@@ -185,8 +185,7 @@ const ChangeFieldTypeModal = ({
                         inputProps={{ 'aria-label': 'Select Field Type For Field' }}
                         required />
         </Input>
-        {
-          showSelectionTable && (
+        {showSelectionTable && (
           <>
             <StyledLabel>Select Targeted Index Sets</StyledLabel>
             <p>
@@ -194,8 +193,7 @@ const ChangeFieldTypeModal = ({
             </p>
             <IndexSetsTable field={fieldName} setIndexSetSelection={setIndexSetSelection} fieldTypes={fieldTypes} initialSelection={initialSelectedIndexSets} />
           </>
-          )
-        }
+        )}
         <StyledLabel>Select Rotation Strategy</StyledLabel>
         <p>
           To see and use the {type ? <b>{type}</b> : 'selected field type'} as a field type{fieldName ? <> for <b>{fieldName}</b></> : ''}, you have to rotate indices. You can automatically rotate affected indices after submitting this form or do that manually later.

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/hooks/useInitialSelection.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/hooks/useInitialSelection.tsx
@@ -20,13 +20,13 @@ import { useStore } from 'stores/connect';
 import type { Stream } from 'views/stores/StreamsStore';
 import { StreamsStore } from 'views/stores/StreamsStore';
 import useCurrentStream from 'views/logic/fieldactions/ChangeFieldType/hooks/useCurrentStream';
-import type { IndexSet, IndexSetsStoreState } from 'stores/indices/IndexSetsStore';
-import { IndexSetsStore } from 'stores/indices/IndexSetsStore';
+import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import isIndexFieldTypeChangeAllowed from 'components/indices/helpers/isIndexFieldTypeChangeAllowed';
+import useIndexSetsList from 'components/indices/hooks/useIndexSetsList';
 
 const streamsMapper = ({ streams }) => streams.map((stream: Stream) => ({ indexSet: stream.index_set_id, id: stream.id }));
 
-const indexSetsStoreMapper = ({ indexSets }: IndexSetsStoreState): Record<string, IndexSet> => {
+const indexSetsMapper = (indexSets: Array<IndexSet>): Record<string, IndexSet> => {
   if (!indexSets) return null;
 
   return Object.fromEntries(indexSets.map((indexSet) => ([indexSet.id, indexSet])));
@@ -34,8 +34,10 @@ const indexSetsStoreMapper = ({ indexSets }: IndexSetsStoreState): Record<string
 
 const useInitialSelection = () => {
   const currentStreams = useCurrentStream();
-  const indexSets = useStore(IndexSetsStore, indexSetsStoreMapper);
+
   const availableStreams: Array<{ indexSet: string, id: string }> = useStore(StreamsStore, streamsMapper);
+  const { data } = useIndexSetsList();
+  const indexSets = useMemo(() => indexSetsMapper(data.indexSets), [data.indexSets]);
 
   return useMemo(() => {
     const currentStreamSet = new Set(currentStreams);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is possible to change a field type by opening the search page and clicking on "Change field type" in the fiel name action of a field in the message table.

Before this fix there was a problem that the initial selection of index sets is empty (introduce with https://github.com/Graylog2/graylog2-server/pull/19936).

<img width="287" alt="image" src="https://github.com/user-attachments/assets/49261d1f-c253-4b13-b7a5-1afacb6bb002">


With this PR they are selected again:

<img width="255" alt="image" src="https://github.com/user-attachments/assets/ecd8fab8-100a-4231-a8b2-1e6900e27ca0">


/nocl