### PR TITLE
Add feature flag for setup mode

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -90,3 +90,6 @@ remote_reindex_migration=off
 
 # Enable preview of data warehouse data
 data_warehouse_search=off
+
+# Enable preview of input setup wizard
+setup_mode=off


### PR DESCRIPTION
/nocl

`SETUP_MODE` feature flag exists to allow a preview of the Input Setup Wizard.

Set it to `off` in the config to avoid noisy warnings in the log file.
