### PR TITLE
Relax Maven version requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,7 @@
                                 </banDynamicVersions>
                                 <requireMavenVersion>
                                     <!-- Enforce the same version we define in the maven wrapper -->
-                                    <version>[3.9.9]</version>
+                                    <version>[3.9.6,3.99.99]</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[17.0,17.99]</version>


### PR DESCRIPTION
This fixes issues with backports where the Maven version in the project parent is newer than in the server.

Require 3.9.6 as a minimum. That's what our stable branches currently use.

/nocl Infrastructure