### PR TITLE
Fix 'writes' metric for ElasticSearchOutput

### DIFF
--- a/changelog/unreleased/pr-21286.toml
+++ b/changelog/unreleased/pr-21286.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix `org.graylog2.outputs.ElasticSearchOutput.writes` metric."
+
+pulls = ["21286"]

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -80,7 +80,6 @@ public class ElasticSearchOutput implements MessageOutput, FilteredMessageOutput
                 .filter(message -> !message.destinations().get(FILTER_KEY).isEmpty())
                 .toList();
 
-        writes.mark(messages.size());
         ignores.mark(filteredMessages.size() - messages.size());
 
         writeMessageEntries(messages);


### PR DESCRIPTION
Fixes the `org.graylog2.outputs.ElasticSearchOutput.writes` metric (Prometheus metric name: `gl_elasticsearch_output_writes_total`) which was counted twice.

