### PR TITLE
Backport 6.1: Syslog inputs: Trim newlines for Fortigate messages

### DIFF
--- a/changelog/unreleased/pr-20788.toml
+++ b/changelog/unreleased/pr-20788.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Automatically trim newline characters for Fortigate messages received through Syslog inputs."
+
+issues = ["graylog-plugin-enterprise#8980"]
+pulls = ["20788"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
@@ -137,7 +137,7 @@ public class SyslogCodec extends AbstractCodec {
         } else if (CISCO_WITH_SEQUENCE_NUMBERS_PATTERN.matcher(msg).matches()) {
             e = new CiscoSyslogServerEvent(msg, remoteAddress, defaultTimeZone);
         } else if (FORTIGATE_PATTERN.matcher(msg).matches()) {
-            e = new FortiGateSyslogEvent(msg, defaultTimeZone);
+            e = new FortiGateSyslogEvent(msg.trim(), defaultTimeZone);
         } else {
             e = new SyslogServerEvent(msg, remoteAddress, defaultTimeZone);
         }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
 
 public class SyslogCodecTest {
     private static final int YEAR = Tools.nowUTC().getYear();
+    private static final String FORTIGATE = "<45>date=2017-03-06 time=12:53:10 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\"";
     private static String STRUCTURED = "<165>1 2012-12-25T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry";
     private static String STRUCTURED_ISSUE_845 = "<190>1 2015-01-06T20:56:33.287Z app-1 app - - [mdc@18060 ip=\"::ffff:132.123.15.30\" logger=\"{c.corp.Handler}\" session=\"4ot7\" user=\"user@example.com\" user-agent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11\"] User page 13 requested";
     private static String STRUCTURED_ISSUE_845_EMPTY = "<128>1 2015-01-11T16:35:21.335797+01:00 s000000.example.com - - - - tralala";
@@ -426,8 +427,18 @@ public class SyslogCodecTest {
     }
 
     @Test
-    public void testFortiGateFirewall() {
-        final RawMessage rawMessage = buildRawMessage("<45>date=2017-03-06 time=12:53:10 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\"");
+    public void testFortiGate() {
+        doTestFortigate(FORTIGATE);
+    }
+
+    @Test
+    public void testFortiGateTrimLineBreaks() {
+        // Ensure that trailing line breaks are trimmed for Fortigate messages to avoid parsing error.
+        doTestFortigate(FORTIGATE + "\r\n ");
+    }
+
+    private void doTestFortigate(String fortigateMessage) {
+        final RawMessage rawMessage = buildRawMessage(fortigateMessage);
         final Message message = codec.decode(rawMessage);
 
         assertThat(message).isNotNull();


### PR DESCRIPTION
Backport https://github.com/Graylog2/graylog2-server/pull/20788 to the `6.1` branch.