### PR TITLE
Improve reusability of `PaginatedSelect`.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select/PaginatedSelect.tsx
+++ b/graylog2-web-interface/src/components/common/Select/PaginatedSelect.tsx
@@ -15,17 +15,82 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
+import debounce from 'lodash/debounce';
 
 import Select from 'components/common/Select';
+import { Spinner } from 'components/common';
 
-type Props = React.ComponentProps<typeof Select>;
+const DEFAULT_PAGINATION = { page: 1, perPage: 50, query: '' };
 
-const PaginatedSelect = (props: Props) => {
+type Pagination = {
+  page: number,
+  perPage: number,
+  query: string,
+}
+
+type PaginatedOptions = {
+  total: number,
+  pagination: Pagination,
+  list: Array<{ label: string, value: unknown }>,
+}
+
+type Props = Omit<React.ComponentProps<typeof Select>, 'options'> & {
+  onLoadOptions: (pagination: Pagination) => Promise<PaginatedOptions>,
+}
+
+const PaginatedSelect = ({ onLoadOptions, ...rest }: Props) => {
   const selectRef = useRef();
+  const [paginatedOptions, setPaginatedOptions] = useState<PaginatedOptions | undefined>();
+  const [isSearching, setIsSearching] = useState(false);
+
+  const handleSearch = debounce((newValue, actionMeta) => {
+    if (actionMeta.action === 'input-change') {
+      setIsSearching(true);
+
+      onLoadOptions({ ...DEFAULT_PAGINATION, query: newValue }).then((results) => {
+        setIsSearching(false);
+        setPaginatedOptions(results);
+      });
+    } else if (actionMeta.action === 'menu-close') {
+      onLoadOptions(DEFAULT_PAGINATION).then(setPaginatedOptions);
+    }
+  }, 400);
+
+  const handleLoadMore = debounce(() => {
+    const { pagination, total, list } = paginatedOptions;
+
+    if (isSearching) {
+      return;
+    }
+
+    if (total > list.length) {
+      onLoadOptions({ ...pagination, page: pagination.page + 1, query: '' }).then((res) => setPaginatedOptions((cur) => ({
+        ...res,
+        list: [...cur.list, ...res.list],
+      })));
+    }
+  }, 400);
+
+  useEffect(() => {
+    if (!paginatedOptions) {
+      onLoadOptions(DEFAULT_PAGINATION).then(setPaginatedOptions);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!paginatedOptions) {
+    return <Spinner text="Loading options..." />;
+  }
 
   return (
-    <Select ref={selectRef} async {...props} />
+    <Select {...rest}
+            ref={selectRef}
+            options={paginatedOptions.list}
+            onInputChange={handleSearch}
+            loadOptions={handleLoadMore}
+            async
+            total={paginatedOptions.total} />
   );
 };
 

--- a/graylog2-web-interface/src/components/users/UsersSelectField.tsx
+++ b/graylog2-web-interface/src/components/users/UsersSelectField.tsx
@@ -15,99 +15,46 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useEffect, useState, useCallback } from 'react';
-import debounce from 'lodash/debounce';
-import type { PaginatedUsers } from 'src/stores/users/UsersStore';
+import { useCallback } from 'react';
 
 import UsersDomain from 'domainActions/users/UsersDomain';
 import { isPermitted } from 'util/PermissionsMixin';
-import { Spinner } from 'components/common';
 import useCurrentUser from 'hooks/useCurrentUser';
 
 import PaginatedSelect from '../common/Select/PaginatedSelect';
 
-const DEFAULT_PAGINATION = { page: 1, perPage: 50, query: '', total: 0 };
-
 const formatUsers = (users) => users.map((user) => ({ label: `${user.username} (${user.fullName})`, value: user.username }));
 
 type Props = {
-    value: string,
-    onChange: (nextValue) => void,
+  value: string,
+  onChange: (nextValue) => void,
 }
 
 const UsersSelectField = ({ value, onChange }: Props) => {
   const currentUser = useCurrentUser();
-  const [paginatedUsers, setPaginatedUsers] = useState<PaginatedUsers | undefined>();
-  const [isNextPageLoading, setIsNextPageLoading] = useState(false);
-  const [isSearching, setIsSearching] = useState(false);
-  const loadUsersPaginated = useCallback((pagination = DEFAULT_PAGINATION) => {
-    if (isPermitted(currentUser.permissions, 'users:list')) {
-      setIsNextPageLoading(true);
 
-      return UsersDomain.loadUsersPaginated(pagination).then((newPaginatedUser) => {
-        setIsNextPageLoading(false);
-
-        return newPaginatedUser;
+  const loadUsers = useCallback((pagination: { page: number, perPage: number, query: string }) => {
+    if (!isPermitted(currentUser.permissions, 'users:list')) {
+      return Promise.resolve({
+        pagination,
+        total: 0,
+        list: [],
       });
     }
 
-    return undefined;
+    return UsersDomain.loadUsersPaginated(pagination).then((results) => ({
+      total: results.pagination.total,
+      list: formatUsers(results.list.toArray()),
+      pagination,
+    }));
   }, [currentUser.permissions]);
-
-  const loadUsers = (pagination, query = '') => {
-    loadUsersPaginated({ ...pagination, page: pagination.page + 1, query }).then((response) => {
-      setPaginatedUsers((prevUsers) => {
-        const list = prevUsers.list.concat(response.list);
-        const newPagination = { ...prevUsers.pagination, ...response.pagination };
-
-        return { ...prevUsers, list, pagination: newPagination } as PaginatedUsers;
-      });
-    });
-  };
-
-  const loadMoreOptions = debounce(() => {
-    const { pagination, pagination: { total }, list } = paginatedUsers;
-
-    if (total > list.count()) {
-      loadUsers(pagination);
-    }
-  }, 400);
-
-  useEffect(() => {
-    if (!paginatedUsers) {
-      loadUsersPaginated().then(setPaginatedUsers);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleSearch = debounce((newValue, actionMeta) => {
-    if ((actionMeta.action === 'input-change')) {
-      setIsSearching(true);
-
-      loadUsersPaginated({ ...DEFAULT_PAGINATION, query: newValue }).then((results) => {
-        setIsSearching(true);
-        setPaginatedUsers(results);
-      });
-    } else if (actionMeta.action === 'menu-close') {
-      loadUsersPaginated().then(setPaginatedUsers);
-    }
-  }, 400);
-
-  if (!paginatedUsers) {
-    return <p><Spinner text="Loading User select..." /></p>;
-  }
-
-  const { list, pagination: { total } } = paginatedUsers;
 
   return (
     <PaginatedSelect id="user-select-list"
                      value={value}
                      placeholder="Select user(s)..."
-                     options={formatUsers(list.toArray())}
-                     onInputChange={handleSearch}
-                     loadOptions={isNextPageLoading || isSearching ? () => {} : loadMoreOptions}
+                     onLoadOptions={loadUsers}
                      multi
-                     total={total}
                      onChange={onChange} />
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This PR is improving the reusability of the `PaginatedSelect` component. Currently we are only using the select in the `UsersSelectField` component. When using it in more places, we have to repeat some of the logic in the `UsersSelectField` component. With this PR we are moving this logic (mainly the state management) into the `PaginatedSelect`, so we do not have to repeat it.

When using the `PaginatedSelect` you now just need to provide a function to fetch the data and the component will take care of the state management.

/nocl