### PR TITLE
Fixing text color of bar labels in bar chart, which are displayed outside of a bar. `6.1`

### DIFF
--- a/changelog/unreleased/issue-20789.toml
+++ b/changelog/unreleased/issue-20789.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing text color of bar labels in bar chart, which are displayed outside of a bar."
+
+issues = ["20789"]
+pulls = ["20948"]

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -174,7 +174,7 @@ const usePlotLayout = (layout: Partial<Layout>) => {
   }, [colors, interactive, layout, theme]);
 };
 
-const usePlotChatData = (chartData: Array<any>, setChartColor: (data: ChartConfig, color: ColorMapper) => ChartColor) => {
+const usePlotChartData = (chartData: Array<any>, setChartColor: (data: ChartConfig, color: ColorMapper) => ChartColor) => {
   const theme = useTheme();
   const { colors } = useContext(ChartColorContext);
 
@@ -182,9 +182,7 @@ const usePlotChatData = (chartData: Array<any>, setChartColor: (data: ChartConfi
     if (setChartColor && colors) {
       const conf = setChartColor(chart, colors);
 
-      if (chart.type === 'pie') {
-        conf.outsidetextfont = { color: theme.colors.global.textDefault };
-      }
+      conf.outsidetextfont = { color: theme.colors.global.textDefault };
 
       if (chart?.name === eventsDisplayName) {
         const eventColor = colors.get(eventsDisplayName, EVENT_COLOR);
@@ -206,7 +204,7 @@ const usePlotChatData = (chartData: Array<any>, setChartColor: (data: ChartConfi
 const GenericPlot = ({ chartData, layout, setChartColor, onClickMarker, onHoverMarker, onUnhoverMarker, onZoom, onAfterPlot }: Props) => {
   const interactive = useContext(InteractiveContext);
   const plotLayout = usePlotLayout(layout);
-  const plotChartData = usePlotChatData(chartData, setChartColor);
+  const plotChartData = usePlotChartData(chartData, setChartColor);
   const onRenderComplete = useContext(RenderCompletionCallback);
 
   const _onRelayout = useCallback((axis: Axis) => {


### PR DESCRIPTION
Please note, this PR is a backport of https://github.com/Graylog2/graylog2-server/pull/20948 for `6.1`.

As described in https://github.com/Graylog2/graylog2-server/issues/20789 the label of a bar in the bar chart is not readable in the dark mode, when the label is displayed outside of the bar.

Before:
![image](https://github.com/user-attachments/assets/c75e9d48-67be-444b-a278-5a89963295b7)

After:
![image](https://github.com/user-attachments/assets/33452398-2615-4bb9-8034-afd37d139105)

Fixes https://github.com/Graylog2/graylog2-server/issues/20789