### PR TITLE
User list endpoint returns current user only instead of error when permission is missing

### DIFF
--- a/changelog/unreleased/pr-20558.toml
+++ b/changelog/unreleased/pr-20558.toml
@@ -1,5 +1,5 @@
 type = "c" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
-message = "UserResource.list() now works for every authenticated user. In case the calling user lacks the 'RestPermissions.USERS_LIST' permission, only the calling user is returned."
+message = "API endpoint for listing users will not return an error anymore when user is lacking permission, but return current user only instead."
 
 issues = []
 pulls = ["20558"]

--- a/changelog/unreleased/pr-20558.toml
+++ b/changelog/unreleased/pr-20558.toml
@@ -1,0 +1,5 @@
+type = "c" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "UserResource.list() now works for every authenticated user. In case the calling user lacks the 'RestPermissions.USERS_LIST' permission, only the calling user is returned."
+
+issues = []
+pulls = ["20558"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We are using the `list` method on the user resource in a context where a user can only have the Reader role. That role lacks the permission to list all users. In this case, we only want to return the user itself in the list.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/8692

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

