### PR TITLE
Fix input configuration encryption error

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog2/inputs/InputCreationIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/inputs/InputCreationIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.inputs;
+
+import org.graylog.testing.completebackend.Lifecycle;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS)
+public class InputCreationIT {
+
+    private final GraylogApis apis;
+
+    public InputCreationIT(GraylogApis apis) {
+        this.apis = apis;
+    }
+
+    @ContainerMatrixTest
+    void testHttpRandomInputCreation() {
+        String inputId = apis.inputs().createGlobalInput("testInput",
+                "org.graylog2.inputs.random.FakeHttpMessageInput",
+                Map.of("sleep", 30,
+                        "sleep_deviation", 30,
+                        "source", "example.org"));
+        apis.inputs().getInput(inputId)
+                .assertThat().body("title", equalTo("testInput"));
+        apis.waitFor(() ->
+                        apis.inputs().getInputState(inputId)
+                                .extract().body().jsonPath().get("state")
+                                .equals("RUNNING"),
+                "Timed out waiting for HTTP Random Message Input to become available");
+        apis.inputs().deleteInput(inputId);
+    }
+
+    /**
+     * Test to make sure configuration encryption serialization/deserialization works
+     */
+    @ContainerMatrixTest
+    void testFailingAwsCloudTrailInputCreation() {
+        String inputId = apis.inputs().createGlobalInput("testInput",
+                "org.graylog.aws.inputs.cloudtrail.CloudTrailInput",
+                Map.of("aws_sqs_region", "us-east-1",
+                        "aws_s3_region", "us-east-1",
+                        "aws_sqs_queue_name", "invalid-queue-no-messages-read",
+                        "aws_access_key", "invalid-access-key",
+                        "aws_secret_key", "invalid-secret-key"));
+        apis.inputs().getInput(inputId)
+                .assertThat().body("attributes.aws_access_key", equalTo("invalid-access-key"));
+        apis.waitFor(() ->
+                        apis.inputs().getInputState(inputId)
+                                .extract().body().jsonPath().get("state")
+                                .equals("FAILING"),
+                "Timed out waiting for AWS CloudTrail Input to reach failing state");
+        apis.inputs().deleteInput(inputId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/CommonNodeConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/CommonNodeConfiguration.java
@@ -51,6 +51,11 @@ public interface CommonNodeConfiguration extends GraylogNodeConfiguration {
     }
 
     @Override
+    default boolean withInputs() {
+        return false;
+    }
+
+    @Override
     default Set<ServerStatus.Capability> withCapabilities() {
         return Set.of(ServerStatus.Capability.SERVER);
     }

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -670,4 +670,9 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
     public boolean withPlugins() {
         return true;
     }
+
+    @Override
+    public boolean withInputs() {
+        return true;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/GraylogNodeConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/GraylogNodeConfiguration.java
@@ -52,6 +52,11 @@ public interface GraylogNodeConfiguration {
     boolean withNodeIdFile();
 
     /**
+     * Will only bind an InputConfigurationDeserializerModifier stub if there are no inputs configured
+     */
+    boolean withInputs();
+
+    /**
      * Provides the {@link ServerStatus.Capability} to be used by ServerStatusBindings.
      */
     Set<ServerStatus.Capability> withCapabilities();

--- a/graylog2-server/src/main/java/org/graylog2/bindings/GraylogNodeModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/GraylogNodeModule.java
@@ -78,7 +78,9 @@ public class GraylogNodeModule extends Graylog2Module {
         install(new ServerStatusBindings(configuration.withCapabilities()));
 
         bind(EncryptedValueService.class).asEagerSingleton();
-        bind(InputConfigurationBeanDeserializerModifier.class).toInstance(InputConfigurationBeanDeserializerModifier.withoutConfig());
+        if (!configuration.withInputs()) {
+            bind(InputConfigurationBeanDeserializerModifier.class).toInstance(InputConfigurationBeanDeserializerModifier.withoutConfig());
+        }
     }
 
     public Set<Object> getConfigurationBeans() {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.testing.completebackend.GraylogBackend;
 import org.graylog.testing.completebackend.apis.inputs.GelfInputApi;
+import org.graylog.testing.completebackend.apis.inputs.Inputs;
 import org.graylog.testing.completebackend.apis.inputs.PortBoundGelfInputApi;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -67,6 +68,7 @@ public class GraylogApis implements GraylogRestApi {
     private final EventDefinitions eventDefinitions;
     private final Dashboards dashboards;
     private final Pipelines pipelines;
+    private final Inputs inputs;
 
     public GraylogApis(GraylogBackend backend) {
         this.backend = backend;
@@ -83,6 +85,7 @@ public class GraylogApis implements GraylogRestApi {
         this.eventDefinitions = new EventDefinitions(this);
         this.dashboards = new Dashboards(this);
         this.pipelines = new Pipelines(this);
+        this.inputs = new Inputs(this);
     }
 
     public RequestSpecification requestSpecification() {
@@ -154,6 +157,10 @@ public class GraylogApis implements GraylogRestApi {
 
     public Pipelines pipelines() {
         return pipelines;
+    }
+
+    public Inputs inputs() {
+        return inputs;
     }
 
     protected RequestSpecification prefix(final Users.User user) {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/inputs/Inputs.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/inputs/Inputs.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.completebackend.apis.inputs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.restassured.response.ValidatableResponse;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.GraylogRestApi;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class Inputs implements GraylogRestApi {
+
+    private final GraylogApis api;
+
+    public Inputs(GraylogApis api) {
+        this.api = api;
+    }
+
+    record CreateInputRequest(@JsonProperty("title") String title,
+                              @JsonProperty("type") String type,
+                              @JsonProperty("global") boolean global,
+                              @JsonProperty("configuration") Map<String, Object> configuration) {}
+
+    public String createGlobalInput(String title, String type, Map<String, Object> configuration) {
+        final CreateInputRequest body = new CreateInputRequest(title, type, true, configuration);
+        return given().
+                spec(api.requestSpecification())
+                .when()
+                .body(body)
+                .post("/system/inputs")
+                .then()
+                .log().ifError()
+                .statusCode(201)
+                .assertThat().body("id", notNullValue())
+                .extract().body().jsonPath().getString("id");
+    }
+
+    public ValidatableResponse getInput(String inputId) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .get("/system/inputs/" + inputId)
+                .then()
+                .log().ifError()
+                .statusCode(200);
+    }
+
+    public ValidatableResponse getInputState(String inputId) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .get("/system/inputstates/" + inputId)
+                .then()
+                .log().ifError()
+                .statusCode(200);
+    }
+
+    public ValidatableResponse deleteInput(String inputId) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .delete("/system/inputs/" + inputId)
+                .then()
+                .log().ifError()
+                .statusCode(204);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/commands/MinimalNodeCommandTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/commands/MinimalNodeCommandTest.java
@@ -123,6 +123,11 @@ public class MinimalNodeCommandTest {
             public boolean isMessageRecordingsEnabled() {
                 return false;
             }
+
+            @Override
+            public boolean withInputs() {
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a regression introduced by https://github.com/Graylog2/graylog2-server/pull/20181 that produced an error when configuring inputs with encrypted configuration values.
This was caused by binding InputConfigurationBeanDeserializerModifier without config explicitly.
The change introduces a configuration parameter `withInputs()` that avoids the static binding for nodes which run inputs.

/nocl

## How Has This Been Tested?
- create AWS cloud trail input manually
- added IT which creates and tries to read the created input to ensure serialization/deserialization without errors

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

