### PR TITLE
Add certutil truststore command to the graylog server commands

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilTruststore.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertutilTruststore.java
@@ -24,6 +24,7 @@ import org.graylog2.bootstrap.CliCommand;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
@@ -66,6 +67,11 @@ public class CertutilTruststore implements CliCommand {
         console.printLine("Using certificate authority " + caKeystorePath.toAbsolutePath());
 
         try {
+
+            if(!Files.exists(caKeystorePath)) {
+                throw new IllegalArgumentException("File " + caKeystorePath.toAbsolutePath() + " doesn't exist!");
+            }
+
             char[] password = console.readPassword(PROMPT_ENTER_CA_PASSWORD);
             KeyStore caKeystore = KeyStore.getInstance(PKCS12);
             caKeystore.load(new FileInputStream(caKeystorePath.toFile()), password);

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
@@ -24,6 +24,7 @@ import org.graylog.security.certutil.CertutilCert;
 import org.graylog.security.certutil.CertutilCsr;
 import org.graylog.security.certutil.CertutilCsrSign;
 import org.graylog.security.certutil.CertutilHttp;
+import org.graylog.security.certutil.CertutilTruststore;
 import org.graylog2.bootstrap.commands.CliCommandHelp;
 import org.graylog2.bootstrap.commands.ShowVersion;
 
@@ -40,6 +41,7 @@ public class Main {
                         CertutilHttp.class,
                         CertutilCsr.class,
                         CertutilCsrSign.class,
+                        CertutilTruststore.class,
                         ShowVersion.class,
                         CliCommandHelp.class));
 

--- a/graylog2-server/src/test/java/org/graylog2/security/certutil/CertutilTruststoreTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/certutil/CertutilTruststoreTest.java
@@ -79,4 +79,22 @@ class CertutilTruststoreTest {
                 .extracting(c -> c.getSubjectX500Principal().getName())
                 .isEqualTo("CN=Graylog CA");
     }
+
+    @Test
+    void testUnknownCaPath(@TempDir Path tempDir) {
+        TestableConsole inputHttp = TestableConsole.empty()
+                .silent()
+                .register(CertutilTruststore.PROMPT_ENTER_CA_PASSWORD, "asdfgh")
+                .register(CertutilTruststore.PROMPT_ENTER_TRUSTSTORE_PASSWORD, "asdfgh");
+
+        final String caPath = tempDir.resolve("unknown-file.p12").toAbsolutePath().toString();
+
+        CertutilTruststore certutilCert = new CertutilTruststore(
+                caPath,
+                tempDir.resolve("truststore.p12").toAbsolutePath().toString(),
+                inputHttp);
+
+        Assertions.assertThatThrownBy(certutilCert::run)
+                        .hasMessageContaining("File " + caPath + " doesn't exist!");
+    }
 }


### PR DESCRIPTION
Forgot to link the truststore command in the graylog server, added now. Also added explicit handling of unknown CA file. 

/nocl

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

