### PR TITLE
Adding "Replay Search" bulk action for alerts/events.

### DIFF
--- a/changelog/unreleased/pr-21262.toml
+++ b/changelog/unreleased/pr-21262.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Adding 'Replay Search' Bulk action to alerts & events."
+
+pulls = ["21262"]

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
@@ -39,7 +39,11 @@ import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_VISIBLE;
@@ -69,20 +73,38 @@ public class EventsResource extends RestResource implements PluginRestResource {
     @Path("{event_id}")
     @ApiOperation("Get event by ID")
     public Optional<EventsSearchResult.Event> getById(@ApiParam(name = "event_id") @PathParam("event_id") final String eventId) {
+        return searchByIds(List.of(eventId))
+                .stream()
+                .findFirst();
+    }
 
+    public record BulkEventsByIds(Collection<String> eventIds) {}
+
+    @POST
+    @Path("/byIds")
+    @ApiOperation("Get multiple events by IDs")
+    @NoAuditEvent("Does not change any data")
+    public Map<String, EventsSearchResult.Event> getByIds(@ApiParam(name = "body") BulkEventsByIds request) {
+        return searchByIds(request.eventIds())
+                .stream()
+                .collect(Collectors.toMap(event -> event.event().id(), event -> event));
+    }
+
+    private List<EventsSearchResult.Event> searchByIds(Collection<String> eventIds) {
+        final var query = eventIds.stream()
+                .map(eventId -> EventDto.FIELD_ID + ":" + eventId)
+                .collect(Collectors.joining(" OR "));
         final EventsSearchParameters parameters = EventsSearchParameters.builder()
                 .page(1)
-                .perPage(1)
+                .perPage(eventIds.size())
                 .timerange(RelativeRange.allTime())
-                .query(EventDto.FIELD_ID + ":" + eventId)
+                .query(query)
                 .filter(EventsSearchFilter.empty())
                 .sortBy(Message.FIELD_TIMESTAMP)
                 .sortDirection(EventsSearchParameters.SortDirection.DESC)
                 .build();
 
         final EventsSearchResult result = searchService.search(parameters, getSubject());
-        return result.events()
-                .stream()
-                .findFirst();
+        return result.events();
     }
 }

