### PR TITLE
Backport 5.2: Fix unescaped double quotes in nested event fields for TeamsNotificationV2 

### DIFF
--- a/changelog/unreleased/pr-20389.toml
+++ b/changelog/unreleased/pr-20389.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed issue where invalid JSON characters being unescaped broke TeamsNotificationV2 notifications."
+
+pulls = ["20389"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2.java
@@ -19,6 +19,7 @@ package org.graylog.integrations.notifications.types.microsoftteams;
 import com.floreysoft.jmte.Engine;
 import com.google.common.annotations.VisibleForTesting;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationException;
@@ -40,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,7 +51,7 @@ public class TeamsEventNotificationV2 implements EventNotification {
 
     private static final Logger LOG = LoggerFactory.getLogger(TeamsEventNotificationV2.class);
     private final EventNotificationService notificationCallbackService;
-    private final Engine templateEngine;
+    private final Engine jsonTemplateEngine;
     private final NotificationService notificationService;
     private final ObjectMapperProvider objectMapperProvider;
     private final NodeId nodeId;
@@ -61,13 +61,13 @@ public class TeamsEventNotificationV2 implements EventNotification {
     @Inject
     public TeamsEventNotificationV2(EventNotificationService notificationCallbackService,
                                     ObjectMapperProvider objectMapperProvider,
-                                    Engine templateEngine,
+                                    @Named("JsonSafe") Engine jsonTemplateEngine,
                                     NotificationService notificationService,
                                     NodeId nodeId, RequestClient requestClient,
                                     HttpConfiguration httpConfiguration) {
         this.notificationCallbackService = notificationCallbackService;
         this.objectMapperProvider = requireNonNull(objectMapperProvider);
-        this.templateEngine = requireNonNull(templateEngine);
+        this.jsonTemplateEngine = requireNonNull(jsonTemplateEngine);
         this.notificationService = requireNonNull(notificationService);
         this.nodeId = requireNonNull(nodeId);
         this.requestClient = requireNonNull(requestClient);
@@ -121,7 +121,7 @@ public class TeamsEventNotificationV2 implements EventNotification {
         final List<MessageSummary> backlog = getMessageBacklog(ctx, config);
         Map<String, Object> model = getCustomMessageModel(ctx, config.type(), backlog, config.timeZone());
         try {
-            return templateEngine.transform(config.adaptiveCard(), model);
+            return jsonTemplateEngine.transform(config.adaptiveCard(), model);
         } catch (Exception e) {
             String error = "Invalid Custom Message template.";
             LOG.error("{} [{}]", error, e.toString());
@@ -146,17 +146,8 @@ public class TeamsEventNotificationV2 implements EventNotification {
         final Map<String, Object> objectMap = objectMapperProvider.getForTimeZone(timeZone).convertValue(modelData, TypeReferences.MAP_STRING_OBJECT);
         objectMap.put("type", type);
         objectMap.put("http_external_uri", this.httpExternalUri);
-        final Map<String, Object> escapedModelMap = new HashMap<>();
-        objectMap.forEach((k, v) -> {
-            if (v instanceof String str) {
-                escapedModelMap.put(k, str.replace("\"", "\\\""));
-            } else {
-                escapedModelMap.put(k, v);
-            }
-        });
-        LOG.debug("Finalized model map: {}", escapedModelMap);
 
-        return escapedModelMap;
+        return objectMap;
     }
 
     public interface Factory extends EventNotification.Factory<TeamsEventNotificationV2> {

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2Test.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.integrations.notifications.types.microsoftteams;
 
-import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -30,6 +29,7 @@ import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.integrations.notifications.types.util.RequestClient;
+import org.graylog2.bindings.providers.JsonSafeEngineProvider;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
@@ -65,6 +65,107 @@ public class TeamsEventNotificationV2Test {
     TeamsEventNotificationV2 teamsEventNotification;
 
     private final NodeId nodeId = new SimpleNodeId("12345");
+    private final MessageFactory messageFactory = new TestMessageFactory();
+    private final String defaultTemplate = """
+            {  "type": "message",
+              "attachments": [
+                {
+                  "contentType": "application/vnd.microsoft.card.adaptive",
+                  "content": {
+                    "type": "AdaptiveCard",
+                    "version": "1.6",
+                    "msTeams": { "width": "full" },
+                    "body": [
+                      {
+                        "type": "TextBlock",
+                        "size": "Large",
+                        "weight": "Bolder",
+                        "text": "${event_definition_title} triggered",
+                        "style": "heading",
+                        "fontType": "Default"
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "${event_definition_description}",
+                        "wrap": true
+                      },
+                      {
+                        "type": "TextBlock",
+                        "text": "Event Details",
+                        "wrap": true
+                      },
+                      {
+                        "type": "FactSet",
+                        "facts": [
+                          {
+                            "title": "Type",
+                            "value": "${event_definition_type}"
+                          },
+                          {
+                            "title": "Timestamp",
+                            "value": "${event.timestamp_processing}"
+                          },
+                          {
+                            "title": "Message",
+                            "value": "${event.message}"
+                          },
+                          {
+                            "title": "Source",
+                            "value": "${event.source}"
+                          },
+                          {
+                            "title": "Key",
+                            "value": "${event.key}"
+                          },
+                          {
+                            "title": "Priority",
+                            "value": "${event.priority}"
+                          },
+                          {
+                            "title": "Alert",
+                            "value": "${event.alert}"
+                          },
+                          {
+                            "title": "Timerange Start",
+                            "value": "${event.timerange_start}"
+                          },
+                          {
+                            "title": "Timerange End",
+                            "value": "${event.timerange_end}"
+                          }
+                        ]
+                      }${if event.fields},
+                      {
+                        "type": "TextBlock",
+                        "text": "Event Fields",
+                        "weight": "bolder",
+                        "size": "medium"
+                      },
+                      {
+                        "type": "FactSet",
+                        "facts": [${foreach event.fields field}
+                          { "title": "${field.key}", "value": "${field.value}" }${if last_field}${else},${end}${end}
+                        ]
+                      }${end}${if backlog},
+                      {
+                        "type": "TextBlock",
+                        "text": "Backlog",
+                        "weight": "bolder",
+                        "size": "medium"
+                      },
+                      {
+                        "type": "FactSet",
+                        "facts": [${foreach backlog message}
+                          { "title": "Message", "value": "${message.message}" }${if last_message}${else},${end}${end}
+                        ]
+                      }${end}
+                    ],
+                    "$schema": "[http://adaptivecards.io/schemas/adaptive-card.json](https://link.edgepilot.com/s/8e5962e4/2Jj9cedkLka5KIsBRuMOIg?u=http://adaptivecards.io/schemas/adaptive-card.json)",
+                    "rtl": false
+                  }
+                }
+              ]
+            }""";
 
     @Mock
     NotificationService mockNotificationService;
@@ -87,7 +188,7 @@ public class TeamsEventNotificationV2Test {
 
         teamsEventNotification = new TeamsEventNotificationV2(notificationCallbackService,
                 new ObjectMapperProvider(),
-                Engine.createEngine(),
+                new JsonSafeEngineProvider().get(),
                 mockNotificationService,
                 nodeId,
                 mockrequestClient,
@@ -95,15 +196,22 @@ public class TeamsEventNotificationV2Test {
     }
 
     @Test
-    public void testEscapedQuotes() {
+    public void testEscapedQuotes() throws PermanentEventNotificationException {
         if (eventNotificationContext.eventDefinition().isPresent()) {
             EventDefinitionDto definition = eventNotificationContext.eventDefinition().get();
             definition = definition.toBuilder().description("A Description with \"Double Quotes\"").build();
             eventNotificationContext = eventNotificationContext.toBuilder().eventDefinition(definition).build();
         }
-        List<MessageSummary> messageSummaries = generateMessageSummaries(50);
-        Map<String, Object> customMessageModel = teamsEventNotification.getCustomMessageModel(eventNotificationContext, notificationConfig.type(), messageSummaries, DateTimeZone.UTC);
-        assertThat(customMessageModel.get("event_definition_description")).isEqualTo("A Description with \\\"Double Quotes\\\"");
+        when(notificationCallbackService.getBacklogForEvent(any())).thenReturn(generateMessageSummariesWithDoubleQuotes(5));
+        TeamsEventNotificationConfigV2 config = TeamsEventNotificationConfigV2.builder()
+                .adaptiveCard(defaultTemplate)
+                .backlogSize(5)
+                .timeZone(DateTimeZone.UTC)
+                .webhookUrl("http://localhost:12345")
+                .build();
+        String body = teamsEventNotification.generateBody(eventNotificationContext, config);
+        assertThat(body).contains("A Description with \\\"Double Quotes\\\"");
+        assertThat(body).contains("Test message1 with \\\"Double Quotes\\\"");
     }
 
     @Test
@@ -239,6 +347,15 @@ public class TeamsEventNotificationV2Test {
         List<MessageSummary> messageSummaries = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             MessageSummary summary = new MessageSummary("graylog_" + i, new Message("Test message_" + i + " : with a colon and another colon : just for good measure", "source" + i, new DateTime(2020, 9, 6, 17, 0, DateTimeZone.UTC)));
+            messageSummaries.add(summary);
+        }
+        return ImmutableList.copyOf(messageSummaries);
+    }
+
+    private ImmutableList<MessageSummary> generateMessageSummariesWithDoubleQuotes(int size) {
+        List<MessageSummary> messageSummaries = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            MessageSummary summary = new MessageSummary("graylog_" + i, new Message("Test message" + i + " with \"Double Quotes\"", "source" + i, new DateTime(2020, 9, 6, 17, 0, DateTimeZone.UTC)));
             messageSummaries.add(summary);
         }
         return ImmutableList.copyOf(messageSummaries);


### PR DESCRIPTION
Backport #20389 to 5.2

* Fix unescaped double quotes in nested event fields for TeamsNotificationV2

* Changelog

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

