### PR TITLE
New endpoint, filtering of index sets moved to BE

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.indexset;
 
+import jakarta.inject.Inject;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypesService;
 import org.graylog2.rest.models.tools.responses.PageListResponse;
@@ -23,9 +24,8 @@ import org.graylog2.rest.resources.entities.EntityAttribute;
 import org.graylog2.rest.resources.entities.EntityDefaults;
 import org.graylog2.rest.resources.entities.Sorting;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldTypeSummary;
+import org.graylog2.rest.resources.system.indexer.responses.IndexSetIdAndType;
 import org.graylog2.streams.StreamService;
-
-import jakarta.inject.Inject;
 
 import java.util.Comparator;
 import java.util.List;
@@ -89,6 +89,7 @@ public class IndexSetFieldTypeSummaryService {
                 .map(indexSetService::get)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+                .filter(IndexSetConfig::canHaveCustomFieldMappings)
                 .sorted(getComparator(sort, order))
                 .skip((long) (page - 1) * perPage)
                 .limit(perPage)
@@ -104,6 +105,8 @@ public class IndexSetFieldTypeSummaryService {
                 .filter(indexSetPermissionPredicate)
                 .map(indexSetService::get)
                 .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(IndexSetConfig::canHaveCustomFieldMappings)
                 .count();
 
         return PageListResponse.create("",
@@ -119,6 +122,22 @@ public class IndexSetFieldTypeSummaryService {
                 ATTRIBUTES,
                 ENTITY_DEFAULTS);
 
+    }
+
+    public List<IndexSetIdAndType> getIndexSetIdsAndTypes(final Set<String> streamIds,
+                                                          final Predicate<String> indexSetPermissionPredicate) {
+        //There is a potential to improve performance by introducing a complicated aggregation pipeline joining multiple Mongo collections, especially if permission restrictions were simplified or sorting not necessary.
+        //For now simpler solution has been used in the implementation.
+        final Set<String> indexSetsIds = streamService.indexSetIdsByIds(streamIds);
+
+        return indexSetsIds.stream()
+                .filter(indexSetPermissionPredicate)
+                .map(indexSetService::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(IndexSetConfig::canHaveCustomFieldMappings)
+                .map(indexSetConfig -> new IndexSetIdAndType(indexSetConfig.id(), indexSetConfig.indexTemplateType().orElse(""))
+                ).collect(Collectors.toList());
     }
 
     private Comparator<IndexSetConfig> getComparator(final String sort,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetFieldTypeSummaryService.java
@@ -124,8 +124,8 @@ public class IndexSetFieldTypeSummaryService {
 
     }
 
-    public List<IndexSetIdAndType> getIndexSetIdsAndTypes(final Set<String> streamIds,
-                                                          final Predicate<String> indexSetPermissionPredicate) {
+    public List<IndexSetIdAndType> getIdsAndTypesOfIndexSetsWhereFieldTypeChangeIsAllowed(final Set<String> streamIds,
+                                                                                          final Predicate<String> indexSetPermissionPredicate) {
         //There is a potential to improve performance by introducing a complicated aggregation pipeline joining multiple Mongo collections, especially if permission restrictions were simplified or sorting not necessary.
         //For now simpler solution has been used in the implementation.
         final Set<String> indexSetsIds = streamService.indexSetIdsByIds(streamIds);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -152,15 +152,15 @@ public class IndexSetsMappingResource extends RestResource {
         );
     }
 
-    @GET
-    @Path("/all_ids")
+    @POST
+    @Path("/all_index_sets_supporting_field_type_change")
     @Timed
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Get field type summaries for given index sets and field")
-    public List<IndexSetIdAndType> fieldTypeSummaries(@ApiParam("streams") @QueryParam("streams") Set<String> streamIds,
+    public List<IndexSetIdAndType> fieldTypeSummaries(@ApiParam(name = "Stream ids", required = true) Set<String> streamIds,
                                                       @Context SearchUser searchUser) {
         final Set<String> streamsIds = normalizeStreamIds(streamIds, searchUser);
-        return indexSetFieldTypeSummaryService.getIndexSetIdsAndTypes(streamsIds,
+        return indexSetFieldTypeSummaryService.getIdsAndTypesOfIndexSetsWhereFieldTypeChangeIsAllowed(streamsIds,
                 indexSetId -> isPermitted(RestPermissions.INDEXSETS_READ, indexSetId));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -157,8 +157,8 @@ public class IndexSetsMappingResource extends RestResource {
     @Timed
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Get field type summaries for given index sets and field")
-    public List<IndexSetIdAndType> fieldTypeSummaries(@ApiParam(name = "Stream ids", required = true) Set<String> streamIds,
-                                                      @Context SearchUser searchUser) {
+    public List<IndexSetIdAndType> indexSetsWithFieldTypeChangeSupport(@ApiParam(name = "Stream ids", required = true) Set<String> streamIds,
+                                                                       @Context SearchUser searchUser) {
         final Set<String> streamsIds = normalizeStreamIds(streamIds, searchUser);
         return indexSetFieldTypeSummaryService.getIdsAndTypesOfIndexSetsWhereFieldTypeChangeIsAllowed(streamsIds,
                 indexSetId -> isPermitted(RestPermissions.INDEXSETS_READ, indexSetId));

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -43,6 +43,7 @@ import org.graylog2.rest.resources.entities.Sorting;
 import org.graylog2.rest.resources.system.indexer.requests.FieldTypeSummaryRequest;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldType;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetFieldTypeSummary;
+import org.graylog2.rest.resources.system.indexer.responses.IndexSetIdAndType;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 
@@ -149,6 +150,18 @@ public class IndexSetsMappingResource extends RestResource {
                 sort,
                 Sorting.Direction.valueOf(order.toUpperCase(Locale.ROOT))
         );
+    }
+
+    @GET
+    @Path("/all_ids")
+    @Timed
+    @NoAuditEvent("No change to the DB")
+    @ApiOperation(value = "Get field type summaries for given index sets and field")
+    public List<IndexSetIdAndType> fieldTypeSummaries(@ApiParam("streams") @QueryParam("streams") Set<String> streamIds,
+                                                      @Context SearchUser searchUser) {
+        final Set<String> streamsIds = normalizeStreamIds(streamIds, searchUser);
+        return indexSetFieldTypeSummaryService.getIndexSetIdsAndTypes(streamsIds,
+                indexSetId -> isPermitted(RestPermissions.INDEXSETS_READ, indexSetId));
     }
 
     private Set<String> normalizeStreamIds(Set<String> streams, SearchUser searchUser) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsMappingResource.java
@@ -153,7 +153,7 @@ public class IndexSetsMappingResource extends RestResource {
     }
 
     @POST
-    @Path("/all_index_sets_supporting_field_type_change")
+    @Path("/index_sets_with_field_type_change_support")
     @Timed
     @NoAuditEvent("No change to the DB")
     @ApiOperation(value = "Get field type summaries for given index sets and field")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetIdAndType.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetIdAndType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.rest.resources.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetIdAndType.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetIdAndType.java
@@ -1,0 +1,10 @@
+package org.graylog2.rest.resources.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record IndexSetIdAndType(@JsonProperty(INDEX_SET_ID) String id,
+                                @JsonProperty(INDEX_SET_TYPE) String type) {
+
+    public static final String INDEX_SET_ID = "index_set_id";
+    public static final String INDEX_SET_TYPE = "type";
+}


### PR DESCRIPTION
## Description
New endpoint, filtering of index sets moved to BE.
/nocl

## Motivation and Context
It is better to filter out index sets that cannot have their field types changes in the BE, instead of fighting with a way to disable them in the FE.
FE needs a way to figure out all index sets' IDs, not only the ones on the first page, so that field type can be changed everywhere.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0d2963c3-94aa-451d-8938-f05df019713a)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

