### PR TITLE
Fixing key warning for `StreamsField` component.

### DIFF
--- a/graylog2-web-interface/src/views/components/fieldtypes/StreamsField.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/StreamsField.tsx
@@ -33,7 +33,7 @@ const StreamsList = styled.span`
 const StreamsField = ({ value }: Props) => {
   const streams = useContext(StreamsContext);
   const streamsMap = useMemo(() => Object.fromEntries(streams.map((stream) => [stream.id, stream]) ?? []), [streams]);
-  const renderStream = useCallback((streamId: string) => <span title={streamId}>{streamsMap[streamId]?.title ?? streamId}</span>, [streamsMap]);
+  const renderStream = useCallback((streamId: string) => <span key={streamId} title={streamId}>{streamsMap[streamId]?.title ?? streamId}</span>, [streamsMap]);
 
   return Array.isArray(value)
     ? <StreamsList>{value.map(renderStream)}</StreamsList>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR contains a simple fix to get rid of the `Each child in a list should have a unique "key" prop.` warning for the `StreamsField` component.

/nocl