### PR TITLE
Allow disabling header in expanded sections.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/ExpandedSections.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ExpandedSections.tsx
@@ -64,27 +64,28 @@ const ExpandedSections = <Entity extends EntityBase>({
   return (
     <Container>
       <td colSpan={1000}>
-        {Object.entries(expandedSectionsRenderer ?? {}).map(([sectionName, section]) => {
-          if (!expandedEntitySections.includes(sectionName)) {
-            return null;
-          }
+        {Object.entries(expandedSectionsRenderer ?? {})
+          .filter(([sectionName]) => expandedEntitySections.includes(sectionName))
+          .map(([sectionName, section]) => {
+            const hideSection = () => toggleSection(entity.id, sectionName);
+            const actions = section.actions?.(entity);
 
-          const hideSection = () => toggleSection(entity.id, sectionName);
-          const actions = section.actions?.(entity);
-
-          return (
-            <div key={`${sectionName}-${entity.id}`}>
-              <Header>
-                <h3>{section.title}</h3>
-                <Actions>
-                  {actions}
-                  <HideSectionButton name="close" onClick={hideSection} title="Hide section" />
-                </Actions>
-              </Header>
-              {section.content(entity)}
-            </div>
-          );
-        })}
+            return (
+              <div key={`${sectionName}-${entity.id}`}>
+                {section.disableHeader !== true
+                  ? (
+                    <Header>
+                      <h3>{section.title}</h3>
+                      <Actions>
+                        {actions}
+                        <HideSectionButton name="close" onClick={hideSection} title="Hide section" />
+                      </Actions>
+                    </Header>
+                  ) : null}
+                {section.content(entity)}
+              </div>
+            );
+          })}
       </td>
     </Container>
   );

--- a/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
@@ -70,4 +70,5 @@ export type ExpandedSectionRenderer<Entity> = {
   title: string,
   content: (entity: Entity) => React.ReactNode,
   actions?: (entity: Entity) => React.ReactNode,
+  disableHeader?: boolean,
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows disabling the header in expanded sections of the entity
data table by setting the `disableHeader` prop to `true` in the
definition of an expanded section renderer.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.