### PR TITLE
Escape double quotes in all strings, not just top level model strings

### DIFF
--- a/changelog/unreleased/pr-19951.toml
+++ b/changelog/unreleased/pr-19951.toml
@@ -1,4 +1,4 @@
 type = "fixed"
 message = "Fixed issue where unescaped quotes in Custom HTTP notification JSON payloads breaks the notifications."
 
-pulls = ["19951"]
+pulls = ["19951", "20318"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -35,6 +35,7 @@ import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
 import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
+import org.graylog2.bindings.providers.JsonSafeEngineProvider;
 import org.graylog2.bindings.providers.SecureFreemarkerConfigProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
@@ -191,6 +192,7 @@ public class ServerBindings extends Graylog2Module {
         bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
         bind(Engine.class).toInstance(Engine.createEngine());
         bind(Engine.class).annotatedWith(Names.named("HtmlSafe")).toProvider(HtmlSafeJmteEngineProvider.class).asEagerSingleton();
+        bind(Engine.class).annotatedWith(Names.named("JsonSafe")).toProvider(JsonSafeEngineProvider.class).asEagerSingleton();
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.Renderer;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+import java.util.Locale;
+import java.util.Map;
+
+@Singleton
+public class JsonSafeEngineProvider implements Provider<Engine> {
+    private final Engine engine;
+
+    @Inject
+    public JsonSafeEngineProvider() {
+        engine = Engine.createEngine();
+        engine.registerRenderer(String.class, new EscapedQuoteStringRenderer());
+    }
+    @Override
+    public Engine get() {
+        return engine;
+    }
+
+    private static class EscapedQuoteStringRenderer implements Renderer<String> {
+
+        @Override
+        public String render(String s, Locale locale, Map<String, Object> map) {
+            return s.replace("\"", "\\\"");
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
@@ -21,6 +21,7 @@ import com.floreysoft.jmte.Renderer;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
+import org.apache.commons.lang.StringEscapeUtils;
 
 import java.util.Locale;
 import java.util.Map;
@@ -32,18 +33,23 @@ public class JsonSafeEngineProvider implements Provider<Engine> {
     @Inject
     public JsonSafeEngineProvider() {
         engine = Engine.createEngine();
-        engine.registerRenderer(String.class, new EscapedQuoteStringRenderer());
+        engine.registerRenderer(String.class, new JsonSafeRenderer());
     }
     @Override
     public Engine get() {
         return engine;
     }
 
-    private static class EscapedQuoteStringRenderer implements Renderer<String> {
+    private static class JsonSafeRenderer implements Renderer<String> {
 
         @Override
         public String render(String s, Locale locale, Map<String, Object> map) {
-            return s.replace("\"", "\\\"");
+            // Current version of Apache Commons does not have native support for escapeJson. However,
+            // https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringEscapeUtils.html#escapeJson(java.lang.String)
+            // current Apache Commons docs states:
+            // 'The only difference between Java strings and Json strings is that in Json, forward-slash (/) is escaped.'
+            // So we use escapeJava and tack on an extra String.replace() call to escape forward slashes.
+            return StringEscapeUtils.escapeJava(s).replace("/", "\\/");
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
@@ -18,6 +18,7 @@ package org.graylog.events.notifications.types;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.floreysoft.jmte.Engine;
+import com.google.common.collect.ImmutableList;
 import org.graylog.events.configuration.EventsConfigurationProvider;
 import org.graylog.events.notifications.EventNotificationService;
 import org.graylog2.bindings.providers.JsonSafeEngineProvider;
@@ -36,7 +37,6 @@ import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Map;

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.events.notifications.types;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.floreysoft.jmte.Engine;
+import org.graylog.events.configuration.EventsConfigurationProvider;
+import org.graylog.events.notifications.EventNotificationService;
+import org.graylog2.bindings.providers.JsonSafeEngineProvider;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.TestMessageFactory;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.bindings.providers.ParameterizedHttpClientProvider;
+import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
+import org.graylog2.system.urlwhitelist.UrlWhitelistService;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HTTPEventNotificationV2Test {
+    @Mock
+    private EventNotificationService notificationCallbackService;
+    @Mock
+    private ObjectMapperProvider objectMapperProvider;
+    @Mock
+    private UrlWhitelistService whitelistService;
+    @Mock
+    private UrlWhitelistNotificationService urlWhitelistNotificationService;
+    @Mock
+    private EncryptedValueService encryptedValueService;
+    @Mock
+    private EventsConfigurationProvider configurationProvider;
+    @Mock
+    private ParameterizedHttpClientProvider parameterizedHttpClientProvider;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private NodeId nodeId;
+
+    private HTTPEventNotificationV2 notification;
+
+    @BeforeEach
+    void setUp() {
+        notification = new HTTPEventNotificationV2(notificationCallbackService, objectMapperProvider,
+                whitelistService, urlWhitelistNotificationService, encryptedValueService, configurationProvider,
+                new Engine(), new JsonSafeEngineProvider().get(), notificationService, nodeId,
+                parameterizedHttpClientProvider);
+    }
+
+    @Test
+    public void testEscapedQuotesInBacklog() throws UnsupportedEncodingException, JsonProcessingException {
+        Map<String, Object> model = Map.of(
+                "event_definition_title", "<<Test Event Title>>",
+                "event", Map.of("message", "Event Message & Whatnot"),
+                "backlog", createBacklog()
+        );
+        String bodyTemplate = "${if backlog}{\"backlog\": [${foreach backlog message}{ \"title\": \"Message\", \"value\": \"${message.message}\" }${if last_message}${else},${end}${end}]}${end}";
+        String body = notification.transformBody(bodyTemplate, HTTPEventNotificationConfigV2.ContentType.JSON, model);
+        assertThat(body).contains("\"value\": \"Message with \\\"Double Quotes\\\"");
+    }
+
+    private ImmutableList<MessageSummary> createBacklog() {
+        Message message = new TestMessageFactory().createMessage("Message with \"Double Quotes\"", "Unit Test", DateTime.now(DateTimeZone.UTC));
+        MessageSummary summary = new MessageSummary("index1", message);
+        return ImmutableList.of(summary);
+    }
+
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The original fix for escaping double quotes in Custom HTTP Notifications fixed only top level strings in the model map. However, the backlog is a list of MessageSummary objects so the message.message fields were not properly being escaped. These changes add a `JsonSafeEngineProvider` which escapes all double quotes in String objects whenever they are substituted into a JSON formatted payload. This should handle all strings in the model, not just those that are top-level values.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Graylog2/support#69
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local tests and unit tests
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

