### PR TITLE
Grouping `@graylog/*-api` as external modules in ESLint.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -99,6 +99,11 @@ module.exports = {
     'import/no-unresolved': 'off',
     'import/order': ['error', {
       groups: ['builtin', 'external', 'internal', ['sibling', 'index'], 'parent'],
+      pathGroups: [{
+        pattern: '@graylog/*-api',
+        group: 'external',
+        position: 'after',
+      }],
       'newlines-between': 'always',
     }],
     'sort-imports': 'off', // disabled in favor of 'import/order'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that ESLint is grouping the generated API modules as `external` consistently.

Fixes Graylog2/graylog-plugin-enterprise#9294.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.