### PR TITLE
Remove unused GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2 from datanode containers

### DIFF
--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeDevContainerBuilder.java
@@ -169,7 +169,7 @@ public class DatanodeDevContainerBuilder implements org.graylog.testing.datanode
 
                 .withEnv("GRAYLOG_DATANODE_ROOT_USERNAME", rootUsername)
                 .withEnv("GRAYLOG_DATANODE_PASSWORD_SECRET", passwordSecret)
-                .withEnv("GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2", rootPasswordSha2)
+                //.withEnv("GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2", rootPasswordSha2)
 
                 .withEnv("GRAYLOG_DATANODE_NODE_ID_FILE", "./node-id")
                 .withEnv("GRAYLOG_DATANODE_HTTP_BIND_ADDRESS", "0.0.0.0:" + restPort)

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/DatanodeInstance.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/testing/DatanodeInstance.java
@@ -69,7 +69,7 @@ public class DatanodeInstance extends OpenSearchInstance {
                 .withReuse(isNull(System.getenv("CI")))
                 .withEnv("OPENSEARCH_JAVA_OPTS", getEsJavaOpts())
                 .withEnv("GRAYLOG_DATANODE_PASSWORD_SECRET", passwordSecret)
-                .withEnv("GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2", rootPasswordSha2)
+                //.withEnv("GRAYLOG_DATANODE_ROOT_PASSWORD_SHA2", rootPasswordSha2)
                 .withEnv("GRAYLOG_DATANODE_MONGODB_URI", mongoDBUri)
                 .withEnv("GRAYLOG_DATANODE_SINGLE_NODE_ONLY", "true")
                 .withEnv("GRAYLOG_DATANODE_INSECURE_STARTUP", "true")


### PR DESCRIPTION
This property is neither required nor used in the datanode. We should remove it everywhere. 

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

