### PR TITLE
Fixing `unknown format` issue when using gradient highlighting search page.

### DIFF
--- a/changelog/unreleased/issue-20876.toml
+++ b/changelog/unreleased/issue-20876.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing `unkown format` issue in widgets when using gradiant highlighting."
+
+issues = ["20876"]
+pulls = ["20882"]

--- a/graylog2-web-interface/src/views/components/highlighting/CustomHighlighting.test.tsx
+++ b/graylog2-web-interface/src/views/components/highlighting/CustomHighlighting.test.tsx
@@ -21,7 +21,7 @@ import HighlightingRulesContext from 'views/components/contexts/HighlightingRule
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
 import FieldType from 'views/logic/fieldtypes/FieldType';
-import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import { StaticColor, GradientColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 import CustomHighlighting from './CustomHighlighting';
 
@@ -115,5 +115,21 @@ describe('CustomHighlighting', () => {
     const elem = await findByText('42');
 
     expect(elem).not.toHaveStyleRule('background-color');
+  });
+
+  describe('gradiant highlight', () => {
+    it('renders highlighted value if rule for value exists', async () => {
+      const rule = HighlightingRule.builder()
+        .field(field)
+        .value(String(value))
+        .color(GradientColor.create('Picnic', 0, 100))
+        .build();
+
+      const { findByText } = render(<CustomHighlightingWithContext highlightingRules={[rule]} />);
+
+      const elem = await findByText('42');
+
+      expect(elem).toHaveStyle('background-color: rgb(214, 214, 255)');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
+++ b/graylog2-web-interface/src/views/logic/views/formatting/highlighting/HighlightingColor.ts
@@ -156,7 +156,7 @@ export class GradientColor extends HighlightingColor {
     const spread = this.upper - this.lower;
     const normalizedValue = Math.max(this.lower, Math.min(this.upper, parsedValue));
 
-    return this._scale((normalizedValue - this.lower) / spread);
+    return this._scale((normalizedValue - this.lower) / spread).hex();
   }
 
   static fromJSON({ gradient, lower, upper }: GradientColorJson) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the `unknown format` error which can occur for widgets on the search page, when using a gradient highlight.

The error seems to happen since updating `chroma.js` from `2.4.2` to `2.6.0`.

We are using `chroma.js` to generate the highlight background color and a contrasting text color. Before this PR we were generating a chroma color object for the gradient highlight color. When generating the contrasting text color, chroma threw an error, because the highlighting color has no mode:

https://github.com/gka/chroma.js/blob/v2.6.0/dist/chroma.cjs#L182

The error message `unknown format: hex-color-value` is a bit misleading.

With this PR we are just generating a hex color for the highlight instead of a color object.

Fixes https://github.com/Graylog2/graylog2-server/issues/20876
