### PR TITLE
Adjusting output class name in prometheus config. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-20790.toml
+++ b/changelog/unreleased/issue-20790.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing output class name for prometheus exporter."
+
+issues = ["20790"]
+pulls = ["20844"]

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -961,19 +961,19 @@ metric_mappings:
     match_pattern: "org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter.httpURLErrors"
 
   - metric_name: "blocking_elasticsearch_output_batch_size"
-    match_pattern: "org.graylog2.outputs.BlockingBatchedESOutput.batchSize"
+    match_pattern: "org.graylog2.outputs.BatchedMessageFilterOutput.batchSize"
 
   - metric_name: "blocking_elasticsearch_output_buffer_flushes"
-    match_pattern: "org.graylog2.outputs.BlockingBatchedESOutput.bufferFlushes"
+    match_pattern: "org.graylog2.outputs.BatchedMessageFilterOutput.bufferFlushes"
 
   - metric_name: "blocking_elasticsearch_output_buffer_flushes_requested"
-    match_pattern: "org.graylog2.outputs.BlockingBatchedESOutput.bufferFlushesRequested"
+    match_pattern: "org.graylog2.outputs.BatchedMessageFilterOutput.bufferFlushesRequested"
 
   - metric_name: "blocking_elasticsearch_output_buffer_flush_failures"
-    match_pattern: "org.graylog2.outputs.BlockingBatchedESOutput.bufferFlushFailures"
+    match_pattern: "org.graylog2.outputs.BatchedMessageFilterOutput.bufferFlushFailures"
 
   - metric_name: "blocking_elasticsearch_output_process_time"
-    match_pattern: "org.graylog2.outputs.BlockingBatchedESOutput.processTime"
+    match_pattern: "org.graylog2.outputs.BatchedMessageFilterOutput.processTime"
 
   - metric_name: "elasticsearch_output_failures"
     match_pattern: "org.graylog2.outputs.ElasticSearchOutput.failures"


### PR DESCRIPTION
**Note:** This is a backport of #20844 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the output class name changed from `BlockingBatchedESOutput` to `BatchedMessageFilterOutput`, but this was not reflected in the prometheus exporter config. This PR fixes this.

Fixes #20790.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.