### PR TITLE
Reset "is_cancelled" flag on job trigger release

### DIFF
--- a/changelog/unreleased/pr-20287.toml
+++ b/changelog/unreleased/pr-20287.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Reset `is_cancelled` flag on job trigger release."
+
+pulls = ["20287"]

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -418,6 +418,8 @@ public class DBJobTriggerService {
 
         final List<Bson> updates = new ArrayList<>();
         updates.add(unset(FIELD_LOCK_OWNER));
+        // Reset the cancellation status on release to make sure we start uncancelled on the next trigger execution
+        updates.add(set(FIELD_IS_CANCELLED, false));
 
         if (triggerUpdate.concurrencyReschedule()) {
             updates.add(inc(FIELD_CONCURRENCY_RESCHEDULE_COUNT, 1));
@@ -466,6 +468,8 @@ public class DBJobTriggerService {
         );
         final var update = combine(
                 unset(FIELD_LOCK_OWNER),
+                // Reset the cancellation status on force-release to make sure we start uncancelled on the next trigger execution
+                set(FIELD_IS_CANCELLED, false),
                 set(FIELD_STATUS, JobTriggerStatus.RUNNABLE));
 
         return Ints.saturatedCast(collection.updateMany(filter, update).getModifiedCount());

--- a/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/DBJobTriggerServiceTest.java
@@ -31,6 +31,7 @@ import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoCollections;
+import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.plugin.system.SimpleNodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -745,6 +746,50 @@ public class DBJobTriggerServiceTest {
     }
 
     @Test
+    public void releaseCancelledTrigger() {
+        final JobTriggerDto trigger1 = dbJobTriggerService.create(JobTriggerDto.Builder.create(clock)
+                .jobDefinitionId("abc-123")
+                .jobDefinitionType("event-processor-execution-v1")
+                .concurrencyRescheduleCount(42)
+                .schedule(IntervalJobSchedule.builder()
+                        .interval(1)
+                        .unit(TimeUnit.SECONDS)
+                        .build())
+                .build());
+        final JobTriggerData newData = TestJobTriggerData.create(Collections.singletonMap("hello", "world"));
+        final JobTriggerUpdate update = JobTriggerUpdate.withNextTimeAndData(clock.nowUTC().plusSeconds(20), newData);
+
+        // Lock the trigger
+        final Optional<JobTriggerDto> runnableTrigger = dbJobTriggerService.nextRunnableTrigger();
+        assertThat(runnableTrigger).isNotEmpty();
+
+        clock.plus(15, TimeUnit.SECONDS);
+
+        // Cancel the trigger
+        dbJobTriggerService.cancelTriggerByQuery(MongoUtils.idEq(requireNonNull(trigger1.id())));
+
+        // Check that the "is_cancelled" field is set to true
+        assertThat(dbJobTriggerService.get(trigger1.id()))
+                .map(JobTriggerDto::isCancelled)
+                .get()
+                .isEqualTo(true);
+
+        // Release the trigger
+        assertThat(dbJobTriggerService.releaseTrigger(runnableTrigger.get(), update)).isTrue();
+
+        assertThat(dbJobTriggerService.get(trigger1.id()))
+                .isPresent()
+                .get()
+                .satisfies(trigger -> {
+                    // Make sure the lock is gone
+                    assertThat(trigger.lock().owner()).isNull();
+                    assertThat(trigger.status()).isEqualTo(JobTriggerStatus.RUNNABLE);
+                    // Releasing the lock should reset the "is_cancelled" flag to false
+                    assertThat(trigger.isCancelled()).isFalse();
+                });
+    }
+
+    @Test
     public void setTriggerError() {
         final JobTriggerDto trigger1 = dbJobTriggerService.create(JobTriggerDto.Builder.create(clock)
                 .jobDefinitionId("abc-123")
@@ -827,6 +872,27 @@ public class DBJobTriggerServiceTest {
 
         // Running triggers not owned by this node should not be released
         assertThat(newTriggerIds).containsOnly("54e3deadbeefdeadbeef0002");
+    }
+
+    @Test
+    @MongoDBFixtures("stale-job-triggers.json")
+    public void forceReleaseOwnedCancelledTriggers() {
+        final Set<String> cancelledTriggerIds = dbJobTriggerService.all().stream()
+                .filter(JobTriggerDto::isCancelled)
+                .map(JobTriggerDto::id)
+                .collect(Collectors.toSet());
+
+        assertThat(cancelledTriggerIds).containsOnly("54e3deadbeefdeadbeef0001");
+
+        assertThat(dbJobTriggerService.forceReleaseOwnedTriggers()).isEqualTo(2);
+
+        final Set<String> newCancelledTriggerIds = dbJobTriggerService.all().stream()
+                .filter(JobTriggerDto::isCancelled)
+                .map(JobTriggerDto::id)
+                .collect(Collectors.toSet());
+
+        // Force releasing triggers should reset the "is_cancelled" flag to false
+        assertThat(newCancelledTriggerIds).isEmpty();
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/scheduler/stale-job-triggers.json
+++ b/graylog2-server/src/test/resources/org/graylog/scheduler/stale-job-triggers.json
@@ -37,6 +37,7 @@
       },
       "job_definition_id": "54e3deadbeefdeadbeefaff3",
       "job_definition_type": "event-processor-execution-v1",
+      "is_cancelled": true,
       "start_time": {
         "$date": "2019-01-01T00:00:00.000Z"
       },


### PR DESCRIPTION
This is required for scheduled jobs which are cancelled. Otherwise, a cancelled scheduled job would always abort on next execution because it's cancelled.