### PR TITLE
Fix when widget title input in widget edit mode looses cursor position on change

### DIFF
--- a/changelog/unreleased/issue-21145.toml
+++ b/changelog/unreleased/issue-21145.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix when widget title input in widget edit mode looses cursor position on change"
+
+pulls = ["21327"]
+issues = ["21145"]

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -96,6 +96,3 @@ setup_mode=off
 
 # Show security events in paginated entity data table
 show_security_events_in_pedt=off
-
-# Show executive dashboard
-show_executive_dashboard_page=off

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -96,3 +96,6 @@ setup_mode=off
 
 # Show security events in paginated entity data table
 show_security_events_in_pedt=off
+
+# Show executive dashboard
+show_executive_dashboard_page=off

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -93,7 +93,7 @@ const WidgetTitle = ({ onChange, editing, title, titleIcon }: WidgetTitleProps) 
         <TitleInput type="text"
                     id="widget-title"
                     onChange={(e) => onChange(e.target.value)}
-                    value={title}
+                    defaultValue={title}
                     required />
       </TitleInputWrapper>
     );

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -82,7 +82,7 @@ type WidgetTitleProps = {
   titleIcon?: React.ReactNode,
 }
 
-const WidgetTitle = ({ onChange, editing, title, titleIcon }: WidgetTitleProps) => {
+const WidgetTitle = ({ onChange = undefined, editing, title, titleIcon = undefined }: WidgetTitleProps) => {
   if (typeof onChange !== 'function') {
     return <><Title>{title}</Title>{titleIcon}</>;
   }
@@ -125,9 +125,9 @@ const WidgetHeader = ({
   editing,
   hideDragHandle = false,
   loading = false,
-  children,
-  titleIcon,
-  onRename,
+  children = undefined,
+  titleIcon = undefined,
+  onRename = undefined,
 }: Props) => (
   <Container>
     <Col>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
fix: #21145 

we might need backports to 6.1 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

