### PR TITLE
Improve reusability of query input component.

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.test.tsx
@@ -31,7 +31,7 @@ import OriginalDashboardSearchBar from './DashboardSearchBar';
 jest.mock('hooks/useHotkey', () => jest.fn());
 jest.mock('views/components/searchbar/queryinput/QueryInput');
 jest.mock('views/components/DashboardActionsMenu', () => () => <span>View Actions</span>);
-
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('views/hooks/useAutoRefresh');
 
 jest.mock('views/hooks/useMinimumRefreshInterval', () => () => ({

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -24,7 +24,7 @@ import RefreshControls from 'views/components/searchbar/RefreshControls';
 import { Spinner } from 'components/common';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import SearchButton from 'views/components/searchbar/SearchButton';
-import QueryInput from 'views/components/searchbar/queryinput/AsyncQueryInput';
+import ViewsQueryInput from 'views/components/searchbar/ViewsQueryInput';
 import DashboardActionsMenu from 'views/components/DashboardActionsMenu';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
@@ -172,20 +172,20 @@ const DashboardSearchBar = () => {
                                 {({ warnings }) => (
                                   <PluggableCommands usage="global_override_query">
                                     {(customCommands) => (
-                                      <QueryInput value={value}
-                                                  view={view}
-                                                  timeRange={values?.timerange}
-                                                  placeholder="Apply filter to all widgets"
-                                                  name={name}
-                                                  onChange={onChange}
-                                                  disableExecution={disableSearchSubmit}
-                                                  error={error}
-                                                  isValidating={isValidating}
-                                                  validate={validateForm}
-                                                  warning={warnings.queryString}
-                                                  ref={editorRef}
-                                                  onExecute={handleSubmit as () => void}
-                                                  commands={customCommands} />
+                                      <ViewsQueryInput value={value}
+                                                       view={view}
+                                                       timeRange={values?.timerange}
+                                                       placeholder="Apply filter to all widgets"
+                                                       name={name}
+                                                       onChange={onChange}
+                                                       disableExecution={disableSearchSubmit}
+                                                       error={error}
+                                                       isValidating={isValidating}
+                                                       validate={validateForm}
+                                                       warning={warnings.queryString}
+                                                       ref={editorRef}
+                                                       onExecute={handleSubmit as () => void}
+                                                       commands={customCommands} />
                                     )}
                                   </PluggableCommands>
                                 )}

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -27,7 +27,7 @@ import { Spinner } from 'components/common';
 import SearchButton from 'views/components/searchbar/SearchButton';
 import SearchActionsMenu from 'views/components/searchbar/saved-search/SearchActionsMenu';
 import TimeRangeFilter from 'views/components/searchbar/time-range-filter';
-import QueryInput from 'views/components/searchbar/queryinput/AsyncQueryInput';
+import ViewsQueryInput from 'views/components/searchbar/ViewsQueryInput';
 import StreamsFilter from 'views/components/searchbar/StreamsFilter';
 import RefreshControls from 'views/components/searchbar/RefreshControls';
 import ScrollToHint from 'views/components/common/ScrollToHint';
@@ -258,21 +258,21 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
                                   {({ warnings }) => (
                                     <PluggableCommands usage="search_query">
                                       {(customCommands) => (
-                                        <QueryInput value={value}
-                                                    ref={editorRef}
-                                                    view={view}
-                                                    timeRange={values.timerange}
-                                                    streams={values.streams}
-                                                    name={name}
-                                                    onChange={onChange}
-                                                    placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
-                                                    error={error}
-                                                    isValidating={isValidating}
-                                                    warning={warnings.queryString}
-                                                    disableExecution={disableSearchSubmit}
-                                                    validate={validateForm}
-                                                    onExecute={handleSubmit as () => void}
-                                                    commands={customCommands} />
+                                        <ViewsQueryInput value={value}
+                                                         ref={editorRef}
+                                                         view={view}
+                                                         timeRange={values.timerange}
+                                                         streams={values.streams}
+                                                         name={name}
+                                                         onChange={onChange}
+                                                         placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
+                                                         error={error}
+                                                         isValidating={isValidating}
+                                                         warning={warnings.queryString}
+                                                         disableExecution={disableSearchSubmit}
+                                                         validate={validateForm}
+                                                         onExecute={handleSubmit as () => void}
+                                                         commands={customCommands} />
                                       )}
                                     </PluggableCommands>
                                   )}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.pluggableControls.test.tsx
@@ -41,7 +41,7 @@ jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mo
 
 jest.mock('views/components/searchbar/queryinput/QueryInput');
 jest.mock('views/components/searchbar/queryinput/BasicQueryInput');
-
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
 
 jest.mock('hooks/useSearchConfiguration', () => () => ({

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.tsx
@@ -34,7 +34,7 @@ jest.mock('views/components/searchbar/queryvalidation/QueryValidation', () => mo
 
 jest.mock('views/components/searchbar/queryinput/QueryInput');
 jest.mock('views/components/searchbar/queryinput/BasicQueryInput');
-
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('views/hooks/useGlobalOverride');
 
 jest.mock('views/logic/slices/searchExecutionSlice', () => ({

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -73,7 +73,7 @@ import TimeRangeOverrideInfo from './searchbar/WidgetTimeRangeOverride';
 import TimeRangeFilter from './searchbar/time-range-filter';
 import StreamsFilter from './searchbar/StreamsFilter';
 import SearchButton from './searchbar/SearchButton';
-import QueryInput from './searchbar/queryinput/AsyncQueryInput';
+import ViewsQueryInput from './searchbar/ViewsQueryInput';
 import SearchBarForm from './searchbar/SearchBarForm';
 import WidgetQueryOverride from './WidgetQueryOverride';
 import PluggableSearchBarControls from './searchbar/PluggableSearchBarControls';
@@ -260,21 +260,21 @@ const WidgetQueryControls = ({ availableStreams }: Props) => {
                         {({ warnings }) => (
                           <PluggableCommands usage="widget_query">
                             {(customCommands) => (
-                              <QueryInput value={value}
-                                          view={view}
-                                          timeRange={!isEmpty(globalOverride?.timerange) ? globalOverride.timerange : values?.timerange}
-                                          streams={values?.streams}
-                                          placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
-                                          error={error}
-                                          ref={editorRef}
-                                          disableExecution={disableSearchSubmit}
-                                          isValidating={isValidatingQuery}
-                                          warning={warnings.queryString}
-                                          validate={validateForm}
-                                          name={name}
-                                          onChange={onChange}
-                                          onExecute={handleSubmit as () => void}
-                                          commands={customCommands} />
+                              <ViewsQueryInput value={value}
+                                               view={view}
+                                               timeRange={!isEmpty(globalOverride?.timerange) ? globalOverride.timerange : values?.timerange}
+                                               streams={values?.streams}
+                                               placeholder='Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'
+                                               error={error}
+                                               ref={editorRef}
+                                               disableExecution={disableSearchSubmit}
+                                               isValidating={isValidatingQuery}
+                                               warning={warnings.queryString}
+                                               validate={validateForm}
+                                               name={name}
+                                               onChange={onChange}
+                                               onExecute={handleSubmit as () => void}
+                                               commands={customCommands} />
                             )}
                           </PluggableCommands>
                         )}

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.test.tsx
@@ -23,7 +23,7 @@ import { validationError } from 'fixtures/queryValidationState';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 
-import QueryInput from './QueryInput';
+import ViewsQueryInput from './ViewsQueryInput';
 
 jest.mock('views/logic/fieldtypes/useFieldTypes');
 jest.mock('hooks/useHotkey', () => jest.fn());
@@ -42,18 +42,18 @@ class Completer {
 }
 
 describe('QueryInput', () => {
-  const getQueryInput = () => screen.getByRole('textbox');
+  const findQueryInput = () => screen.findByRole('textbox');
 
-  const SimpleQueryInput = (props: Partial<React.ComponentProps<typeof QueryInput>>) => (
+  const SimpleQueryInput = (props: Partial<React.ComponentProps<typeof ViewsQueryInput>>) => (
     <TestStoreProvider>
-      <QueryInput value=""
-                  name="search-query"
-                  onChange={() => Promise.resolve('')}
-                  validate={() => Promise.resolve({})}
-                  isValidating={false}
-                  onExecute={() => {}}
-                  completerFactory={() => new Completer()}
-                  {...props} />
+      <ViewsQueryInput value=""
+                       name="search-query"
+                       onChange={() => Promise.resolve('')}
+                       validate={() => Promise.resolve({})}
+                       isValidating={false}
+                       onExecute={() => {}}
+                       completerFactory={() => new Completer()}
+                       {...props} />
     </TestStoreProvider>
   );
 
@@ -63,38 +63,38 @@ describe('QueryInput', () => {
     jest.clearAllMocks();
   });
 
-  it('renders with minimal props', () => {
+  it('renders with minimal props', async () => {
     render(<SimpleQueryInput />);
 
-    expect(getQueryInput()).toBeInTheDocument();
+    expect(await findQueryInput()).toBeInTheDocument();
   });
 
-  it('triggers onChange when input is changed', () => {
+  it('triggers onChange when input is changed', async () => {
     const onChange = jest.fn();
     render(<SimpleQueryInput onChange={onChange} />);
 
-    userEvent.paste(getQueryInput(), 'the query');
+    userEvent.paste(await findQueryInput(), 'the query');
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith({ target: { value: 'the query', name: 'search-query' } });
   });
 
-  it('triggers onBlur when input is blurred', () => {
+  it('triggers onBlur when input is blurred', async () => {
     const onBlur = jest.fn();
     render(<SimpleQueryInput onBlur={onBlur} />);
 
-    userEvent.paste(getQueryInput(), 'the query');
+    userEvent.paste(await findQueryInput(), 'the query');
     userEvent.tab();
 
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   describe('execution', () => {
-    it('triggers onExecute on enter', () => {
+    it('triggers onExecute on enter', async () => {
       const onExecute = jest.fn();
       render(<SimpleQueryInput value="the query" onExecute={onExecute} />);
 
-      const queryInput = getQueryInput();
+      const queryInput = await findQueryInput();
       queryInput.focus();
       userEvent.type(queryInput, '{enter}');
 
@@ -102,22 +102,22 @@ describe('QueryInput', () => {
       expect(onExecute).toHaveBeenCalledWith('the query');
     });
 
-    it('does not trigger onExecute on enter when execution is disabled', () => {
+    it('does not trigger onExecute on enter when execution is disabled', async () => {
       const onExecute = jest.fn();
       render(<SimpleQueryInput value="the query" onExecute={onExecute} disableExecution />);
 
-      const queryInput = getQueryInput();
+      const queryInput = await findQueryInput();
       queryInput.focus();
       userEvent.type(queryInput, '{enter}');
 
       expect(onExecute).not.toHaveBeenCalledTimes(1);
     });
 
-    it('triggers QueryValidationActions.displayValidationErrors when there in an error', () => {
+    it('triggers QueryValidationActions.displayValidationErrors when there in an error', async () => {
       const onExecute = jest.fn();
       render(<SimpleQueryInput value="source:" onExecute={onExecute} error={validationError} />);
 
-      const queryInput = getQueryInput();
+      const queryInput = await findQueryInput();
       queryInput.focus();
       userEvent.type(queryInput, '{enter}');
 
@@ -126,12 +126,12 @@ describe('QueryInput', () => {
       expect(onExecute).not.toHaveBeenCalled();
     });
 
-    it('triggers QueryValidationActions.displayValidationErrors when there is an error after a change', () => {
+    it('triggers QueryValidationActions.displayValidationErrors when there is an error after a change', async () => {
       const onExecute = jest.fn();
       const { rerender } = render(<SimpleQueryInput value="source" onExecute={onExecute} />);
       rerender(<SimpleQueryInput value="source:" onExecute={onExecute} error={validationError} />);
 
-      const queryInput = getQueryInput();
+      const queryInput = await findQueryInput();
       queryInput.focus();
       userEvent.type(queryInput, '{enter}');
 
@@ -155,7 +155,7 @@ describe('QueryInput', () => {
 
       render(<SimpleQueryInput commands={commands} />);
 
-      const queryInput = getQueryInput();
+      const queryInput = await findQueryInput();
       queryInput.focus();
       userEvent.type(queryInput, '{ctrl}{enter}');
 

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo, forwardRef } from 'react';
 import type { FormikErrors } from 'formik';

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
@@ -70,7 +70,8 @@ type Props = {
   validate: () => Promise<FormikErrors<{}>>,
   commands?: Array<Command>,
   disableExecution?: boolean,
-  placeholder: string,
+  placeholder?: string,
+  onBlur?: (query: string) => void,
 }
 
 const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBarAutoCompletions>) => new SearchBarAutoCompletions(...args);
@@ -78,13 +79,14 @@ const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBar
 const ViewsQueryInput = forwardRef<Editor, Props>(({
   value, timeRange, streams, name, onChange, error,
   isValidating, disableExecution, validate, onExecute,
-  commands, view, warning, placeholder,
+  commands, view, warning, placeholder, onBlur,
   completerFactory = defaultCompleterFactory,
 }, ref) => {
   const completer = useCompleter({ streams, timeRange, completerFactory, view });
 
   return (
     <AsyncQueryInput value={value}
+                     onBlur={onBlur}
                      completer={completer}
                      ref={ref}
                      name={name}

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
@@ -49,9 +49,7 @@ const useCompleter = ({ streams, timeRange, completerFactory, view }: Pick<Props
 };
 
 type Props = {
-  streams?: Array<string> | undefined,
-  timeRange?: TimeRange | NoTimeRangeOverride | undefined,
-  view?: View
+  commands?: Array<Command>,
   completerFactory?: (
     completers: Array<Completer>,
     timeRange: TimeRange | NoTimeRangeOverride | undefined,
@@ -60,18 +58,21 @@ type Props = {
     userTimezone: string,
     view: View | undefined,
   ) => AutoCompleter,
-  value: string,
-  name: string,
-  isValidating: boolean,
+  disableExecution?: boolean,
   error?: QueryValidationState,
-  warning?: QueryValidationState,
+  inputId?: string
+  isValidating: boolean,
+  name: string,
+  onBlur?: (query: string) => void,
   onChange: (changeEvent: { target: { value: string, name: string } }) => Promise<string>,
   onExecute: (query: string) => void,
-  validate: () => Promise<FormikErrors<{}>>,
-  commands?: Array<Command>,
-  disableExecution?: boolean,
   placeholder?: string,
-  onBlur?: (query: string) => void,
+  streams?: Array<string> | undefined,
+  timeRange?: TimeRange | NoTimeRangeOverride | undefined,
+  validate: () => Promise<FormikErrors<{}>>,
+  value: string,
+  view?: View
+  warning?: QueryValidationState,
 }
 
 const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBarAutoCompletions>) => new SearchBarAutoCompletions(...args);
@@ -79,7 +80,7 @@ const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBar
 const ViewsQueryInput = forwardRef<Editor, Props>(({
   value, timeRange, streams, name, onChange, error,
   isValidating, disableExecution, validate, onExecute,
-  commands, view, warning, placeholder, onBlur,
+  commands, view, warning, placeholder, onBlur, inputId,
   completerFactory = defaultCompleterFactory,
 }, ref) => {
   const completer = useCompleter({ streams, timeRange, completerFactory, view });
@@ -87,6 +88,7 @@ const ViewsQueryInput = forwardRef<Editor, Props>(({
   return (
     <AsyncQueryInput value={value}
                      onBlur={onBlur}
+                     inputId={inputId}
                      completer={completer}
                      ref={ref}
                      name={name}

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { useMemo, forwardRef } from 'react';
+import type { FormikErrors } from 'formik';
+
+import type { Editor, AutoCompleter, Command } from 'views/components/searchbar/queryinput/ace-types';
+import AsyncQueryInput from 'views/components/searchbar/queryinput/AsyncQueryInput';
+import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
+import type View from 'views/logic/views/View';
+import useUserDateTime from 'hooks/useUserDateTime';
+import usePluginEntities from 'hooks/usePluginEntities';
+import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
+import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
+import { DEFAULT_TIMERANGE } from 'views/Constants';
+import type { Completer, FieldTypes } from 'views/components/searchbar/SearchBarAutocompletions';
+import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+
+import SearchBarAutoCompletions from './SearchBarAutocompletions';
+
+const useCompleter = ({ streams, timeRange, completerFactory, view }: Pick<Props, 'streams' | 'timeRange' | 'completerFactory' | 'view'>) => {
+  const { userTimezone } = useUserDateTime();
+  const completers = usePluginEntities('views.completers');
+  const { data: queryFields } = useFieldTypes(streams, isNoTimeRangeOverride(timeRange) ? DEFAULT_TIMERANGE : timeRange);
+  const { data: allFields } = useFieldTypes([], DEFAULT_TIMERANGE);
+  const fieldTypes = useMemo(() => {
+    const queryFieldsByName = Object.fromEntries((queryFields ?? []).map((field) => [field.name, field]));
+    const allFieldsByName = Object.fromEntries((allFields ?? []).map((field) => [field.name, field]));
+
+    return { all: allFieldsByName, query: queryFieldsByName };
+  }, [allFields, queryFields]);
+
+  return useMemo(() => completerFactory?.(completers ?? [], timeRange, streams, fieldTypes, userTimezone, view),
+    [completerFactory, completers, timeRange, streams, fieldTypes, userTimezone, view]);
+};
+
+type Props = {
+  streams?: Array<string> | undefined,
+  timeRange?: TimeRange | NoTimeRangeOverride | undefined,
+  view?: View
+  completerFactory?: (
+    completers: Array<Completer>,
+    timeRange: TimeRange | NoTimeRangeOverride | undefined,
+    streams: Array<string>,
+    fieldTypes: FieldTypes,
+    userTimezone: string,
+    view: View | undefined,
+  ) => AutoCompleter,
+  value: string,
+  name: string,
+  isValidating: boolean,
+  error?: QueryValidationState,
+  warning?: QueryValidationState,
+  onChange: (changeEvent: { target: { value: string, name: string } }) => Promise<string>,
+  onExecute: (query: string) => void,
+  validate: () => Promise<FormikErrors<{}>>,
+  commands?: Array<Command>,
+  disableExecution?: boolean,
+  placeholder: string,
+}
+
+const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBarAutoCompletions>) => new SearchBarAutoCompletions(...args);
+
+const ViewsQueryInput = forwardRef<Editor, Props>(({
+  value, timeRange, streams, name, onChange, error,
+  isValidating, disableExecution, validate, onExecute,
+  commands, view, warning, placeholder,
+  completerFactory = defaultCompleterFactory,
+}, ref) => {
+  const completer = useCompleter({ streams, timeRange, completerFactory, view });
+
+  return (
+    <AsyncQueryInput value={value}
+                     completer={completer}
+                     ref={ref}
+                     name={name}
+                     onChange={onChange}
+                     placeholder={placeholder}
+                     error={error}
+                     isValidating={isValidating}
+                     warning={warning}
+                     disableExecution={disableExecution}
+                     validate={validate}
+                     onExecute={onExecute}
+                     commands={commands} />
+  );
+});
+
+export default ViewsQueryInput;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -21,15 +21,8 @@ import type { FormikErrors } from 'formik';
 import styled, { createGlobalStyle, css } from 'styled-components';
 
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
-import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
 import QueryValidationActions from 'views/actions/QueryValidationActions';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
-import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
-import { DEFAULT_TIMERANGE } from 'views/Constants';
-import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
-import usePluginEntities from 'hooks/usePluginEntities';
-import useUserDateTime from 'hooks/useUserDateTime';
-import type View from 'views/logic/views/View';
 import useElementDimensions from 'hooks/useElementDimensions';
 import { displayHistoryCompletions } from 'views/components/searchbar/QueryHistoryButton';
 import { startAutocomplete } from 'views/components/searchbar/queryinput/commands';
@@ -38,11 +31,6 @@ import useHotkey from 'hooks/useHotkey';
 import type { AutoCompleter, Editor, Command } from './ace-types';
 import type { BaseProps } from './BasicQueryInput';
 import BasicQueryInput from './BasicQueryInput';
-
-import SearchBarAutoCompletions from '../SearchBarAutocompletions';
-import type { Completer, FieldTypes } from '../SearchBarAutocompletions';
-
-const defaultCompleterFactory = (...args: ConstructorParameters<typeof SearchBarAutoCompletions>) => new SearchBarAutoCompletions(...args);
 
 const GlobalEditorStyles = createGlobalStyle<{ $width?: number; $offsetLeft: number }>`
   .ace_editor.ace_autocomplete {
@@ -177,22 +165,6 @@ const _updateEditorConfiguration = (node: { editor: Editor; }, completer: AutoCo
   }
 };
 
-const useCompleter = ({ streams, timeRange, completerFactory, view }: Pick<Props, 'streams' | 'timeRange' | 'completerFactory' | 'view'>) => {
-  const { userTimezone } = useUserDateTime();
-  const completers = usePluginEntities('views.completers');
-  const { data: queryFields } = useFieldTypes(streams, isNoTimeRangeOverride(timeRange) ? DEFAULT_TIMERANGE : timeRange);
-  const { data: allFields } = useFieldTypes([], DEFAULT_TIMERANGE);
-  const fieldTypes = useMemo(() => {
-    const queryFieldsByName = Object.fromEntries((queryFields ?? []).map((field) => [field.name, field]));
-    const allFieldsByName = Object.fromEntries((allFields ?? []).map((field) => [field.name, field]));
-
-    return { all: allFieldsByName, query: queryFieldsByName };
-  }, [allFields, queryFields]);
-
-  return useMemo(() => completerFactory?.(completers ?? [], timeRange, streams, fieldTypes, userTimezone, view),
-    [completerFactory, completers, timeRange, streams, fieldTypes, userTimezone, view]);
-};
-
 const useShowHotkeysInOverview = () => {
   const options = { enabled: false };
 
@@ -229,30 +201,19 @@ const useShowHotkeysInOverview = () => {
 
 type Props = BaseProps & {
   commands?: Array<Command>,
-  completerFactory?: (
-    completers: Array<Completer>,
-    timeRange: TimeRange | NoTimeRangeOverride | undefined,
-    streams: Array<string>,
-    fieldTypes: FieldTypes,
-    userTimezone: string,
-    view: View | undefined,
-  ) => AutoCompleter,
   disableExecution?: boolean,
   isValidating?: boolean,
   name: string,
   onBlur?: (query: string) => void,
   onChange: (changeEvent: { target: { value: string, name: string } }) => Promise<string>,
   onExecute: (query: string) => void,
-  streams?: Array<string> | undefined,
-  timeRange?: TimeRange | NoTimeRangeOverride | undefined,
   validate: () => Promise<FormikErrors<{}>>,
-  view?: View
+  completer: any,
 };
 
 const QueryInput = React.forwardRef<Editor, Props>(({
   className = '',
   commands = [],
-  completerFactory = defaultCompleterFactory,
   disableExecution = false,
   error,
   height,
@@ -263,21 +224,18 @@ const QueryInput = React.forwardRef<Editor, Props>(({
   onChange,
   onExecute: onExecuteProp,
   placeholder = '',
-  streams,
-  timeRange,
   value = '',
   validate,
   warning,
   wrapEnabled,
   name,
-  view,
+  completer,
 }, outerRef) => {
   const innerRef = useRef<Editor>(null);
   const inputElement = innerRef.current?.container;
   const { width: inputWidth } = useElementDimensions(inputElement);
   const isInitialTokenizerUpdate = useRef(true);
   const { enableSmartSearch } = useContext(UserPreferencesContext);
-  const completer = useCompleter({ streams, timeRange, completerFactory, view });
   const onLoadEditor = useCallback((editor: Editor) => _onLoadEditor(editor, isInitialTokenizerUpdate), []);
   const onExecute = useCallback((editor: Editor) => handleExecution({
     editor,

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -42,6 +42,7 @@ import FieldTypesContext from '../contexts/FieldTypesContext';
 jest.mock('../searchbar/queryinput/QueryInput');
 jest.mock('./WidgetHeader', () => 'widget-header');
 jest.mock('./WidgetColorContext', () => ({ children }) => children);
+jest.mock('views/logic/fieldtypes/useFieldTypes');
 
 const searchExplainContext = (searchedIndexRanges = [
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we move all the views related code from the `QueryInput` component in to a new `ViewsQueryInput` component. This way we can reuse the `QueryInput` outside of the search page.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/8995
/nocl