### PR TITLE
add two helper methods to build ObjectId related eq filters

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -110,6 +110,28 @@ public class MongoUtils<T extends MongoEntity> {
     }
 
     /**
+     * Create a query constraint to match a field against an {@link ObjectId}.
+     *
+     * @param fieldName the field to check
+     * @param id        the String value of the ObjectId
+     * @return the filter
+     */
+    public static Bson objectIdEq(@Nonnull String fieldName, @Nonnull String id) {
+        return objectIdEq(fieldName, new ObjectId(id));
+    }
+
+    /**
+     * Create a query constraint to match a field against an {@link ObjectId}.
+     *
+     * @param fieldName the field to check
+     * @param objectId  the ObjectId
+     * @return the filter
+     */
+    public static Bson objectIdEq(@Nonnull String fieldName, @Nonnull ObjectId objectId) {
+        return Filters.eq(fieldName, objectId);
+    }
+
+    /**
      * Create a query constraint to match a document's ID against the given list of Hex strings.
      *
      * @param ids Collection of hex string representations of an {@link ObjectId}

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -46,14 +46,19 @@ class MongoUtilsTest {
 
     private record DTO(@Id @org.mongojack.ObjectId String id, String name) implements MongoEntity {}
 
+    private record DTORef(@Id @org.mongojack.ObjectId String id, @org.mongojack.ObjectId ObjectId refId,
+                          String name) implements MongoEntity {}
+
     private MongoCollections mongoCollections;
     private MongoCollection<DTO> collection;
+    private MongoCollection<DTORef> collectionRef;
     private MongoUtils<DTO> utils;
 
     @BeforeEach
     void setUp(MongoDBTestService mongoDBTestService, MongoJackObjectMapperProvider objectMapperProvider) {
         mongoCollections = new MongoCollections(objectMapperProvider, mongoDBTestService.mongoConnection());
         collection = mongoCollections.collection("test", DTO.class);
+        collectionRef = mongoCollections.collection("test1", DTORef.class);
         utils = mongoCollections.utils(collection);
     }
 
@@ -94,6 +99,16 @@ class MongoUtilsTest {
         assertThat(collection.find(idEq(new ObjectId(a.id()))).first()).isEqualTo(a);
         assertThat(collection.find(idEq(b.id())).first()).isEqualTo(b);
         assertThat(collection.find(idEq(new ObjectId(b.id()))).first()).isEqualTo(b);
+    }
+
+    @Test
+    void testObjectIdEq() {
+        final var a = new DTORef("6627add0ee216425dd6df37c", new ObjectId("6627add0ee216425dd6df37d"), "a");
+        final var b = new DTORef("6627add0ee216425dd6df37d", new ObjectId("6627add0ee216425dd6df37c"), "b");
+        collectionRef.insertMany(List.of(a, b));
+
+        assertThat(collectionRef.find(MongoUtils.objectIdEq("ref_id", a.id())).first()).isEqualTo(b);
+        assertThat(collectionRef.find(MongoUtils.objectIdEq("ref_id", new ObjectId("6627add0ee216425dd6df37d"))).first()).isEqualTo(a);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -46,7 +46,7 @@ class MongoUtilsTest {
 
     private record DTO(@Id @org.mongojack.ObjectId String id, String name) implements MongoEntity {}
 
-    private record DTORef(@Id @org.mongojack.ObjectId String id, @org.mongojack.ObjectId ObjectId refId,
+    private record DTORef(@Id @org.mongojack.ObjectId String id, ObjectId refId,
                           String name) implements MongoEntity {}
 
     private MongoCollections mongoCollections;


### PR DESCRIPTION
## Description

we already have helpers for the _id field, but sometimes we store objectid 
references in other fields and it's unwieldy to create objectid instances all the time

/nocl helper methods

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

