### PR TITLE
Allow sorting events/alerts based on aggregation time range.

### DIFF
--- a/changelog/unreleased/pr-21044.toml
+++ b/changelog/unreleased/pr-21044.toml
@@ -1,0 +1,4 @@
+type = "added"
+message = "Allow sorting events/alerts based on aggregation time range."
+
+pulls = ["21044"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -106,17 +106,13 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
             filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
         }
 
-        final SortOrder order = sortOrderMapper.fromSorting(sorting);
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
                 .query(filter)
                 .from((page - 1) * perPage)
                 .size(perPage)
                 .trackTotalHits(true);
-        final FieldSortBuilder sortBuilder = new FieldSortBuilder(sorting.getField()).order(order);
-        sorting.getUnmappedType().ifPresent(unmappedType -> sortBuilder
-                .unmappedType(unmappedType)
-                .missing(order.equals(SortOrder.ASC) ? "_first" : "_last"));
-        searchSourceBuilder.sort(sortBuilder);
+        final var sortBuilders = createSorting(sorting);
+        sortBuilders.forEach(searchSourceBuilder::sort);
 
         final Set<String> indices = affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices;
         final SearchRequest searchRequest = new SearchRequest(indices.toArray(new String[0]))
@@ -143,6 +139,27 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
                 .usedIndexNames(affectedIndices)
                 .executedQuery(searchSourceBuilder.toString())
                 .build();
+    }
+
+    private List<FieldSortBuilder> createSorting(Sorting sorting) {
+        final SortOrder order = sortOrderMapper.fromSorting(sorting);
+        final List<FieldSortBuilder> sortBuilders;
+        if (EventDto.FIELD_TIMERANGE_START.equals(sorting.getField())) {
+            sortBuilders = List.of(
+                    new FieldSortBuilder(EventDto.FIELD_TIMERANGE_START),
+                    new FieldSortBuilder(EventDto.FIELD_TIMERANGE_END)
+            );
+        } else {
+            sortBuilders = List.of(new FieldSortBuilder(sorting.getField()));
+        }
+        return sortBuilders.stream()
+                .map(sortBuilder -> {
+                    sorting.getUnmappedType().ifPresent(unmappedType -> sortBuilder
+                            .unmappedType(unmappedType)
+                            .missing(order.equals(SortOrder.ASC) ? "_first" : "_last"));
+                    return sortBuilder.order(order);
+                })
+                .toList();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -85,9 +85,9 @@ public class MoreSearch {
         checkArgument(forbiddenSourceStreams != null, "forbiddenSourceStreams cannot be null");
 
         final Sorting.Direction sortDirection = parameters.sortDirection() == EventsSearchParameters.SortDirection.ASC ? Sorting.Direction.ASC : Sorting.Direction.DESC;
-        final Sorting sorting = parameters.sortUnmappedType().isPresent() ?
-                new Sorting(parameters.sortBy(), sortDirection, parameters.sortUnmappedType().get())
-                : new Sorting(parameters.sortBy(), sortDirection);
+        final Sorting sorting = parameters.sortUnmappedType()
+                .map(unmappedType -> new Sorting(parameters.sortBy(), sortDirection, unmappedType))
+                .orElse(new Sorting(parameters.sortBy(), sortDirection));
         final String queryString = parameters.query().trim();
         final Set<String> affectedIndices = getAffectedIndices(eventStreams, parameters.timerange());
 

--- a/graylog2-web-interface/src/components/events/Constants.ts
+++ b/graylog2-web-interface/src/components/events/Constants.ts
@@ -61,6 +61,7 @@ export const detailsAttributes: Array<Attribute> = [
   {
     id: 'timerange_start',
     title: 'Aggregation time range',
+    sortable: true,
   },
   {
     id: 'key',

--- a/graylog2-web-interface/src/components/events/events/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/events/events/ColumnRenderers.tsx
@@ -114,9 +114,9 @@ const MessageRenderer = ({ message, eventId }: { message: string, eventId: strin
 
 const TimeRangeRenderer = ({ eventData }: { eventData: Event}) => (eventData.timerange_start && eventData.timerange_end ? (
   <div>
-    <Timestamp dateTime={new Date()} />
+    <Timestamp dateTime={new Date(eventData.timerange_start)} />
       &ensp;&mdash;&ensp;
-    <Timestamp dateTime={new Date()} />
+    <Timestamp dateTime={new Date(eventData.timerange_end)} />
   </div>
 ) : (
   <em>No time range</em>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR enables sorting alerts/events based on aggregation time range both in the front- and backend.

The sorting for this field needs to be created so that both `timerange_start` & `timerange_end` are taken into account.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.