### PR TITLE
Make `App` component a singleton.

### DIFF
--- a/graylog2-web-interface/src/routing/App.tsx
+++ b/graylog2-web-interface/src/routing/App.tsx
@@ -34,6 +34,7 @@ import HotkeysProvider from 'contexts/HotkeysProvider';
 import HotkeysModalContainer from 'components/hotkeys/HotkeysModalContainer';
 import PerspectivesProvider from 'components/perspectives/contexts/PerspectivesProvider';
 import PageContextProviders from 'components/page/contexts/PageContextProviders';
+import { singleton } from 'logic/singleton';
 
 const AppLayout = styled.div`
   display: flex;
@@ -106,4 +107,4 @@ const App = () => (
   </QueryParamProvider>
 );
 
-export default App;
+export default singleton('components.App', () => App);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


With this PR we register the `App` component as a `singleton`. This is necessary for reliable comparison checks. Currently a compression check happens in the `AppRouter` for plugin routes with a `parentComponent`. Defining the `App` as a parent component allows rendering the page independent of the `PageContentLayout`.

/nocl