### PR TITLE
Fixing AWS integration routes when path prefix is present. `6.1`

### DIFF
--- a/changelog/unreleased/pr-20969.toml
+++ b/changelog/unreleased/pr-20969.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fixing route for AWS integration when path prefix is present."
+
+pulls = ["20969"]

--- a/graylog2-web-interface/src/integrations/aws/AWSInputConfiguration.jsx
+++ b/graylog2-web-interface/src/integrations/aws/AWSInputConfiguration.jsx
@@ -18,7 +18,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
-import Routes from 'integrations/aws/common/Routes.js';
+import Routes from 'integrations/aws/common/Routes';
 
 const AWSInputConfiguration = ({ url }) => {
   const navigate = useNavigate();

--- a/graylog2-web-interface/src/integrations/aws/common/Routes.ts
+++ b/graylog2-web-interface/src/integrations/aws/common/Routes.ts
@@ -14,7 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-const Routes = {
+import { qualifyUrls } from 'routing/Routes';
+
+const AwsRoutes = {
   INTEGRATIONS: {
     AWS: {
       CLOUDWATCH: {
@@ -54,6 +56,9 @@ const DocsRoutes = {
   },
 };
 
-export default Routes;
+export default {
+  ...qualifyUrls(AwsRoutes),
+  unqualified: AwsRoutes,
+};
 
 export { ApiRoutes, DocsRoutes };

--- a/graylog2-web-interface/src/integrations/bindings.jsx
+++ b/graylog2-web-interface/src/integrations/bindings.jsx
@@ -37,7 +37,7 @@ import TeamsNotificationV2Details from './event-notifications/event-notification
 
 const bindings = {
   routes: [
-    { path: Routes.INTEGRATIONS.AWS.CLOUDWATCH.index, component: AWSCloudWatchApp },
+    { path: Routes.unqualified.INTEGRATIONS.AWS.CLOUDWATCH.index, component: AWSCloudWatchApp },
   ],
   inputConfiguration: [
     {


### PR DESCRIPTION
**Please note**, this PR is a backport of https://github.com/Graylog2/graylog2-server/pull/20969 for `6.1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When running Graylog with a path prefix (e.g. `http://localhost:9000/graylog`), a route in the AWs integration was broken, because it did not include the path prefix. This PR is fixing the issue by qualifying the related route properly.

Realted to: https://github.com/Graylog2/graylog-plugin-enterprise/issues/9148