### PR TITLE
fix write index in data node migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/DatanodeMigrationBindings.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.graylog.plugins.views.storage.migration.state.actions.MigrationActions;
 import org.graylog.plugins.views.storage.migration.state.actions.MigrationActionsFactory;
 import org.graylog.plugins.views.storage.migration.state.actions.MigrationActionsImpl;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationShutdownService;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
 import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineProvider;
 import org.graylog.plugins.views.storage.migration.state.persistence.DatanodeMigrationConfigurationImpl;
@@ -35,5 +36,6 @@ public class DatanodeMigrationBindings extends Graylog2Module {
         install(new FactoryModuleBuilder().implement(MigrationActions.class, MigrationActionsImpl.class).build(
                 MigrationActionsFactory.class));
         bind(MigrationStateMachine.class).toProvider(MigrationStateMachineProvider.class);
+        serviceBinder().addBinding().to(MigrationShutdownService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationShutdownService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.storage.migration.state.machine;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import jakarta.inject.Inject;
+import org.graylog2.configuration.RunsWithDataNode;
+import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.datanode.CurrentWriteIndices;
+import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class MigrationShutdownService extends AbstractIdleService {
+
+    private final Logger log = LoggerFactory.getLogger(AbstractIdleService.class);
+
+    private final Boolean runsWithDataNode;
+    private final MigrationStateMachine migrationStateMachine;
+    private final IndexSetRegistry indexSetRegistry;
+
+    @Inject
+    public MigrationShutdownService(@RunsWithDataNode Boolean runsWithDataNode,
+                                    MigrationStateMachine migrationStateMachine,
+                                    IndexSetRegistry indexSetRegistry) {
+        this.runsWithDataNode = runsWithDataNode;
+        this.migrationStateMachine = migrationStateMachine;
+        this.indexSetRegistry = indexSetRegistry;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        if (List.of(MigrationState.EXISTING_DATA_MIGRATION_QUESTION_PAGE,
+                MigrationState.MIGRATE_EXISTING_DATA,
+                MigrationState.REMOTE_REINDEX_RUNNING).contains(migrationStateMachine.getState())) {
+            log.info("Storing active write indices for data node migration");
+            HashMap<String, String> indices = new HashMap<>();
+            indexSetRegistry.getAll().stream()
+                    .filter(indexSet -> indexSet.isUp() && indexSet.getConfig().isWritable())
+                    .forEach(indexSet -> {
+                        indices.put(indexSet.getConfig().id(), indexSet.getActiveWriteIndex());
+                    });
+            migrationStateMachine.getContext().addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES,
+                    new CurrentWriteIndices(indices));
+            migrationStateMachine.saveContext();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineContext.java
@@ -112,6 +112,10 @@ public class MigrationStateMachineContext {
         return Optional.of((T) value);
     }
 
+    public void removeExtendedState(String name) {
+        this.extendedState.remove(name);
+    }
+
     public void setResponse(Object response) {
         this.response = response;
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/storage/migration/state/machine/MigrationStateMachineImpl.java
@@ -55,8 +55,13 @@ public class MigrationStateMachineImpl implements MigrationStateMachine {
         } catch (Exception e) {
             errorMessage = Objects.nonNull(e.getMessage()) ? e.getMessage() : e.toString();
         }
-        persistenceService.saveStateMachineContext(context);
+        saveContext();
         return new CurrentStateInformation(getState(), nextSteps(), errorMessage, context.getResponse());
+    }
+
+    @Override
+    public void saveContext() {
+        persistenceService.saveStateMachineContext(context);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.indexer.datanode;
 
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record CurrentWriteIndices(Map<String, String> writeIndices) {
+import java.util.HashMap;
+
+public record CurrentWriteIndices(@JsonProperty("write_indices") HashMap<String, String> writeIndices) {
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
@@ -18,7 +18,7 @@ package org.graylog2.indexer.datanode;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
+import java.util.Map;
 
-public record CurrentWriteIndices(@JsonProperty("write_indices") HashMap<String, String> writeIndices) {
+public record CurrentWriteIndices(@JsonProperty("write_indices") Map<String, String> writeIndices) {
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/CurrentWriteIndices.java
@@ -14,26 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog.plugins.views.storage.migration.state.machine;
+package org.graylog2.indexer.datanode;
 
-import org.graylog.plugins.views.storage.migration.state.rest.CurrentStateInformation;
-
-import java.util.List;
 import java.util.Map;
 
-public interface MigrationStateMachine {
-
-    CurrentStateInformation trigger(MigrationStep step, Map<String, Object> args);
-
-    MigrationState getState();
-
-    List<MigrationStep> nextSteps();
-
-    void saveContext();
-
-    MigrationStateMachineContext getContext();
-
-    String serialize();
-
-    void reset();
+public record CurrentWriteIndices(Map<String, String> writeIndices) {
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/RemoteReindexingMigrationAdapter.java
@@ -26,6 +26,8 @@ import java.net.URI;
 import java.util.Optional;
 
 public interface RemoteReindexingMigrationAdapter {
+
+    String EXISTING_INDEX_SET_WRITE_INDICES = "indexSetWriteIndices";
     boolean isMigrationRunning(IndexSet indexSet);
 
     enum Status {

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -70,5 +70,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20230904073300_MigrateThemePreferences.class);
         addMigration(V20240312140000_RemoveFieldTypeMappingsManagerRole.class);
         addMigration(V202404170856_UpdateIndexSetTemplates.class);
+        addMigration(V20240927120300_DataNodeMigrationIndexSet.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSet.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import jakarta.inject.Inject;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog2.configuration.RunsWithDataNode;
+import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.NoTargetIndexException;
+import org.graylog2.indexer.datanode.CurrentWriteIndices;
+import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
+import org.graylog2.indexer.indices.Indices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Migration creating the default index set from the legacy settings.
+ */
+public class V20240927120300_DataNodeMigrationIndexSet extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20240927120300_DataNodeMigrationIndexSet.class);
+
+    private final Boolean runsWithDataNode;
+    private final MigrationStateMachine migrationStateMachine;
+    private final IndexSetRegistry indexSetRegistry;
+    private final Indices indices;
+
+    @Inject
+    public V20240927120300_DataNodeMigrationIndexSet(@RunsWithDataNode Boolean runsWithDataNode, MigrationStateMachine migrationStateMachine, IndexSetRegistry indexSetRegistry, Indices indices) {
+        this.runsWithDataNode = runsWithDataNode;
+        this.migrationStateMachine = migrationStateMachine;
+        this.indexSetRegistry = indexSetRegistry;
+        this.indices = indices;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2024-09-27T12:03:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (!runsWithDataNode) {
+            return;
+        }
+        migrationStateMachine.getContext()
+                .getExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, CurrentWriteIndices.class)
+                .ifPresent(currentWriteIndices -> {
+                    currentWriteIndices.writeIndices().forEach((indexSetId, currentWriteIndex) -> {
+                        indexSetRegistry.get(indexSetId).ifPresent(indexSet -> {
+                            try {
+                                indexSet.getNewestIndex();
+                            } catch (NoTargetIndexException e) {
+                                LOG.info("No existing index found for {}, creating last known index now", indexSetId);
+                                indices.create(currentWriteIndex, indexSet);
+                                indexSet.setUp();
+                            }
+                        });
+                    });
+                    migrationStateMachine.getContext().removeExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES);
+                    migrationStateMachine.saveContext();
+                });
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachine;
+import org.graylog.plugins.views.storage.migration.state.machine.MigrationStateMachineContext;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.NoTargetIndexException;
+import org.graylog2.indexer.datanode.CurrentWriteIndices;
+import org.graylog2.indexer.datanode.RemoteReindexingMigrationAdapter;
+import org.graylog2.indexer.indices.Indices;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class V20240927120300_DataNodeMigrationIndexSetTest {
+
+    @Mock
+    MigrationStateMachine migrationStateMachine;
+    @Mock
+    IndexSetRegistry indexSetRegistry;
+    @Mock
+    Indices indices;
+
+    V20240927120300_DataNodeMigrationIndexSet migration;
+
+    @BeforeEach
+    public void setup() {
+        migration = new V20240927120300_DataNodeMigrationIndexSet(true,
+                migrationStateMachine, indexSetRegistry, indices);
+    }
+
+    @Test
+    public void testSkipWithoutDatanode() {
+        migration = new V20240927120300_DataNodeMigrationIndexSet(false,
+                migrationStateMachine, indexSetRegistry, indices);
+        migration.upgrade();
+        verifyNoInteractions(migrationStateMachine, indexSetRegistry, indices);
+    }
+
+    @Test
+    public void testSkipWithoutExtendedStateProp() {
+        MigrationStateMachineContext c = new MigrationStateMachineContext();
+        when(migrationStateMachine.getContext()).thenReturn(c);
+        migration.upgrade();
+        verifyNoMoreInteractions(migrationStateMachine, indexSetRegistry, indices);
+    }
+
+    @Test
+    public void testSkipIndexCreationWithIndexPresent() {
+        MigrationStateMachineContext c = new MigrationStateMachineContext();
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
+        c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
+        when(migrationStateMachine.getContext()).thenReturn(c);
+        IndexSet indexSet = mock(IndexSet.class);
+        when(indexSet.getNewestIndex()).thenReturn("graylog_25");
+        when(indexSetRegistry.get("id1")).thenReturn(Optional.of(indexSet));
+        migration.upgrade();
+        verifyNoMoreInteractions(indexSet);
+        verifyNoInteractions(indices);
+    }
+
+    @Test
+    public void testIndexCreatedWhenNotPresent() {
+        MigrationStateMachineContext c = new MigrationStateMachineContext();
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
+        c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
+        when(migrationStateMachine.getContext()).thenReturn(c);
+        IndexSet indexSet = mock(IndexSet.class);
+        when(indexSet.getNewestIndex()).thenThrow(new NoTargetIndexException(""));
+        when(indexSetRegistry.get("id1")).thenReturn(Optional.of(indexSet));
+        migration.upgrade();
+        verify(indices, times(1)).create("graylog_11", indexSet);
+        verify(indexSet, times(1)).setUp();
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,7 +77,7 @@ public class V20240927120300_DataNodeMigrationIndexSetTest {
     @Test
     public void testSkipIndexCreationWithIndexPresent() {
         MigrationStateMachineContext c = new MigrationStateMachineContext();
-        CurrentWriteIndices writeIndices = new CurrentWriteIndices(new HashMap<>(Map.of("id1", "graylog_11")));
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
         c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
         when(migrationStateMachine.getContext()).thenReturn(c);
         IndexSet indexSet = mock(IndexSet.class);
@@ -92,7 +91,7 @@ public class V20240927120300_DataNodeMigrationIndexSetTest {
     @Test
     public void testIndexCreatedWhenNotPresent() {
         MigrationStateMachineContext c = new MigrationStateMachineContext();
-        CurrentWriteIndices writeIndices = new CurrentWriteIndices(new HashMap<>(Map.of("id1", "graylog_11")));
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
         c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
         when(migrationStateMachine.getContext()).thenReturn(c);
         IndexSet indexSet = mock(IndexSet.class);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20240927120300_DataNodeMigrationIndexSetTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -77,7 +78,7 @@ public class V20240927120300_DataNodeMigrationIndexSetTest {
     @Test
     public void testSkipIndexCreationWithIndexPresent() {
         MigrationStateMachineContext c = new MigrationStateMachineContext();
-        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(new HashMap<>(Map.of("id1", "graylog_11")));
         c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
         when(migrationStateMachine.getContext()).thenReturn(c);
         IndexSet indexSet = mock(IndexSet.class);
@@ -91,7 +92,7 @@ public class V20240927120300_DataNodeMigrationIndexSetTest {
     @Test
     public void testIndexCreatedWhenNotPresent() {
         MigrationStateMachineContext c = new MigrationStateMachineContext();
-        CurrentWriteIndices writeIndices = new CurrentWriteIndices(Map.of("id1", "graylog_11"));
+        CurrentWriteIndices writeIndices = new CurrentWriteIndices(new HashMap<>(Map.of("id1", "graylog_11")));
         c.addExtendedState(RemoteReindexingMigrationAdapter.EXISTING_INDEX_SET_WRITE_INDICES, writeIndices);
         when(migrationStateMachine.getContext()).thenReturn(c);
         IndexSet indexSet = mock(IndexSet.class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR stores the current write index into the migration state machine context when stopping Graylog and the migration state machine is in a matching state.
Upon startup, these indices are the restored for the corresponding index sets if they do not exist (i.e. in an empty data node) to make sure that data node starts indexing into the last known index instead of `_0` which causes problems that data might get lost. 

/nocl

## Motivation and Context
see https://github.com/Graylog2/graylog-plugin-enterprise/issues/8367

## How Has This Been Tested?
manually, added unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

