### PR TITLE
Fix to load indices status in batches so that the URL used to call OpenSearch does not exceed maximum length

### DIFF
--- a/changelog/unreleased/pr-21208.toml
+++ b/changelog/unreleased/pr-21208.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "batching request for index block status if the combined length of the indices exceed the max possible URL length "
+
+pulls = ["21208"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -445,11 +445,12 @@ public class IndicesAdapterES7 implements IndicesAdapter {
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
                 .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
 
-        final GetSettingsRequest getSettingsRequest = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH ? request : request.indices(indices.toArray(new String[]{}));
+        final var maxLengthExceeded = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH;
+        final GetSettingsRequest getSettingsRequest = maxLengthExceeded ? request : request.indices(indices.toArray(new String[]{}));
 
         return client.execute((c, requestOptions) -> {
             final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-            return BlockSettingsParser.parseBlockSettings(settingsResponse);
+            return BlockSettingsParser.parseBlockSettings(settingsResponse, maxLengthExceeded ? Optional.of(indices) : Optional.empty());
         });
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -441,23 +441,16 @@ public class IndicesAdapterES7 implements IndicesAdapter {
             throw new IllegalArgumentException("Expecting list of indices with at least one index present.");
         }
 
-        if(String.join(",", indices).length() > MAX_INDICES_URL_LENGTH) {
-            final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
-                    .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                    .names(new String[]{});
-            final GetSettingsResponse settingsResponse = client.execute((c, requestOptions) -> c.indices().getSettings(getSettingsRequest, requestOptions));
-            return BlockSettingsParser.parseBlockSettings(settingsResponse, Optional.of(indices));
-        } else {
-            final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
-                    .indices(indices.toArray(new String[]{}))
-                    .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                    .names(new String[]{});
+        final GetSettingsRequest request = new GetSettingsRequest()
+                .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
+                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
 
-            return client.execute((c, requestOptions) -> {
-                final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-                return BlockSettingsParser.parseBlockSettings(settingsResponse);
-            });
-        }
+        final GetSettingsRequest getSettingsRequest = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH ? request : request.indices(indices.toArray(new String[]{}));
+
+        return client.execute((c, requestOptions) -> {
+            final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
+            return BlockSettingsParser.parseBlockSettings(settingsResponse);
+        });
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -443,7 +443,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         final GetSettingsRequest request = new GetSettingsRequest()
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
+                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata", "index.blocks.read_only", "index.blocks.read_only_allow_delete");
 
         final var maxLengthExceeded = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH;
         final GetSettingsRequest getSettingsRequest = maxLengthExceeded ? request : request.indices(indices.toArray(new String[]{}));

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -445,23 +445,16 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
             throw new IllegalArgumentException("Expecting list of indices with at least one index present.");
         }
 
-        if(String.join(",", indices).length() > MAX_INDICES_URL_LENGTH) {
-            final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
-                    .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                    .names(new String[]{});
-            final GetSettingsResponse settingsResponse = client.execute((c, requestOptions) -> c.indices().getSettings(getSettingsRequest, requestOptions));
-            return BlockSettingsParser.parseBlockSettings(settingsResponse, Optional.of(indices));
-        } else {
-            final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
-                    .indices(indices.toArray(new String[]{}))
-                    .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                    .names(new String[]{});
+        final GetSettingsRequest request = new GetSettingsRequest()
+                .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
+                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
 
-            return client.execute((c, requestOptions) -> {
-                final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-                return BlockSettingsParser.parseBlockSettings(settingsResponse);
-            });
-        }
+        final GetSettingsRequest getSettingsRequest = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH ? request : request.indices(indices.toArray(new String[]{}));
+
+        return client.execute((c, requestOptions) -> {
+            final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
+            return BlockSettingsParser.parseBlockSettings(settingsResponse);
+        });
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -442,7 +442,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
         List<String> partition = new ArrayList<>();
         int length = 0;
         for(String index: indices) {
-            if(length > MAX_INDICES_URL_PART_LENGTH) {
+            if(length + index.length() > MAX_INDICES_URL_PART_LENGTH) {
                 partitions.add(partition);
                 partition = new ArrayList<>();
             }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -114,7 +114,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     // this is the maximum amount of bytes that the index list is supposed to fill in a request,
     // it assumes that these don't need url encoding. If we exceed the maximum, we request settings for all indices
     // and filter after wards
-    private final int MAX_INDICES_URL_LENGTH = 3000;
+    private final int MAX_INDICES_URL_LENGTH = 20;
 
     @Inject
     public IndicesAdapterOS2(OpenSearchClient client,
@@ -447,7 +447,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
 
         final GetSettingsRequest request = new GetSettingsRequest()
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
+                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata", "index.blocks.read_only", "index.blocks.read_only_allow_delete");
 
         final var maxLengthExceeded = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH;
         final GetSettingsRequest getSettingsRequest = maxLengthExceeded ? request : request.indices(indices.toArray(new String[]{}));

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -114,7 +114,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     // this is the maximum amount of bytes that the index list is supposed to fill in a request,
     // it assumes that these don't need url encoding. If we exceed the maximum, we request settings for all indices
     // and filter after wards
-    private final int MAX_INDICES_URL_LENGTH = 20;
+    private final int MAX_INDICES_URL_LENGTH = 3000;
 
     @Inject
     public IndicesAdapterOS2(OpenSearchClient client,

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -445,6 +445,7 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
             if(length + index.length() > MAX_INDICES_URL_PART_LENGTH) {
                 partitions.add(partition);
                 partition = new ArrayList<>();
+                length = 0;
             }
             length += index.length();
             partition.add(index);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -449,11 +449,12 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
                 .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata");
 
-        final GetSettingsRequest getSettingsRequest = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH ? request : request.indices(indices.toArray(new String[]{}));
+        final var maxLengthExceeded = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH;
+        final GetSettingsRequest getSettingsRequest = maxLengthExceeded ? request : request.indices(indices.toArray(new String[]{}));
 
         return client.execute((c, requestOptions) -> {
             final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-            return BlockSettingsParser.parseBlockSettings(settingsResponse);
+            return BlockSettingsParser.parseBlockSettings(settingsResponse, maxLengthExceeded ? Optional.of(indices) : Optional.empty());
         });
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
@@ -20,6 +20,8 @@ import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,22 +29,32 @@ public class BlockSettingsParser {
 
     static final String BLOCK_SETTINGS_PREFIX = "index.blocks.";
 
-    public static void parseBlockSettings(final IndicesBlockStatus result, final GetSettingsResponse settingsResponse) {
-        final var indexToSettingsMap = settingsResponse.getIndexToSettings();
-        final String[] indicesInResponse = indexToSettingsMap.keySet().toArray(new String[0]);
-        for (String index : indicesInResponse) {
-            final Settings blockSettings = indexToSettingsMap.get(index).getByPrefix(BLOCK_SETTINGS_PREFIX);
+    public static IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse) {
+        return parseBlockSettings(settingsResponse, Optional.empty());
+    }
 
-            if (!blockSettings.isEmpty()) {
-                final Set<String> blockSettingsNames = blockSettings.names();
-                final Set<String> blockSettingsSetToTrue = blockSettingsNames.stream()
-                        .filter(s -> blockSettings.getAsBoolean(s, false))
-                        .map(s -> BLOCK_SETTINGS_PREFIX + s)
-                        .collect(Collectors.toSet());
-                if (!blockSettingsSetToTrue.isEmpty()) {
-                    result.addIndexBlocks(index, blockSettingsSetToTrue);
+    public static IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse, final Optional<List<String>> indices) {
+        final IndicesBlockStatus result = new IndicesBlockStatus();
+        final var indexToSettingsMap = settingsResponse.getIndexToSettings();
+
+        indices.orElse(indexToSettingsMap.keySet().stream().toList()).forEach(index -> {
+            final var settings = indexToSettingsMap.get(index);
+            if(settings != null) {
+                final Settings blockSettings = settings.getByPrefix(BLOCK_SETTINGS_PREFIX);
+
+                if (!blockSettings.isEmpty()) {
+                    final Set<String> blockSettingsNames = blockSettings.names();
+                    final Set<String> blockSettingsSetToTrue = blockSettingsNames.stream()
+                            .filter(s -> blockSettings.getAsBoolean(s, false))
+                            .map(s -> BLOCK_SETTINGS_PREFIX + s)
+                            .collect(Collectors.toSet());
+                    if (!blockSettingsSetToTrue.isEmpty()) {
+                        result.addIndexBlocks(index, blockSettingsSetToTrue);
+                    }
                 }
             }
-        }
+        });
+
+        return result;
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
@@ -27,8 +27,7 @@ public class BlockSettingsParser {
 
     static final String BLOCK_SETTINGS_PREFIX = "index.blocks.";
 
-    public static IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse) {
-        IndicesBlockStatus result = new IndicesBlockStatus();
+    public static void parseBlockSettings(final IndicesBlockStatus result, final GetSettingsResponse settingsResponse) {
         final var indexToSettingsMap = settingsResponse.getIndexToSettings();
         final String[] indicesInResponse = indexToSettingsMap.keySet().toArray(new String[0]);
         for (String index : indicesInResponse) {
@@ -45,7 +44,5 @@ public class BlockSettingsParser {
                 }
             }
         }
-
-        return result;
     }
 }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
@@ -35,7 +35,8 @@ public class BlockSettingsParserTest {
     @Test
     public void noBlockedIndicesIdentifiedIfEmptyResponseParsed() {
         GetSettingsResponse emptyResponse = new GetSettingsResponse(Map.of(), Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptyResponse);
+        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
+        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, emptyResponse);
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -44,7 +45,8 @@ public class BlockSettingsParserTest {
     public void noBlockedIndicesIdentifiedIfEmptySettingsPresent() {
         var settingsBuilder = Map.of("index_0", Settings.builder().build());
         GetSettingsResponse emptySettingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptySettingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
+        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, emptySettingsResponse);
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -64,7 +66,8 @@ public class BlockSettingsParserTest {
                         .put("index.blocks.read_only_allow_delete", true)
                         .build());
         GetSettingsResponse settingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(settingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
+        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, settingsResponse);
         assertNotNull(indicesBlockStatus);
         assertEquals(3, indicesBlockStatus.countBlockedIndices());
         final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -35,8 +36,7 @@ public class BlockSettingsParserTest {
     @Test
     public void noBlockedIndicesIdentifiedIfEmptyResponseParsed() {
         GetSettingsResponse emptyResponse = new GetSettingsResponse(Map.of(), Map.of());
-        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
-        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, emptyResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptyResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -45,8 +45,7 @@ public class BlockSettingsParserTest {
     public void noBlockedIndicesIdentifiedIfEmptySettingsPresent() {
         var settingsBuilder = Map.of("index_0", Settings.builder().build());
         GetSettingsResponse emptySettingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
-        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, emptySettingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptySettingsResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -66,8 +65,7 @@ public class BlockSettingsParserTest {
                         .put("index.blocks.read_only_allow_delete", true)
                         .build());
         GetSettingsResponse settingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = new IndicesBlockStatus();
-        BlockSettingsParser.parseBlockSettings(indicesBlockStatus, settingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(settingsResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(3, indicesBlockStatus.countBlockedIndices());
         final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prior to this PR, a call to `getIndicesBlocksStatus()`  would exceed to URL maximum of 4096 bytes if the number of indices would be large. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually by setting index.blocks on indices manually in OpenSearch and by reducing the threshold to a small amount that leads to reading all indices instead of only the list.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

