### PR TITLE
Make `WidgetContext` a singleton.

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetContext.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 
+import { singleton } from 'logic/singleton';
 import type Widget from 'views/logic/widgets/Widget';
 
 const WidgetContext = React.createContext<Widget | undefined>(undefined);
 
-export default WidgetContext;
+export default singleton('contexts.WidgetContext', () => WidgetContext);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR makes the `WidgetContext` a singleton, so it can be consumed in plugins.

/nocl
