### PR TITLE
Fix node name resolution in data node

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/opensearch/OpensearchProcessImpl.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/OpensearchProcessImpl.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import jakarta.inject.Inject;
-import jakarta.inject.Named;
 import org.apache.commons.collections4.queue.CircularFifoQueue;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.http.client.utils.URIBuilder;
@@ -119,7 +118,7 @@ public class OpensearchProcessImpl implements OpensearchProcess, ProcessListener
     @Inject
     OpensearchProcessImpl(DatanodeConfiguration datanodeConfiguration, final CustomCAX509TrustManager trustManager,
                           final Configuration configuration, final NodeService<DataNodeDto> nodeService,
-                          ObjectMapper objectMapper, OpensearchStateMachine processState, @Named("node_name") String nodeName, NodeId nodeId, EventBus eventBus) {
+                          ObjectMapper objectMapper, OpensearchStateMachine processState, NodeId nodeId, EventBus eventBus) {
         this.datanodeConfiguration = datanodeConfiguration;
         this.processState = processState;
         this.stdout = new CircularFifoQueue<>(datanodeConfiguration.processLogsBufferSize());
@@ -128,7 +127,7 @@ public class OpensearchProcessImpl implements OpensearchProcess, ProcessListener
         this.nodeService = nodeService;
         this.configuration = configuration;
         this.objectMapper = objectMapper;
-        this.nodeName = nodeName;
+        this.nodeName = configuration.getDatanodeNodeName();
         this.nodeId = nodeId;
         this.eventBus = eventBus;
     }

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/OpensearchProcessImplTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/OpensearchProcessImplTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
 import org.graylog.datanode.Configuration;
 import org.graylog.datanode.configuration.DatanodeConfiguration;
+import org.graylog.datanode.opensearch.statemachine.OpensearchEvent;
 import org.graylog.datanode.opensearch.statemachine.OpensearchStateMachine;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.cluster.settings.ClusterGetSettingsResponse;
@@ -83,8 +84,9 @@ public class OpensearchProcessImplTest {
     @Before
     public void setup() throws IOException {
         when(datanodeConfiguration.processLogsBufferSize()).thenReturn(100);
+        when(configuration.getDatanodeNodeName()).thenReturn(nodeName);
         this.opensearchProcess = spy(new OpensearchProcessImpl(datanodeConfiguration, trustmManager, configuration,
-                nodeService, objectMapper, processState, nodeName, nodeId, eventBus));
+                nodeService, objectMapper, processState, nodeId, eventBus));
         when(opensearchProcess.restClient()).thenReturn(Optional.of(restClient));
         when(restClient.cluster()).thenReturn(clusterClient);
     }
@@ -128,7 +130,7 @@ public class OpensearchProcessImplTest {
         final ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
         opensearchProcess.executorService = executor;
         opensearchProcess.checkRemovalStatus();
-        verify(opensearchProcess).stop();
+        verify(processState).fire(OpensearchEvent.PROCESS_STOPPED);
         verify(executor).shutdown();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the configuration getter for `node_name` config parameter instead of the named annotation.
`node_name` is optional and might not be set, the getter has the fallback to the hostname.

/nocl

## Motivation and Context
fixes #20523

## How Has This Been Tested?
fixed unit test 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

