### PR TITLE
Add ability to filter by double values within Mongo search queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
@@ -30,12 +30,13 @@ public class SearchQueryField {
     public enum Type {
         STRING(value -> value),
         DATE(value -> dateParser.parseDate(value)),
+        DOUBLE(value -> Double.parseDouble(value)),
         INT(value -> Integer.parseInt(value)),
         LONG(value -> Long.parseLong(value)),
         OBJECT_ID(value -> new ObjectId(value)),
         BOOLEAN(value -> Boolean.parseBoolean(value));
 
-        public static final Collection<Type> NUMERIC_TYPES = List.of(DATE, LONG, INT);
+        public static final Collection<Type> NUMERIC_TYPES = List.of(DATE, LONG, INT, DOUBLE);
 
         private final Function<String, Object> mongoValueConverter;
 

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/DbFilterExpressionParserTest.java
@@ -184,6 +184,20 @@ class DbFilterExpressionParserTest {
     }
 
     @Test
+    void parsesFilterExpressionCorrectlyForDoubleType() {
+
+        assertEquals(Filters.eq("num", 22.5),
+                toTest.parseSingleExpression("num:22.5",
+                        List.of(EntityAttribute.builder()
+                                .id("num")
+                                .title("Num")
+                                .type(SearchQueryField.Type.DOUBLE)
+                                .filterable(true)
+                                .build())
+                ));
+    }
+
+    @Test
     void parsesFilterExpressionCorrectlyForIntType() {
 
         assertEquals(Filters.eq("num", 42),
@@ -247,6 +261,26 @@ class DbFilterExpressionParserTest {
                         Filters.lte("created_at", dateObject.toDate())
                 ),
                 toTest.parseSingleExpression("created_at:" + RANGE_VALUES_SEPARATOR + dateString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForDoubleRanges() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("number")
+                .title("Number")
+                .type(SearchQueryField.Type.DOUBLE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                Filters.and(
+                        Filters.gte("number", 22.5),
+                        Filters.lte("number", 44.5)
+                ),
+
+                toTest.parseSingleExpression("number:22.5" + RANGE_VALUES_SEPARATOR + "44.5",
                         entityAttributes
                 ));
     }


### PR DESCRIPTION
Adds ability to supply a pagination request filter to the `SearchQueryParser` with a `double` value persisted in MongoDB.

For example:
```
SearchQueryField.create("my_field", SearchQueryField.Type.DOUBLE)
```

/nocl Provides needed server changes for https://github.com/Graylog2/graylog-plugin-enterprise/pull/8924.