### PR TITLE
Improve handling of `Select` `aria-label` prop.

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.tsx
@@ -82,7 +82,6 @@ const BackendCreateSelect = () => {
                 {({ field: { name, value, onChange }, meta: { error } }) => (
                   <>
                     <Select clearable={false}
-                            inputProps={{ 'aria-label': 'Select a service' }}
                             onChange={(authService) => {
                               sendTelemetry(TELEMETRY_EVENT_TYPE.AUTHENTICATION.SERVICE_SELECTED, {
                                 app_pathname: getPathnameWithoutId(pathname),

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
@@ -179,8 +179,7 @@ const UserSyncStep = ({
                      label="Default Roles"
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9">
-                <Select inputProps={{ 'aria-label': 'Search for roles' }}
-                        multi
+                <Select multi
                         onBlur={onBlur}
                         onChange={(selectedRoles) => onChange({ target: { value: selectedRoles, name } })}
                         options={rolesOptions}

--- a/graylog2-web-interface/src/components/common/Select/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.test.jsx
@@ -25,7 +25,7 @@ import Select from './index';
 const createOption = (x) => ({ label: x, value: x });
 
 describe('Select', () => {
-  const SimpleSelect = (props) => <Select inputProps={{ 'aria-label': 'Select value' }} {...props} />;
+  const SimpleSelect = (props) => <Select placeholder="Select value" {...props} />;
 
   it('calls `onChange` upon selecting option', async () => {
     const options = ['foo', 'bar'].map(createOption);

--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -510,6 +510,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       onChange: onReactSelectChange || this._onChange,
       onInputChange,
       'aria-label': ariaLabel ?? placeholder,
+      placeholder,
       async,
       isMulti,
       isDisabled,

--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -143,7 +143,7 @@ const singleValueAndPlaceholder = ({ theme }) => (base) => ({
   fontWeight: 400,
 });
 
-const placeholder = ({ theme }) => (base) => ({
+const placeholderStyling = ({ theme }) => (base) => ({
   ...base,
   color: theme.colors.input.placeholder,
   lineHeight: '28px',
@@ -202,7 +202,7 @@ const _styles = ({ size, theme }) => ({
   menu,
   menuPortal,
   singleValue: singleValueAndPlaceholder({ theme }),
-  placeholder: placeholder({ theme }),
+  placeholder: placeholderStyling({ theme }),
   control: controlFocus({ size, theme }),
   valueContainer: valueContainer({ size }),
 });
@@ -213,6 +213,8 @@ type ComponentsProp = {
 };
 
 export type Props<OptionValue> = {
+  // The placeholder will be used by default for the aria label.
+  'aria-label'?: string,
   addLabelText?: string,
   allowCreate?: boolean,
   autoFocus?: boolean,
@@ -484,6 +486,8 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       total,
       onInputChange,
       loadOptions,
+      'aria-label': ariaLabel,
+      placeholder,
       ...rest
     } = this.props;
 
@@ -500,10 +504,12 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       async: boolean,
       loadOptions: () => void,
       total: number,
+
     } = {
       ...rest,
       onChange: onReactSelectChange || this._onChange,
       onInputChange,
+      'aria-label': ariaLabel ?? placeholder,
       async,
       isMulti,
       isDisabled,

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfileForm.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfileForm.tsx
@@ -116,7 +116,7 @@ const ProfileFormSelect = ({ onChange, options, error, name, value, placeholder,
               onChange={(newVal) => {
                 onChange({ target: { value: newVal, name } });
               }}
-              inputProps={{ 'aria-label': `Select ${name}` }}
+              aria-label={`Select ${name}`}
               placeholder={placeholder}
               allowCreate={allowCreate} />
     </Input>

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.tsx
@@ -118,7 +118,6 @@ const SetProfileModal = ({ show, onClose, currentProfile }: Props) => {
                             options={options}
                             value={profile}
                             onChange={onChangeProfile}
-                            inputProps={{ 'aria-label': 'Select index set profile' }}
                             placeholder="Select index set profile"
                             disabled={profileOptionsIsLoading}
                             required />

--- a/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
+++ b/graylog2-web-interface/src/components/lookup-table-parameters/LookupTableParameterEdit.tsx
@@ -79,7 +79,6 @@ const LookupTableParameterEdit = ({
              error={validationState?.lookupTable?.[1]}
              help="Select the lookup table Graylog should use to get the values.">
         <Select placeholder="Select lookup table"
-                inputProps={{ 'aria-label': 'Select lookup table' }}
                 onChange={_handleChange('lookupTable')}
                 options={lookupTableOptions}
                 value={lookupTable}

--- a/graylog2-web-interface/src/components/permissions/CapabilitySelect.tsx
+++ b/graylog2-web-interface/src/components/permissions/CapabilitySelect.tsx
@@ -51,7 +51,6 @@ const CapabilitySelect = ({ capabilities, onChange, title = 'Select a capability
       {({ field: { name, value, onChange: onFieldChange } }) => (
         <Select {...rest}
                 clearable={false}
-                inputProps={{ 'aria-label': title }}
                 onChange={(capabilityId) => handleChange(name, capabilityId, onFieldChange)}
                 options={capabilitiesOptions}
                 placeholder={title}

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.tsx
@@ -130,8 +130,7 @@ const GranteesSelector = ({ availableGrantees, availableCapabilities, className,
               <StyledSelectGroup>
                 <Field name="granteeId" validate={_isRequired('grantee')}>
                   {({ field: { name, value, onChange } }) => (
-                    <GranteesSelect inputProps={{ 'aria-label': 'Search for users and teams' }}
-                                    onChange={(granteeId) => onChange({ target: { value: granteeId, name } })}
+                    <GranteesSelect onChange={(granteeId) => onChange({ target: { value: granteeId, name } })}
                                     optionRenderer={_renderGranteesSelectOption}
                                     options={granteesOptions}
                                     placeholder="Search for users and teams"

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.tsx
@@ -117,8 +117,7 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier = (role) => role
   return (
     <div>
       <FormElements>
-        <StyledSelect inputProps={{ 'aria-label': 'Search for roles' }}
-                      onChange={onChange}
+        <StyledSelect onChange={onChange}
                       optionRenderer={_renderRoleOption}
                       options={options}
                       placeholder="Search for roles"

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.tsx
@@ -133,10 +133,7 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
             <FormElements>
               <Field name="user" validate={_isRequired('user')}>
                 {({ field: { name, value, onChange } }) => (
-                  <StyledSelect inputProps={{ 'aria-label': 'Search for users' }}
-                                onChange={(user) => {
-                                  onChange({ target: { value: user, name } });
-                                }}
+                  <StyledSelect onChange={(user) => { onChange({ target: { value: user, name } }); }}
                                 optionRenderer={_renderOption}
                                 multi
                                 options={options}

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBlockForm.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBlockForm.tsx
@@ -182,7 +182,6 @@ const RuleBlockForm = ({
                   <Select id={`existingBlock-select-${type}`}
                           name={`existingBlock-select-${type}`}
                           placeholder={`Add ${type}`}
-                          aria-label={`Add ${type}`}
                           options={options}
                           optionRenderer={optionRenderer}
                           clearable={false}

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
@@ -158,7 +158,6 @@ const StreamRuleModal = ({
                                   options={streamRuleTypesOptions}
                                   inputId={name}
                                   placeholder="Select a type"
-                                  inputProps={{ 'aria-label': 'Select a type' }}
                                   value={value} />
                         </Input>
                       )}
@@ -179,7 +178,7 @@ const StreamRuleModal = ({
                                         options={inputOptions}
                                         inputId={name}
                                         placeholder="Select an input"
-                                        inputProps={{ 'aria-label': 'Select an input' }}
+                                        aria-label="Select an input"
                                         value={value} />
                               </Input>
                             )}

--- a/graylog2-web-interface/src/components/streams/IndexSetSelect.tsx
+++ b/graylog2-web-interface/src/components/streams/IndexSetSelect.tsx
@@ -52,7 +52,6 @@ const IndexSetSelect = ({ indexSets, help = 'Messages that match this stream wil
                   options={indexSetOptions}
                   inputId={name}
                   placeholder="Select an index set"
-                  inputProps={{ 'aria-label': 'Select an index set' }}
                   value={value} />
         </Input>
       )}

--- a/graylog2-web-interface/src/components/users/TimeoutUnitSelect.tsx
+++ b/graylog2-web-interface/src/components/users/TimeoutUnitSelect.tsx
@@ -34,7 +34,7 @@ const OPTIONS = [
 
 const TimeoutUnitSelect = (props) => (
   <TimeoutSelect {...props}
-                 inputProps={{ 'aria-label': 'Timeout unit' }}
+                 aria-label="Timeout unit"
                  options={OPTIONS} />
 );
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/MultiSelectField.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/configurationFields/MultiSelectField.tsx
@@ -80,7 +80,7 @@ const MultiSelectField = ({ name, field, title, error, value, onChange, values }
               multi
               menuPortalTarget={document.body}
               onChange={onSelect}
-              inputProps={{ 'aria-label': `Select ${field.title}` }}
+              aria-label={`Select ${field.title}`}
               displayKey="key"
               inputId="multi-select-visualization" />
     </Input>

--- a/graylog2-web-interface/src/views/components/searchbar/StreamCategoryFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamCategoryFilter.tsx
@@ -47,7 +47,6 @@ const StreamCategoryFilter = ({ disabled = false, value = [], streamCategories, 
     <Container data-testid="stream-category-filter" title={placeholder}>
       <Select placeholder={placeholder}
               disabled={disabled}
-              inputProps={{ 'aria-label': placeholder }}
               displayKey="key"
               inputId="stream-categories-filter"
               onChange={handleChange}

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingColorForm.tsx
@@ -120,7 +120,7 @@ const GradientColorPicker = () => (
                    error={meta?.error}
                    label="Gradient Name">
               <Select options={GRADIENTS}
-                      inputProps={{ 'aria-label': 'Select gradient colors' }}
+                      placeholder="Select gradient colors"
                       value={value}
                       onChange={(newGradient) => onChange({ target: { name, value: newGradient } })} />
             </Input>
@@ -129,7 +129,7 @@ const GradientColorPicker = () => (
         <Field name="color.lower">
           {({ field: { name, value, onChange }, meta }) => (
             <Input id={name}
-                   aria-label="Specify lowest value"
+                   placeholder="Specify lowest value"
                    label="Lowest Value"
                    type="number"
                    value={value}

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.tsx
@@ -184,7 +184,7 @@ const ChangeFieldTypeModal = ({
                         onChange={onChangeFieldType}
                         placeholder="Select field type"
                         disabled={isLoadingFieldTypes}
-                        inputProps={{ 'aria-label': 'Select Field Type For Field' }}
+                        aria-label="Select Field Type For Field"
                         required />
         </Input>
         {showSelectionTable && initialSelectionDataLoaded && (

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/FieldSelect.tsx
@@ -56,7 +56,7 @@ const FieldSelect = ({ indexSetId, onFieldChange, field }: Props) => {
                       onChange={_onFieldChange}
                       placeholder="Select or type the field"
                       disabled={isLoading}
-                      inputProps={{ 'aria-label': 'Select Field' }}
+                      aria-label="Select Field"
                       required
                       allowCreate />
       </Input>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are:
- using the `Select` `placeholder` prop for the `Select` aria label, if no custom `aria-label` prop has been defined
- extending the `Select` `Props` type with the `aria-label` attribute.
- replacing usages of `inputProps={ 'aria-label': ... }` with `aria-label=...`
- removing the `aria-label` prop when it is identical to the `placeholder` prop

Defining the `aria-label` prop for the `Select` was possible before, but now we added proper types for this case and unified the usage.

I made this change because:
- The `Select` `placeholder` and `aria-label` were often identical
- There is no disadvantage in using the `placeholder` for the aria label.
- We often need to rely on the `Select` aria label in tests, because it is a reliable way to "find" the `Select`. For example finding the `Select` by placeholder only works when the select has no value.


/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9282
/nocl