### PR TITLE
Catch stack overflow error in grok and regex pattern matching

### DIFF
--- a/changelog/unreleased/issue-19975.toml
+++ b/changelog/unreleased/issue-19975.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Catch and report exceptions during grok pattern matching."
 
 issues=["19975"]
-pulls = [""]
+pulls = ["21290"]

--- a/changelog/unreleased/issue-19975.toml
+++ b/changelog/unreleased/issue-19975.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Catch and report exceptions during grok pattern matching."
+
+issues=["19975"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
@@ -19,14 +19,13 @@ package org.graylog.plugins.pipelineprocessor.functions.strings;
 import com.google.common.collect.ForwardingMap;
 import io.krakens.grok.api.Grok;
 import io.krakens.grok.api.Match;
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog2.grok.GrokPatternRegistry;
-
-import jakarta.inject.Inject;
 
 import java.util.Map;
 
@@ -63,8 +62,12 @@ public class GrokMatch extends AbstractFunction<GrokMatch.GrokResult> {
 
         final Grok grok = grokPatternRegistry.cachedGrokForPattern(pattern, onlyNamedCaptures);
 
-        final Match match = grok.match(value);
-        return new GrokResult(match.captureFlattened());
+        try {
+            final Match match = grok.match(value);
+            return new GrokResult(match.captureFlattened());
+        } catch (StackOverflowError e) {
+            throw new IllegalStateException("Stack overflow during grok pattern matching");
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/RegexMatch.java
@@ -60,10 +60,14 @@ public class RegexMatch extends AbstractFunction<RegexMatch.RegexMatchResult> {
         final List<String> groupNames =
                 (List<String>) optionalGroupNames.optional(args, context).orElse(Collections.emptyList());
 
-        final Matcher matcher = regex.matcher(value);
-        final boolean matches = matcher.find();
+        try {
+            final Matcher matcher = regex.matcher(value);
+            final boolean matches = matcher.find();
 
-        return new RegexMatchResult(matches, matcher.toMatchResult(), groupNames);
+            return new RegexMatchResult(matches, matcher.toMatchResult(), groupNames);
+        } catch (StackOverflowError e) {
+            throw new IllegalStateException("Stack overflow during regex pattern matching");
+        }
 
     }
 


### PR DESCRIPTION
Resolves #19975 

Catch `StackOverflowError` in grok pattern matching. Log the error and add message to failure index, if enabled.
Same applies to regex matching.

## Description
<!--- Describe your changes in detail -->
Catch `StackOverflowError` and throw an `IllegalStateException` instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The message processor catches exceptions but not virtual machine errors. Since `StackOverflowError` is not an `Exception`, it causes processing to fail silently: the message is not processed and no entry is written to the failures index. The only indication is the raw exception in the server log:

> 2025-01-08 14:46:42,668 WARN : org.graylog2.shared.buffers.ProcessBuffer - Unable to process event MessageEvent{raw=null, message=null, messages=null}, sequence 0
> java.lang.StackOverflowError: null
> 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a pipeline with this rule:

> rule "groktest"
> when
>   true
> then
>   let result = grok("%{DATA:timestamp2} \\[%{DATA:severity}\\]\\[TID:%{DATA:thread_id}\\]\\[%{DATA:conversation_id}\\]\\[%{DATA:message_id}\\]\\[%{DATA:source_context}\\] -(?<msg>(.|\\r|\\n)*)?", to_string($message.message));
> end
> 

- Enable failure processing in system configuration
- Send this message to the attached input: 
[data.txt](https://github.com/user-attachments/files/18347988/data.txt)
- Observe that message appears in the Processing and Indexing Failures stream
- Observe that server log contains a detailed warning instead of a raw exception:

> 2025-01-08 14:49:01,697 WARN : org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter - Error evaluating action for rule <groktest/677e40dc33290c563c2f9c9e> in pipeline <p1/stage 0> with message: source: 127.0.0.1 | message: 2024-07-11 12:08:34.163 [ERR][TID:1][][][] -  An error occurred:System.Exception: Exception at level 20 ---> System.Exception: Exception at level 19 ---> System.Exception: Exception at level 18 ---> System.Exception: Exceptio (...) { gl2_receive_timestamp: 2025-01-08 13:46:42.609 | gl2_remote_ip: 127.0.0.1 | gl2_remote_port: 45492 | gl2_source_node: b7dee723-2ab1-4c91-b183-de7d6f38d017 | _id: 513af8e0-cdc7-11ef-b955-9e92e3dddb8a | gl2_source_input: 677e5d7533290c563c301fce | timestamp: 2025-01-08T13:46:42.609Z } (Error: In call to function 'grok' at 5:15 an exception was thrown: Stack overflow during grok pattern matching)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


