### PR TITLE
Add specific labels for sizes

### DIFF
--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -28,9 +28,10 @@ import StreamsField from 'views/components/fieldtypes/StreamsField';
 import PercentageField from 'views/components/fieldtypes/PercentageField';
 import { getPrettifiedValue } from 'views/components/visualizations/utils/unitConverters';
 import type FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';
-import { DECIMAL_PLACES, UNIT_FEATURE_FLAG } from 'views/components/visualizations/Constants';
+import { UNIT_FEATURE_FLAG } from 'views/components/visualizations/Constants';
 import useFeature from 'hooks/useFeature';
 import { MISSING_BUCKET_NAME } from 'views/Constants';
+import formatValueWithUnitLabel from 'views/components/visualizations/utils/formatValueWithUnitLabel';
 
 import EmptyValue from './EmptyValue';
 import CustomPropTypes from './CustomPropTypes';
@@ -60,7 +61,7 @@ type TypeSpecificValueProps = {
 const ValueWithUnitRenderer = ({ value, unit }: { value: number, unit: FieldUnit}) => {
   const prettified = getPrettifiedValue(value, { abbrev: unit.abbrev, unitType: unit.unitType });
 
-  return <span title={value.toString()}>{`${Number(prettified?.value).toFixed(DECIMAL_PLACES)} ${prettified.unit.abbrev}`}</span>;
+  return <span title={value.toString()}>{formatValueWithUnitLabel(prettified?.value, prettified.unit.abbrev)}</span>;
 };
 
 const FormattedValue = ({ field, value, truncate, render, unit, type }: TypeSpecificValueProps) => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -27,6 +27,7 @@ import type { Unit } from 'views/components/visualizations/utils/unitConverters'
 import { mappedUnitsFromJSON as units } from 'views/components/visualizations/utils/unitConverters';
 import type { FieldUnitsFormValues } from 'views/types';
 import type FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';
+import getUnitTextLabel from 'views/components/visualizations/utils/getUnitTextLabel';
 
 const Container = styled.div`
   display: flex;
@@ -76,7 +77,7 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
   const badgeLabel = useMemo(() => {
     const curUnit = values?.units?.[field]?.abbrev;
 
-    return curUnit || '...';
+    return getUnitTextLabel(curUnit) || '...';
   }, [field, values?.units]);
 
   const predefinedInfo = useMemo(() => {

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/useChartDataSettingsWithCustomUnits.test.ts
@@ -97,7 +97,7 @@ describe('useChartDataSettingsWithCustomUnits', () => {
       fullPath: 'Name2',
       hovertemplate: '%{text}<br><extra>%{meta}</extra>',
       meta: 'Name2',
-      text: ['1.0 Mb', '2.0 Mb', '3.0 Mb'],
+      text: ['1.0 MB', '2.0 MB', '3.0 MB'],
       y: [1000000, 2000000, 3000000],
       yaxis: 'y2',
     });

--- a/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/chartLayoutGenerators.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/chartLayoutGenerators.test.ts
@@ -212,9 +212,9 @@ describe('Chart Layout Generators', () => {
         hovertemplate: '%{text}<br><extra>%{meta}</extra>',
         meta: 'Name2',
         text: [
-          '10.0 b',
-          '20.0 b',
-          '30.0 b',
+          '10.0 B',
+          '20.0 B',
+          '30.0 B',
         ],
       });
     });
@@ -272,9 +272,9 @@ describe('Chart Layout Generators', () => {
         textinfo: 'percent',
         meta: 'Name2',
         text: [
-          '10.0 b',
-          '20.0 b',
-          '30.0 b',
+          '10.0 B',
+          '20.0 B',
+          '30.0 B',
         ],
       });
     });

--- a/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/fixtures.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/fixtures.ts
@@ -423,10 +423,10 @@ export const layoutsFor4axis = {
       size: 16,
     },
     ticktext: [
-      '130.3 b',
-      '260.5 b',
-      '390.8 b',
-      '521.0 b',
+      '130.3 B',
+      '260.5 B',
+      '390.8 B',
+      '521.0 B',
     ],
     tickvals: [
       130.25,

--- a/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
@@ -43,6 +43,7 @@ import type {
   PieHoverTemplateSettings,
 } from 'views/components/visualizations/hooks/usePieChartDataSettingsWithCustomUnits';
 import getDefaultPlotYLayoutSettings from 'views/components/visualizations/utils/getDefaultPlotYLayoutSettings';
+import formatValueWithUnitLabel from 'views/components/visualizations/utils/formatValueWithUnitLabel';
 
 type DefaultAxisKey = 'withoutUnit';
 
@@ -93,7 +94,7 @@ const getFormatSettingsWithCustomTickVals = (values: Array<any>, fieldType: Fiel
   const timeBaseUnit = getBaseUnit(fieldType);
   const prettyValues = tickvals.map((value) => getPrettifiedValue(value, { abbrev: timeBaseUnit.abbrev, unitType: timeBaseUnit.unitType }));
 
-  const ticktext = prettyValues.map((prettified) => `${Number(prettified?.value).toFixed(DECIMAL_PLACES)} ${prettified.unit.abbrev}`);
+  const ticktext = prettyValues.map((prettified) => formatValueWithUnitLabel(prettified?.value, prettified.unit.abbrev));
 
   return ({
     tickvals,
@@ -317,7 +318,7 @@ const getHoverTexts = ({ convertedValues, unit }: { convertedValues: Array<any>,
 
   if (!prettified) return value;
 
-  return `${Number(prettified?.value).toFixed(DECIMAL_PLACES)} ${prettified.unit.abbrev}`;
+  return formatValueWithUnitLabel(prettified?.value, prettified.unit.abbrev);
 });
 
 export const getHoverTemplateSettings = ({ convertedValues, unit, name }: {

--- a/graylog2-web-interface/src/views/components/visualizations/utils/formatValueWithUnitLabel.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/formatValueWithUnitLabel.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { DECIMAL_PLACES } from 'views/components/visualizations/Constants';
+import getUnitTextLabel from 'views/components/visualizations/utils/getUnitTextLabel';
+
+const formatValueWithUnitLabel = (value: number | string, abbrev: string) => `${Number(value).toFixed(DECIMAL_PLACES)} ${getUnitTextLabel(abbrev)}`;
+
+export default formatValueWithUnitLabel;

--- a/graylog2-web-interface/src/views/components/visualizations/utils/getUnitTextLabel.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/getUnitTextLabel.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+const labelMapper = {
+  b: 'B',
+  kb: 'kB',
+  Mb: 'MB',
+  Gb: 'GB',
+};
+
+const getUnitTextLabel = (abbrev: string) => labelMapper[abbrev] ?? abbrev;
+
+export default getUnitTextLabel;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As we already use `abbrev` param as a key we cant change it to fix the problem. Because of that, we add a new mapper for labels. 

## Motivation and Context
fix: https://github.com/Graylog2/graylog2-server/issues/20518

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
