### PR TITLE
Fix logic for showing/hiding pluggable event actions

### DIFF
--- a/changelog/unreleased/pr-20847.toml
+++ b/changelog/unreleased/pr-20847.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixes issue where some event types did not display all actions that should have been available."
+
+issues = ["graylog-plugin-enterprise#8638"]
+pulls = ["20847"]

--- a/graylog2-web-interface/src/components/events/events/EventDetails.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.tsx
@@ -87,12 +87,14 @@ const EventDetails = ({ event, eventDefinitionContext }: Props) => {
               <i>No remediation steps</i>
             )}
           </dd>
-          {event.replay_info && (
+          {!event.event_definition_type.startsWith('system-notifications') && (
             <>
               <dt>Actions</dt>
+              {event.replay_info && (
               <dd>
                 <LinkToReplaySearch id={event.id} isEvent />
               </dd>
+              )}
               {pluggableActions}
             </>
           )}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes logic for displaying the pluggable event actions on the Events & Alerts page. Previously, some events did not have these actions which should have. This change correctly only completely hides the actions for system notification events.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For further context see the issue this fixes Graylog2/graylog-plugin-enterprise#8638

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

