### PR TITLE
Add telemetry to every filter action in entity data table

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
@@ -120,8 +120,8 @@ describe('<EntityFilters />', () => {
     },
   ];
 
-  const EntityFilters = (props: Optional<React.ComponentProps<typeof OriginalEntityFilters>, 'setUrlQueryFilters' | 'attributes'>) => (
-    <OriginalEntityFilters setUrlQueryFilters={setUrlQueryFilters} attributes={attributes} {...props} />
+  const EntityFilters = (props: Optional<React.ComponentProps<typeof OriginalEntityFilters>, 'setUrlQueryFilters' | 'attributes' | 'appSection'>) => (
+    <OriginalEntityFilters setUrlQueryFilters={setUrlQueryFilters} attributes={attributes} appSection="test-app-section" {...props} />
   );
 
   const dropdownIsHidden = (dropdownTitle: string) => expect(screen.queryByRole('heading', { name: new RegExp(dropdownTitle, 'i') })).not.toBeInTheDocument();

--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
@@ -79,7 +79,7 @@ const EntityFilters = ({ attributes = [], filterValueRenderers, urlQueryFilters,
     sendTelemetry(TELEMETRY_EVENT_TYPE.ENTITY_DATA_TABLE.FILTER_CREATED, {
       app_pathname: getPathnameWithoutId(pathname),
       app_section: appSection,
-      app_action_value: 'new-filter-created',
+      app_action_value: 'filter-created',
       attribute_id: attributeId,
     });
 

--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
@@ -44,14 +44,14 @@ const FilterCreation = styled.div`
 `;
 
 type Props = {
-  attributes: Attributes,
+  attributes?: Attributes,
   urlQueryFilters: UrlQueryFilters | undefined,
   setUrlQueryFilters: (urlQueryFilters: UrlQueryFilters) => void,
   filterValueRenderers?: { [attributeId: string]: (value: Filter['value'], title: string) => React.ReactNode },
   appSection: string,
 }
 
-const EntityFilters = ({ attributes = [], filterValueRenderers, urlQueryFilters, setUrlQueryFilters, appSection }: Props) => {
+const EntityFilters = ({ attributes = [], filterValueRenderers = undefined, urlQueryFilters, setUrlQueryFilters, appSection }: Props) => {
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
 

--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.tsx
@@ -23,12 +23,12 @@ import type { Attributes } from 'stores/PaginationTypes';
 import type { Filters, Filter, UrlQueryFilters } from 'components/common/EntityFilters/types';
 import ActiveFilters from 'components/common/EntityFilters/ActiveFilters';
 import useFiltersWithTitle from 'components/common/EntityFilters/hooks/useFiltersWithTitle';
-
-import { ROW_MIN_HEIGHT } from './Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
-import {TELEMETRY_EVENT_TYPE} from 'logic/telemetry/Constants';
-import {getPathnameWithoutId} from 'util/URLUtils';
+import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import { getPathnameWithoutId } from 'util/URLUtils';
+
+import { ROW_MIN_HEIGHT } from './Constants';
 
 const SUPPORTED_ATTRIBUTE_TYPES = ['STRING', 'BOOLEAN', 'DATE', 'OBJECT_ID'];
 
@@ -87,7 +87,7 @@ const EntityFilters = ({ attributes = [], filterValueRenderers, urlQueryFilters,
       attributeId,
       [...(activeFilters?.get(attributeId) ?? []), filter],
     ));
-  }, [activeFilters, onChangeFilters]);
+  }, [activeFilters, appSection, onChangeFilters, pathname, sendTelemetry]);
 
   const onDeleteFilter = useCallback((attributeId: string, filterId: string) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.ENTITY_DATA_TABLE.FILTER_DELETED, {
@@ -105,7 +105,7 @@ const EntityFilters = ({ attributes = [], filterValueRenderers, urlQueryFilters,
     }
 
     return onChangeFilters(activeFilters.remove(attributeId));
-  }, [activeFilters, onChangeFilters]);
+  }, [activeFilters, appSection, onChangeFilters, pathname, sendTelemetry]);
 
   const onChangeFilter = useCallback((attributeId: string, prevValue: string, newFilter: Filter) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.ENTITY_DATA_TABLE.FILTER_CHANGED, {
@@ -121,7 +121,7 @@ const EntityFilters = ({ attributes = [], filterValueRenderers, urlQueryFilters,
     updatedFilterGroup[targetFilterIndex] = newFilter;
 
     onChangeFilters(activeFilters.set(attributeId, updatedFilterGroup));
-  }, [activeFilters, onChangeFilters]);
+  }, [activeFilters, appSection, onChangeFilters, pathname, sendTelemetry]);
 
   if (!filterableAttributes.length) {
     return null;

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -107,6 +107,8 @@ const PaginatedEntityTable = <T extends EntityBase, M = unknown>({
     setUrlQueryFilters(newUrlQueryFilters);
   }, [paginationQueryParameter, setUrlQueryFilters]);
 
+  const appSection = `${tableLayout.entityTableId}-list`;
+
   const {
     onPageSizeChange,
     onSearch,
@@ -114,7 +116,7 @@ const PaginatedEntityTable = <T extends EntityBase, M = unknown>({
     onColumnsChange,
     onSortChange,
   } = useTableEventHandlers({
-    appSection: `${tableLayout.entityTableId}-list`,
+    appSection,
     paginationQueryParameter,
     updateTableLayout,
     setQuery,
@@ -146,7 +148,8 @@ const PaginatedEntityTable = <T extends EntityBase, M = unknown>({
               <EntityFilters attributes={attributes}
                              urlQueryFilters={urlQueryFilters}
                              setUrlQueryFilters={onChangeFilters}
-                             filterValueRenderers={filterValueRenderers} />
+                             filterValueRenderers={filterValueRenderers}
+                             appSection={appSection} />
             </div>
           </SearchForm>
           {topRightCol}

--- a/graylog2-web-interface/src/logic/telemetry/Constants.ts
+++ b/graylog2-web-interface/src/logic/telemetry/Constants.ts
@@ -404,5 +404,8 @@ export const TELEMETRY_EVENT_TYPE = {
     COLUMNS_CHANGED: 'Entity Data Table Columns Changed',
     SORT_CHANGED: 'Entity Data Table Sort Changed',
     PAGE_SIZE_CHANGED: 'Entity Data Table Page Size Changed',
+    FILTER_CREATED: 'Entity Data Table Filter Created',
+    FILTER_DELETED: 'Entity Data Table Filter Deleted',
+    FILTER_CHANGED: 'Entity Data Table Filter Changed',
   },
 } as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds telemetry for every filter change in entity data table 
```
FILTER_CREATED: 'Entity Data Table Filter Created',
FILTER_DELETED: 'Entity Data Table Filter Deleted',
FILTER_CHANGED: 'Entity Data Table Filter Changed',
```

to find out by which field was done filtration we can use `attribute_id` property 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
