### PR TITLE
Resolve widget streams for content pack entities

### DIFF
--- a/changelog/unreleased/pr-20265.toml
+++ b/changelog/unreleased/pr-20265.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix issue where content pack stream dependencies were not properly resolved when a dashboard was imported and immediately exported."
+
+pulls = ["20265"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
@@ -28,6 +28,8 @@ import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.plugins.views.search.searchfilters.model.UsesSearchFilters;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.WidgetEntity;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -153,6 +155,13 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity>, UsesSe
 
     @Override
     public void resolveNativeEntity(EntityDescriptor entityDescriptor, MutableGraph<EntityDescriptor> mutableGraph) {
+        streams().forEach(streamId -> {
+            final EntityDescriptor depStream = EntityDescriptor.builder()
+                    .id(ModelId.of(streamId))
+                    .type(ModelTypes.STREAM_REF_V1)
+                    .build();
+            mutableGraph.putEdge(entityDescriptor, depStream);
+        });
         filters().forEach(filter -> filter.resolveNativeEntity(entityDescriptor, mutableGraph));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For Dashboards exported to content packs the current logic attempts to resolve any Stream dependencies that are present in the saved Search that part of the view object.

However if a Dashboard containing a Widget with a Stream in imported via Content Pack, the Stream will not be present on the Search until the first time it is run.
This PR adds additional Stream dependency resolution logic to check for Streams on any widget objects that are part of the Dashboard.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A user can create or import a Dashboard, and immediately export it to a content pack before the Dashboard search is ever run. This will result in stream dependencies not being auto populated/exported for the Content Pack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in a development environment.

Steps to reproduce:
1. Create a Dashboard with a widget scoped to a Stream
2. Export the above Dashboard to a Content Pack
3. Install the Content Pack
4. Attempt to create a new Content Pack from the new Dashboard entity created in step 3
5. See that the appropriate stream is not present in the exported Entity List

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

