### PR TITLE
Improve performance for working with indices

### DIFF
--- a/changelog/unreleased/issue-18563.toml
+++ b/changelog/unreleased/issue-18563.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Improve performance when working with a lot of IndexSets."
+
+issues = ["18563"]
+pulls = ["21195"]

--- a/changelog/unreleased/issue-18563.toml
+++ b/changelog/unreleased/issue-18563.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Improve performance when working with a lot of IndexSets."
+message = "Improve performance of close and delete actions when working with a lot of index sets."
 
 issues = ["18563"]
 pulls = ["21195"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -22,14 +22,14 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
 import org.graylog2.indexer.indexset.events.IndexSetDeletedEvent;
 import org.graylog2.indexer.indices.TooManyAliasesException;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -215,6 +215,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
                 .orElse(false);
     }
 
+    @Nonnull
     @Override
     public Iterator<IndexSet> iterator() {
         return getAll().iterator();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -28,15 +29,21 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
 
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class MongoIndexSetRegistryTest {
@@ -66,15 +73,15 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(indexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(indexSetConfig);
 
         final List<IndexSetConfig> cachedResult = this.indexSetsCache.get();
         assertThat(cachedResult)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(indexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(indexSetConfig);
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -87,9 +94,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(indexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(indexSetConfig);
 
         this.indexSetsCache.invalidate();
 
@@ -100,9 +107,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(newIndexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -115,9 +122,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(indexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(indexSetConfig);
 
         this.indexSetsCache.handleIndexSetCreation(mock(IndexSetCreatedEvent.class));
 
@@ -128,9 +135,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(newIndexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -143,9 +150,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(indexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(indexSetConfig);
 
         this.indexSetsCache.handleIndexSetDeletion(mock(IndexSetDeletedEvent.class));
 
@@ -156,9 +163,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-            .isNotNull()
-            .hasSize(1)
-            .containsExactly(newIndexSetConfig);
+                .isNotNull()
+                .hasSize(1)
+                .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -169,12 +176,12 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isEmpty();
+                .isNotNull()
+                .isEmpty();
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isEmpty();
+                .isNotNull()
+                .isEmpty();
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -188,16 +195,16 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isNotEmpty()
-            .hasSize(1)
-            .containsExactly(indexSet);
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1)
+                .containsExactly(indexSet);
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isNotEmpty()
-            .hasSize(1)
-            .containsExactly(indexSet);
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1)
+                .containsExactly(indexSet);
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -211,18 +218,18 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isNotEmpty()
-            .hasSize(1)
-            .containsExactly(indexSet);
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1)
+                .containsExactly(indexSet);
 
         this.indexSetsCache.invalidate();
 
         assertThat(this.indexSetRegistry.getAll())
-            .isNotNull()
-            .isNotEmpty()
-            .hasSize(1)
-            .containsExactly(indexSet);
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1)
+                .containsExactly(indexSet);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -265,5 +272,96 @@ public class MongoIndexSetRegistryTest {
         when(indexSet.isManagedIndex("index")).thenReturn(false);
 
         assertThat(indexSetRegistry.isManagedIndex("index")).isFalse();
+    }
+
+    @Test
+    public void isCurrentWriteIndexSingleIndexSetConfigHappyPath() {
+        final String idxName = "index";
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = Collections.singletonList(indexSetConfig);
+        final MongoIndexSet indexSet = mock(MongoIndexSet.class);
+        when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+        //End caching
+        when(indexSet.isManagedIndex(idxName)).thenReturn(true);
+        when(indexSet.getActiveWriteIndex()).thenReturn(idxName);
+        assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isTrue();
+
+        verify(indexSet).isManagedIndex(idxName);
+        verify(indexSet).getActiveWriteIndex();
+        verifyNoMoreInteractions(indexSetConfig, indexSet);
+    }
+
+    @Test
+    public void isCurrentWriteIndexSingleIndexSetConfigNoneFound() {
+        final String idxName = "index";
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = Collections.singletonList(indexSetConfig);
+        final MongoIndexSet indexSet = mock(MongoIndexSet.class);
+        when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+        //End caching
+        when(indexSet.getActiveWriteIndex()).thenReturn("non_existing_index");
+        assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isFalse();
+
+        verify(indexSet).isManagedIndex(idxName);
+        verify(indexSetService).findAll();
+        verifyNoMoreInteractions(indexSetConfig, indexSet);
+    }
+
+    @Test
+    public void isCurrentWriteIndex500IndexSetConfigNoneFoundDueToMismatchingIndexName() {
+        final String idxName = "index";
+        final int noOfIndices = 500;
+        // The following constructs are necessary, because internally the IndexSetConfigs are handled as Set.
+        // Simply mocking a gazillion of them would de-duplicate, rendering the entire test useless.
+        final List<IndexSetConfig> indexSetConfigs = mkIndexSetConfigs(noOfIndices);
+        final ImmutableSet.Builder<MongoIndexSet> mockedMongosBuilder = ImmutableSet.builder();
+        final AtomicReference<MongoIndexSet> matchingMongoMock = new AtomicReference<>();
+        when(mongoIndexSetFactory.create(any(IndexSetConfig.class)))
+                .thenAnswer((Answer<MongoIndexSet>) invocation -> {
+                    Object[] args = invocation.getArguments();
+                    final IndexSetConfig cfg = (IndexSetConfig) args[0];
+                    final MongoIndexSet mockedIndexSet = mock(MongoIndexSet.class);
+                    when(mockedIndexSet.getConfig()).thenReturn(cfg);
+                    final int currentIndex = Integer.parseInt(Objects.requireNonNull(cfg.id()));
+                    if (currentIndex == noOfIndices - 1) {
+                        when(mockedIndexSet.getActiveWriteIndex()).thenReturn(cfg.indexPrefix() + "_0");
+                        //Let the last MongoIndexSet be the one responsible to the index we're looking for:
+                        when(mockedIndexSet.isManagedIndex(idxName)).thenReturn(true);
+                        matchingMongoMock.getAndSet(mockedIndexSet);
+                    }
+                    mockedMongosBuilder.add(mockedIndexSet);
+                    return mockedIndexSet;
+                }
+                );
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+        assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isFalse();
+
+        final ImmutableSet<MongoIndexSet> mockedMongos = mockedMongosBuilder.build();
+        mockedMongos.forEach(mockedMongo -> verify(mockedMongo).isManagedIndex(idxName));
+        verify(matchingMongoMock.get()).getActiveWriteIndex();
+        verifyNoMoreInteractions(mockedMongos.toArray(new Object[0]));
+    }
+
+    private List<IndexSetConfig> mkIndexSetConfigs(final int howMany) {
+        final ImmutableList.Builder<IndexSetConfig> configs = ImmutableList.builder();
+        for (int i = 0; i < howMany; i++) {
+            configs.add(IndexSetConfig.builder()
+                    .id(String.valueOf(i))
+                    .title("title " + i)
+                    .indexPrefix("index" + i)
+                    .shards(1)
+                    .replicas(0)
+                    .creationDate(ZonedDateTime.now())
+                    .indexOptimizationMaxNumSegments(1)
+                    .indexOptimizationDisabled(false)
+                    .indexAnalyzer("any")
+                    .indexTemplateName("template" + i)
+                    .build()
+            );
+
+        }
+        return configs.build();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,15 +74,15 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(indexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
 
         final List<IndexSetConfig> cachedResult = this.indexSetsCache.get();
         assertThat(cachedResult)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(indexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -94,9 +95,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(indexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
 
         this.indexSetsCache.invalidate();
 
@@ -107,9 +108,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(newIndexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -122,9 +123,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(indexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
 
         this.indexSetsCache.handleIndexSetCreation(mock(IndexSetCreatedEvent.class));
 
@@ -135,9 +136,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(newIndexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -150,9 +151,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> result = this.indexSetsCache.get();
         assertThat(result)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(indexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
 
         this.indexSetsCache.handleIndexSetDeletion(mock(IndexSetDeletedEvent.class));
 
@@ -163,9 +164,9 @@ public class MongoIndexSetRegistryTest {
 
         final List<IndexSetConfig> newResult = this.indexSetsCache.get();
         assertThat(newResult)
-                .isNotNull()
-                .hasSize(1)
-                .containsExactly(newIndexSetConfig);
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -176,12 +177,12 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isEmpty();
+            .isNotNull()
+            .isEmpty();
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isEmpty();
+            .isNotNull()
+            .isEmpty();
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -195,16 +196,16 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1)
-                .containsExactly(indexSet);
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1)
-                .containsExactly(indexSet);
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
 
         verify(indexSetService, times(1)).findAll();
     }
@@ -218,18 +219,18 @@ public class MongoIndexSetRegistryTest {
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1)
-                .containsExactly(indexSet);
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
 
         this.indexSetsCache.invalidate();
 
         assertThat(this.indexSetRegistry.getAll())
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1)
-                .containsExactly(indexSet);
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
 
         verify(indexSetService, times(2)).findAll();
     }
@@ -282,7 +283,6 @@ public class MongoIndexSetRegistryTest {
         final MongoIndexSet indexSet = mock(MongoIndexSet.class);
         when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
-        //End caching
         when(indexSet.isManagedIndex(idxName)).thenReturn(true);
         when(indexSet.getActiveWriteIndex()).thenReturn(idxName);
         assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isTrue();
@@ -300,8 +300,7 @@ public class MongoIndexSetRegistryTest {
         final MongoIndexSet indexSet = mock(MongoIndexSet.class);
         when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
-        //End caching
-        when(indexSet.getActiveWriteIndex()).thenReturn("non_existing_index");
+        lenient().when(indexSet.getActiveWriteIndex()).thenReturn("non_existing_index");
         assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isFalse();
 
         verify(indexSet).isManagedIndex(idxName);
@@ -323,7 +322,7 @@ public class MongoIndexSetRegistryTest {
                             Object[] args = invocation.getArguments();
                             final IndexSetConfig cfg = (IndexSetConfig) args[0];
                             final MongoIndexSet mockedIndexSet = mock(MongoIndexSet.class);
-                            when(mockedIndexSet.getConfig()).thenReturn(cfg);
+                            lenient().when(mockedIndexSet.getConfig()).thenReturn(cfg);
                             final int currentIndex = Integer.parseInt(Objects.requireNonNull(cfg.id()));
                             if (currentIndex == noOfIndices - 1) {
                                 when(mockedIndexSet.getActiveWriteIndex()).thenReturn(cfg.indexPrefix() + "_0");

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -309,9 +309,9 @@ public class MongoIndexSetRegistryTest {
     }
 
     @Test
-    public void isCurrentWriteIndex500IndexSetConfigNoneFoundDueToMismatchingIndexName() {
+    public void isCurrentWriteIndexOnManyIndexSetConfigsNoneFoundDueToMismatchingIndexName() {
         final String idxName = "index";
-        final int noOfIndices = 500;
+        final int noOfIndices = 2;
         // The following constructs are necessary, because internally the IndexSetConfigs are handled as Set.
         // Simply mocking a gazillion of them would de-duplicate, rendering the entire test useless.
         final List<IndexSetConfig> indexSetConfigs = mkIndexSetConfigs(noOfIndices);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -320,20 +320,20 @@ public class MongoIndexSetRegistryTest {
         final AtomicReference<MongoIndexSet> matchingMongoMock = new AtomicReference<>();
         when(mongoIndexSetFactory.create(any(IndexSetConfig.class)))
                 .thenAnswer((Answer<MongoIndexSet>) invocation -> {
-                    Object[] args = invocation.getArguments();
-                    final IndexSetConfig cfg = (IndexSetConfig) args[0];
-                    final MongoIndexSet mockedIndexSet = mock(MongoIndexSet.class);
-                    when(mockedIndexSet.getConfig()).thenReturn(cfg);
-                    final int currentIndex = Integer.parseInt(Objects.requireNonNull(cfg.id()));
-                    if (currentIndex == noOfIndices - 1) {
-                        when(mockedIndexSet.getActiveWriteIndex()).thenReturn(cfg.indexPrefix() + "_0");
-                        //Let the last MongoIndexSet be the one responsible to the index we're looking for:
-                        when(mockedIndexSet.isManagedIndex(idxName)).thenReturn(true);
-                        matchingMongoMock.getAndSet(mockedIndexSet);
-                    }
-                    mockedMongosBuilder.add(mockedIndexSet);
-                    return mockedIndexSet;
-                }
+                            Object[] args = invocation.getArguments();
+                            final IndexSetConfig cfg = (IndexSetConfig) args[0];
+                            final MongoIndexSet mockedIndexSet = mock(MongoIndexSet.class);
+                            when(mockedIndexSet.getConfig()).thenReturn(cfg);
+                            final int currentIndex = Integer.parseInt(Objects.requireNonNull(cfg.id()));
+                            if (currentIndex == noOfIndices - 1) {
+                                when(mockedIndexSet.getActiveWriteIndex()).thenReturn(cfg.indexPrefix() + "_0");
+                                //Let the last MongoIndexSet be the one responsible to the index we're looking for:
+                                when(mockedIndexSet.isManagedIndex(idxName)).thenReturn(true);
+                                matchingMongoMock.getAndSet(mockedIndexSet);
+                            }
+                            mockedMongosBuilder.add(mockedIndexSet);
+                            return mockedIndexSet;
+                        }
                 );
         when(indexSetService.findAll()).thenReturn(indexSetConfigs);
         assertThat(indexSetRegistry.isCurrentWriteIndex(idxName)).isFalse();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't iterate over all IndexSets for a given indexName, instead use `getForIndex(String)` directly to avoid unnecessary calls. Also converted some loops to streaming for further cleanup of the code.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #18563.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There's an new test to simulate having 500 IndexSets and checking if only the one responsible for a given specific index is being called.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

