### PR TITLE
Add/mongo dup key utility

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -18,6 +18,8 @@ package org.graylog2.database.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Streams;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Filters;
@@ -166,6 +168,16 @@ public class MongoUtils<T extends MongoEntity> {
     public static <T> Stream<T> stream(@Nonnull MongoIterable<T> mongoIterable) {
         final var cursor = mongoIterable.cursor();
         return Streams.stream(cursor).onClose(cursor::close);
+    }
+
+    /**
+     * Checks if the given {@link MongoException} represents a duplicate key error by checking its error code.
+     *
+     * @param e Exception that has been thrown by a MongoDB operation
+     * @return true if the exception represents a duplicate key error, false otherwise
+     */
+    public static boolean isDuplicateKeyError(MongoException e) {
+        return ErrorCategory.fromErrorCode(e.getCode()) == ErrorCategory.DUPLICATE_KEY;
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -20,7 +20,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
 import com.mongodb.client.MongoCollection;
+import org.bson.BsonDocument;
 import org.bson.RawBsonDocument;
 import org.bson.types.ObjectId;
 import org.graylog.testing.mongodb.MongoDBExtension;
@@ -35,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mongojack.Id;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -184,6 +190,25 @@ class MongoUtilsTest {
         assertThatThrownBy(() -> utils.getOrCreate(new DTO(null, "test")))
                 .hasMessageContaining("entity ID cannot be null")
                 .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIsDuplicateKeyError() {
+        final var clientException = new MongoClientException("Something went wrong!");
+        final var madeUpServerException = new MongoWriteException(
+                new WriteError(12345,
+                        "E12345 some error that I just made up",
+                        new BsonDocument()),
+                new ServerAddress(), Collections.emptySet());
+        final var dupKeyException = new MongoWriteException(
+                new WriteError(11000,
+                        "E11000 duplicate key error collection: graylog.example index: action_id_1 dup key: { foo_id: \"bar\" }",
+                        new BsonDocument()),
+                new ServerAddress(), Collections.emptySet());
+
+        assertThat(MongoUtils.isDuplicateKeyError(clientException)).isFalse();
+        assertThat(MongoUtils.isDuplicateKeyError(madeUpServerException)).isFalse();
+        assertThat(MongoUtils.isDuplicateKeyError(dupKeyException)).isTrue();
     }
 
     @AutoValue

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -20,12 +20,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoWriteException;
 import com.mongodb.ServerAddress;
+import com.mongodb.WriteConcernResult;
 import com.mongodb.WriteError;
 import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.RawBsonDocument;
 import org.bson.types.ObjectId;
 import org.graylog.testing.mongodb.MongoDBExtension;
@@ -205,10 +208,14 @@ class MongoUtilsTest {
                         "E11000 duplicate key error collection: graylog.example index: action_id_1 dup key: { foo_id: \"bar\" }",
                         new BsonDocument()),
                 new ServerAddress(), Collections.emptySet());
+        final var legacyDupKeyException = new DuplicateKeyException(
+                new BsonDocument("err", new BsonString("E11000 duplicate key error collection: graylog.example index: action_id_1 dup key: { foo_id: \"bar\" }")),
+                new ServerAddress(), WriteConcernResult.acknowledged(0, false, null));
 
         assertThat(MongoUtils.isDuplicateKeyError(clientException)).isFalse();
         assertThat(MongoUtils.isDuplicateKeyError(madeUpServerException)).isFalse();
         assertThat(MongoUtils.isDuplicateKeyError(dupKeyException)).isTrue();
+        assertThat(MongoUtils.isDuplicateKeyError(legacyDupKeyException)).isTrue();
     }
 
     @AutoValue


### PR DESCRIPTION
A `DuplicateKeyException` will only be thrown when using the "legacy deprecated API". See https://github.com/mongodb/mongo-java-driver/blob/a8a5577a43d13cffa623f93d7229e9f6e9eaadf2/driver-core/src/main/com/mongodb/DuplicateKeyException.java#L24.

For the newer `MongoCollection` based API, the error code has to be inspected.

/nocl
