### PR TITLE
Let dependabot ignore Lucene versions >=10 until we update to JDK 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
         update-types: ["version-update:semver-patch"]
       - dependency-name: "com.amazonaws:aws-java-sdk-bom"
         update-types: ["version-update:semver-patch"]
+      # Lucene >=10 requires JDK 21
+      - dependency-name: "org.apache.lucene:lucene-queryparser"
+        versions:
+          - "> 9"
+      - dependency-name: "org.apache.lucene:lucene-analysis-common"
+        versions:
+          - "> 9"
     open-pull-requests-limit: 25
     labels:
       - dependencies


### PR DESCRIPTION
See: https://lucene.apache.org/core/corenews.html#apache-lucenetm-1000-available

Refs #20700

/nocl