### PR TITLE
Display only name instead of name with link for node in message details.

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageDetail.tsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.tsx
@@ -30,6 +30,8 @@ import MessagePermalinkButton from 'views/components/common/MessagePermalinkButt
 import type { Message } from 'views/components/messagelist/Types';
 import type { Stream } from 'views/stores/StreamsStore';
 import type { Input } from 'components/messageloaders/Types';
+import { NodesStore } from 'stores/nodes/NodesStore';
+import { useStore } from 'stores/connect';
 
 const Span = styled.span`
   word-break: break-word;
@@ -49,7 +51,9 @@ const InputName = ({ inputs, inputId }: { inputs: Immutable.Map<string, Input> |
   return input ? <Span>{input.title}</Span> : <>deleted input</>;
 };
 
-const NodeName = ({ nodes, nodeId }: { nodes: Immutable.Map<string, { short_node_id: string, hostname: string }> | undefined, nodeId: string }) => {
+const NodeName = ({ nodeId }: { nodeId: string }) => {
+  const nodesStore = useStore(NodesStore);
+  const nodes = Immutable.Map(nodesStore.nodes);
   const node = nodes?.get(nodeId);
   let nodeInformation;
 
@@ -100,13 +104,12 @@ const StreamLinks = ({ messageStreams, streamIds, streams }: {
 type Props = {
   message: Message & { streams?: Array<Stream> },
   inputs?: Immutable.Map<string, Input>,
-  nodes?: Immutable.Map<string, { short_node_id: string, hostname: string }>,
   streams?: Immutable.Map<string, Stream>,
   renderForDisplay: (fieldName: string) => React.ReactNode,
   customFieldActions?: React.ReactNode
 }
 
-const MessageDetail = ({ renderForDisplay, inputs, nodes, streams, message, customFieldActions }: Props) => {
+const MessageDetail = ({ renderForDisplay, inputs, streams, message, customFieldActions }: Props) => {
   const streamIds = Immutable.Set(message.stream_ids);
   const rawTimestamp = message.fields.timestamp;
   const timestamp = [
@@ -136,12 +139,12 @@ const MessageDetail = ({ renderForDisplay, inputs, nodes, streams, message, cust
         <Col md={3}>
           <MessageDetailsDefinitionList>
             {timestamp}
-            {(message.source_input_id && message.source_node_id && nodes) && (
+            {(message.source_input_id && message.source_node_id) && (
               <div>
                 <dt>Received by</dt>
                 <dd>
                   <em><InputName inputs={inputs} inputId={message.source_input_id} /></em>{' '}
-                  on <NodeName nodes={nodes} nodeId={message.source_node_id} />
+                  on <NodeName nodeId={message.source_node_id} />
 
                   {/* Legacy */}
                   {message.source_radio_id && (
@@ -149,7 +152,7 @@ const MessageDetail = ({ renderForDisplay, inputs, nodes, streams, message, cust
                       <br />
                       <span>
                         via <em><InputName inputs={inputs} inputId={message.source_radio_input_id} /></em> on
-                        radio <NodeName nodes={nodes} nodeId={message.source_radio_id} />
+                        radio <NodeName nodeId={message.source_radio_id} />
                       </span>
                     </>
                   )}
@@ -186,7 +189,6 @@ const MessageDetail = ({ renderForDisplay, inputs, nodes, streams, message, cust
 
 MessageDetail.defaultProps = {
   inputs: undefined,
-  nodes: undefined,
   streams: undefined,
   customFieldActions: undefined,
 };

--- a/graylog2-web-interface/src/components/search/MessageDetail.tsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.tsx
@@ -25,13 +25,11 @@ import StreamLink from 'components/streams/StreamLink';
 import MessageFields from 'components/search/MessageFields';
 import MessageDetailsTitle from 'components/search/MessageDetailsTitle';
 import Routes from 'routing/Routes';
-import AppConfig from 'util/AppConfig';
 import MessagePermalinkButton from 'views/components/common/MessagePermalinkButton';
 import type { Message } from 'views/components/messagelist/Types';
 import type { Stream } from 'views/stores/StreamsStore';
 import type { Input } from 'components/messageloaders/Types';
-import { NodesStore } from 'stores/nodes/NodesStore';
-import { useStore } from 'stores/connect';
+import NodeName from 'views/components/messagelist/NodeName';
 
 const Span = styled.span`
   word-break: break-word;
