### PR TITLE
Hide stream rule Matching-Type-Switcher when stream is not editable

### DIFF
--- a/changelog/unreleased/pr-20714.toml
+++ b/changelog/unreleased/pr-20714.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Hide stream rule Matching-Type-Switcher when stream is not editable"
+
+pulls = ["20714"]

--- a/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.tsx
+++ b/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.tsx
@@ -53,6 +53,7 @@ type Props = {
 
 const MatchingTypeSwitcher = ({ stream, onChange }: Props) => {
   const [matchingType, setMatchingType] = useState<'AND'|'OR'|undefined>(undefined);
+  const disabled = stream.is_default || !stream.is_editable;
 
   const handleTypeChange = (newValue: 'AND'|'OR') => {
     StreamsStore.update(stream.id, { matching_type: newValue }, (response) => {
@@ -72,12 +73,14 @@ const MatchingTypeSwitcher = ({ stream, onChange }: Props) => {
                type="radio"
                label="A message must match all of the following rules"
                checked={stream.matching_type === 'AND'}
-               onChange={() => setMatchingType('AND')} />
+               onChange={() => setMatchingType('AND')}
+               disabled={disabled} />
         <Input id="streamrule-or-connector"
                type="radio"
                label="A message must match at least one of the following rules"
                checked={stream.matching_type === 'OR'}
-               onChange={() => setMatchingType('OR')} />
+               onChange={() => setMatchingType('OR')}
+               disabled={disabled} />
       </div>
       {matchingType && (
         <ConfirmDialog show

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
@@ -40,6 +40,7 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
   const hasStreamRules = !!stream.rules?.length;
   const isDefaultStream = stream.is_default;
   const isNotEditable = !stream.is_editable;
+  const disableStreamRuleActions = isDefaultStream || isNotEditable;
 
   const handleMatchingTypeSwitched = () => {
     queryClient.invalidateQueries(['stream', stream.id]);
@@ -56,11 +57,13 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
                actions={(
                  <IfPermitted permissions={`streams:edit:${stream.id}`}>
                    <CreateStreamRuleButton bsStyle="success"
-                                           disabled={isDefaultStream || isNotEditable}
+                                           disabled={disableStreamRuleActions}
                                            streamId={stream.id} />
                  </IfPermitted>
              )}>
-        <MatchingTypeSwitcher stream={stream} onChange={handleMatchingTypeSwitched} />
+        {!disableStreamRuleActions && (
+          <MatchingTypeSwitcher stream={stream} onChange={handleMatchingTypeSwitched} />
+        )}
         <Table condensed striped hover>
           <thead>
             <tr>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
@@ -40,7 +40,6 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
   const hasStreamRules = !!stream.rules?.length;
   const isDefaultStream = stream.is_default;
   const isNotEditable = !stream.is_editable;
-  const disableStreamRuleActions = isDefaultStream || isNotEditable;
 
   const handleMatchingTypeSwitched = () => {
     queryClient.invalidateQueries(['stream', stream.id]);
@@ -57,13 +56,11 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
                actions={(
                  <IfPermitted permissions={`streams:edit:${stream.id}`}>
                    <CreateStreamRuleButton bsStyle="success"
-                                           disabled={disableStreamRuleActions}
+                                           disabled={isDefaultStream || isNotEditable}
                                            streamId={stream.id} />
                  </IfPermitted>
              )}>
-        {!disableStreamRuleActions && (
-          <MatchingTypeSwitcher stream={stream} onChange={handleMatchingTypeSwitched} />
-        )}
+        <MatchingTypeSwitcher stream={stream} onChange={handleMatchingTypeSwitched} />
         <Table condensed striped hover>
           <thead>
             <tr>


### PR DESCRIPTION
The issue was introduced with this PR: https://github.com/Graylog2/graylog2-server/pull/20678

![Screenshot 2024-10-17 at 11 11 47](https://github.com/user-attachments/assets/4a873d5d-0230-4260-88a0-ccdab09dac17)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

