### PR TITLE
Set unit settings to undefined on clear unit type

### DIFF
--- a/changelog/unreleased/issue-21398.toml
+++ b/changelog/unreleased/issue-21398.toml
@@ -1,5 +1,5 @@
 type = "f"
-message = "Fix an issue when was impossible to save search/dashboard after clearing the unit type"
+message = "Fix an issue causing saving searches/dashboards after clearing the unit type to fail with error."
 
 pulls = ["21399"]
 issues = ["21398"]

--- a/changelog/unreleased/issue-21398.toml
+++ b/changelog/unreleased/issue-21398.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix an issue when was impossible to save search/dashboard after clearing the unit type"
+
+pulls = ["21399"]
+issues = ["21398"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -70,10 +70,6 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
   const unitOptions = useMemo(() => currentUnitType && units[currentUnitType]
     .map(({ abbrev, name }: Unit) => ({ value: abbrev, label: capitalize(name) })), [currentUnitType]);
   const toggleShow = () => setShow((cur) => !cur);
-  const onClear = useCallback(() => {
-    setFieldValue(`units.${field}`, undefined);
-    toggleShow();
-  }, [field, setFieldValue]);
   const onUnitTypeChange = useCallback((val: string) => {
     const fieldUnitSettings = val
       ? { unitType: val, abbrev: undefined }
@@ -94,6 +90,11 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
 
     return <>Unit <b>{unitName}</b> was defined for field <b>{field}</b> by Graylog. Changing this unit might represent data incorrectly on the charts</>;
   }, [field, predefinedUnit?.abbrev, predefinedUnit?.isDefined, predefinedUnit?.unitType]);
+
+  const onClear = useCallback(() => {
+    setFieldValue(`units.${field}`, undefined);
+    toggleShow();
+  }, [field, setFieldValue]);
 
   return (
     <Popover position="right" opened={show} withArrow>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -70,8 +70,15 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
   const unitOptions = useMemo(() => currentUnitType && units[currentUnitType]
     .map(({ abbrev, name }: Unit) => ({ value: abbrev, label: capitalize(name) })), [currentUnitType]);
   const toggleShow = () => setShow((cur) => !cur);
+  const onClear = useCallback(() => {
+    setFieldValue(`units.${field}`, undefined);
+    toggleShow();
+  }, [field, setFieldValue]);
   const onUnitTypeChange = useCallback((val: string) => {
-    setFieldValue(`units.${field}`, { unitType: val || undefined, abbrev: undefined });
+    const fieldUnitSettings = val
+      ? { unitType: val, abbrev: undefined }
+      : undefined;
+    setFieldValue(`units.${field}`, fieldUnitSettings);
   }, [field, setFieldValue]);
 
   const badgeLabel = useMemo(() => {
@@ -87,11 +94,6 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string, predefined
 
     return <>Unit <b>{unitName}</b> was defined for field <b>{field}</b> by Graylog. Changing this unit might represent data incorrectly on the charts</>;
   }, [field, predefinedUnit?.abbrev, predefinedUnit?.isDefined, predefinedUnit?.unitType]);
-
-  const onClear = useCallback(() => {
-    setFieldValue(`units.${field}`, undefined);
-    toggleShow();
-  }, [field, setFieldValue]);
 
   return (
     <Popover position="right" opened={show} withArrow>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR set unit settings to undefined on clear unit type. In this case instead of empty object we send undefined to BE and that fix an issue 

## Motivation and Context
fix: #21398

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