--- a/graylog2-web-interface/src/components/common/IconButton.tsx
+++ b/graylog2-web-interface/src/components/common/IconButton.tsx
@@ -44,7 +44,7 @@ const Wrapper = styled.button<{ disabled: boolean }>(({ theme, disabled }) => cs
 type Props = {
   focusable?: boolean,
   title: string,
-  onClick?: () => void,
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void,
   className?: string,
   name: IconName
   iconType?: IconType,
@@ -54,9 +54,9 @@ type Props = {
   size?: SizeProp,
 };
 
-const handleClick = (onClick: () => void | undefined) => {
+const handleClick = (onClick: (e: React.MouseEvent<HTMLButtonElement>) => void | undefined, e: React.MouseEvent<HTMLButtonElement>) => {
   if (typeof onClick === 'function') {
-    onClick();
+    onClick(e);
   }
 };
 
@@ -75,7 +75,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props>(({
            data-testid={dataTestId}
            title={title}
            aria-label={title}
-           onClick={() => handleClick(onClick)}
+           onClick={(e) => handleClick(onClick, e)}
            className={className}
            type="button"
            disabled={disabled}>

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -132,6 +132,10 @@ const ReplayedSearch = ({ total, completed, selectedEvent }: React.PropsWithChil
   return <ReplaySearch key={`replaying-search-for-event-${selectedEvent.event.id}`} event={selectedEvent.event} />;
 };
 
+const Headline = styled.h2`
+  margin-bottom: 10px;
+`;
+
 const BulkEventReplay = ({ initialEventIds, events: _events, onClose }: Props) => {
   const [events] = useState<Props['events']>(_events);
   const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
@@ -143,7 +147,7 @@ const BulkEventReplay = ({ initialEventIds, events: _events, onClose }: Props) =
   return (
     <Container>
       <EventsListSidebar>
-        <h3>Replay Search</h3>
+        <Headline>Replay Search</Headline>
         <p>
           The following list contains all of the events/alerts you selected in the previous step, allowing you to
           investigate the replayed search for each of them.

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
+import { useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import EventListItem from 'components/events/bulk-replay/EventListItem';
 import useSelectedEvents from 'components/events/bulk-replay/useSelectedEvents';
-
-import type { Event } from './types';
+import ReplaySearch from 'components/events/bulk-replay/ReplaySearch';
+import type { Event } from 'components/events/events/types';
 
 const Container = styled.div`
   display: flex;
@@ -12,6 +13,7 @@ const Container = styled.div`
 `;
 
 const EventsListSidebar = styled.div(({ theme }) => css`
+  flex-shrink: 0;
   position: relative;
   width: 25vw;
   height: 100%;
@@ -28,6 +30,7 @@ const EventsListSidebar = styled.div(({ theme }) => css`
 `);
 
 const ReplayedSearchContainer = styled.div`
+  width: 100%;
   overflow: auto;
   padding: 5px;
 `;
@@ -42,7 +45,8 @@ type Props = {
   events: { [eventId: string]: { event: Event } };
 }
 
-const BulkEventReplay = ({ initialEventIds, events }: Props) => {
+const BulkEventReplay = ({ initialEventIds, events: _events }: Props) => {
+  const [events] = useState<Props['events']>(_events);
   const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
   const selectedEvent = events?.[selectedId];
   const total = eventIds.length;
@@ -71,9 +75,7 @@ const BulkEventReplay = ({ initialEventIds, events }: Props) => {
       <ReplayedSearchContainer>
         {selectedEvent
           ? (
-            <span>
-              Replayed Search for {selectedEvent.event.id}: {selectedEvent.event.message}
-            </span>
+            <ReplaySearch key={`replaying-search-for-event-${selectedEvent.event.id}`} event={selectedEvent.event} />
           )
           : <span>You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.</span>}
       </ReplayedSearchContainer>

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -151,7 +151,8 @@ const BulkEventReplay = ({ initialEventIds, events: _events, onClose }: Props) =
         <i>Investigation of {completed}/{total} events completed.</i>
         <StyledList>
           {eventIds.map(({ id: eventId, status }) => (
-            <EventListItem event={events?.[eventId]?.event}
+            <EventListItem key={`bulk-replay-search-item-${eventId}`}
+                           event={events?.[eventId]?.event}
                            selected={eventId === selectedId}
                            done={status === 'DONE'}
                            removeItem={removeItem}

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -9,8 +9,8 @@ import type { Event } from 'components/events/events/types';
 import Button from 'components/bootstrap/Button';
 import DropdownButton from 'components/bootstrap/DropdownButton';
 import useEventBulkActions from 'components/events/events/hooks/useEventBulkActions';
-
-import ButtonToolbar from '../../bootstrap/ButtonToolbar';
+import Center from 'components/common/Center';
+import ButtonToolbar from 'components/bootstrap/ButtonToolbar';
 
 const Container = styled.div`
   display: flex;
@@ -84,6 +84,38 @@ const RemainingBulkActions = ({ completed, events }: RemainingBulkActionsProps) 
   );
 };
 
+const ReplayedSearch = ({ total, completed, selectedEvent }: React.PropsWithChildren<{
+  total: number;
+  completed: number;
+  selectedEvent: { event: Event } | undefined;
+}>) => {
+  if (total === 0) {
+    return (
+      <Center>
+        You have removed all events from the list. You can now return back by clicking the &ldquo;Close&rdquo; button.
+      </Center>
+    );
+  }
+
+  if (!selectedEvent && total === completed) {
+    return (
+      <Center>
+        You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.
+      </Center>
+    );
+  }
+
+  if (!selectedEvent) {
+    return (
+      <Center>
+        You have no event selected. Please select an event from the list to replay its search.
+      </Center>
+    );
+  }
+
+  return <ReplaySearch key={`replaying-search-for-event-${selectedEvent.event.id}`} event={selectedEvent.event} />;
+};
+
 const BulkEventReplay = ({ initialEventIds, events: _events, onClose }: Props) => {
   const [events] = useState<Props['events']>(_events);
   const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
@@ -117,11 +149,7 @@ const BulkEventReplay = ({ initialEventIds, events: _events, onClose }: Props) =
         </ActionsBar>
       </EventsListSidebar>
       <ReplayedSearchContainer>
-        {selectedEvent
-          ? (
-            <ReplaySearch key={`replaying-search-for-event-${selectedEvent.event.id}`} event={selectedEvent.event} />
-          )
-          : <span>You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.</span>}
+        <ReplayedSearch total={total} completed={completed} selectedEvent={selectedEvent} />
       </ReplayedSearchContainer>
     </Container>
   );

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useState } from 'react';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -18,7 +18,7 @@ const EventsListSidebar = styled.div(({ theme }) => css`
   top: 0;
   left: 0;
   overflow: auto;
-  padding: 5px;
+  padding: 5px 10px;
 
   background: ${theme.colors.global.contentBackground};
   border-right: none;
@@ -32,6 +32,11 @@ const ReplayedSearchContainer = styled.div`
   padding: 5px;
 `;
 
+const StyledList = styled.ul`
+  padding-inline-start: 0;
+  margin-top: 20px;
+`;
+
 type Props = {
   initialEventIds: Array<string>;
   events: { [eventId: string]: { event: Event } };
@@ -40,6 +45,8 @@ type Props = {
 const BulkEventReplay = ({ initialEventIds, events }: Props) => {
   const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
   const selectedEvent = events?.[selectedId];
+  const total = eventIds.length;
+  const completed = eventIds.filter((event) => event.status === 'DONE').length;
 
   return (
     <Container>
@@ -49,7 +56,8 @@ const BulkEventReplay = ({ initialEventIds, events }: Props) => {
           The following list contains all of the events/alerts you selected in the previous step, allowing you to
           investigate the replayed search for each of them.
         </p>
-        <ul>
+        <i>Investigation of {completed}/{total} events completed.</i>
+        <StyledList>
           {eventIds.map(({ id: eventId, status }) => (
             <EventListItem event={events?.[eventId]?.event}
                            selected={eventId === selectedId}
@@ -58,7 +66,7 @@ const BulkEventReplay = ({ initialEventIds, events }: Props) => {
                            onClick={() => selectItem(eventId)}
                            markItemAsDone={markItemAsDone} />
           ))}
-        </ul>
+        </StyledList>
       </EventsListSidebar>
       <ReplayedSearchContainer>
         {selectedEvent

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+
+import EventListItem from 'components/events/bulk-replay/EventListItem';
+import useSelectedEvents from 'components/events/bulk-replay/useSelectedEvents';
+
+import type { Event } from './types';
+
+const Container = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+const EventsListSidebar = styled.div(({ theme }) => css`
+  position: relative;
+  width: 25vw;
+  height: 100%;
+  top: 0;
+  left: 0;
+  overflow: auto;
+  padding: 5px;
+
+  background: ${theme.colors.global.contentBackground};
+  border-right: none;
+  box-shadow: 3px 3px 3px ${theme.colors.global.navigationBoxShadow};
+
+  z-index: 1030;
+`);
+
+const ReplayedSearchContainer = styled.div`
+  overflow: auto;
+  padding: 5px;
+`;
+
+type Props = {
+  initialEventIds: Array<string>;
+  events: { [eventId: string]: { event: Event } };
+}
+
+const BulkEventReplay = ({ initialEventIds, events }: Props) => {
+  const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
+  const selectedEvent = events?.[selectedId];
+
+  return (
+    <Container>
+      <EventsListSidebar>
+        <h3>Replay Search</h3>
+        <p>
+          The following list contains all of the events/alerts you selected in the previous step, allowing you to
+          investigate the replayed search for each of them.
+        </p>
+        <ul>
+          {eventIds.map(({ id: eventId, status }) => (
+            <EventListItem event={events?.[eventId]?.event}
+                           selected={eventId === selectedId}
+                           done={status === 'DONE'}
+                           removeItem={removeItem}
+                           onClick={() => selectItem(eventId)}
+                           markItemAsDone={markItemAsDone} />
+          ))}
+        </ul>
+      </EventsListSidebar>
+      <ReplayedSearchContainer>
+        {selectedEvent
+          ? (
+            <span>
+              Replayed Search for {selectedEvent.event.id}: {selectedEvent.event.message}
+            </span>
+          )
+          : <span>You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.</span>}
+      </ReplayedSearchContainer>
+    </Container>
+  );
+};
+
+export default BulkEventReplay;

--- a/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/BulkEventReplay.tsx
@@ -23,7 +23,7 @@ const EventsListSidebar = styled.div(({ theme }) => css`
   
   flex-shrink: 0;
   position: relative;
-  width: 25vw;
+  width: 20vw;
   height: 100%;
   top: 0;
   left: 0;

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import type { Event } from './types';
+
+type EventListItemProps = {
+  event: Event,
+  done: boolean,
+  selected: boolean,
+  onClick: () => void,
+  removeItem: (id: string) => void,
+  markItemAsDone: (id: string) => void,
+}
+const EventListItem = ({ event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
+  <li key={`event-replay-list-${event?.id}`}>
+    {selected ? '-' : ''}
+    <a onClick={onClick}>{event?.message ?? <i>Unknown</i>}</a>
+
+    <button onClick={() => removeItem(event.id)}>x</button>
+    <button onClick={() => markItemAsDone(event.id)}>done</button>
+  </li>
+);
+
+export default EventListItem;

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -85,7 +85,7 @@ const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsD
 
       <ButtonGroup>
         <IconButton onClick={_removeItem} title={`Remove event "${event?.id}" from list`} name="delete" />
-        <CompletedButton onClick={_markItemAsDone} title={`Mark event "${event?.id}" as investigated`} name="check" $done={done} />
+        <CompletedButton onClick={_markItemAsDone} title={`Mark event "${event?.id}" as ${done ? 'not' : ''} investigated`} name="check" $done={done} />
       </ButtonGroup>
     </StyledItem>
   );

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -85,7 +85,11 @@ const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsD
 
       <ButtonGroup>
         <IconButton onClick={_removeItem} title={`Remove event "${event?.id}" from list`} name="delete" />
-        <CompletedButton onClick={_markItemAsDone} title={`Mark event "${event?.id}" as ${done ? 'not' : ''} investigated`} name="check" $done={done} />
+        <CompletedButton onClick={_markItemAsDone}
+                         title={`Mark event "${event?.id}" as ${done ? 'not' : ''} investigated`}
+                         name="verified"
+                         iconType={done ? 'solid' : 'regular'}
+                         $done={done} />
       </ButtonGroup>
     </StyledItem>
   );

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -47,6 +47,10 @@ const Summary = styled.span<SummaryProps>(({ theme, $done }) => css`
   }
 `);
 
+const CompletedButton = styled(IconButton)<{ $done: boolean }>(({ theme, $done }) => css`
+  color: ${$done ? theme.colors.variant.success : theme.colors.global.textDefault};
+`);
+
 const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => {
   const _removeItem = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -65,7 +69,7 @@ const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsD
 
       <ButtonGroup>
         <IconButton onClick={_removeItem} title="Remove event from list" name="delete" />
-        <IconButton onClick={_markItemAsDone} title="Mark event as investigated" name="check" />
+        <CompletedButton onClick={_markItemAsDone} title="Mark event as investigated" name="check" $done={done} />
       </ButtonGroup>
     </StyledItem>
   );

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
+import styled, { css } from 'styled-components';
+
+import IconButton from 'components/common/IconButton';
+import ButtonGroup from 'components/bootstrap/ButtonGroup';
 
 import type { Event } from './types';
 
@@ -10,14 +14,44 @@ type EventListItemProps = {
   removeItem: (id: string) => void,
   markItemAsDone: (id: string) => void,
 }
-const EventListItem = ({ event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
-  <li key={`event-replay-list-${event?.id}`}>
-    {selected ? '-' : ''}
-    <a onClick={onClick}>{event?.message ?? <i>Unknown</i>}</a>
 
-    <button onClick={() => removeItem(event.id)}>x</button>
-    <button onClick={() => markItemAsDone(event.id)}>done</button>
-  </li>
+type StyledItemProps = {
+  $selected: boolean;
+}
+const StyledItem = styled.li<StyledItemProps>(({ theme, $selected }) => css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 30px;
+  background-color: ${$selected ? theme.colors.background.secondaryNav : 'transparent'};
+`);
+
+type SummaryProps = {
+  $done: boolean;
+}
+
+const Summary = styled.span<SummaryProps>(({ theme, $done }) => css`
+  margin: 10px;
+  cursor: pointer;
+  color: ${$done ? theme.colors.global.textSecondary : theme.colors.global.textDefault};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`);
+
+const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
+  <StyledItem key={`event-replay-list-${event?.id}`} $selected={selected}>
+    <Summary $done={done} onClick={onClick}>{event?.message ?? <i>Unknown</i>}</Summary>
+
+    <ButtonGroup>
+      <IconButton onClick={() => removeItem(event.id)} title="Remove event from list" name="delete" />
+      <IconButton onClick={() => markItemAsDone(event.id)} title="Mark event as investigated" name="check" />
+    </ButtonGroup>
+  </StyledItem>
 );
 
 export default EventListItem;

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -84,8 +84,8 @@ const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsD
       <Summary $done={done}>{event?.message ?? <i>Unknown</i>}</Summary>
 
       <ButtonGroup>
-        <IconButton onClick={_removeItem} title="Remove event from list" name="delete" />
-        <CompletedButton onClick={_markItemAsDone} title="Mark event as investigated" name="check" $done={done} />
+        <IconButton onClick={_removeItem} title={`Remove event "${event?.id}" from list`} name="delete" />
+        <CompletedButton onClick={_markItemAsDone} title={`Mark event "${event?.id}" as investigated`} name="check" $done={done} />
       </ButtonGroup>
     </StyledItem>
   );

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -64,7 +64,7 @@ const Summary = styled.span<SummaryProps>(({ theme, $done }) => css`
 `);
 
 const CompletedButton = styled(IconButton)<{ $done: boolean }>(({ theme, $done }) => css`
-  color: ${$done ? theme.colors.variant.success : theme.colors.global.textDefault};
+  color: ${$done ? theme.colors.variant.success : theme.colors.gray[60]};
 `);
 
 const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => {

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback } from 'react';
 import styled, { css } from 'styled-components';
 
 import IconButton from 'components/common/IconButton';
@@ -24,6 +25,11 @@ const StyledItem = styled.li<StyledItemProps>(({ theme, $selected }) => css`
   justify-content: space-between;
   height: 30px;
   background-color: ${$selected ? theme.colors.background.secondaryNav : 'transparent'};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.colors.background.body};
+  }
 `);
 
 type SummaryProps = {
@@ -32,7 +38,6 @@ type SummaryProps = {
 
 const Summary = styled.span<SummaryProps>(({ theme, $done }) => css`
   margin: 10px;
-  cursor: pointer;
   color: ${$done ? theme.colors.global.textSecondary : theme.colors.global.textDefault};
   white-space: nowrap;
   overflow: hidden;
@@ -43,15 +48,28 @@ const Summary = styled.span<SummaryProps>(({ theme, $done }) => css`
   }
 `);
 
-const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
-  <StyledItem key={`event-replay-list-${event?.id}`} $selected={selected}>
-    <Summary $done={done} onClick={onClick}>{event?.message ?? <i>Unknown</i>}</Summary>
+const EventListItem = ({ done, event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => {
+  const _removeItem = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
 
-    <ButtonGroup>
-      <IconButton onClick={() => removeItem(event.id)} title="Remove event from list" name="delete" />
-      <IconButton onClick={() => markItemAsDone(event.id)} title="Mark event as investigated" name="check" />
-    </ButtonGroup>
-  </StyledItem>
-);
+    return removeItem(event.id);
+  }, [event?.id, removeItem]);
+  const _markItemAsDone = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    return markItemAsDone(event.id);
+  }, [event?.id, markItemAsDone]);
+
+  return (
+    <StyledItem key={`event-replay-list-${event?.id}`} $selected={selected} onClick={onClick}>
+      <Summary $done={done}>{event?.message ?? <i>Unknown</i>}</Summary>
+
+      <ButtonGroup>
+        <IconButton onClick={_removeItem} title="Remove event from list" name="delete" />
+        <IconButton onClick={_markItemAsDone} title="Mark event as investigated" name="check" />
+      </ButtonGroup>
+    </StyledItem>
+  );
+};
 
 export default EventListItem;

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -4,8 +4,7 @@ import styled, { css } from 'styled-components';
 
 import IconButton from 'components/common/IconButton';
 import ButtonGroup from 'components/bootstrap/ButtonGroup';
-
-import type { Event } from './types';
+import type { Event } from 'components/events/events/types';
 
 type EventListItemProps = {
   event: Event,

--- a/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useMemo } from 'react';
 

--- a/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
@@ -22,7 +22,8 @@ const ViewReplaySearch = ({ eventData, eventDefinition, aggregations }) => {
       isShown: false,
     },
     infoBar: { component: EventInfoBar },
-  }), []);
+    synchronizeUrl: false,
+  } as const), []);
 
   return (
     <SearchPageLayoutProvider value={searchPageLayout}>

--- a/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/ReplaySearch.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+
+import useCreateSearch from 'views/hooks/useCreateSearch';
+import EventInfoBar from 'components/event-definitions/replay-search/EventInfoBar';
+import SearchPageLayoutProvider from 'views/components/contexts/SearchPageLayoutProvider';
+import SearchPage from 'views/pages/SearchPage';
+import useCreateViewForEvent from 'views/logic/views/UseCreateViewForEvent';
+import useEventDefinition from 'hooks/useEventDefinition';
+import Spinner from 'components/common/Spinner';
+import type { Event } from 'components/events/events/types';
+
+type Props = {
+  event: Event;
+}
+
+const ViewReplaySearch = ({ eventData, eventDefinition, aggregations }) => {
+  const _view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
+  const view = useCreateSearch(_view);
+  const searchPageLayout = useMemo(() => ({
+    sidebar: {
+      isShown: false,
+    },
+    infoBar: { component: EventInfoBar },
+  }), []);
+
+  return (
+    <SearchPageLayoutProvider value={searchPageLayout}>
+      <SearchPage view={view} isNew />
+    </SearchPageLayoutProvider>
+  );
+};
+
+const ReplaySearch = ({ event }: Props) => {
+  const { data, isLoading } = useEventDefinition(event.event_definition_id);
+
+  return isLoading ? <Spinner />
+    : <ViewReplaySearch eventData={event} eventDefinition={data?.eventDefinition} aggregations={data?.aggregations} />;
+};
+
+export default ReplaySearch;

--- a/graylog2-web-interface/src/components/events/bulk-replay/__tests__/BulkEventReplay.test.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/__tests__/BulkEventReplay.test.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';

--- a/graylog2-web-interface/src/components/events/bulk-replay/__tests__/BulkEventReplay.test.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/__tests__/BulkEventReplay.test.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+import { PluginManifest } from 'graylog-web-plugin/plugin';
+
+import type { Event } from 'components/events/events/types';
+import { usePlugin } from 'views/test/testPlugins';
+import MenuItem from 'components/bootstrap/menuitem/MenuItem';
+
+import events from './events.fixtures';
+
+import BulkEventReplay from '../BulkEventReplay';
+
+const initialEventIds = [
+  '01JH007XPDF710TPJZT8K2CN3W',
+  '01JH006340WP7HQ5E7P71Q9HHX',
+  '01JH0029TS9PX5ED87TZ1RVRT2',
+];
+
+jest.mock('components/events/bulk-replay/ReplaySearch', () => ({ event }: { event: Event }) => <span>Replaying search for event {event.id}</span>);
+
+const markEventAsInvestigated = async (eventId: string) => {
+  const markAsInvestigatedButton = await screen.findByRole('button', { name: new RegExp(`mark event "${eventId}" as investigated`, 'i') });
+
+  return userEvent.click(markAsInvestigatedButton);
+};
+
+const removeEvent = async (eventId: string) => {
+  const removeEventButton = await screen.findByRole('button', { name: new RegExp(`remove event "${eventId}" from list`, 'i') });
+
+  return userEvent.click(removeEventButton);
+};
+
+const expectReplayingEvent = (eventId: string) => screen.findByText(new RegExp(`replaying search for event ${eventId}`, 'i'));
+
+const eventByIndex = (index: number) => events[initialEventIds[index]].event;
+const eventMessage = (index: number) => eventByIndex(index).message;
+
+const SUT = (props: Partial<React.ComponentProps<typeof BulkEventReplay>>) => (
+  <BulkEventReplay events={events} initialEventIds={initialEventIds} onClose={() => {}} {...props} />
+);
+
+const bulkAction = jest.fn();
+const testPlugin = new PluginManifest({}, {
+  'views.components.eventActions': [{
+    key: 'test-bulk-action',
+    component: ({ events: _events }) => (
+      <MenuItem onClick={() => bulkAction(_events)}>Test Action</MenuItem>
+    ),
+    useCondition: () => true,
+    isBulk: true,
+  }],
+});
+
+describe('BulkEventReplay', () => {
+  usePlugin(testPlugin);
+
+  it('calls `onClose` when close button is clicked', async () => {
+    const onClose = jest.fn();
+    render(<SUT onClose={onClose} />);
+    const closeButton = await screen.findByRole('button', { name: 'Close' });
+    userEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('renders list of selected events', async () => {
+    render(<SUT />);
+    await screen.findByText(eventMessage(0));
+    await screen.findByText(eventMessage(1));
+    await screen.findByText(eventMessage(2));
+
+    await expectReplayingEvent(initialEventIds[0]);
+  });
+
+  it('clicking delete button removes event from list', async () => {
+    render(<SUT />);
+    await removeEvent(initialEventIds[0]);
+
+    await screen.findByText(eventMessage(1));
+    await expectReplayingEvent(initialEventIds[1]);
+
+    expect(screen.queryByText(eventMessage(0))).not.toBeInTheDocument();
+  });
+
+  it('marking events as investigated jumps to next one', async () => {
+    render(<SUT />);
+    await markEventAsInvestigated(initialEventIds[0]);
+
+    await expectReplayingEvent(initialEventIds[1]);
+
+    await markEventAsInvestigated(initialEventIds[1]);
+    await expectReplayingEvent(initialEventIds[2]);
+
+    await markEventAsInvestigated(initialEventIds[2]);
+    await screen.findByText('You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.');
+  });
+
+  it('allows jumping to specific events', async () => {
+    render(<SUT />);
+    await expectReplayingEvent(initialEventIds[0]);
+
+    userEvent.click(await screen.findByText(eventMessage(1)));
+
+    await expectReplayingEvent(initialEventIds[1]);
+
+    userEvent.click(await screen.findByText(eventMessage(0)));
+
+    await expectReplayingEvent(initialEventIds[0]);
+  });
+
+  it('skips removed event when jumping to next one', async () => {
+    render(<SUT />);
+    await removeEvent(initialEventIds[1]);
+    await markEventAsInvestigated(initialEventIds[0]);
+    await expectReplayingEvent(initialEventIds[2]);
+  });
+
+  it('skips event marked as investigated when jumping to next one', async () => {
+    render(<SUT />);
+    await markEventAsInvestigated(initialEventIds[1]);
+    await markEventAsInvestigated(initialEventIds[0]);
+    await expectReplayingEvent(initialEventIds[2]);
+  });
+
+  it('bulk actions get current list of events', async () => {
+    render(<SUT />);
+    await removeEvent(initialEventIds[1]);
+
+    userEvent.click(await screen.findByRole('button', { name: /bulk actions/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /test action/i }));
+
+    await waitFor(() => {
+      expect(bulkAction).toHaveBeenCalledWith([eventByIndex(0), eventByIndex(2)]);
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/events/bulk-replay/__tests__/events.fixtures.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/__tests__/events.fixtures.ts
@@ -1,0 +1,182 @@
+export default {
+  '01JH006340WP7HQ5E7P71Q9HHX': {
+    event: {
+      id: '01JH006340WP7HQ5E7P71Q9HHX',
+      event_definition_type: 'aggregation-v1',
+      event_definition_id: '66d719128a7ffa68df52fd7f',
+      origin_context: null,
+      timestamp: '2025-01-07T09:05:23.262Z',
+      timestamp_processing: '2025-01-07T09:05:29.216Z',
+      timerange_start: '2025-01-07T09:04:23.262Z',
+      timerange_end: '2025-01-07T09:05:23.262Z',
+      streams: [
+        '000000000000000000000002',
+      ],
+      source_streams: [
+        '66e962c1b3a0040a1570faf9',
+        '000000000000000000000001',
+      ],
+      message: 'Error Rate: count()=4758.0',
+      source: 'church',
+      key_tuple: [
+        'foo',
+        'hey there!',
+      ],
+      key: 'foo|hey there!',
+      priority: 3,
+      scores: {
+        raw_risk: 6,
+        normalized_risk: 6,
+      },
+      associated_assets: [],
+      alert: false,
+      fields: {
+        mightyalert: 'foo',
+        secondkey: 'hey there!',
+      },
+      group_by_fields: {},
+      replay_info: {
+        timerange_start: '2025-01-07T09:04:23.262Z',
+        timerange_end: '2025-01-07T09:05:23.262Z',
+        query: '',
+        streams: [
+          '66e962c1b3a0040a1570faf9',
+          '000000000000000000000001',
+        ],
+        filters: [
+          {
+            type: 'inlineQueryString',
+            title: 'Index Actions',
+            id: 'd1057daf-f0e0-4159-ae00-e7e340629bb3',
+            description: '',
+            queryString: 'action:index',
+            negation: false,
+            disabled: false,
+          },
+        ],
+      },
+    },
+    index_name: 'gl-events_13',
+    index_type: 'message',
+  },
+  '01JH0029TS9PX5ED87TZ1RVRT2': {
+    event: {
+      id: '01JH0029TS9PX5ED87TZ1RVRT2',
+      event_definition_type: 'aggregation-v1',
+      event_definition_id: '66d719128a7ffa68df52fd7f',
+      origin_context: null,
+      timestamp: '2025-01-07T09:03:23.262Z',
+      timestamp_processing: '2025-01-07T09:03:25.017Z',
+      timerange_start: '2025-01-07T09:02:23.262Z',
+      timerange_end: '2025-01-07T09:03:23.262Z',
+      streams: [
+        '000000000000000000000002',
+      ],
+      source_streams: [
+        '66e962c1b3a0040a1570faf9',
+        '000000000000000000000001',
+      ],
+      message: 'Error Rate: count()=4760.0',
+      source: 'church',
+      key_tuple: [
+        'foo',
+        'hey there!',
+      ],
+      key: 'foo|hey there!',
+      priority: 3,
+      scores: {
+        raw_risk: 6,
+        normalized_risk: 6,
+      },
+      associated_assets: [],
+      alert: false,
+      fields: {
+        mightyalert: 'foo',
+        secondkey: 'hey there!',
+      },
+      group_by_fields: {},
+      replay_info: {
+        timerange_start: '2025-01-07T09:02:23.262Z',
+        timerange_end: '2025-01-07T09:03:23.262Z',
+        query: '',
+        streams: [
+          '66e962c1b3a0040a1570faf9',
+          '000000000000000000000001',
+        ],
+        filters: [
+          {
+            type: 'inlineQueryString',
+            title: 'Index Actions',
+            id: 'd1057daf-f0e0-4159-ae00-e7e340629bb3',
+            description: '',
+            queryString: 'action:index',
+            negation: false,
+            disabled: false,
+          },
+        ],
+      },
+    },
+    index_name: 'gl-events_13',
+    index_type: 'message',
+  },
+  '01JH007XPDF710TPJZT8K2CN3W': {
+    event: {
+      id: '01JH007XPDF710TPJZT8K2CN3W',
+      event_definition_type: 'aggregation-v1',
+      event_definition_id: '66d719128a7ffa68df52fd7f',
+      origin_context: null,
+      timestamp: '2025-01-07T09:06:23.262Z',
+      timestamp_processing: '2025-01-07T09:06:29.197Z',
+      timerange_start: '2025-01-07T09:05:23.262Z',
+      timerange_end: '2025-01-07T09:06:23.262Z',
+      streams: [
+        '000000000000000000000002',
+      ],
+      source_streams: [
+        '66e962c1b3a0040a1570faf9',
+        '000000000000000000000001',
+      ],
+      message: 'Error Rate: count()=4718.0',
+      source: 'church',
+      key_tuple: [
+        'foo',
+        'hey there!',
+      ],
+      key: 'foo|hey there!',
+      priority: 3,
+      scores: {
+        raw_risk: 6,
+        normalized_risk: 6,
+      },
+      associated_assets: [],
+      alert: false,
+      fields: {
+        mightyalert: 'foo',
+        secondkey: 'hey there!',
+      },
+      group_by_fields: {},
+      replay_info: {
+        timerange_start: '2025-01-07T09:05:23.262Z',
+        timerange_end: '2025-01-07T09:06:23.262Z',
+        query: '',
+        streams: [
+          '66e962c1b3a0040a1570faf9',
+          '000000000000000000000001',
+        ],
+        filters: [
+          {
+            type: 'inlineQueryString',
+            title: 'Index Actions',
+            id: 'd1057daf-f0e0-4159-ae00-e7e340629bb3',
+            description: '',
+            queryString: 'action:index',
+            negation: false,
+            disabled: false,
+          },
+        ],
+      },
+    },
+    index_name: 'gl-events_13',
+    index_type: 'message',
+  },
+};

--- a/graylog2-web-interface/src/components/events/bulk-replay/__tests__/events.fixtures.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/__tests__/events.fixtures.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 export default {
   '01JH006340WP7HQ5E7P71Q9HHX': {
     event: {

--- a/graylog2-web-interface/src/components/events/bulk-replay/types.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/types.ts
@@ -1,0 +1,4 @@
+export type Event = {
+  id: string,
+  message: string,
+}

--- a/graylog2-web-interface/src/components/events/bulk-replay/types.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/types.ts
@@ -1,4 +1,0 @@
-export type Event = {
-  id: string,
-  message: string,
-}

--- a/graylog2-web-interface/src/components/events/bulk-replay/useSelectedEvents.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/useSelectedEvents.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useCallback, useReducer } from 'react';
 
 import assertUnreachable from 'logic/assertUnreachable';

--- a/graylog2-web-interface/src/components/events/bulk-replay/useSelectedEvents.ts
+++ b/graylog2-web-interface/src/components/events/bulk-replay/useSelectedEvents.ts
@@ -1,0 +1,79 @@
+import { useCallback, useReducer } from 'react';
+
+import assertUnreachable from 'logic/assertUnreachable';
+
+type ResolutionState = { id: string, status: 'OPEN' | 'DONE' };
+
+type Action = {
+  type: 'remove' | 'done' | 'select',
+  id: string,
+}
+type State = {
+  selectedId: string,
+  eventIds: Array<ResolutionState>,
+}
+
+const pickNextId = (eventIds: Array<ResolutionState>) => eventIds.find((event) => event.status === 'OPEN')?.id;
+
+const createInitialState = (_eventIds: Array<string>) => {
+  const eventIds = _eventIds.map((id) => ({ id, status: 'OPEN' } as const));
+  const selectedId = pickNextId(eventIds);
+
+  return {
+    selectedId,
+    eventIds,
+  };
+};
+
+const reducer = (state: State, action: Action) => {
+  if (action.type === 'remove') {
+    const eventIds = state.eventIds.filter((event) => event.id !== action.id);
+    const selectedId = state.selectedId === action.id
+      ? pickNextId(eventIds)
+      : state.selectedId;
+
+    return {
+      selectedId,
+      eventIds,
+    };
+  }
+
+  if (action.type === 'done') {
+    const eventIds = state.eventIds.map((event) => (event.id === action.id
+      ? { id: action.id, status: 'DONE' } as const
+      : event));
+    const selectedId = state.selectedId === action.id
+      ? pickNextId(eventIds)
+      : state.selectedId;
+
+    return {
+      selectedId,
+      eventIds,
+    };
+  }
+
+  if (action.type === 'select') {
+    return {
+      ...state,
+      selectedId: action.id,
+    };
+  }
+
+  return assertUnreachable(action.type, `Invalid action dispatched: ${action}`);
+};
+
+const useSelectedEvents = (eventIds: Array<string>) => {
+  const [state, dispatch] = useReducer(reducer, createInitialState(eventIds));
+  const removeItem = useCallback((eventId: string) => dispatch({ type: 'remove', id: eventId }), []);
+  const markItemAsDone = useCallback((eventId: string) => dispatch({ type: 'done', id: eventId }), []);
+  const selectItem = useCallback((eventId: string) => dispatch({ type: 'select', id: eventId }), []);
+
+  return {
+    ...state,
+    removeItem,
+    markItemAsDone,
+    selectItem,
+  };
+};
+
+export default useSelectedEvents;

--- a/graylog2-web-interface/src/components/events/events/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/events/events/BulkActions.test.tsx
@@ -42,6 +42,7 @@ const getEvent = (id: string): Event => ({
   source_streams: ['000000000000000000000001'],
   replay_info: undefined,
   alert: undefined,
+  message: '',
 });
 
 const mockedSelectedEntitiesData = {

--- a/graylog2-web-interface/src/components/events/events/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/events/events/BulkActions.tsx
@@ -24,6 +24,7 @@ import useEventBulkActions from 'components/events/events/hooks/useEventBulkActi
 import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import type { BulkEventReplayState } from 'views/pages/BulkEventReplayPage';
+import useLocation from 'routing/useLocation';
 
 type Props = {
   selectedEntitiesData: { [eventId: string]: Event }
@@ -33,11 +34,14 @@ const BulkActions = ({ selectedEntitiesData }: Props) => {
   const events = Object.values(selectedEntitiesData);
   const { actions, pluggableActionModals } = useEventBulkActions(events);
 
+  const location = useLocation();
+  const returnUrl = `${location.pathname}${location.search}`;
+
   const history = useHistory();
   const onReplaySearchClick = useCallback(() => {
     const eventIds = events.map((event) => event.id);
-    history.pushWithState<BulkEventReplayState>(Routes.ALERTS.BULK_REPLAY_SEARCH, { eventIds });
-  }, [events, history]);
+    history.pushWithState<BulkEventReplayState>(Routes.ALERTS.BULK_REPLAY_SEARCH, { eventIds, returnUrl });
+  }, [events, history, returnUrl]);
 
   return (
     <>

--- a/graylog2-web-interface/src/components/events/events/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/events/events/BulkActions.tsx
@@ -15,21 +15,34 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback } from 'react';
 
+import MenuItem from 'components/bootstrap/menuitem/MenuItem';
 import BulkActionsDropdown from 'components/common/EntityDataTable/BulkActionsDropdown';
 import type { Event } from 'components/events/events/types';
 import useEventBulkActions from 'components/events/events/hooks/useEventBulkActions';
+import useHistory from 'routing/useHistory';
+import Routes from 'routing/Routes';
+import type { BulkEventReplayState } from 'views/pages/BulkEventReplayPage';
 
 type Props = {
-  selectedEntitiesData: {[eventId: string]: Event}
+  selectedEntitiesData: { [eventId: string]: Event }
 }
 
 const BulkActions = ({ selectedEntitiesData }: Props) => {
-  const { actions, pluggableActionModals } = useEventBulkActions(Object.values(selectedEntitiesData));
+  const events = Object.values(selectedEntitiesData);
+  const { actions, pluggableActionModals } = useEventBulkActions(events);
+
+  const history = useHistory();
+  const onReplaySearchClick = useCallback(() => {
+    const eventIds = events.map((event) => event.id);
+    history.pushWithState<BulkEventReplayState>(Routes.ALERTS.BULK_REPLAY_SEARCH, { eventIds });
+  }, [events, history]);
 
   return (
     <>
       <BulkActionsDropdown>
+        <MenuItem onClick={onReplaySearchClick}>Replay Search</MenuItem>
         {actions}
       </BulkActionsDropdown>
       {pluggableActionModals}

--- a/graylog2-web-interface/src/components/events/events/types.ts
+++ b/graylog2-web-interface/src/components/events/events/types.ts
@@ -37,6 +37,7 @@ export type Event = {
   source_streams: string[],
   replay_info: EventReplayInfo | undefined,
   alert: boolean | undefined,
+  message: string,
 };
 
 export type EventDefinitionContext = {

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
@@ -35,7 +35,7 @@ const CreateProfile = () => {
   const navigate = useNavigate();
   const { createProfile } = useProfileMutations();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
-  const location = useLocation();
+  const location = useLocation<{ customFieldMappings: any }>();
   const history = useHistory();
   const initialValues = useMemo<IndexSetFieldTypeProfileForm>(() => {
     const defaultCustomFieldMappings = location?.state?.customFieldMappings;

--- a/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.tsx
+++ b/graylog2-web-interface/src/hooks/useAlertAndEventDefinitionData.tsx
@@ -16,21 +16,21 @@
  */
 
 import { useMemo } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 
 import useLocation from 'routing/useLocation';
 import Routes from 'routing/Routes';
 import useParams from 'routing/useParams';
 import type { Event } from 'components/events/events/types';
 import type { EventDefinitionAggregation } from 'hooks/useEventDefinition';
+import useEventDefinition from 'hooks/useEventDefinition';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
+import useEventById from 'hooks/useEventById';
 
 const useAlertAndEventDefinitionData = () => {
   const { pathname: path } = useLocation();
   const { alertId, definitionId } = useParams<{ alertId?: string, definitionId?: string }>();
-  const queryClient = useQueryClient();
-  const eventData = queryClient.getQueryData(['event-by-id', alertId]) as Event;
-  const data = queryClient.getQueryData(['event-definition-by-id', definitionId || eventData?.event_definition_id]) as { eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation>};
+  const { data: eventData } = useEventById(alertId);
+  const { data } = useEventDefinition(definitionId ?? eventData?.event_definition_id);
   const eventDefinition = data?.eventDefinition;
   const aggregations = data?.aggregations;
 

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -53,6 +53,7 @@ const Routes = {
   ALERTS: {
     LIST: '/alerts',
     replay_search: (alertId: string) => `/alerts/${alertId}/replay-search`,
+    BULK_REPLAY_SEARCH: '/alerts/replay-search',
     DEFINITIONS: {
       LIST: '/alerts/definitions',
       CREATE: '/alerts/definitions/new',

--- a/graylog2-web-interface/src/routing/useHistory.ts
+++ b/graylog2-web-interface/src/routing/useHistory.ts
@@ -23,7 +23,7 @@ const useHistory = () => {
   return useMemo(() => ({
     goBack: () => navigate(-1),
     push: (to: string) => navigate(to),
-    pushWithState: (to: string, state: any) => navigate(to, { state }),
+    pushWithState: <T>(to: string, state: T) => navigate(to, { state }),
     replace: (to: string) => navigate(to, { replace: true }),
   }), [navigate]);
 };

--- a/graylog2-web-interface/src/routing/useLocation.ts
+++ b/graylog2-web-interface/src/routing/useLocation.ts
@@ -15,5 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useLocation } from 'react-router-dom';
+import type { Location } from 'react-router-dom';
 
-export default useLocation;
+const _useLocation = <T, >(): Location<T> => useLocation();
+export default _useLocation;

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -55,7 +55,7 @@ import {
   NewDashboardPage,
   StreamSearchPage,
   EventDefinitionReplaySearchPage,
-  EventReplaySearchPage,
+  EventReplaySearchPage, BulkEventReplayPage,
 } from 'views/pages';
 import AddMessageCountActionHandler, { CreateMessageCount } from 'views/logic/fieldactions/AddMessageCountActionHandler';
 import AddMessageTableActionHandler, { CreateMessagesWidget } from 'views/logic/fieldactions/AddMessageTableActionHandler';
@@ -162,6 +162,7 @@ const exports: PluginExports = {
     { path: extendedSearchPath, component: NewSearchPage, parentComponent: App },
     { path: showViewsPath, component: ShowViewPage, parentComponent: App },
     { path: Routes.unqualified.ALERTS.replay_search(':alertId'), component: EventReplaySearchPage, parentComponent: App },
+    { path: Routes.unqualified.ALERTS.BULK_REPLAY_SEARCH, component: BulkEventReplayPage, parentComponent: App },
     { path: Routes.unqualified.ALERTS.DEFINITIONS.replay_search(':definitionId'), component: EventDefinitionReplaySearchPage, parentComponent: App },
   ],
   enterpriseWidgets: [

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -133,9 +133,10 @@ type Props = {
 const Search = ({ forceSideBarPinned = false }: Props) => {
   const dispatch = useAppDispatch();
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
-  const { sidebar: { isShown: showSidebar }, searchAreaContainer, infoBar } = useSearchPageLayout();
+  const { sidebar: { isShown: showSidebar }, searchAreaContainer, infoBar, synchronizeUrl = true } = useSearchPageLayout();
   const InfoBar = infoBar?.component;
   const SearchAreaContainer = searchAreaContainer?.component;
+  const SynchronizationComponent = synchronizeUrl ? SynchronizeUrl : React.Fragment;
 
   useEffect(() => {
     refreshSearch();
@@ -149,7 +150,7 @@ const Search = ({ forceSideBarPinned = false }: Props) => {
 
   return (
     <>
-      <SynchronizeUrl />
+      <SynchronizationComponent />
       <ExternalValueActionsProvider>
         <SearchExplainContextProvider>
           <WidgetFocusProvider>

--- a/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
+++ b/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
@@ -16,8 +16,6 @@
  */
 import { useEffect } from 'react';
 
-import type { Location } from 'routing/withLocation';
-import withLocation from 'routing/withLocation';
 import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
 import type { AppDispatch } from 'stores/useAppDispatch';
@@ -25,6 +23,8 @@ import type { RootState } from 'views/types';
 import { selectView } from 'views/logic/slices/viewSelectors';
 import useAppDispatch from 'stores/useAppDispatch';
 import { selectSearchExecutionState } from 'views/logic/slices/searchExecutionSelectors';
+import useLocation from 'routing/useLocation';
+import useQuery from 'routing/useQuery';
 
 const bindSearchParamsFromQueryThunk = (query: { [key: string]: unknown; }) => (_dispatch: AppDispatch, getState: () => RootState) => {
   const view = selectView(getState());
@@ -41,17 +41,13 @@ const useBindSearchParamsFromQuery = (query: { [key: string]: unknown }) => {
   }, [query]);
 };
 
-type Props = {
-  location: Location,
-};
-
-const SynchronizeUrl = ({ location }: Props) => {
-  const { pathname, search } = location;
-  const query = `${pathname}${search}`;
-  useBindSearchParamsFromQuery(location.query);
-  useSyncWithQueryParameters(query);
+const SynchronizeUrl = () => {
+  const { pathname, search } = useLocation();
+  const query = useQuery();
+  useBindSearchParamsFromQuery(query);
+  useSyncWithQueryParameters(`${pathname}${search}`);
 
   return null;
 };
 
-export default withLocation(SynchronizeUrl);
+export default SynchronizeUrl;

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -59,8 +59,11 @@ const useCleanupQueryParams = ({ uriParams, query, navigate }) => {
   useEffect(() => {
     if (uriParams?.page === undefined) {
       const baseURI = _clearURI(query);
+      const newQuery = baseURI.toString();
 
-      navigate(baseURI.toString(), { replace: true });
+      if (query !== newQuery) {
+        navigate(newQuery, { replace: true });
+      }
     }
   }, [query, navigate, uriParams?.page]);
 };

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageLayoutContext.tsx
@@ -41,8 +41,9 @@ export type LayoutState = {
     share: { isShown: boolean },
     actionsDropdown: { isShown: boolean },
   },
-  searchAreaContainer?: { component: React.ComponentType }
-  infoBar?: { component: React.ComponentType }
+  searchAreaContainer?: { component: React.ComponentType },
+  infoBar?: { component: React.ComponentType },
+  synchronizeUrl?: boolean,
 }
 
 export const DEFAULT_STATE: LayoutState = {
@@ -53,6 +54,7 @@ export const DEFAULT_STATE: LayoutState = {
     share: { isShown: true },
     actionsDropdown: { isShown: true },
   },
+  synchronizeUrl: true,
 };
 
 const SearchPageLayoutContext = React.createContext<LayoutState>(DEFAULT_STATE);

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent } from 'wrappedTestingLibrary';
+import { useLocation } from 'react-router-dom';
 
-import useLocation from 'routing/useLocation';
 import { asMock } from 'helpers/mocking';
 import WidgetFocusProvider from 'views/components/contexts/WidgetFocusProvider';
 import type { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -125,8 +125,11 @@ const useCleanupQueryParams = ({ focusUriParams, widgetIds, query, history }: Cl
   useEffect(() => {
     if ((focusUriParams?.id && !widgetIds.includes(focusUriParams.id) && focusUriParams.isPageShown) || (focusUriParams?.id === undefined)) {
       const baseURI = _clearURI(query);
+      const newQuery = baseURI.toString();
 
-      history.replace(baseURI.toString());
+      if (query !== newQuery) {
+        history.replace(newQuery);
+      }
     }
   }, [focusUriParams, widgetIds, query, history]);
 };

--- a/graylog2-web-interface/src/views/logic/views/Actions.ts
+++ b/graylog2-web-interface/src/views/logic/views/Actions.ts
@@ -19,6 +19,7 @@ import { stringify } from 'qs';
 import Routes from 'routing/Routes';
 import type View from 'views/logic/views/View';
 import type { HistoryFunction } from 'routing/useHistory';
+import type { NewDashboardPageState } from 'views/pages/NewDashboardPage';
 
 export const loadNewView = (history: HistoryFunction) => history.push(`${Routes.SEARCH}/new`);
 
@@ -32,7 +33,7 @@ export const loadDashboard = (history: HistoryFunction, dashboardId: string, ini
   `${Routes.pluginRoute('DASHBOARDS_VIEWID')(dashboardId)}${initialPage ? `?${stringify({ page: initialPage })}` : ''}`,
 );
 
-export const loadAsDashboard = (history: HistoryFunction, view: View) => history.pushWithState(
+export const loadAsDashboard = (history: HistoryFunction, view: View) => history.pushWithState<NewDashboardPageState>(
   Routes.pluginRoute('DASHBOARDS_NEW'),
   {
     view,

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -1,181 +1,26 @@
 import * as React from 'react';
-import { useCallback, useReducer } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import styled, { css } from 'styled-components';
 
 import { Events } from '@graylog/server-api';
 
 import useLocation from 'routing/useLocation';
 import Spinner from 'components/common/Spinner';
-import assertUnreachable from 'logic/assertUnreachable';
+import BulkEventReplay from 'components/events/bulk-replay/BulkEventReplay';
 
 export type BulkEventReplayState = {
   eventIds: Array<string>;
 }
 
-const Container = styled.div`
-  display: flex;
-  height: 100%;
-`;
-
-const EventsListSidebar = styled.div(({ theme }) => css`
-  position: relative;
-  width: 25vw;
-  height: 100%;
-  top: 0;
-  left: 0;
-  overflow: auto;
-  padding: 5px;
-
-  background: ${theme.colors.global.contentBackground};
-  border-right: none;
-  box-shadow: 3px 3px 3px ${theme.colors.global.navigationBoxShadow};
-
-  z-index: 1030;
-`);
-
-const ReplayedSearchContainer = styled.div`
-  overflow: auto;
-  padding: 5px;
-`;
-
 const useEventsById = (eventIds: Array<string>) => useQuery(['events', eventIds], () => Events.getByIds({ event_ids: eventIds }));
-type Event = {
-  id: string,
-  message: string,
-}
-
-type EventListItemProps = {
-  event: Event,
-  done: boolean,
-  selected: boolean,
-  onClick: () => void,
-  removeItem: (id: string) => void,
-  markItemAsDone: (id: string) => void,
-}
-const EventListItem = ({ event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
-  <li key={`event-replay-list-${event?.id}`}>
-    {selected ? '-' : ''}
-    <a onClick={onClick}>{event?.message ?? <i>Unknown</i>}</a>
-
-    <button onClick={() => removeItem(event.id)}>x</button>
-    <button onClick={() => markItemAsDone(event.id)}>done</button>
-  </li>
-);
-
-type ResolutionState = { id: string, status: 'OPEN' | 'DONE' };
-
-type Action = {
-  type: 'remove' | 'done' | 'select',
-  id: string,
-}
-type State = {
-  selectedId: string,
-  eventIds: Array<ResolutionState>,
-}
-
-const pickNextId = (eventIds: Array<ResolutionState>) => eventIds.find((event) => event.status === 'OPEN')?.id;
-
-const createInitialState = (_eventIds: Array<string>) => {
-  const eventIds = _eventIds.map((id) => ({ id, status: 'OPEN' } as const));
-  const selectedId = pickNextId(eventIds);
-
-  return {
-    selectedId,
-    eventIds,
-  };
-};
-
-const reducer = (state: State, action: Action) => {
-  if (action.type === 'remove') {
-    const eventIds = state.eventIds.filter((event) => event.id !== action.id);
-    const selectedId = state.selectedId === action.id
-      ? pickNextId(eventIds)
-      : state.selectedId;
-
-    return {
-      selectedId,
-      eventIds,
-    };
-  }
-
-  if (action.type === 'done') {
-    const eventIds = state.eventIds.map((event) => (event.id === action.id
-      ? { id: action.id, status: 'DONE' } as const
-      : event));
-    const selectedId = state.selectedId === action.id
-      ? pickNextId(eventIds)
-      : state.selectedId;
-
-    return {
-      selectedId,
-      eventIds,
-    };
-  }
-
-  if (action.type === 'select') {
-    return {
-      ...state,
-      selectedId: action.id,
-    };
-  }
-
-  return assertUnreachable(action.type, `Invalid action dispatched: ${action}`);
-};
-
-const useSelectedEvents = (eventIds: Array<string>) => {
-  const [state, dispatch] = useReducer(reducer, createInitialState(eventIds));
-  const removeItem = useCallback((eventId: string) => dispatch({ type: 'remove', id: eventId }), []);
-  const markItemAsDone = useCallback((eventId: string) => dispatch({ type: 'done', id: eventId }), []);
-  const selectItem = useCallback((eventId: string) => dispatch({ type: 'select', id: eventId }), []);
-
-  return {
-    ...state,
-    removeItem,
-    markItemAsDone,
-    selectItem,
-  };
-};
 
 const BulkEventReplayPage = () => {
   const location = useLocation<BulkEventReplayState>();
   const initialEventIds = location.state.eventIds ?? [];
-  const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
   const { data: events, isInitialLoading } = useEventsById(initialEventIds);
-  const selectedEvent = events?.[selectedId];
 
   return isInitialLoading
     ? <Spinner />
-    : (
-      <Container>
-        <EventsListSidebar>
-          <h3>Replay Search</h3>
-          <p>
-            The following list contains all of the events/alerts you selected in the previous step, allowing you to
-            investigate the replayed search for each of them.
-          </p>
-          <ul>
-            {eventIds.map(({ id: eventId, status }) => (
-              <EventListItem event={events?.[eventId]?.event}
-                             selected={eventId === selectedId}
-                             done={status === 'DONE'}
-                             removeItem={removeItem}
-                             onClick={() => selectItem(eventId)}
-                             markItemAsDone={markItemAsDone} />
-            ))}
-          </ul>
-        </EventsListSidebar>
-        <ReplayedSearchContainer>
-          {selectedEvent
-            ? (
-              <span>
-                Replayed Search for {selectedEvent.event.id}: {selectedEvent.event.message}
-              </span>
-            )
-            : <span>You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.</span>}
-        </ReplayedSearchContainer>
-      </Container>
-    );
+    : <BulkEventReplay events={events} initialEventIds={initialEventIds} />;
 };
 
 export default BulkEventReplayPage;

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { Events } from '@graylog/server-api';
@@ -6,6 +7,8 @@ import { Events } from '@graylog/server-api';
 import useLocation from 'routing/useLocation';
 import Spinner from 'components/common/Spinner';
 import BulkEventReplay from 'components/events/bulk-replay/BulkEventReplay';
+import useHistory from 'routing/useHistory';
+import Routes from 'routing/Routes';
 
 export type BulkEventReplayState = {
   eventIds: Array<string>;
@@ -18,9 +21,14 @@ const BulkEventReplayPage = () => {
   const initialEventIds = location.state?.eventIds ?? [];
   const { data: events, isInitialLoading } = useEventsById(initialEventIds);
 
+  const history = useHistory();
+  const onClose = useCallback(() => {
+    history.push(Routes.ALERTS.LIST);
+  }, []);
+
   return isInitialLoading
     ? <Spinner />
-    : <BulkEventReplay events={events} initialEventIds={initialEventIds} />;
+    : <BulkEventReplay events={events} initialEventIds={initialEventIds} onClose={onClose} />;
 };
 
 export default BulkEventReplayPage;

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import useLocation from 'routing/useLocation';
+
+export type BulkEventReplayState = {
+  eventIds: Array<string>;
+}
+
+const BulkEventReplayPage = () => {
+  const location = useLocation<BulkEventReplayState>();
+
+  return (<span>Foo: {JSON.stringify(location.state)}</span>);
+};
+
+export default BulkEventReplayPage;

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -24,7 +24,7 @@ const BulkEventReplayPage = () => {
   const history = useHistory();
   const onClose = useCallback(() => {
     history.push(Routes.ALERTS.LIST);
-  }, []);
+  }, [history]);
 
   return isInitialLoading
     ? <Spinner />

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -15,7 +15,7 @@ const useEventsById = (eventIds: Array<string>) => useQuery(['events', eventIds]
 
 const BulkEventReplayPage = () => {
   const location = useLocation<BulkEventReplayState>();
-  const initialEventIds = location.state.eventIds ?? [];
+  const initialEventIds = location.state?.eventIds ?? [];
   const { data: events, isInitialLoading } = useEventsById(initialEventIds);
 
   return isInitialLoading

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -28,19 +28,20 @@ import Routes from 'routing/Routes';
 
 export type BulkEventReplayState = {
   eventIds: Array<string>;
+  returnUrl: string;
 }
 
 const useEventsById = (eventIds: Array<string>) => useQuery(['events', eventIds], () => Events.getByIds({ event_ids: eventIds }));
 
 const BulkEventReplayPage = () => {
   const location = useLocation<BulkEventReplayState>();
-  const initialEventIds = location.state?.eventIds ?? [];
+  const { eventIds: initialEventIds = [], returnUrl } = location.state;
   const { data: events, isInitialLoading } = useEventsById(initialEventIds);
 
   const history = useHistory();
   const onClose = useCallback(() => {
-    history.push(Routes.ALERTS.LIST);
-  }, [history]);
+    history.push(returnUrl ?? Routes.ALERTS.LIST);
+  }, [history, returnUrl]);
 
   return isInitialLoading
     ? <Spinner />

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -1,15 +1,181 @@
 import * as React from 'react';
+import { useCallback, useReducer } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import styled, { css } from 'styled-components';
+
+import { Events } from '@graylog/server-api';
 
 import useLocation from 'routing/useLocation';
+import Spinner from 'components/common/Spinner';
+import assertUnreachable from 'logic/assertUnreachable';
 
 export type BulkEventReplayState = {
   eventIds: Array<string>;
 }
 
+const Container = styled.div`
+  display: flex;
+  height: 100%;
+`;
+
+const EventsListSidebar = styled.div(({ theme }) => css`
+  position: relative;
+  width: 25vw;
+  height: 100%;
+  top: 0;
+  left: 0;
+  overflow: auto;
+  padding: 5px;
+
+  background: ${theme.colors.global.contentBackground};
+  border-right: none;
+  box-shadow: 3px 3px 3px ${theme.colors.global.navigationBoxShadow};
+
+  z-index: 1030;
+`);
+
+const ReplayedSearchContainer = styled.div`
+  overflow: auto;
+  padding: 5px;
+`;
+
+const useEventsById = (eventIds: Array<string>) => useQuery(['events', eventIds], () => Events.getByIds({ event_ids: eventIds }));
+type Event = {
+  id: string,
+  message: string,
+}
+
+type EventListItemProps = {
+  event: Event,
+  done: boolean,
+  selected: boolean,
+  onClick: () => void,
+  removeItem: (id: string) => void,
+  markItemAsDone: (id: string) => void,
+}
+const EventListItem = ({ event, onClick, selected, removeItem, markItemAsDone }: EventListItemProps) => (
+  <li key={`event-replay-list-${event?.id}`}>
+    {selected ? '-' : ''}
+    <a onClick={onClick}>{event?.message ?? <i>Unknown</i>}</a>
+
+    <button onClick={() => removeItem(event.id)}>x</button>
+    <button onClick={() => markItemAsDone(event.id)}>done</button>
+  </li>
+);
+
+type ResolutionState = { id: string, status: 'OPEN' | 'DONE' };
+
+type Action = {
+  type: 'remove' | 'done' | 'select',
+  id: string,
+}
+type State = {
+  selectedId: string,
+  eventIds: Array<ResolutionState>,
+}
+
+const pickNextId = (eventIds: Array<ResolutionState>) => eventIds.find((event) => event.status === 'OPEN')?.id;
+
+const createInitialState = (_eventIds: Array<string>) => {
+  const eventIds = _eventIds.map((id) => ({ id, status: 'OPEN' } as const));
+  const selectedId = pickNextId(eventIds);
+
+  return {
+    selectedId,
+    eventIds,
+  };
+};
+
+const reducer = (state: State, action: Action) => {
+  if (action.type === 'remove') {
+    const eventIds = state.eventIds.filter((event) => event.id !== action.id);
+    const selectedId = state.selectedId === action.id
+      ? pickNextId(eventIds)
+      : state.selectedId;
+
+    return {
+      selectedId,
+      eventIds,
+    };
+  }
+
+  if (action.type === 'done') {
+    const eventIds = state.eventIds.map((event) => (event.id === action.id
+      ? { id: action.id, status: 'DONE' } as const
+      : event));
+    const selectedId = state.selectedId === action.id
+      ? pickNextId(eventIds)
+      : state.selectedId;
+
+    return {
+      selectedId,
+      eventIds,
+    };
+  }
+
+  if (action.type === 'select') {
+    return {
+      ...state,
+      selectedId: action.id,
+    };
+  }
+
+  return assertUnreachable(action.type, `Invalid action dispatched: ${action}`);
+};
+
+const useSelectedEvents = (eventIds: Array<string>) => {
+  const [state, dispatch] = useReducer(reducer, createInitialState(eventIds));
+  const removeItem = useCallback((eventId: string) => dispatch({ type: 'remove', id: eventId }), []);
+  const markItemAsDone = useCallback((eventId: string) => dispatch({ type: 'done', id: eventId }), []);
+  const selectItem = useCallback((eventId: string) => dispatch({ type: 'select', id: eventId }), []);
+
+  return {
+    ...state,
+    removeItem,
+    markItemAsDone,
+    selectItem,
+  };
+};
+
 const BulkEventReplayPage = () => {
   const location = useLocation<BulkEventReplayState>();
+  const initialEventIds = location.state.eventIds ?? [];
+  const { eventIds, selectedId, removeItem, selectItem, markItemAsDone } = useSelectedEvents(initialEventIds);
+  const { data: events, isInitialLoading } = useEventsById(initialEventIds);
+  const selectedEvent = events?.[selectedId];
 
-  return (<span>Foo: {JSON.stringify(location.state)}</span>);
+  return isInitialLoading
+    ? <Spinner />
+    : (
+      <Container>
+        <EventsListSidebar>
+          <h3>Replay Search</h3>
+          <p>
+            The following list contains all of the events/alerts you selected in the previous step, allowing you to
+            investigate the replayed search for each of them.
+          </p>
+          <ul>
+            {eventIds.map(({ id: eventId, status }) => (
+              <EventListItem event={events?.[eventId]?.event}
+                             selected={eventId === selectedId}
+                             done={status === 'DONE'}
+                             removeItem={removeItem}
+                             onClick={() => selectItem(eventId)}
+                             markItemAsDone={markItemAsDone} />
+            ))}
+          </ul>
+        </EventsListSidebar>
+        <ReplayedSearchContainer>
+          {selectedEvent
+            ? (
+              <span>
+                Replayed Search for {selectedEvent.event.id}: {selectedEvent.event.message}
+              </span>
+            )
+            : <span>You are done investigating all events. You can now select a bulk action to apply to all remaining events, or close the page to return to the events list.</span>}
+        </ReplayedSearchContainer>
+      </Container>
+    );
 };
 
 export default BulkEventReplayPage;

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useMemo } from 'react';
-import type { Location } from 'react-router-dom';
 
 import useLocation from 'routing/useLocation';
 import viewTransformer from 'views/logic/views/ViewTransformer';
@@ -28,12 +27,12 @@ import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';
 
 import SearchPage from './SearchPage';
 
-type LocationState = Location & { state: {
+export type NewDashboardPageState = {
   view?: View,
-} };
+};
 
 const NewDashboardPage = () => {
-  const location: LocationState = useLocation();
+  const location = useLocation<NewDashboardPageState>();
   const searchView = location?.state?.view;
 
   const viewPromise = useMemo(() => (searchView?.search

--- a/graylog2-web-interface/src/views/pages/index.ts
+++ b/graylog2-web-interface/src/views/pages/index.ts
@@ -24,6 +24,7 @@ const NewDashboardPage = loadAsync(() => import(/* webpackChunkName: "NewDashboa
 const ShowViewPage = loadAsync(() => import(/* webpackChunkName: "ShowViewPage" */ './ShowViewPage'));
 const EventReplaySearchPage = loadAsync(() => import(/* webpackChunkName: "ShowViewPage" */ './EventReplaySearchPage'));
 const EventDefinitionReplaySearchPage = loadAsync(() => import(/* webpackChunkName: "ShowViewPage" */ './EventDefinitionReplaySearchPage'));
+const BulkEventReplayPage = loadAsync(() => import(/* webpackChunkName: "BulkEventReplayPage" */ './BulkEventReplayPage'));
 
 export {
   DashboardsPage,
@@ -33,4 +34,5 @@ export {
   NewDashboardPage,
   EventReplaySearchPage,
   EventDefinitionReplaySearchPage,
+  BulkEventReplayPage,
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding a bulk action that allows replaying searches for multiple alerts/events. This is targeted at analysts wanting to investigate multiple events closely, filtering out non-relevant events and performing actions on the ones remaining. To support this, this feature is building a stack of events, showing the on the left side of the screen, allowing the user to replay them one by one.

The user can now mark individual events as viewed, jumping to the next one which was not viewed yet. The user can also remove events which have turned out to be irrelevant. This allows the user to keep track of the progress and make sure that no event is missed. At the end, the user can perform further bulk actions on the events remaining in the stack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![bulk-replay-search-2](https://github.com/user-attachments/assets/2aa1c503-8782-4f53-8c52-97ba12b98815)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.