### PR TITLE
Avoid pushing to history in `WidgetFocusProvider` when new query is identical.

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -160,7 +160,9 @@ const WidgetFocusProvider = ({ children }: { children: React.ReactNode }): React
       query,
     );
 
-    history.replace(newURI);
+    if (newURI !== query) {
+      history.replace(newURI);
+    }
   }, [history, query]);
 
   const setWidgetFocusing = useCallback((widgetId: string) => updateFocusQueryParams({

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -62,7 +62,6 @@ const ShowDocumentsHandler = ({
     .query(createElasticsearchQueryString(query))
     .newId()
     .config(MessagesWidgetConfig.builder()
-      // @ts-ignore
       .fields([...messageListFields])
       .showMessageRow(true).build())
     .build();

--- a/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
+++ b/graylog2-web-interface/src/views/pages/BulkEventReplayPage.tsx
@@ -35,7 +35,7 @@ const useEventsById = (eventIds: Array<string>) => useQuery(['events', eventIds]
 
 const BulkEventReplayPage = () => {
   const location = useLocation<BulkEventReplayState>();
-  const { eventIds: initialEventIds = [], returnUrl } = location.state;
+  const { eventIds: initialEventIds = [], returnUrl } = (location?.state ?? {});
   const { data: events, isInitialLoading } = useEventsById(initialEventIds);
 
   const history = useHistory();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that no new history entry is pushed by URL<->parameter synchronization when the resulting URL is identical.

This fixes an issue for the embedded search (e.g. when replaying search) when the "Show Documents" action is used.

/nocl Fixes issue with unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.