### PR TITLE
Do not use retry in use-query on 4xx failure statuses

### DIFF
--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -19,6 +19,7 @@ import { useMemo } from 'react';
 import type { QueryClientConfig } from '@tanstack/react-query';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import merge from 'lodash/merge';
+import isNumber from 'lodash/isNumber';
 
 type Props = {
   children: React.ReactNode,
@@ -31,7 +32,7 @@ const defaultOptions = {
       refetchOnWindowFocus: false,
       networkMode: 'always' as const,
       retry: (failureCount, error) => {
-        if ((error.status >= 400) && (error.status <= 417)) return false;
+        if (isNumber(error?.status) && (error.status >= 400) && (error.status <= 417)) return false;
 
         return failureCount < 4;
       },

--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -30,6 +30,11 @@ const defaultOptions = {
     queries: {
       refetchOnWindowFocus: false,
       networkMode: 'always' as const,
+      retry: (failureCount, error) => {
+        if ((error.status >= 400) && (error.status <= 417)) return false;
+
+        return failureCount < 4;
+      },
     },
   },
 };

--- a/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
+++ b/graylog2-web-interface/src/contexts/DefaultQueryClientProvider.tsx
@@ -19,7 +19,6 @@ import { useMemo } from 'react';
 import type { QueryClientConfig } from '@tanstack/react-query';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import merge from 'lodash/merge';
-import isNumber from 'lodash/isNumber';
 
 type Props = {
   children: React.ReactNode,
@@ -32,7 +31,7 @@ const defaultOptions = {
       refetchOnWindowFocus: false,
       networkMode: 'always' as const,
       retry: (failureCount, error) => {
-        if (isNumber(error?.status) && (error.status >= 400) && (error.status <= 417)) return false;
+        if (error.status >= 400 && error.status < 500) return false;
 
         return failureCount < 4;
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR sets the default parameter for DefaultQueryClientProvider to not rerun react query requests when there are client errors.

## Motivation and Context
When we use react-query to get some data and requests fail, react-query retries this action several times (by default 3). Sometimes that doesn't make any sense, because the response is always the same. That happens mainly when we have missing data in the request body or an unauthorized user or any other client errors. All these errors have status 400-417. So it makes sense not to overload the server with unnecessary requests the response of which is already known and not to use rerun when we catch this kind of error for the first time. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl