### PR TITLE
Deprecate MongoDBUpsertRetryer and remove usages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventProcessorStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventProcessorStateService.java
@@ -19,10 +19,10 @@ package org.graylog.events.processor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
+import jakarta.inject.Inject;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.database.MongoDBUpsertRetryer;
 import org.joda.time.DateTime;
 import org.mongojack.DBQuery;
 import org.mongojack.DBUpdate;
@@ -31,8 +31,6 @@ import org.mongojack.UpdateOperationValue;
 import org.mongojack.internal.update.SingleUpdateOperationValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.util.Optional;
 import java.util.Set;
@@ -140,7 +138,7 @@ public class DBEventProcessorStateService {
                 .addOperation("$min", FIELD_MIN_PROCESSED_TIMESTAMP, updateValue(minProcessedTimestamp))
                 .addOperation("$max", FIELD_MAX_PROCESSED_TIMESTAMP, updateValue(maxProcessedTimestamp));
 
-        return Optional.ofNullable(MongoDBUpsertRetryer.run(() -> db.findAndModify(
+        return Optional.ofNullable(db.findAndModify(
                 // We have a unique index on the eventDefinitionId so this query is enough
                 DBQuery.is(FIELD_EVENT_DEFINITION_ID, eventDefinitionId),
                 null,
@@ -148,7 +146,7 @@ public class DBEventProcessorStateService {
                 false,
                 update,
                 true, // We want to return the updated document to the caller
-                true)));
+                true));
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -28,7 +28,6 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.database.MongoDBUpsertRetryer;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
@@ -132,7 +131,7 @@ public class IndexFieldTypesService {
     }
 
     public Optional<IndexFieldTypesDTO> upsert(IndexFieldTypesDTO dto) {
-        final WriteResult<IndexFieldTypesDTO, ObjectId> update = MongoDBUpsertRetryer.run(() -> db.update(
+        final WriteResult<IndexFieldTypesDTO, ObjectId> update = db.update(
                 DBQuery.and(
                         DBQuery.is(FIELD_INDEX_NAME, dto.indexName()),
                         DBQuery.is(FIELD_INDEX_SET_ID, dto.indexSetId())
@@ -140,7 +139,7 @@ public class IndexFieldTypesService {
                 dto,
                 true,
                 false
-        ));
+        );
 
         final Object upsertedId = update.getUpsertedId();
         if (upsertedId instanceof ObjectId) {

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -21,11 +21,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import org.bson.types.ObjectId;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.database.MongoDBUpsertRetryer;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.system.NodeId;
@@ -35,9 +36,6 @@ import org.mongojack.DBCursor;
 import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
 import org.mongojack.JacksonDBCollection;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
 
 import java.util.List;
 import java.util.Optional;
@@ -132,14 +130,14 @@ public class DBProcessingStatusService {
         // TODO: Using a timestamp provided by the node for "updated_at" can be bad if the node clock is skewed.
         //       Ideally we would use MongoDB's "$currentDate" but there doesn't seem to be a way to use that
         //       with mongojack.
-        return MongoDBUpsertRetryer.run(() -> db.findAndModify(
+        return db.findAndModify(
                 DBQuery.is(ProcessingStatusDto.FIELD_NODE_ID, nodeId),
                 null,
                 null,
                 false,
                 ProcessingStatusDto.of(nodeId, processingStatusRecorder, updatedAt, baseConfiguration.isMessageJournalEnabled()),
                 true, // We want to return the updated document to the caller
-                true));
+                true);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
@@ -28,7 +28,6 @@ import jakarta.validation.Validator;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
-import org.graylog2.database.MongoDBUpsertRetryer;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.shared.security.Permissions;
@@ -204,8 +203,7 @@ public class RoleServiceImpl implements RoleService {
         if (!violations.isEmpty()) {
             throw new ValidationException("Validation failed.", violations.toString());
         }
-        return MongoDBUpsertRetryer.run(() ->
-                dbCollection.findAndModify(is(NAME_LOWER, role.nameLower()), null, null, false, role, true, true));
+        return dbCollection.findAndModify(is(NAME_LOWER, role.nameLower()), null, null, false, role, true, true);
     }
 
     @Override


### PR DESCRIPTION
The MongoDBUpsertRetryer was intended to fix issues with MongoDB upsert behaviour for MongoDB versions < 4.2. Graylog does not support MongoDB versions < 5.0 anymore, so we can deprecate the class and remove its usages.

see https://jira.mongodb.org/browse/SERVER-14322 and [the original issue](https://github.com/Graylog2/graylog2-server/issues/7258) which lead to the introduction of the class.

/nocl