### PR TITLE
Add definition id when render summaryComponent in event definition

### DIFF
--- a/changelog/unreleased/pr-21359.toml
+++ b/changelog/unreleased/pr-21359.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix error when clicking the Replay search link in event definition summary in edit modal on security events page"
+
+issues = ["graylog-plugin-enterprise#9289"]
+pulls = ["21359"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.tsx
@@ -38,7 +38,7 @@ import commonStyles from '../common/commonStyles.css';
 import { SYSTEM_EVENT_DEFINITION_TYPE } from '../constants';
 
 type Props = {
-  eventDefinition: Omit<EventDefinition, 'id'>,
+  eventDefinition: EventDefinition,
   notifications: Array<EventNotification>,
   validation?: {
     errors: {
@@ -91,12 +91,13 @@ const EventDefinitionSummary = ({ eventDefinition, notifications, validation, cu
     return PluginStore.exports(name).find((edt) => edt.type === type);
   };
 
-  const renderCondition = (config: EventDefinition['config']) => {
+  const renderCondition = (config: EventDefinition['config'], definitionId: string) => {
     const conditionPlugin = getPlugin('eventDefinitionTypes', config.type);
     const component = (conditionPlugin?.summaryComponent
       ? React.createElement(conditionPlugin.summaryComponent, {
         config,
         currentUser,
+        definitionId,
       })
       : <p>Condition plugin <em>{config.type}</em> does not provide a summary.</p>
     );
@@ -252,7 +253,7 @@ const EventDefinitionSummary = ({ eventDefinition, notifications, validation, cu
 
           {!isSystemEventDefinition && (
             <Col md={5} mdOffset={1}>
-              {renderCondition(eventDefinition.config)}
+              {renderCondition(eventDefinition.config, eventDefinition.id)}
             </Col>
           )}
         </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the definition id as a prop to the summary component. That helps to create correct replay link and fix the issue 

## Motivation and Context
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/9289

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

