### PR TITLE
Inject the backend query type map for pluggable backend selection

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
@@ -24,6 +24,7 @@ import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 import org.graylog.plugins.views.ViewsModule;
 import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.export.ExportBackend;
@@ -86,8 +87,7 @@ public class ViewsESBackendModule extends ViewsModule {
     protected void configure() {
         install(new FactoryModuleBuilder().build(ESGeneratedQueryContext.Factory.class));
 
-        bindForVersion(supportedSearchVersion, new TypeLiteral<QueryBackend<? extends GeneratedQueryContext>>() {})
-                .to(ElasticsearchBackend.class);
+        registerVersionedQueryBackend(supportedSearchVersion, ElasticsearchQueryString.NAME, ElasticsearchBackend.class);
 
         registerESSearchTypeHandler(MessageList.NAME, ESMessageList.class);
         registerESSearchTypeHandler(EventList.NAME, ESEventList.class);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ViewsESBackendModule.java
@@ -24,9 +24,6 @@ import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 import org.graylog.plugins.views.ViewsModule;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
-import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.export.ExportBackend;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.events.EventList;
@@ -87,7 +84,7 @@ public class ViewsESBackendModule extends ViewsModule {
     protected void configure() {
         install(new FactoryModuleBuilder().build(ESGeneratedQueryContext.Factory.class));
 
-        registerVersionedQueryBackend(supportedSearchVersion, ElasticsearchQueryString.NAME, ElasticsearchBackend.class);
+        registerVersionedQueryBackend(supportedSearchVersion, ElasticsearchBackend.class);
 
         registerESSearchTypeHandler(MessageList.NAME, ESMessageList.class);
         registerESSearchTypeHandler(EventList.NAME, ESEventList.class);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
@@ -25,6 +25,7 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog.plugins.views.ViewsModule;
 import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.export.ExportBackend;
@@ -89,8 +90,7 @@ public class ViewsOSBackendModule extends ViewsModule {
     protected void configure() {
         install(new FactoryModuleBuilder().build(OSGeneratedQueryContext.Factory.class));
 
-        bindForVersion(supportedSearchVersion, new TypeLiteral<QueryBackend<? extends GeneratedQueryContext>>() {})
-                .to(OpenSearchBackend.class);
+        registerVersionedQueryBackend(supportedSearchVersion, ElasticsearchQueryString.NAME, OpenSearchBackend.class);
 
         registerOSSearchTypeHandler(MessageList.NAME, OSMessageList.class);
         registerOSSearchTypeHandler(EventList.NAME, OSEventListDelegate.class);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ViewsOSBackendModule.java
@@ -25,9 +25,6 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog.plugins.views.ViewsModule;
 import org.graylog.plugins.views.search.SearchType;
-import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
-import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
-import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog.plugins.views.search.export.ExportBackend;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.events.EventList;
@@ -90,7 +87,7 @@ public class ViewsOSBackendModule extends ViewsModule {
     protected void configure() {
         install(new FactoryModuleBuilder().build(OSGeneratedQueryContext.Factory.class));
 
-        registerVersionedQueryBackend(supportedSearchVersion, ElasticsearchQueryString.NAME, OpenSearchBackend.class);
+        registerVersionedQueryBackend(supportedSearchVersion, OpenSearchBackend.class);
 
         registerOSSearchTypeHandler(MessageList.NAME, OSMessageList.class);
         registerOSSearchTypeHandler(EventList.NAME, OSEventListDelegate.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -181,6 +181,8 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(StreamCategoryFilter.class);
         registerJacksonSubtype(QueryStringFilter.class);
 
+        // to support unversioned query backends
+        queryBackendBinder();
         // query backends for jackson
         registerJacksonSubtype(ElasticsearchQueryString.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsModule.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.views;
 
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
-import com.google.inject.binder.ScopedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
@@ -92,15 +91,8 @@ public abstract class ViewsModule extends VersionAwareModule {
 
     }
 
-    /**
-     * Use this binder for versioned backends, it also registers the backend in the overall MapBinder in
-     * @param version
-     * @param name
-     * @param implementation
-     */
-    protected void registerVersionedQueryBackend(SearchVersion version, String name, Class<? extends QueryBackend<? extends GeneratedQueryContext>> implementation) {
+    protected void registerVersionedQueryBackend(SearchVersion version, Class<? extends QueryBackend<? extends GeneratedQueryContext>> implementation) {
         bindForVersion(version, new TypeLiteral<QueryBackend<? extends GeneratedQueryContext>>() {}).to(implementation);
-        queryBackendBinder().addBinding(name).to(implementation);
     }
 
     protected void registerESQueryDecorator(Class<? extends QueryStringDecorator> esQueryDecorator) {
@@ -142,4 +134,6 @@ public abstract class ViewsModule extends VersionAwareModule {
     protected Multibinder<SearchValidator> searchValidatorBinder() {
         return Multibinder.newSetBinder(binder(), SearchValidator.class);
     }
+
+
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsModule.java
@@ -85,15 +85,22 @@ public abstract class ViewsModule extends VersionAwareModule {
         seriesSpecBinder().addBinding(name).toInstance(SeriesDescription.create(name, description));
     }
 
-    protected MapBinder<String, QueryBackend<? extends GeneratedQueryContext>> queryBackendBinder(SearchVersion version) {
+    protected MapBinder<String, QueryBackend<? extends GeneratedQueryContext>> queryBackendBinder() {
         return MapBinder.newMapBinder(binder(),
                 TypeLiteral.get(String.class),
-                new TypeLiteral<QueryBackend<? extends GeneratedQueryContext>>() {});
+                new TypeLiteral<>() {});
 
     }
 
-    protected ScopedBindingBuilder registerQueryBackend(SearchVersion version, String name, Class<? extends QueryBackend<? extends GeneratedQueryContext>> implementation) {
-        return queryBackendBinder(version).addBinding(name).to(implementation);
+    /**
+     * Use this binder for versioned backends, it also registers the backend in the overall MapBinder in
+     * @param version
+     * @param name
+     * @param implementation
+     */
+    protected void registerVersionedQueryBackend(SearchVersion version, String name, Class<? extends QueryBackend<? extends GeneratedQueryContext>> implementation) {
+        bindForVersion(version, new TypeLiteral<QueryBackend<? extends GeneratedQueryContext>>() {}).to(implementation);
+        queryBackendBinder().addBinding(name).to(implementation);
     }
 
     protected void registerESQueryDecorator(Class<? extends QueryStringDecorator> esQueryDecorator) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -52,13 +52,13 @@ public class QueryEngine {
 
     // TODO proper thread pool with tunable settings
     private final Executor queryPool = Executors.newFixedThreadPool(4, new ThreadFactoryBuilder().setNameFormat("query-engine-%d").build());
-    private final QueryBackend<? extends GeneratedQueryContext> backend;
+    private final Map<String, QueryBackend<? extends GeneratedQueryContext>> backends;
 
     @Inject
-    public QueryEngine(QueryBackend<? extends GeneratedQueryContext> backend,
+    public QueryEngine(Map<String, QueryBackend<? extends GeneratedQueryContext>> backends,
                        Set<QueryMetadataDecorator> queryMetadataDecorators,
                        QueryParser queryParser) {
-        this.backend = backend;
+        this.backends = backends;
         this.queryMetadataDecorators = queryMetadataDecorators;
         this.queryParser = queryParser;
     }
@@ -75,6 +75,7 @@ public class QueryEngine {
     public ExplainResults explain(SearchJob searchJob, Set<SearchError> validationErrors, DateTimeZone timezone) {
         final Map<String, ExplainResults.QueryExplainResult> queries = searchJob.getSearch().queries().stream()
                 .collect(Collectors.toMap(Query::id, q -> {
+                    var backend = backends.get(q.query().type());
                     final GeneratedQueryContext generatedQueryContext = backend.generate(q, Set.of(), timezone);
 
                     return backend.explain(searchJob, q, generatedQueryContext);
@@ -116,6 +117,7 @@ public class QueryEngine {
     }
 
     private QueryResult prepareAndRun(SearchJob searchJob, Query query, Set<SearchError> validationErrors, DateTimeZone timezone) {
+        final var backend = backends.get(query.query().type());
         LOG.debug("[{}] Using {} to generate query", query.id(), backend);
         // with all the results done, we can execute the current query and eventually complete our own result
         // if any of this throws an exception, the handle in #execute will convert it to an error and return a "failed" result instead

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/QueryEngine.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.views.search.engine;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.graylog.plugins.views.search.ExplainResults;
 import org.graylog.plugins.views.search.Query;
@@ -27,9 +28,12 @@ import org.graylog.plugins.views.search.QueryMetadataDecorator;
 import org.graylog.plugins.views.search.QueryResult;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchException;
+import org.graylog2.storage.DetectedSearchVersion;
+import org.graylog2.storage.SearchVersion;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,13 +56,19 @@ public class QueryEngine {
 
     // TODO proper thread pool with tunable settings
     private final Executor queryPool = Executors.newFixedThreadPool(4, new ThreadFactoryBuilder().setNameFormat("query-engine-%d").build());
-    private final Map<String, QueryBackend<? extends GeneratedQueryContext>> backends;
+    private final SearchVersion detectedVersion;
+    private final Map<SearchVersion, Provider<QueryBackend<? extends GeneratedQueryContext>>> versionedBackends;
+    private final Map<String, QueryBackend<? extends GeneratedQueryContext>> unversionedBackends;
 
     @Inject
-    public QueryEngine(Map<String, QueryBackend<? extends GeneratedQueryContext>> backends,
+    public QueryEngine(@DetectedSearchVersion SearchVersion detectedVersion,
+                       Map<SearchVersion, Provider<QueryBackend<? extends GeneratedQueryContext>>> versionedBackends,
+                       Map<String, QueryBackend<? extends GeneratedQueryContext>> unversionedBackends,
                        Set<QueryMetadataDecorator> queryMetadataDecorators,
                        QueryParser queryParser) {
-        this.backends = backends;
+        this.detectedVersion = detectedVersion;
+        this.versionedBackends = versionedBackends;
+        this.unversionedBackends = unversionedBackends;
         this.queryMetadataDecorators = queryMetadataDecorators;
         this.queryParser = queryParser;
     }
@@ -75,7 +85,7 @@ public class QueryEngine {
     public ExplainResults explain(SearchJob searchJob, Set<SearchError> validationErrors, DateTimeZone timezone) {
         final Map<String, ExplainResults.QueryExplainResult> queries = searchJob.getSearch().queries().stream()
                 .collect(Collectors.toMap(Query::id, q -> {
-                    var backend = backends.get(q.query().type());
+                    var backend = getBackendForQuery(q);
                     final GeneratedQueryContext generatedQueryContext = backend.generate(q, Set.of(), timezone);
 
                     return backend.explain(searchJob, q, generatedQueryContext);
@@ -117,7 +127,7 @@ public class QueryEngine {
     }
 
     private QueryResult prepareAndRun(SearchJob searchJob, Query query, Set<SearchError> validationErrors, DateTimeZone timezone) {
-        final var backend = backends.get(query.query().type());
+        final var backend = getBackendForQuery(query);
         LOG.debug("[{}] Using {} to generate query", query.id(), backend);
         // with all the results done, we can execute the current query and eventually complete our own result
         // if any of this throws an exception, the handle in #execute will convert it to an error and return a "failed" result instead
@@ -138,5 +148,16 @@ public class QueryEngine {
                 .map(q -> (QueryError) q)
                 .map(QueryError::queryId)
                 .anyMatch(id -> Objects.equals(id, query.id()));
+    }
+
+    private QueryBackend<? extends GeneratedQueryContext> getBackendForQuery(Query query) {
+        var backendQuery = query.query();
+        if (backendQuery.type().equals(ElasticsearchQueryString.NAME)) {
+            return versionedBackends.get(detectedVersion).get();
+        }
+        if (unversionedBackends.containsKey(backendQuery.type())) {
+            return unversionedBackends.get(backendQuery.type());
+        }
+        throw new IllegalArgumentException("Unknown backend type: " + backendQuery.type());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/DecorateQueryStringsNormalizer.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/normalization/DecorateQueryStringsNormalizer.java
@@ -38,6 +38,10 @@ public class DecorateQueryStringsNormalizer implements SearchNormalizer {
 
     @Override
     public Query normalizeQuery(final Query query, final ParameterProvider parameterProvider) {
+        // this only makes sense for ElasticsearchQueryString instances, don't touch any other type
+        if (!(query.query() instanceof ElasticsearchQueryString)) {
+            return query;
+        }
         return query.toBuilder()
                 .query(ElasticsearchQueryString.of(this.queryStringDecorators.decorate(query.query().queryString(), parameterProvider, query)))
                 .filter(normalizeFilter(query.filter(), query, parameterProvider))


### PR DESCRIPTION
always also bind backends in the generic map binder, even for versioned backends
in non-versioned backends, use the map binder directly so the engine can pick the correct backend based on the BackendQuery instance used

for query normalization, ignore non-elasticsearch based queries for now, we will need to address normalizers later to make them type safe (or just live with the instanceof check)

Simplified version of https://github.com/Graylog2/graylog2-server/pull/21073
The minimal version for making this work is in https://github.com/Graylog2/graylog-plugin-enterprise/pull/9343.

/nocl 
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9343

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
