### PR TITLE
Fix flaky test in SearchesCleanUpJobWithDBServicesTest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
@@ -119,6 +119,6 @@ public class SearchesCleanUpJobWithDBServicesTest {
         final ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
         verify(searchDbService, times(2)).delete(idCaptor.capture());
 
-        assertThat(idCaptor.getAllValues()).containsExactly("5b3b44ca77196aa4679e4da1", "5b3b44ca77196aa4679e4da2");
+        assertThat(idCaptor.getAllValues()).containsExactlyInAnyOrder("5b3b44ca77196aa4679e4da1", "5b3b44ca77196aa4679e4da2");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I encountered non-deterministic behavior for test:
`org.graylog.plugins.views.search.db.SearchesCleanUpJobWithDBServicesTest#testMixedExpiredNonExpiredReferencedAndNonReferencedSearches`

Error Message: 

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.819 s <<< FAILURE! -- in org.graylog.plugins.views.search.db.SearchesCleanUpJobWithDBServicesTest
[ERROR] org.graylog.plugins.views.search.db.SearchesCleanUpJobWithDBServicesTest.testMixedExpiredNonExpiredReferencedAndNonReferencedSearches -- Time elapsed: 4.795 s <<< FAILURE!
org.opentest4j.AssertionFailedError:

Expecting actual:
  ["5b3b44ca77196aa4679e4da2", "5b3b44ca77196aa4679e4da1"]
to contain exactly (and in same order):
  ["5b3b44ca77196aa4679e4da1", "5b3b44ca77196aa4679e4da2"]
but there were differences at these indexes:
  - element at index 0: expected "5b3b44ca77196aa4679e4da1" but was "5b3b44ca77196aa4679e4da2"
  - element at index 1: expected "5b3b44ca77196aa4679e4da2" but was "5b3b44ca77196aa4679e4da1"

```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The test was previously using `containsExactly`, which assumes a strict order for the captured values. However, captured value inherently relies on unordered collection `HashSet` at [SearchesCleanUpJob.java#L99](https://github.com/Graylog2/graylog2-server/blob/9a2686173b1e12c401c4c9adcb35638008ad3434/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java#L99) which inherently calls [SearchDbService.java#L145](https://github.com/Graylog2/graylog2-server/blob/9a2686173b1e12c401c4c9adcb35638008ad3434/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchDbService.java#L145). 

For this test, to avoid flakiness, I think we can switch to `containsExactlyInAnyOrder` by checking for the presence of all elements, regardless of their order. 

## How Has This Been Tested?

I found this non-deterministic behavior by running NonDex.

### NonDex:https://github.com/TestingResearchIllinois/NonDex

In short, NonDex is a tool that introduces randomness by deliberately shuffling e.g. unordered collections like HashSet to detect flakiness in code. 

You can reproduce the failures/run the tests with NonDex by using the command e.g.: 
```
mvn -pl graylog2-server edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.graylog.plugins.views.search.db.SearchesCleanUpJobWithDBServicesTest#testMixedExpiredNonExpiredReferencedAndNonReferencedSearches -DnondexMode=ONE
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

