### PR TITLE
Handle path prefix when serving web interface assets.

### DIFF
--- a/changelog/unreleased/issue-21015.toml
+++ b/changelog/unreleased/issue-21015.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Handle path prefix when serving web interface assets."
+
+issues = ["21015"]
+pulls = ["21104"]

--- a/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceBase.java
+++ b/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceBase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.web.resources;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.HttpStatus;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+
+import static io.restassured.RestAssured.given;
+
+public abstract class WebInterfaceAssetsResourceBase {
+    private final GraylogApis apis;
+
+    protected WebInterfaceAssetsResourceBase(GraylogApis apis) {
+        this.apis = apis;
+    }
+
+    private RequestSpecification backend() {
+        return given()
+                .baseUri(apis.backend().uri())
+                .port(apis.backend().apiPort());
+    }
+
+    protected void testFrontend(String prefix) {
+        final var scriptSrcs = backend()
+                .get(prefix)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .contentType(ContentType.HTML)
+                .extract()
+                .htmlPath()
+                .<String>getList("html.body.script*.@src");
+
+        scriptSrcs.forEach(src -> {
+            backend()
+                    .get(src)
+                    .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_OK)
+                    .contentType(ContentType.JSON);
+        });
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.web.resources;
+
+import org.graylog.testing.completebackend.MavenProjectDirProviderWithFrontend;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.SearchServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+@ContainerMatrixTestsConfiguration(mavenProjectDirProvider = MavenProjectDirProviderWithFrontend.class,
+                                   searchVersions = {SearchServer.DATANODE_DEV})
+public class WebInterfaceAssetsResourceIT extends WebInterfaceAssetsResourceBase {
+    public WebInterfaceAssetsResourceIT(GraylogApis graylogApis) {
+        super(graylogApis);
+    }
+
+    @ContainerMatrixTest
+    void testIndexHtml() {
+        testFrontend("/");
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceWithPrefixIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/web/resources/WebInterfaceAssetsResourceWithPrefixIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.web.resources;
+
+import org.graylog.testing.completebackend.MavenProjectDirProviderWithFrontend;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.SearchServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+@ContainerMatrixTestsConfiguration(mavenProjectDirProvider = MavenProjectDirProviderWithFrontend.class,
+                                   searchVersions = {SearchServer.DATANODE_DEV},
+                                   additionalConfigurationParameters = {
+                                           @ContainerMatrixTestsConfiguration.ConfigurationParameter(key = "GRAYLOG_HTTP_PUBLISH_URI", value = "http://localhost:9000/graylog")
+                                   })
+public class WebInterfaceAssetsResourceWithPrefixIT extends WebInterfaceAssetsResourceBase {
+    public WebInterfaceAssetsResourceWithPrefixIT(GraylogApis graylogApis) {
+        super(graylogApis);
+    }
+
+    @ContainerMatrixTest
+    void testIndexHtml() {
+        testFrontend("/graylog/");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
@@ -138,6 +138,7 @@ public class WebInterfaceAssetsResource {
         } catch (IOException | URISyntaxException e) {
             return generateIndexHtml(headers, (String) request.getProperty(CSPDynamicFeature.CSP_NONCE_PROPERTY));
         }
+
     }
 
     private String trimBasePath(String filename, HttpHeaders headers) {

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
@@ -22,19 +22,8 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
-import org.glassfish.jersey.server.ContainerRequest;
-import org.graylog2.plugin.Plugin;
-import org.graylog2.shared.rest.resources.csp.CSP;
-import org.graylog2.shared.rest.resources.csp.CSPDynamicFeature;
-import org.graylog2.web.IndexHtmlGenerator;
-import org.graylog2.web.PluginAssets;
-
-import javax.activation.MimetypesFileTypeMap;
-import javax.annotation.Nonnull;
-
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
@@ -46,7 +35,17 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.plugin.Plugin;
+import org.graylog2.rest.RestTools;
+import org.graylog2.shared.rest.resources.csp.CSP;
+import org.graylog2.shared.rest.resources.csp.CSPDynamicFeature;
+import org.graylog2.web.IndexHtmlGenerator;
+import org.graylog2.web.PluginAssets;
 
+import javax.activation.MimetypesFileTypeMap;
+import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -73,15 +72,20 @@ import static java.util.Objects.requireNonNull;
 @CSP(group = CSP.DEFAULT)
 public class WebInterfaceAssetsResource {
     private final MimetypesFileTypeMap mimeTypes;
+    private final HttpConfiguration httpConfiguration;
     private final IndexHtmlGenerator indexHtmlGenerator;
     private final Set<Plugin> plugins;
     private final LoadingCache<URI, FileSystem> fileSystemCache;
 
     @Inject
-    public WebInterfaceAssetsResource(IndexHtmlGenerator indexHtmlGenerator, Set<Plugin> plugins, MimetypesFileTypeMap mimeTypes) {
+    public WebInterfaceAssetsResource(IndexHtmlGenerator indexHtmlGenerator,
+                                      Set<Plugin> plugins,
+                                      MimetypesFileTypeMap mimeTypes,
+                                      HttpConfiguration httpConfiguration) {
         this.indexHtmlGenerator = indexHtmlGenerator;
         this.plugins = plugins;
         this.mimeTypes = requireNonNull(mimeTypes);
+        this.httpConfiguration = httpConfiguration;
         this.fileSystemCache = CacheBuilder.newBuilder()
                 .maximumSize(1024)
                 .build(new CacheLoader<>() {
@@ -103,16 +107,18 @@ public class WebInterfaceAssetsResource {
     @Path("assets/plugin/{plugin}/{filename}")
     @GET
     public Response get(@Context Request request,
+                        @Context HttpHeaders headers,
                         @PathParam("plugin") String pluginName,
                         @PathParam("filename") String filename) {
         final Plugin plugin = getPluginForName(pluginName)
                 .orElseThrow(() -> new NotFoundException("Couldn't find plugin " + pluginName));
+        final var filenameWithoutSuffix = trimBasePath(filename, headers);
 
         try {
-            final URL resourceUrl = getResourceUri(true, filename, plugin.metadata().getClass());
-            return getResponse(request, filename, resourceUrl, true);
+            final URL resourceUrl = getResourceUri(true, filenameWithoutSuffix, plugin.metadata().getClass());
+            return getResponse(request, filenameWithoutSuffix, resourceUrl, true);
         } catch (URISyntaxException | IOException e) {
-            throw new NotFoundException("Couldn't find " + filename + " in plugin " + pluginName, e);
+            throw new NotFoundException("Couldn't find " + filenameWithoutSuffix + " in plugin " + pluginName, e);
         }
     }
 
@@ -125,17 +131,32 @@ public class WebInterfaceAssetsResource {
     public Response get(@Context ContainerRequest request,
                         @Context HttpHeaders headers,
                         @PathParam("filename") String filename) {
+        final var filenameWithoutSuffix = trimBasePath(filename, headers);
         try {
-            final URL resourceUrl = getResourceUri(false, filename, this.getClass());
-            return getResponse(request, filename, resourceUrl, false);
+            final URL resourceUrl = getResourceUri(false, filenameWithoutSuffix, this.getClass());
+            return getResponse(request, filenameWithoutSuffix, resourceUrl, false);
         } catch (IOException | URISyntaxException e) {
             return generateIndexHtml(headers, (String) request.getProperty(CSPDynamicFeature.CSP_NONCE_PROPERTY));
         }
     }
 
+    private String trimBasePath(String filename, HttpHeaders headers) {
+        final String baseUriPath = removeTrailingSlash(RestTools.buildRelativeExternalUri(headers.getRequestHeaders(), httpConfiguration.getHttpExternalUri()).getPath());
+        return filename.startsWith(baseUriPath) ? filename.substring(baseUriPath.length()) : filename;
+    }
+
+    private String removeTrailingSlash(String basePath) {
+        if (basePath == null || !basePath.endsWith("/")) {
+            return basePath;
+        }
+
+        return basePath.substring(0, basePath.length() - 1);
+    }
+
     @GET
     @Path("{filename:.*}")
-    public Response getIndex(@Context ContainerRequest request, @Context HttpHeaders headers) {
+    public Response getIndex(@Context ContainerRequest request,
+                             @Context HttpHeaders headers) {
         final URI originalLocation = request.getRequestUri();
         return get(request, headers, originalLocation.getPath());
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/MavenProjectDirProviderWithFrontend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/MavenProjectDirProviderWithFrontend.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.completebackend;
+
+public class MavenProjectDirProviderWithFrontend extends DefaultMavenProjectDirProvider {
+    @Override
+    public boolean includeFrontend() {
+        return true;
+    }
+}


### PR DESCRIPTION
**Note:** This needs a backport to `6.0`, `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that if a path prefix is configured through the `http_publish_uri` (in contrast to through the `X-Graylog-Server-URL` header), it will be considered when looking up assets.

Fixes #21015.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It has been tested with configuring `http_publish_uri` with and without a path prefix, with a trailing slash and without it and without the directive at all.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.