### PR TITLE
Refactor DBJobDefinitionService to use new MongoDB API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBCustomJobDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBCustomJobDefinitionService.java
@@ -16,55 +16,25 @@
  */
 package org.graylog.scheduler;
 
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.FindOneAndUpdateOptions;
-import com.mongodb.client.model.ReturnDocument;
-import com.mongodb.client.model.Updates;
 import jakarta.inject.Inject;
-import org.bson.BsonDocument;
-import org.bson.BsonDocumentWriter;
-import org.bson.codecs.EncoderContext;
-import org.bson.types.ObjectId;
-import org.graylog2.database.MongoCollections;
-
-import static java.util.Objects.requireNonNull;
-import static org.graylog2.shared.utilities.StringUtils.f;
 
 /**
- * The {@link DBJobDefinitionService} is still using the old mongojack version, so we can't implement a
- * {@code findOrCreate} method and have to use this custom service until the class is migrated to the new mongojack
- * version.
- * TODO: Remove once DBJobDefinitionService is migrated to the new mongojack version.
+ * @deprecated Use {@link DBJobDefinitionService} instead.
  */
 @Deprecated(since = "6.1.0")
 public class DBCustomJobDefinitionService {
-    private final MongoCollection<JobDefinitionDto> db;
+    private final DBJobDefinitionService delegate;
 
     @Inject
-    public DBCustomJobDefinitionService(MongoCollections collections) {
-        this.db = collections.collection(DBJobDefinitionService.COLLECTION_NAME, JobDefinitionDto.class);
+    public DBCustomJobDefinitionService(DBJobDefinitionService dbJobDefinitionService) {
+        this.delegate = dbJobDefinitionService;
     }
 
+    /**
+     * @deprecated Use {@link DBJobDefinitionService#findOrCreate(JobDefinitionDto)} instead.
+     */
     @Deprecated(since = "6.1.0")
     public JobDefinitionDto findOrCreate(JobDefinitionDto dto) {
-        var jobDefinitionId = new ObjectId(requireNonNull(dto.id(), "Job definition ID cannot be null"));
-
-        final var codec = db.getCodecRegistry().get(JobDefinitionDto.class);
-        try (final var writer = new BsonDocumentWriter(new BsonDocument())) {
-            // Convert the DTO class to a Bson object, so we can use it with $setOnInsert
-            codec.encode(writer, dto, EncoderContext.builder().build());
-
-            return db.findOneAndUpdate(
-                    Filters.and(
-                            Filters.eq("_id", jobDefinitionId),
-                            Filters.eq(f("%s.%s", JobDefinitionDto.FIELD_CONFIG, JobDefinitionConfig.TYPE_FIELD), dto.config().type())
-                    ),
-                    Updates.setOnInsert(writer.getDocument()),
-                    new FindOneAndUpdateOptions()
-                            .returnDocument(ReturnDocument.AFTER)
-                            .upsert(true)
-            );
-        }
+        return delegate.findOrCreate(dto);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
@@ -48,7 +48,7 @@ public class DBJobDefinitionService {
     public DBJobDefinitionService(MongoCollections mongoCollections, MongoJackObjectMapperProvider mapper) {
         collection = mongoCollections.collection(COLLECTION_NAME, JobDefinitionDto.class);
         mongoUtils = mongoCollections.utils(collection);
-        this.objectMapper = mapper.get();
+        objectMapper = mapper.get();
     }
 
     /**
@@ -121,5 +121,9 @@ public class DBJobDefinitionService {
 
     public Stream<JobDefinitionDto> streamAll() {
         return mongoUtils.stream(collection.find());
+    }
+
+    public JobDefinitionDto findOrCreate(JobDefinitionDto dto) {
+        return mongoUtils.getOrCreate(dto);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
@@ -18,37 +18,37 @@ package org.graylog.scheduler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
 import jakarta.inject.Inject;
 import one.util.streamex.StreamEx;
+import org.bson.conversions.Bson;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
-import org.graylog2.database.MongoConnection;
-import org.graylog2.database.PaginatedDbService;
-import org.graylog2.database.PaginatedList;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.utils.MongoUtils;
 import org.mongojack.DBQuery;
-import org.mongojack.DBSort;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class DBJobDefinitionService extends PaginatedDbService<JobDefinitionDto> {
+public class DBJobDefinitionService {
     public static final String COLLECTION_NAME = "scheduler_job_definitions";
 
     private final ObjectMapper objectMapper;
+    private final MongoCollection<JobDefinitionDto> collection;
+    private final MongoUtils<JobDefinitionDto> mongoUtils;
 
     @Inject
-    public DBJobDefinitionService(MongoConnection mongoConnection, MongoJackObjectMapperProvider mapper) {
-        super(mongoConnection, mapper, JobDefinitionDto.class, COLLECTION_NAME);
+    public DBJobDefinitionService(MongoCollections mongoCollections, MongoJackObjectMapperProvider mapper) {
+        collection = mongoCollections.collection(COLLECTION_NAME, JobDefinitionDto.class);
+        mongoUtils = mongoCollections.utils(collection);
         this.objectMapper = mapper.get();
-    }
-
-    public PaginatedList<JobDefinitionDto> getAllPaginated(String sortByField, int page, int perPage) {
-        return findPaginatedWithQueryAndSort(DBQuery.empty(), DBSort.asc(sortByField), page, perPage);
     }
 
     /**
@@ -59,7 +59,7 @@ public class DBJobDefinitionService extends PaginatedDbService<JobDefinitionDto>
      * @return the job definition with the given config field, or an empty optional
      */
     public Optional<JobDefinitionDto> getByConfigField(String configField, Object value) {
-        return Optional.ofNullable(db.findOne(buildConfigFieldQuery(configField, value)));
+        return Optional.ofNullable(collection.find(buildConfigFieldQuery(configField, value)).first());
     }
 
     /**
@@ -70,16 +70,22 @@ public class DBJobDefinitionService extends PaginatedDbService<JobDefinitionDto>
      * @return a stream of job definitions with the given config field.
      */
     public Stream<JobDefinitionDto> streamByConfigField(String configField, Object value) {
-        return streamQuery(buildConfigFieldQuery(configField, value));
+        return MongoUtils.stream(collection.find(buildConfigFieldQuery(configField, value)));
     }
 
-    private static DBQuery.Query buildConfigFieldQuery(String configField, Object value) {
+    private static Bson buildConfigFieldQuery(String configField, Object value) {
         final String field = String.format(Locale.US, "%s.%s", JobDefinitionDto.FIELD_CONFIG, configField);
-        return DBQuery.is(field, value);
+        return Filters.eq(field, value);
     }
 
+    @Deprecated
     public List<JobDefinitionDto> getByQuery(DBQuery.Query query) {
-        return StreamEx.of(db.find(query)).collect(Collectors.toList());
+        mongoUtils.initializeLegacyMongoJackBsonObject(query);
+        return getByQuery((Bson) query);
+    }
+
+    public List<JobDefinitionDto> getByQuery(Bson query) {
+        return collection.find(query).into(new ArrayList<>());
     }
 
     /**
@@ -92,12 +98,28 @@ public class DBJobDefinitionService extends PaginatedDbService<JobDefinitionDto>
     public Map<String, List<JobDefinitionDto>> getAllByConfigField(String configField, Collection<? extends Object> values) {
         final String field = String.format(Locale.US, "%s.%s", JobDefinitionDto.FIELD_CONFIG, configField);
 
-        return StreamEx.of(db.find(DBQuery.in(field, values))).groupingBy(configFieldGroup(configField));
+        return StreamEx.of(collection.find(Filters.in(field, values)).iterator()).groupingBy(configFieldGroup(configField));
     }
 
     private Function<JobDefinitionDto, String> configFieldGroup(final String key) {
         // Since JobDefinitionDto#config() is a pluggable interface type and we don't have methods we can access,
         // convert the value to a JsonNode and access the group key with that.
         return jobDefinition -> objectMapper.convertValue(jobDefinition.config(), JsonNode.class).path(key).asText();
+    }
+
+    public JobDefinitionDto save(JobDefinitionDto jobDefinitionDto) {
+        return mongoUtils.save(jobDefinitionDto);
+    }
+
+    public void delete(String id) {
+        mongoUtils.deleteById(id);
+    }
+
+    public Optional<JobDefinitionDto> get(String id) {
+        return mongoUtils.getById(id);
+    }
+
+    public Stream<JobDefinitionDto> streamAll() {
+        return mongoUtils.stream(collection.find());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobDefinitionDto.java
@@ -20,13 +20,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import org.graylog2.database.MongoEntity;
+import org.graylog2.database.BuildableMongoEntity;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 @AutoValue
 @JsonDeserialize(builder = JobDefinitionDto.Builder.class)
-public abstract class JobDefinitionDto implements MongoEntity {
+public abstract class JobDefinitionDto implements BuildableMongoEntity<JobDefinitionDto, JobDefinitionDto.Builder> {
     private static final String FIELD_ID = "id";
     public static final String FIELD_TITLE = "title";
     private static final String FIELD_DESCRIPTION = "description";
@@ -48,7 +48,7 @@ public abstract class JobDefinitionDto implements MongoEntity {
     public abstract Builder toBuilder();
 
     @AutoValue.Builder
-    public static abstract class Builder {
+    public static abstract class Builder implements BuildableMongoEntity.Builder<JobDefinitionDto, Builder> {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_JobDefinitionDto.Builder();

--- a/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
@@ -131,7 +131,7 @@ public class LegacyAlertConditionMigratorTest {
         final MongoJackObjectMapperProvider mongoJackObjectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
         final MongoConnection mongoConnection = mongodb.mongoConnection();
         final JobSchedulerTestClock clock = new JobSchedulerTestClock(DateTime.now(DateTimeZone.UTC));
-        final DBJobDefinitionService jobDefinitionService = new DBJobDefinitionService(mongoConnection, mongoJackObjectMapperProvider);
+        final DBJobDefinitionService jobDefinitionService = new DBJobDefinitionService(new MongoCollections(mongoJackObjectMapperProvider, mongoConnection), mongoJackObjectMapperProvider);
         final MongoCollections mongoCollections = new MongoCollections(mongoJackObjectMapperProvider, mongoConnection);
         final DBJobTriggerService jobTriggerService = new DBJobTriggerService(mongoCollections, new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000"), clock, schedulerCapabilitiesService, Duration.minutes(5));
         notificationService = new DBNotificationService(mongoCollections, mock(EntityOwnershipService.class));

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
@@ -109,7 +109,7 @@ public class EventDefinitionHandlerTest {
         this.clock = new JobSchedulerTestClock(DateTime.now(DateTimeZone.UTC));
         final MongoCollections mongoCollections = new MongoCollections(mapperProvider, mongodb.mongoConnection());
         this.eventDefinitionService = spy(new DBEventDefinitionService(mongoCollections, stateService, mock(EntityOwnershipService.class), new EntityScopeService(ENTITY_SCOPES), new IgnoreSearchFilters()));
-        this.jobDefinitionService = spy(new DBJobDefinitionService(mongodb.mongoConnection(), mapperProvider));
+        this.jobDefinitionService = spy(new DBJobDefinitionService(new MongoCollections(mapperProvider, mongodb.mongoConnection()), mapperProvider));
         this.jobTriggerService = spy(new DBJobTriggerService(mongoCollections, nodeId, clock, schedulerCapabilitiesService, Duration.minutes(5)));
 
         this.handler = new EventDefinitionHandler(eventDefinitionService, jobDefinitionService, jobTriggerService, clock);

--- a/graylog2-server/src/test/java/org/graylog/scheduler/DBJobDefinitionServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/DBJobDefinitionServiceTest.java
@@ -24,6 +24,7 @@ import org.graylog.events.processor.EventProcessorExecutionJob;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoCollections;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,7 +56,9 @@ public class DBJobDefinitionServiceTest {
         objectMapper.registerSubtypes(new NamedType(TestEventProcessorParameters.class, TestEventProcessorParameters.TYPE_NAME));
         objectMapper.registerSubtypes(new NamedType(EventProcessorExecutionJob.Config.class, EventProcessorExecutionJob.TYPE_NAME));
 
-        this.service = new DBJobDefinitionService(mongodb.mongoConnection(), new MongoJackObjectMapperProvider(objectMapper));
+        this.service = new DBJobDefinitionService(
+                new MongoCollections(new MongoJackObjectMapperProvider(objectMapper), mongodb.mongoConnection()),
+                new MongoJackObjectMapperProvider(objectMapper));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
@@ -77,7 +77,7 @@ class JobSchedulerServiceIT {
     SchedulerCapabilitiesService schedulerCapabilitiesService;
 
     private DBJobTriggerService jobTriggerService;
-    private DBCustomJobDefinitionService customJobDefinitionService;
+    private DBJobDefinitionService jobDefinitionService;
     private JobSchedulerService jobSchedulerService;
     private JobSchedulerClock clock;
 
@@ -100,12 +100,13 @@ class JobSchedulerServiceIT {
         final JobSchedulerConfig schedulerConfig = new TestSchedulerConfig();
         final Duration lockExpirationDuration = Duration.seconds(10);
 
-        customJobDefinitionService = new DBCustomJobDefinitionService(
-                new MongoCollections(new MongoJackObjectMapperProvider(objectMapper),
-                        mongoDBTestService.mongoConnection()));
+        final var mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+        jobDefinitionService = new DBJobDefinitionService(
+                new MongoCollections(mapperProvider,
+                        mongoDBTestService.mongoConnection()), mapperProvider);
 
         jobTriggerService = new DBJobTriggerService(
-                new MongoCollections(new MongoJackObjectMapperProvider(objectMapper), mongoDBTestService.mongoConnection()),
+                new MongoCollections(mapperProvider, mongoDBTestService.mongoConnection()),
                 nodeId,
                 clock,
                 schedulerCapabilitiesService,
@@ -113,9 +114,9 @@ class JobSchedulerServiceIT {
         );
 
         final DBJobDefinitionService jobDefinitionService = new DBJobDefinitionService(
-                new MongoCollections(new MongoJackObjectMapperProvider(objectMapper),
+                new MongoCollections(mapperProvider,
                         mongoDBTestService.mongoConnection()),
-                new MongoJackObjectMapperProvider(objectMapper));
+                mapperProvider);
         final JobScheduleStrategies scheduleStrategies = new JobScheduleStrategies(clock);
 
         final JobTriggerUpdates.Factory jobTriggerUpdatesFactory = trigger -> new JobTriggerUpdates(
@@ -179,8 +180,8 @@ class JobSchedulerServiceIT {
 
         jobSchedulerService.startAsync().awaitRunning();
         try {
-            createTriggers(nLimited, customJobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
-            createTriggers(nUnlimited, customJobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
+            createTriggers(nLimited, jobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
+            createTriggers(nUnlimited, jobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
             outstandingJobs.await();
         } finally {
             jobSchedulerService.stopAsync().awaitTerminated();
@@ -220,8 +221,8 @@ class JobSchedulerServiceIT {
 
         jobSchedulerService.startAsync().awaitRunning();
         try {
-            createTriggers(nLimited, customJobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
-            createTriggers(nUnlimited, customJobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
+            createTriggers(nLimited, jobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
+            createTriggers(nUnlimited, jobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
             outstandingJobsTotal.await();
         } finally {
             jobSchedulerService.stopAsync().awaitTerminated();
@@ -253,8 +254,8 @@ class JobSchedulerServiceIT {
         jobSchedulerService.startAsync().awaitRunning();
         try {
             for (int i = 0; i < (nJobs / 2); i++) {
-                createTriggers(1, customJobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
-                createTriggers(1, customJobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
+                createTriggers(1, jobDefinitionService.findOrCreate(jobDefinitionDto(new LimitedJobA())));
+                createTriggers(1, jobDefinitionService.findOrCreate(jobDefinitionDto(new UnlimitedJob())));
             }
             outstandingJobs.await();
         } finally {

--- a/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/JobSchedulerServiceIT.java
@@ -113,7 +113,9 @@ class JobSchedulerServiceIT {
         );
 
         final DBJobDefinitionService jobDefinitionService = new DBJobDefinitionService(
-                mongoDBTestService.mongoConnection(), new MongoJackObjectMapperProvider(objectMapper));
+                new MongoCollections(new MongoJackObjectMapperProvider(objectMapper),
+                        mongoDBTestService.mongoConnection()),
+                new MongoJackObjectMapperProvider(objectMapper));
         final JobScheduleStrategies scheduleStrategies = new JobScheduleStrategies(clock);
 
         final JobTriggerUpdates.Factory jobTriggerUpdatesFactory = trigger -> new JobTriggerUpdates(


### PR DESCRIPTION
Also strips the deprecated `DBCustomJobDefinitionService` down to a shallow wrapper and removes usages.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9243
/nocl
