### PR TITLE
Disable cross_subdomain_cookie for telemetry

### DIFF
--- a/graylog2-web-interface/src/logic/telemetry/TelemetryInit.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryInit.tsx
@@ -46,6 +46,8 @@ const init = (key: string, host: string) => {
       api_host: host,
       capture_pageview: false,
       capture_pageleave: false,
+      cross_subdomain_cookie: false,
+      persistence: 'cookie',
     },
   );
 


### PR DESCRIPTION
This PR disables `cross_subdomain_cookie` for Posthog telemetry and sets default persistence to cookie.
/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

