### PR TITLE
Add change log for stream_title param fix

### DIFF
--- a/changelog/unreleased/pr-20244.toml
+++ b/changelog/unreleased/pr-20244.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Fix error when installing content pack with stream_title parameter."
+
+pulls = ["20244"]


### PR DESCRIPTION
Add change log for https://github.com/Graylog2/graylog2-server/pull/20244. Not a critical change to surface in the change log, but I figure it can't hurt to have the entry.

/nocl