### PR TITLE
Display only name instead of name with link for node in message details. `5.2`

### DIFF
--- a/changelog/unreleased/issue-20464.toml
+++ b/changelog/unreleased/issue-20464.toml
@@ -1,0 +1,5 @@
+type="f"
+message="In cloud env display only node name instead of name with link in message details on the search page."
+
+issues=["20464"]
+pulls=["20505"]

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.tsx
@@ -23,37 +23,52 @@ import { Icon } from 'components/common';
 import { useStore } from 'stores/connect';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { Link } from 'components/common/router';
+import AppConfig from 'util/AppConfig';
 
 type NodeId = string;
+
+const BreakWord = styled.span`
+  word-break: break-word;
+`;
+
+type NodeTitleProps = {
+  shortNodeId: string,
+  hostname: string
+}
+
+const NodeTitle = ({ shortNodeId, hostname }: NodeTitleProps) => (
+  <>
+    <Icon name="circle-nodes" />
+    &nbsp;
+    <BreakWord>
+      {shortNodeId}
+    </BreakWord>&nbsp;/&nbsp;
+    <BreakWord>
+      {hostname}
+    </BreakWord>
+  </>
+);
+
 type Props = {
   nodeId: NodeId,
 };
 
-const BreakWord = styled.span`
-  word-break: 'break-word';
-`;
-
 const NodeName = ({ nodeId }: Props) => {
   const node = useStore(NodesStore, (state) => state?.nodes?.[nodeId]);
 
-  if (node) {
-    const nodeURL = Routes.node(nodeId);
-
-    return (
-      <Link to={nodeURL}>
-        <Icon name="circle-nodes" />
-        &nbsp;
-        <BreakWord>
-          {node.short_node_id}
-        </BreakWord>&nbsp;/&nbsp;
-        <BreakWord>
-          {node.hostname}
-        </BreakWord>
-      </Link>
-    );
+  if (!node) {
+    return <BreakWord>stopped node</BreakWord>;
   }
 
-  return <BreakWord>stopped node</BreakWord>;
+  if (AppConfig.isCloud()) {
+    return <NodeTitle shortNodeId={node.short_node_id} hostname={node.hostname} />;
+  }
+
+  return (
+    <Link to={Routes.node(nodeId)}>
+      <NodeTitle shortNodeId={node.short_node_id} hostname={node.hostname} />
+    </Link>
+  );
 };
 
 NodeName.propTypes = {


### PR DESCRIPTION
Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/20505 for `5.2`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With this PR we display only node name instead of name with link in message details on the search page In cloud env.