### PR TITLE
Hide Custom Config attribute in UI column dropdown

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/template/IndexSetTemplateService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/template/IndexSetTemplateService.java
@@ -58,7 +58,7 @@ public class IndexSetTemplateService {
             EntityAttribute.builder().id(TITLE_FIELD_NAME).title("Template Name").sortable(true).searchable(true).build(),
             EntityAttribute.builder().id(DESCRIPTION_FIELD_NAME).title("Template Description").sortable(false).build(),
             EntityAttribute.builder().id(BUILT_IN_FIELD_NAME).type(SearchQueryField.Type.BOOLEAN).title("Is Built-in").sortable(false).searchable(true).build(),
-            EntityAttribute.builder().id(INDEX_SET_CONFIG_FIELD_NAME).title("Custom Config").sortable(false).build()
+            EntityAttribute.builder().id(INDEX_SET_CONFIG_FIELD_NAME).title("Custom Config").hidden(true).sortable(false).build()
     );
 
     private static final EntityDefaults DEFAULTS = EntityDefaults.builder()


### PR DESCRIPTION
/nocl unreleased feature

## Description 
<!--- Provide a general summary of your changes in the Title above -->
Attribute `index_set_config` (title: `Custom Config`) is not intended to be displayed in the UI. Currently you can toggle it on in the indexset template list, resulting in an error message.

Add missing `hidden` annotation.

## How Tested

- Dropdown no longer displays this attribute
- All other columns can be toggled successfully
