### PR TITLE
Restore original example config for output_batch_size

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -453,7 +453,9 @@ field_value_suggestion_mode = on
 # everything that is available will be flushed at once.
 # Each output buffer processor has to keep an entire batch of messages in memory until it has been sent to
 # Elasticsearch, so increasing this value will also increase the memory requirements of the Graylog server.
-output_batch_size = 10mb
+# Batch sizes can be specified in data units (e.g. bytes, kilobytes, megabytes) or as an absolute number of messages.
+# Example: output_batch_size = 10mb
+output_batch_size = 500
 
 # Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
 # batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages


### PR DESCRIPTION
Restores the original  example config to 

```
output_batch_size = 500
```

to make sure that when the example config is merged during OS package updates, the previously configured value is kept as is. Otherwise it might have been overwritten with

```
output_batch_size = 10mb
```

and cause an unintended change.

/nocl