### PR TITLE
Using `http_external_uri` for Jersey context path.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -199,7 +199,7 @@ public class JerseyService extends AbstractIdleService {
                         configuration.getHttpTlsKeyPassword()) : null;
 
         final HostAndPort bindAddress = configuration.getHttpBindAddress();
-        final String contextPath = configuration.getHttpPublishUri().getPath();
+        final String contextPath = configuration.getHttpExternalUri().getPath();
         final URI listenUri = new URI(
                 configuration.getUriScheme(),
                 null,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the fix for #21015 in #21104 by using `http_external_uri` (which falls back to `http_publish_uri`) instead of `http_publish_uri` for configuring Jersey's context path.

Fixes #21104.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.