### PR TITLE
Update password hashing command in configuration files

### DIFF
--- a/data-node/migration/env
+++ b/data-node/migration/env
@@ -8,7 +8,7 @@ GRAYLOG_PASSWORD_SECRET=
 # system and in case you lose connectivity to your authentication backend)
 # This password cannot be changed using the API or via the web interface. If you need to change it,
 # modify it in this file.
-# Create one by using for example: echo -n yourpassword | shasum -a 256
+# Create one by using for example: echo -n yourpassword | sha256sum
 # and put the resulting hash value into the following line
 # CHANGE THIS!
 GRAYLOG_ROOT_PASSWORD_SHA2=

--- a/misc/datanode.conf
+++ b/misc/datanode.conf
@@ -62,7 +62,7 @@ password_secret =
 # system and in case you lose connectivity to your authentication backend)
 # This password cannot be changed using the API or via the web interface. If you need to change it,
 # modify it in this file.
-# Create one by using for example: echo -n yourpassword | shasum -a 256
+# Create one by using for example: echo -n yourpassword | sha256sum
 # and put the resulting hash value into the following line
 root_password_sha2 =
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -63,7 +63,7 @@ password_secret =
 # system and in case you lose connectivity to your authentication backend)
 # This password cannot be changed using the API or via the web interface. If you need to change it,
 # modify it in this file.
-# Create one by using for example: echo -n yourpassword | shasum -a 256
+# Create one by using for example: echo -n yourpassword | sha256sum
 # and put the resulting hash value into the following line
 root_password_sha2 =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR updates the config file comment for creating a SHA-256 checksum for Graylog's root password.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've been following my company's internal documentation for the field that need  to be configured, and when I had to configure `root_password_sha2`, I saw that the suggested command was shasum, which is a perl script command not installed by default, instead of the sha256sum command, which is a default command from GNU coreutils (and is installed by default on all systems). (https://github.com/portainer/portainer/issues/507)

Also, it fix a small inconsistency between the config file and the offical documentation :
![2025-01-03 17_56_01-Red Hat Installation — Mozilla Firefox](https://github.com/user-attachments/assets/0a1b11fb-afd7-403e-8bc2-e8a227720852)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change should not need any tests as it's only comments.

## Screenshots (if appropriate):

None 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. > yes but the link is broken
- [ ] I have added tests to cover my changes.

