### PR TITLE
Bumping `@types/react` effectively to `18.3.12`.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -176,7 +176,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "resolutions": {
-    "@types/react": "18.0.28",
+    "@types/react": "18.3.12",
     "nth-check": "2.0.1",
     "typescript": "5.6.3"
   }

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.tsx
@@ -108,7 +108,6 @@ function Editor({ id, value, height, readOnly = false, onChange, onFullMode }: P
         </TabsRow>
         {!showPreview && (
           <EditorStyles>
-            {/* @ts-ignore */}
             <SourceCodeEditor id={id ?? 'md-editor'}
                               mode="markdown"
                               theme="light"

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
@@ -119,7 +119,6 @@ function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone 
             {height > 0 && (
               <>
                 <EditorWrapper style={{ width: '50%' }}>
-                  {/* @ts-ignore */}
                   <SourceCodeEditor id="md-editor"
                                     mode="markdown"
                                     theme="light"

--- a/graylog2-web-interface/src/components/rules/RuleForm.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.tsx
@@ -126,8 +126,6 @@ const RuleForm = ({ create = false }: Props) => {
         <PipelinesUsingRule create={create} />
 
         <Input id="rule-source-editor" label="Rule source" help="Rule source, see quick reference for more information." error={errorMessage}>
-          {/* TODO: Figure out issue with props */}
-          {/* @ts-ignore */}
           <StyledContainer>
             <SourceCodeEditor id={`source${create ? '-create' : '-edit'}`}
                               mode="pipeline"

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -318,8 +318,6 @@ const ConfigurationForm = ({
               <FormGroup controlId="template"
                          validationState={_validationState('template')}>
                 <ControlLabel>Configuration</ControlLabel>
-                {/* TODO: Figure out issue with props */}
-                {/* @ts-ignore */}
                 <SourceCodeEditor id="template"
                                   height={400}
                                   value={formData.template || ''}

--- a/graylog2-web-interface/src/routing/loadAsync.tsx
+++ b/graylog2-web-interface/src/routing/loadAsync.tsx
@@ -37,12 +37,12 @@ type ComponentSupplier<TProps> = () => Promise<{ default: React.ComponentType<TP
 const emptyPlaceholder = <></>;
 
 const loadAsync = <TProps, >(factory: ComponentSupplier<TProps>) => {
-  const Component = React.lazy(factory) as React.ForwardRefExoticComponent<TProps>;
+  const Component = React.lazy(factory);
 
   return React.forwardRef((props: React.PropsWithoutRef<TProps>, ref) => (
     <ErrorBoundary FallbackComponent={ErrorComponent}>
       <React.Suspense fallback={emptyPlaceholder}>
-        <Component {...props as TProps} ref={ref} />
+        <Component {...props} ref={ref} />
       </React.Suspense>
     </ErrorBoundary>
   ));

--- a/graylog2-web-interface/src/routing/loadAsync.tsx
+++ b/graylog2-web-interface/src/routing/loadAsync.tsx
@@ -39,10 +39,10 @@ const emptyPlaceholder = <></>;
 const loadAsync = <TProps, >(factory: ComponentSupplier<TProps>) => {
   const Component = React.lazy(factory) as React.ForwardRefExoticComponent<TProps>;
 
-  return React.forwardRef((props: TProps, ref) => (
+  return React.forwardRef((props: React.PropsWithoutRef<TProps>, ref) => (
     <ErrorBoundary FallbackComponent={ErrorComponent}>
       <React.Suspense fallback={emptyPlaceholder}>
-        <Component {...props} ref={ref} />
+        <Component {...props as TProps} ref={ref} />
       </React.Suspense>
     </ErrorBoundary>
   ));

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -263,29 +263,32 @@ type MessageDetailContextProviderProps = {
   message: Message,
 }
 
-type DashboardActionComponentProps = {
+type DashboardActionComponentProps<T> = {
   dashboard: View,
-  modalRef: () => unknown,
+  modalRef: () => T,
 }
 
-type EventWidgetActionComponentProps = {
+type EventWidgetActionComponentProps<T> = {
   eventId: string,
-  modalRef: () => unknown,
+  modalRef: () => T,
 }
 
-type DashboardActionModalProps = {
+type DashboardActionModalProps<T> = React.PropsWithRef<{
   dashboard: View,
-  ref: React.Ref<unknown>,
-}
+}> & {
+  ref: React.LegacyRef<T>
+};
 
-type EventActionModalProps = {
+type EventActionModalProps<T> = React.PropsWithRef<{
   eventId: string,
-  ref: React.Ref<unknown>,
+}> & {
+  ref: React.LegacyRef<T>,
 }
 
-type SearchActionModalProps = {
+type SearchActionModalProps = React.PropsWithRef<{
   search: View,
-  ref: React.Ref<unknown>,
+}> & {
+  ref: React.LegacyRef<unknown>,
 }
 
 type AssetInformationComponentProps = {
@@ -300,22 +303,23 @@ type SearchAction = {
   useCondition: () => boolean,
 };
 
-type DashboardAction = {
+type DashboardAction<T> = {
   key: string,
-  component: React.ComponentType<DashboardActionComponentProps>,
-  modal?: React.ComponentType<DashboardActionModalProps>,
+  component: React.ComponentType<DashboardActionComponentProps<T>>,
+  modal?: React.ComponentType<DashboardActionModalProps<T>>,
   useCondition?: () => boolean,
 }
 
-type EventWidgetAction = {
+type EventWidgetAction<T> = {
   key: string,
-  component: React.ComponentType<EventWidgetActionComponentProps>,
-  modal?: React.ComponentType<EventActionModalProps>,
+  component: React.ComponentType<EventWidgetActionComponentProps<T>>,
+  modal?: React.ComponentType<EventActionModalProps<T>>,
   useCondition?: () => boolean,
 }
 
 type AssetInformation = {
   component: React.ComponentType<AssetInformationComponentProps>,
+  key: string,
 }
 
 type EventActionComponentProps = {
@@ -470,7 +474,7 @@ declare module 'graylog-web-plugin/plugin' {
     valueActions?: Array<ActionDefinition>;
     'views.completers'?: Array<Completer>;
     'views.components.assetInformationActions'?: Array<AssetInformation>;
-    'views.components.dashboardActions'?: Array<DashboardAction>;
+    'views.components.dashboardActions'?: Array<DashboardAction<unknown>>;
     'views.components.eventActions'?: Array<{
       useCondition: () => boolean,
       component: React.ComponentType<EventActionComponentProps>,
@@ -492,7 +496,7 @@ declare module 'graylog-web-plugin/plugin' {
       useCondition: () => boolean,
       key: string,
     }>;
-    'views.components.widgets.events.actions'?: Array<EventWidgetAction>;
+    'views.components.widgets.events.actions'?: Array<EventWidgetAction<unknown>>;
     'views.components.searchActions'?: Array<SearchAction>;
     'views.components.searchBar'?: Array<() => SearchBarControl | null>;
     'views.components.saveViewForm'?: Array<() => SaveViewControls | null>;

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -3385,13 +3385,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.0.28", "@types/react@18.3.12", "@types/react@^16", "@types/react@^16.9.11", "@types/react@^16.9.9":
-  version "18.0.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
-  integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
+"@types/react@*", "@types/react@18.3.12", "@types/react@^16", "@types/react@^16.9.11", "@types/react@^16.9.9":
+  version "18.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
+  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/reactcss@*":
@@ -3405,11 +3404,6 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
-
-"@types/scheduler@*":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
-  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/semver@^7.3.12":
   version "7.3.12"
@@ -7146,7 +7140,7 @@ eslint-config-airbnb@19.0.4:
     eslint-config-airbnb "19.0.4"
     eslint-import-resolver-webpack "0.13.9"
     eslint-plugin-compat "4.2.0"
-    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-fed42ddc-cade-4030-ba6a-b2b7eaf0b1a3-1730119170660/node_modules/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:packages/eslint-plugin-graylog"
     eslint-plugin-import "2.25.3"
     eslint-plugin-jest "28.8.3"
     eslint-plugin-jest-dom "5.4.0"
@@ -8634,11 +8628,11 @@ graphemer@^1.4.0:
     "@types/react" "18.3.12"
     babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.2.0-SNAPSHOT-749f323e-ba13-4ed3-a688-ae9a3f057eeb-1730119170463/node_modules/babel-preset-graylog"
     create-react-class "15.7.0"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.2.0-SNAPSHOT-749f323e-ba13-4ed3-a688-ae9a3f057eeb-1730119170463/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:packages/eslint-config-graylog"
     formik "2.4.6"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-6.2.0-SNAPSHOT-749f323e-ba13-4ed3-a688-ae9a3f057eeb-1730119170463/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:packages/jest-preset-graylog"
     jquery "3.7.1"
     moment "2.30.1"
     moment-timezone "0.5.46"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is bumping the React types package effectively to `18.3.12` due to the current need to set its version explicitly in the `resolutions` clause.

/nocl No user-facing change.
/prd Graylog2/graylog-plugin-enterprise#9000

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.