### PR TITLE
Fix documentation link target for search query errors.

### DIFF
--- a/changelog/unreleased/issue-13822.toml
+++ b/changelog/unreleased/issue-13822.toml
@@ -1,0 +1,9 @@
+type = "fixed"
+message = "Fix documentation link target for search query errors. "
+
+issues = ["13822"]
+pulls = ["20563"]
+
+details.user = """
+The documentation link now points to the error types section again, instead of just the search query page.
+"""

--- a/changelog/unreleased/issue-13822.toml
+++ b/changelog/unreleased/issue-13822.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Fix documentation link target for search query errors. "
+message = "Fix link target for search query error documentation links."
 
 issues = ["13822"]
 pulls = ["20563"]

--- a/graylog2-web-interface/src/util/DocsHelper.ts
+++ b/graylog2-web-interface/src/util/DocsHelper.ts
@@ -50,12 +50,7 @@ const docsHelper = {
     PIPELINES: 'pipelines',
     REPORTING: 'reporting',
     ROLLING_ES_UPGRADE: 'rolling-es-upgrade',
-    SEARCH_QUERY_ERRORS: {
-      UNKNOWN_FIELD: 'query-language#unknown-field',
-      QUERY_PARSING_ERROR: 'query-language#parse-exception',
-      INVALID_OPERATOR: 'query-language#invalid-operator',
-      UNDECLARED_PARAMETER: 'query-language#undeclared-parameter',
-    },
+    SEARCH_QUERY_ERRORS: 'query-language#ErrorTypes',
     SEARCH_QUERY_LANGUAGE: 'query-language',
     STREAMS: 'streams',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams#stream-processing-runtime-limits',

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -86,7 +86,7 @@ describe('QueryValidation', () => {
     await openExplanation();
 
     await screen.findByText('Parse Exception');
-    await screen.findByTitle('Parse Exception documentation');
+    await screen.findByTitle('Query error documentation');
   });
 
   it('renders pluggable validation explanation', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -146,21 +146,6 @@ const useTriggerIfErrorsPersist = (trigger: () => void) => {
   return [showExplanation, toggleShow] as const;
 };
 
-const getErrorDocumentationLink = (errorType: string) => {
-  switch (errorType) {
-    case 'UNKNOWN_FIELD':
-      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNKNOWN_FIELD;
-    case 'QUERY_PARSING_ERROR':
-      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.QUERY_PARSING_ERROR;
-    case 'INVALID_OPERATOR':
-      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.INVALID_OPERATOR;
-    case 'UNDECLARED_PARAMETER':
-      return DocsHelper.PAGES.SEARCH_QUERY_ERRORS.UNDECLARED_PARAMETER;
-    default:
-      return DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE;
-  }
-};
-
 type QueryForm = {
   queryString: QueryValidationState,
 };
@@ -230,9 +215,9 @@ const QueryValidation = () => {
               <Explanation key={id}>
                 <span><b>{errorTitle}</b>: {errorMessage}</span>
                 {errorType && (
-                <DocumentationLink page={getErrorDocumentationLink(errorType)}
-                                   title={`${errorTitle} documentation`}
-                                   text={<DocumentationIcon name="lightbulb_circle" />} />
+                  <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_ERRORS}
+                                     title="Query error documentation"
+                                     text={<DocumentationIcon name="lightbulb_circle" />} />
                 )}
               </Explanation>
             ))}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/13822 the documentation link for search errors only points to the search query documentation page.

Now it points to the error types section again.

We talked with the docs team about using error type specific links and they suggested to just link to the section, because:
- the section is small
- there are just a few error types
- it is at the end of the page and it wont make a difference to link to a specific error type.

Fixes: https://github.com/Graylog2/graylog2-server/issues/13822
