### PR TITLE
feat: Include stream categories in Query.filter

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.tsx
@@ -37,6 +37,7 @@ import commonStyles from '../common/commonStyles.css';
 type EventDefinitionConfig = {
   group_by: Array<string>,
   streams: Array<string>,
+  stream_categories?: Array<string>,
 };
 
 type EventDefinition = {

--- a/graylog2-web-interface/src/components/events/events/types.ts
+++ b/graylog2-web-interface/src/components/events/events/types.ts
@@ -20,6 +20,7 @@ export type EventReplayInfo = {
   timerange_end: string,
   query: string,
   streams: string[],
+  stream_categories?: string[],
 };
 
 export type Event = {

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as Immutable from 'immutable';
+
 import isDeepEqual from 'stores/isDeepEqual';
 import type { ViewHook, ViewHookArguments } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
@@ -25,9 +27,9 @@ const bindSearchParamsFromQuery: ViewHook = async ({ query, view, executionState
     return [view, executionState];
   }
 
-  const { queryString, timeRange, streamsFilter } = normalizeSearchURLQueryParams(query);
+  const { queryString, timeRange, streamsFilter, streamCategoriesFilter } = normalizeSearchURLQueryParams(query);
 
-  if (!queryString && !timeRange && !streamsFilter) {
+  if (!queryString && !timeRange && !streamsFilter && !streamCategoriesFilter) {
     return [view, executionState];
   }
 
@@ -48,8 +50,15 @@ const bindSearchParamsFromQuery: ViewHook = async ({ query, view, executionState
     queryBuilder = queryBuilder.timerange(timeRange);
   }
 
-  if (streamsFilter) {
-    queryBuilder = queryBuilder.filter(streamsFilter);
+  const combinedFilters = streamsFilter && streamCategoriesFilter
+    ? Immutable.Map({
+      type: 'or',
+      filters: Immutable.List.of(streamsFilter, streamCategoriesFilter),
+    })
+    : streamsFilter || streamCategoriesFilter;
+
+  if (combinedFilters) {
+    queryBuilder = queryBuilder.filter(combinedFilters);
   }
 
   const newQuery = queryBuilder.build();

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.ts
@@ -71,16 +71,17 @@ export const syncWithQueryParameters = (viewType: ViewType, query: string, searc
       .reduce((prev, [key, value]) => prev.setSearch(key, String(value)), baseUri);
     const currentStreams = filtersToStreamSet(filter);
     const currentStreamCategories = filtersToStreamCategorySet(filter);
+
     const uriWithStreams = currentStreams.isEmpty()
       ? uriWithTimerange.removeSearch('streams')
       : uriWithTimerange.setSearch('streams', currentStreams.join(','));
 
     const uri = currentStreamCategories.isEmpty()
-      ? uriWithStreams.removeSearch('stream_categories').toString()
-      : uriWithStreams.setSearch('stream_categories', currentStreamCategories.join(',')).toString();
+      ? uriWithStreams.removeSearch('stream_categories')
+      : uriWithStreams.setSearch('stream_categories', currentStreamCategories.join(','));
 
-    if (query !== uri) {
-      action(uri);
+    if (query !== uri.toString()) {
+      action(uri.toString());
     }
   }
 };

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.test.ts
@@ -25,6 +25,7 @@ describe('NormalizeSearchURLQueryParams', () => {
     expect(result).toEqual({
       queryString: undefined,
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: { type: 'relative', range: 600 },
     });
   });
@@ -35,6 +36,7 @@ describe('NormalizeSearchURLQueryParams', () => {
     expect(result).toEqual({
       queryString: undefined,
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: { type: 'relative', from: 600 },
     });
   });
@@ -45,6 +47,7 @@ describe('NormalizeSearchURLQueryParams', () => {
     expect(result).toEqual({
       queryString: undefined,
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: { type: 'relative', from: 600, to: 300 },
     });
   });
@@ -59,6 +62,7 @@ describe('NormalizeSearchURLQueryParams', () => {
     expect(result).toEqual({
       queryString: undefined,
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: { type: 'absolute', from: '2020-01-01T10:00:00.850Z', to: '2020-01-02T10:00:00.000Z' },
     });
   });
@@ -69,6 +73,7 @@ describe('NormalizeSearchURLQueryParams', () => {
     expect(result).toEqual({
       queryString: undefined,
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: { type: 'keyword', keyword: 'yesterday' },
     });
   });
@@ -82,6 +87,7 @@ describe('NormalizeSearchURLQueryParams', () => {
         type: 'elasticsearch',
       },
       streamsFilter: null,
+      streamCategoriesFilter: null,
       timeRange: undefined,
     });
   });
@@ -101,6 +107,65 @@ describe('NormalizeSearchURLQueryParams', () => {
           Immutable.Map({
             type: 'stream',
             id: 'stream-id-2',
+          }),
+        ]),
+      }),
+      streamCategoriesFilter: null,
+      timeRange: undefined,
+    });
+  });
+
+  it('should normalize stream categories filter', async () => {
+    const result = normalizeSearchURLQueryParams({ stream_categories: 'firewall,graylog' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: null,
+      streamCategoriesFilter: Immutable.Map({
+        type: 'or',
+        filters: Immutable.List([
+          Immutable.Map({
+            type: 'stream_category',
+            category: 'firewall',
+          }),
+          Immutable.Map({
+            type: 'stream_category',
+            category: 'graylog',
+          }),
+        ]),
+      }),
+      timeRange: undefined,
+    });
+  });
+
+  it('should normalize streams and stream categories filter', async () => {
+    const result = normalizeSearchURLQueryParams({ streams: 'stream-id-1,stream-id-2', stream_categories: 'firewall,graylog' });
+
+    expect(result).toEqual({
+      queryString: undefined,
+      streamsFilter: Immutable.Map({
+        type: 'or',
+        filters: Immutable.List([
+          Immutable.Map({
+            type: 'stream',
+            id: 'stream-id-1',
+          }),
+          Immutable.Map({
+            type: 'stream',
+            id: 'stream-id-2',
+          }),
+        ]),
+      }),
+      streamCategoriesFilter: Immutable.Map({
+        type: 'or',
+        filters: Immutable.List([
+          Immutable.Map({
+            type: 'stream_category',
+            category: 'firewall',
+          }),
+          Immutable.Map({
+            type: 'stream_category',
+            category: 'graylog',
           }),
         ]),
       }),

--- a/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
@@ -19,12 +19,13 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { DEFAULT_TIMERANGE } from 'views/Constants';
 import type { TimeRange, ElasticsearchQueryString, QueryId, FilterType } from 'views/logic/queries/Query';
-import Query, { createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';
+import Query, { createElasticsearchQueryString, newFiltersForQuery } from 'views/logic/queries/Query';
 import generateId from 'logic/generateId';
 import type { SearchFilter } from 'components/event-definitions/event-definitions-types';
 
 export default (
   streamId?: string | string[],
+  streamCategory?: string | string[],
   // eslint-disable-next-line default-param-last
   id: QueryId | undefined = generateId(),
   timeRange?: TimeRange,
@@ -37,7 +38,13 @@ export default (
       ? streamId
       : [streamId]
     : null;
-  const streamFilter = filtersForQuery(streamIds);
+  // eslint-disable-next-line no-nested-ternary
+  const streamCategories = streamCategory
+    ? streamCategory instanceof Array
+      ? streamCategory
+      : [streamCategory]
+    : null;
+  const queryFilter = newFiltersForQuery(streamIds, streamCategories);
   const searchFiltersMap: FilterType = searchFilters
     ? OrderedMap(searchFilters?.map((filter) => [filter.id || uuidv4(), filter]))
     : OrderedMap();
@@ -47,5 +54,5 @@ export default (
     .timerange(timeRange ?? DEFAULT_TIMERANGE)
     .filters(searchFiltersMap.toList());
 
-  return streamFilter ? builder.filter(streamFilter).build() : builder.build();
+  return queryFilter ? builder.filter(queryFilter).build() : builder.build();
 };

--- a/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
@@ -23,16 +23,18 @@ import type Parameter from 'views/logic/parameters/Parameter';
 
 const useCreateSavedSearch = ({
   streamId,
+  streamCategory,
   timeRange,
   queryString,
   parameters,
 }:{
   streamId?: string | string[],
+  streamCategory?: string | string[],
   timeRange?: TimeRange,
   queryString?: ElasticsearchQueryString,
   parameters?: Array<Parameter>,
 }) => useMemo(
-  () => ViewGenerator({ type: View.Type.Search, streamId, timeRange, queryString, parameters }),
+  () => ViewGenerator({ type: View.Type.Search, streamId, streamCategory, timeRange, queryString, parameters }),
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [],
 );

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinition.ts
@@ -29,6 +29,7 @@ const useCreateViewForEventDefinition = (
   }: { eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
 ) => {
   const streams = eventDefinition?.config?.streams ?? [];
+  const streamCategories = eventDefinition?.config?.stream_categories ?? [];
   const timeRange: RelativeTimeRangeStartOnly = {
     type: 'relative',
     range: (eventDefinition?.config?.search_within_ms ?? 0) / 1000,
@@ -45,7 +46,7 @@ const useCreateViewForEventDefinition = (
   const searchFilters = eventDefinition?.config?.filters ?? [];
 
   return useMemo(
-    () => ViewGenerator({ streams, timeRange, queryString, aggregations, groupBy, queryParameters, searchFilters }),
+    () => ViewGenerator({ streams, streamCategories, timeRange, queryString, aggregations, groupBy, queryParameters, searchFilters }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
@@ -28,18 +28,20 @@ import QueryGenerator from '../queries/QueryGenerator';
 export default async ({
   type,
   streamId,
+  streamCategory,
   timeRange,
   queryString,
   parameters,
 }: {
   type: ViewType,
   streamId?: string | string[],
+  streamCategory?: string | string[],
   timeRange?: TimeRange,
   queryString?: ElasticsearchQueryString,
   parameters?: Array<Parameter>,
 },
 ) => {
-  const query = QueryGenerator(streamId, undefined, timeRange, queryString);
+  const query = QueryGenerator(streamId, streamCategory, undefined, timeRange, queryString);
   const search = Search.create().toBuilder().queries([query]).parameters(parameters)
     .build();
   const viewState = await ViewStateGenerator(type, streamId);

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.tsx
@@ -90,6 +90,7 @@ describe('NewSearchPage', () => {
         parameters: undefined,
         queryString: undefined,
         streamId: [],
+        streamCategory: [],
         timeRange: undefined,
       }));
     });

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.tsx
@@ -56,8 +56,14 @@ const useParametersFromStore = () => {
 
 const NewSearchPage = () => {
   const { parameters, parameterBindings } = useParametersFromStore();
-  const { timeRange, queryString, streams } = useSearchURLQueryParams();
-  const viewPromise = useCreateSavedSearch({ streamId: streams, timeRange, queryString, parameters });
+  const { timeRange, queryString, streams, streamCategories } = useSearchURLQueryParams();
+  const viewPromise = useCreateSavedSearch({
+    streamId: streams,
+    streamCategory: streamCategories,
+    timeRange,
+    queryString,
+    parameters,
+  });
   const view = useCreateSearch(viewPromise);
 
   return <SearchPage view={view} executionState={SearchExecutionState.create(parameterBindings)} isNew />;

--- a/graylog2-web-interface/test/fixtures/createEventDefinitionFromValue.ts
+++ b/graylog2-web-interface/test/fixtures/createEventDefinitionFromValue.ts
@@ -122,7 +122,7 @@ export const negationSearchFilter: SearchFilter = {
   queryString: 'action: login',
   negation: true,
 };
-const query = QueryGenerator([], 'query-id', {
+const query = QueryGenerator([], [], 'query-id', {
   type: 'relative',
   from: 300,
 

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -50,6 +50,9 @@ export const mockEventData = {
     streams: [
       '002',
     ],
+    stream_categories: [
+      'firewall',
+    ],
     source_streams: [
       '001',
     ],
@@ -65,6 +68,9 @@ export const mockEventData = {
       query: 'http_method: GET',
       streams: [
         '001',
+      ],
+      stream_categories: [
+        'firewall',
       ],
     },
     group_by_fields: { field4: 'value4' },
@@ -88,6 +94,9 @@ export const mockEventDefinitionTwoAggregations:EventDefinition = {
     _is_scheduled: true,
     streams: [
       '001',
+    ],
+    stream_categories: [
+      'firewall',
     ],
     group_by: [
       'field1',
@@ -214,7 +223,7 @@ export const mockedMappedAggregationNoField: Array<EventDefinitionAggregation> =
   },
 ];
 const eventData = mockEventData.event;
-const query = QueryGenerator(eventData.replay_info.streams, 'query-id', {
+const query = QueryGenerator(eventData.replay_info.streams, eventData.replay_info.stream_categories, 'query-id', {
   type: 'absolute',
   from: eventData?.replay_info?.timerange_start,
   to: eventData?.replay_info?.timerange_end,
@@ -308,6 +317,11 @@ const searchTwoAggregations = Search.create().toBuilder().id('search-id').querie
     .toBuilder()
     .searchTypes(Array(5).fill({
       filters: [],
+      id: undefined,
+      query: undefined,
+      stream_categories: undefined,
+      streams: undefined,
+      timerange: undefined,
       type: 'AGGREGATION',
       typeDefinition: {},
     })).build()])
@@ -416,7 +430,7 @@ export const mockedViewWithOneAggregationNoField = View.create()
   .search(searchOneAggregation)
   .build();
 
-const queryED = QueryGenerator(eventData.replay_info.streams, 'query-id', {
+const queryED = QueryGenerator(eventData.replay_info.streams, eventData.replay_info.stream_categories, 'query-id', {
   type: 'relative',
   range: 60,
 }, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Include stream categories in Query.filter in the same way streams work

closes: Graylog2/graylog-plugin-enterprise#7926

/nocl

## Description
<!--- Describe your changes in detail -->
These are the required modifications to include the new stream categories in Query.filter object to complement with stream filters

Users now can execute searches using stream categories linked to multiple streams

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.

