### PR TITLE
Handle stream references in content pack persistence service filtering

### DIFF
--- a/changelog/unreleased/pr-20265.toml
+++ b/changelog/unreleased/pr-20265.toml
@@ -1,4 +1,4 @@
 type = "f"
-message = "Fix issue where content pack stream dependencies were not properly resolved when a dashboard was imported and immediately exported."
+message = "Fix issue where content pack stream dependencies were not properly resolved for some dashboards."
 
-pulls = ["20265"]
+pulls = ["20265", "20288"]

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackPersistenceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackPersistenceService.java
@@ -33,6 +33,7 @@ import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackV1;
 import org.graylog2.contentpacks.model.Identified;
 import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.Revisioned;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.database.MongoConnection;
@@ -136,7 +137,7 @@ public class ContentPackPersistenceService {
 
         cpv1.entities()
                 .stream()
-                .filter(entity -> "stream".equals(entity.type().name()) && "1".equals(entity.type().version()))
+                .filter(entity -> ModelTypes.STREAM_V1.equals(entity.type()) || ModelTypes.STREAM_REF_V1.equals(entity.type()))
                 .map(entity -> new Tuple2<String, JsonNode>(entity.id().id(), ((EntityV1) entity).data().findValue("title")))
                 .forEach(tuple2 -> {
                     JsonNode title = tuple2.v2().findValue("@value");

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/content_pack_with_dashboard_with_stream.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/content_pack_with_dashboard_with_stream.json
@@ -1,0 +1,217 @@
+{
+  "v": 1,
+  "id": "72d61b7b-3fb3-44d2-9c6e-48b250a1854e",
+  "rev": 1,
+  "name": "pack with dashboard with stream",
+  "summary": "pack summary",
+  "description": "",
+  "vendor": "pack vendor",
+  "url": "",
+  "parameters": [],
+  "entities": [
+    {
+      "v": "1",
+      "type": {
+        "name": "dashboard",
+        "version": "2"
+      },
+      "id": "d81b7366-40e6-4f39-84d5-cb8f6e59d8db",
+      "data": {
+        "summary": {
+          "@type": "string",
+          "@value": ""
+        },
+        "search": {
+          "queries": [
+            {
+              "id": "7c1cf63c-a94d-427a-bc24-cad9b637fae9",
+              "timerange": {
+                "from": 300,
+                "type": "relative"
+              },
+              "filters": [],
+              "query": {
+                "type": "elasticsearch",
+                "query_string": ""
+              },
+              "search_types": [
+                {
+                  "size": 100,
+                  "query": {
+                    "type": "elasticsearch",
+                    "query_string": ""
+                  },
+                  "name": null,
+                  "timerange": {
+                    "from": 300,
+                    "type": "relative"
+                  },
+                  "streams": [
+                    "06f3a308-cd97-4495-80a0-5dc150adedcf"
+                  ],
+                  "filter": null,
+                  "fields": [
+                    "source",
+                    "message",
+                    "timestamp"
+                  ],
+                  "type": "logs",
+                  "id": "ddd5bff2-d55a-4178-84df-8448c614e715",
+                  "filters": [],
+                  "after": null,
+                  "tie_breaker": null,
+                  "sort": "DESC"
+                }
+              ]
+            }
+          ],
+          "parameters": [],
+          "requires": {},
+          "owner": "admin",
+          "created_at": "2024-08-26T17:14:07.414Z"
+        },
+        "created_at": "2024-08-26T17:13:49.568Z",
+        "requires": {},
+        "state": {
+          "7c1cf63c-a94d-427a-bc24-cad9b637fae9": {
+            "selected_fields": null,
+            "static_message_list_id": null,
+            "titles": {},
+            "widgets": [
+              {
+                "id": "f706f276-0982-4d85-845e-3124825dc8b2",
+                "type": "logs",
+                "filter": null,
+                "filters": [],
+                "timerange": {
+                  "from": 300,
+                  "type": "relative"
+                },
+                "query": {
+                  "type": "elasticsearch",
+                  "query_string": ""
+                },
+                "streams": [
+                  "06f3a308-cd97-4495-80a0-5dc150adedcf"
+                ],
+                "config": {
+                  "fields": [
+                    "timestamp",
+                    "source",
+                    "message"
+                  ],
+                  "units": {},
+                  "size": 100,
+                  "after": null,
+                  "sort": "DESC",
+                  "tie_breaker": null
+                }
+              }
+            ],
+            "widget_mapping": {
+              "f706f276-0982-4d85-845e-3124825dc8b2": [
+                "ddd5bff2-d55a-4178-84df-8448c614e715"
+              ]
+            },
+            "positions": {
+              "f706f276-0982-4d85-845e-3124825dc8b2": {
+                "col": 1,
+                "row": 1,
+                "height": 4,
+                "width": 12
+              }
+            },
+            "formatting": null,
+            "display_mode_settings": {
+              "positions": {}
+            }
+          }
+        },
+        "properties": [],
+        "owner": "admin",
+        "title": {
+          "@type": "string",
+          "@value": "pack title"
+        },
+        "type": "DASHBOARD",
+        "description": {
+          "@type": "string",
+          "@value": ""
+        }
+      },
+      "constraints": [
+        {
+          "type": "server-version",
+          "version": ">=6.1.0"
+        }
+      ]
+    },
+    {
+      "v": "1",
+      "type": {
+        "name": "stream",
+        "version": "1"
+      },
+      "id": "06f3a308-cd97-4495-80a0-5dc150adedcf",
+      "data": {
+        "alarm_callbacks": [],
+        "outputs": [],
+        "remove_matches": {
+          "@type": "boolean",
+          "@value": true
+        },
+        "title": {
+          "@type": "string",
+          "@value": "Stream A"
+        },
+        "stream_rules": [
+          {
+            "type": {
+              "@type": "string",
+              "@value": "EXACT"
+            },
+            "field": {
+              "@type": "string",
+              "@value": "source"
+            },
+            "value": {
+              "@type": "string",
+              "@value": "random-b"
+            },
+            "inverted": {
+              "@type": "boolean",
+              "@value": false
+            },
+            "description": {
+              "@type": "string",
+              "@value": ""
+            }
+          }
+        ],
+        "alert_conditions": [],
+        "matching_type": {
+          "@type": "string",
+          "@value": "AND"
+        },
+        "disabled": {
+          "@type": "boolean",
+          "@value": false
+        },
+        "description": {
+          "@type": "string",
+          "@value": ""
+        },
+        "default_stream": {
+          "@type": "boolean",
+          "@value": false
+        }
+      },
+      "constraints": [
+        {
+          "type": "server-version",
+          "version": ">=6.1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/content_pack_with_dashboard_with_stream_reference.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/content_pack_with_dashboard_with_stream_reference.json
@@ -1,0 +1,170 @@
+{
+  "v": 1,
+  "id": "72d61b7b-3fb3-44d2-9c6e-48b250a1854e",
+  "rev": 1,
+  "name": "pack with dashboard with stream reference",
+  "summary": "pack summary",
+  "description": "",
+  "vendor": "pack vendor",
+  "url": "",
+  "parameters": [],
+  "entities": [
+    {
+      "v": "1",
+      "type": {
+        "name": "dashboard",
+        "version": "2"
+      },
+      "id": "d81b7366-40e6-4f39-84d5-cb8f6e59d8db",
+      "data": {
+        "summary": {
+          "@type": "string",
+          "@value": ""
+        },
+        "search": {
+          "queries": [
+            {
+              "id": "7c1cf63c-a94d-427a-bc24-cad9b637fae9",
+              "timerange": {
+                "from": 300,
+                "type": "relative"
+              },
+              "filters": [],
+              "query": {
+                "type": "elasticsearch",
+                "query_string": ""
+              },
+              "search_types": [
+                {
+                  "size": 100,
+                  "query": {
+                    "type": "elasticsearch",
+                    "query_string": ""
+                  },
+                  "name": null,
+                  "timerange": {
+                    "from": 300,
+                    "type": "relative"
+                  },
+                  "streams": [
+                    "06f3a308-cd97-4495-80a0-5dc150adedcf"
+                  ],
+                  "filter": null,
+                  "fields": [
+                    "source",
+                    "message",
+                    "timestamp"
+                  ],
+                  "type": "logs",
+                  "id": "ddd5bff2-d55a-4178-84df-8448c614e715",
+                  "filters": [],
+                  "after": null,
+                  "tie_breaker": null,
+                  "sort": "DESC"
+                }
+              ]
+            }
+          ],
+          "parameters": [],
+          "requires": {},
+          "owner": "admin",
+          "created_at": "2024-08-26T17:14:07.414Z"
+        },
+        "created_at": "2024-08-26T17:13:49.568Z",
+        "requires": {},
+        "state": {
+          "7c1cf63c-a94d-427a-bc24-cad9b637fae9": {
+            "selected_fields": null,
+            "static_message_list_id": null,
+            "titles": {},
+            "widgets": [
+              {
+                "id": "f706f276-0982-4d85-845e-3124825dc8b2",
+                "type": "logs",
+                "filter": null,
+                "filters": [],
+                "timerange": {
+                  "from": 300,
+                  "type": "relative"
+                },
+                "query": {
+                  "type": "elasticsearch",
+                  "query_string": ""
+                },
+                "streams": [
+                  "06f3a308-cd97-4495-80a0-5dc150adedcf"
+                ],
+                "config": {
+                  "fields": [
+                    "timestamp",
+                    "source",
+                    "message"
+                  ],
+                  "units": {},
+                  "size": 100,
+                  "after": null,
+                  "sort": "DESC",
+                  "tie_breaker": null
+                }
+              }
+            ],
+            "widget_mapping": {
+              "f706f276-0982-4d85-845e-3124825dc8b2": [
+                "ddd5bff2-d55a-4178-84df-8448c614e715"
+              ]
+            },
+            "positions": {
+              "f706f276-0982-4d85-845e-3124825dc8b2": {
+                "col": 1,
+                "row": 1,
+                "height": 4,
+                "width": 12
+              }
+            },
+            "formatting": null,
+            "display_mode_settings": {
+              "positions": {}
+            }
+          }
+        },
+        "properties": [],
+        "owner": "admin",
+        "title": {
+          "@type": "string",
+          "@value": "pack title"
+        },
+        "type": "DASHBOARD",
+        "description": {
+          "@type": "string",
+          "@value": ""
+        }
+      },
+      "constraints": [
+        {
+          "type": "server-version",
+          "version": ">=6.1.0"
+        }
+      ]
+    },
+    {
+      "v": "1",
+      "type": {
+        "name": "stream_title",
+        "version": "1"
+      },
+      "id": "06f3a308-cd97-4495-80a0-5dc150adedcf",
+      "data": {
+        "title": {
+          "@type": "string",
+          "@value": "Stream A"
+        }
+      },
+      "constraints": [
+        {
+          "type": "server-version",
+          "version": ">=6.1.0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In `ContentPackPersistenceService.filterMissingResourcesAndInsert()` there is logic to remove streams from some embedded dashboard search entities before a content pack is stored in MongoDB if the referenced stream cannot be found.

This logic was checking for Stream Entities but not Stream Reference Entities, resulting in stream references getting filtered out of the searches.

This PR updates the filter logic to include any Stream Reference Entities as valid streams to be included included in the content pack.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In some instances content packs with a Stream-scoped Dashboard Entity and Stream Title entity had searches that were not properly scoped to the referenced Stream. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in development environment and unit tests.

Steps to reproduce:
1. Create a Dashboard with Log View widget
2. Scope the Log View widget to a stream
3. Create a Content Pack with the Dashboard (and stream title dependency)
4. Install the Content Pack
5. See that the newly created Dashboard is not actually scoped to the Stream
6. See that underlying Search Saved in MongoDB has no `streams` value

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.

