### PR TITLE
Replacing use of store with `useQuery` for content packs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
@@ -16,8 +16,11 @@
  */
 package org.graylog2.contentpacks.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.net.URI;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = Versioned.FIELD_META_VERSION, defaultImpl = LegacyContentPack.class)
 @JsonSubTypes({
@@ -27,4 +30,19 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface ContentPack extends Identified, Revisioned, Versioned {
     interface ContentPackBuilder<SELF> extends IdBuilder<SELF>, RevisionBuilder<SELF>, VersionBuilder<SELF> {
     }
+
+    @JsonProperty
+    String name();
+
+    @JsonProperty
+    String description();
+
+    @JsonProperty
+    String summary();
+
+    @JsonProperty
+    URI url();
+
+    @JsonProperty
+    String vendor();
 }

--- a/graylog2-web-interface/src/components/common/router.tsx
+++ b/graylog2-web-interface/src/components/common/router.tsx
@@ -49,7 +49,7 @@ type Props = {
   target?: string,
 };
 
-const isLeftClickEvent = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => (e.button === 0);
+const isLeftClickEvent = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => (e?.button === 0);
 
 const isModifiedEvent = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallEntityList.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallEntityList.tsx
@@ -27,7 +27,7 @@ type ContentPackInstallEntityListProps = {
 };
 
 const ContentPackInstallEntityList = ({
-  entities,
+  entities = undefined,
   uninstall = false,
 }: ContentPackInstallEntityListProps) => {
   const rowFormatter = (entity: InstalledEntity) => (<tr><td>{entity.title}</td><td>{entity.type.name}</td></tr>);

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallEntityList.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallEntityList.tsx
@@ -18,11 +18,11 @@ import React from 'react';
 
 import Spinner from 'components/common/Spinner';
 import { DataTable } from 'components/common';
-
 import 'components/content-packs/ContentPackDetails.css';
+import type { InstalledEntity } from 'components/content-packs/Types';
 
 type ContentPackInstallEntityListProps = {
-  entities?: any[];
+  entities?: InstalledEntity[];
   uninstall?: boolean;
 };
 
@@ -30,7 +30,7 @@ const ContentPackInstallEntityList = ({
   entities,
   uninstall = false,
 }: ContentPackInstallEntityListProps) => {
-  const rowFormatter = (entity) => (<tr><td>{entity.title}</td><td>{entity.type.name}</td></tr>);
+  const rowFormatter = (entity: InstalledEntity) => (<tr><td>{entity.title}</td><td>{entity.type.name}</td></tr>);
   const headers = ['Title', 'Type'];
   const headerTitle = uninstall ? 'Entites to be uninstalled' : 'Installed Entities';
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.tsx
@@ -23,13 +23,16 @@ import 'components/content-packs/ContentPackDetails.css';
 import ContentPackInstallEntityList from './ContentPackInstallEntityList';
 
 type ContentPackInstallViewProps = {
-  install: any;
+  install: {
+    comment: string,
+    created_at: string,
+    created_by: string,
+    entities: any[],
+  };
 };
 
-const ContentPackInstallView = (props: ContentPackInstallViewProps) => {
-  const { comment } = props.install;
-  const createdAt = props.install.created_at;
-  const createdBy = props.install.created_by;
+const ContentPackInstallView = ({ install }: ContentPackInstallViewProps) => {
+  const { comment, created_at: createdAt, created_by: createdBy, entities } = install;
 
   return (
     <div>
@@ -48,7 +51,7 @@ const ContentPackInstallView = (props: ContentPackInstallViewProps) => {
       </Row>
       <Row>
         <Col smOffset={1} sm={10}>
-          <ContentPackInstallEntityList entities={props.install.entities} />
+          <ContentPackInstallEntityList entities={entities} />
         </Col>
       </Row>
     </div>

--- a/graylog2-web-interface/src/components/content-packs/Types.ts
+++ b/graylog2-web-interface/src/components/content-packs/Types.ts
@@ -16,17 +16,17 @@
  */
 
 export type ContentPackInstallation = {
-  created_at: string,
+  created_at?: string,
   description: string,
   entities?: Array<ContentPackEntity>,
   id: string,
   name: string,
   parameters?: Array<any>,
   rev: number,
-  server_version: string,
+  server_version?: string,
   summary: string,
   url: string,
-  v: number,
+  v: string,
   vendor: string,
 }
 
@@ -70,9 +70,9 @@ export interface Constraint {
 }
 
 export type ContentPackMetadata = {
-  [key: number]: {
-    [key: number]: {
-      [key: string]: number,
+  [string: number]: {
+    [string: number]: {
+      installation_count: number,
     },
   },
 }

--- a/graylog2-web-interface/src/components/content-packs/Types.ts
+++ b/graylog2-web-interface/src/components/content-packs/Types.ts
@@ -76,3 +76,10 @@ export type ContentPackMetadata = {
     },
   },
 }
+
+export type InstalledEntity = {
+  title: string,
+  type: {
+    name: string
+  }
+}

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackListItem.test.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackListItem.test.tsx
@@ -30,7 +30,7 @@ describe('<ContentPackListItem />', () => {
     server_version: '6.0.0-SNAPSHOT',
     summary: 'The Open Thread Exchange Lookup Table of the Threat Intel Plugin',
     url: 'https://github.com/Graylog2/graylog2-server',
-    v: 1,
+    v: '1',
     vendor: 'Graylog <hello@graylog.com>',
   };
 

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPackInstallations.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPackInstallations.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { SystemContentPacks } from '@graylog/server-api';
+
+const useContentPackInstallations = (id: string) => useQuery(
+  ['content-packs', 'installations', id],
+  () => SystemContentPacks.listContentPackInstallationsById(id),
+);
+export default useContentPackInstallations;

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPackInstallations.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPackInstallations.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useQuery } from '@tanstack/react-query';
 
 import { SystemContentPacks } from '@graylog/server-api';

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { SystemContentPacks } from '@graylog/server-api';
+
+import ContentPackRevisions from 'logic/content-packs/ContentPackRevisions';
+import { onError } from 'util/conditional/onError';
+
+const fetchContentPackRevisions = async (id: string) => {
+  const response = await SystemContentPacks.listContentPackRevisions(id);
+  const contentPackRevision = new ContentPackRevisions(response.content_pack_revisions);
+  const constraints = response.constraints_result;
+
+  return {
+    contentPackRevisions: contentPackRevision,
+    selectedVersion: contentPackRevision.latestRevision,
+    constraints: constraints,
+  };
+};
+
+const useContentPackRevisions = (id: string, onFetchError: (e: Error) => void) => useQuery(
+  ['content-packs', 'revisions', id],
+  () => onError(fetchContentPackRevisions(id), onFetchError),
+);
+export default useContentPackRevisions;

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useQuery } from '@tanstack/react-query';
 
 import { SystemContentPacks } from '@graylog/server-api';

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPackRevisions.ts
@@ -4,6 +4,7 @@ import { SystemContentPacks } from '@graylog/server-api';
 
 import ContentPackRevisions from 'logic/content-packs/ContentPackRevisions';
 import { onError } from 'util/conditional/onError';
+import UserNotification from 'util/UserNotification';
 
 const fetchContentPackRevisions = async (id: string) => {
   const response = await SystemContentPacks.listContentPackRevisions(id);
@@ -17,7 +18,9 @@ const fetchContentPackRevisions = async (id: string) => {
   };
 };
 
-const useContentPackRevisions = (id: string, onFetchError: (e: Error) => void) => useQuery(
+const defaultErrorHandler = (error: Error) => UserNotification.error(`Error while fetching content pack revisions: ${error}`, 'Unable to fetch content pack');
+
+const useContentPackRevisions = (id: string, onFetchError: (e: Error) => void = defaultErrorHandler) => useQuery(
   ['content-packs', 'revisions', id],
   () => onError(fetchContentPackRevisions(id), onFetchError),
 );

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPacks.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPacks.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { SystemContentPacks } from '@graylog/server-api';
+
+const useContentPacks = () => useQuery(['content-packs', 'list'], () => SystemContentPacks.listContentPacks());
+export default useContentPacks;

--- a/graylog2-web-interface/src/components/content-packs/hooks/useContentPacks.ts
+++ b/graylog2-web-interface/src/components/content-packs/hooks/useContentPacks.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { useQuery } from '@tanstack/react-query';
 
 import { SystemContentPacks } from '@graylog/server-api';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with loading/refreshing content pack revisions/installations on the content pack details page by replacing the use of the Reflux store with `useQuery`.

Fixes #21122.

/nocl Fixes bug in unreleased change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.