### PR TITLE
Register GracefullShutdownHook for BatchedFilteredMessageOutput

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/BatchedMessageFilterOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BatchedMessageFilterOutput.java
@@ -32,6 +32,8 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.outputs.FilteredMessageOutput;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
+import org.graylog2.system.shutdown.GracefulShutdownHook;
+import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +47,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -55,7 +56,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  * registered {@link FilteredMessageOutput} outputs.
  */
 @Singleton
-public class BatchedMessageFilterOutput implements MessageOutput {
+public class BatchedMessageFilterOutput implements MessageOutput, GracefulShutdownHook {
     private static final Logger LOG = LoggerFactory.getLogger(BatchedMessageFilterOutput.class);
 
     private final Map<String, FilteredMessageOutput> outputs;
@@ -73,9 +74,9 @@ public class BatchedMessageFilterOutput implements MessageOutput {
     private final MessageQueueAcknowledger acknowledger;
     private final Meter outputWriteFailures;
     private final Timer processTime;
-    private ScheduledFuture<?> flushTask;
+    private final GracefulShutdownService gracefulShutdownService;
     private final IndexSetAwareMessageOutputBuffer buffer;
-    private AtomicBoolean isRunning =  new AtomicBoolean(false);
+    private ScheduledFuture<?> flushTask;
 
     @Inject
     public BatchedMessageFilterOutput(Map<String, FilteredMessageOutput> outputs,
@@ -84,6 +85,7 @@ public class BatchedMessageFilterOutput implements MessageOutput {
                                       Cluster cluster,
                                       MessageQueueAcknowledger acknowledger,
                                       IndexSetAwareMessageOutputBuffer indexSetAwareMessageOutputBuffer,
+                                      GracefulShutdownService gracefulShutdownService,
                                       @Named("output_flush_interval") int outputFlushInterval,
                                       @Named("shutdown_timeout") int shutdownTimeoutMs,
                                       @Named("daemonScheduler") ScheduledExecutorService daemonScheduler) {
@@ -107,6 +109,7 @@ public class BatchedMessageFilterOutput implements MessageOutput {
         this.bufferFlushesRequested = metricRegistry.meter(name(this.getClass(), "bufferFlushesRequested"));
         this.processTime = metricRegistry.timer(name(this.getClass(), "processTime"));
         this.outputWriteFailures = metricRegistry.meter(name(this.getClass(), "outputWriteFailures"));
+        this.gracefulShutdownService = gracefulShutdownService;
     }
 
     @Override
@@ -121,7 +124,7 @@ public class BatchedMessageFilterOutput implements MessageOutput {
                 LOG.error("Caught exception while trying to flush outputs", e);
             }
         }, outputFlushInterval.toMillis(), outputFlushInterval.toMillis(), TimeUnit.MILLISECONDS);
-        isRunning.set(true);
+        gracefulShutdownService.register(this);
     }
 
     @VisibleForTesting
@@ -177,7 +180,7 @@ public class BatchedMessageFilterOutput implements MessageOutput {
 
     @Override
     public boolean isRunning() {
-        return isRunning.get();
+        return true;
     }
 
     @Override
@@ -214,6 +217,16 @@ public class BatchedMessageFilterOutput implements MessageOutput {
     @Override
     public void stop() {
         LOG.debug("Stopping output filter");
+        doGracefulShutdown();
+        try {
+            gracefulShutdownService.unregister(this);
+        } catch (IllegalStateException e) {
+            LOG.debug("Couldn't unregister from graceful shutdown service: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void doGracefulShutdown() {
         cancelFlushTask();
 
         if (cluster.isConnected() && cluster.isDeflectorHealthy()) {
@@ -231,7 +244,6 @@ public class BatchedMessageFilterOutput implements MessageOutput {
                 LOG.warn("Timed out flushing current batch to outputs while stopping.");
             } finally {
                 executorService.shutdownNow();
-                isRunning.set(false);
             }
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BatchedMessageFilterOutputTest.java
@@ -36,6 +36,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
+import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -75,6 +76,8 @@ class BatchedMessageFilterOutputTest {
     private IndexSet indexSet;
     @Mock(extraInterfaces = MessageOutput.class)
     private FilteredMessageOutput targetOutput1;
+    @Mock
+    private GracefulShutdownService gracefulShutdownService;
 
     private static final int MESSAGES_PER_BATCH = 3;
 
@@ -129,6 +132,7 @@ class BatchedMessageFilterOutputTest {
                 cluster,
                 acknowledger,
                 buffer,
+                gracefulShutdownService,
                 outputFlushInterval,
                 shutdownTimeoutMs,
                 Executors.newSingleThreadScheduledExecutor()


### PR DESCRIPTION
/nocl part of unreleased featured
Registering a GracefullShutdownHook for the BatchedMessageOutput to make sure that we shut down this service first before other services get exterminated by the service manager