### PR TITLE
Display indices in sections seperated by tier

### DIFF
--- a/changelog/unreleased/pr-20352.toml
+++ b/changelog/unreleased/pr-20352.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Display index overview by tier type."
+
+pulls = ["20352"]
+issues=["Graylog2/graylog-plugin-enterprise#8400"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -51,12 +51,10 @@ public abstract class IndexSummary {
     public abstract boolean isReopened();
 
     @JsonProperty("tier")
-    @Nullable
     public abstract TierType tier();
 
     @JsonProperty("shard_count")
-    @Nullable
-    public abstract Long shardCount();
+    public abstract long shardCount();
 
     @JsonCreator
     public static IndexSummary create(@JsonProperty("index_name") String indexName,
@@ -65,8 +63,8 @@ public abstract class IndexSummary {
                                       @JsonProperty("is_deflector") boolean isDeflector,
                                       @JsonProperty("is_closed") boolean isClosed,
                                       @JsonProperty("is_reopened") boolean isReopened,
-                                      @JsonProperty("tier") @Nullable TierType tier,
-                                      @JsonProperty("shard_count") @Nullable Long shardCount) {
+                                      @JsonProperty("tier") TierType tier,
+                                      @JsonProperty("shard_count") long shardCount) {
         return new AutoValue_IndexSummary(indexName, size, range, isDeflector, isClosed, isReopened, tier, shardCount);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class IndexSummary {
+    public static final String HOT_TIER = "hot";
+    public static final String WARM_TIER = "warm";
 
     @JsonProperty("index_name")
     public abstract String indexName();
@@ -49,13 +51,23 @@ public abstract class IndexSummary {
     @JsonProperty("is_reopened")
     public abstract boolean isReopened();
 
+    @JsonProperty("tier")
+    @Nullable
+    public abstract String tier();
+
+    @JsonProperty("shard_count")
+    @Nullable
+    public abstract Long shardCount();
+
     @JsonCreator
     public static IndexSummary create(@JsonProperty("index_name") String indexName,
                                       @JsonProperty("size") @Nullable IndexSizeSummary size,
                                       @JsonProperty("range") @Nullable IndexRangeSummary range,
                                       @JsonProperty("is_deflector") boolean isDeflector,
                                       @JsonProperty("is_closed") boolean isClosed,
-                                      @JsonProperty("is_reopened") boolean isReopened) {
-        return new AutoValue_IndexSummary(indexName, size, range, isDeflector, isClosed, isReopened);
+                                      @JsonProperty("is_reopened") boolean isReopened,
+                                      @JsonProperty("tier") @Nullable String tier,
+                                      @JsonProperty("shard_count") @Nullable Long shardCount) {
+        return new AutoValue_IndexSummary(indexName, size, range, isDeflector, isClosed, isReopened, tier, shardCount);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -28,8 +28,7 @@ import javax.annotation.Nullable;
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class IndexSummary {
-    public static final String HOT_TIER = "hot";
-    public static final String WARM_TIER = "warm";
+    public enum TierType {HOT, WARM}
 
     @JsonProperty("index_name")
     public abstract String indexName();
@@ -53,7 +52,7 @@ public abstract class IndexSummary {
 
     @JsonProperty("tier")
     @Nullable
-    public abstract String tier();
+    public abstract TierType tier();
 
     @JsonProperty("shard_count")
     @Nullable
@@ -66,7 +65,7 @@ public abstract class IndexSummary {
                                       @JsonProperty("is_deflector") boolean isDeflector,
                                       @JsonProperty("is_closed") boolean isClosed,
                                       @JsonProperty("is_reopened") boolean isReopened,
-                                      @JsonProperty("tier") @Nullable String tier,
+                                      @JsonProperty("tier") @Nullable TierType tier,
                                       @JsonProperty("shard_count") @Nullable Long shardCount) {
         return new AutoValue_IndexSummary(indexName, size, range, isDeflector, isClosed, isReopened, tier, shardCount);
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -57,8 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.HOT_TIER;
-import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.WARM_TIER;
+import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.TierType.HOT;
+import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.TierType.WARM;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
@@ -187,8 +187,8 @@ public class IndexerOverviewResource extends RestResource {
                 shardCount);
     }
 
-    private String getTierType(String indexName) {
-        return indicesAdapter.getWarmIndexInfo(indexName).isPresent() ? WARM_TIER : HOT_TIER;
+    private IndexSummary.TierType getTierType(String indexName) {
+        return indicesAdapter.getWarmIndexInfo(indexName).isPresent() ? WARM : HOT;
     }
 
     private IndexSummary buildClosedIndexSummary(String indexName, List<IndexRangeSummary> indexRanges, DeflectorSummary deflectorSummary) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -21,6 +21,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
@@ -28,6 +36,7 @@ import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.counts.Counts;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.indexer.indices.util.NumberBasedIndexNameComparator;
 import org.graylog2.rest.models.count.responses.MessageCountResponse;
@@ -41,16 +50,6 @@ import org.graylog2.rest.resources.system.DeflectorResource;
 import org.graylog2.rest.resources.system.IndexRangesResource;
 import org.graylog2.shared.rest.resources.RestResource;
 
-import jakarta.inject.Inject;
-
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.ServiceUnavailableException;
-import jakarta.ws.rs.core.MediaType;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -58,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.HOT_TIER;
+import static org.graylog2.rest.models.system.indexer.responses.IndexSummary.WARM_TIER;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
 
 @RequiresAuthentication
@@ -71,6 +72,7 @@ public class IndexerOverviewResource extends RestResource {
     private final IndexSetRegistry indexSetRegistry;
     private final Indices indices;
     private final Cluster cluster;
+    private final IndicesAdapter indicesAdapter;
 
     @Inject
     public IndexerOverviewResource(DeflectorResource deflectorResource,
@@ -79,7 +81,8 @@ public class IndexerOverviewResource extends RestResource {
                                    Counts counts,
                                    IndexSetRegistry indexSetRegistry,
                                    Indices indices,
-                                   Cluster cluster) {
+                                   Cluster cluster,
+                                   IndicesAdapter indicesAdapter) {
         this.deflectorResource = deflectorResource;
         this.indexerClusterResource = indexerClusterResource;
         this.indexRangesResource = indexRangesResource;
@@ -87,6 +90,7 @@ public class IndexerOverviewResource extends RestResource {
         this.indexSetRegistry = indexSetRegistry;
         this.indices = indices;
         this.cluster = cluster;
+        this.indicesAdapter = indicesAdapter;
     }
 
     @GET
@@ -143,22 +147,17 @@ public class IndexerOverviewResource extends RestResource {
         final List<IndexSummary> indexSummaries = new ArrayList<>();
         while (fields.hasNext()) {
             final Map.Entry<String, JsonNode> entry = fields.next();
-            indexSummaries.add(buildIndexSummary(entry, indexRanges, deflectorSummary, areReopened));
+            indexSummaries.add(buildIndexSummary(entry.getKey(), entry, indexRanges, deflectorSummary, areReopened));
 
         }
-        indices.getClosedIndices(indexSet).forEach(indexName -> indexSummaries.add(IndexSummary.create(
-                indexName,
-                null,
-                indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
-                indexName.equals(deflectorSummary.currentTarget()),
-                true,
-                false
-        )));
+        indices.getClosedIndices(indexSet).forEach(indexName ->
+                indexSummaries.add(buildClosedIndexSummary(indexName, indexRanges, deflectorSummary)));
         indexSummaries.sort(Comparator.comparing(IndexSummary::indexName, new NumberBasedIndexNameComparator(MongoIndexSet.SEPARATOR)));
         return indexSummaries;
     }
 
-    private IndexSummary buildIndexSummary(Map.Entry<String, JsonNode> indexStats,
+    private IndexSummary buildIndexSummary(String indexName,
+                                           Map.Entry<String, JsonNode> indexStats,
                                            List<IndexRangeSummary> indexRanges,
                                            DeflectorSummary deflectorSummary,
                                            Map<String, Boolean> areReopened) {
@@ -169,6 +168,7 @@ public class IndexerOverviewResource extends RestResource {
         final long deleted = docs.path("deleted").asLong();
         final JsonNode store = primaries.path("store");
         final long sizeInBytes = store.path("size_in_bytes").asLong();
+        final long shardCount = indicesAdapter.getShardsInfo(indexName).size();
 
         final Optional<IndexRangeSummary> range = indexRanges.stream()
                 .filter(indexRangeSummary -> indexRangeSummary.indexName().equals(index))
@@ -177,12 +177,31 @@ public class IndexerOverviewResource extends RestResource {
         final boolean isReopened = areReopened.get(index);
 
         return IndexSummary.create(
-                indexStats.getKey(),
+                indexName,
                 IndexSizeSummary.create(count, deleted, sizeInBytes),
                 range.orElse(null),
                 isDeflector,
                 false,
-                isReopened);
+                isReopened,
+                getTierType(indexName),
+                shardCount);
+    }
+
+    private String getTierType(String indexName) {
+        return indicesAdapter.getWarmIndexInfo(indexName).isPresent() ? WARM_TIER : HOT_TIER;
+    }
+
+    private IndexSummary buildClosedIndexSummary(String indexName, List<IndexRangeSummary> indexRanges, DeflectorSummary deflectorSummary) {
+        final long shardCount = indicesAdapter.getShardsInfo(indexName).size();
+        return IndexSummary.create(
+                indexName,
+                null,
+                indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
+                indexName.equals(deflectorSummary.currentTarget()),
+                true,
+                false,
+                getTierType(indexName),
+                shardCount);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -192,16 +192,15 @@ public class IndexerOverviewResource extends RestResource {
     }
 
     private IndexSummary buildClosedIndexSummary(String indexName, List<IndexRangeSummary> indexRanges, DeflectorSummary deflectorSummary) {
-        final long shardCount = indicesAdapter.getShardsInfo(indexName).size();
         return IndexSummary.create(
                 indexName,
                 null,
-                indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
+                indexRanges.stream().filter(indexRangeSummary -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
                 indexName.equals(deflectorSummary.currentTarget()),
                 true,
                 false,
                 getTierType(indexName),
-                shardCount);
+                0L);
     }
 
 }

--- a/graylog2-web-interface/src/components/indices/IndexSection.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSection.tsx
@@ -110,7 +110,7 @@ const StatList = styled.dl`
 `;
 
 const IndexSection = ({ headline, subheading, indices, indexDetails, indexSetId }: Props) => {
-  const size = indices.map((index) => index.size?.bytes).reduce((partialSum, a) => partialSum + a, 0) || 0;
+  const size = indices.map((index) => index.size?.bytes || 0).reduce((partialSum, a) => partialSum + a, 0) || 0;
   const shards = indices.map((index) => index.shard_count).reduce((partialSum, a) => partialSum + a, 0) || 0;
 
   return (

--- a/graylog2-web-interface/src/components/indices/IndexSection.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSection.tsx
@@ -110,7 +110,7 @@ const StatList = styled.dl`
 `;
 
 const IndexSection = ({ headline, subheading, indices, indexDetails, indexSetId }: Props) => {
-  const size = indices.map((index) => index.size.bytes).reduce((partialSum, a) => partialSum + a, 0) || 0;
+  const size = indices.map((index) => index.size?.bytes).reduce((partialSum, a) => partialSum + a, 0) || 0;
   const shards = indices.map((index) => index.shard_count).reduce((partialSum, a) => partialSum + a, 0) || 0;
 
   return (

--- a/graylog2-web-interface/src/components/indices/IndexSection.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSection.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import type { IndexInfo } from 'stores/indices/IndicesStore';
+import { Row, Col } from 'components/bootstrap';
+import type { IndexSummary as IndexSummaryType } from 'stores/indexers/IndexerOverviewStore';
+import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indices';
+import NumberUtils from 'util/NumberUtils';
+
+const Index = ({ index, indexDetails, indexSetId }: { index: IndexSummaryType, indexDetails: Array<IndexInfo>, indexSetId: string }) => {
+  const indexRange = index && index.range ? index.range : null;
+  const details = indexDetails.find(({ index_name }) => index_name === index.index_name);
+
+  return (
+    <Row className="content index-description">
+      <Col md={12}>
+        <IndexSummary index={index}
+                      name={index.index_name}
+                      count={index.size}
+                      indexRange={indexRange}
+                      isDeflector={index.is_deflector}>
+          <span>
+            <IndexDetails index={details}
+                          indexName={index.index_name}
+                          indexRange={indexRange}
+                          indexSetId={indexSetId}
+                          isDeflector={index.is_deflector} />
+          </span>
+        </IndexSummary>
+      </Col>
+    </Row>
+  );
+};
+
+const ClosedIndex = ({ index }: { index: IndexSummaryType }) => {
+  const indexRange = index.range;
+
+  return (
+    <Row className="content index-description">
+      <Col md={12}>
+        <IndexSummary index={index} name={index.index_name} indexRange={indexRange} isDeflector={index.is_deflector}>
+          <span>
+            <ClosedIndexDetails indexName={index.index_name} indexRange={indexRange} />
+          </span>
+        </IndexSummary>
+      </Col>
+    </Row>
+  );
+};
+
+const IndexListItem = ({ indexDetails, index, indexSetId } : {indexDetails: Array<IndexInfo>, index: IndexSummaryType, indexSetId: string}) => (
+  !index.is_closed
+    ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} key={`index-summary-${index.index_name}`} />
+    : <ClosedIndex index={index} key={`index-summary-${index.index_name}`} />
+);
+
+type Props = {
+  headline: string,
+  subheading: string,
+  indices: Array<IndexSummaryType>,
+  indexDetails: Array<IndexInfo>,
+  indexSetId: string
+}
+
+const SectionHeader = styled(Row)(({ theme }) => css`
+  margin-top: ${theme.spacings.lg};
+  margin-bottom: ${theme.spacings.lg};
+`);
+
+const SectionHeadline = styled.h2(({ theme }) => css`
+  margin-bottom: ${theme.spacings.xs};
+`);
+
+const SectionSubheading = styled.p`
+  margin-bottom: 0;
+`;
+
+const StatList = styled.dl`
+  margin-bottom: 0;
+
+  dt {
+    float: left;
+    width: 190px;
+    overflow: hidden;
+    clear: left;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  dd {
+    margin-left: 180px;
+  }
+`;
+
+const IndexSection = ({ headline, subheading, indices, indexDetails, indexSetId }: Props) => {
+  const size = indices.map((index) => index.size.bytes).reduce((partialSum, a) => partialSum + a, 0) || 0;
+  const shards = indices.map((index) => index.shard_count).reduce((partialSum, a) => partialSum + a, 0) || 0;
+
+  return (
+    <>
+      <SectionHeader>
+        <Col md={6}>
+          <SectionHeadline>{headline}</SectionHeadline>
+          <SectionSubheading>{subheading}</SectionSubheading>
+        </Col>
+        <Col md={6}>
+          <StatList>
+            <dt>Indices:</dt>
+            <dd>{indices.length}</dd>
+            <dt>Shards:</dt>
+            <dd>{shards}</dd>
+            <dt>Total Size:</dt>
+            <dd>{NumberUtils.formatBytes(size)}</dd>
+          </StatList>
+        </Col>
+      </SectionHeader>
+      {indices.map((index) => <IndexListItem indexDetails={indexDetails} index={index} indexSetId={indexSetId} />)}
+    </>
+  );
+};
+
+export default IndexSection;

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
@@ -35,17 +35,19 @@ const IndicesOverview = ({ indexDetails, indices, indexSetId }: Props) => {
   const warmTierIndices = indicesFilteredByTier(indices, 'warm');
   const hotTierIndices = indicesFilteredByTier(indices, 'hot');
   const hotTierList = hotTierIndices.length > 0 ? hotTierIndices : indicesFilteredByTier(indices, undefined);
+  const hotTierSubheading = 'Indices in this section are stored as active shards within the Search cluster, facilitating fast retrieval and search jobs. Data held in the Hot Tier has a permanent footprint in the Java Heap memory of the Search Cluster and in excess, will degrade search performance.';
+  const warmTierSubheading = 'Indices in this section are stored as searchable snapshots within the Warm Tier Repository, facilitating cheap storage and low resource overheads. Retrieval and Search jobs of data held in the Warm Tier will be slower. Note that only Search nodes with the "Search" role can participate in Warm Tier search and retrieval.';
 
   return (
     <>
       <IndexSection headline="Hot Tier"
-                    subheading="Hot Tier subheading TODO"
+                    subheading={hotTierSubheading}
                     indices={hotTierList}
                     indexDetails={indexDetails}
                     indexSetId={indexSetId} />
       {warmTierIndices.length > 0 && (
         <IndexSection headline="Warm Tier"
-                      subheading="Warm Tier subheading TODO"
+                      subheading={warmTierSubheading}
                       indices={warmTierIndices}
                       indexDetails={indexDetails}
                       indexSetId={indexSetId} />

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
@@ -17,50 +17,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Col, Row } from 'components/bootstrap';
-import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indices';
+import type { IndexSummary } from 'stores/indexers/IndexerOverviewStore';
+import { IndexSection } from 'components/indices';
 import type { IndexInfo } from 'stores/indices/IndicesStore';
-
-const Index = ({ index, indexDetails, indexSetId }: { index: IndexSummary, indexDetails: Array<IndexInfo>, indexSetId: string }) => {
-  const indexRange = index && index.range ? index.range : null;
-  const details = indexDetails.find(({ index_name }) => index_name === index.index_name);
-
-  return (
-    <Row className="content index-description">
-      <Col md={12}>
-        <IndexSummary index={index}
-                      name={index.index_name}
-                      count={index.size}
-                      indexRange={indexRange}
-                      isDeflector={index.is_deflector}>
-          <span>
-            <IndexDetails index={details}
-                          indexName={index.index_name}
-                          indexRange={indexRange}
-                          indexSetId={indexSetId}
-                          isDeflector={index.is_deflector} />
-          </span>
-        </IndexSummary>
-      </Col>
-    </Row>
-  );
-};
-
-const ClosedIndex = ({ index }: { index: IndexSummary }) => {
-  const indexRange = index.range;
-
-  return (
-    <Row className="content index-description">
-      <Col md={12}>
-        <IndexSummary index={index} name={index.index_name} indexRange={indexRange} isDeflector={index.is_deflector}>
-          <span>
-            <ClosedIndexDetails indexName={index.index_name} indexRange={indexRange} />
-          </span>
-        </IndexSummary>
-      </Col>
-    </Row>
-  );
-};
 
 type Props = {
   indexDetails: Array<IndexInfo>,
@@ -68,14 +27,32 @@ type Props = {
   indexSetId: string,
 }
 
-const IndicesOverview = ({ indexDetails, indices, indexSetId }: Props) => (
-  <span>
-    {indices.map((index) => (!index.is_closed
-      ? <Index index={index} indexDetails={indexDetails} indexSetId={indexSetId} key={`index-summary-${index.index_name}`} />
-      : <ClosedIndex index={index} key={`index-summary-${index.index_name}`} />),
-    )}
-  </span>
-);
+const IndicesOverview = ({ indexDetails, indices, indexSetId }: Props) => {
+  const indicesFilteredByTier = (indicesList: Array<IndexSummary>, tier: 'warm' | 'hot' | undefined): Array<IndexSummary> => (
+    indicesList.filter((index) => index.tier === tier)
+  );
+
+  const warmTierIndices = indicesFilteredByTier(indices, 'warm');
+  const hotTierIndices = indicesFilteredByTier(indices, 'hot');
+  const hotTierList = hotTierIndices.length > 0 ? hotTierIndices : indicesFilteredByTier(indices, undefined);
+
+  return (
+    <>
+      <IndexSection headline="Hot Tier"
+                    subheading="Hot Tier subheading TODO"
+                    indices={hotTierList}
+                    indexDetails={indexDetails}
+                    indexSetId={indexSetId} />
+      {warmTierIndices.length > 0 && (
+        <IndexSection headline="Warm Tier"
+                      subheading="Warm Tier subheading TODO"
+                      indices={warmTierIndices}
+                      indexDetails={indexDetails}
+                      indexSetId={indexSetId} />
+      )}
+    </>
+  );
+};
 
 IndicesOverview.propTypes = {
   indexDetails: PropTypes.array.isRequired,

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.tsx
@@ -28,12 +28,12 @@ type Props = {
 }
 
 const IndicesOverview = ({ indexDetails, indices, indexSetId }: Props) => {
-  const indicesFilteredByTier = (indicesList: Array<IndexSummary>, tier: 'warm' | 'hot' | undefined): Array<IndexSummary> => (
+  const indicesFilteredByTier = (indicesList: Array<IndexSummary>, tier: 'WARM' | 'HOT' | undefined): Array<IndexSummary> => (
     indicesList.filter((index) => index.tier === tier)
   );
 
-  const warmTierIndices = indicesFilteredByTier(indices, 'warm');
-  const hotTierIndices = indicesFilteredByTier(indices, 'hot');
+  const warmTierIndices = indicesFilteredByTier(indices, 'WARM');
+  const hotTierIndices = indicesFilteredByTier(indices, 'HOT');
   const hotTierList = hotTierIndices.length > 0 ? hotTierIndices : indicesFilteredByTier(indices, undefined);
   const hotTierSubheading = 'Indices in this section are stored as active shards within the Search cluster, facilitating fast retrieval and search jobs. Data held in the Hot Tier has a permanent footprint in the Java Heap memory of the Search Cluster and in excess, will degrade search performance.';
   const warmTierSubheading = 'Indices in this section are stored as searchable snapshots within the Warm Tier Repository, facilitating cheap storage and low resource overheads. Retrieval and Search jobs of data held in the Warm Tier will be slower. Note that only Search nodes with the "Search" role can participate in Warm Tier search and retrieval.';

--- a/graylog2-web-interface/src/components/indices/index.tsx
+++ b/graylog2-web-interface/src/components/indices/index.tsx
@@ -19,6 +19,7 @@ export { default as CreateIndexSet } from './CreateIndexSet';
 export { default as IndexDetails } from './IndexDetails';
 export { default as IndexRangeSummary } from './IndexRangeSummary';
 export { default as IndicesConfigurationDropdown } from './IndicesConfigurationDropdown';
+export { default as IndexSection } from './IndexSection';
 export { default as IndexSetConfigurationForm } from './IndexSetConfigurationForm';
 export { default as IndexSetDeletionForm } from './IndexSetDeletionForm';
 export { default as IndexSetDetails } from './IndexSetDetails';

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
@@ -32,6 +32,7 @@ export const IndexerOverviewActions = singletonActions(
 );
 
 export type IndexSummary = {
+  index_name: string,
   size: {
     events: number,
     deleted: number,
@@ -43,10 +44,12 @@ export type IndexSummary = {
     end: string,
     calculated_at: string,
     took_ms: number,
-  },
+  } | null,
   is_deflector: boolean,
   is_closed: boolean,
   is_reopened: boolean,
+  shard_count: number,
+  tier: 'warm' | 'hot'
 };
 
 export type IndexerOverview = {

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.ts
@@ -49,7 +49,7 @@ export type IndexSummary = {
   is_closed: boolean,
   is_reopened: boolean,
   shard_count: number,
-  tier: 'warm' | 'hot'
+  tier: 'WARM' | 'HOT'
 };
 
 export type IndexerOverview = {


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-enterprise#8400

Extends the `GET /system/indexer/overview/${indexSetId}` API to provide tier type (`hot` or `warm`) and shard count for each index.

```
{
    "deflector": {
...
    },
    "indexer_cluster": {
...
    },
    "counts": {
        "events": 0
    },
    "indices": [
        {
            "index_name": "graylog_60",
            "size": {
                "events": 0,
                "deleted": 0,
                "bytes": 624
            },
            "range": {
                "index_name": "graylog_60",
                "begin": "1970-01-01T00:00:00.000Z",
                "end": "1970-01-01T00:00:00.000Z",
                "calculated_at": "2024-09-02T10:42:31.474Z",
                "took_ms": 0
            },
            "tier": "hot",
            "shard_count": 3,
            "is_reopened": false,
            "is_deflector": true,
            "is_closed": false
        }
    ]
}

```

