### PR TITLE
Proper cancellation for multi-query search

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ElasticsearchBackend.java
@@ -277,7 +277,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
         //ES does not support per-request cancel_after_time_interval. We have to use simplified solution - the whole multi-search will be cancelled if it takes more than configured max. exec. time.
         final PlainActionFuture<MultiSearchResponse> mSearchFuture = client.cancellableMsearch(searches);
-        job.setSearchEngineTaskFuture(mSearchFuture);
+        job.setQueryExecutionFuture(query.id(), mSearchFuture);
         final List<MultiSearchResponse.Item> results = getResults(mSearchFuture, job.getCancelAfterSeconds(), searches.size());
 
         for (SearchType searchType : query.searchTypes()) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OpenSearchBackend.java
@@ -283,7 +283,7 @@ public class OpenSearchBackend implements QueryBackend<OSGeneratedQueryContext> 
                 .toList();
 
         final PlainActionFuture<MultiSearchResponse> mSearchFuture = client.cancellableMsearch(searches);
-        job.setSearchEngineTaskFuture(mSearchFuture);
+        job.setQueryExecutionFuture(query.id(), mSearchFuture);
         final List<MultiSearchResponse.Item> results = getResults(mSearchFuture, searches.size());
 
         for (SearchType searchType : query.searchTypes()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -28,7 +28,9 @@ import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.rest.ExecutionInfo;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -46,7 +48,7 @@ public class SearchJob implements ParameterProvider {
 
     private final Search search;
 
-    private Future<?> searchEngineTaskFuture;
+    private Map<String, Future<?>> queryExecutionFutures;
 
     private CompletableFuture<Void> resultFuture;
 
@@ -72,6 +74,7 @@ public class SearchJob implements ParameterProvider {
         this.search = search;
         this.searchJobIdentifier = new SearchJobIdentifier(id, search.id(), owner, executingNodeId);
         this.cancelAfterSeconds = cancelAfterSeconds != null ? cancelAfterSeconds : NO_CANCELLATION;
+        this.queryExecutionFutures = new HashMap<>();
     }
 
     @JsonIgnore //covered by @JsonUnwrapped
@@ -120,14 +123,14 @@ public class SearchJob implements ParameterProvider {
     }
 
     @JsonIgnore
-    public void setSearchEngineTaskFuture(final Future<?> searchEngineTaskFuture) {
-        this.searchEngineTaskFuture = searchEngineTaskFuture;
+    public void setQueryExecutionFuture(final String queryId, final Future<?> future) {
+        this.queryExecutionFutures.put(queryId, future);
     }
 
     public void cancel() {
-        if (this.searchEngineTaskFuture != null) {
-            this.searchEngineTaskFuture.cancel(true);
-        }
+        this.queryExecutionFutures.values().stream()
+                .filter(Objects::nonNull)
+                .forEach(f -> f.cancel(true));
     }
 
     @JsonProperty("results")
@@ -141,8 +144,8 @@ public class SearchJob implements ParameterProvider {
 
     @JsonProperty("execution")
     public ExecutionInfo execution() {
-        final boolean isDone = (resultFuture == null || resultFuture.isDone()) && (searchEngineTaskFuture == null || searchEngineTaskFuture.isDone());
-        final boolean isCancelled = (searchEngineTaskFuture != null && searchEngineTaskFuture.isCancelled()) || (resultFuture != null && resultFuture.isCancelled());
+        final boolean isDone = (resultFuture == null || resultFuture.isDone()) && (queryExecutionFutures.values().stream().allMatch(f -> f == null || f.isDone()));
+        final boolean isCancelled = (queryExecutionFutures.values().stream().allMatch(f -> f != null && f.isCancelled()) || (resultFuture != null && resultFuture.isCancelled()));
         return new ExecutionInfo(isDone, isCancelled, !errors.isEmpty());
     }
 


### PR DESCRIPTION
/nocl

## Description
Proper cancellation for multi-query search.

As `SearchJob` is envisioned to be used not only in OS/ES, but possibly also with D.W., the naming has been changed a little bit to reflect that.

## Motivation and Context
`SearchJob` class contains only one `Future` field, used for search execution cancellation.
It worked fine, but probably only because of the fact that we use `keep_queries` approach in both searches and dashboards, effectively limiting searches to a single query...

This field was replaced with query->future map.
When we cancel, we cancel on all futures.
When we check the status, we do it on all futures.

While this change may not be in fact fixing any bug existing right now, it should improve correctness of the approach for possible future use cases.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

