### PR TITLE
Fix query creation for missing bucket values.

### DIFF
--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -14,7 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { concatQueryStrings, escape } from './QueryHelper';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
+
+import { concatQueryStrings, escape, predicate } from './QueryHelper';
 
 describe('QueryHelper', () => {
   it('quotes $ in values', () => {
@@ -50,6 +52,21 @@ describe('QueryHelper', () => {
       const result = concatQueryStrings([undefined, 'field1:value1 OR field2:value2', null, '']);
 
       expect(result).toEqual('field1:value1 OR field2:value2');
+    });
+  });
+
+  describe('predicate', () => {
+    it('creates simple field/value predicate for strings', () => {
+      expect(predicate('foo', 'bar')).toEqual('foo:bar');
+    });
+
+    it('creates simple field/value predicate for numbers', () => {
+      expect(predicate('foo', 23)).toEqual('foo:23');
+    });
+
+    it('treats missing value bucket correctly', () => {
+      expect(predicate('foo', MISSING_BUCKET_NAME)).toEqual('NOT _exists_:foo');
+      expect(predicate('foo', escape(MISSING_BUCKET_NAME))).toEqual('NOT _exists_:foo');
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -69,3 +69,5 @@ export const formatTimestamp = (value: string | number) => {
 export const predicate = (field: string, value: string | number) => ((value === MISSING_BUCKET_NAME || value === escape(MISSING_BUCKET_NAME))
   ? `NOT _exists_:${field}`
   : `${field}:${value}`);
+
+export const not = (query:string) => `NOT ${query}`.replace(/^NOT NOT /, '');

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -15,10 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import trim from 'lodash/trim';
+import moment from 'moment-timezone';
 
-const isPhrase = (searchTerm: string | undefined | null) => String(searchTerm).indexOf(' ') !== -1;
+import { DATE_TIME_FORMATS } from 'util/DateTime';
+import { MISSING_BUCKET_NAME } from 'views/Constants';
 
-const escape = (searchTerm: string | number | undefined | null) => {
+export const isPhrase = (searchTerm: string | undefined | null) => String(searchTerm).indexOf(' ') !== -1;
+
+export const escape = (searchTerm: string | number | undefined | null) => {
   let escapedTerm = String(searchTerm);
 
   // Replace newlines.
@@ -37,7 +41,7 @@ const escape = (searchTerm: string | number | undefined | null) => {
   return escapedTerm;
 };
 
-const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND') => {
+export const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND') => {
   if (trim(oldQuery) === '*' || trim(oldQuery) === '') {
     return newTerm;
   }
@@ -49,11 +53,19 @@ const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND')
   return `${oldQuery} ${operator} ${newTerm}`;
 };
 
-const concatQueryStrings = (queryStrings: Array<string>, { operator = 'AND', withBrackets = true } = {}): string => {
+export const concatQueryStrings = (queryStrings: Array<string>, { operator = 'AND', withBrackets = true } = {}): string => {
   const withRemovedEmpty = queryStrings.filter((s: string) => !!(s?.trim()));
   const showBracketsForChild = withBrackets && withRemovedEmpty.length > 1;
 
   return withRemovedEmpty.map((s) => (showBracketsForChild ? `(${s})` : s)).join(` ${operator} `);
 };
 
-export { isPhrase, escape, addToQuery, concatQueryStrings };
+export const formatTimestamp = (value: string | number) => {
+  const utc = moment(value).tz('UTC');
+
+  return `"${utc.format(DATE_TIME_FORMATS.internalIndexer)}"`;
+};
+
+export const predicate = (field: string, value: string | number) => ((value === MISSING_BUCKET_NAME || value === escape(MISSING_BUCKET_NAME))
+  ? `NOT _exists_:${field}`
+  : `${field}:${value}`);

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -14,32 +14,19 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import moment from 'moment-timezone';
-
-import { DATE_TIME_FORMATS } from 'util/DateTime';
-import { MISSING_BUCKET_NAME } from 'views/Constants';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
-import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
+import { escape, addToQuery, formatTimestamp, predicate } from 'views/logic/queries/QueryHelper';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type { RootState } from 'views/types';
 
-const formatTimestampForES = (value: string | number) => {
-  const utc = moment(value).tz('UTC');
-
-  return `"${utc.format(DATE_TIME_FORMATS.internalIndexer)}"`;
-};
-
 const formatNewQuery = (oldQuery: string, field: string, value: string | number, type: FieldType) => {
   const predicateValue = type.type === 'date'
-    ? formatTimestampForES(value)
+    ? formatTimestamp(value)
     : escape(value);
-  const fieldPredicate = value === MISSING_BUCKET_NAME
-    ? `NOT _exists_:${field}`
-    : `${field}:${predicateValue}`;
 
-  return addToQuery(oldQuery, fieldPredicate);
+  return addToQuery(oldQuery, predicate(field, predicateValue));
 };
 
 type Arguments = {

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
@@ -41,6 +41,10 @@ jest.mock('views/logic/slices/viewSlice', () => ({
 }));
 
 describe('ExcludeFromQueryHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const defaultView = createSearch();
 
   const createViewWithQuery = (query: Query, type: ViewType = View.Type.Search) => {

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -14,14 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { escape, addToQuery, predicate } from 'views/logic/queries/QueryHelper';
+import { escape, addToQuery, predicate, not } from 'views/logic/queries/QueryHelper';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type { RootState } from 'views/types';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
 
 const formatNewQuery = (oldQuery: string, field: string, value: any) => {
-  const fieldPredicate = predicate(field, escape(value));
+  const fieldPredicate = not(predicate(field, escape(value)));
 
   return addToQuery(oldQuery, fieldPredicate);
 };

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -14,17 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
-import { MISSING_BUCKET_NAME } from 'views/Constants';
+import { escape, addToQuery, predicate } from 'views/logic/queries/QueryHelper';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type { RootState } from 'views/types';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
 
 const formatNewQuery = (oldQuery: string, field: string, value: any) => {
-  const fieldPredicate = value === MISSING_BUCKET_NAME
-    ? `_exists_:${field}`
-    : `NOT ${field}:${escape(value)}`;
+  const fieldPredicate = predicate(field, escape(value));
 
   return addToQuery(oldQuery, fieldPredicate);
 };

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { DEFAULT_MESSAGE_FIELDS, MISSING_BUCKET_NAME } from 'views/Constants';
-import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
+import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
+import { escape, addToQuery, predicate } from 'views/logic/queries/QueryHelper';
 import TitleTypes from 'views/stores/TitleTypes';
 import type { AppDispatch } from 'stores/useAppDispatch';
 import type { GetState } from 'views/types';
@@ -53,7 +53,7 @@ const ShowDocumentsHandler = ({
   const mergedObject = Object.fromEntries(valuePath.flatMap(Object.entries));
   const widgetQuery = widget && widget.query ? widget.query.query_string : '';
   const valuePathQuery = Object.entries(mergedObject)
-    .map(([k, v]) => (v === MISSING_BUCKET_NAME ? `NOT _exists_:${k}` : `${k}:${escape(String(v))}`))
+    .map(([k, v]) => (predicate(k, escape(v))))
     .reduce((prev: string, next: string) => addToQuery(prev, next), '');
   const query = addToQuery(widgetQuery, valuePathQuery);
   const valuePathFields = extractFieldsFromValuePath(valuePath);

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -47,7 +47,7 @@ import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import type { ParameterJson } from 'views/logic/parameters/Parameter';
 import Parameter from 'views/logic/parameters/Parameter';
-import { concatQueryStrings, escape } from 'views/logic/queries/QueryHelper';
+import { concatQueryStrings, escape, predicate } from 'views/logic/queries/QueryHelper';
 import HighlightingRule, { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { exprToConditionMapper } from 'views/logic/ExpressionConditionMappers';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
@@ -225,7 +225,7 @@ export const UseCreateViewForEvent = (
   { eventData, eventDefinition, aggregations }: { eventData?: Event, eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
 ) => {
   const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData?.group_by_fields ?? {})
-    .map(([field, value]) => `${field}:${escape(value)}`), { withBrackets: false });
+    .map(([field, value]) => predicate(field, escape(value))), { withBrackets: false });
   const eventQueryString = eventData?.replay_info?.query ?? eventDefinition?.config?.query ?? '';
   const streams = eventData?.replay_info?.streams ?? eventDefinition?.config?.streams ?? [];
   const streamCategories = eventData?.replay_info?.stream_categories ?? eventDefinition?.config?.stream_categories ?? [];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the queries generated when replaying events for fields which contain the missing value bucket in their grouping fields. It also creates and reuses a common `predicate` helper for creating field/value-based lucene predicates.

/nocl Fixing unreleased code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.