### PR TITLE
Improving Hotkeys for query input

### DIFF
--- a/changelog/unreleased/issue-20423.toml
+++ b/changelog/unreleased/issue-20423.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing keyboard shortcut conflicts for opening query history by changing it to ctrl+space on win and linux os"
+
+issues = ["20423"]
+pulls = ["21336"]

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -96,6 +96,3 @@ setup_mode=off
 
 # Show security events in paginated entity data table
 show_security_events_in_pedt=off
-
-# Show executive dashboard
-show_executive_dashboard_page=off

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -96,3 +96,6 @@ setup_mode=off
 
 # Show security events in paginated entity data table
 show_security_events_in_pedt=off
+
+# Show executive dashboard
+show_executive_dashboard_page=off

--- a/graylog2-web-interface/src/components/hotkeys/HotkeyCollectionSection.tsx
+++ b/graylog2-web-interface/src/components/hotkeys/HotkeyCollectionSection.tsx
@@ -53,6 +53,9 @@ const KeySeparator = styled.div`
 const keyMapper = (key: string, isMacOS: boolean) => {
   const keyMap = {
     mod: isMacOS ? '⌘' : 'Ctrl',
+    alt: isMacOS ? '⌥' : 'Alt',
+    ctrl: isMacOS ? '⌃' : 'Ctrl',
+    meta: isMacOS ? '⌘' : 'Win',
   };
 
   return keyMap[key] || key;

--- a/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
+++ b/graylog2-web-interface/src/contexts/HotkeysProvider.tsx
@@ -25,6 +25,7 @@ import Immutable from 'immutable';
 
 import type { ScopeName, ActiveHotkeys, HotkeyCollections, Options } from 'contexts/HotkeysContext';
 import HotkeysContext from 'contexts/HotkeysContext';
+import { isMacOS } from 'util/OSUtils';
 
 const viewActions = {
   undo: { keys: 'mod+shift+z', description: 'Undo last action' },
@@ -68,7 +69,7 @@ export const hotKeysCollections: HotkeyCollections = {
       'submit-search': { keys: 'return', description: 'Execute the search' },
       'insert-newline': { keys: 'shift+return', description: 'Create a new line' },
       'create-search-filter': { keys: 'alt+return', description: 'Create search filter based on current query' },
-      'show-suggestions': { keys: 'alt+space', description: 'Show suggestions, displays query history when input is empty' },
+      'show-suggestions': { keys: isMacOS() ? 'alt+space' : 'mod+space', description: 'Show suggestions, displays query history when input is empty' },
       'show-history': { keys: 'alt+shift+h', description: 'View your search query history' },
     },
   },

--- a/graylog2-web-interface/src/util/OSUtils.ts
+++ b/graylog2-web-interface/src/util/OSUtils.ts
@@ -16,4 +16,4 @@
  */
 
 // eslint-disable-next-line import/prefer-default-export
-export const isMacOS = () => navigator.userAgent.indexOf('Mac OS X') !== -1;
+export const isMacOS = () => /Macintosh|MacIntel/.test(navigator.userAgent);

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -255,7 +255,7 @@ const QueryInput = React.forwardRef<Editor, Props>(({
     },
     {
       name: 'Show completions',
-      bindKey: { win: 'Alt-Space', mac: 'Alt-Space' },
+      bindKey: { win: 'Ctrl-Space', mac: 'Alt-Space' },
       exec: async (editor: Editor) => {
         if (editor.getValue()) {
           startAutocomplete(editor);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR improves hotkeys for search query input. 
Now for win/linux we are using` ctrl+space` to show suggestions
Also this PR do some improvements: 
- add mapping with mac symbols for ctrl and option keys
- improve isMacOS function

## Motivation and Context
fix: #20423 

we might need backports to 6.1 and 6.0
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

