### PR TITLE
Introducing and reusing `DefaultLayout` type.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.ts
@@ -16,16 +16,11 @@
  */
 import { useMemo } from 'react';
 
-import type { Sort } from 'stores/PaginationTypes';
+import type { DefaultLayout } from 'components/common/EntityDataTable/types';
 
 import useUserLayoutPreferences from './useUserLayoutPreferences';
 
-const useTableLayout = ({ entityTableId, defaultSort, defaultPageSize, defaultDisplayedAttributes }: {
-  entityTableId: string,
-  defaultSort: Sort,
-  defaultDisplayedAttributes: Array<string>
-  defaultPageSize: number,
-}) => {
+const useTableLayout = ({ entityTableId, defaultSort, defaultPageSize, defaultDisplayedAttributes }: DefaultLayout) => {
   const { data: userLayoutPreferences = {}, isInitialLoading } = useUserLayoutPreferences(entityTableId);
 
   return useMemo(() => ({

--- a/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
@@ -72,3 +72,10 @@ export type ExpandedSectionRenderer<Entity> = {
   actions?: (entity: Entity) => React.ReactNode,
   disableHeader?: boolean,
 }
+
+export type DefaultLayout = {
+  entityTableId: string,
+  defaultSort: Sort,
+  defaultDisplayedAttributes: Array<string>
+  defaultPageSize: number,
+}

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -78,9 +78,9 @@ const INITIAL_DATA = {
  */
 const PaginatedEntityTable = <T extends EntityBase, M = unknown>({
   actionsCellWidth = 160, columnsOrder, entityActions, tableLayout, fetchEntities, keyFn,
-  humanName, columnRenderers, queryHelpComponent, filterValueRenderers,
-  expandedSectionsRenderer, bulkSelection, additionalAttributes = [],
-  entityAttributesAreCamelCase, topRightCol, searchPlaceholder, fetchOptions: reactQueryOptions,
+  humanName, columnRenderers, queryHelpComponent = undefined, filterValueRenderers = undefined,
+  expandedSectionsRenderer = undefined, bulkSelection = undefined, additionalAttributes = [],
+  entityAttributesAreCamelCase, topRightCol = undefined, searchPlaceholder = undefined, fetchOptions: reactQueryOptions = undefined,
 }: Props<T, M>) => {
   const [urlQueryFilters, setUrlQueryFilters] = useUrlQueryFilters();
   const [query, setQuery] = useQueryParam('query', StringParam);

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -25,7 +25,7 @@ import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/ho
 import { useTableEventHandlers } from 'components/common/EntityDataTable';
 import { Spinner, PaginatedList, SearchForm, NoSearchResult, EntityDataTable } from 'components/common';
 import type { Attribute, SearchParams } from 'stores/PaginationTypes';
-import type { EntityBase } from 'components/common/EntityDataTable/types';
+import type { EntityBase, DefaultLayout } from 'components/common/EntityDataTable/types';
 import EntityFilters from 'components/common/EntityFilters';
 import useUrlQueryFilters from 'components/common/EntityFilters/hooks/useUrlQueryFilters';
 import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
@@ -59,7 +59,7 @@ type Props<T, M> = {
   keyFn: (options: SearchParams) => Array<unknown>,
   queryHelpComponent?: React.ReactNode,
   searchPlaceholder?: string,
-  tableLayout: Parameters<typeof useTableLayout>[0],
+  tableLayout: DefaultLayout,
   topRightCol?: React.ReactNode,
 }
 

--- a/graylog2-web-interface/src/components/events/ExpandedSection.tsx
+++ b/graylog2-web-interface/src/components/events/ExpandedSection.tsx
@@ -16,14 +16,14 @@
  */
 import React from 'react';
 
-import type useTableLayout from 'components/common/EntityDataTable/hooks/useTableLayout';
 import type { Event, EventsAdditionalData } from 'components/events/events/types';
 import useMetaDataContext from 'components/common/EntityDataTable/hooks/useMetaDataContext';
 import GeneralEventDetailsTable from 'components/events/events/GeneralEventDetailsTable';
 import useNonDisplayedAttributes from 'components/events/events/hooks/useNonDisplayedAttributes';
+import type { DefaultLayout } from 'components/common/EntityDataTable/types';
 
 type Props = {
-  defaultLayout: Parameters<typeof useTableLayout>[0],
+  defaultLayout: DefaultLayout,
   event: Event,
 }
 

--- a/graylog2-web-interface/src/components/events/events/hooks/useTableComponents.tsx
+++ b/graylog2-web-interface/src/components/events/events/hooks/useTableComponents.tsx
@@ -21,11 +21,11 @@ import keyBy from 'lodash/keyBy';
 import EventActions from 'components/events/events/EventActions';
 import type { Event } from 'components/events/events/types';
 import ExpandedSection from 'components/events/ExpandedSection';
-import type useTableLayout from 'components/common/EntityDataTable/hooks/useTableLayout';
 import BulkActions from 'components/events/events/BulkActions';
+import type { DefaultLayout } from 'components/common/EntityDataTable/types';
 
 const useTableElements = ({ defaultLayout }: {
-  defaultLayout: Parameters<typeof useTableLayout>[0],
+  defaultLayout: DefaultLayout,
 }) => {
   const entityActions = useCallback((event: Event) => (
     <EventActions event={event} />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a smaller cleanup PR, which introduces the `DefaultLayout` type which can be used instead of referencing `useTableLayout` parameters when working with the paginated data table.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.