### PR TITLE
Add button to delete failed snapshot

### DIFF
--- a/graylog2-web-interface/src/components/indices/hooks/useDeleteFailedSnapshotMutation.tsx
+++ b/graylog2-web-interface/src/components/indices/hooks/useDeleteFailedSnapshotMutation.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useMutation } from '@tanstack/react-query';
 
 import ApiRoutes from 'routing/ApiRoutes';

--- a/graylog2-web-interface/src/components/indices/hooks/useDeleteFailedSnapshotMutation.tsx
+++ b/graylog2-web-interface/src/components/indices/hooks/useDeleteFailedSnapshotMutation.tsx
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+
+import ApiRoutes from 'routing/ApiRoutes';
+import { qualifyUrl } from 'util/URLUtils';
+import fetch from 'logic/rest/FetchProvider';
+import UserNotification from 'util/UserNotification';
+
+const deleteLicense = async (id : string) => {
+  const url = qualifyUrl(ApiRoutes.IndexSetsApiController.deleteFailedSnapshot(id).url);
+
+  return fetch('DELETE', url);
+};
+
+const useDeleteFailedSnapshotMutation = (id: string) => {
+  const remove = useMutation(() => deleteLicense(id), {
+    onError: (errorThrown) => {
+      UserNotification.error(`Snapshot deletion failed: ${errorThrown}`,
+        'Could not delete snapshot');
+    },
+    onSuccess: () => {
+      UserNotification.success('Snapshot has been successfully deleted.', 'Success!');
+    },
+  });
+
+  return { deleteFailedSnapshot: remove.mutateAsync };
+};
+
+export default useDeleteFailedSnapshotMutation;

--- a/graylog2-web-interface/src/routing/ApiRoutes.ts
+++ b/graylog2-web-interface/src/routing/ApiRoutes.ts
@@ -171,6 +171,7 @@ const ApiRoutes = {
     searchPaginated: (searchTerm, skip, limit, stats) => ({ url: `/system/indices/index_sets/search?searchTitle=${searchTerm}&skip=${skip}&limit=${limit}&stats=${stats}` }),
     setDefault: (indexSetId: string) => ({ url: `/system/indices/index_sets/${indexSetId}/default` }),
     stats: () => ({ url: '/system/indices/index_sets/stats' }),
+    deleteFailedSnapshot: (id: string) => ({ url: `/system/indices/index_sets/${id}/failed_snapshot` }),
   },
   IndicesApiController: {
     close: (indexName: string) => ({ url: `/system/indexer/indices/${indexName}/close` }),

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.ts
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.ts
@@ -73,7 +73,11 @@ export type IndexSetConfig = {
   use_legacy_rotation?: boolean
 }
 
-export type IndexSet = IndexSetConfig & { data_tiering?: DataTieringConfig };
+export type IndexSet = IndexSetConfig & {
+  data_tiering?: DataTieringConfig,
+  has_failed_snapshot?: boolean,
+  failed_snapshot_name?: string,
+};
 
 export type IndexSetFormValues = IndexSetConfig & { data_tiering?: DataTieringFormValues };
 


### PR DESCRIPTION
Part of https://github.com/Graylog2/graylog-plugin-enterprise/issues/8233

## Description
- Adds a button to delete a failed snapshot to the maintenance dropdown on the index set page.
- Clicking the button shows a confirm modal with further information on the impact of this process.


This feature relies on the attributes as part of the response of `GET /system/indices/index_sets/ID`:
**Example response:**
``` json
{
  id: "234asd2",
  title: "foo",
  index_prefix: "bar",
  has_failed_snapshot: true,
  failed_snapshot_name: "foor_warm"
}
```

- `has_failed_snapshot` (boolean) to determine whether to display the button
- `failed_snapshot_name` (optional string) to display the name of the index to delete in the confirm modal

It uses the following call to delete the snapshot:
`DELETE /api/system/indices/index_sets/INDEX_SET_ID/failed_snapshot`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1403" alt="Screenshot 2024-08-29 at 12 11 56" src="https://github.com/user-attachments/assets/da83f180-a7ea-441c-81e5-f99e8afaefd1">
<img width="709" alt="Screenshot 2024-08-29 at 12 12 01" src="https://github.com/user-attachments/assets/4dd75d67-f087-4566-9fd1-dcafbb92d662">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

