### PR TITLE
Use external URI for base URL of API browser.

### DIFF
--- a/changelog/unreleased/pr-20379.toml
+++ b/changelog/unreleased/pr-20379.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Use external URI for base URL of API browser."
+
+pulls = ["20379"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -83,7 +83,7 @@ public class DocumentationBrowserResource extends RestResource {
         final URL templateUrl = this.getClass().getResource("/swagger/index.html.template");
         final String template = Resources.toString(templateUrl, StandardCharsets.UTF_8);
         final Map<String, Object> model = ImmutableMap.of(
-                "baseUri", httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API).toString(),
+                "baseUri", httpConfiguration.getHttpExternalUri().resolve(HttpConfiguration.PATH_API).toString(),
                 "globalModePath", "",
                 "globalUriMarker", "",
                 "showWarning", "");


### PR DESCRIPTION
**Note:** This PR requires backports to `5.2` and `6.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Use the external URI for the base URL of the API browser. This avoids leaking internal hostnames when an external URI is configured.
closes #20391
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.