### PR TITLE
Fix can not read `formComponent` of `undefined` error on create event notification page.

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.tsx
@@ -139,7 +139,7 @@ class EventNotificationForm extends React.Component<EventNotificationFormProps, 
     const { isSubmitEnabled } = this.state;
 
     const notificationPlugin = getNotificationPlugin(notification.config.type);
-    const notificationFormComponent = notificationPlugin.formComponent
+    const notificationFormComponent = notificationPlugin?.formComponent
       ? React.createElement(notificationPlugin.formComponent, {
         config: notification.config,
         onChange: this.handleConfigChange,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to this change 
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/f1963338-4610-4073-b878-96ab60be08ad">

in https://github.com/Graylog2/graylog2-server/pull/20727, we are now returning `undefined` instead of an empty object, which led to the runtime error.

This error occurred when opening the create event notification form.

/nocl