### PR TITLE
Removing usage of `ReactDOM.render` in preflight UI.

### DIFF
--- a/graylog2-web-interface/src/preflight/index.tsx
+++ b/graylog2-web-interface/src/preflight/index.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Notifications } from '@mantine/notifications';
 
 import PreflightThemeProvider from 'preflight/theme/PreflightThemeProvider';
@@ -29,7 +29,10 @@ import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
 import '@mantine/dropzone/styles.css';
 
-ReactDOM.render((
+const appContainer = document.querySelector('div#app-root');
+const root = createRoot(appContainer);
+
+root.render((
   <PreflightThemeProvider>
     <GlobalThemeStyles />
     <DefaultQueryClientProvider>
@@ -41,12 +44,4 @@ ReactDOM.render((
       </ThemeWrapper>
     </DefaultQueryClientProvider>
   </PreflightThemeProvider>
-),
-document.getElementById('app-root'),
-);
-
-// @ts-ignore
-if (import.meta.webpackHot) {
-  // @ts-ignore
-  import.meta.webpackHot.accept();
-}
+));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is removing the usage of `ReactDOM.render` in the preflight UI, as according to the React 19 [migration notes](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-reactdom-render).

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.