### PR TITLE
Relax Maven version requirement (#21171)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,7 @@
                                 </banDynamicVersions>
                                 <requireMavenVersion>
                                     <!-- Enforce the same version we define in the maven wrapper -->
-                                    <version>[3.9.6]</version>
+                                    <version>[3.9.6,3.99.99]</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[17.0,17.99]</version>


### PR DESCRIPTION
This fixes issues with backports where the Maven version in the project parent is newer than in the server.

(cherry picked from commit 1000827bdbc1b85b6dbe9ceb2b34726fafb5a53d)

/nocl Infrastructure