### PR TITLE
Fix issue when Unable to save dashboard containing a formattable unit field

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -88,7 +88,7 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
   }, [field, predefinedUnit?.abbrev, predefinedUnit?.isDefined, predefinedUnit?.unitType]);
 
   const onClear = useCallback(() => {
-    setFieldValue(`units.${field}`, { unitType: undefined, abbrev: undefined });
+    setFieldValue(`units.${field}`, undefined);
     toggleShow();
   }, [field, setFieldValue]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The bug happens because we send an empty object as a cleared state. PR set unit to undefined on clear top fix this issue 

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/20399

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl