### PR TITLE
Consider assigned perspective when merging navigation dropdowns.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -118,7 +118,7 @@ const _existingDropdownItemIndex = (existingNavigationItems: Array<PluginNavigat
     return -1;
   }
 
-  return existingNavigationItems.findIndex(({ description, children }) => newNavigationItem.description === description && children);
+  return existingNavigationItems.findIndex(({ description, perspective, children }) => newNavigationItem.description === description && newNavigationItem.perspective === perspective && children);
 };
 
 const mergeDuplicateDropdowns = (navigationItems: Array<PluginNavigation>): Array<PluginNavigation> => navigationItems.reduce((result, current) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is possible to merge navigation dropdowns, by using the same dropdown title. This way navigation dropdowns from core can be extended via plugins.

With this PR we are also considering the perspective when merging the dropdowns. They only get merged, when their assigned perspective matches. 


/nocl