### PR TITLE
Use name instead of originName in hover labels templates

### DIFF
--- a/changelog/unreleased/issue-20434.toml
+++ b/changelog/unreleased/issue-20434.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Use name instead of originName in hover labels templates to fix that advanced field types not resolved in label texts for charts with custom units"
+
+issues=["20434"]
+pulls=["20453"]

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.tsx
@@ -58,7 +58,7 @@ const AreaVisualization = makeVisualization(({
     fill: 'tozeroy',
     line: { shape: toPlotly(interpolation) },
     originalName,
-    ...getChartDataSettingsWithCustomUnits({ originalName, fullPath, values }),
+    ...getChartDataSettingsWithCustomUnits({ name, fullPath, values }),
   }), [_mapKeys, getChartDataSettingsWithCustomUnits, interpolation]);
 
   const rows = useMemo(() => retrieveChartData(data), [data]);

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -100,7 +100,7 @@ const BarVisualization = makeVisualization(({
     const opacity = visualizationConfig?.opacity ?? 1.0;
     const mappedKeys = _mapKeys(labels);
 
-    return ({
+    const charttD = ({
       type,
       name,
       x: mappedKeys,
@@ -109,6 +109,10 @@ const BarVisualization = makeVisualization(({
       originalName,
       ...getBarChartDataSettingsWithCustomUnits({ originalName, name, fullPath, values, idx, total, xAxisItemsLength: mappedKeys.length }),
     }) as ChartDefinition;
+
+    console.log({ charttD });
+
+    return charttD;
   },
   [visualizationConfig?.opacity, _mapKeys, getBarChartDataSettingsWithCustomUnits]);
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.tsx
@@ -100,7 +100,7 @@ const BarVisualization = makeVisualization(({
     const opacity = visualizationConfig?.opacity ?? 1.0;
     const mappedKeys = _mapKeys(labels);
 
-    const charttD = ({
+    return ({
       type,
       name,
       x: mappedKeys,
@@ -109,10 +109,6 @@ const BarVisualization = makeVisualization(({
       originalName,
       ...getBarChartDataSettingsWithCustomUnits({ originalName, name, fullPath, values, idx, total, xAxisItemsLength: mappedKeys.length }),
     }) as ChartDefinition;
-
-    console.log({ charttD });
-
-    return charttD;
   },
   [visualizationConfig?.opacity, _mapKeys, getBarChartDataSettingsWithCustomUnits]);
 

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/useBarChartDataSettingsWithCustomUnits.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/useBarChartDataSettingsWithCustomUnits.ts
@@ -42,12 +42,12 @@ const useBarChartDataSettingsWithCustomUnits = ({ config, barmode, effectiveTime
   const getChartDataSettingsWithCustomUnits = useChartDataSettingsWithCustomUnits({ config });
 
   return useCallback(({
-    originalName, values, idx, total, xAxisItemsLength, fullPath,
+    values, idx, total, xAxisItemsLength, fullPath, name,
   }: { xAxisItemsLength: number, originalName: string, name: string, values: Array<any>, idx: number, total: number, fullPath: string }):Partial<ChartDefinition> => {
     if (!unitFeatureEnabled) return ({});
 
     const fieldNameKey = getFieldNameFromTrace({ fullPath, series: config.series }) ?? NO_FIELD_NAME_SERIES;
-    const { y: convertedValues, yaxis, ...hoverTemplateSettings } = getChartDataSettingsWithCustomUnits({ originalName, fullPath, values });
+    const { y: convertedValues, yaxis, ...hoverTemplateSettings } = getChartDataSettingsWithCustomUnits({ name, fullPath, values });
     const axisNumber = fieldNameToAxisCountMapper?.[fieldNameKey];
     const totalAxis = Object.keys(unitTypeMapper).length;
 

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.test.ts
@@ -66,7 +66,7 @@ describe('useChartDataSettingsWithCustomUnits', () => {
 
     act(() => {
       chartDataSettingsWithCustomUnits = result.current(
-        { originalName: 'Name1', fullPath: 'Name1', values: [1000, 2000, 3000] },
+        { name: 'Name1', fullPath: 'Name1', values: [1000, 2000, 3000] },
       );
     });
 
@@ -89,7 +89,7 @@ describe('useChartDataSettingsWithCustomUnits', () => {
 
     act(() => {
       chartDataSettingsWithCustomUnits = result.current(
-        { originalName: 'Name2', fullPath: 'Name2', values: [1000, 2000, 3000] },
+        { name: 'Name2', fullPath: 'Name2', values: [1000, 2000, 3000] },
       );
     });
 
@@ -112,7 +112,7 @@ describe('useChartDataSettingsWithCustomUnits', () => {
 
     act(() => {
       chartDataSettingsWithCustomUnits = result.current(
-        { originalName: 'Name3', fullPath: 'Name3', values: [100, 200, 300] },
+        { name: 'Name3', fullPath: 'Name3', values: [100, 200, 300] },
       );
     });
 
@@ -132,7 +132,7 @@ describe('useChartDataSettingsWithCustomUnits', () => {
 
     act(() => {
       chartDataSettingsWithCustomUnits = result.current(
-        { originalName: 'count()', fullPath: 'count()', values: [100, 200, 300] },
+        { name: 'count()', fullPath: 'count()', values: [100, 200, 300] },
       );
     });
 

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.ts
@@ -37,7 +37,7 @@ const useChartDataSettingsWithCustomUnits = ({ config }: {
   const widgetUnits = useWidgetUnits(config);
   const { fieldNameToAxisNameMapper } = useMemo(() => generateMappersForYAxis({ series: config.series, units: widgetUnits }), [config.series, widgetUnits]);
 
-  return useCallback(({ originalName, values, fullPath }: { originalName: string, values: Array<any>, fullPath: string }): Partial<ChartDefinition> => {
+  return useCallback(({ name, values, fullPath }: { name: string, values: Array<any>, fullPath: string }): Partial<ChartDefinition> => {
     if (!unitFeatureEnabled) return ({});
     const fieldNameKey = getFieldNameFromTrace({ fullPath, series: config.series }) ?? NO_FIELD_NAME_SERIES;
     const yaxis = fieldNameToAxisNameMapper[fieldNameKey];
@@ -51,7 +51,7 @@ const useChartDataSettingsWithCustomUnits = ({ config }: {
       yaxis,
       y: convertedValues,
       fullPath,
-      ...getHoverTemplateSettings({ unit, convertedValues, originalName }),
+      ...getHoverTemplateSettings({ unit, convertedValues, name }),
     });
   }, [config.series, fieldNameToAxisNameMapper, unitFeatureEnabled, widgetUnits]);
 };

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/usePieChartDataSettingsWithCustomUnits.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/usePieChartDataSettingsWithCustomUnits.ts
@@ -25,13 +25,13 @@ import getFieldNameFromTrace from 'views/components/visualizations/utils/getFiel
 import { getPieHoverTemplateSettings } from 'views/components/visualizations/utils/chartLayoutGenerators';
 
 export type PieHoverTemplateSettings = { text: Array<string>, hovertemplate: string, meta: string, textinfo: 'percent' };
-export type PieChartDataSettingsWithCustomUnits = (props: { originalName: string, fullPath: string, values: Array<any> }) => PieHoverTemplateSettings | {};
+export type PieChartDataSettingsWithCustomUnits = (props: { name: string, fullPath: string, values: Array<any> }) => PieHoverTemplateSettings | {};
 
 const usePieChartDataSettingsWithCustomUnits = ({ config }: { config: AggregationWidgetConfig }) => {
   const unitFeatureEnabled = useFeature(UNIT_FEATURE_FLAG);
   const widgetUnits = useWidgetUnits(config);
 
-  return useCallback<PieChartDataSettingsWithCustomUnits>(({ originalName, fullPath, values }) => {
+  return useCallback<PieChartDataSettingsWithCustomUnits>(({ name, fullPath, values }) => {
     if (!unitFeatureEnabled) return ({});
 
     const fieldNameKey = getFieldNameFromTrace({ fullPath, series: config.series }) ?? NO_FIELD_NAME_SERIES;
@@ -39,7 +39,7 @@ const usePieChartDataSettingsWithCustomUnits = ({ config }: { config: Aggregatio
 
     return ({
       fullPath,
-      ...getPieHoverTemplateSettings({ convertedValues: values, unit, originalName }),
+      ...getPieHoverTemplateSettings({ convertedValues: values, unit, name }),
     });
   }, [config.series, unitFeatureEnabled, widgetUnits]);
 };

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.tsx
@@ -58,7 +58,7 @@ const LineVisualization = makeVisualization(({
     y: values,
     originalName,
     line: { shape: toPlotly(interpolation) },
-    ...getChartDataSettingsWithCustomUnits({ originalName, fullPath, values }),
+    ...getChartDataSettingsWithCustomUnits({ name, fullPath, values }),
   }), [_mapKeys, getChartDataSettingsWithCustomUnits, interpolation]);
 
   const rows = useMemo(() => retrieveChartData(data), [data]);

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.tsx
@@ -69,7 +69,7 @@ const _generateSeries = (mapKeys: KeyMapper, getPieChartDataSettingsWithCustomUn
   fullPath,
 }): ChartDefinition => {
   const rowPivots = config?.rowPivots?.flatMap((pivot) => pivot.fields) ?? [];
-  const extendedSettings = getPieChartDataSettingsWithCustomUnits({ values, originalName, fullPath });
+  const extendedSettings = getPieChartDataSettingsWithCustomUnits({ values, name, fullPath });
 
   const definition = {
     type,

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.tsx
@@ -56,7 +56,7 @@ const ScatterVisualization = makeVisualization(({
     y: values,
     mode: 'markers',
     originalName,
-    ...getChartDataSettingsWithCustomUnits({ originalName, fullPath: fullPath, values }),
+    ...getChartDataSettingsWithCustomUnits({ name, fullPath: fullPath, values }),
   }), [_mapKeys, getChartDataSettingsWithCustomUnits]);
   const _chartDataResult = useChartData(rows, {
     widgetConfig: config,

--- a/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/chartLayoutGenerators.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/chartLayoutGenerators.test.ts
@@ -187,7 +187,7 @@ describe('Chart Layout Generators', () => {
       const result = getHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: 'ms', unit_type: 'time' }),
-        originalName: 'Name1',
+        name: 'Name1',
       });
 
       expect(result).toEqual({
@@ -205,7 +205,7 @@ describe('Chart Layout Generators', () => {
       const result = getHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: 'b', unit_type: 'size' }),
-        originalName: 'Name2',
+        name: 'Name2',
       });
 
       expect(result).toEqual({
@@ -223,7 +223,7 @@ describe('Chart Layout Generators', () => {
       const result = getHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: '%', unit_type: 'percent' }),
-        originalName: 'Name3',
+        name: 'Name3',
       });
 
       expect(result).toEqual({});
@@ -233,7 +233,7 @@ describe('Chart Layout Generators', () => {
       const result = getHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: null,
-        originalName: 'Name4',
+        name: 'Name4',
       });
 
       expect(result).toEqual({});
@@ -245,7 +245,7 @@ describe('Chart Layout Generators', () => {
       const result = getPieHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: 'ms', unit_type: 'time' }),
-        originalName: 'Name1',
+        name: 'Name1',
       });
 
       expect(result).toEqual({
@@ -264,7 +264,7 @@ describe('Chart Layout Generators', () => {
       const result = getPieHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: 'b', unit_type: 'size' }),
-        originalName: 'Name2',
+        name: 'Name2',
       });
 
       expect(result).toEqual({
@@ -283,7 +283,7 @@ describe('Chart Layout Generators', () => {
       const result = getPieHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: FieldUnit.fromJSON({ abbrev: '%', unit_type: 'percent' }),
-        originalName: 'Name3',
+        name: 'Name3',
       });
 
       expect(result).toEqual({
@@ -302,7 +302,7 @@ describe('Chart Layout Generators', () => {
       const result = getPieHoverTemplateSettings({
         convertedValues: [10, 20, 30],
         unit: null,
-        originalName: 'Name4',
+        name: 'Name4',
       });
 
       expect(result).toEqual({

--- a/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
@@ -320,29 +320,29 @@ const getHoverTexts = ({ convertedValues, unit }: { convertedValues: Array<any>,
   return `${Number(prettified?.value).toFixed(DECIMAL_PLACES)} ${prettified.unit.abbrev}`;
 });
 
-export const getHoverTemplateSettings = ({ convertedValues, unit, originalName }: {
+export const getHoverTemplateSettings = ({ convertedValues, unit, name }: {
   convertedValues: Array<any>,
   unit: FieldUnit,
-  originalName: string,
+  name: string,
 }): { text: Array<string>, hovertemplate: string, meta: string } | {} => {
   if (unit?.unitType === 'time' || unit?.unitType === 'size') {
     return ({
       text: getHoverTexts({ convertedValues, unit }),
       hovertemplate: '%{text}<br><extra>%{meta}</extra>',
-      meta: originalName,
+      meta: name,
     });
   }
 
   return ({});
 };
 
-export const getPieHoverTemplateSettings = ({ convertedValues, unit, originalName }: {
+export const getPieHoverTemplateSettings = ({ convertedValues, unit, name }: {
   convertedValues: Array<any>,
   unit: FieldUnit,
-  originalName: string,
+  name: string,
 }): PieHoverTemplateSettings | {} => ({
   text: getHoverTexts({ convertedValues, unit }),
   hovertemplate: '<b>%{label}</b><br>%{text}<br>%{percent}',
-  meta: originalName,
+  meta: name,
   textinfo: 'percent',
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously we use originalName in hover templates, but in some cases they are only ids of the field with advanced field types. To fix this issue we have to use name instead 
## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/20434

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

