### PR TITLE
Fixing large plot legends for non-interactive contexts.

### DIFF
--- a/changelog/unreleased/pr-20426.toml
+++ b/changelog/unreleased/pr-20426.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixing plot legend for larger label sets."
+
+pulls = ["20426"]

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -178,10 +178,14 @@ const TableCell = ({ value, fieldTypes, activeQuery, labelFields }: TableCellPro
   );
 };
 
-const InteractiveLegend = ({ config, labelFields, labels }: Pick<Props, 'config' | 'labelFields'> & { labels: Array<string> }) => {
+type LegendComponentProps = Pick<Props, 'config' | 'labelFields'> & {
+  activeQuery: string,
+  fieldTypes: FieldTypes,
+  labels: Array<string>,
+};
+
+const InteractiveLegend = ({ activeQuery, config, fieldTypes, labelFields, labels }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
-  const fieldTypes = useContext(FieldTypesContext);
-  const activeQuery = useActiveQueryId();
   const tableCells = labels.sort(stringLenSort).map((value) => (
     <TableCell key={value}
                value={value}
@@ -210,10 +214,8 @@ const FlexLegendContainer = styled.div`
   flex-wrap: wrap;
 `;
 
-const NoninteractiveLegend = ({ config, labels, labelFields }: Pick<Props, 'config' | 'labelFields'> & { labels: Array<string> }) => {
+const NoninteractiveLegend = ({ activeQuery, config, fieldTypes, labels, labelFields }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
-  const fieldTypes = useContext(FieldTypesContext);
-  const activeQuery = useActiveQueryId();
 
   return (
     <FlexLegendContainer>
@@ -243,20 +245,20 @@ const PlotLegend = ({
   const { focusedWidget } = useContext(WidgetFocusContext);
   const interactive = useContext(InteractiveContext);
   const labels: Array<string> = labelMapper(chartData);
+  const fieldTypes = useContext(FieldTypesContext);
+  const activeQuery = useActiveQueryId();
 
   if (!neverHide && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
   }
 
-  const legend = interactive
-    ? <InteractiveLegend config={config} labelFields={labelFields} labels={labels} />
-    : <NoninteractiveLegend config={config} labelFields={labelFields} labels={labels} />;
+  const LegendComponent = interactive ? InteractiveLegend : NoninteractiveLegend;
 
   return (
     <Container>
       {children}
-      {legend}
+      <LegendComponent activeQuery={activeQuery} config={config} fieldTypes={fieldTypes} labelFields={labelFields} labels={labels} />
     </Container>
   );
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is improving plot legend rendering for non-interactive contexts (reporting, rendering, big display mode), by rendering it differently. Instead of a chunked, height-limited rendering, we do use flex to render a single row (with wrapping) taking up as much space as required.

Fixes Graylog2/graylog-plugin-enterprise#8199
Fixes Graylog2/graylog-plugin-enterprise#8315

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/6d20f2d0-be58-4c1c-aeec-20becadeafbb)

After (Misplaced/cut-off pie chart will be addressed in separate PR):
![image](https://github.com/user-attachments/assets/7a3f23f7-3dbb-44a2-82fc-ec5f0753f494)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.