### PR TITLE
Prevent charts from being cut off.

### DIFF
--- a/changelog/unreleased/pr-20426.toml
+++ b/changelog/unreleased/pr-20426.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixing plot legend for larger label sets."
+
+pulls = ["20426"]

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -169,7 +169,6 @@ const exports: PluginExports = {
       type: 'MESSAGES',
       displayName: 'Message List',
       defaultHeight: 5,
-      reportStyle: () => ({ width: 800 }),
       defaultWidth: 6,
       // TODO: Subtyping needs to be taken into account
       visualizationComponent: MessageList as unknown as React.ComponentType<WidgetComponentProps>,
@@ -185,7 +184,6 @@ const exports: PluginExports = {
       displayName: 'Results',
       defaultHeight: 4,
       defaultWidth: 4,
-      reportStyle: () => ({ width: 600 }),
       visualizationComponent: AggregationBuilder,
       editComponent: AggregationWizard,
       hasEditSubmitButton: true,

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -28,7 +28,6 @@ import type { OnVisualizationConfigChange } from 'views/components/aggregationwi
 import OnVisualizationConfigChangeContext from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
-import FullSizeContainer from './FullSizeContainer';
 
 const defaultVisualizationType = 'table';
 
@@ -94,6 +93,8 @@ const AggregationBuilder = ({
   fields,
   toggleEdit,
   setLoadingState,
+  height,
+  width,
 }: WidgetComponentProps<AggregationWidgetConfig>) => {
   const onVisualizationConfigChange = useContext(OnVisualizationConfigChangeContext);
 
@@ -113,20 +114,16 @@ const AggregationBuilder = ({
   ) as VisualizationResult;
 
   return (
-    <FullSizeContainer>
-      {({ height, width }) => (
-        <VisComponent config={config}
-                      data={rows}
-                      setLoadingState={setLoadingState}
-                      effectiveTimerange={effectiveTimerange}
-                      editing={editing}
-                      fields={fields}
-                      height={height}
-                      width={width}
-                      toggleEdit={toggleEdit}
-                      onChange={onVisualizationConfigChange} />
-      )}
-    </FullSizeContainer>
+    <VisComponent config={config}
+                  data={rows}
+                  setLoadingState={setLoadingState}
+                  effectiveTimerange={effectiveTimerange}
+                  editing={editing}
+                  fields={fields}
+                  height={height}
+                  width={width}
+                  toggleEdit={toggleEdit}
+                  onChange={onVisualizationConfigChange} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.ts
@@ -18,6 +18,7 @@ import flatten from 'lodash/flatten';
 import flow from 'lodash/flow';
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
+import type { PlotData } from 'plotly.js';
 
 import type { Key, Leaf, Row, Rows, Value } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -29,7 +30,7 @@ import transformKeys from './TransformKeys';
 const keySeparator = '\u2E31';
 const humanSeparator = '-';
 
-export type ChartDefinition = {
+export type ChartDefinition = Partial<Omit<PlotData, 'type' | 'colorbar'>> & {
   type: string,
   name: string,
   x?: Array<string>,
@@ -62,6 +63,7 @@ export type ChartDefinition = {
   width?: number,
   offset?: number,
   fullPath?: string,
+  values?: unknown[],
 };
 
 type FullTracePath = string;
@@ -71,8 +73,10 @@ export type ValuesBySeries = { [key: string]: Array<number> };
 
 export type KeyJoiner = (keys: Array<any>) => string;
 
+type ChartType = string;
+
 type ChartInput = {
-  type: string,
+  type: ChartType,
   name: string,
   originalName: string,
   labels: Array<string>,
@@ -136,7 +140,7 @@ export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValu
 };
 
 export const generateChart = (
-  chartType: string,
+  chartType: ChartType,
   generator: Generator = _defaultChartGenerator,
   config: AggregationWidgetConfig = undefined,
   mapKeys: KeyMapper = (key) => key,
@@ -170,7 +174,7 @@ const doNotSuffixTraceForSingleSeries = (keys: Array<Key>) => (keys.length > 1 ?
 
 export type ChartDataConfig = {
   widgetConfig: AggregationWidgetConfig,
-  chartType: string,
+  chartType: ChartType,
   generator?: Generator,
   seriesFormatter?: (values: { valuesBySeries: ValuesBySeries, xLabels: Array<any> }) => ExtractedSeries,
   leafValueMatcher?: (value: Value) => boolean,

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -54,7 +54,11 @@ const SUT = ({ chartDataProp = chartData, plotConfig = config, neverHide = false
   }}>
 
     <ChartColorContext.Provider value={{ colors, setColor }}>
-      <PlotLegend config={plotConfig} chartData={chartDataProp} neverHide={neverHide}>
+      <PlotLegend config={plotConfig}
+                  chartData={chartDataProp}
+                  height={480}
+                  width={640}
+                  neverHide={neverHide}>
         <div>Plot</div>
       </PlotLegend>
     </ChartColorContext.Provider>

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -88,7 +88,7 @@ const LegendEntryContainer = styled.div`
 `;
 
 const ValueContainer = styled.div`
-  margin-left: 8px;
+  margin-left: 5px;
   line-height: 1;
 `;
 
@@ -223,7 +223,7 @@ const InteractiveLegend = ({ activeQuery, config, fieldTypes, labelFields, label
 
 const FlexLegendContainer = styled.div`
   display: flex;
-  gap: 5px;
+  gap: 8px;
   flex-wrap: wrap;
 `;
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -35,6 +35,7 @@ import type { ChartDefinition } from 'views/components/visualizations/ChartData'
 import { keySeparator, humanSeparator } from 'views/Constants';
 import useMapKeys from 'views/components/visualizations/useMapKeys';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import WidgetRenderingContext from 'views/components/widgets/WidgetRenderingContext';
 
 const ColorHint = styled.div(({ color }) => css`
   cursor: pointer;
@@ -44,12 +45,22 @@ const ColorHint = styled.div(({ color }) => css`
   height: 12px;
 `);
 
-const Container = styled.div`
+const FixedContainer = styled.div<{ $height: number, $width: number }>`
   display: grid;
   grid-template: 4fr auto / 1fr;
   grid-template-areas: '.' '.';
   height: 100%;
 `;
+
+const VariableContainer = styled.div<{ $height: number, $width: number }>(({ $height, $width }) => css`
+  display: grid;
+  width: ${$width}px;
+  grid-template-columns: ${$width}px;
+  grid-template-rows: ${$height}px auto;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  justify-content: center;
+`);
 
 const LegendContainer = styled.div`
   padding: 5px;
@@ -88,6 +99,8 @@ type Props = {
   labelFields?: (config: Props['config']) => Array<string>,
   labelMapper?: (data: Array<any>) => Array<string> | undefined | null,
   neverHide?: boolean,
+  height: number,
+  width: number,
 };
 
 const defaultLabelMapper = (data: Array<Pick<ChartDefinition, 'name' | 'originalName'>>) => data.map(({
@@ -240,22 +253,27 @@ const PlotLegend = ({
   labelMapper = defaultLabelMapper,
   labelFields = columnPivotsToFields,
   neverHide,
+  height,
+  width,
 }: Props) => {
   const { columnPivots, series } = config;
   const { focusedWidget } = useContext(WidgetFocusContext);
   const interactive = useContext(InteractiveContext);
-  const labels: Array<string> = labelMapper(chartData);
   const fieldTypes = useContext(FieldTypesContext);
+  const { limitHeight } = useContext(WidgetRenderingContext);
+
+  const labels = labelMapper(chartData);
   const activeQuery = useActiveQueryId();
+  const Container = limitHeight ? FixedContainer : VariableContainer;
 
   if (!neverHide && !focusedWidget?.editing && series.length <= 1 && columnPivots.length <= 0) {
-    return <>{children}</>;
+    return <Container $height={height} $width={width}>{children}</Container>;
   }
 
   const LegendComponent = interactive ? InteractiveLegend : NoninteractiveLegend;
 
   return (
-    <Container>
+    <Container $height={height} $width={width}>
       {children}
       <LegendComponent activeQuery={activeQuery} config={config} fieldTypes={fieldTypes} labelFields={labelFields} labels={labels} />
     </Container>

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -248,7 +248,7 @@ const PlotLegend = ({
   const fieldTypes = useContext(FieldTypesContext);
   const activeQuery = useActiveQueryId();
 
-  if (!neverHide && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
+  if (!neverHide && !focusedWidget?.editing && series.length <= 1 && columnPivots.length <= 0) {
     return <>{children}</>;
   }
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -57,8 +57,8 @@ const VariableContainer = styled.div<{ $height: number, $width: number }>(({ $he
   width: ${$width}px;
   grid-template-columns: ${$width}px;
   grid-template-rows: ${$height}px auto;
-  grid-column-gap: 0px;
-  grid-row-gap: 0px;
+  grid-column-gap: 0;
+  grid-row-gap: 0;
   justify-content: center;
 `);
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -178,10 +178,14 @@ const TableCell = ({ value, fieldTypes, activeQuery, labelFields }: TableCellPro
   );
 };
 
-const InteractiveLegend = ({ config, labelFields, labels }: Pick<Props, 'config' | 'labelFields'> & { labels: Array<string> }) => {
+type LegendComponentProps = Pick<Props, 'config' | 'labelFields'> & {
+  activeQuery: string,
+  fieldTypes: FieldTypes,
+  labels: Array<string>,
+};
+
+const InteractiveLegend = ({ activeQuery, config, fieldTypes, labelFields, labels }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
-  const fieldTypes = useContext(FieldTypesContext);
-  const activeQuery = useActiveQueryId();
   const tableCells = labels.sort(stringLenSort).map((value) => (
     <TableCell key={value}
                value={value}
@@ -210,10 +214,8 @@ const FlexLegendContainer = styled.div`
   flex-wrap: wrap;
 `;
 
-const NoninteractiveLegend = ({ config, labels, labelFields }: Pick<Props, 'config' | 'labelFields'> & { labels: Array<string> }) => {
+const NoninteractiveLegend = ({ activeQuery, config, fieldTypes, labels, labelFields }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
-  const fieldTypes = useContext(FieldTypesContext);
-  const activeQuery = useActiveQueryId();
 
   return (
     <FlexLegendContainer>
@@ -243,20 +245,20 @@ const PlotLegend = ({
   const { focusedWidget } = useContext(WidgetFocusContext);
   const interactive = useContext(InteractiveContext);
   const labels: Array<string> = labelMapper(chartData);
+  const fieldTypes = useContext(FieldTypesContext);
+  const activeQuery = useActiveQueryId();
 
   if (!neverHide && (!focusedWidget || !focusedWidget.editing) && series.length <= 1 && columnPivots.length <= 0) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <>{children}</>;
   }
 
-  const legend = interactive
-    ? <InteractiveLegend config={config} labelFields={labelFields} labels={labels} />
-    : <NoninteractiveLegend config={config} labelFields={labelFields} labels={labels} />;
+  const LegendComponent = interactive ? InteractiveLegend : NoninteractiveLegend;
 
   return (
     <Container>
       {children}
-      {legend}
+      <LegendComponent activeQuery={activeQuery} config={config} fieldTypes={fieldTypes} labelFields={labelFields} labels={labels} />
     </Container>
   );
 };

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -42,7 +42,8 @@ export type Props = {
     from: string,
     to: string,
   },
-  height?: number;
+  height: number;
+  width: number;
   setChartColor?: (config: ChartConfig, color: ColorMapper) => ChartColor,
   plotLayout?: Partial<PlotLayout>,
   onZoom?: (from: string, to: string, userTimezone: string) => boolean,
@@ -77,6 +78,7 @@ const XYPlot = ({
   effectiveTimerange,
   setChartColor,
   height,
+  width,
   plotLayout = {},
   onZoom,
 }: Props) => {
@@ -115,7 +117,7 @@ const XYPlot = ({
   }
 
   return (
-    <PlotLegend config={config} chartData={chartData}>
+    <PlotLegend config={config} chartData={chartData} height={height} width={width}>
       <GenericPlot chartData={chartData}
                    layout={layout}
                    onZoom={_onZoom}
@@ -145,7 +147,6 @@ XYPlot.defaultProps = {
   setChartColor: defaultSetColor,
   effectiveTimerange: undefined,
   onZoom: undefined,
-  height: undefined,
 };
 
 export default XYPlot;

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -68,6 +68,8 @@ describe('XYPlot', () => {
         <XYPlot chartData={chartData}
                 config={config}
                 setChartColor={setChartColor}
+                height={480}
+                width={640}
                 {...props} />
       </TestStoreProvider>
     );

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -97,6 +97,7 @@ describe('XYPlot', () => {
       yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: 'linear' },
       xaxis: { fixedrange: true },
       hovermode: 'x',
+      legend: { y: -0.14 },
     });
 
     expect(genericPlot).toHaveProp('chartData', chartData);

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -38,6 +38,7 @@ const AreaVisualization = makeVisualization(({
   data,
   effectiveTimerange,
   height,
+  width,
 }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig || AreaVisualizationConfig.empty()) as AreaVisualizationConfig;
   const getChartDataSettingsWithCustomUnits = useChartDataSettingsWithCustomUnits({ config });
@@ -85,6 +86,7 @@ const AreaVisualization = makeVisualization(({
             plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             height={height}
+            width={width}
             chartData={chartDataResult} />
   );
 }, 'area');

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -108,7 +108,7 @@ const BarVisualization = makeVisualization(({
       opacity,
       originalName,
       ...getBarChartDataSettingsWithCustomUnits({ originalName, name, fullPath, values, idx, total, xAxisItemsLength: mappedKeys.length }),
-    }) as ChartDefinition;
+    });
   },
   [visualizationConfig?.opacity, _mapKeys, getBarChartDataSettingsWithCustomUnits]);
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -81,6 +81,7 @@ const BarVisualization = makeVisualization(({
   data,
   effectiveTimerange,
   height,
+  width,
 }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig ?? BarVisualizationConfig.empty()) as BarVisualizationConfig;
 
@@ -149,6 +150,7 @@ const BarVisualization = makeVisualization(({
             effectiveTimerange={effectiveTimerange}
             setChartColor={setChartColor}
             height={height}
+            width={width}
             plotLayout={layout} />
   );
 }, 'bar');

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.tsx
@@ -21,7 +21,7 @@ import fill from 'lodash/fill';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
 import type { DefaultTheme } from 'styled-components';
-import { useTheme } from 'styled-components';
+import styled, { useTheme, css } from 'styled-components';
 
 import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -33,6 +33,10 @@ import useMapKeys from 'views/components/visualizations/useMapKeys';
 
 import type { ChartDefinition, ExtractedSeries, ValuesBySeries, Generator } from '../ChartData';
 import GenericPlot from '../GenericPlot';
+
+const Container = styled.div<{ $height: number }>(({ $height }) => css`
+  height: ${$height ? `${$height}px` : '100%'};
+`);
 
 const _generateSeriesTitles = (config, x, y) => {
   const seriesTitles = config.series.map((s) => s.function);
@@ -152,7 +156,7 @@ const _chartLayout = (heatmapData: ChartDefinition[]) => {
 
 const _leafSourceMatcher = ({ source }: { source: string }) => source.endsWith('leaf') && source !== 'row-leaf';
 
-const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+const HeatmapVisualization = makeVisualization(({ config, data, height }: VisualizationComponentProps) => {
   const theme = useTheme();
   const visualizationConfig = (config.visualizationConfig ?? HeatmapVisualizationConfig.empty()) as HeatmapVisualizationConfig;
   const rows = retrieveChartData(data);
@@ -167,7 +171,9 @@ const HeatmapVisualization = makeVisualization(({ config, data }: VisualizationC
   const layout = _chartLayout(heatmapData);
 
   return (
-    <GenericPlot chartData={heatmapData} layout={layout} />
+    <Container $height={height}>
+      <GenericPlot chartData={heatmapData} layout={layout} />
+    </Container>
   );
 }, 'heatmap');
 

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -39,6 +39,7 @@ const LineVisualization = makeVisualization(({
   data,
   effectiveTimerange,
   height,
+  width,
 }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig ?? LineVisualizationConfig.empty()) as LineVisualizationConfig;
   const getChartDataSettingsWithCustomUnits = useChartDataSettingsWithCustomUnits({ config });
@@ -84,6 +85,7 @@ const LineVisualization = makeVisualization(({
             axisType={axisType}
             effectiveTimerange={effectiveTimerange}
             height={height}
+            width={width}
             chartData={chartDataResult} />
   );
 }, 'line');

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useContext, useEffect, useRef } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
@@ -31,22 +31,23 @@ import ElementDimensions from 'components/common/ElementDimensions';
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
 
-const GridContainer = styled.div`
+const Container = styled.div<{ $height: number }>(({ $height }) => css`
+  height: ${$height}px;
+  width: 100%;
+`);
+
+const GridContainer = styled(Container)`
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: 1fr auto;
   grid-gap: 0;
-  height: 100%;
-  width: 100%;
 `;
 
-const SingleItemGrid = styled.div`
+const SingleItemGrid = styled(Container)`
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: 1fr;
   grid-gap: 0;
-  height: 100%;
-  width: 100%;
 `;
 
 const NumberBox = styled(ElementDimensions)`
@@ -86,7 +87,7 @@ const _extractFirstSeriesName = (config) => {
     : series[0].function;
 };
 
-const NumberVisualization = ({ config, fields, data }: VisualizationComponentProps) => {
+const NumberVisualization = ({ config, fields, data, height: heightProp }: VisualizationComponentProps) => {
   const targetRef = useRef();
   const onRenderComplete = useContext(RenderCompletionCallback);
   const visualizationConfig = (config.visualizationConfig as NumberVisualizationConfig) ?? NumberVisualizationConfig.create();
@@ -103,10 +104,10 @@ const NumberVisualization = ({ config, fields, data }: VisualizationComponentPro
     return <>N/A</>;
   }
 
-  const Container = visualizationConfig.trend ? GridContainer : SingleItemGrid;
+  const ContainerComponent = visualizationConfig.trend ? GridContainer : SingleItemGrid;
 
   return (
-    <Container>
+    <ContainerComponent $height={heightProp}>
       <NumberBox resizeDelay={20}>
         {({ height, width }) => (
           <AutoFontSizer height={height} width={width} center>
@@ -131,7 +132,7 @@ const NumberVisualization = ({ config, fields, data }: VisualizationComponentPro
           )}
         </TrendBox>
       )}
-    </Container>
+    </ContainerComponent>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -71,7 +71,7 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
   const rowPivots = config?.rowPivots?.flatMap((pivot) => pivot.fields) ?? [];
   const extendedSettings = getPieChartDataSettingsWithCustomUnits({ values, name, fullPath });
 
-  const definition = {
+  return {
     type,
     name,
     hole: 0.4,
@@ -79,7 +79,6 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
     originalLabels: labels,
     values,
     automargin: true,
-    outsidetextfont: { color: 'transparent' },
     textposition: 'inside',
     domain: {
       x: _horizontalDimensions(idx, total),
@@ -88,8 +87,6 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
     originalName,
     ...extendedSettings,
   };
-
-  return definition;
 };
 
 const setChartColor = (chart: ChartConfig, colorMap: ColorMapper) => {

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -104,14 +104,14 @@ const labelMapper = (data: Array<{ labels: Array<string>, originalLabels?: Array
 
 const rowPivotsToFields = (config: AggregationWidgetConfig) => config?.rowPivots?.flatMap((pivot) => pivot.fields);
 
-const PieVisualization = makeVisualization(({ config, data }: VisualizationComponentProps) => {
+const PieVisualization = makeVisualization(({ config, data, height, width }: VisualizationComponentProps) => {
   const rows = useMemo(() => retrieveChartData(data), [data]);
   const mapKeys = useMapKeys();
   const getPieChartDataSettingsWithCustomUnits = usePieChartDataSettingsWithCustomUnits({ config });
   const transformedData = useChartData(rows, { widgetConfig: config, chartType: 'pie', generator: _generateSeries(mapKeys, getPieChartDataSettingsWithCustomUnits) });
 
   return (
-    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} labelFields={rowPivotsToFields} neverHide>
+    <PlotLegend config={config} chartData={transformedData} labelMapper={labelMapper} labelFields={rowPivotsToFields} neverHide height={height} width={width}>
       <GenericPlot chartData={transformedData}
                    setChartColor={setChartColor} />
     </PlotLegend>

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -78,6 +78,8 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
     labels: labels.map((label) => label.split(keySeparator).map((l, i) => mapKeys(l, rowPivots[i])).join(humanSeparator)),
     originalLabels: labels,
     values,
+    automargin: true,
+    rotation: 70,
     domain: {
       x: _horizontalDimensions(idx, total),
       y: _verticalDimensions(idx, total),

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -79,7 +79,8 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
     originalLabels: labels,
     values,
     automargin: true,
-    rotation: 70,
+    outsidetextfont: { color: 'transparent' },
+    textposition: 'inside',
     domain: {
       x: _horizontalDimensions(idx, total),
       y: _verticalDimensions(idx, total),

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -38,6 +38,7 @@ const ScatterVisualization = makeVisualization(({
   data,
   effectiveTimerange,
   height,
+  width,
 }: VisualizationComponentProps) => {
   const visualizationConfig = (config.visualizationConfig ?? ScatterVisualizationConfig.empty()) as ScatterVisualizationConfig;
   const getChartDataSettingsWithCustomUnits = useChartDataSettingsWithCustomUnits({ config });
@@ -78,6 +79,7 @@ const ScatterVisualization = makeVisualization(({
             chartData={chartDataResult}
             plotLayout={layout}
             height={height}
+            width={width}
             effectiveTimerange={effectiveTimerange} />
   );
 }, 'scatter');

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -140,6 +140,8 @@ describe('MessageList', () => {
                    data={props.data}
                    config={props.config}
                    fields={props.fields}
+                   height={480}
+                   width={640}
                    {...props} />
     </TestStoreProvider>
   );

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -45,6 +45,7 @@ import useAutoRefresh from 'views/hooks/useAutoRefresh';
 import useViewType from 'views/hooks/useViewType';
 import View from 'views/logic/views/View';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
+import FullSizeContainer from 'views/components/aggregationbuilder/FullSizeContainer';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -122,18 +123,24 @@ const Visualization = ({
     const { config, filter } = widget;
 
     return (
-      <VisComponent config={config}
-                    data={data as WidgetResults}
-                    editing={editing}
-                    fields={fields}
-                    filter={filter}
-                    queryId={queryId}
-                    onConfigChange={onWidgetConfigChange}
-                    setLoadingState={setLoadingState}
-                    title={title}
-                    toggleEdit={onToggleEdit}
-                    type={widget.type}
-                    id={id} />
+      <FullSizeContainer>
+        {({ height, width }) => (
+          <VisComponent config={config}
+                        data={data as WidgetResults}
+                        editing={editing}
+                        fields={fields}
+                        filter={filter}
+                        queryId={queryId}
+                        onConfigChange={onWidgetConfigChange}
+                        setLoadingState={setLoadingState}
+                        title={title}
+                        toggleEdit={onToggleEdit}
+                        type={widget.type}
+                        id={id}
+                        height={height}
+                        width={width} />
+        )}
+      </FullSizeContainer>
     );
   }
 

--- a/graylog2-web-interface/src/views/components/widgets/WidgetRenderingContext.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetRenderingContext.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 
 import { singleton } from 'logic/singleton';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetRenderingContext.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetRenderingContext.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { singleton } from 'logic/singleton';
+
+type WidgetRendering = {
+  limitHeight: boolean,
+};
+
+const defaultWidgetRendering = {
+  limitHeight: true,
+};
+const WidgetRenderingContext = React.createContext<WidgetRendering>(defaultWidgetRendering);
+export default singleton('contexts.WidgetRenderingContext', () => WidgetRenderingContext);

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
@@ -87,6 +87,8 @@ describe('EventsList', () => {
                   data={props.data}
                   config={props.config}
                   fields={props.fields}
+                  height={480}
+                  width={640}
                   {...props} />
     </TestStoreProvider>
   );

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.ts
@@ -124,7 +124,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   get isEmpty(): boolean {
-    const empty = (arr) => !arr.length;
+    const empty = (arr: Array<unknown>) => !arr.length;
 
     return empty(this.rowPivots) && empty(this.columnPivots) && empty(this.series);
   }

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -102,8 +102,8 @@ export interface WidgetComponentProps<Config extends WidgetConfig = WidgetConfig
   toggleEdit: () => void;
   type: string;
   id: string;
-  height: number;
-  width: number;
+  height?: number;
+  width?: number;
 }
 
 export interface WidgetExport {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -102,8 +102,8 @@ export interface WidgetComponentProps<Config extends WidgetConfig = WidgetConfig
   toggleEdit: () => void;
   type: string;
   id: string;
-  height?: number;
-  width?: number;
+  height: number;
+  width: number;
 }
 
 export interface WidgetExport {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -102,6 +102,8 @@ export interface WidgetComponentProps<Config extends WidgetConfig = WidgetConfig
   toggleEdit: () => void;
   type: string;
   id: string;
+  height: number;
+  width: number;
 }
 
 export interface WidgetExport {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -94,13 +94,13 @@ export interface WidgetComponentProps<Config extends WidgetConfig = WidgetConfig
   data: Results;
   editing: boolean;
   fields: Immutable.List<FieldTypeMapping>;
-  filter: string;
+  filter?: string;
   queryId: string;
-  onConfigChange: (newConfig: Config) => Promise<void>;
+  onConfigChange?: (newConfig: Config) => Promise<void>;
   setLoadingState: (loading: boolean) => void;
-  title: string;
-  toggleEdit: () => void;
-  type: string;
+  title?: string;
+  toggleEdit?: () => void;
+  type?: string;
   id: string;
   height: number;
   width: number;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -116,7 +116,6 @@ export interface WidgetExport {
   searchResultTransformer?: (data: Array<unknown>) => unknown;
   searchTypes: (widget: Widget) => Array<any>;
   titleGenerator?: (widget: { config: Widget['config'] }) => string;
-  reportStyle?: () => { width: React.CSSProperties['width'] };
   exportComponent?: React.ComponentType<{ widget: Widget }>;
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is doing multiple things to prevent charts from being cut off:

  - Using the `automargin` setting in charts to prevent labels from being cut off by scaling down the chart if necessary
  - Using only "inside" labels in pie charts (avoiding labels outside of the pie chart with lines pointing to the slice, as they do lead to tiny charts with lots of slices
  - Introducing `WidgetRenderingContext` which can specify if a widget has a limited height in the current context (i.e. on dashboards, a widget is constrained by the widget frame, while in reporting/export it is not). This can be used in widgets to have a different layout for these scenarios.

Refs Graylog2/graylog-plugin-enterprise#8248.
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/8605

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.