### PR TITLE
Allow showing validation error for streams filter.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.tsx
@@ -21,8 +21,9 @@ import Select from 'components/common/Select';
 import { defaultCompare } from 'logic/DefaultCompare';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import { FormGroup } from 'components/bootstrap';
 
-const Container = styled.div`
+const Container = styled(FormGroup)`
   flex: 1;
   grid-area: streams;
 `;
@@ -34,11 +35,12 @@ type Props = {
   onChange: (newStreamIds: Array<string>) => void,
   multi?: boolean,
   clearable?: boolean
+  hasError?: boolean
 };
 
 const StreamsFilter = ({
   disabled = false, value = [], streams, onChange, multi = true,
-  clearable = true,
+  clearable = true, hasError = false,
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const selectedStreams = value.join(',');
@@ -59,7 +61,7 @@ const StreamsFilter = ({
   };
 
   return (
-    <Container data-testid="streams-filter" title={placeholder}>
+    <Container data-testid="streams-filter" title={placeholder} validationState={hasError ? 'error' : undefined} bsClass="no-bm">
       <Select placeholder={placeholder}
               disabled={disabled}
               clearable={clearable}
@@ -70,6 +72,7 @@ const StreamsFilter = ({
               options={options}
               multi={multi}
               value={selectedStreams} />
+
     </Container>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR it will be possible to display the streams filter in an "error" state.

<img width="855" alt="image" src="https://github.com/user-attachments/assets/b7a5c766-662c-455e-8060-3954ea2f2662">


/nocl