### PR TITLE
Fixing highlighting of message in message table by id. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-19058.toml
+++ b/changelog/unreleased/issue-19058.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing highlighting of message in message table by id."
+
+issues = ["19058"]
+pulls = ["21389"]

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useCallback, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import { useStore } from 'stores/connect';
@@ -52,11 +52,11 @@ export const TableBody = styled.tbody<{ $expanded?: boolean, $highlighted?: bool
   && {
     border-top: 0;
 
-    ${$expanded ? css`
+    ${$expanded ? `
   border-left: 7px solid ${theme.colors.variant.light.info};
 ` : ''}
 
-    ${$highlighted ? css`
+    ${$highlighted ? `
   border-left: 7px solid ${theme.colors.variant.light.success};
 ` : ''}
   }

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.tsx
@@ -100,19 +100,19 @@ type Props = {
   message: Message,
   selectedFields?: Immutable.OrderedSet<string>,
   showMessageRow?: boolean,
-  toggleDetail: (string) => void,
+  toggleDetail: (messageId: string) => void,
 };
 
-const isDecoratedField = (field, decorationStats) => decorationStats
+const isDecoratedField = (field: string | number, decorationStats: Message['decoration_stats']) => decorationStats
   && (decorationStats.added_fields[field] !== undefined || decorationStats.changed_fields[field] !== undefined);
 
-const fieldType = (fieldName, { decoration_stats: decorationStats }: {
-  decoration_stats?: any
-}, fields) => (isDecoratedField(fieldName, decorationStats)
-  ? FieldType.Decorated
-  : ((fields && fields.find((f) => f.name === fieldName)) || { type: FieldType.Unknown }).type);
+const fieldType = (fieldName: string, { decoration_stats: decorationStats }: Message, fields: FieldTypeMappingsList) => (
+  isDecoratedField(fieldName, decorationStats)
+    ? FieldType.Decorated
+    : ((fields?.find((f) => f.name === fieldName)) ?? { type: FieldType.Unknown }).type
+);
 
-const Strong = ({ children, strong = false }: React.PropsWithChildren<{ strong: boolean }>) => (strong
+const Strong = ({ children = undefined, strong }: React.PropsWithChildren<{ strong: boolean }>) => (strong
   ? <strong>{children}</strong>
 
   : <>{children}</>);


### PR DESCRIPTION
**Note:** This is a backport of #21389 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing message highlighting by id in the message table, e.g. when using the "Show surrounding messages" functionality.
Previously, the css function was used inline, which generated invalid css for the left border color.

Fixes #19058.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.