### PR TITLE
Improve reusability of `QueryInput` and `StreamsFilter`.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.tsx
@@ -33,9 +33,13 @@ type Props = {
   streams: Array<{ key: string, value: string }>,
   onChange: (newStreamIds: Array<string>) => void,
   multi?: boolean,
+  clearable?: boolean
 };
 
-const StreamsFilter = ({ disabled = false, value = [], streams, onChange, multi = true }: Props) => {
+const StreamsFilter = ({
+  disabled = false, value = [], streams, onChange, multi = true,
+  clearable = true,
+}: Props) => {
   const sendTelemetry = useSendTelemetry();
   const selectedStreams = value.join(',');
   const placeholder = 'Select streams the search should include. Searches in all streams if empty.';
@@ -58,6 +62,7 @@ const StreamsFilter = ({ disabled = false, value = [], streams, onChange, multi 
     <Container data-testid="streams-filter" title={placeholder}>
       <Select placeholder={placeholder}
               disabled={disabled}
+              clearable={clearable}
               inputProps={{ 'aria-label': placeholder }}
               displayKey="key"
               inputId="streams-filter"

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -170,7 +170,10 @@ const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCo
     });
 
     commands.forEach((command) => editor.commands.addCommand(command));
-    editor.completers = [completer];
+
+    if (completer) {
+      editor.completers = [completer];
+    }
   }
 };
 
@@ -186,7 +189,7 @@ const useCompleter = ({ streams, timeRange, completerFactory, view }: Pick<Props
     return { all: allFieldsByName, query: queryFieldsByName };
   }, [allFields, queryFields]);
 
-  return useMemo(() => completerFactory(completers ?? [], timeRange, streams, fieldTypes, userTimezone, view),
+  return useMemo(() => completerFactory?.(completers ?? [], timeRange, streams, fieldTypes, userTimezone, view),
     [completerFactory, completers, timeRange, streams, fieldTypes, userTimezone, view]);
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR contains two small changes for the search bar components.

We:
- ensure `completers` prop of `QueryInput` can be not defined.
- ensure `clearable` props of `StreamsFilter` can be configured.

/nocl
