### PR TITLE
Delete stream destination filters when deleting a stream

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
@@ -69,7 +69,6 @@ public class StreamDestinationFilterService {
     private final MongoPaginationHelper<StreamDestinationFilterRuleDTO> paginationHelper;
     private final MongoUtils<StreamDestinationFilterRuleDTO> utils;
     private final ClusterEventBus clusterEventBus;
-    private final EventBus eventBus;
     private final Optional<DestinationFilterCreationValidator> optionalDestinationFilterCreationValidator;
 
     @Inject
@@ -82,13 +81,12 @@ public class StreamDestinationFilterService {
         this.utils = mongoCollections.utils(collection);
         this.clusterEventBus = clusterEventBus;
         this.optionalDestinationFilterCreationValidator = optionalDestinationFilterCreationValidator;
-        this.eventBus = eventBus;
-
-        eventBus.register(this);
 
         collection.createIndex(Indexes.ascending(FIELD_STREAM_ID));
         collection.createIndex(Indexes.ascending(FIELD_DESTINATION_TYPE));
         collection.createIndex(Indexes.ascending(FIELD_STATUS));
+
+        eventBus.register(this);
     }
 
     private Bson parseQuery(String queryString) {
@@ -187,9 +185,7 @@ public class StreamDestinationFilterService {
     @Subscribe
     @SuppressWarnings("unused")
     public void handleStreamDeleted(StreamDeletedEvent streamDeletedEvent) {
-        collection.find(eq(FIELD_STREAM_ID, streamDeletedEvent.streamId())).forEach(
-                dto -> deleteFromStream(streamDeletedEvent.streamId(), dto.id())
-        );
+        collection.deleteOne(eq(FIELD_STREAM_ID, streamDeletedEvent.streamId()));
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
@@ -18,6 +18,8 @@ package org.graylog2.streams.filters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Accumulators;
 import com.mongodb.client.model.Aggregates;
@@ -31,6 +33,7 @@ import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
+import org.graylog2.streams.events.StreamDeletedEvent;
 import org.mongojack.Id;
 
 import java.util.List;
@@ -66,17 +69,22 @@ public class StreamDestinationFilterService {
     private final MongoPaginationHelper<StreamDestinationFilterRuleDTO> paginationHelper;
     private final MongoUtils<StreamDestinationFilterRuleDTO> utils;
     private final ClusterEventBus clusterEventBus;
+    private final EventBus eventBus;
     private final Optional<DestinationFilterCreationValidator> optionalDestinationFilterCreationValidator;
 
     @Inject
     public StreamDestinationFilterService(MongoCollections mongoCollections,
                                           ClusterEventBus clusterEventBus,
+                                          EventBus eventBus,
                                           Optional<DestinationFilterCreationValidator> optionalDestinationFilterCreationValidator) {
         this.collection = mongoCollections.collection(COLLECTION, StreamDestinationFilterRuleDTO.class);
         this.paginationHelper = mongoCollections.paginationHelper(collection);
         this.utils = mongoCollections.utils(collection);
         this.clusterEventBus = clusterEventBus;
         this.optionalDestinationFilterCreationValidator = optionalDestinationFilterCreationValidator;
+        this.eventBus = eventBus;
+
+        eventBus.register(this);
 
         collection.createIndex(Indexes.ascending(FIELD_STREAM_ID));
         collection.createIndex(Indexes.ascending(FIELD_DESTINATION_TYPE));
@@ -175,4 +183,13 @@ public class StreamDestinationFilterService {
                 ))
         ), GroupByStreamResult.class).forEach(consumer);
     }
+
+    @Subscribe
+    @SuppressWarnings("unused")
+    public void handleStreamDeleted(StreamDeletedEvent streamDeletedEvent) {
+        collection.find(eq(FIELD_STREAM_ID, streamDeletedEvent.streamId())).forEach(
+                dto -> deleteFromStream(streamDeletedEvent.streamId(), dto.id())
+        );
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/filters/StreamDestinationFilterService.java
@@ -185,7 +185,7 @@ public class StreamDestinationFilterService {
     @Subscribe
     @SuppressWarnings("unused")
     public void handleStreamDeleted(StreamDeletedEvent streamDeletedEvent) {
-        collection.deleteOne(eq(FIELD_STREAM_ID, streamDeletedEvent.streamId()));
+        collection.deleteMany(eq(FIELD_STREAM_ID, streamDeletedEvent.streamId()));
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.streams.filters;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.mongodb.client.model.Sorts;
 import org.graylog.plugins.pipelineprocessor.rulebuilder.RuleBuilder;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -50,7 +52,7 @@ class StreamDestinationFilterServiceTest {
 
     @BeforeEach
     void setUp(MongoCollections mongoCollections) {
-        this.service = new StreamDestinationFilterService(mongoCollections, new ClusterEventBus(MoreExecutors.directExecutor()), Optional.of(mockedFilterLicenseCheck));
+        this.service = new StreamDestinationFilterService(mongoCollections, new ClusterEventBus(MoreExecutors.directExecutor()), mock(EventBus.class), Optional.of(mockedFilterLicenseCheck));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/filters/StreamDestinationFilterServiceTest.java
@@ -295,10 +295,24 @@ class StreamDestinationFilterServiceTest {
     @Test
     @MongoDBFixtures("StreamDestinationFilterServiceTest-2024-07-01-1.json")
     void streamDeletionEvent() {
-        final var optionalDto = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0000");
+        var optionalDto = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0000");
         assertThat(optionalDto).isPresent();
+
+        optionalDto = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0001");
+        assertThat(optionalDto).isPresent();
+
+        optionalDto = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0002");
+        assertThat(optionalDto).isPresent();
+
         eventBus.post(StreamDeletedEvent.create("54e3deadbeefdeadbeef1000"));
-        final var afterDeletionEvent = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0000");
+
+        var afterDeletionEvent = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0000");
+        assertThat(afterDeletionEvent).isNotPresent();
+
+        afterDeletionEvent = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0001");
+        assertThat(afterDeletionEvent).isNotPresent();
+
+        afterDeletionEvent = service.findByIdForStream("54e3deadbeefdeadbeef1000", "54e3deadbeefdeadbeef0002");
         assertThat(afterDeletionEvent).isNotPresent();
     }
 }


### PR DESCRIPTION
/nocl unreleased
Resolves Graylog2/graylog-plugin-enterprise#7833 

<!--- Provide a general summary of your changes in the Title above -->
Add handler for stream deletion to `StreamDestinationFilterService`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

