### PR TITLE
add archive restore retry on mapper parsing exception

### DIFF
--- a/changelog/unreleased/pr-21197.toml
+++ b/changelog/unreleased/pr-21197.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Add archive restore retry on mapper parsing exception."
+
+issues = ["graylog-plugin-enterprise#9208"]
+pulls = ["graylog-plugin-enterprise#9413, 21197"]

--- a/changelog/unreleased/pr-21197.toml
+++ b/changelog/unreleased/pr-21197.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Add archive restore retry on mapper parsing exception."
 
 issues = ["graylog-plugin-enterprise#9208"]
-pulls = ["21197"]
+pulls = ["21197", "Graylog2/graylog-plugin-enterprise#9413"]

--- a/changelog/unreleased/pr-21197.toml
+++ b/changelog/unreleased/pr-21197.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Add archive restore retry on mapper parsing exception."
 
 issues = ["graylog-plugin-enterprise#9208"]
-pulls = ["graylog-plugin-enterprise#9413, 21197"]
+pulls = ["21197"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -42,6 +42,7 @@ import org.graylog.storage.errors.ResponseError;
 import org.graylog2.indexer.BatchSizeTooLargeException;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.InvalidWriteTargetException;
+import org.graylog2.indexer.MapperParsingException;
 import org.graylog2.indexer.MasterNotDiscoveredException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,6 +203,9 @@ public class ElasticsearchClient {
             if (isBatchSizeTooLargeException(elasticsearchException)) {
                 throw new BatchSizeTooLargeException(elasticsearchException.getMessage());
             }
+            if (isMapperParsingExceptionException(elasticsearchException)) {
+                throw new MapperParsingException(elasticsearchException.getMessage());
+            }
         } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
             throw new BatchSizeTooLargeException(e.getMessage());
         }
@@ -229,6 +233,10 @@ public class ElasticsearchClient {
 
     private boolean isIndexNotFoundException(ElasticsearchException elasticsearchException) {
         return elasticsearchException.getMessage().contains("index_not_found_exception");
+    }
+
+    private boolean isMapperParsingExceptionException(ElasticsearchException openSearchException) {
+        return openSearchException.getMessage().contains("mapper_parsing_exception");
     }
 
     private boolean isBatchSizeTooLargeException(ElasticsearchException elasticsearchException) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
@@ -42,6 +42,7 @@ import org.graylog.storage.errors.ResponseError;
 import org.graylog2.indexer.BatchSizeTooLargeException;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.InvalidWriteTargetException;
+import org.graylog2.indexer.MapperParsingException;
 import org.graylog2.indexer.MasterNotDiscoveredException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -202,6 +203,9 @@ public class OpenSearchClient {
             if (isBatchSizeTooLargeException(openSearchException)) {
                 throw new BatchSizeTooLargeException(openSearchException.getMessage());
             }
+            if (isMapperParsingExceptionException(openSearchException)) {
+                throw new MapperParsingException(openSearchException.getMessage());
+            }
         } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
             throw new BatchSizeTooLargeException(e.getMessage());
         }
@@ -229,6 +233,10 @@ public class OpenSearchClient {
 
     private boolean isIndexNotFoundException(OpenSearchException openSearchException) {
         return openSearchException.getMessage().contains("index_not_found_exception");
+    }
+
+    private boolean isMapperParsingExceptionException(OpenSearchException openSearchException) {
+        return openSearchException.getMessage().contains("mapper_parsing_exception");
     }
 
     private boolean isBatchSizeTooLargeException(OpenSearchException openSearchException) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MapperParsingException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MapperParsingException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.indexer;
+
+public class MapperParsingException extends ElasticsearchException {
+    public MapperParsingException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since this [PR](https://github.com/Graylog2/graylog-plugin-enterprise/pull/9271), we save the mapping in the `archive-metadata.json` file and use this mapping to create an index. The problem is that if a mapping contains field properties that reference a field from the index settings, this leads to an error. We have therefore started to also store the index settings in the `archive-metadata.json` and apply them during index creation. This has been done in this [PR](https://github.com/Graylog2/graylog-plugin-enterprise/pull/9271). Unfortunately, there is still an error case for archives that do not contain any settings. For this scenario, this PR implements a retry with default mappings/settings if such an error occurs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



companion PR:
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#9413