### PR TITLE
Fix handling of path prefix in `useSendTelemetry`. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-20899.toml
+++ b/changelog/unreleased/issue-20899.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix handling of path prefix in `useSendTelemetry`."
+
+issues = ["20899"]
+pulls = ["20909"]

--- a/changelog/unreleased/issue-20899.toml
+++ b/changelog/unreleased/issue-20899.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Fix handling of path prefix in `useSendTelemetry`."
 
 issues = ["20899"]
-pulls = ["20909"]
+pulls = ["20951"]

--- a/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
@@ -26,7 +26,7 @@ jest.mock('util/AppConfig');
 const contextValue = {
   sendTelemetry: jest.fn(),
 };
-const DummyTelemetryContext = ({ children }: React.PropsWithChildren<{}>) => (
+const DummyTelemetryContext = ({ children = undefined }: React.PropsWithChildren<{}>) => (
   <TelemetryContext.Provider value={contextValue}>{children}</TelemetryContext.Provider>
 );
 

--- a/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { renderHook } from 'wrappedTestingLibrary/hooks';
 

--- a/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+
+import TelemetryContext from 'logic/telemetry/TelemetryContext';
+
+import useSendTelemetry from './useSendTelemetry';
+
+jest.mock('util/AppConfig');
+
+const contextValue = {
+  sendTelemetry: jest.fn(),
+};
+const DummyTelemetryContext = ({ children }: React.PropsWithChildren<{}>) => (
+  <TelemetryContext.Provider value={contextValue}>{children}</TelemetryContext.Provider>
+);
+
+describe('useSendTelemetry', () => {
+  const setLocation = (pathname: string) => Object.defineProperty(window, 'location', {
+    value: {
+      pathname,
+    },
+    writable: true,
+  });
+
+  const oldLocation = window.location;
+
+  afterEach(() => {
+    window.location = oldLocation;
+  });
+
+  it('should return `sendTelemetry` that retrieves current route', () => {
+    setLocation('/welcome');
+    const { result } = renderHook(() => useSendTelemetry(), { wrapper: DummyTelemetryContext });
+
+    const sendTelemetry = result.current;
+
+    expect(sendTelemetry).toBeDefined();
+
+    sendTelemetry('$pageview', { app_section: 'welcome section' });
+
+    expect(contextValue.sendTelemetry).toHaveBeenCalledWith('$pageview', { app_path_pattern: undefined, app_section: 'welcome section' });
+  });
+});

--- a/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/useSendTelemetry.tsx
@@ -21,7 +21,8 @@ import type { DataRouterContextObject } from 'react-router/dist/lib/context';
 
 import type { TelemetryEventType, TelemetryEvent } from 'logic/telemetry/TelemetryContext';
 import TelemetryContext from 'logic/telemetry/TelemetryContext';
-import { currentPathnameWithoutPrefix } from 'util/URLUtils';
+import { currentPathname, stripPrefixFromPathname } from 'util/URLUtils';
+import { singleton } from 'logic/singleton';
 
 const retrieveCurrentRoute = (dataRouterContext: DataRouterContextObject) => {
   if (!dataRouterContext?.router?.routes) {
@@ -29,10 +30,10 @@ const retrieveCurrentRoute = (dataRouterContext: DataRouterContextObject) => {
   }
 
   const { router: { routes } } = dataRouterContext;
-  const pathname = currentPathnameWithoutPrefix();
+  const pathname = currentPathname();
   const matches = matchRoutes(routes, pathname);
 
-  return matches.at(-1).route.path;
+  return stripPrefixFromPathname(matches?.at(-1)?.route.path);
 };
 
 const useSendTelemetry = () => {
@@ -49,4 +50,4 @@ const useSendTelemetry = () => {
   }, [dataRouterContext, sendTelemetry]);
 };
 
-export default useSendTelemetry;
+export default singleton('core.useSendTelemetry', () => useSendTelemetry);

--- a/graylog2-web-interface/src/util/URLUtils.test.ts
+++ b/graylog2-web-interface/src/util/URLUtils.test.ts
@@ -91,5 +91,14 @@ describe('qualifyUrl', () => {
 
       expect(currentPathnameWithoutPrefix()).toBe(pathname);
     });
+
+    it('returns current path when prefix is defined and ends with `/`', () => {
+      const pathname = '/welcome';
+      setLocation(`/foo${pathname}`);
+
+      mockPathPrefix('/foo/');
+
+      expect(currentPathnameWithoutPrefix()).toBe(pathname);
+    });
   });
 });

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -98,7 +98,7 @@ const URLUtils = {
     try {
       // eslint-disable-next-line
       new URL(str);
-    } catch (e) {
+    } catch (ignored) {
       isValid = false;
     }
 

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -113,12 +113,25 @@ const URLUtils = {
   getPathnameWithoutId(pathname: string) {
     return pathname.replace(/\/[0-9a-fA-F]{24}/, '').slice(1);
   },
+  currentPathname() {
+    return window.location.pathname;
+  },
   currentPathnameWithoutPrefix() {
-    const pathPrefix = AppConfig.gl2AppPathPrefix();
+    return URLUtils.stripPrefixFromPathname(URLUtils.currentPathname());
+  },
+  stripPrefixFromPathname(path: string) {
+    if (!path) {
+      return path;
+    }
+
+    const rawPathPrefix = AppConfig.gl2AppPathPrefix();
+    const pathPrefix = rawPathPrefix?.length > 1 && rawPathPrefix.endsWith('/')
+      ? rawPathPrefix.slice(0, -1)
+      : rawPathPrefix;
 
     const pathPrefixLength = (!pathPrefix || pathPrefix === '' || pathPrefix === '/') ? 0 : pathPrefix.length;
 
-    return window.location.pathname.slice(pathPrefixLength);
+    return path.slice(pathPrefixLength);
   },
 };
 
@@ -134,5 +147,7 @@ export const {
   concatURLPath,
   isValidURL,
   hasAcceptedProtocol,
+  currentPathname,
   currentPathnameWithoutPrefix,
+  stripPrefixFromPathname,
 } = URLUtils;

--- a/graylog2-web-interface/src/util/URLUtils.ts
+++ b/graylog2-web-interface/src/util/URLUtils.ts
@@ -98,6 +98,7 @@ const URLUtils = {
     try {
       // eslint-disable-next-line
       new URL(str);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (ignored) {
       isValid = false;
     }


### PR DESCRIPTION
**Note:** This is a backport of #20909 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This PR is fixing an issue related to path prefix handling in the `useSendTelemetry` hook. When a path prefix is defined, that hook is preparing a function to send telemetry (regardless if telemetry is enabled or not) and pre-constructs a context including the pathname of the current page. Previously, the logic to strip the path prefix from the route was incorrect, in that it tries to remove it before matching it to routes instead of stripping it from the matched route. 

This PR is fixing this by changing the order in which the path prefix is stripped.

Fixes #20899.
Fixes #20837.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.