### PR TITLE
improve user access right check on stream getConnectedPipelines

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/pipelines/StreamsPipelinesIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/StreamsPipelinesIT.java
@@ -84,6 +84,6 @@ public class StreamsPipelinesIT {
         final var pipeline1 = Map.of("id", pipeline1Id, "title", pipeline1Title);
         final var pipeline2 = Map.of("id", pipeline2Id, "title", pipeline2Title);
 
-        assertThat(result.getList("")).containsExactly(pipeline1, pipeline2);
+        assertThat(result.getList("")).containsExactlyInAnyOrder(pipeline1, pipeline2);
     }
 }

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/StreamsPipelinesIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/StreamsPipelinesIT.java
@@ -75,4 +75,15 @@ public class StreamsPipelinesIT {
         assertThat(result.getList(stream2Id)).containsExactlyInAnyOrder(pipeline1);
         assertThat(result.getList(stream3Id)).containsExactlyInAnyOrder(pipeline2);
     }
+
+    @ContainerMatrixTest
+    void retrievePipelineConnectionsForASingleStream() {
+        var result = api.get("/streams/" + stream1Id + "/pipelines", 200)
+                .extract().body().jsonPath();
+
+        final var pipeline1 = Map.of("id", pipeline1Id, "title", pipeline1Title);
+        final var pipeline2 = Map.of("id", pipeline2Id, "title", pipeline2Title);
+
+        assertThat(result.getList("")).containsExactly(pipeline1, pipeline2);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -610,6 +610,10 @@ public class StreamResource extends RestResource {
     @ApiOperation(value = "Get pipelines associated with a stream")
     @Produces(MediaType.APPLICATION_JSON)
     public List<PipelineCompactSource> getConnectedPipelines(@ApiParam(name = "streamId", required = true) @PathParam("streamId") String streamId) throws NotFoundException {
+        if (!isPermitted(RestPermissions.STREAMS_READ, streamId)) {
+            throw new ForbiddenException("Not allowed to read configuration for stream with id: " + streamId);
+        }
+
         PipelineConnections pipelineConnections = pipelineStreamConnectionsService.load(streamId);
         List<PipelineCompactSource> list = new ArrayList<>();
 


### PR DESCRIPTION
/nocl 
Improve access check and check if the authenticated user has access to the stream before returning the connected pipelines.

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9272