### PR TITLE
Fix flaky DataNode proxy test

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/datanode/DatanodeOpensearchProxyIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/datanode/DatanodeOpensearchProxyIT.java
@@ -46,7 +46,7 @@ public class DatanodeOpensearchProxyIT {
     void testProxyPlaintextGet() throws ExecutionException, RetryException {
         final ValidatableResponse response = apis.get("/datanodes/any/opensearch/_cat/indices", 200);
         final String responseBody = response.extract().body().asString();
-        Assertions.assertThat(responseBody).contains(".ds-gl-datanode-metrics").contains("graylog_0").contains("gl-system-events_0");
+        Assertions.assertThat(responseBody).contains("graylog_0").contains("gl-system-events_0");
     }
 
     @ContainerMatrixTest


### PR DESCRIPTION
Removes the check for an index which in some cases is not present yet.

This is presumably causing the build failures for https://github.com/Graylog2/graylog2-server/pull/21188

/nocl

