### PR TITLE
Use max z-index in Tooltip

### DIFF
--- a/changelog/unreleased/pr-20272.toml
+++ b/changelog/unreleased/pr-20272.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fix tooltips not being visible in modals."
+
+issues = [""]
+pulls = ["20272"]

--- a/graylog2-web-interface/src/components/common/Tooltip.tsx
+++ b/graylog2-web-interface/src/components/common/Tooltip.tsx
@@ -31,7 +31,7 @@ const Tooltip = (props: Props) => {
     },
   });
 
-  return <MantineTooltip styles={styles} {...props} />;
+  return <MantineTooltip zIndex="var(--mantine-z-index-max)" styles={styles} {...props} />;
 };
 
 export default Tooltip;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use max z-index for Tooltip as it should be visible in overlays. Added it to the component directly as it got ignored on the styles.
Using a mantine z-index variable, which we should implement in other places as well to avoid these issues. Todo: Create issue for that.
See https://mantine.dev/styles/css-variables/#z-index-variables.

## Motivation and Context
This fixes tooltips not being visible in Modals, e.g. the Copy to Clipboard button in AI Report modal (Security/Investivations).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

