### PR TITLE
Remove `JacksonDBCollection` usage from content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackPersistenceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackPersistenceService.java
@@ -22,12 +22,16 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DuplicateKeyException;
+import com.google.common.primitives.Ints;
+import com.mongodb.MongoException;
 import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.Document;
 import org.bson.conversions.Bson;
-import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackV1;
@@ -36,18 +40,14 @@ import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.Revisioned;
 import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.database.MongoCollections;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.database.utils.MongoUtils;
+import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamService;
 import org.jooq.lambda.tuple.Tuple2;
-import org.mongojack.DBCursor;
-import org.mongojack.DBQuery;
-import org.mongojack.JacksonDBCollection;
-import org.mongojack.WriteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -58,38 +58,40 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+
 @Singleton
 public class ContentPackPersistenceService {
     public static final String COLLECTION_NAME = "content_packs";
 
-    private final JacksonDBCollection<ContentPack, ObjectId> dbCollection;
     private static final Logger LOG = LoggerFactory.getLogger(ContentPackPersistenceService.class);
     private final StreamService streamService;
     private final MongoConnection mongoConnection;
+    private final MongoCollection<ContentPack> collection;
 
     @Inject
     public ContentPackPersistenceService(final MongoJackObjectMapperProvider mapperProvider,
                                          final MongoConnection mongoConnection, final StreamService streamService) {
-        this(JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
-                ContentPack.class, ObjectId.class, mapperProvider.get()), streamService, mongoConnection);
-    }
-
-    ContentPackPersistenceService(final JacksonDBCollection<ContentPack, ObjectId> dbCollection, final StreamService streamService,
-                                  MongoConnection mongoConnection) {
-        this.dbCollection = dbCollection;
         this.streamService = streamService;
         this.mongoConnection = mongoConnection;
+        this.collection = new MongoCollections(mapperProvider, mongoConnection)
+                .nonEntityCollection(COLLECTION_NAME, ContentPack.class);
 
         try {
-            dbCollection.createIndex(new BasicDBObject(Identified.FIELD_META_ID, 1).append(Revisioned.FIELD_META_REVISION, 1), new BasicDBObject("unique", true));
-        } catch (DuplicateKeyException e) {
-            // Ignore - this can happen if this runs before the migration of old content packs
+            collection.createIndex(
+                    Indexes.ascending(Identified.FIELD_META_ID, Revisioned.FIELD_META_REVISION),
+                    new IndexOptions().unique(true));
+        } catch (MongoException e) {
+            // Ignore duplicate key error - this can happen if this runs before the migration of old content packs
+            if (!MongoUtils.isDuplicateKeyError(e)) {
+                throw e;
+            }
         }
     }
 
     public Set<ContentPack> loadAll() {
-        final DBCursor<ContentPack> contentPacks = dbCollection.find();
-        return ImmutableSet.copyOf((Iterable<ContentPack>) contentPacks);
+        return ImmutableSet.copyOf(collection.find());
     }
 
     public Set<ContentPack> loadAllLatest() {
@@ -111,13 +113,12 @@ public class ContentPackPersistenceService {
     }
 
     public Set<ContentPack> findAllById(ModelId id) {
-        final DBCursor<ContentPack> result = dbCollection.find(DBQuery.is(Identified.FIELD_META_ID, id));
-        return ImmutableSet.copyOf((Iterable<ContentPack>) result);
+        return ImmutableSet.copyOf(collection.find(eq(Identified.FIELD_META_ID, id)));
     }
 
     public Optional<ContentPack> findByIdAndRevision(ModelId id, int revision) {
-        final DBQuery.Query query = DBQuery.is(Identified.FIELD_META_ID, id).is(Revisioned.FIELD_META_REVISION, revision);
-        return Optional.ofNullable(dbCollection.findOne(query));
+        final var query = and(eq(Identified.FIELD_META_ID, id), eq(Revisioned.FIELD_META_REVISION, revision));
+        return Optional.ofNullable(collection.find(query).first());
     }
 
     public Optional<ContentPack> insert(final ContentPack pack) {
@@ -125,14 +126,18 @@ public class ContentPackPersistenceService {
             LOG.debug("Content pack already found: id: {} revision: {}. Did not insert!", pack.id(), pack.revision());
             return Optional.empty();
         }
-        final WriteResult<ContentPack, ObjectId> writeResult = dbCollection.insert(pack);
-        return Optional.of(writeResult.getSavedObject());
+
+        // The ContentPack interface doesn't allow access to the _id field, therefore we don't bother trying to return
+        // an object with the field set. Instead, we just return the original pack.
+        collection.insertOne(pack);
+
+        return Optional.of(pack);
     }
 
     public Optional<ContentPack> filterMissingResourcesAndInsert(final ContentPack pack) {
         ContentPackV1 cpv1 = (ContentPackV1) pack;
 
-        final Set<String> allStreams = streamService.loadAll().stream().map(stream -> stream.getTitle()).collect(Collectors.toSet());
+        final Set<String> allStreams = streamService.loadAll().stream().map(Stream::getTitle).collect(Collectors.toSet());
         final Map<String, String> streamsInContentPack = new HashMap<>();
 
         cpv1.entities()
@@ -170,15 +175,13 @@ public class ContentPackPersistenceService {
     }
 
     public int deleteById(ModelId id) {
-        final DBQuery.Query query = DBQuery.is(Identified.FIELD_META_ID, id);
-        final WriteResult<ContentPack, ObjectId> writeResult = dbCollection.remove(query);
-        return writeResult.getN();
+        final var query = eq(Identified.FIELD_META_ID, id);
+        return Ints.saturatedCast(collection.deleteMany(query).getDeletedCount());
     }
 
     public int deleteByIdAndRevision(ModelId id, int revision) {
-        final DBQuery.Query query = DBQuery.is(Identified.FIELD_META_ID, id).is(Revisioned.FIELD_META_REVISION, revision);
-        final WriteResult<ContentPack, ObjectId> writeResult = dbCollection.remove(query);
-        return writeResult.getN();
+        final var query = and(eq(Identified.FIELD_META_ID, id), eq(Revisioned.FIELD_META_REVISION, revision));
+        return Ints.saturatedCast(collection.deleteMany(query).getDeletedCount());
     }
 
     public AggregateIterable<Document> aggregate(List<Bson> aggregates) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
@@ -18,9 +18,6 @@ package org.graylog2.contentpacks.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.graylog2.contentpacks.model.constraints.Constraint;
-
-import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = Versioned.FIELD_META_VERSION, defaultImpl = LegacyContentPack.class)
 @JsonSubTypes({

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackInstallation.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackInstallation.java
@@ -23,7 +23,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.bson.types.ObjectId;
-import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
@@ -72,11 +71,12 @@ public abstract class ContentPackInstallation {
         return new AutoValue_ContentPackInstallation.Builder();
     }
 
+    public abstract Builder toBuilder();
+
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonProperty(FIELD_ID)
-        @Nullable
-        abstract Builder id(ObjectId id);
+        public abstract Builder id(ObjectId id);
 
         @JsonProperty(FIELD_CONTENT_PACK_ID)
         public abstract Builder contentPackId(ModelId contentPackId);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.java
@@ -25,6 +25,7 @@ import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.contentpacks.model.ContentPackInstallation;
 import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.database.MongoCollections;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,8 +50,7 @@ public class ContentPackInstallationPersistenceServiceTest {
         final MongoJackObjectMapperProvider mongoJackObjectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
 
         persistenceService = new ContentPackInstallationPersistenceService(
-                mongoJackObjectMapperProvider,
-                mongodb.mongoConnection());
+                new MongoCollections(mongoJackObjectMapperProvider, mongodb.mongoConnection()));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
@@ -30,6 +30,7 @@ import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackInstallation;
 import org.graylog2.contentpacks.model.ContentPackUninstallation;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.database.MongoCollections;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
@@ -103,7 +104,8 @@ class V20230601104500_AddSourcesPageV2Test {
         var mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
         var mongoConnection = mongodb.mongoConnection();
         ContentPackPersistenceService contentPackPersistenceService = new ContentPackPersistenceService(mapperProvider, mongoConnection, streamService);
-        ContentPackInstallationPersistenceService contentPackInstallationPersistenceService = new ContentPackInstallationPersistenceService(mapperProvider, mongoConnection);
+        ContentPackInstallationPersistenceService contentPackInstallationPersistenceService =
+                new ContentPackInstallationPersistenceService(new MongoCollections(mapperProvider, mongoConnection));
         ContentPackService contentPackService = new TestContentPackService();
         this.migration = new V20230601104500_AddSourcesPageV2(contentPackService, objectMapper, clusterConfigService,
                 contentPackPersistenceService, contentPackInstallationPersistenceService, mongoConnection, notificationService);


### PR DESCRIPTION
Removed usage of `JacksonDBCollection` because it's scheduled for removal.

/nocl
