### PR TITLE
Fixing up store initialization on sidecars page.

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.test.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 

--- a/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.test.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.test.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import OperatingSystemIcon from './OperatingSystemIcon';
+
+describe('OperatingSystemIcon', () => {
+  it('returns default icon when empty operating system is passed', async () => {
+    render(<OperatingSystemIcon />);
+    await screen.findByText('help');
+  });
+});

--- a/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.tsx
+++ b/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.tsx
@@ -31,7 +31,18 @@ type Props = {
   operatingSystem?: string
 };
 
-const matchIcon = (os: string) => {
+const defaultIcon = {
+  iconName: 'help',
+  iconType: 'default',
+} as const;
+
+const matchIcon = (_os: string) => {
+  if (!_os) {
+    return defaultIcon;
+  }
+
+  const os = _os.trim().toLowerCase();
+
   if (os.includes('darwin') || os.includes('mac os')) {
     return {
       iconName: 'apple',
@@ -60,14 +71,11 @@ const matchIcon = (os: string) => {
     } as const;
   }
 
-  return {
-    iconName: 'help',
-    iconType: 'default',
-  } as const;
+  return defaultIcon;
 };
 
-const OperatingSystemIcon = ({ operatingSystem }: Props) => {
-  const { iconName, iconType } = matchIcon(operatingSystem.trim().toLowerCase());
+const OperatingSystemIcon = ({ operatingSystem = undefined }: Props) => {
+  const { iconName, iconType } = matchIcon(operatingSystem);
 
   return (
     <Container>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -248,18 +248,18 @@ const ConfigurationForm = ({
       const collector = _collectors ? _collectors.find((c) => c.id === collectorId) : undefined;
 
       return (
-        <span>
+        <>
           <FormControl.Static>{_formatCollector(collector)}</FormControl.Static>
           <HelpBlock bsClass="warning">
             <b>Note:</b> Log Collector cannot change while the Configuration is in use. Clone the Configuration
             to test it using another Collector.
           </HelpBlock>
-        </span>
+        </>
       );
     }
 
     return (
-      <span>
+      <>
         <Select inputId="collector_id"
                 options={_formatCollectorOptions()}
                 value={collectorId}
@@ -267,7 +267,7 @@ const ConfigurationForm = ({
                 placeholder="Collector"
                 required />
         <HelpBlock>Choose the log collector this configuration is meant for.</HelpBlock>
-      </span>
+      </>
     );
   };
 

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.tsx
@@ -217,7 +217,7 @@ class ConfigurationVariablesHelper extends React.Component<ConfigurationVariable
                                title="Delete Configuration Variable?"
                                onConfirm={this._handleDeleteConfirm}
                                onCancel={this._closeErrorModal}>
-          <p>Are you sure you want to remove the configuration variable <strong>{variableToDelete.name}</strong>?</p>
+          <p>Are you sure you want to remove the configuration variable <strong>{variableToDelete?.name}</strong>?</p>
         </BootstrapModalConfirm>
       </div>
     );

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.test.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.test.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.test.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import type { Collector } from 'components/sidecars/types';
+
+import CollectorList from './CollectorList';
+
+const collectors: Array<Collector> = [
+  {
+    id: '659bce1c00e5295c3218f4b4',
+    name: 'auditbeat',
+    service_type: 'exec',
+    node_operating_system: 'linux',
+  },
+  {
+    id: '659bb9b5a5d6ba4b611c7170',
+    name: 'filebeat',
+    service_type: 'exec',
+    node_operating_system: 'linux',
+  },
+  {
+    id: '659bb9b5a5d6ba4b611c7171',
+    name: 'filebeat',
+    service_type: 'exec',
+    node_operating_system: 'darwin',
+  },
+  {
+    id: '659bb9b6a5d6ba4b611c7172',
+    name: 'filebeat',
+    service_type: 'exec',
+    node_operating_system: 'freebsd',
+  },
+  {
+    id: '659bb9b6a5d6ba4b611c7176',
+    name: 'filebeat',
+    service_type: 'svc',
+    node_operating_system: 'windows',
+  },
+  {
+    id: '659bb9b6a5d6ba4b611c7174',
+    name: 'nxlog',
+    service_type: 'exec',
+    node_operating_system: 'linux',
+  },
+  {
+    id: '659bb9b6a5d6ba4b611c7175',
+    name: 'nxlog',
+    service_type: 'svc',
+    node_operating_system: 'windows',
+  },
+  {
+    id: '659bb9b6a5d6ba4b611c7173',
+    name: 'winlogbeat',
+    service_type: 'svc',
+    node_operating_system: 'windows',
+  },
+];
+
+const SUT = (props: Partial<React.ComponentProps<typeof CollectorList>>) => (
+  <CollectorList collectors={collectors}
+                 onClone={jest.fn()}
+                 onDelete={jest.fn()}
+                 onPageChange={jest.fn()}
+                 onQueryChange={jest.fn()}
+                 validateCollector={jest.fn()}
+                 pagination={{ page: 1, pageSize: 10, total: 1 }}
+                 query=""
+                 total={collectors.length}
+                 {...props} />
+);
+
+describe('CollectorList', () => {
+  it('renders list of collectors', async () => {
+    render(<SUT />);
+
+    await screen.findByText('auditbeat');
+    await screen.findAllByText('filebeat');
+    await screen.findAllByText('nxlog');
+    await screen.findAllByText('winlogbeat');
+  });
+
+  it('triggers `onQueryChange` when query is changed', async () => {
+    const onQueryChange = jest.fn();
+    render(<SUT onQueryChange={onQueryChange} />);
+
+    const queryInput = await screen.findByPlaceholderText('Find collectors');
+    userEvent.type(queryInput, 'newquery{enter}');
+
+    await waitFor(() => {
+      expect(onQueryChange).toHaveBeenCalledWith('newquery', expect.any(Function));
+    });
+  });
+
+  it('triggers `onPageChange` when page size is changed', async () => {
+    const onPageChange = jest.fn();
+    render(<SUT onPageChange={onPageChange} />);
+
+    const pageDropdown = await screen.findByRole('button', { name: /configure page size/i });
+    userEvent.click(pageDropdown);
+
+    userEvent.click(await screen.findByRole('menuitem', { name: '25' }));
+
+    await waitFor(() => {
+      expect(onPageChange).toHaveBeenCalledWith(1, 25);
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
@@ -34,21 +34,21 @@ type CollectorListProps = {
   },
   query: string,
   total: number,
-  onClone: (...args: any[]) => void,
-  onDelete: (...args: any[]) => void,
-  onPageChange: (...args: any[]) => void,
-  onQueryChange: (...args: any[]) => void,
+  onClone: (collector: string, name: string, callback: () => void) => void,
+  onDelete: (collector: Collector) => void,
+  onPageChange: (page: number, pageSize: number) => void,
+  onQueryChange: () => void,
   validateCollector: (collector: Collector) => Promise<{ errors: { name: string[] } }>,
 }
 
+const headerCellFormatter = (header: React.ReactNode) => {
+  const className = (header === 'Actions' ? style.actionsColumn : '');
+
+  return <th className={className}>{header}</th>;
+};
+
 class CollectorList extends React.Component<CollectorListProps> {
-  headerCellFormatter(header) {
-    const className = (header === 'Actions' ? style.actionsColumn : '');
-
-    return <th className={className}>{header}</th>;
-  }
-
-  collectorFormatter(collector) {
+  collectorFormatter = (collector: Collector) => {
     const { onClone, onDelete, validateCollector } = this.props;
 
     return (
@@ -57,7 +57,7 @@ class CollectorList extends React.Component<CollectorListProps> {
                     onDelete={onDelete}
                     validateCollector={validateCollector} />
     );
-  }
+  };
 
   render() {
     const { collectors, pagination, query, total, onPageChange, onQueryChange } = this.props;
@@ -100,7 +100,7 @@ class CollectorList extends React.Component<CollectorListProps> {
                 <DataTable id="collector-list"
                            className="table-hover"
                            headers={headers}
-                           headerCellFormatter={this.headerCellFormatter}
+                           headerCellFormatter={headerCellFormatter}
                            rows={collectors}
                            dataRowFormatter={this.collectorFormatter}
                            noDataText="There are no log collectors to display, why don't you create one?"

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.tsx
@@ -48,7 +48,7 @@ class CollectorListContainer extends React.Component<CollectorListContainerProps
     loadCollectors();
   }
 
-  handleClone = (collector, name, callback) => {
+  handleClone = (collector: string, name: string, callback: () => void) => {
     const { sendTelemetry } = this.props;
 
     sendTelemetry(TELEMETRY_EVENT_TYPE.SIDECARS.LOG_COLLECTOR_CLONED, {
@@ -73,7 +73,7 @@ class CollectorListContainer extends React.Component<CollectorListContainerProps
     await CollectorsActions.delete(collector);
   };
 
-  handlePageChange = (page, pageSize) => {
+  handlePageChange = (page: number, pageSize: number) => {
     const { query } = this.props.collectors;
 
     CollectorsActions.list({ query: query, page: page, pageSize: pageSize });

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.tsx
@@ -29,7 +29,7 @@ import CopyCollectorModal from './CopyCollectorModal';
 
 type Props = {
   collector: Collector,
-  onClone: () => void,
+  onClone: (collector: string, name: string, callback: () => void) => void,
   onDelete: (collector: Collector) => void,
   validateCollector: (collector: Collector) => Promise<{ errors: { name: string[] } }>,
 }

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarListContainer.tsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarListContainer.tsx
@@ -62,14 +62,14 @@ const SidecarListContainer = ({ paginationQueryParameter }: Props) => {
     options.page = effectivePage;
 
     return SidecarsActions.listPaginated(options);
-  }, [paginationQueryParameter?.page, paginationQueryParameter?.pageSize]);
+  }, [paginationQueryParameter.page, paginationQueryParameter.pageSize, sidecars.onlyActive, sidecars.query, sidecars.sort]);
 
   useEffect(() => {
     _reloadSidecars();
     const interval = setInterval(() => _reloadSidecars({}), SIDECAR_DATA_REFRESH);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [_reloadSidecars]);
 
   const handleSortChange = useCallback((field) => () => {
     _reloadSidecars({
@@ -77,11 +77,11 @@ const SidecarListContainer = ({ paginationQueryParameter }: Props) => {
       // eslint-disable-next-line no-nested-ternary
       order: (sidecars.sort.field === field ? (sidecars.sort.order === 'asc' ? 'desc' : 'asc') : 'asc'),
     });
-  }, []);
+  }, [_reloadSidecars, sidecars.sort.field, sidecars.sort.order]);
 
   const handlePageChange = useCallback((page, pageSize) => {
     _reloadSidecars({ page: page, pageSize: pageSize });
-  }, []);
+  }, [_reloadSidecars]);
 
   const handleQueryChange = useCallback((query = '', callback = () => {}) => {
     const { resetPage } = paginationQueryParameter;
@@ -89,7 +89,7 @@ const SidecarListContainer = ({ paginationQueryParameter }: Props) => {
     resetPage();
 
     _reloadSidecars({ query: query }).finally(callback);
-  }, []);
+  }, [_reloadSidecars, paginationQueryParameter]);
 
   const toggleShowInactive = useCallback(() => {
     const { resetPage } = paginationQueryParameter;
@@ -97,11 +97,11 @@ const SidecarListContainer = ({ paginationQueryParameter }: Props) => {
     resetPage();
 
     _reloadSidecars({ onlyActive: !sidecars.onlyActive });
-  }, []);
+  }, [_reloadSidecars, paginationQueryParameter, sidecars.onlyActive]);
 
   const { sidecars: sidecarsList, onlyActive, pagination, query, sort } = sidecars;
 
-  const isLoading = !sidecars;
+  const isLoading = !sidecarsList;
 
   if (isLoading) {
     return <Spinner />;

--- a/graylog2-web-interface/src/components/sidecars/types.ts
+++ b/graylog2-web-interface/src/components/sidecars/types.ts
@@ -27,10 +27,10 @@ export type Collector = {
   service_type: string;
   node_operating_system: string;
   name: string;
-  validation_parameters: string;
-  executable_path: string;
-  execute_parameters: string;
-  default_template: string;
+  validation_parameters?: string;
+  executable_path?: string;
+  execute_parameters?: string;
+  default_template?: string;
   id: string;
 }
 

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.tsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.tsx
@@ -30,9 +30,7 @@ type SidecarEditConfigurationPageProps = {
   params: any;
 };
 
-const SidecarEditConfigurationPage = ({
-  params,
-}: SidecarEditConfigurationPageProps) => {
+const SidecarEditConfigurationPage = ({ params }: SidecarEditConfigurationPageProps) => {
   const [configuration, setConfiguration] = useState<Configuration>(null);
   const [configurationSidecars, setConfigurationSidecars] = useState<ConfigurationSidecarsResponse>(null);
   const history = useHistory();

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -42,7 +42,7 @@ export function useStore<U> (store: StoreType<U>): U;
 export function useStore<U, M extends (props: U) => any> (store: StoreType<U>, propsMapper: M): ReturnType<M>;
 
 export function useStore(store, propsMapper = id) {
-  const [storeState, setStoreState] = useState(() => store.getInitialState());
+  const [storeState, setStoreState] = useState(() => store.getInitialState?.());
   const storeStateRef = useRef(storeState);
 
   const mappedStoreState = useMemo(() => propsMapper(storeState), [propsMapper, storeState]);
@@ -54,7 +54,7 @@ export function useStore(store, propsMapper = id) {
         storeStateRef.current = newState;
       }
     });
-    setStoreState(store.getInitialState());
+    setStoreState(store.getInitialState?.());
 
     return unsub;
   }, [store]);

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.ts
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.ts
@@ -96,18 +96,18 @@ export const SidecarsStore = singletonStore(
       order: undefined,
     },
 
-    init() {
-      this.propagateChanges();
-    },
-
-    propagateChanges() {
-      this.trigger({
+    getInitialState() {
+      return {
         sidecars: this.sidecars,
         query: this.query,
         onlyActive: this.onlyActive,
         pagination: this.pagination,
         sort: this.sort,
-      });
+      };
+    },
+
+    propagateChanges() {
+      this.trigger(this.getInitialState());
     },
 
     listPaginated({ query = '', page = 1, pageSize = 50, onlyActive = false, sortField = 'node_name', order = 'asc' }) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue on the sidecars page, where the missing `getInitialState` function of the `SidecarsStore` lead to an issue after switching over its usage to `useStore`.

This PR is fixing this issue with the store, but also the `useStore` function's handling of a missing `getInitialState` function.

Fixes #20873.
Fixes Graylog2/collector-sidecar#455.

/nocl Regression was not in a released version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.