### PR TITLE
Do not render table row when showMessageRow is false

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/MessagePreview.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessagePreview.tsx
@@ -54,15 +54,15 @@ type Props = {
 const MessagePreview = ({ onRowClick, colSpanFixup, message, messageFieldType, showMessageRow, config }: Props) => {
   const MessageRowOverride = usePluginEntities('views.components.widgets.messageTable.messageRowOverride')?.[0];
 
-  return (
+  return showMessageRow && (
     <TableRow onClick={onRowClick}>
       <td colSpan={colSpanFixup}>
-        {showMessageRow && !!MessageRowOverride && (
+        {!!MessageRowOverride && (
           <MessageRowOverride messageFields={message.fields}
                               config={config}
                               renderMessageRow={() => renderMessageFieldRow(message, messageFieldType)} />
         )}
-        {(showMessageRow && !MessageRowOverride) && renderMessageFieldRow(message, messageFieldType)}
+        {(!MessageRowOverride) && renderMessageFieldRow(message, messageFieldType)}
       </td>
     </TableRow>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Even if the showMessageRow is false we render the table row component. That caused the issue that we rendered an empty row. This PR set showMessageRow condition to the table, not to the content. That prevents rendering empty row which is later visible on PDF document

## Motivation and Context
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/8208

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl