### PR TITLE
Add stream categories to search replay

### DIFF
--- a/changelog/unreleased/pr-20110.toml
+++ b/changelog/unreleased/pr-20110.toml
@@ -2,4 +2,4 @@ type = "a"
 message = "Added categories to Streams to allow Illuminate content to be scoped to multiple products."
 
 issues = ["graylog-plugin-enterprise#7945"]
-pulls = ["20110", "20160", "20199", "20371", "20373", "graylog-plugin-enterprise#8295", "graylog-plugin-enterprise#8418", "graylog-plugin-enterprise#8437" ]
+pulls = ["20110", "20160", "20199", "20371", "20373", "20380", "graylog-plugin-enterprise#8295", "graylog-plugin-enterprise#8418", "graylog-plugin-enterprise#8437", "graylog-plugin-enterprise#8452", "graylog-plugin-enterprise#8454" ]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -32,6 +32,7 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.EmptyTimeRange;
 import org.graylog.plugins.views.search.filter.AndFilter;
+import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.StreamCategoryFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.permissions.StreamPermissions;
@@ -52,6 +53,7 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -249,6 +251,22 @@ public abstract class Query implements ContentPackable<QueryEntity>, UsesSearchF
     public Query addStreamsToFilter(Set<String> streamIds) {
         final Filter newFilter = addStreamsTo(filter(), streamIds);
         return toBuilder().filter(newFilter).build();
+    }
+
+    // This is a very specific call to set a flat OrFilter of a set of streamIds and categories when replaying a search.
+    // It is unlikely that it would need to be called outside the context of recreating a top-level search.
+    public Query orStreamAndStreamCategoryFilters(Set<String> streamIds, Set<String> categories) {
+        List<Filter> combinedFilters = new ArrayList<>();
+        if (streamIds != null && !streamIds.isEmpty()) {
+            combinedFilters.add(StreamFilter.anyIdOf(streamIds.toArray(new String[]{})));
+        }
+
+        if (categories != null && !categories.isEmpty()) {
+            categories.forEach(category -> {
+                combinedFilters.add(StreamCategoryFilter.ofCategory(category));
+            });
+        }
+        return toBuilder().filter(OrFilter.or(combinedFilters.toArray(new Filter[]{}))).build();
     }
 
     public Query replaceStreamCategoryFilters(Function<Collection<String>, Stream<String>> categoryMappingFunction,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
@@ -119,6 +119,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
     @NoAuditEvent("Creating audit event manually in method body.")
     public TabularResponse executeQuery(@ApiParam(name = "query") @QueryParam("query") String query,
                                         @ApiParam(name = "streams") @QueryParam("streams") Set<String> streams,
+                                        @ApiParam(name = "stream_categories") @QueryParam("stream_categories") Set<String> streamCategories,
                                         @ApiParam(name = "timerange") @QueryParam("timerange") String timerangeKeyword,
                                         @ApiParam(name = "fields") @QueryParam("fields") List<String> fields,
                                         @ApiParam(name = "sort") @QueryParam("sort") String sort,
@@ -130,6 +131,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
         try {
             MessagesRequestSpec messagesRequestSpec = queryParamsToFullRequestSpecificationMapper.simpleQueryParamsToFullRequestSpecification(query,
                     splitByComma(streams),
+                    splitByComma(streamCategories),
                     timerangeKeyword,
                     splitByComma(fields),
                     sort,
@@ -171,6 +173,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
     @NoAuditEvent("Creating audit event manually in method body.")
     public TabularResponse executeQuery(@ApiParam(name = "query") @QueryParam("query") String query,
                                         @ApiParam(name = "streams") @QueryParam("streams") Set<String> streams,
+                                        @ApiParam(name = "stream_categories") @QueryParam("stream_categories") Set<String> streamCategories,
                                         @ApiParam(name = "timerange") @QueryParam("timerange") String timerangeKeyword,
                                         @ApiParam(name = "groups") @QueryParam("groups") List<String> groups,
                                         @ApiParam(name = "metrics") @QueryParam("metrics") List<String> metrics,
@@ -179,6 +182,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
             AggregationRequestSpec aggregationRequestSpec = queryParamsToFullRequestSpecificationMapper.simpleQueryParamsToFullRequestSpecification(
                     query,
                     StringUtils.splitByComma(streams),
+                    StringUtils.splitByComma(streamCategories),
                     timerangeKeyword,
                     splitByComma(groups),
                     splitByComma(metrics)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapper.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.rest.scriptingapi.mapping;
 
+import jakarta.inject.Inject;
 import org.apache.commons.collections4.CollectionUtils;
 import org.graylog.plugins.views.search.rest.scriptingapi.parsing.TimerangeParser;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
@@ -23,8 +24,6 @@ import org.graylog.plugins.views.search.rest.scriptingapi.request.Grouping;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
 import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
-
-import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,6 +41,7 @@ public class QueryParamsToFullRequestSpecificationMapper {
 
     public MessagesRequestSpec simpleQueryParamsToFullRequestSpecification(final String query,
                                                                            final Set<String> streams,
+                                                                           final Set<String> streamCategories,
                                                                            final String timerangeKeyword,
                                                                            final List<String> fields,
                                                                            final String sort,
@@ -51,6 +51,7 @@ public class QueryParamsToFullRequestSpecificationMapper {
 
         return new MessagesRequestSpec(query,
                 streams,
+                streamCategories,
                 timerangeParser.parseTimeRange(timerangeKeyword),
                 sort,
                 sortOrder,
@@ -61,6 +62,7 @@ public class QueryParamsToFullRequestSpecificationMapper {
 
     public AggregationRequestSpec simpleQueryParamsToFullRequestSpecification(final String query,
                                                                               final Set<String> streams,
+                                                                              final Set<String> streamCategories,
                                                                               final String timerangeKeyword,
                                                                               List<String> groups,
                                                                               List<String> metrics) {
@@ -80,6 +82,7 @@ public class QueryParamsToFullRequestSpecificationMapper {
         return new AggregationRequestSpec(
                 query,
                 streams,
+                streamCategories,
                 timerangeParser.parseTimeRange(timerangeKeyword),
                 groups.stream().map(Grouping::new).collect(Collectors.toList()),
                 metrics.stream().map(Metric::fromStringRepresentation).flatMap(Optional::stream).collect(Collectors.toList())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/AggregationRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/AggregationRequestSpec.java
@@ -19,11 +19,10 @@ package org.graylog.plugins.views.search.rest.scriptingapi.request;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
-import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
-import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.ResponseSchemaEntry;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.List;
 import java.util.Set;
@@ -32,6 +31,7 @@ import java.util.stream.Stream;
 
 public record AggregationRequestSpec(@JsonProperty("query") String queryString,
                                      @JsonProperty("streams") Set<String> streams,
+                                     @JsonProperty("stream_categories") Set<String> streamCategories,
                                      @JsonProperty("timerange") TimeRange timerange,
                                      @JsonProperty("group_by") @Valid @NotEmpty List<Grouping> groupings,
                                      @JsonProperty("metrics") @Valid @NotEmpty List<Metric> metrics) implements SearchRequestSpec {
@@ -46,6 +46,9 @@ public record AggregationRequestSpec(@JsonProperty("query") String queryString,
         }
         if (streams == null) {
             streams = Set.of();
+        }
+        if (streamCategories == null) {
+            streamCategories = Set.of();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/MessagesRequestSpec.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 public record MessagesRequestSpec(@JsonProperty("query") String queryString,
                                   @JsonProperty("streams") Set<String> streams,
+                                  @JsonProperty("stream_categories") Set<String> streamCategories,
                                   @JsonProperty("timerange") TimeRange timerange,
                                   @JsonProperty("sort") String sort,
                                   @JsonProperty("sort_order") SortSpec.Direction sortOrder,
@@ -57,6 +58,9 @@ public record MessagesRequestSpec(@JsonProperty("query") String queryString,
         }
         if (streams == null) {
             streams = Set.of();
+        }
+        if (streamCategories == null) {
+            streamCategories = Set.of();
         }
         if (from < 0) {
             from = DEFAULT_FROM;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/SearchRequestSpec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/request/SearchRequestSpec.java
@@ -31,6 +31,8 @@ public interface SearchRequestSpec {
 
     Set<String> streams();
 
+    Set<String> streamCategories();
+
     TimeRange timerange();
 
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/QueryParamsToFullRequestSpecificationMapperTest.java
@@ -57,6 +57,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
     void throwsExceptionOnNullGroups() {
         assertThrows(IllegalArgumentException.class, () -> toTest.simpleQueryParamsToFullRequestSpecification("*",
                 Set.of(),
+                Set.of(),
                 "42d",
                 null,
                 List.of("avg:joe")));
@@ -66,6 +67,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
     void throwsExceptionOnEmptyGroups() {
         assertThrows(IllegalArgumentException.class, () -> toTest.simpleQueryParamsToFullRequestSpecification("*",
                 Set.of(),
+                Set.of(),
                 "42d",
                 List.of(),
                 List.of("avg:joe")));
@@ -74,6 +76,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
     @Test
     void throwsExceptionOnWrongMetricFormat() {
         assertThrows(IllegalArgumentException.class, () -> toTest.simpleQueryParamsToFullRequestSpecification("*",
+                Set.of(),
                 Set.of(),
                 "42d",
                 List.of("http_method"),
@@ -85,12 +88,14 @@ class QueryParamsToFullRequestSpecificationMapperTest {
         AggregationRequestSpec aggregationRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification(null,
                 null,
                 null,
+                null,
                 List.of("http_method"),
                 null);
 
         assertThat(aggregationRequestSpec).isEqualTo(new AggregationRequestSpec(
                         "*",
                         Set.of(),
+                Set.of(),
                         DEFAULT_TIMERANGE,
                         List.of(new Grouping("http_method")),
                         List.of(new Metric("count", null))
@@ -100,12 +105,14 @@ class QueryParamsToFullRequestSpecificationMapperTest {
         aggregationRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification(null,
                 null,
                 null,
+                null,
                 List.of("http_method"),
                 List.of());
 
         assertThat(aggregationRequestSpec).isEqualTo(new AggregationRequestSpec(
                         "*",
                         Set.of(),
+                Set.of(),
                         DEFAULT_TIMERANGE,
                         List.of(new Grouping("http_method")),
                         List.of(new Metric("count", null))
@@ -113,10 +120,11 @@ class QueryParamsToFullRequestSpecificationMapperTest {
                 )
         );
 
-        final MessagesRequestSpec messagesRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification(null, null, null, null, null, null, 0, 10);
+        final MessagesRequestSpec messagesRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification(null, null, null, null, null, null, null, 0, 10);
         assertThat(messagesRequestSpec).isEqualTo(new MessagesRequestSpec(
                         "*",
                         Set.of(),
+                Set.of(),
                         DEFAULT_TIMERANGE,
                         DEFAULT_SORT,
                         DEFAULT_SORT_ORDER,
@@ -134,6 +142,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
         doReturn(KeywordRange.create("last 1 day", "UTC")).when(timerangeParser).parseTimeRange("1d");
         final AggregationRequestSpec aggregationRequestSpec = toTest.simpleQueryParamsToFullRequestSpecification("http_method:GET",
                 Set.of("000000000000000000000001"),
+                Set.of("category1"),
                 "1d",
                 List.of("http_method", "controller"),
                 List.of("avg:took_ms"));
@@ -141,6 +150,7 @@ class QueryParamsToFullRequestSpecificationMapperTest {
         assertThat(aggregationRequestSpec).isEqualTo(new AggregationRequestSpec(
                         "http_method:GET",
                         Set.of("000000000000000000000001"),
+                Set.of("category1"),
                         KeywordRange.create("last 1 day", "UTC"),
                         List.of(new Grouping("http_method"), new Grouping("controller")),
                         List.of(new Metric("avg", "took_ms"))

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.tsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.tsx
@@ -44,9 +44,10 @@ const buildFilterFields = (messageFields: {
 
 const buildSearchLink = (id: string, from: string, to: string, filterFields: {
   [key: string]: unknown;
-}, streams: string[]) => SearchLink.builder()
+}, streams: string[], streamCategories: string[]) => SearchLink.builder()
   .timerange({ type: 'absolute', from, to })
   .streams(streams)
+  .streamCategories(streamCategories)
   .filterFields(filterFields)
   .highlightedMessage(id)
   .build()
@@ -54,12 +55,12 @@ const buildSearchLink = (id: string, from: string, to: string, filterFields: {
 
 const searchLink = (range: string, timestamp: moment.MomentInput, id: string, messageFields: {
   [key: string]: unknown;
-}, searchConfig: Pick<SearchesConfig, 'surrounding_filter_fields'>, streams: string[]) => {
+}, searchConfig: Pick<SearchesConfig, 'surrounding_filter_fields'>, streams: string[], streamCategories: string[]) => {
   const fromTime = moment(timestamp).subtract(Number(range), 'seconds').toISOString();
   const toTime = moment(timestamp).add(Number(range), 'seconds').toISOString();
   const filterFields = buildFilterFields(messageFields, searchConfig);
 
-  return buildSearchLink(id, fromTime, toTime, filterFields, streams);
+  return buildSearchLink(id, fromTime, toTime, filterFields, streams, streamCategories);
 };
 
 type Props = {
@@ -70,7 +71,7 @@ type Props = {
 };
 
 const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields }: Props) => {
-  const { streams } = useContext(DrilldownContext);
+  const { streams, streamCategories } = useContext(DrilldownContext);
   const timeRangeOptions = buildTimeRangeOptions(searchConfig);
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
@@ -91,7 +92,7 @@ const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields }:
     .map((range) => (
       <MenuItem key={range}
                 onClick={() => sendEvent(range)}
-                href={searchLink(range, timestamp, id, messageFields, searchConfig, streams)}
+                href={searchLink(range, timestamp, id, messageFields, searchConfig, streams, streamCategories)}
                 target="_blank"
                 rel="noopener noreferrer">
         {timeRangeOptions[range]}

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -42,6 +42,7 @@ type SearchQueryParams = {
   to?: string,
   keyword?: string,
   streams?: string,
+  stream_categories?: string,
 }
 
 const Routes = {
@@ -213,7 +214,7 @@ const Routes = {
   },
   EXTENDEDSEARCH: extendedSearchPath,
   KEYBOARD_SHORTCUTS: '/keyboard-shortcuts',
-  search_with_query: (query: string, rangeType: TimeRangeTypes, timeRange: RoutesTimeRange, streams?: string[]) => {
+  search_with_query: (query: string, rangeType: TimeRangeTypes, timeRange: RoutesTimeRange, streams?: string[], streamCategories?: string[]) => {
     const route = new URI(Routes.SEARCH);
     const queryParams: SearchQueryParams = {
       q: query,
@@ -240,6 +241,10 @@ const Routes = {
 
     if (streams) {
       queryParams.streams = streams.join(',');
+    }
+
+    if (streamCategories) {
+      queryParams.stream_categories = streamCategories.join(',');
     }
 
     route.query(queryParams);

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -39,7 +39,8 @@ import type Query from 'views/logic/queries/Query';
 import {
   createElasticsearchQueryString,
   filtersToStreamSet,
-  filtersToStreamCategorySet, newFiltersForQuery,
+  filtersToStreamCategorySet,
+  newFiltersForQuery,
 } from 'views/logic/queries/Query';
 import type { SearchBarFormValues } from 'views/Constants';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
@@ -23,12 +23,14 @@ import { DEFAULT_TIMERANGE } from 'views/Constants';
 export type Drilldown = {
   query: QueryString,
   streams: Array<string>,
+  streamCategories: Array<string>,
   timerange: TimeRange,
 };
 
 const defaultValue: Drilldown = {
   query: createElasticsearchQueryString(''),
   streams: [],
+  streamCategories: [],
   timerange: DEFAULT_TIMERANGE,
 };
 

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.tsx
@@ -19,7 +19,11 @@ import * as React from 'react';
 import type Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
 import type Query from 'views/logic/queries/Query';
-import { createElasticsearchQueryString, filtersToStreamSet } from 'views/logic/queries/Query';
+import {
+  createElasticsearchQueryString,
+  filtersToStreamSet,
+  filtersToStreamCategorySet,
+} from 'views/logic/queries/Query';
 import type GlobalOverride from 'views/logic/search/GlobalOverride';
 import useViewType from 'views/hooks/useViewType';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
@@ -34,13 +38,14 @@ const useDrillDownContextValue = (widget: Widget, globalOverride: GlobalOverride
   const viewType = useViewType();
 
   if (viewType === View.Type.Dashboard) {
-    const { streams, timerange, query } = widget;
+    const { streams, timerange, query, streamCategories } = widget;
     const dashboardAndWidgetQueryString = globalOverride?.query?.query_string
       ? concatQueryStrings([query?.query_string, globalOverride.query.query_string])
       : query?.query_string;
 
     return ({
       streams,
+      streamCategories,
       timerange: (globalOverride?.timerange ? globalOverride.timerange : timerange) || DEFAULT_TIMERANGE,
       query: createElasticsearchQueryString(dashboardAndWidgetQueryString || ''),
     });
@@ -48,9 +53,10 @@ const useDrillDownContextValue = (widget: Widget, globalOverride: GlobalOverride
 
   if (currentQuery) {
     const streams = filtersToStreamSet(currentQuery.filter).toJS();
+    const streamCategories = filtersToStreamCategorySet(currentQuery.filter).toJS();
     const { timerange, query } = currentQuery;
 
-    return ({ streams, timerange, query });
+    return ({ streams, streamCategories, timerange, query });
   }
 
   return undefined;

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -54,12 +54,14 @@ const buildSearchLink = (
   timerange: TimeRange,
   queryString: string,
   streams: Array<string>,
+  streamCategories: Array<string>,
   parameters?: Immutable.Set<Parameter>,
 ) => {
   let searchLink = SearchLink.builder()
     .query(createElasticsearchQueryString(queryString))
     .timerange(timerange)
     .streams(streams)
+    .streamCategories(streamCategories)
     .build()
     .toURL();
 
@@ -86,14 +88,15 @@ type Props = {
   queryString?: string | undefined,
   timerange?: TimeRange | undefined,
   streams?: string[] | undefined,
+  streamCategories?: string[] | undefined,
   parameters?: Immutable.Set<Parameter>,
   children?: React.ReactNode,
   parameterBindings?: ParameterBindings,
 };
 
-const ReplaySearchButton = ({ queryString, timerange, streams, parameters, children, parameterBindings }: Props) => {
+const ReplaySearchButton = ({ queryString, timerange, streams, streamCategories, parameters, children, parameterBindings }: Props) => {
   const sessionId = useMemo(() => `replay-search-${generateId()}`, []);
-  const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, parameters);
+  const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, streamCategories, parameters);
 
   const onReplaySearch = useCallback(() => {
     if (parameters?.size) {
@@ -112,6 +115,7 @@ ReplaySearchButton.defaultProps = {
   queryString: undefined,
   timerange: undefined,
   streams: undefined,
+  streamCategories: undefined,
   parameters: undefined,
   parameterBindings: undefined,
   children: undefined,

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -155,7 +155,7 @@ const WidgetActionsMenu = ({
 }: Props) => {
   const widget = useContext(WidgetContext);
   const view = useView();
-  const { query, timerange, streams } = useContext(DrilldownContext);
+  const { query, timerange, streams, streamCategories } = useContext(DrilldownContext);
   const { setWidgetFocusing, unsetWidgetFocusing } = useContext(WidgetFocusContext);
   const [showCopyToDashboard, setShowCopyToDashboard] = useState(false);
   const [showExport, setShowExport] = useState(false);
@@ -230,6 +230,7 @@ const WidgetActionsMenu = ({
           <ReplaySearchButton queryString={query.query_string}
                               timerange={timerange}
                               streams={streams}
+                              streamCategories={streamCategories}
                               parameterBindings={parameterBindings}
                               parameters={parameters} />
         </IfDashboard>

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
@@ -22,7 +22,7 @@ import type { ViewType } from 'views/logic/views/View';
 import View from 'views/logic/views/View';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type Query from 'views/logic/queries/Query';
-import { filtersToStreamSet } from 'views/logic/queries/Query';
+import { filtersToStreamSet, filtersToStreamCategorySet } from 'views/logic/queries/Query';
 import { isTypeRelativeWithStartOnly, isTypeRelativeWithEnd } from 'views/typeGuards/timeRange';
 import useViewType from 'views/hooks/useViewType';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
@@ -70,9 +70,14 @@ export const syncWithQueryParameters = (viewType: ViewType, query: string, searc
     const uriWithTimerange = extractTimerangeParams(timerange)
       .reduce((prev, [key, value]) => prev.setSearch(key, String(value)), baseUri);
     const currentStreams = filtersToStreamSet(filter);
-    const uri = currentStreams.isEmpty()
-      ? uriWithTimerange.removeSearch('streams').toString()
-      : uriWithTimerange.setSearch('streams', currentStreams.join(',')).toString();
+    const currentStreamCategories = filtersToStreamCategorySet(filter);
+    const uriWithStreams = currentStreams.isEmpty()
+      ? uriWithTimerange.removeSearch('streams')
+      : uriWithTimerange.setSearch('streams', currentStreams.join(','));
+
+    const uri = currentStreamCategories.isEmpty()
+      ? uriWithStreams.removeSearch('stream_categories').toString()
+      : uriWithStreams.setSearch('stream_categories', currentStreamCategories.join(',')).toString();
 
     if (query !== uri) {
       action(uri);

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -84,6 +84,10 @@ export const filtersToStreamSet = (filter: Immutable.Map<string, any> | null | u
     return Immutable.Set([filter.get('id')]);
   }
 
+  if (type === 'stream_category') {
+    return Immutable.Set();
+  }
+
   const filters = filter.get('filters', Immutable.List());
 
   return filters.map(filtersToStreamSet).reduce((prev, cur) => prev.merge(cur), Immutable.Set());

--- a/graylog2-web-interface/src/views/logic/search/SearchLink.ts
+++ b/graylog2-web-interface/src/views/logic/search/SearchLink.ts
@@ -27,6 +27,7 @@ type InternalState = {
   timerange: TimeRange,
   query: QueryString,
   streams: Array<string>,
+  streamCategories: Array<string>,
   highlightedMessage: string,
   filterFields: { [key: string]: unknown },
 };
@@ -44,6 +45,7 @@ export default class SearchLink {
     timerange: InternalState['timerange'],
     query: InternalState['query'],
     streams: InternalState['streams'],
+    streamCategories: InternalState['streamCategories'],
     highlightedMessage: InternalState['highlightedMessage'],
     filterFields: InternalState['filterFields'],
   ) {
@@ -52,6 +54,7 @@ export default class SearchLink {
       timerange,
       query,
       streams,
+      streamCategories,
       highlightedMessage,
       filterFields,
     };
@@ -73,6 +76,10 @@ export default class SearchLink {
     return this._value.streams;
   }
 
+  get streamCategories() {
+    return this._value.streamCategories;
+  }
+
   get highlightedMessage() {
     return this._value.highlightedMessage;
   }
@@ -87,7 +94,7 @@ export default class SearchLink {
   }
 
   toURL() {
-    const { id, query, highlightedMessage, streams, filterFields, timerange } = this._value;
+    const { id, query, highlightedMessage, streams, streamCategories, filterFields, timerange } = this._value;
     const queryWithFilterFields = _mergeFilterFieldsToQuery(query, filterFields);
 
     const searchTimerange = timerange ? timeRangeToQueryParameter(timerange) : {};
@@ -102,10 +109,14 @@ export default class SearchLink {
       ? { ...params, streams: streams.join(',') }
       : params;
 
+    const paramsWithStreamsAndCategories = streamCategories && streamCategories.length > 0
+      ? { ...params, stream_categories: streamCategories.join(',') }
+      : paramsWithStreams;
+
     const urlPrefix = id ? `${Routes.SEARCH}/${id}` : Routes.SEARCH;
 
     const uri = new URI(urlPrefix)
-      .setSearch(paramsWithStreams);
+      .setSearch(paramsWithStreamsAndCategories);
 
     return uri.toString();
   }
@@ -136,6 +147,10 @@ class Builder {
     return new Builder(this.value.set('streams', value));
   }
 
+  streamCategories(value: InternalState['streamCategories']) {
+    return new Builder(this.value.set('streamCategories', value));
+  }
+
   highlightedMessage(value: InternalState['highlightedMessage']) {
     return new Builder(this.value.set('highlightedMessage', value));
   }
@@ -150,10 +165,11 @@ class Builder {
       timerange,
       query,
       streams,
+      streamCategories,
       highlightedMessage,
       filterFields,
     } = this.value.toObject();
 
-    return new SearchLink(id, timerange, query, streams, highlightedMessage, filterFields);
+    return new SearchLink(id, timerange, query, streams, streamCategories, highlightedMessage, filterFields);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds Stream Categories of searches to the URL and Search Replay logic

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
maintain stream categories when navigating through history like streams currently are

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

