### PR TITLE
Projection functionality added to MongoPaginationHelper

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/pagination/MongoPaginationHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/pagination/MongoPaginationHelper.java
@@ -49,6 +49,17 @@ public interface MongoPaginationHelper<T extends MongoEntity> {
     MongoPaginationHelper<T> sort(Bson sort);
 
     /**
+     * Sets the projection BSON to apply to the query.
+     * It will limit the number of fields retrieved from MongoDB for each document.
+     * Keep in mind that you can only exclude fields that are optional in related MongoEntity
+     * and you are responsible for ensuring that excluded fields are not needed in your use case.
+     *
+     * @param projection the projection BSON, which may be null.
+     * @return A new pagination helper with the setting applied
+     */
+    MongoPaginationHelper<T> projection(Bson projection);
+
+    /**
      * Sets the page size.
      *
      * @param perPage the number of documents to put on one page


### PR DESCRIPTION
## Description
Projection functionality added to MongoPaginationHelper.
/nocl

## Motivation and Context
Add a way to fetch multiple entities without optional fields of big size (for performance reasons).
The example of this need can be spotted in Investigations, where each Investigation can contain AI-generated report, which can be only needed when working with single Investigation, never when you paginate multiple ones.

## How Has This Been Tested?
With new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