@@ -49,34 +47,6 @@ const InputName = ({ inputs, inputId }: { inputs: Immutable.Map<string, Input> |
   const input = inputs?.get(inputId);
 
   return input ? <Span>{input.title}</Span> : <>deleted input</>;
-};
-
-const NodeName = ({ nodeId }: { nodeId: string }) => {
-  const nodesStore = useStore(NodesStore);
-  const nodes = Immutable.Map(nodesStore.nodes);
-  const node = nodes?.get(nodeId);
-  let nodeInformation;
-
-  if (node) {
-    const nodeURL = Routes.node(nodeId);
-
-    const nodeContent = (
-      <>
-        <Icon name="fork_right" />
-        &nbsp;
-        <Span>{node.short_node_id}</Span>&nbsp;/&nbsp;
-        <Span>{node.hostname}</Span>
-      </>
-    );
-
-    nodeInformation = AppConfig.isCloud()
-      ? nodeContent
-      : <a href={nodeURL}>{nodeContent}</a>;
-  } else {
-    nodeInformation = <Span>stopped node</Span>;
-  }
-
-  return nodeInformation;
 };
 
 const StreamLinks = ({ messageStreams, streamIds, streams }: {

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -23,6 +23,10 @@ import StringUtils from 'util/StringUtils';
 
 import MessageDetail from './MessageDetail';
 
+const getImmutableProps = (props) => ({
+  streams: props.streams ? Immutable.Map(props.streams) : props.streams,
+});
+
 class MessageShow extends React.Component {
   static propTypes = {
     message: PropTypes.object.isRequired,
@@ -40,18 +44,14 @@ class MessageShow extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = this._getImmutableProps(props);
+    this.state = getImmutableProps(props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState(this._getImmutableProps(nextProps));
+    this.setState(getImmutableProps(nextProps));
   }
 
   // eslint-disable-next-line class-methods-use-this
-  _getImmutableProps = (props) => ({
-    streams: props.streams ? Immutable.Map(props.streams) : props.streams,
-    nodes: props.nodes ? Immutable.Map(props.nodes) : props.nodes,
-  });
 
   renderForDisplay = (fieldName) => {
     // No highlighting for the message details view.
@@ -62,7 +62,7 @@ class MessageShow extends React.Component {
 
   render() {
     const { inputs, message } = this.props;
-    const { streams, nodes } = this.state;
+    const { streams } = this.state;
 
     return (
       <Row className="content">
@@ -71,7 +71,6 @@ class MessageShow extends React.Component {
                          message={message}
                          inputs={inputs}
                          streams={streams}
-                         nodes={nodes}
                          renderForDisplay={this.renderForDisplay}
                          showTimestamp />
         </Col>

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
@@ -23,37 +23,52 @@ import { Icon } from 'components/common';
 import { useStore } from 'stores/connect';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { Link } from 'components/common/router';
+import AppConfig from 'util/AppConfig';
 
 type NodeId = string;
-type Props = {
-  nodeId: NodeId,
-};
 
 const BreakWord = styled.span`
   word-break: break-word;
 `;
 
+type NodeTitleProps = {
+  shortNodeId: string,
+  hostname: string
+}
+
+const NodeTitle = ({ shortNodeId, hostname }: NodeTitleProps) => (
+  <>
+    <Icon name="lan" />
+    &nbsp;
+    <BreakWord>
+      {shortNodeId}
+    </BreakWord>&nbsp;/&nbsp;
+    <BreakWord>
+      {hostname}
+    </BreakWord>
+  </>
+);
+
+type Props = {
+  nodeId: NodeId,
+};
+
 const NodeName = ({ nodeId }: Props) => {
   const node = useStore(NodesStore, (state) => state?.nodes?.[nodeId]);
 
-  if (node) {
-    const nodeURL = Routes.node(nodeId);
-
-    return (
-      <Link to={nodeURL}>
-        <Icon name="lan" />
-        &nbsp;
-        <BreakWord>
-          {node.short_node_id}
-        </BreakWord>&nbsp;/&nbsp;
-        <BreakWord>
-          {node.hostname}
-        </BreakWord>
-      </Link>
-    );
+  if (!node) {
+    return <BreakWord>stopped node</BreakWord>;
   }
 
-  return <BreakWord>stopped node</BreakWord>;
+  if (AppConfig.isCloud()) {
+    return <NodeTitle shortNodeId={node.short_node_id} hostname={node.hostname} />;
+  }
+
+  return (
+    <Link to={Routes.node(nodeId)}>
+      <NodeTitle shortNodeId={node.short_node_id} hostname={node.hostname} />
+    </Link>
+  );
 };
 
 NodeName.propTypes = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing two problems:
- In cloud env display only name instead of name with link for node in message details on the search page.
- Fix display node information in message details on e.g. create extractor page, it was missing before this change.


Please note, this PR needs a backport for `5.2` and `6.0`

