### PR TITLE
Remove initial query value from event search form.

### DIFF
--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -77,8 +77,7 @@ class EventsSearchBar extends React.Component {
       <div className={styles.eventsSearchBar}>
         <div>
           <div className={styles.searchForm}>
-            <SearchForm query={parameters.query}
-                        onSearch={onQueryChange}
+            <SearchForm onSearch={onQueryChange}
                         placeholder="Find Events"
                         topMargin={0}
                         useLoadingState>


### PR DESCRIPTION
Before these changes, On the Alert and Event page, we were getting the query param we sent during the search back with API call and using it to set the searchForm query value. This caused the search input value to be removed while typing.
These changes remove the search form initial value as it's not needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

