### PR TITLE
Remove EVENT_LIMIT_REACHED notification

### DIFF
--- a/changelog/unreleased/issue-20785.toml
+++ b/changelog/unreleased/issue-20785.toml
@@ -2,4 +2,4 @@ type = "c"
 message = "Removed noisy system notification when event limit is exceeded."
 
 issues = ["20785"]
-pulls = [""]
+pulls = ["21080"]

--- a/changelog/unreleased/issue-20785.toml
+++ b/changelog/unreleased/issue-20785.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Removed noisy system notification when event limit is exceeded."
+
+issues = ["20785"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -52,7 +52,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.HasOptionalFiel
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
-import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageFactory;
@@ -78,7 +77,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.graylog.events.search.MoreSearch.luceneEscape;
-import static org.graylog2.notifications.Notification.Type.EVENT_LIMIT_REACHED;
 
 public class AggregationEventProcessor implements EventProcessor {
     public interface Factory extends EventProcessor.Factory<AggregationEventProcessor> {
@@ -285,15 +283,6 @@ public class AggregationEventProcessor implements EventProcessor {
             moreSearch.scrollQuery(config.query(), streams, config.filters(), config.queryParameters(),
                     parameters.timerange(), parameters.batchSize(), callback);
         } catch (EventLimitReachedException e) {
-            notificationService.publishIfFirst(notificationService.buildNow()
-                    .addType(EVENT_LIMIT_REACHED)
-                    .addKey(eventDefinition.id())
-                    .addDetail("event_definition_title", eventDefinition.title())
-                    .addDetail("event_definition_id", eventDefinition.id())
-                    .addDetail("event_limit", config.eventLimit())
-                    .addSeverity(Notification.Severity.NORMAL)
-            );
-
             LOG.debug("Event limit reached at {} for '{}/{}' event definition.", config.eventLimit(), eventDefinition.title(), eventDefinition.id());
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -94,7 +94,6 @@ public interface Notification extends Persisted {
         SEARCH_ERROR,
         SIDECAR_STATUS_UNKNOWN,
         CERTIFICATE_NEEDS_RENEWAL,
-        EVENT_LIMIT_REACHED,
         DRAWDOWN_LICENSE_ERROR,
         REMOTE_REINDEX_RUNNING,
         REMOTE_REINDEX_FINISHED,

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/event_limit_reached.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/HTML/event_limit_reached.ftl
@@ -1,9 +1,0 @@
-<#if _title>
-    Event limit reached
-</#if>
-
-<#if _description>
-    <span>
-        Event limit »${event_limit}« reached for event definition »${event_definition_title}(${event_definition_id})«. Try to use a more specific search query or use aggregations. Otherwise try to raise the limit.
-    </span>
-</#if>

--- a/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/event_limit_reached.ftl
+++ b/graylog2-server/src/main/resources/org/graylog2/freemarker/templates/PLAINTEXT/event_limit_reached.ftl
@@ -1,7 +1,0 @@
-<#if _title>
-    Event limit reached
-</#if>
-
-<#if _description>
-    Event limit »${event_limit}« reached for event definition »${event_definition_title}(${event_definition_id})«. Try to use a more specific search query or use aggregations. Otherwise try to raise the limit.
-</#if>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
@@ -150,7 +150,8 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
                      label="Event Limit"
                      type="number"
                      bsStyle={validation.errors.event_limit ? 'error' : null}
-                     help={get(validation, 'errors.event_limit',
+                     help={get(validation,
+                       'errors.event_limit',
                        'Maximum number of events to be created per execution of this event definition. Excess events will be suppressed.') as string}
                      value={eventDefinition.config.event_limit}
                      onChange={handleConfigChange}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
@@ -150,7 +150,8 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
                      label="Event Limit"
                      type="number"
                      bsStyle={validation.errors.event_limit ? 'error' : null}
-                     help={get(validation, 'errors.event_limit', 'Maximum number of events to be created.') as string}
+                     help={get(validation, 'errors.event_limit',
+                       'Maximum number of events to be created per execution of this event definition. Excess events will be suppressed.') as string}
                      value={eventDefinition.config.event_limit}
                      onChange={handleConfigChange}
                      required />


### PR DESCRIPTION
Resolves #20785 

<!--- Provide a general summary of your changes in the Title above -->
Removes the system notification EVENT_LIMIT_REACHED. 
See linked issue for details.

In short: suppressing events that exceed the limit is the desired behavior, hence no notification or logging to alert the user.
