### PR TITLE
Avoiding n+1 when retrieving bulk pipeline connections for streams.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.pipelineprocessor.db;
 import org.graylog2.database.NotFoundException;
 
 import java.util.Collection;
+import java.util.Set;
 
 public interface PipelineService {
     PipelineDao save(PipelineDao pipeline);
@@ -30,4 +31,6 @@ public interface PipelineService {
     Collection<PipelineDao> loadAll();
 
     void delete(String id);
+
+    Set<PipelineDao> loadByIds(Set<String> pipelineIds);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
@@ -20,6 +20,8 @@ import org.graylog2.database.NotFoundException;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public interface PipelineService {
     PipelineDao save(PipelineDao pipeline);
@@ -32,5 +34,13 @@ public interface PipelineService {
 
     void delete(String id);
 
-    Set<PipelineDao> loadByIds(Set<String> pipelineIds);
+    default Set<PipelineDao> loadByIds(Set<String> pipelineIds) {
+        return pipelineIds.stream().flatMap(id -> {
+            try {
+                return Stream.of(load(id));
+            } catch (NotFoundException e) {
+                return Stream.empty();
+            }
+        }).collect(Collectors.toSet());
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.pipelineprocessor.db;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.database.NotFoundException;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 public interface PipelineStreamConnectionsService {
@@ -31,4 +33,6 @@ public interface PipelineStreamConnectionsService {
     Set<PipelineConnections> loadByPipelineId(String pipelineId);
 
     void delete(String streamId);
+
+    Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineService.java
@@ -26,8 +26,10 @@ import org.graylog2.events.ClusterEventBus;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 /**
  * A PipelineService that does not persist any data, but simply keeps it in memory.
@@ -101,6 +103,13 @@ public class InMemoryPipelineService implements PipelineService {
         }
 
         clusterBus.post(PipelinesChangedEvent.deletedPipelineId(id));
+    }
+
+    @Override
+    public Set<PipelineDao> loadByIds(Set<String> pipelineIds) {
+        return pipelineIds.stream()
+                .map(store::get)
+                .collect(Collectors.toSet());
     }
 
     private String createId() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
@@ -17,14 +17,14 @@
 package org.graylog.plugins.pipelineprocessor.db.memory;
 
 import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.events.PipelineConnectionsChangedEvent;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 
-import jakarta.inject.Inject;
-
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,6 +86,12 @@ public class InMemoryPipelineStreamConnectionsService implements PipelineStreamC
         } catch (NotFoundException e) {
             // Do nothing
         }
+    }
+
+    @Override
+    public Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds) {
+        return streamIds.stream()
+                .collect(Collectors.toMap(streamId -> streamId, store::get));
     }
 
     private String createId() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -35,11 +35,14 @@ import org.graylog2.events.ClusterEventBus;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter.getRateLimitedLog;
 import static org.graylog2.database.utils.MongoUtils.idEq;
 import static org.graylog2.database.utils.MongoUtils.insertedIdAsString;
+import static org.graylog2.database.utils.MongoUtils.stringIdsIn;
 
 public class MongoDbPipelineService implements PipelineService {
     private static final RateLimitedLog log = getRateLimitedLog(MongoDbPipelineService.class);
@@ -107,6 +110,11 @@ public class MongoDbPipelineService implements PipelineService {
     public void delete(String id) {
         collection.deleteOne(idEq(id));
         clusterBus.post(PipelinesChangedEvent.deletedPipelineId(id));
+    }
+
+    @Override
+    public Set<PipelineDao> loadByIds(Set<String> pipelineIds) {
+        return MongoUtils.stream(collection.find(stringIdsIn(pipelineIds))).collect(Collectors.toSet());
     }
 
     public long count(Bson filter) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
@@ -21,6 +21,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.events.PipelineConnectionsChangedEvent;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
@@ -34,10 +35,11 @@ import org.mongojack.DBSort;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
 
-import jakarta.inject.Inject;
-
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter.getRateLimitedLog;
 
@@ -122,5 +124,11 @@ public class MongoDbPipelineStreamConnectionsService implements PipelineStreamCo
         } catch (NotFoundException e) {
             log.debug("No connections found for stream " + streamId);
         }
+    }
+
+    @Override
+    public Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds) {
+        return dbCollection.find(DBQuery.in("stream_id", streamIds)).toArray().stream()
+                .collect(Collectors.toMap(PipelineConnections::streamId, conn -> conn));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -121,6 +121,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -651,7 +652,9 @@ public class StreamResource extends RestResource {
                 .collect(Collectors.toMap(MongoEntity::id, pipeline -> pipeline));
         return request.streamIds().stream()
                 .collect(Collectors.toMap(streamId -> streamId, streamId -> {
-                    final var pipelinesForStream = pipelineConnections.get(streamId).pipelineIds();
+                    final var pipelinesForStream = Optional.ofNullable(pipelineConnections.get(streamId))
+                            .map(PipelineConnections::pipelineIds)
+                            .orElse(Set.of());
                     return pipelinesForStream.stream()
                             .map(pipelines::get)
                             .map(pipeline -> PipelineCompactSource.create(pipeline.id(), pipeline.title()))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up to #21057, avoiding an n+1 performance issue when retrieving pipeline connections for multiple streams. This change is now fetching the associated pipeline connections and referenced pipelines in single bulk requests instead of for each stream + for each connected pipeline.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.