### PR TITLE
Fix grok_exists pipeline rule

### DIFF
--- a/changelog/unreleased/pr-20263.toml
+++ b/changelog/unreleased/pr-20263.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed issue where grok_exists pipeline rule would return true for substrings of pattern names."
+
+pulls = ["20263"]

--- a/changelog/unreleased/pr-20263.toml
+++ b/changelog/unreleased/pr-20263.toml
@@ -1,4 +1,5 @@
 type = "f"
 message = "Fixed issue where grok_exists pipeline rule would return true for substrings of pattern names."
 
+issues = ["20264"]
 pulls = ["20263"]

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -25,15 +25,13 @@ import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.krakens.grok.api.Grok;
 import io.krakens.grok.api.GrokCompiler;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -86,7 +84,7 @@ public class GrokPatternRegistry {
     }
 
     public boolean grokPatternExists(String patternName) {
-        return patterns.get().stream().anyMatch(pattern -> pattern.name().contains(patternName));
+        return patterns.get().stream().anyMatch(pattern -> pattern.name().equals(patternName));
     }
 
     public Grok cachedGrokForPattern(String pattern) {

--- a/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
@@ -110,4 +110,11 @@ public class GrokPatternRegistryTest {
     public void patterns() {
         assertThat(grokPatternRegistry.patterns()).isEqualTo(GROK_PATTERNS);
     }
+
+    @Test
+    public void patternExists() {
+        assertThat(grokPatternRegistry.grokPatternExists("TEST")).isFalse();
+        assertThat(grokPatternRegistry.grokPatternExists("NUM")).isFalse();
+        assertThat(grokPatternRegistry.grokPatternExists("TESTNUM")).isTrue();
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`grok_exists` is supposed to return true only if the requested pattern exists in the list of Grok patterns. Right now it is returning true if any pattern contains the requested pattern as a substring. This changes to `contains` to an `equals` call to fix the issue and adds a simple unit test to prevent future issues.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #20264
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

