### PR TITLE
Improve reusability of widget edit components

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,7 +3,11 @@ Upgrading to Graylog 6.2.x
 
 ## Breaking Changes
 
-- tbd
+### Plugins
+
+Adjustment of `enterpriseWidgets` web interface plugin. The `editComponent` attribute now no longer has a `onSubmit` prop.
+Before this change the prop had to be called to close the widget edit mode. Now it is enough to call `applyAllWidgetChanges` from the `WidgetEditApplyAllChangesContext`.
+Alternatively the `SaveOrCancelButtons` component can be used in the edit component for custom widgets. It renders a cancel and submit button and calls `applyAllWidgetChanges` on submit.
 
 ## Configuration File Changes
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -168,7 +168,8 @@ const StreamActions = ({
                     sendTelemetry(TELEMETRY_EVENT_TYPE.STREAMS.STREAM_ITEM_DATA_ROUTING_CLICKED, {
                       app_pathname: 'stream',
                     });
-                  }}>Data Routing
+                  }}>
+            Data routing
           </Button>
         </LinkContainer>
       </IfPermitted>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
@@ -42,7 +42,6 @@ describe('AggregationWizard', () => {
     <TestStoreProvider>
       <FieldTypesContext.Provider value={fieldTypes}>
         <AggregationWizard onChange={() => {}}
-                           onSubmit={() => {}}
                            onCancel={() => {}}
                            config={widgetConfig}
                            editing
@@ -96,14 +95,6 @@ describe('AggregationWizard', () => {
 
     await waitFor(() => within(metricsSection).findByText('Function'));
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
-  });
-
-  it('should call onSubmit', async () => {
-    const onSubmit = jest.fn();
-    renderSUT({ onSubmit });
-    userEvent.click(await screen.findByRole('button', { name: /update widget/i }));
-
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 
   it('should call onCancel', async () => {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -100,7 +100,7 @@ const validateForm = (formValues: WidgetConfigFormValues) => {
   return elementValidationResults.reduce((prev, cur) => ({ ...prev, ...cur }), {});
 };
 
-const AggregationWizard = ({ onChange, config, children, onSubmit, onCancel }: EditWidgetComponentProps<AggregationWidgetConfig> & { children: React.ReactElement }) => {
+const AggregationWizard = ({ onChange, config, children, onCancel }: EditWidgetComponentProps<AggregationWidgetConfig> & { children: React.ReactElement }) => {
   const initialFormValues = _initialFormValues(config);
 
   return (
@@ -114,7 +114,6 @@ const AggregationWizard = ({ onChange, config, children, onSubmit, onCancel }: E
             <ElementsConfiguration aggregationElementsByKey={aggregationElementsByKey}
                                    config={config}
                                    onCreate={onCreateElement}
-                                   onSubmit={onSubmit}
                                    onCancel={onCancel}
                                    onConfigChange={onChange} />
           </Section>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/ElementsConfiguration.tsx
@@ -52,11 +52,10 @@ type Props = {
     values: WidgetConfigFormValues,
     setValues: (formValues: WidgetConfigFormValues) => void,
   ) => void,
-  onSubmit: () => void,
   onCancel: () => void,
 }
 
-const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange, onCreate, onSubmit, onCancel }: Props) => {
+const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChange, onCreate, onCancel }: Props) => {
   const { values, setValues } = useFormikContext<WidgetConfigFormValues>();
 
   return (
@@ -64,7 +63,7 @@ const ElementsConfiguration = ({ aggregationElementsByKey, config, onConfigChang
       <StickyBottomActions actions={(
         <>
           <ElementsConfigurationActions />
-          <SaveOrCancelButtons onCancel={onCancel} onSubmit={onSubmit} />
+          <SaveOrCancelButtons onCancel={onCancel} />
         </>
       )}>
         <div>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -1,167 +1,21 @@
-/*
- * Copyright (C) 2020 Graylog, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the Server Side Public License, version 1,
- * as published by MongoDB, Inc.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Server Side Public License for more details.
- *
- * You should have received a copy of the Server Side Public License
- * along with this program. If not, see
- * <http://www.mongodb.com/licensing/server-side-public-license>.
- */
 import * as React from 'react';
-import type { SyntheticEvent } from 'react';
-import { useCallback, useContext, useMemo } from 'react';
-import * as Immutable from 'immutable';
-import styled, { css } from 'styled-components';
+import { useContext } from 'react';
+import Immutable from 'immutable';
 
-import { defaultCompare } from 'logic/DefaultCompare';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import Select from 'components/common/Select';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import FieldTypeIcon from 'views/components/sidebar/fields/FieldTypeIcon';
-import type FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldSelectBase from 'views/components/aggregationwizard/FieldSelectBase';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
-import type { SelectRef } from 'components/common/Select/Select';
-import { Button } from 'components/bootstrap';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
-const FieldName = styled.span`
-  display: inline-flex;
-  gap: 2px;
-  align-items: center;
-`;
+type Props = Omit<React.ComponentProps<typeof FieldSelectBase>, 'options'>
 
-const ButtonRow = styled.div`
-  margin-top: 5px;
-  display: inline-flex;
-  gap: 5px;
-  margin-bottom: 10px;  
-`;
-
-type Props = {
-  ariaLabel?: string,
-  autoFocus?: boolean,
-  allowCreate?: boolean,
-  className?: string,
-  clearable?: boolean,
-  excludedFields?: Array<string>,
-  id: string,
-  isFieldQualified?: (field: FieldTypeMapping) => boolean,
-  menuPortalTarget?: HTMLElement,
-  name: string,
-  onChange: (fieldName: string) => void,
-  onMenuClose?: () => void,
-  openMenuOnFocus?: boolean,
-  persistSelection?: boolean,
-  placeholder?: string,
-  selectRef?: SelectRef,
-  size?: 'normal' | 'small',
-  value: string | undefined,
-  onSelectAllRest?: (fieldNames: Array<string>) => void,
-  showSelectAllRest?: boolean,
-  onDeSelectAll?: (e: SyntheticEvent) => void,
-  showDeSelectAll?: boolean,
-}
-
-const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
-
-const UnqualifiedOption = styled.span(({ theme }) => css`
-  color: ${theme.colors.gray[70]};
-`);
-
-type OptionRendererProps = {
-  label: string,
-  qualified: boolean,
-  type?: FieldType,
-};
-
-const OptionRenderer = ({ label, qualified, type }: OptionRendererProps) => {
-  const children = (
-    <FieldName>
-      {type && <><FieldTypeIcon type={type} /> </>}{label}
-    </FieldName>
-  );
-
-  return qualified ? <span>{children}</span> : <UnqualifiedOption>{children}</UnqualifiedOption>;
-};
-
-const FieldSelect = ({
-  ariaLabel,
-  autoFocus,
-  allowCreate = false,
-  className,
-  clearable = false,
-  excludedFields = [],
-  id,
-  isFieldQualified = () => true,
-  menuPortalTarget,
-  name,
-  onChange,
-  onMenuClose,
-  openMenuOnFocus,
-  persistSelection,
-  placeholder,
-  selectRef,
-  size = 'small',
-  value,
-  onSelectAllRest,
-  showSelectAllRest = false,
-  onDeSelectAll,
-  showDeSelectAll = false,
-}: Props) => {
+const FieldSelect = (props: Props) => {
   const activeQuery = useActiveQueryId();
   const fieldTypes = useContext(FieldTypesContext);
-  const fieldOptions = useMemo(() => fieldTypes.queryFields
-    .get(activeQuery, Immutable.List())
-    .filter((field) => !excludedFields.includes(field.name))
-    .map((field) => ({
-      label: field.name,
-      value: field.name,
-      type: field.type,
-      qualified: isFieldQualified(field),
-    }))
-    .toArray()
-    .sort(sortByLabel), [activeQuery, excludedFields, fieldTypes.queryFields, isFieldQualified]);
-
-  const _onSelectAllRest = useCallback(() => onSelectAllRest(fieldOptions.map(({ value: fieldValue }) => fieldValue)), [fieldOptions, onSelectAllRest]);
-
-  const _showSelectAllRest = !!fieldOptions?.length && showSelectAllRest && typeof _onSelectAllRest === 'function';
-
-  const _showDeSelectAll = showDeSelectAll && typeof onDeSelectAll === 'function';
+  const fieldOptions = fieldTypes.queryFields.get(activeQuery, Immutable.List()).toArray();
 
   return (
-    <>
-      <Select options={fieldOptions}
-              inputId={`select-${id}`}
-              forwardedRef={selectRef}
-              allowCreate={allowCreate}
-              className={className}
-              onMenuClose={onMenuClose}
-              openMenuOnFocus={openMenuOnFocus}
-              persistSelection={persistSelection}
-              clearable={clearable}
-              placeholder={placeholder}
-              name={name}
-              value={value}
-              aria-label={ariaLabel}
-              optionRenderer={OptionRenderer}
-              size={size}
-              autoFocus={autoFocus}
-              menuPortalTarget={menuPortalTarget}
-              onChange={onChange} />
-      {(_showSelectAllRest || _showDeSelectAll) && (
-      <ButtonRow>
-        {_showSelectAllRest && <Button bsSize="xs" onClick={_onSelectAllRest}>Select all fields</Button>}
-        {_showDeSelectAll && <Button bsSize="xs" onClick={onDeSelectAll}>Deselect all fields</Button>}
-      </ButtonRow>
-      )}
-    </>
-
+    <FieldSelectBase options={fieldOptions}
+                     {...props} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useContext } from 'react';
 import Immutable from 'immutable';

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelectBase.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelectBase.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import type { SyntheticEvent } from 'react';
+import { useCallback, useMemo } from 'react';
+import styled, { css } from 'styled-components';
+
+import { defaultCompare } from 'logic/DefaultCompare';
+import Select from 'components/common/Select';
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldTypeIcon from 'views/components/sidebar/fields/FieldTypeIcon';
+import type FieldType from 'views/logic/fieldtypes/FieldType';
+import type { SelectRef } from 'components/common/Select/Select';
+import { Button } from 'components/bootstrap';
+
+const FieldName = styled.span`
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+`;
+
+const ButtonRow = styled.div`
+  margin-top: 5px;
+  display: inline-flex;
+  gap: 5px;
+  margin-bottom: 10px;  
+`;
+
+type Props = {
+  ariaLabel?: string,
+  autoFocus?: boolean,
+  allowCreate?: boolean,
+  className?: string,
+  clearable?: boolean,
+  excludedFields?: Array<string>,
+  id: string,
+  isFieldQualified?: (field: FieldTypeMapping) => boolean,
+  menuPortalTarget?: HTMLElement,
+  name: string,
+  onChange: (fieldName: string) => void,
+  onMenuClose?: () => void,
+  openMenuOnFocus?: boolean,
+  persistSelection?: boolean,
+  placeholder?: string,
+  selectRef?: SelectRef,
+  size?: 'normal' | 'small',
+  value: string | undefined,
+  onSelectAllRest?: (fieldNames: Array<string>) => void,
+  showSelectAllRest?: boolean,
+  onDeSelectAll?: (e: SyntheticEvent) => void,
+  options: Array<FieldTypeMapping>
+  showDeSelectAll?: boolean,
+}
+
+const sortByLabel = ({ label: label1 }: { label: string }, { label: label2 }: { label: string }) => defaultCompare(label1, label2);
+
+const UnqualifiedOption = styled.span(({ theme }) => css`
+  color: ${theme.colors.gray[70]};
+`);
+
+type OptionRendererProps = {
+  label: string,
+  qualified: boolean,
+  type?: FieldType,
+};
+
+const OptionRenderer = ({ label, qualified, type }: OptionRendererProps) => {
+  const children = (
+    <FieldName>
+      {type && <><FieldTypeIcon type={type} /> </>}{label}
+    </FieldName>
+  );
+
+  return qualified ? <span>{children}</span> : <UnqualifiedOption>{children}</UnqualifiedOption>;
+};
+
+const FieldSelect = ({
+  ariaLabel,
+  autoFocus,
+  allowCreate = false,
+  className,
+  clearable = false,
+  excludedFields = [],
+  id,
+  isFieldQualified = () => true,
+  menuPortalTarget,
+  name,
+  onChange,
+  onMenuClose,
+  openMenuOnFocus,
+  persistSelection,
+  placeholder,
+  selectRef,
+  size = 'small',
+  value,
+  onSelectAllRest,
+  showSelectAllRest = false,
+  onDeSelectAll,
+  showDeSelectAll = false,
+  options,
+}: Props) => {
+  const fieldOptions = useMemo(() => options
+    .filter((field) => !excludedFields.includes(field.name))
+    .map((field) => ({
+      label: field.name,
+      value: field.name,
+      type: field.type,
+      qualified: isFieldQualified(field),
+    }))
+    .sort(sortByLabel), [excludedFields, isFieldQualified, options]);
+
+  const _onSelectAllRest = useCallback(() => onSelectAllRest(fieldOptions.map(({ value: fieldValue }) => fieldValue)), [fieldOptions, onSelectAllRest]);
+
+  const _showSelectAllRest = !!fieldOptions?.length && showSelectAllRest && typeof _onSelectAllRest === 'function';
+
+  const _showDeSelectAll = showDeSelectAll && typeof onDeSelectAll === 'function';
+
+  return (
+    <>
+      <Select options={fieldOptions}
+              inputId={`select-${id}`}
+              forwardedRef={selectRef}
+              allowCreate={allowCreate}
+              className={className}
+              onMenuClose={onMenuClose}
+              openMenuOnFocus={openMenuOnFocus}
+              persistSelection={persistSelection}
+              clearable={clearable}
+              placeholder={placeholder}
+              name={name}
+              value={value}
+              aria-label={ariaLabel}
+              optionRenderer={OptionRenderer}
+              size={size}
+              autoFocus={autoFocus}
+              menuPortalTarget={menuPortalTarget}
+              onChange={onChange} />
+      {(_showSelectAllRest || _showDeSelectAll) && (
+        <ButtonRow>
+          {_showSelectAllRest && <Button bsSize="xs" onClick={_onSelectAllRest}>Select all fields</Button>}
+          {_showDeSelectAll && <Button bsSize="xs" onClick={onDeSelectAll}>Deselect all fields</Button>}
+        </ButtonRow>
+      )}
+    </>
+
+  );
+};
+
+export default FieldSelect;

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -61,7 +61,6 @@ const SimpleAggregationWizard = (props: Partial<React.ComponentProps<typeof Aggr
                          fields={Immutable.List([])}
                          onCancel={() => {}}
                          onChange={() => {}}
-                         onSubmit={() => {}}
                          {...props}>
         <span>The visualization</span>
       </AggregationWizard>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -94,7 +94,6 @@ describe('AggregationWizard', () => {
                          editing
                          id="widget-id"
                          type="AGGREGATION"
-                         onSubmit={() => {}}
                          onCancel={() => {}}
                          fields={Immutable.List([])}
                          onChange={() => {}}

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -93,7 +93,6 @@ describe('AggregationWizard', () => {
   const renderSUT = (props = {}) => render(
     <FieldTypesContext.Provider value={fieldTypes}>
       <AggregationWizard onChange={() => {}}
-                         onSubmit={() => {}}
                          onCancel={() => {}}
                          config={widgetConfig}
                          editing

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -94,7 +94,6 @@ const renderSUT = (props = {}) => render((
   <TestStoreProvider>
     <FieldTypesContext.Provider value={fieldTypes}>
       <AggregationWizard onChange={() => {}}
-                         onSubmit={() => {}}
                          onCancel={() => {}}
                          config={widgetConfig}
                          editing

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.tsx
@@ -19,7 +19,7 @@ import styled, { css } from 'styled-components';
 
 import styles from './EditableTitle.css';
 
-const StyledStaticSpan = styled.span(({ theme }) => css`
+export const Title = styled.span(({ theme }) => css`
   border: 1px solid ${theme.colors.global.contentBackground};
   font-size: ${theme.fonts.size.large};
   text-overflow: ellipsis;
@@ -119,6 +119,6 @@ export default class EditableTitle extends React.Component<Props, State> {
                        onChange={this._onChange} />
         </form>
       </span>
-    ) : <StyledStaticSpan onDoubleClick={this._toggleEditing} title={`${value} - Double click the title to edit it.`}>{value}</StyledStaticSpan>;
+    ) : <Title onDoubleClick={this._toggleEditing} title={`${value} - Double click the title to edit it.`}>{value}</Title>;
   }
 }

--- a/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetEditApplyAllChangesProvider.tsx
@@ -38,7 +38,7 @@ const useApplyAllWidgetChanges = (
   widget: Widget,
   applySearchControlsChanges: React.RefObject<(widget: Widget) => Widget>,
   applyElementConfigurationChanges: React.RefObject<(widgetConfig: WidgetConfig) => WidgetConfig>,
-  onChange: (newWidget: Widget) => Promise<void>,
+  onSubmit: (newWidget: Widget, hasChanges: boolean) => Promise<void>,
 ) => {
   const { setDisabled } = useContext(DisableSubmissionStateContext);
   const setDisableWidgetEditSubmit = useCallback(
@@ -67,31 +67,27 @@ const useApplyAllWidgetChanges = (
       }
     }
 
-    if (hasChanges) {
-      setDisableWidgetEditSubmit(true);
+    setDisableWidgetEditSubmit(true);
 
-      return onChange(newWidget)
-        .catch((error) => {
-          UserNotification.error(`Applying widget changes failed with status: ${error}`);
+    return onSubmit(newWidget, hasChanges)
+      .catch((error) => {
+        UserNotification.error(`Applying widget changes failed with status: ${error}`);
 
-          return error;
-        }).finally(() => setDisableWidgetEditSubmit(false));
-    }
-
-    return Promise.resolve();
-  }, [widget, applySearchControlsChanges, applyElementConfigurationChanges, setDisableWidgetEditSubmit, onChange]);
+        return error;
+      }).finally(() => setDisableWidgetEditSubmit(false));
+  }, [widget, applySearchControlsChanges, applyElementConfigurationChanges, setDisableWidgetEditSubmit, onSubmit]);
 };
 
 type Props = {
-  widget: Widget,
   children: React.ReactNode,
-  onChange: (newWidget: Widget) => Promise<void>,
+  onSubmit: (newWidget: Widget, hasChanges: boolean) => Promise<void>,
+  widget: Widget,
 }
 
-const WidgetEditApplyAllChangesProvider = ({ children, widget, onChange }: Props) => {
+const WidgetEditApplyAllChangesProvider = ({ children, widget, onSubmit }: Props) => {
   const { applyChangesRef: applySearchControlsChanges, bindApplyChanges: bindApplySearchControlsChanges } = useBindApplyChanges();
   const { applyChangesRef: applyElementConfigurationChanges, bindApplyChanges: bindApplyElementConfigurationChanges } = useBindApplyChanges();
-  const applyAllWidgetChanges = useApplyAllWidgetChanges(widget, applySearchControlsChanges, applyElementConfigurationChanges, onChange);
+  const applyAllWidgetChanges = useApplyAllWidgetChanges(widget, applySearchControlsChanges, applyElementConfigurationChanges, onSubmit);
 
   const contextValue = useMemo(() => ({
     applyAllWidgetChanges,

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.tsx
@@ -69,7 +69,7 @@ const _onSortDirectionChange = (direction: SortConfig['direction'], config, onCh
   return onChange(newConfig);
 };
 
-const EditMessageList = ({ children, config, fields, onChange, onCancel, onSubmit }: EditWidgetComponentProps<MessagesWidgetConfig>) => {
+const EditMessageList = ({ children, config, fields, onChange, onCancel }: EditWidgetComponentProps<MessagesWidgetConfig>) => {
   const { sort } = config;
   const [sortDirection] = (sort || []).map((s) => s.direction);
   const onDecoratorsChange = (newDecorators) => onChange(config.toBuilder().decorators(newDecorators).build());
@@ -79,7 +79,7 @@ const EditMessageList = ({ children, config, fields, onChange, onCancel, onSubmi
   return (
     <FullHeightRow>
       <FullHeightCol md={3}>
-        <StickyBottomActions actions={<SaveOrCancelButtons onCancel={onCancel} onSubmit={onSubmit} />}
+        <StickyBottomActions actions={<SaveOrCancelButtons onCancel={onCancel} />}
                              alignActionsAtBottom>
           <DescriptionBox description="Fields">
             <FieldsConfiguration onChange={(newFields) => _onFieldSelectionChanged(newFields, config, onChange)}

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -70,7 +70,7 @@ describe('EditWidgetFrame', () => {
     const renderSUT = (props?: Partial<React.ComponentProps<typeof EditWidgetFrame>>) => render((
       <TestStoreProvider>
         <WidgetContext.Provider value={widget}>
-          <EditWidgetFrame onSubmit={() => {}} onCancel={() => {}} onChange={() => Promise.resolve()} {...props}>
+          <EditWidgetFrame onCancel={() => {}} onSubmit={() => Promise.resolve()} {...props}>
             Hello World!
             These are some buttons!
           </EditWidgetFrame>
@@ -114,7 +114,7 @@ describe('EditWidgetFrame', () => {
     });
 
     it('calls onSubmit', async () => {
-      const onSubmit = jest.fn();
+      const onSubmit = jest.fn(() => Promise.resolve());
       renderSUT({ onSubmit });
 
       fireEvent.click(await screen.findByRole('button', { name: /update widget/i }));

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.tsx
@@ -70,7 +70,7 @@ describe('EditWidgetFrame', () => {
     const renderSUT = (props?: Partial<React.ComponentProps<typeof EditWidgetFrame>>) => render((
       <TestStoreProvider>
         <WidgetContext.Provider value={widget}>
-          <EditWidgetFrame onSubmit={() => {}} onCancel={() => {}} {...props}>
+          <EditWidgetFrame onSubmit={() => {}} onCancel={() => {}} onChange={() => Promise.resolve()} {...props}>
             Hello World!
             These are some buttons!
           </EditWidgetFrame>

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -23,8 +23,7 @@ import WidgetContext from 'views/components/contexts/WidgetContext';
 import QueryEditModeContext from 'views/components/contexts/QueryEditModeContext';
 import SaveOrCancelButtons from 'views/components/widgets/SaveOrCancelButtons';
 import WidgetEditApplyAllChangesProvider from 'views/components/contexts/WidgetEditApplyAllChangesProvider';
-import useViewType from 'views/hooks/useViewType';
-import View from 'views/logic/views/View';
+import type Widget from 'views/logic/widgets/Widget';
 
 import WidgetQueryControls from '../WidgetQueryControls';
 import WidgetOverrideElements from '../WidgetOverrideElements';
@@ -50,25 +49,25 @@ const Visualization = styled.div`
 
 type Props = {
   children: React.ReactNode,
+  displaySubmitActions?: boolean,
   onCancel: () => void,
   onSubmit: () => void,
-  displaySubmitActions?: boolean,
+  showQueryControls?: boolean,
+  onChange: (widgetId: string, newWidget: Widget) => Promise<void>,
 };
 
-const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true }: Props) => {
+const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true, showQueryControls = true, onChange }: Props) => {
   const widget = useContext(WidgetContext);
-  const viewType = useViewType();
-  const isDashboard = viewType === View.Type.Dashboard;
 
   if (!widget) {
     return <Spinner text="Loading widget ..." />;
   }
 
   return (
-    <WidgetEditApplyAllChangesProvider widget={widget}>
+    <WidgetEditApplyAllChangesProvider widget={widget} onChange={onChange}>
       <DisableSubmissionStateProvider>
         <Container>
-          {(isDashboard && !widget.returnsAllRecords) && (
+          {(showQueryControls && !widget.returnsAllRecords) && (
             <QueryControls>
               <QueryEditModeContext.Provider value="widget">
                 <WidgetQueryControls />

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -64,7 +64,7 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = 
   }
 
   return (
-    <WidgetEditApplyAllChangesProvider widget={widget} onChange={onChange}>
+    <WidgetEditApplyAllChangesProvider widget={widget}>
       <DisableSubmissionStateProvider>
         <Container>
           {(showQueryControls && !widget.returnsAllRecords) && (

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -53,10 +53,11 @@ type Props = {
   onCancel: () => void,
   onSubmit: () => void,
   showQueryControls?: boolean,
-  onChange: (widgetId: string, newWidget: Widget) => Promise<void>,
+  onChange: (newWidget: Widget) => Promise<void>,
+  containerComponent?: React.ComponentType<React.PropsWithChildren>
 };
 
-const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true, showQueryControls = true, onChange }: Props) => {
+const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true, showQueryControls = true, onChange, containerComponent: ContainerComponent = WidgetOverrideElements }: Props) => {
   const widget = useContext(WidgetContext);
 
   if (!widget) {
@@ -64,7 +65,7 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = 
   }
 
   return (
-    <WidgetEditApplyAllChangesProvider widget={widget}>
+    <WidgetEditApplyAllChangesProvider widget={widget} onChange={onChange}>
       <DisableSubmissionStateProvider>
         <Container>
           {(showQueryControls && !widget.returnsAllRecords) && (
@@ -75,9 +76,9 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = 
             </QueryControls>
           )}
           <Visualization role="presentation">
-            <WidgetOverrideElements>
+            <ContainerComponent>
               {children}
-            </WidgetOverrideElements>
+            </ContainerComponent>
           </Visualization>
           {displaySubmitActions && (
             <div>

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.tsx
@@ -51,13 +51,12 @@ type Props = {
   children: React.ReactNode,
   displaySubmitActions?: boolean,
   onCancel: () => void,
-  onSubmit: () => void,
   showQueryControls?: boolean,
-  onChange: (newWidget: Widget) => Promise<void>,
+  onSubmit: (newWidget: Widget, hasChanges: boolean) => Promise<void>,
   containerComponent?: React.ComponentType<React.PropsWithChildren>
 };
 
-const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true, showQueryControls = true, onChange, containerComponent: ContainerComponent = WidgetOverrideElements }: Props) => {
+const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = true, showQueryControls = true, containerComponent: ContainerComponent = WidgetOverrideElements }: Props) => {
   const widget = useContext(WidgetContext);
 
   if (!widget) {
@@ -65,7 +64,7 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = 
   }
 
   return (
-    <WidgetEditApplyAllChangesProvider widget={widget} onChange={onChange}>
+    <WidgetEditApplyAllChangesProvider widget={widget} onSubmit={onSubmit}>
       <DisableSubmissionStateProvider>
         <Container>
           {(showQueryControls && !widget.returnsAllRecords) && (
@@ -82,7 +81,7 @@ const EditWidgetFrame = ({ children, onCancel, onSubmit, displaySubmitActions = 
           </Visualization>
           {displaySubmitActions && (
             <div>
-              <SaveOrCancelButtons onSubmit={onSubmit} onCancel={onCancel} />
+              <SaveOrCancelButtons onCancel={onCancel} />
             </div>
           )}
         </Container>

--- a/graylog2-web-interface/src/views/components/widgets/FieldsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldsConfiguration.tsx
@@ -50,6 +50,7 @@ type Props = {
   showDeSelectAll?: boolean,
   showListCollapseButton?: boolean
   showUnit?: boolean,
+  fieldSelect?: React.ComponentType<React.ComponentProps<typeof FieldSelect>>
 }
 
 const FieldsConfiguration = ({
@@ -65,6 +66,7 @@ const FieldsConfiguration = ({
   showDeSelectAll = false,
   showListCollapseButton = false,
   showUnit = false,
+  fieldSelect: FieldSelectComponent = FieldSelect,
 }: Props) => {
   const [showSelectedList, setShowSelectedList] = useState(true);
   const onAddField = useCallback((newField: string) => (
@@ -106,22 +108,22 @@ const FieldsConfiguration = ({
                           onChange={onChange}
                           showUnit={showUnit} />
       )}
-      <FieldSelect id="field-create-select"
-                   onChange={onAddField}
-                   clearable={false}
-                   isFieldQualified={isFieldQualified}
-                   persistSelection={false}
-                   name="field-create-select"
-                   value={undefined}
-                   size={selectSize}
-                   menuPortalTarget={menuPortalTarget}
-                   excludedFields={selectedFields ?? []}
-                   placeholder={createSelectPlaceholder}
-                   ariaLabel={createSelectPlaceholder}
-                   onSelectAllRest={showSelectAllRest && onSelectAllRest}
-                   showSelectAllRest={showSelectAllRest}
-                   onDeSelectAll={onDeselectAll}
-                   showDeSelectAll={showDeSelectAll && !!selectedFields.length} />
+      <FieldSelectComponent id="field-create-select"
+                            onChange={onAddField}
+                            clearable={false}
+                            isFieldQualified={isFieldQualified}
+                            persistSelection={false}
+                            name="field-create-select"
+                            value={undefined}
+                            size={selectSize}
+                            menuPortalTarget={menuPortalTarget}
+                            excludedFields={selectedFields ?? []}
+                            placeholder={createSelectPlaceholder}
+                            ariaLabel={createSelectPlaceholder}
+                            onSelectAllRest={showSelectAllRest && onSelectAllRest}
+                            showSelectAllRest={showSelectAllRest}
+                            onDeSelectAll={onDeselectAll}
+                            showDeSelectAll={showDeSelectAll && !!selectedFields.length} />
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.tsx
@@ -25,10 +25,9 @@ export const UPDATE_WIDGET_BTN_TEXT = 'Update widget';
 
 type Props = {
   onCancel: () => void,
-  onSubmit: () => void,
 };
 
-const SaveOrCancelButtons = ({ onSubmit, onCancel }: Props) => {
+const SaveOrCancelButtons = ({ onCancel }: Props) => {
   const { applyAllWidgetChanges } = useContext(WidgetEditApplyAllChangesContext);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { disabled: disabledSubmit } = useContext(DisableSubmissionStateContext);
@@ -38,7 +37,6 @@ const SaveOrCancelButtons = ({ onSubmit, onCancel }: Props) => {
 
     return applyAllWidgetChanges().then(() => {
       setIsSubmitting(false);
-      onSubmit();
     }).catch(() => {
       setIsSubmitting(false);
     });

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -174,16 +174,15 @@ export const EditWrapper = ({
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);
-  const _onWidgetConfigChange = useCallback((_widgetId: string, widget: WidgetType) => {
-    onWidgetConfigChange(widget.config);
-
-    return Promise.resolve();
-  }, [onWidgetConfigChange]);
+  const dispatch = useAppDispatch();
+  const onChangeWidget = useCallback((newWidget: WidgetType) => (
+    dispatch(updateWidget(newWidget.id, newWidget)).then(() => {})
+  ), [dispatch]);
 
   return editing ? (
     <EditWidgetFrame onSubmit={onToggleEdit}
                      onCancel={onCancelEdit}
-                     onChange={_onWidgetConfigChange}
+                     onChange={onChangeWidget}
                      displaySubmitActions={!hasOwnSubmitButton}
                      showQueryControls={showQueryControls}>
       <EditComponent config={config}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -45,6 +45,7 @@ import useViewType from 'views/hooks/useViewType';
 import View from 'views/logic/views/View';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import FullSizeContainer from 'views/components/aggregationbuilder/FullSizeContainer';
+import type WidgetType from 'views/logic/widgets/Widget';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -173,11 +174,16 @@ export const EditWrapper = ({
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);
+  const _onWidgetConfigChange = useCallback((_widgetId: string, widget: WidgetType) => {
+    onWidgetConfigChange(widget.config);
+
+    return Promise.resolve();
+  }, [onWidgetConfigChange]);
 
   return editing ? (
     <EditWidgetFrame onSubmit={onToggleEdit}
                      onCancel={onCancelEdit}
-                     onChange={onWidgetConfigChange}
+                     onChange={_onWidgetConfigChange}
                      displaySubmitActions={!hasOwnSubmitButton}
                      showQueryControls={showQueryControls}>
       <EditComponent config={config}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -175,14 +175,19 @@ export const EditWrapper = ({
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);
   const dispatch = useAppDispatch();
-  const onChangeWidget = useCallback((newWidget: WidgetType) => (
-    dispatch(updateWidget(newWidget.id, newWidget)).then(() => {})
-  ), [dispatch]);
+  const onSubmitEdit = useCallback((newWidget: WidgetType, hasChanges: boolean) => {
+    if (hasChanges) {
+      return dispatch(updateWidget(newWidget.id, newWidget)).then(() => onToggleEdit());
+    }
+
+    onToggleEdit();
+
+    return Promise.resolve();
+  }, [dispatch, onToggleEdit]);
 
   return editing ? (
-    <EditWidgetFrame onSubmit={onToggleEdit}
+    <EditWidgetFrame onSubmit={onSubmitEdit}
                      onCancel={onCancelEdit}
-                     onChange={onChangeWidget}
                      displaySubmitActions={!hasOwnSubmitButton}
                      showQueryControls={showQueryControls}>
       <EditComponent config={config}
@@ -190,7 +195,6 @@ export const EditWrapper = ({
                      editing={editing}
                      id={id}
                      type={type}
-                     onSubmit={onToggleEdit}
                      onCancel={onCancelEdit}
                      onChange={onWidgetConfigChange}>
         {children}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -152,13 +152,14 @@ type EditWrapperProps = {
   editing: boolean,
   fields: FieldTypeMappingsList,
   id: string,
-  onToggleEdit: () => void,
   onCancelEdit: () => void,
+  onToggleEdit: () => void,
   onWidgetConfigChange: (newWidgetConfig: WidgetConfig) => void,
+  showQueryControls?: boolean,
   type: string,
 };
 
-const EditWrapper = ({
+export const EditWrapper = ({
   children,
   config,
   editing,
@@ -168,12 +169,17 @@ const EditWrapper = ({
   onCancelEdit,
   onWidgetConfigChange,
   type,
+  showQueryControls,
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);
 
   return editing ? (
-    <EditWidgetFrame onSubmit={onToggleEdit} onCancel={onCancelEdit} displaySubmitActions={!hasOwnSubmitButton}>
+    <EditWidgetFrame onSubmit={onToggleEdit}
+                     onCancel={onCancelEdit}
+                     onChange={onWidgetConfigChange}
+                     displaySubmitActions={!hasOwnSubmitButton}
+                     showQueryControls={showQueryControls}>
       <EditComponent config={config}
                      fields={fields}
                      editing={editing}
@@ -282,6 +288,7 @@ const Widget = ({ id, editing = false, widget, title, position, onPositionsChang
         </InteractiveContext.Consumer>
         <EditWrapper onToggleEdit={onToggleEdit}
                      onCancelEdit={onCancelEdit}
+                     showQueryControls={isDashboard}
                      onWidgetConfigChange={onWidgetConfigChange}
                      config={config}
                      editing={editing}

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { Spinner, Icon } from 'components/common';
-import EditableTitle from 'views/components/common/EditableTitle';
+import EditableTitle, { Title } from 'views/components/common/EditableTitle';
 import { Input } from 'components/bootstrap';
 
 const LoadingSpinner = styled(Spinner)`
@@ -75,6 +75,41 @@ const TitleInput = styled(Input)(({ theme }) => css`
   width: 100%;
 `);
 
+type WidgetTitleProps = {
+  onChange?: (newTitle: string) => void,
+  editing: boolean,
+  title: string,
+  titleIcon?: React.ReactNode,
+}
+
+const WidgetTitle = ({ onChange, editing, title, titleIcon }: WidgetTitleProps) => {
+  if (typeof onChange !== 'function') {
+    return <><Title>{title}</Title>{titleIcon}</>;
+  }
+
+  if (editing) {
+    return (
+      <TitleInputWrapper>
+        <TitleInput type="text"
+                    id="widget-title"
+                    onChange={(e) => onChange(e.target.value)}
+                    value={title}
+                    required />
+      </TitleInputWrapper>
+    );
+  }
+
+  return (
+    <>
+      <EditableTitle key={title}
+                     disabled={!onChange}
+                     value={title}
+                     onChange={onChange} />
+      {titleIcon}
+    </>
+  );
+};
+
 type Props = {
   children?: React.ReactNode
   onRename?: (newTitle: string) => unknown
@@ -90,30 +125,14 @@ const WidgetHeader = ({
   editing,
   hideDragHandle = false,
   loading = false,
-  children = null,
-  titleIcon = null,
-  onRename = null,
+  children,
+  titleIcon,
+  onRename,
 }: Props) => (
   <Container>
     <Col>
       {hideDragHandle || <DragHandleContainer className="widget-drag-handle" title={`Drag handle for ${title}`}><WidgetDragHandle name="drag_indicator" /></DragHandleContainer>}
-      {editing ? (
-        <TitleInputWrapper>
-          <TitleInput type="text"
-                      id="widget-title"
-                      onChange={(e) => onRename && onRename(e.target.value)}
-                      value={title}
-                      required />
-        </TitleInputWrapper>
-      ) : (
-        <>
-          <EditableTitle key={title}
-                         disabled={!onRename}
-                         value={title}
-                         onChange={onRename} />
-          {titleIcon}
-        </>
-      )}
+      <WidgetTitle editing={editing} title={title} titleIcon={titleIcon} onChange={onRename} />
       {loading && <LoadingSpinner text="" delay={0} />}
     </Col>
     <WidgetActionDropdown>

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsWidgetEdit.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsWidgetEdit.tsx
@@ -107,7 +107,7 @@ const SubmitOnChange = () => {
   return <></>;
 };
 
-const EventsWidgetEdit = ({ children, onCancel, config, onChange, onSubmit }: EditWidgetComponentProps<EventsWidgetConfig>) => {
+const EventsWidgetEdit = ({ children, onCancel, config, onChange }: EditWidgetComponentProps<EventsWidgetConfig>) => {
   const filterComponents = usePluginEntities('views.components.widgets.events.filterComponents');
   const eventAttributes = useEventAttributes();
 
@@ -172,7 +172,7 @@ const EventsWidgetEdit = ({ children, onCancel, config, onChange, onSubmit }: Ed
             <FullHeightRow>
               <FullHeightCol md={4} lg={3}>
                 <Container>
-                  <StickyBottomActions actions={<SaveOrCancelButtons onCancel={onCancel} onSubmit={onSubmit} />}
+                  <StickyBottomActions actions={<SaveOrCancelButtons onCancel={onCancel} />}
                                        alignActionsAtBottom>
                     <DescriptionBox description="Visualization">
                       <WidgetModeConfiguration name="mode" onChange={onChangeType} options={WIDGET_MODE_OPTIONS} />

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -83,7 +83,6 @@ export interface EditWidgetComponentProps<Config extends WidgetConfig = WidgetCo
   type: string;
   fields: Immutable.List<FieldTypeMapping>,
   onChange: (newConfig: Config) => void,
-  onSubmit: () => void,
   onCancel: () => void,
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the reusability of some widget related component, so they can be reused outside of the search page.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9261
/nocl