### PR TITLE
reflect client certificate expiry date test to reflect generated expiry

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/datanode/ClientCertResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/datanode/ClientCertResourceIT.java
@@ -53,7 +53,8 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -95,8 +96,8 @@ public class ClientCertResourceIT {
                 .toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDate();
-        Assertions.assertThat(expires).isBefore(LocalDate.now(Clock.systemDefaultZone()).plusMonths(6).plusDays(2));
-        Assertions.assertThat(expires).isAfter(LocalDate.now(Clock.systemDefaultZone()).plusMonths(6).minusDays(2));
+        LocalDate shouldExpire = Instant.now().plus(Duration.ofDays(180)).atZone(ZoneId.systemDefault()).toLocalDate();
+        Assertions.assertThat(expires).isBetween(shouldExpire.minusDays(2), shouldExpire.plusDays(2));
 
         final SSLContext sslContext = createSslContext(
                 createKeystore(privateKey, certificate, caCertificate),


### PR DESCRIPTION
## Description
Adjust `ClientCertResourceIT` to match the generated expiration date.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

