### PR TITLE
Make config parameters not final

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/config/GeoIpProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/config/GeoIpProcessorConfig.java
@@ -25,6 +25,7 @@ import org.graylog2.configuration.PathConfiguration;
 import java.nio.file.Path;
 import java.util.Optional;
 
+@SuppressWarnings({"unused", "FieldMayBeFinal"})
 @Singleton
 public class GeoIpProcessorConfig extends PathConfiguration {
     private static final String PREFIX = "geo_ip_processor";
@@ -40,5 +41,5 @@ public class GeoIpProcessorConfig extends PathConfiguration {
     }
 
     @Parameter(value = DISABLE_IPINFO_DB_TYPE_CHECK)
-    private final boolean disableIpInfoDBTypeCheck = false;
+    private boolean disableIpInfoDBTypeCheck = false;
 }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerConfiguration.java
@@ -29,20 +29,20 @@ import java.util.Map;
 /**
  * Job scheduler specific configuration fields for the server configuration file.
  */
-@SuppressWarnings({"FieldCanBeLocal", "unused", "WeakerAccess"})
+@SuppressWarnings({"FieldCanBeLocal", "unused", "WeakerAccess", "FieldMayBeFinal"})
 public class JobSchedulerConfiguration implements PluginConfigBean {
     public static final String LOOP_SLEEP_DURATION = "job_scheduler_loop_sleep_duration";
     public static final String LOCK_EXPIRATION_DURATION = "job_scheduler_lock_expiration_duration";
     public static final String CONCURRENCY_LIMITS = "job_scheduler_concurrency_limits";
 
     @Parameter(value = LOOP_SLEEP_DURATION, validators = PositiveDurationValidator.class)
-    private final Duration loopSleepDuration = Duration.seconds(1);
+    private Duration loopSleepDuration = Duration.seconds(1);
 
     @Parameter(value = LOCK_EXPIRATION_DURATION, validators = Minimum1MinuteValidator.class)
-    private final Duration lockExpirationDuration = Duration.minutes(5);
+    private Duration lockExpirationDuration = Duration.minutes(5);
 
     @Parameter(value = CONCURRENCY_LIMITS, converter = MapConverter.StringInteger.class)
-    private final Map<String, Integer> concurrencyLimits = Map.of();
+    private Map<String, Integer> concurrencyLimits = Map.of();
 
     /**
      * Concurrency limits per job type. A missing entry signifies unlimited concurrency. (up to the number of worker threads)


### PR DESCRIPTION
If fields annotated with `@Parameter` are make final and then accessed through a method, e.g. a getter, the default value will be inlined by the Java compiler. Setting a differnet value via our configuration mechanism won't have any effect in that case, which is unexpected.

/nocl