### PR TITLE
Fix to load indices status in batches so that the URL used to call OpenSearch does not exceed maximum length (`6.0`)

### DIFF
--- a/changelog/unreleased/pr-21208.toml
+++ b/changelog/unreleased/pr-21208.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "batching request for index block status if the combined length of the indices exceed the max possible URL length "
+
+pulls = ["21208"]

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/IndicesAdapterOS2.java
@@ -109,6 +109,11 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
     private final ClusterStateApi clusterStateApi;
     private final IndexTemplateAdapter indexTemplateAdapter;
 
+    // this is the maximum amount of bytes that the index list is supposed to fill in a request,
+    // it assumes that these don't need url encoding. If we exceed the maximum, we request settings for all indices
+    // and filter after wards
+    private final int MAX_INDICES_URL_LENGTH = 3000;
+
     @Inject
     public IndicesAdapterOS2(OpenSearchClient client,
                              StatsApi statsApi,
@@ -399,19 +404,23 @@ public class IndicesAdapterOS2 implements IndicesAdapter {
         return catApi.getShardsInfo(indexName);
     }
 
+
     @Override
     public IndicesBlockStatus getIndicesBlocksStatus(final List<String> indices) {
         if (indices == null || indices.isEmpty()) {
             throw new IllegalArgumentException("Expecting list of indices with at least one index present.");
         }
-        final GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
-                .indices(indices.toArray(new String[]{}))
+
+        final GetSettingsRequest request = new GetSettingsRequest()
                 .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-                .names(new String[]{});
+                .names("index.blocks.read", "index.blocks.write", "index.blocks.metadata", "index.blocks.read_only", "index.blocks.read_only_allow_delete");
+
+        final var maxLengthExceeded = String.join(",", indices).length() > MAX_INDICES_URL_LENGTH;
+        final GetSettingsRequest getSettingsRequest = maxLengthExceeded ? request : request.indices(indices.toArray(new String[]{}));
 
         return client.execute((c, requestOptions) -> {
             final GetSettingsResponse settingsResponse = c.indices().getSettings(getSettingsRequest, requestOptions);
-            return BlockSettingsParser.parseBlockSettings(settingsResponse);
+            return BlockSettingsParser.parseBlockSettings(settingsResponse, maxLengthExceeded ? Optional.of(indices) : Optional.empty());
         });
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParser.java
@@ -20,6 +20,8 @@ import org.graylog2.indexer.indices.blocks.IndicesBlockStatus;
 import org.graylog.shaded.opensearch2.org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.common.settings.Settings;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,23 +30,30 @@ public class BlockSettingsParser {
     static final String BLOCK_SETTINGS_PREFIX = "index.blocks.";
 
     public static IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse) {
-        IndicesBlockStatus result = new IndicesBlockStatus();
-        final var indexToSettingsMap = settingsResponse.getIndexToSettings();
-        final String[] indicesInResponse = indexToSettingsMap.keySet().toArray(new String[0]);
-        for (String index : indicesInResponse) {
-            final Settings blockSettings = indexToSettingsMap.get(index).getByPrefix(BLOCK_SETTINGS_PREFIX);
+        return parseBlockSettings(settingsResponse, Optional.empty());
+    }
 
-            if (!blockSettings.isEmpty()) {
-                final Set<String> blockSettingsNames = blockSettings.names();
-                final Set<String> blockSettingsSetToTrue = blockSettingsNames.stream()
-                        .filter(s -> blockSettings.getAsBoolean(s, false))
-                        .map(s -> BLOCK_SETTINGS_PREFIX + s)
-                        .collect(Collectors.toSet());
-                if (!blockSettingsSetToTrue.isEmpty()) {
-                    result.addIndexBlocks(index, blockSettingsSetToTrue);
+    public static IndicesBlockStatus parseBlockSettings(final GetSettingsResponse settingsResponse, final Optional<List<String>> indices) {
+        final IndicesBlockStatus result = new IndicesBlockStatus();
+        final var indexToSettingsMap = settingsResponse.getIndexToSettings();
+
+        indices.orElse(indexToSettingsMap.keySet().stream().toList()).forEach(index -> {
+            final var settings = indexToSettingsMap.get(index);
+            if(settings != null) {
+                final Settings blockSettings = settings.getByPrefix(BLOCK_SETTINGS_PREFIX);
+
+                if (!blockSettings.isEmpty()) {
+                    final Set<String> blockSettingsNames = blockSettings.names();
+                    final Set<String> blockSettingsSetToTrue = blockSettingsNames.stream()
+                            .filter(s -> blockSettings.getAsBoolean(s, false))
+                            .map(s -> BLOCK_SETTINGS_PREFIX + s)
+                            .collect(Collectors.toSet());
+                    if (!blockSettingsSetToTrue.isEmpty()) {
+                        result.addIndexBlocks(index, blockSettingsSetToTrue);
+                    }
                 }
             }
-        }
+        });
 
         return result;
     }

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/blocks/BlockSettingsParserTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -35,7 +36,7 @@ public class BlockSettingsParserTest {
     @Test
     public void noBlockedIndicesIdentifiedIfEmptyResponseParsed() {
         GetSettingsResponse emptyResponse = new GetSettingsResponse(Map.of(), Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptyResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptyResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -44,7 +45,7 @@ public class BlockSettingsParserTest {
     public void noBlockedIndicesIdentifiedIfEmptySettingsPresent() {
         var settingsBuilder = Map.of("index_0", Settings.builder().build());
         GetSettingsResponse emptySettingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptySettingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(emptySettingsResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(0, indicesBlockStatus.countBlockedIndices());
     }
@@ -64,7 +65,7 @@ public class BlockSettingsParserTest {
                         .put("index.blocks.read_only_allow_delete", true)
                         .build());
         GetSettingsResponse settingsResponse = new GetSettingsResponse(settingsBuilder, Map.of());
-        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(settingsResponse);
+        final IndicesBlockStatus indicesBlockStatus = BlockSettingsParser.parseBlockSettings(settingsResponse, Optional.empty());
         assertNotNull(indicesBlockStatus);
         assertEquals(3, indicesBlockStatus.countBlockedIndices());
         final Set<String> blockedIndices = indicesBlockStatus.getBlockedIndices();


### PR DESCRIPTION
Note: This is a backport of #21208 to `6.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prior to this PR, a call to `getIndicesBlocksStatus()`  would exceed to URL maximum of 4096 bytes if the number of indices would be large. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually by setting index.blocks on indices manually in OpenSearch and by reducing the threshold to a small amount that leads to reading all indices instead of only the list.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

