### PR TITLE
Add auto refresh button to events page

### DIFF
--- a/changelog/unreleased/pr-20896.toml
+++ b/changelog/unreleased/pr-20896.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add auto refresh to events page"
+
+issues = ["graylog-plugin-enterprise#8661"]
+pulls = ["20896"]

--- a/changelog/unreleased/pr-20996.toml
+++ b/changelog/unreleased/pr-20996.toml
@@ -1,5 +1,5 @@
 type = "a"
-message = "Add auto refresh to events page"
+message = "Add auto refresh button to events page"
 
 issues = ["graylog-plugin-enterprise#8661"]
 pulls = ["20996"]

--- a/changelog/unreleased/pr-20996.toml
+++ b/changelog/unreleased/pr-20996.toml
@@ -2,4 +2,4 @@ type = "a"
 message = "Add auto refresh to events page"
 
 issues = ["graylog-plugin-enterprise#8661"]
-pulls = ["20896"]
+pulls = ["20996"]

--- a/graylog2-web-interface/src/components/common/CommonRefreshControls.tsx
+++ b/graylog2-web-interface/src/components/common/CommonRefreshControls.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React, { useCallback } from 'react';
+import { styled } from 'styled-components';
+
+import { ProgressAnimation, Icon, Spinner, HoverForHelp } from 'components/common/index';
+import { Button, DropdownButton, MenuItem, ButtonGroup } from 'components/bootstrap';
+import ReadableDuration from 'components/common/ReadableDuration';
+import useAutoRefresh from 'views/hooks/useAutoRefresh';
+import { durationToMS } from 'views/hooks/useDefaultIntervalForRefresh';
+
+const FlexibleButtonGroup = styled(ButtonGroup)`
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+
+  > .btn-group {
+    .btn:first-child {
+      max-width: 100%;
+    }
+  }
+`;
+
+const ButtonLabel = () => {
+  const { refreshConfig } = useAutoRefresh();
+
+  if (!refreshConfig?.enabled) {
+    return <>Not updating</>;
+  }
+
+  return (
+    <>
+      Every <ReadableDuration duration={refreshConfig.interval} />
+    </>
+  );
+};
+
+type Props = {
+  disable: boolean,
+  intervalOptions: Array<[string, string]>,
+  isLoadingMinimumInterval: boolean,
+  minimumRefreshInterval: string,
+  defaultInterval: string,
+  onSelectInterval?: (interval: string) => void,
+  onToggle?: (enabled: boolean) => void,
+  onEnable?: () => void,
+  onDisable?: () => void,
+  humanName: string,
+}
+
+const CommonRefreshControls = ({ humanName, disable, onToggle = null, onEnable = null, onDisable = null, intervalOptions, onSelectInterval = null, isLoadingMinimumInterval, minimumRefreshInterval, defaultInterval }: Props) => {
+  const { refreshConfig, startAutoRefresh, stopAutoRefresh, animationId } = useAutoRefresh();
+
+  const selectInterval = useCallback((interval: string) => {
+    startAutoRefresh(durationToMS(interval));
+
+    if (typeof onSelectInterval === 'function') {
+      onSelectInterval(interval);
+    }
+  }, [onSelectInterval, startAutoRefresh]);
+
+  const toggleEnable = useCallback(() => {
+    if (!defaultInterval && !refreshConfig?.interval) {
+      return;
+    }
+
+    if (typeof onToggle === 'function') {
+      onToggle(!refreshConfig?.enabled);
+    }
+
+    if (refreshConfig?.enabled) {
+      stopAutoRefresh();
+
+      if (typeof onDisable === 'function') {
+        onDisable();
+      }
+    } else {
+      startAutoRefresh(refreshConfig?.interval ?? durationToMS(defaultInterval));
+
+      if (typeof onEnable === 'function') {
+        onEnable();
+      }
+    }
+  }, [defaultInterval, onDisable, onEnable, onToggle, refreshConfig?.enabled, refreshConfig?.interval, startAutoRefresh, stopAutoRefresh]);
+
+  return (
+    <FlexibleButtonGroup aria-label={`Refresh ${humanName} Controls`}>
+      {(refreshConfig?.enabled && animationId) && (
+        <ProgressAnimation key={`${refreshConfig.interval}-${animationId}`}
+                           $animationDuration={refreshConfig.interval}
+                           $increase={false} />
+      )}
+
+      <Button onClick={toggleEnable}
+              title={refreshConfig?.enabled ? 'Pause Refresh' : 'Start Refresh'}
+              disabled={disable || isLoadingMinimumInterval || !defaultInterval}>
+        <Icon name={refreshConfig?.enabled ? 'pause' : 'update'} />
+      </Button>
+
+      <DropdownButton title={<ButtonLabel />}
+                      disabled={disable}
+                      id="refresh-options-dropdown">
+        {isLoadingMinimumInterval && <Spinner />}
+        {!isLoadingMinimumInterval && intervalOptions.map(([interval, label]) => {
+          const isBelowMinimum = durationToMS(interval) < durationToMS(minimumRefreshInterval);
+
+          return (
+            <MenuItem key={`RefreshControls-${label}`}
+                      onClick={() => selectInterval(interval)}
+                      disabled={isBelowMinimum}>
+              {label}
+              {isBelowMinimum && (
+                <HoverForHelp displayLeftMargin>
+                  Interval of <ReadableDuration duration={interval} /> ({interval}) is below configured minimum interval
+                  of <ReadableDuration duration={minimumRefreshInterval} /> ({minimumRefreshInterval}).
+                </HoverForHelp>
+              )}
+            </MenuItem>
+          );
+        })}
+      </DropdownButton>
+    </FlexibleButtonGroup>
+  );
+};
+
+export default CommonRefreshControls;

