### PR TITLE
Sorting pivot values numerically when field is numeric. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-enterprise-6479.toml
+++ b/changelog/unreleased/issue-enterprise-6479.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Sorting pivot values numerically when field is numeric."
+
+issues = ["Graylog2/graylog-plugin-enterprise#6479"]
+pulls = ["20918"]

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/AggregationSortingIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/aggregations/AggregationSortingIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.aggregations;
+
+import com.github.rholder.retry.RetryException;
+import io.restassured.response.ValidatableResponse;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSort;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSort;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.inputs.PortBoundGelfInputApi;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.containermatrix.SearchServer.ES7;
+import static org.graylog.testing.containermatrix.SearchServer.OS1;
+import static org.graylog.testing.containermatrix.SearchServer.OS2_LATEST;
+import static org.hamcrest.Matchers.is;
+
+@ContainerMatrixTestsConfiguration(searchVersions = {ES7, OS1, OS2_LATEST})
+public class AggregationSortingIT {
+    private static final String numericField = "numeric_field";
+    private static final String nonNumericField = "non_numeric_field";
+
+    private final GraylogApis api;
+    private PortBoundGelfInputApi gelfInput;
+
+    public AggregationSortingIT(GraylogApis api) {
+        this.api = api;
+    }
+
+    @BeforeAll
+    void setUp() {
+        this.gelfInput = api.gelf().createGelfHttpInput();
+    }
+
+    @ContainerMatrixTest
+    void sortingOnNumericPivotFieldSortsNumerically() throws ExecutionException, RetryException {
+        final var values = Set.of(9, 8, 4, 25, 2, 15, 1);
+        final var messagePrefix = "sorting on numeric pivot test ";
+        try (final var env = createEnvironment()) {
+            IntStream.range(0, 3).forEach((i) -> {
+                for (final var value : values) {
+                    env.ingestMessage(Map.of(
+                            nonNumericField, "foo",
+                            numericField, value,
+                            "short_message", messagePrefix + value
+                    ));
+                }
+            });
+
+            final var pivotBuilder = Pivot.builder()
+                    .rowGroups(Values.builder()
+                            .fields(List.of(nonNumericField, numericField)).limit(10).build())
+                    .series(List.of())
+                    .rollup(false);
+
+            env.waitForMessages(values.stream().map(value -> messagePrefix + value).toList());
+
+            env.waitForFieldTypes(numericField);
+
+            final var resultDesc = env.executePivot(
+                            pivotBuilder
+                                    .sort(PivotSort.create(numericField, SortSpec.Direction.Descending))
+                                    .build()
+            );
+            assertThat(resultDesc).isNotNull();
+
+            expectKeys(resultDesc, "25", "15", "9", "8", "4", "2", "1");
+
+            final var resultAsc = env.executePivot(
+                    pivotBuilder
+                            .sort(PivotSort.create(numericField, SortSpec.Direction.Ascending))
+                            .build());
+
+            expectKeys(resultAsc, "1", "2", "4", "8", "9", "15", "25");
+        }
+    }
+
+    @ContainerMatrixTest
+    void sortingOnNonNumericPivotFieldSortsLexicographically() throws ExecutionException, RetryException {
+        final var values = Set.of("B", "C", "D", "A", "E");
+        final var messagePrefix = "sorting on non-numeric pivot test ";
+        try (final var env = createEnvironment()) {
+            IntStream.range(0, 3).forEach((i) -> {
+                for (final var value : values) {
+                    env.ingestMessage(Map.of(
+                            nonNumericField, value,
+                            numericField, 42,
+                            "short_message", messagePrefix + value
+                    ));
+                }
+            });
+
+            final var pivotBuilder = Pivot.builder()
+                    .rowGroups(Values.builder()
+                            .fields(List.of(numericField, nonNumericField)).limit(10).build())
+                    .series(List.of())
+                    .rollup(false);
+
+            env.waitForMessages(values.stream().map(value -> messagePrefix + value).toList());
+
+            env.waitForFieldTypes(numericField);
+
+            final var resultDesc = env.executePivot(
+                    pivotBuilder
+                            .sort(PivotSort.create(nonNumericField, SortSpec.Direction.Ascending))
+                            .build()
+            );
+            assertThat(resultDesc).isNotNull();
+
+            expectKeys(resultDesc, "A", "B", "C", "D", "E");
+
+            final var resultAsc = env.executePivot(
+                    pivotBuilder
+                            .sort(PivotSort.create(nonNumericField, SortSpec.Direction.Descending))
+                            .build());
+
+            expectKeys(resultAsc, "E", "D", "C", "B", "A");
+        }
+    }
+
+    @ContainerMatrixTest
+    void sortingOnBothNumericFieldAndMetric() throws ExecutionException, RetryException {
+        final var values = List.of(2, 4, 9, 1, 25, 2, 9, 4, 15);
+        final var messagePrefix = "Ingesting value ";
+        try (final var env = createEnvironment()) {
+            IntStream.range(0, 3).forEach((i) -> {
+                for (final var value : values) {
+                    env.ingestMessage(Map.of(
+                            nonNumericField, "Test",
+                            numericField, value,
+                            "short_message", messagePrefix + value
+                    ));
+                }
+            });
+
+            env.waitForMessages(values.stream().distinct().map(value -> messagePrefix + value).toList());
+
+            env.waitForFieldTypes(numericField);
+
+            final var pivotBuilder = Pivot.builder()
+                    .rowGroups(Values.builder()
+                            .fields(List.of(nonNumericField, numericField)).limit(10).build())
+                    .series(List.of(Count.builder().build()))
+                    .rollup(false);
+
+            final var resultAsc = env.executePivot(
+                    pivotBuilder
+                            .sort(
+                                    PivotSort.create(numericField, SortSpec.Direction.Ascending),
+                                    SeriesSort.create("count()", SortSpec.Direction.Descending)
+                            )
+                            .build()
+            );
+
+            expectKeys(resultAsc, "1", "2", "4", "9", "15", "25");
+
+            final var resultDesc = env.executePivot(
+                    pivotBuilder
+                            .sort(
+                                    PivotSort.create(numericField, SortSpec.Direction.Descending),
+                                    SeriesSort.create("count()", SortSpec.Direction.Descending)
+                            )
+                            .build()
+            );
+
+            expectKeys(resultDesc, "25", "15", "9", "4", "2", "1");
+        }
+    }
+
+    private void expectKeys(ValidatableResponse response, String... values) {
+        for (int i = 0; i < values.length; i++) {
+            response.body(".rows[" + i + "].key[1]", is(values[i]));
+        }
+    }
+
+    private GraylogApis.SearchEnvironment createEnvironment() throws ExecutionException, RetryException {
+        return api.createEnvironment(gelfInput);
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
@@ -37,7 +37,6 @@ import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 import java.util.stream.Stream;
 
 public class ESTimeHandler extends ESPivotBucketSpecHandler<Time> {
@@ -73,10 +72,10 @@ public class ESTimeHandler extends ESPivotBucketSpecHandler<Time> {
         } else {
             for (String timeField : timeSpec.fields()) {
                 final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(interval.toDateInterval(query.effectiveTimeRange(pivot)).toString());
-                final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+                final var ordering = orderListForPivot(pivot, queryContext, defaultOrder, query);
                 final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
                         .field(timeField)
-                        .order(ordering)
+                        .order(ordering.orders())
                         .format(DATE_TIME_FORMAT);
 
                 setInterval(builder, dateHistogramInterval);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
@@ -23,6 +23,8 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.aggregations.MissingBucketConstants;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSort;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.ValuesBucketOrdering;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
@@ -44,6 +46,7 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.PivotBucket;
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,20 +55,22 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
     private static final String KEY_SEPARATOR_CHARACTER = "\u2E31";
     private static final String KEY_SEPARATOR_PHRASE = " + \"" + KEY_SEPARATOR_CHARACTER + "\" + ";
     private static final String AGG_NAME = "agg";
-    private static final ImmutableList<String> MISSING_BUCKET_KEYS = ImmutableList.of(MissingBucketConstants.MISSING_BUCKET_NAME);
-    private static final BucketOrder defaultOrder = BucketOrder.count(false);
+    public static final BucketOrder DEFAULT_ORDER = BucketOrder.count(false);
+    public static final String SORT_HELPER = "sort_helper";
 
     @Nonnull
     @Override
     public CreatedAggregations<AggregationBuilder> doCreateAggregation(Direction direction, String name, Pivot pivot, Values bucketSpec, ESGeneratedQueryContext queryContext, Query query) {
-        final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+        final var ordering = orderListForPivot(pivot, queryContext, DEFAULT_ORDER, query);
         final int limit = bucketSpec.limit();
         final List<String> orderedBuckets = ValuesBucketOrdering.orderFields(bucketSpec.fields(), pivot.sort());
-        final AggregationBuilder termsAggregation = createTerms(orderedBuckets, ordering, limit);
+        final var termsAggregation = createTerms(orderedBuckets, limit);
+
+        termsAggregation.order(ordering.orders());
+        ordering.sortingAggregations().forEach(termsAggregation::subAggregation);
 
         final FiltersAggregationBuilder filterAggregation = createFilter(name, orderedBuckets, bucketSpec.skipEmptyValues())
                 .subAggregation(termsAggregation);
-
         return CreatedAggregations.create(filterAggregation, termsAggregation, List.of(termsAggregation, filterAggregation));
     }
 
@@ -79,15 +84,14 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
     }
 
 
-    private AggregationBuilder createTerms(List<String> valueBuckets, List<BucketOrder> ordering, int limit) {
-        return createScriptedTerms(valueBuckets, ordering, limit);
+    private TermsAggregationBuilder createTerms(List<String> valueBuckets, int limit) {
+        return createScriptedTerms(valueBuckets, limit);
     }
 
-    private TermsAggregationBuilder createScriptedTerms(List<String> buckets, List<BucketOrder> ordering, int limit) {
+    private TermsAggregationBuilder createScriptedTerms(List<String> buckets, int limit) {
         return AggregationBuilders.terms(AGG_NAME)
                 .script(scriptForPivots(buckets))
-                .size(limit)
-                .order(ordering);
+                .size(limit);
     }
 
     private Script scriptForPivots(Collection<String> pivots) {
@@ -101,6 +105,32 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
                         """.formatted(bucket, MissingBucketConstants.MISSING_BUCKET_NAME))
                 .collect(Collectors.toList()));
         return new Script(scriptSource);
+    }
+
+    private TermsAggregationBuilder applyOrdering(Pivot pivot, TermsAggregationBuilder terms, List<BucketOrder> ordering, ESGeneratedQueryContext queryContext) {
+        return sortsOnNumericPivotField(pivot, queryContext)
+                /* When we sort on a numeric pivot field, we create a metric sub-aggregation for that field, which returns
+                the numeric value of it, so that we can sort on it numerically. Any metric aggregation (min/max/avg) will work. */
+                .map(pivotSort -> terms
+                        .subAggregation(AggregationBuilders.max(SORT_HELPER).field(pivotSort.field()))
+                        .order(BucketOrder.aggregation(SORT_HELPER, SortSpec.Direction.Ascending.equals(pivotSort.direction()))))
+                .orElseGet(() -> terms
+                        .order(ordering.isEmpty() ? List.of(DEFAULT_ORDER) : ordering));
+    }
+
+    private Optional<PivotSort> sortsOnNumericPivotField(Pivot pivot, ESGeneratedQueryContext queryContext) {
+        return Optional.ofNullable(pivot.sort())
+                .filter(sorts -> sorts.size() == 1)
+                .map(sorts -> sorts.get(0))
+                .filter(sort -> sort instanceof PivotSort)
+                .map(sort -> (PivotSort) sort)
+                .filter(pivotSort -> queryContext.fieldType(pivot.effectiveStreams(), pivotSort.field())
+                        .filter(this::isNumericFieldType)
+                        .isPresent());
+    }
+
+    private boolean isNumericFieldType(String fieldType) {
+        return fieldType.equals("long") || fieldType.equals("double") || fieldType.equals("float");
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/RunningElasticsearchInstanceES7.java
@@ -47,6 +47,10 @@ public class RunningElasticsearchInstanceES7 implements SearchServerInstance {
     private final FixtureImporter fixtureImporter;
     private final Adapters adapters;
 
+    public RunningElasticsearchInstanceES7() {
+        this(List.of());
+    }
+
     public RunningElasticsearchInstanceES7(final List<String> featureFlags) {
         this.restHighLevelClient = buildRestClient();
         this.elasticsearchClient = new ElasticsearchClient(this.restHighLevelClient, new ObjectMapperProvider().get());

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSTimeHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSTimeHandler.java
@@ -37,7 +37,6 @@ import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 import java.util.stream.Stream;
 
 public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
@@ -72,11 +71,13 @@ public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
         } else {
             for (String timeField : timeSpec.fields()) {
                 final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(interval.toDateInterval(query.effectiveTimeRange(pivot)).toString());
-                final List<BucketOrder> ordering = orderListForPivot(pivot, queryContext, defaultOrder);
+                final var ordering = orderListForPivot(pivot, queryContext, defaultOrder, query);
                 final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
                         .field(timeField)
-                        .order(ordering)
+                        .order(ordering.orders())
                         .format(DATE_TIME_FORMAT);
+
+                ordering.sortingAggregations().forEach(builder::subAggregation);
 
                 setInterval(builder, dateHistogramInterval);
 

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/FieldTypes.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/FieldTypes.java
@@ -18,8 +18,10 @@ package org.graylog.testing.completebackend.apis;
 
 import org.graylog.plugins.views.search.rest.FieldTypesForStreamsRequest;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +53,19 @@ public class FieldTypes implements GraylogRestApi {
                 .post("/views/fields")
                 .as(MappedFieldTypeDTO[].class);
         return Arrays.asList(as);
+    }
+
+    public Set<MappedFieldTypeDTO> waitForFieldTypeDefinitions(Set<String> streams, String... fieldName) {
+        final Set<String> expectedFields = Arrays.stream(fieldName).collect(Collectors.toSet());
+        return waitForObject(() -> {
+            final List<MappedFieldTypeDTO> knownTypes = getFieldTypes(RelativeRange.allTime(), streams);
+            final Set<MappedFieldTypeDTO> filtered = knownTypes.stream().filter(t -> expectedFields.contains(t.name())).collect(Collectors.toSet());
+            if (filtered.size() == expectedFields.size()) {
+                return Optional.of(filtered);
+            } else {
+                return Optional.empty();
+            }
+        }, "Timed out waiting for field definition", Duration.ofSeconds(30));
     }
 
     public Set<MappedFieldTypeDTO> waitForFieldTypeDefinitions(String... fieldName) {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
@@ -16,6 +16,10 @@
  */
 package org.graylog.testing.completebackend.apis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.rholder.retry.RetryException;
+import com.google.common.collect.ImmutableMap;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.FailureConfig;
@@ -23,14 +27,22 @@ import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.testing.completebackend.GraylogBackend;
 import org.graylog.testing.completebackend.apis.inputs.GelfInputApi;
+import org.graylog.testing.completebackend.apis.inputs.PortBoundGelfInputApi;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
 import static io.restassured.RestAssured.given;
@@ -255,5 +267,66 @@ public class GraylogApis implements GraylogRestApi {
                             }
                         })
                 );
+    }
+
+    public class SearchEnvironment implements Closeable {
+        private final Map<String, Object> MANDATORY_MESSAGE_FIELDS = Map.of(
+                "source", "test-environment",
+                "host", "test-environment"
+        );
+
+        private final String randomId;
+        private final String streamId;
+        private final String indexSetId;
+        private final PortBoundGelfInputApi gelfPort;
+        private final ObjectMapper objectMapper;
+
+        private SearchEnvironment(String randomId, String streamId, String indexSetId, PortBoundGelfInputApi gelfPort) {
+            this.randomId = randomId;
+            this.streamId = streamId;
+            this.indexSetId = indexSetId;
+            this.gelfPort = gelfPort;
+            this.objectMapper = new ObjectMapperProvider().get();
+        }
+
+        public void ingestMessage(Map<String, Object> message) {
+            final var messageWithTag = ImmutableMap.builder()
+                    .putAll(MANDATORY_MESSAGE_FIELDS)
+                    .putAll(message)
+                    .put("test-environment", randomId)
+                    .build();
+            try {
+                this.gelfPort.postMessage(objectMapper.writeValueAsString(messageWithTag));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Error serializing message for ingestion: ", e);
+            }
+        }
+
+        public void waitForFieldTypes(String... fields) {
+            fieldTypes().waitForFieldTypeDefinitions(Set.of(streamId), fields);
+        }
+
+        public ValidatableResponse executePivot(Pivot pivot) {
+            return search().executePivot(pivot, "", Set.of(streamId));
+        }
+
+        public void waitForMessages(Collection<String> messages) {
+            search().waitForMessages(messages, RelativeRange.allTime(), Set.of(streamId));
+        }
+
+        @Override
+        public void close() {
+            streams().deleteStream(streamId);
+            indices().deleteIndexSet(indexSetId, true);
+        }
+    }
+
+    public SearchEnvironment createEnvironment(PortBoundGelfInputApi gelfPort) throws ExecutionException, RetryException {
+        final var randomId = RandomStringUtils.secure().next(8, false, true);
+        final var indexSetId = this.indices().createIndexSet("Test Environment " + randomId, "An index set for tests", "searchenvironment" + randomId);
+        this.indices().waitForIndexNames(indexSetId);
+        final var streamId = this.streams().createStream("Test Stream " + randomId, indexSetId, true, DefaultStreamMatches.REMOVE, Streams.StreamRule.exact(randomId, "test-environment", false));
+
+        return new SearchEnvironment(randomId, streamId, indexSetId, gelfPort);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Search.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Search.java
@@ -19,25 +19,30 @@ package org.graylog.testing.completebackend.apis;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSet;
 import io.restassured.path.json.JsonPath;
-import io.restassured.specification.RequestSpecification;
+import io.restassured.response.ValidatableResponse;
 import org.bson.types.ObjectId;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.rest.QueryDTO;
 import org.graylog.plugins.views.search.rest.SearchDTO;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
-import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 
@@ -58,15 +63,22 @@ public class Search implements GraylogRestApi {
 
 
     public Search waitForMessages(String... messages) {
-        waitFor(() -> searchAllMessages().containsAll(Arrays.asList(messages)), "Timed out waiting for message to be present");
+        return waitForMessages(Arrays.asList(messages));
+    }
+
+    public Search waitForMessages(Collection<String> messages) {
+        waitFor(() -> searchAllMessages().containsAll(messages), "Timed out waiting for messages to be present");
+        return this;
+    }
+
+    public Search waitForMessages(Collection<String> messages, TimeRange timeRange, Set<String> streams) {
+        waitFor(() -> searchAllMessages(timeRange, streams).containsAll(messages), "Timed out waiting for messages to be present", Duration.ofSeconds(300));
         return this;
     }
 
     private boolean captureMessage(String message) {
         return searchAllMessages().contains(message);
     }
-
-
 
     private boolean captureMessages(Consumer<List<String>> messagesCaptor) {
         List<String> messages = searchAllMessages();
@@ -92,14 +104,18 @@ public class Search implements GraylogRestApi {
      * @return all messages' "message" field as List<String>
      */
     public List<String> searchAllMessages() {
-        return searchAllMessagesInTimeRange(allMessagesTimeRange());
+        return searchAllMessagesInTimeRange(RelativeRange.allTime());
     }
 
     public List<String> searchAllMessagesInTimeRange(TimeRange timeRange) {
+        return searchAllMessages(timeRange, Set.of());
+    }
+
+    public List<String> searchAllMessages(TimeRange timeRange, Set<String> streams) {
         String queryId = "query-id";
         String messageListId = "message-list-id";
 
-        String body = allMessagesJson(queryId, messageListId, timeRange);
+        String body = allMessagesJson(queryId, messageListId, timeRange, streams);
 
         final JsonPath response = given()
                 .spec(api.requestSpecification())
@@ -119,8 +135,8 @@ public class Search implements GraylogRestApi {
         return response.getList(allMessagesJsonPath(queryId, messageListId), String.class);
     }
 
-    private String allMessagesJson(String queryId, String messageListId, TimeRange timeRange) {
-        MessageList messageList = MessageList.builder().id(messageListId).build();
+    private String allMessagesJson(String queryId, String messageListId, TimeRange timeRange, Set<String> streams) {
+        MessageList messageList = MessageList.builder().streams(streams).id(messageListId).build();
         QueryDTO q = QueryDTO.builder()
                 .id(queryId)
                 .query(ElasticsearchQueryString.of(""))
@@ -140,16 +156,51 @@ public class Search implements GraylogRestApi {
         return "results." + queryId + ".search_types." + messageListId + ".messages.message.message";
     }
 
-
-    public AbsoluteRange allMessagesTimeRange() {
-        return AbsoluteRange.create("2010-01-01T00:00:00.0Z", "2050-01-01T00:00:00.0Z");
-    }
-
     public String toJsonString(Object s) {
         try {
             return new ObjectMapperProvider().get().writeValueAsString(s);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to serialize Search", e);
         }
+    }
+
+    public ValidatableResponse executePivot(Pivot pivot) {
+        return executePivot(pivot, "source:pivot-fixtures");
+    }
+
+    public ValidatableResponse executePivot(Pivot pivot, String queryString) {
+        return executePivot(pivot, queryString, Set.of());
+    }
+
+    public ValidatableResponse executePivot(Pivot pivot, String queryString, Set<String> streams) {
+        final var pivotName = "pivotaggregation";
+        final var pivotPath = "results.query1.search_types." + pivotName;
+        final Pivot pivotWithId = pivot.toBuilder()
+                .id(pivotName)
+                .build();
+
+        final SearchDTO search = SearchDTO.builder()
+                .queries(QueryDTO.builder()
+                        .timerange(RelativeRange.allTime())
+                        .id("query1")
+                        .query(ElasticsearchQueryString.of(queryString))
+                        .filter(StreamFilter.anyIdOf(streams.toArray(new String[0])))
+                        .searchTypes(Set.of(pivotWithId))
+                        .build())
+                .build();
+
+        return given()
+                .config(api.withGraylogBackendFailureConfig())
+                .spec(api.requestSpecification())
+                .when()
+                .body(toJsonString(search))
+                .post("/views/search/sync")
+                .then()
+                .log().ifError()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body("execution.completed_exceptionally", equalTo(false))
+                .body("execution.done", equalTo(true))
+                .rootPath(pivotPath);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Streams.java
@@ -144,7 +144,7 @@ public final class Streams implements GraylogRestApi {
             RetryerBuilder.<String>newBuilder()
                     .withWaitStrategy(WaitStrategies.fixedWait(100, TimeUnit.MILLISECONDS))
                     .withStopStrategy(StopStrategies.stopAfterDelay(10, TimeUnit.SECONDS))
-                    .retryIfResult(r -> r.equals(existingEngineFingerprint))
+                    .retryIfResult(r -> r != null && r.equals(existingEngineFingerprint))
                     .build()
                     .call(this::getStreamRouterEngineFingerprint);
         } catch (ExecutionException | RetryException e) {


### PR DESCRIPTION
**Note:** This is a backport of #20918 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing sorting for cases where a numeric pivot is configured as sort order for an aggregation. Previously, the values returned were order lexicographically. This PR makes use of a nested aggregation for sorting, that allows us to sort results numerically instead, if the underlying field type of the pivot is a numeric one.

Fixes Graylog2/graylog-plugin-enterprise#6479.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.