### PR TITLE
Allow multiple encrypted values in Input configurations

### DIFF
--- a/changelog/unreleased/pr-21217.toml
+++ b/changelog/unreleased/pr-21217.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed bug where inputs with multiple encrypted configuration values could not be saved."
+
+pulls = ["21217"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -544,7 +544,6 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
         for (Map.Entry<String, Object> x : doc.entrySet()) {
             if (x.getValue() instanceof EncryptedValue encryptedValue) {
                 doc.put(x.getKey(), objectMapper.convertValue(encryptedValue, TypeReferences.MAP_STRING_OBJECT));
-                return;
             }
         }
         super.fieldTransformations(doc);

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -164,6 +164,8 @@ public class InputServiceImplTest {
         final MessageInput.Config inputConfig = mock(MessageInput.Config.class);
         when(inputConfig.combinedRequestedConfiguration()).thenReturn(ConfigurationRequest.createWithFields(
                 new TextField("encrypted", "", "", "",
+                        ConfigurationField.Optional.OPTIONAL, true),
+                new TextField("encrypted2", "", "", "",
                         ConfigurationField.Optional.OPTIONAL, true)
         ));
         when(messageInputFactory.getConfig("test type")).thenReturn(Optional.of(
@@ -171,23 +173,30 @@ public class InputServiceImplTest {
         ));
 
         final EncryptedValue secret = encryptedValueService.encrypt("secret");
+        final EncryptedValue secret2 = encryptedValueService.encrypt("secret2");
         final String id = inputService.save(new InputImpl(Map.of(
                 FIELD_TYPE, "test type",
                 FIELD_TITLE, "test title",
                 FIELD_CREATED_AT, new Date(),
                 FIELD_CREATOR_USER_ID, "test creator",
                 FIELD_CONFIGURATION, Map.of(
-                        "encrypted", secret
+                        "encrypted", secret,
+                        "encrypted2", secret2
                 )
         )));
 
         assertThat(id).isNotBlank();
 
-        assertThat(inputService.find(id)).satisfies(input ->
-                assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {
-                    assertThat(value).isInstanceOf(EncryptedValue.class);
-                    assertThat(value).isEqualTo(secret);
-                }));
+        assertThat(inputService.find(id)).satisfies(input -> {
+            assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {
+                assertThat(value).isInstanceOf(EncryptedValue.class);
+                assertThat(value).isEqualTo(secret);
+            });
+            assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted2", value -> {
+                assertThat(value).isInstanceOf(EncryptedValue.class);
+                assertThat(value).isEqualTo(secret2);
+            });
+        });
 
         assertThat(inputService.allByType("test type")).hasSize(1).first().satisfies(input ->
                 assertThat(input.getConfiguration()).hasEntrySatisfying("encrypted", value -> {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove `return` from for loop when iterating over input configuration values so that multiple `EncryptedValue` fields can be supported

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The short-circuiting of this for-loop only allowed for one value in an input configuration to be an encrypted value. Any others would not be transformed and the input would fail to be saved to the DB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev env
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

