### PR TITLE
Allow custom filter components for paginated data table.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/FilterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/FilterConfiguration.tsx
@@ -16,28 +16,31 @@
  */
 import * as React from 'react';
 
-import type { Attribute } from 'stores/PaginationTypes';
-import type { Filters, Filter } from 'components/common/EntityFilters/types';
+import type { FilterComponentProps } from 'stores/PaginationTypes';
 import { MenuItem } from 'components/bootstrap';
 import {
   isAttributeWithFilterOptions,
-  isAttributeWithRelatedCollection, isDateAttribute,
+  isAttributeWithRelatedCollection, isDateAttribute, isCustomComponentFilter,
 } from 'components/common/EntityFilters/helpers/AttributeIdentification';
-import GenericFilterInput from 'components/common/EntityFilters/FilterConfiguration/GenericFilterInput';
 
+import SuggestionsListFilter from './SuggestionsListFilter';
+import GenericFilterInput from './GenericFilterInput';
 import StaticOptionsList from './StaticOptionsList';
-import SuggestionsList from './SuggestionsList';
 import DateRangeForm from './DateRangeForm';
 
-type Props = {
-  attribute: Attribute,
-  filter?: Filter,
-  filterValueRenderer: (value: Filter['value'], title: string) => React.ReactNode | undefined,
-  onSubmit: (filter: { title: string, value: string }, closeDropdown?: boolean) => void,
-  allActiveFilters: Filters | undefined,
-}
+const FilterComponent = ({ allActiveFilters, attribute, filter = undefined, filterValueRenderer, onSubmit }: FilterComponentProps) => {
+  if (isCustomComponentFilter(attribute)) {
+    const CustomFilterComponent = attribute.filter_component;
 
-const FilterComponent = ({ allActiveFilters, attribute, filter, filterValueRenderer, onSubmit }: Pick<Props, 'allActiveFilters' | 'attribute' | 'filter' | 'filterValueRenderer' | 'onSubmit'>) => {
+    return (
+      <CustomFilterComponent attribute={attribute}
+                             filterValueRenderer={filterValueRenderer}
+                             onSubmit={onSubmit}
+                             allActiveFilters={allActiveFilters}
+                             filter={filter} />
+    );
+  }
+
   if (isAttributeWithFilterOptions(attribute)) {
     return (
       <StaticOptionsList attribute={attribute}
@@ -49,11 +52,11 @@ const FilterComponent = ({ allActiveFilters, attribute, filter, filterValueRende
 
   if (isAttributeWithRelatedCollection(attribute)) {
     return (
-      <SuggestionsList attribute={attribute}
-                       filterValueRenderer={filterValueRenderer}
-                       onSubmit={onSubmit}
-                       allActiveFilters={allActiveFilters}
-                       filter={filter} />
+      <SuggestionsListFilter attribute={attribute}
+                             filterValueRenderer={filterValueRenderer}
+                             onSubmit={onSubmit}
+                             allActiveFilters={allActiveFilters}
+                             filter={filter} />
     );
   }
 
@@ -73,7 +76,7 @@ export const FilterConfiguration = ({
   filter = undefined,
   filterValueRenderer,
   onSubmit,
-}: Props) => (
+}: FilterComponentProps) => (
   <>
     <MenuItem header>{filter ? 'Edit' : 'Create'} {attribute.title.toLowerCase()} filter</MenuItem>
     <FilterComponent attribute={attribute}

--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/SuggestionsListFilter.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/SuggestionsListFilter.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useState } from 'react';
 

--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/SuggestionsListFilter.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/SuggestionsListFilter.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import type { Filters, Filter } from 'components/common/EntityFilters/types';
+import type { Attribute } from 'stores/PaginationTypes';
+import useFilterValueSuggestions from 'components/common/EntityFilters/hooks/useFilterValueSuggestions';
+
+import SuggestionsList from './SuggestionsList';
+
+type Props = {
+  allActiveFilters: Filters | undefined,
+  attribute: Attribute,
+  filter: Filter | undefined
+  filterValueRenderer: (value: unknown, title: string) => React.ReactNode | undefined,
+  onSubmit: (filter: { title: string, value: string }, closeDropdown: boolean) => void,
+}
+
+const DEFAULT_SEARCH_PARAMS = {
+  query: '',
+  pageSize: 10,
+  page: 1,
+};
+
+const SuggestionsListFilter = ({ attribute, filterValueRenderer, onSubmit, allActiveFilters, filter }: Props) => {
+  const [searchParams, setSearchParams] = useState(DEFAULT_SEARCH_PARAMS);
+  const { data: { pagination, suggestions }, isInitialLoading } = useFilterValueSuggestions(attribute.id, attribute.related_collection, searchParams, attribute.related_property);
+
+  return (
+    <SuggestionsList isLoading={isInitialLoading}
+                     total={pagination.total}
+                     pageSize={searchParams.pageSize}
+                     page={searchParams.page}
+                     setSearchParams={setSearchParams}
+                     allActiveFilters={allActiveFilters}
+                     attribute={attribute}
+                     filter={filter}
+                     filterValueRenderer={filterValueRenderer}
+                     onSubmit={onSubmit}
+                     suggestions={suggestions} />
+  );
+};
+
+export default SuggestionsListFilter;

--- a/graylog2-web-interface/src/components/common/EntityFilters/helpers/AttributeIdentification.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/helpers/AttributeIdentification.ts
@@ -19,3 +19,4 @@ import type { Attribute } from 'stores/PaginationTypes';
 export const isDateAttribute = ({ type }: Attribute) => type === 'DATE';
 export const isAttributeWithFilterOptions = ({ filter_options }: Attribute) => !!filter_options?.length;
 export const isAttributeWithRelatedCollection = ({ related_collection }: Attribute) => !!related_collection;
+export const isCustomComponentFilter = ({ filter_component }: Attribute) => !!filter_component;

--- a/graylog2-web-interface/src/stores/PaginationTypes.ts
+++ b/graylog2-web-interface/src/stores/PaginationTypes.ts
@@ -15,10 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type * as Immutable from 'immutable';
-import type { $PropertyType } from 'utility-types';
 
 import type { AdditionalQueries } from 'util/PaginationURL';
-import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
+import type { UrlQueryFilters, Filter, Filters } from 'components/common/EntityFilters/types';
 
 export type PaginatedResponseType = {
   count: number,
@@ -29,9 +28,9 @@ export type PaginatedResponseType = {
 };
 
 export type PaginatedListJSON = {
-  page: $PropertyType<Pagination, 'page'>,
-  per_page: $PropertyType<Pagination, 'perPage'>,
-  query: $PropertyType<Pagination, 'query'>,
+  page: Pagination['page'],
+  per_page: Pagination['perPage'],
+  query: Pagination['query'],
   total: number,
   count: number,
 };
@@ -72,6 +71,13 @@ export type SearchParams = {
   filters?: UrlQueryFilters
 }
 
+export type FilterComponentProps = {
+  attribute: Attribute,
+  filter?: Filter,
+  filterValueRenderer: (value: Filter['value'], title: string) => React.ReactNode | undefined,
+  onSubmit: (filter: { title: string, value: string }, closeDropdown?: boolean) => void,
+  allActiveFilters: Filters | undefined,
+}
 export type Attribute = {
   id: string,
   title: string,
@@ -80,7 +86,8 @@ export type Attribute = {
   hidden?: boolean,
   searchable?: boolean,
   filterable?: true,
-  filter_options?: Array<{ value: string, title: string }>
+  filter_options?: Array<{ value: string, title: string }>,
+  filter_component?: React.ComponentType<FilterComponentProps>,
   related_collection?: string,
   related_property?: string,
   permissions?: Array<string>,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is introducing the `filter_component` attribute for entities used by the paginated data table. This allows specifying custom components used for rendering a filter for this attribute. Obviously, this only works for attributes which are defined/extended in the frontend, not for backend definitions of attributes, as these cannot reference React components. The main use of this is to specify custom ways for filters in plugins.

/nocl Internal functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.