### PR TITLE
Avoiding double encoding of `query` parameter.

### DIFF
--- a/graylog2-web-interface/src/util/PaginationURL.test.ts
+++ b/graylog2-web-interface/src/util/PaginationURL.test.ts
@@ -46,4 +46,10 @@ describe('PaginationUR', () => {
 
     expect(url).toEqual('https://foo/?page=1&per_page=10&bool=false&scope=scope-1&scope=scope-2&query=bar');
   });
+
+  it('should not URL-encode query parameter twice', () => {
+    const url = PaginationURL('https://foo', 1, 10, 'my search query');
+
+    expect(url).toEqual('https://foo/?page=1&per_page=10&query=my+search+query');
+  });
 });

--- a/graylog2-web-interface/src/util/PaginationURL.ts
+++ b/graylog2-web-interface/src/util/PaginationURL.ts
@@ -44,7 +44,7 @@ export default (destUrl: string, page: number, perPage: number, query?: string, 
   }
 
   if (query) {
-    uri.addSearch('query', encodeURIComponent(query));
+    uri.addSearch('query', query);
   }
 
   return uri.toString();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the pagination helper doing URL-encoding of the `query` parameter twice, effectively turning `foo bar` into `foo%2520bar` on the wire and `foo%20bar` on the receiving end.

This most probably slipped in when `urijs` was introduced in this piece of code, forgetting that it is already doing URL-encoding.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.