### PR TITLE
Create `ClipboardIconButton`.

### DIFF
--- a/graylog2-web-interface/src/components/common/ClipboardButton.test.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import copyToClipboard from 'util/copyToClipboard';
+
+import ClipboardButton from './ClipboardButton';
+
+jest.mock('util/copyToClipboard', () => jest.fn(() => Promise.resolve()));
+
+describe('ClipboardButton', () => {
+  it('should copy provided text to clipboard', async () => {
+    const text = 'Text to copy';
+    render(<ClipboardButton text={text} title="Click here to copy" />);
+
+    userEvent.click(await screen.findByRole('button', { name: /click here to copy/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(text);
+
+    await screen.findByText('Copied!');
+  });
+});

--- a/graylog2-web-interface/src/components/common/ClipboardButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.tsx
@@ -37,7 +37,10 @@ type Props = {
   title: React.ReactNode,
 }
 
-const ClipboardButton = ({ bsSize, bsStyle, buttonTitle, className, disabled, onSuccess, text, title }: Props) => (
+const ClipboardButton = ({
+  bsSize = undefined, bsStyle = undefined, buttonTitle = undefined, className = undefined,
+  disabled = undefined, onSuccess = undefined, text, title,
+}: Props) => (
   <ClipboardContainer text={text}>
     {({ copy }) => (
       <Button bsSize={bsSize}

--- a/graylog2-web-interface/src/components/common/ClipboardContainer.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardContainer.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+import { useTimeout } from '@mantine/hooks';
+
+import copyToClipboard from 'util/copyToClipboard';
+import Tooltip from 'components/common/Tooltip';
+
+/**
+ * This component can be used as a wrapper for other components. When users click on the children,
+ * the provided text will be copied to the clipboard, and they see a tooltip for visual feedback.
+ */
+
+type Props = {
+  children: (props: { copy: () => void }) => JSX.Element,
+  text: string,
+}
+
+type Args = {
+  copied: boolean,
+  copy: () => void,
+}
+
+type CopyProps = {
+  value: string,
+  timeout: number,
+  children: (args: Args) => React.ReactElement,
+};
+
+const Copy = ({ children, value, timeout }: CopyProps) => {
+  const [copied, setCopied] = useState(false);
+  const { start } = useTimeout(() => setCopied(false), timeout);
+  const copy = useCallback(() => copyToClipboard(value).then(() => { setCopied(true); start(); }), [start, value]);
+
+  return children({ copied, copy });
+};
+
+const ClipboardContainer = ({ children, text }: Props) => (
+  <Copy value={text} timeout={2000}>
+    {({ copied, copy }) => (copied ? (
+      <Tooltip label="Copied!" withArrow position="top" opened>
+        {children({ copy })}
+      </Tooltip>
+    ) : children({ copy }))}
+  </Copy>
+);
+
+export default ClipboardContainer;

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.test.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.test.tsx
@@ -27,7 +27,7 @@ jest.mock('util/copyToClipboard', () => jest.fn(() => Promise.resolve()));
 describe('ClipboardIconButton', () => {
   it('should copy provided text to clipboard', async () => {
     const text = 'Text to copy';
-    render(<ClipboardIconButton text={text} buttonTitle="Click here to copy" name="copy_all" />);
+    render(<ClipboardIconButton text={text} buttonTitle="Click here to copy" />);
 
     userEvent.click(await screen.findByRole('button', { name: /click here to copy/i }));
 

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.test.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import copyToClipboard from 'util/copyToClipboard';
+
+import ClipboardIconButton from './ClipboardIconButton';
+
+jest.mock('util/copyToClipboard', () => jest.fn(() => Promise.resolve()));
+
+describe('ClipboardIconButton', () => {
+  it('should copy provided text to clipboard', async () => {
+    const text = 'Text to copy';
+    render(<ClipboardIconButton text={text} buttonTitle="Click here to copy" name="copy_all" />);
+
+    userEvent.click(await screen.findByRole('button', { name: /click here to copy/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(text);
+
+    await screen.findByText('Copied!');
+  });
+});

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
@@ -16,43 +16,38 @@
  */
 import * as React from 'react';
 
-import { Button } from 'components/bootstrap';
-import type { BsSize } from 'components/bootstrap/types';
-import type { StyleProps } from 'components/bootstrap/Button';
 import ClipboardContainer from 'components/common/ClipboardContainer';
+import { IconButton } from 'components/common';
+
+import type { IconName } from './Icon';
 
 /**
- * Component that renders a button to copy some text in the clipboard when pressed.
+ * Component that renders an icon button to copy some text in the clipboard when pressed.
  * The text to be copied can be given in the `text` prop, or in an external element through a CSS selector in the `target` prop.
  */
 
 type Props = {
-  bsSize?: BsSize,
-  bsStyle?: StyleProps,
   buttonTitle?: string,
   className?: string,
   disabled?: boolean,
   onSuccess?: () => void,
   text: string,
-  title: React.ReactNode,
+  name: IconName,
 }
 
-const ClipboardButton = ({ bsSize, bsStyle, buttonTitle, className, disabled, onSuccess, text, title }: Props) => (
+const ClipboardIconButton = ({ buttonTitle, className, disabled, onSuccess, text, name }: Props) => (
   <ClipboardContainer text={text}>
     {({ copy }) => (
-      <Button bsSize={bsSize}
-              bsStyle={bsStyle}
-              className={className}
-              disabled={disabled}
-              title={buttonTitle}
-              onClick={() => {
-                copy();
-                onSuccess?.();
-              }}>
-        {title}
-      </Button>
+      <IconButton className={className}
+                  name={name}
+                  disabled={disabled}
+                  title={buttonTitle}
+                  onClick={() => {
+                    copy();
+                    onSuccess?.();
+                  }} />
     )}
   </ClipboardContainer>
 );
 
-export default ClipboardButton;
+export default ClipboardIconButton;

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
@@ -19,8 +19,6 @@ import * as React from 'react';
 import ClipboardContainer from 'components/common/ClipboardContainer';
 import { IconButton } from 'components/common';
 
-import type { IconName } from './Icon';
-
 /**
  * Component that renders an icon button to copy some text in the clipboard when pressed.
  * The text to be copied can be given in the `text` prop, or in an external element through a CSS selector in the `target` prop.
@@ -32,14 +30,13 @@ type Props = {
   disabled?: boolean,
   onSuccess?: () => void,
   text: string,
-  name: IconName,
 }
 
-const ClipboardIconButton = ({ buttonTitle, className, disabled, onSuccess, text, name }: Props) => (
+const ClipboardIconButton = ({ buttonTitle, className, disabled, onSuccess, text }: Props) => (
   <ClipboardContainer text={text}>
     {({ copy }) => (
       <IconButton className={className}
-                  name={name}
+                  name="content_copy"
                   disabled={disabled}
                   title={buttonTitle}
                   onClick={() => {

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
@@ -37,6 +37,7 @@ const ClipboardIconButton = ({ buttonTitle, className, disabled, onSuccess, text
     {({ copy }) => (
       <IconButton className={className}
                   name="content_copy"
+                  iconType="regular"
                   disabled={disabled}
                   title={buttonTitle}
                   onClick={() => {

--- a/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
+++ b/graylog2-web-interface/src/components/common/ClipboardIconButton.tsx
@@ -32,7 +32,7 @@ type Props = {
   text: string,
 }
 
-const ClipboardIconButton = ({ buttonTitle, className, disabled, onSuccess, text }: Props) => (
+const ClipboardIconButton = ({ buttonTitle = undefined, className = undefined, disabled = undefined, onSuccess = undefined, text }: Props) => (
   <ClipboardContainer text={text}>
     {({ copy }) => (
       <IconButton className={className}

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -29,6 +29,7 @@ export { default as Card } from './Card';
 export { default as Center } from './Center';
 export { default as Carousel } from './Carousel';
 export { default as ClipboardButton } from './ClipboardButton';
+export { default as ClipboardIconButton } from './ClipboardIconButton';
 export { default as ColorPicker } from './ColorPicker';
 export { default as ColorPickerPopover } from './ColorPickerPopover';
 export { default as ConfirmDialog } from './ConfirmDialog';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the past a `ClipboardButton` has been created. Now we want to implement an `IconButton` which copies the provided text on click.

Example of icon buttons:
![image](https://github.com/user-attachments/assets/40591f70-4a6b-41d6-abca-b69da282f5ce)

Since we can't reuse the `ClipboardButton` for this I extracted the related logic into a wrapper component which can be used for the existing `ClipboardButton` component and the newly created `ClipboardIconButton` component.


Screenshot of `CopyIconButton`:
![image](https://github.com/user-attachments/assets/4343965e-3e38-49d8-a33b-863f7ac428b1)


/nocl