--- a/graylog2-web-interface/src/components/common/RefreshControls.tsx
+++ b/graylog2-web-interface/src/components/common/RefreshControls.tsx
@@ -21,7 +21,7 @@ import { ProgressAnimation, Icon, Spinner, HoverForHelp } from 'components/commo
 import { Button, DropdownButton, MenuItem, ButtonGroup } from 'components/bootstrap';
 import ReadableDuration from 'components/common/ReadableDuration';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
-import { durationToMS } from 'views/hooks/useDefaultIntervalForRefresh';
+import { durationToMS } from 'util/DateTime';
 
 const FlexibleButtonGroup = styled(ButtonGroup)`
   display: flex;
@@ -62,7 +62,7 @@ type Props = {
   humanName: string,
 }
 
-const CommonRefreshControls = ({ humanName, disable, onToggle = null, onEnable = null, onDisable = null, intervalOptions, onSelectInterval = null, isLoadingMinimumInterval, minimumRefreshInterval, defaultInterval }: Props) => {
+const RefreshControls = ({ humanName, disable, onToggle = null, onEnable = null, onDisable = null, intervalOptions, onSelectInterval = null, isLoadingMinimumInterval, minimumRefreshInterval, defaultInterval }: Props) => {
   const { refreshConfig, startAutoRefresh, stopAutoRefresh, animationId } = useAutoRefresh();
 
   const selectInterval = useCallback((interval: string) => {
@@ -137,4 +137,4 @@ const CommonRefreshControls = ({ humanName, disable, onToggle = null, onEnable =
   );
 };
 
-export default CommonRefreshControls;
+export default RefreshControls;

--- a/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
+++ b/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
@@ -18,22 +18,15 @@ import React, { useCallback } from 'react';
 
 import useTableElements from 'components/events/events/hooks/useTableComponents';
 import { eventsTableElements } from 'components/events/Constants';
-import PaginatedEntityTable, { useTableFetchContext } from 'components/common/PaginatedEntityTable';
+import PaginatedEntityTable from 'components/common/PaginatedEntityTable';
 import FilterValueRenderers from 'components/events/FilterValueRenderers';
 import fetchEvents, { keyFn } from 'components/events/fetchEvents';
 import type { SearchParams } from 'stores/PaginationTypes';
 import type { Event, EventsAdditionalData } from 'components/events/events/types';
 import useQuery from 'routing/useQuery';
 import useColumnRenderers from 'components/events/events/ColumnRenderers';
-import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
 import EventsRefreshControls from 'components/events/events/EventsRefreshControls';
 import QueryHelper from 'components/common/QueryHelper';
-
-const RefreshControls = () => {
-  const { refetch } = useTableFetchContext();
-
-  return <AutoRefreshProvider onRefresh={refetch}><EventsRefreshControls disable={false} /></AutoRefreshProvider>;
-};
 
 const EventsEntityTable = () => {
   const { stream_id: streamId } = useQuery();
@@ -55,7 +48,7 @@ const EventsEntityTable = () => {
                                                        entityAttributesAreCamelCase={false}
                                                        filterValueRenderers={FilterValueRenderers}
                                                        columnRenderers={columnRenderers}
-                                                       topRightCol={<RefreshControls />} />
+                                                       topRightCol={<EventsRefreshControls />} />
   );
 };
 

--- a/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
+++ b/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
@@ -18,15 +18,22 @@ import React, { useCallback } from 'react';
 
 import useTableElements from 'components/events/events/hooks/useTableComponents';
 import { eventsTableElements } from 'components/events/Constants';
-import PaginatedEntityTable from 'components/common/PaginatedEntityTable';
+import PaginatedEntityTable, { useTableFetchContext } from 'components/common/PaginatedEntityTable';
 import FilterValueRenderers from 'components/events/FilterValueRenderers';
 import fetchEvents, { keyFn } from 'components/events/fetchEvents';
 import type { SearchParams } from 'stores/PaginationTypes';
 import type { Event, EventsAdditionalData } from 'components/events/events/types';
 import useQuery from 'routing/useQuery';
 import useColumnRenderers from 'components/events/events/ColumnRenderers';
+import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
+import EventsRefreshControls from 'components/events/events/EventsRefreshControls';
+import QueryHelper from 'components/common/QueryHelper';
 
-import QueryHelper from '../common/QueryHelper';
+const RefreshControls = () => {
+  const { refetch } = useTableFetchContext();
+
+  return <AutoRefreshProvider onRefresh={refetch}><EventsRefreshControls disable={false} /></AutoRefreshProvider>;
+};
 
 const EventsEntityTable = () => {
   const { stream_id: streamId } = useQuery();
@@ -47,7 +54,8 @@ const EventsEntityTable = () => {
                                                        expandedSectionsRenderer={expandedSections}
                                                        entityAttributesAreCamelCase={false}
                                                        filterValueRenderers={FilterValueRenderers}
-                                                       columnRenderers={columnRenderers} />
+                                                       columnRenderers={columnRenderers}
+                                                       topRightCol={<RefreshControls />} />
   );
 };
 

--- a/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
@@ -23,7 +23,7 @@ import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
 import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
-import CommonRefreshControls from 'components/common/CommonRefreshControls';
+import RefreshControls from 'components/common/RefreshControls';
 import useDefaultInterval from 'views/hooks/useDefaultIntervalForRefresh';
 import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
 import { useTableFetchContext } from 'components/common/PaginatedEntityTable';
@@ -64,14 +64,14 @@ const EventsRefreshControls = () => {
 
   return (
     <AutoRefreshProvider onRefresh={refetch}>
-      <CommonRefreshControls disable={false}
-                             intervalOptions={intervalOptions}
-                             isLoadingMinimumInterval={isLoadingMinimumInterval}
-                             minimumRefreshInterval={minimumRefreshInterval}
-                             defaultInterval={defaultInterval}
-                             humanName="Evets"
-                             onToggle={onToggle}
-                             onSelectInterval={onSelectInterval} />
+      <RefreshControls disable={false}
+                       intervalOptions={intervalOptions}
+                       isLoadingMinimumInterval={isLoadingMinimumInterval}
+                       minimumRefreshInterval={minimumRefreshInterval}
+                       defaultInterval={defaultInterval}
+                       humanName="Evets"
+                       onToggle={onToggle}
+                       onSelectInterval={onSelectInterval} />
     </AutoRefreshProvider>
   );
 };

--- a/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
@@ -25,12 +25,11 @@ import useLocation from 'routing/useLocation';
 import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
 import CommonRefreshControls from 'components/common/CommonRefreshControls';
 import useDefaultInterval from 'views/hooks/useDefaultIntervalForRefresh';
+import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
+import { useTableFetchContext } from 'components/common/PaginatedEntityTable';
 
-type Props = {
-  disable?: boolean
-}
-
-const EventsRefreshControls = ({ disable = false }: Props) => {
+const EventsRefreshControls = () => {
+  const { refetch } = useTableFetchContext();
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
   const { config } = useSearchConfiguration();
@@ -64,14 +63,16 @@ const EventsRefreshControls = ({ disable = false }: Props) => {
   const intervalOptions = autoRefreshTimerangeOptions ? Object.entries(autoRefreshTimerangeOptions) : [];
 
   return (
-    <CommonRefreshControls disable={disable}
-                           intervalOptions={intervalOptions}
-                           isLoadingMinimumInterval={isLoadingMinimumInterval}
-                           minimumRefreshInterval={minimumRefreshInterval}
-                           defaultInterval={defaultInterval}
-                           humanName="Evets"
-                           onToggle={onToggle}
-                           onSelectInterval={onSelectInterval} />
+    <AutoRefreshProvider onRefresh={refetch}>
+      <CommonRefreshControls disable={false}
+                             intervalOptions={intervalOptions}
+                             isLoadingMinimumInterval={isLoadingMinimumInterval}
+                             minimumRefreshInterval={minimumRefreshInterval}
+                             defaultInterval={defaultInterval}
+                             humanName="Evets"
+                             onToggle={onToggle}
+                             onSelectInterval={onSelectInterval} />
+    </AutoRefreshProvider>
   );
 };
 

--- a/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
@@ -15,36 +15,22 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useEffect } from 'react';
-import { useFormikContext } from 'formik';
+import { useCallback } from 'react';
 
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
-import useAutoRefresh from 'views/hooks/useAutoRefresh';
 import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
 import CommonRefreshControls from 'components/common/CommonRefreshControls';
 import useDefaultInterval from 'views/hooks/useDefaultIntervalForRefresh';
-
-const useDisableOnFormChange = () => {
-  const { refreshConfig, stopAutoRefresh } = useAutoRefresh();
-  const { dirty, isSubmitting } = useFormikContext();
-
-  useEffect(() => {
-    if (refreshConfig?.enabled && !isSubmitting && dirty) {
-      stopAutoRefresh();
-    }
-  }, [dirty, isSubmitting, refreshConfig?.enabled, stopAutoRefresh]);
-};
 
 type Props = {
   disable?: boolean
 }
 
-const RefreshControls = ({ disable = false }: Props) => {
-  const { dirty, submitForm } = useFormikContext();
+const EventsRefreshControls = ({ disable = false }: Props) => {
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
   const { config } = useSearchConfiguration();
@@ -53,25 +39,20 @@ const RefreshControls = ({ disable = false }: Props) => {
 
   const defaultInterval = useDefaultInterval();
 
-  useDisableOnFormChange();
   const onSelectInterval = useCallback((interval: string) => {
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_REFRESH_CONTROL_PRESET_SELECTED, {
+    sendTelemetry(TELEMETRY_EVENT_TYPE.ALERTS_REFRESH_CONTROL_PRESET_SELECTED, {
       app_pathname: getPathnameWithoutId(location.pathname),
-      app_section: 'search-bar',
-      app_action_value: 'refresh-search-control-dropdown',
+      app_section: 'alerts-page',
+      app_action_value: 'refresh-alerts-control-dropdown',
       event_details: { interval: interval },
     });
-
-    if (dirty) {
-      submitForm();
-    }
-  }, [dirty, location.pathname, sendTelemetry, submitForm]);
+  }, [location.pathname, sendTelemetry]);
 
   const onToggle = useCallback((enabled) => {
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_REFRESH_CONTROL_TOGGLED, {
-      app_pathname: 'search',
-      app_section: 'search-bar',
-      app_action_value: 'refresh-search-control-enable',
+    sendTelemetry(TELEMETRY_EVENT_TYPE.ALERTS_REFRESH_CONTROL_TOGGLED, {
+      app_pathname: 'alerts',
+      app_section: 'alerts-page',
+      app_action_value: 'refresh-alerts-control-enable',
       event_details: { enabled },
     });
   }, [sendTelemetry]);
@@ -80,7 +61,7 @@ const RefreshControls = ({ disable = false }: Props) => {
     return null;
   }
 
-  const intervalOptions = Object.entries(autoRefreshTimerangeOptions);
+  const intervalOptions = autoRefreshTimerangeOptions ? Object.entries(autoRefreshTimerangeOptions) : [];
 
   return (
     <CommonRefreshControls disable={disable}
@@ -88,11 +69,10 @@ const RefreshControls = ({ disable = false }: Props) => {
                            isLoadingMinimumInterval={isLoadingMinimumInterval}
                            minimumRefreshInterval={minimumRefreshInterval}
                            defaultInterval={defaultInterval}
-                           humanName="Search"
+                           humanName="Evets"
                            onToggle={onToggle}
-                           onEnable={submitForm}
                            onSelectInterval={onSelectInterval} />
   );
 };
 
-export default RefreshControls;
+export default EventsRefreshControls;

--- a/graylog2-web-interface/src/logic/telemetry/Constants.ts
+++ b/graylog2-web-interface/src/logic/telemetry/Constants.ts
@@ -28,6 +28,8 @@ export const TELEMETRY_EVENT_TYPE = {
   SEARCH_STREAM_INPUT_CHANGED: 'Search Stream Input Changed',
   SEARCH_REFRESH_CONTROL_PRESET_SELECTED: 'Search Refresh Control Preset Selected',
   SEARCH_REFRESH_CONTROL_TOGGLED: 'Search Refresh Control Toggled',
+  ALERTS_REFRESH_CONTROL_PRESET_SELECTED: 'Alerts Refresh Control Preset Selected',
+  ALERTS_REFRESH_CONTROL_TOGGLED: 'Alerts Refresh Control Toggled',
   SEARCH_BUTTON_CLICKED: 'Search Button Clicked',
   SEARCH_WIDGET_EXPORT_DOWNLOADED: 'Search Widget Export Downloaded',
   SEARCH_TIMERANGE_PRESET_ADD_QUICK_ACCESS: 'Search TimeRange Preset Add Quick Access',

--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -152,3 +152,7 @@ export const durationInSeconds = (duration: string | number) => moment.duration(
  * Takes a duration (e.g. in milliseconds or seconds, or as a ISO8601 duration) and returns it in minutes.
  */
 export const durationInMinutes = (duration: string | number) => moment.duration(duration).asMinutes();
+/**
+ * Takes a duration (e.g. in minutes or seconds, or as a ISO8601 duration) and returns it in milliseconds.
+ */
+export const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -20,7 +20,7 @@ import { Field } from 'formik';
 import moment from 'moment';
 import styled, { css } from 'styled-components';
 
-import RefreshControls from 'views/components/searchbar/RefreshControls';
+import ViewsRefreshControls from 'views/components/searchbar/ViewsRefreshControls';
 import { Spinner } from 'components/common';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import SearchButton from 'views/components/searchbar/SearchButton';
@@ -156,7 +156,7 @@ const DashboardSearchBar = () => {
                                              limitDuration={limitDuration}
                                              hasErrorOnMount={!!errors.timerange}
                                              noOverride />
-                      <RefreshControls disable={!isValid} />
+                      <ViewsRefreshControls disable={!isValid} />
                     </TimeRangeRow>
 
                     <SearchQueryRow>

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -29,7 +29,7 @@ import SearchActionsMenu from 'views/components/searchbar/saved-search/SearchAct
 import TimeRangeFilter from 'views/components/searchbar/time-range-filter';
 import ViewsQueryInput from 'views/components/searchbar/ViewsQueryInput';
 import StreamsFilter from 'views/components/searchbar/StreamsFilter';
-import RefreshControls from 'views/components/searchbar/RefreshControls';
+import ViewsRefreshControls from 'views/components/searchbar/ViewsRefreshControls';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import { StreamsStore } from 'views/stores/StreamsStore';
 import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
@@ -243,7 +243,7 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
                             )}
                           </Field>
 
-                          <RefreshControls disable={!isValid} />
+                          <ViewsRefreshControls disable={!isValid} />
                         </StreamsAndRefresh>
                       </TimeRangeRow>
                       <SearchQueryRow>

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsRefreshControls.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsRefreshControls.test.tsx
@@ -28,7 +28,7 @@ import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 
-import RefreshControls from './RefreshControls';
+import ViewsRefreshControls from './ViewsRefreshControls';
 
 jest.useFakeTimers();
 
@@ -51,7 +51,7 @@ describe('RefreshControls', () => {
     <TestStoreProvider>
       <Formik initialValues={{}} onSubmit={onSubmit}>
         <Form>
-          <RefreshControls disable={false} />
+          <ViewsRefreshControls disable={false} />
           {children}
         </Form>
       </Formik>

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsRefreshControls.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsRefreshControls.tsx
@@ -25,7 +25,7 @@ import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
 import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
-import CommonRefreshControls from 'components/common/CommonRefreshControls';
+import RefreshControls from 'components/common/RefreshControls';
 import useDefaultInterval from 'views/hooks/useDefaultIntervalForRefresh';
 
 const useDisableOnFormChange = () => {
@@ -43,7 +43,7 @@ type Props = {
   disable?: boolean
 }
 
-const RefreshControls = ({ disable = false }: Props) => {
+const ViewsRefreshControls = ({ disable = false }: Props) => {
   const { dirty, submitForm } = useFormikContext();
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
@@ -83,16 +83,16 @@ const RefreshControls = ({ disable = false }: Props) => {
   const intervalOptions = Object.entries(autoRefreshTimerangeOptions);
 
   return (
-    <CommonRefreshControls disable={disable}
-                           intervalOptions={intervalOptions}
-                           isLoadingMinimumInterval={isLoadingMinimumInterval}
-                           minimumRefreshInterval={minimumRefreshInterval}
-                           defaultInterval={defaultInterval}
-                           humanName="Search"
-                           onToggle={onToggle}
-                           onEnable={submitForm}
-                           onSelectInterval={onSelectInterval} />
+    <RefreshControls disable={disable}
+                     intervalOptions={intervalOptions}
+                     isLoadingMinimumInterval={isLoadingMinimumInterval}
+                     minimumRefreshInterval={minimumRefreshInterval}
+                     defaultInterval={defaultInterval}
+                     humanName="Search"
+                     onToggle={onToggle}
+                     onEnable={submitForm}
+                     onSelectInterval={onSelectInterval} />
   );
 };
 
-export default RefreshControls;
+export default ViewsRefreshControls;

--- a/graylog2-web-interface/src/views/hooks/useDefaultIntervalForRefresh.ts
+++ b/graylog2-web-interface/src/views/hooks/useDefaultIntervalForRefresh.ts
@@ -15,12 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import moment from 'moment/moment';
-
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
-
-export const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();
+import { durationToMS } from 'util/DateTime';
 
 const useDefaultIntervalForRefresh = () => {
   const { config } = useSearchConfiguration();

--- a/graylog2-web-interface/src/views/hooks/useDefaultIntervalForRefresh.ts
+++ b/graylog2-web-interface/src/views/hooks/useDefaultIntervalForRefresh.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import moment from 'moment/moment';
+
+import useSearchConfiguration from 'hooks/useSearchConfiguration';
+import useMinimumRefreshInterval from 'views/hooks/useMinimumRefreshInterval';
+
+export const durationToMS = (duration: string) => moment.duration(duration).asMilliseconds();
+
+const useDefaultIntervalForRefresh = () => {
+  const { config } = useSearchConfiguration();
+  const { data: minimumInterval } = useMinimumRefreshInterval();
+  const minimumIntervalInMS = durationToMS(minimumInterval);
+
+  const autoRefreshTimerangeOptions = config?.auto_refresh_timerange_options;
+  const defaultAutoRefreshInterval = config?.default_auto_refresh_option;
+
+  if (!config || !autoRefreshTimerangeOptions || !defaultAutoRefreshInterval) return null;
+
+  if (durationToMS(defaultAutoRefreshInterval) < minimumIntervalInMS) {
+    const availableIntervals = Object.entries(autoRefreshTimerangeOptions)
+      .filter(([interval]) => durationToMS(interval) >= minimumIntervalInMS)
+      .sort(([interval1], [interval2]) => (
+        durationToMS(interval1) > durationToMS(interval2) ? 1 : -1
+      ));
+
+    return availableIntervals.length ? availableIntervals[0][0] : null;
+  }
+
+  return defaultAutoRefreshInterval;
+};
+
+export default useDefaultIntervalForRefresh;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactor creates CommonRefreshControls components to reuse most of the logic in RefreshControls components.
Also, we add a refresh action to events page.

<img width="1490" alt="Screenshot 2024-11-19 at 14 43 24" src="https://github.com/user-attachments/assets/4ffaf837-1167-4346-ace2-6e3ae0aa00d8">


## Motivation and Context
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/8661

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9269