### PR TITLE
Fix deprecation warning in data node

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/OpensearchConfiguration.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/OpensearchConfiguration.java
@@ -97,6 +97,7 @@ public record OpensearchConfiguration(
         List<String> javaOpts = new LinkedList<>();
         javaOpts.add("-Xms%s".formatted(opensearchSecurityConfiguration.getOpensearchHeap()));
         javaOpts.add("-Xmx%s".formatted(opensearchSecurityConfiguration.getOpensearchHeap()));
+        javaOpts.add("-Dopensearch.transport.cname_in_publish_address=true");
 
         opensearchSecurityConfiguration.getTruststore().ifPresent(truststore -> {
             javaOpts.add("-Djavax.net.ssl.trustStore=" + truststore.location().toAbsolutePath());


### PR DESCRIPTION
## Description
Calls to data node's Opensearch endpoint `_nodes` show a deprecation warning in the logs. This change removes this deprecation warning.

/nocl internal change

## Motivation and Context
fixes #20759 

## How Has This Been Tested?
Startup data node without this change
  -> any call to `_nodes` from Graylog will show warning in Graylog logs
alternatively, call `/api/datanodes/any/opensearch/_nodes` endpoint directly, check Graylog logs

Startup data node with change
  -> no warning is shown

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

