### PR TITLE
Pinning yarn as package manager for integrated packages.

### DIFF
--- a/graylog2-web-interface/packages/babel-preset-graylog/package.json
+++ b/graylog2-web-interface/packages/babel-preset-graylog/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Babel preset for the Graylog project",
   "main": "index.js",
+  "packageManager": "yarn@1.22.22",
   "repository": "https://github.com/Graylog2/graylog2-server",
   "author": "Graylog, Inc. <hello@graylog.com>",
   "license": "SSPL-1.0",

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "Graylog ESLint config for web interface plugin authors",
   "main": "index.js",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/graylog2-web-interface/packages/eslint-plugin-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-plugin-graylog/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Collection of custom ESLint rules.",
   "main": "./lib/index.js",
+  "packageManager": "yarn@1.22.22",
   "exports": "./lib/index.js",
   "author": "Graylog, Inc. <hello@graylog.com>",
   "license": "SSPL-1.0"

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "6.2.0-SNAPSHOT",
   "description": "Helper code for streamlining Graylog web interface plugin development",
   "main": "index.js",
+  "packageManager": "yarn@1.22.22",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Graylog2/graylog-web-plugin.git"

--- a/graylog2-web-interface/packages/jest-preset-graylog/package.json
+++ b/graylog2-web-interface/packages/jest-preset-graylog/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Graylog jest preset, contains the jest configuration and dependencies to setup the test environment for the web interface",
   "main": "jest-preset.js",
+  "packageManager": "yarn@1.22.22",
   "keywords": [
     "graylog",
     "jest"

--- a/graylog2-web-interface/packages/stylelint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/stylelint-config-graylog/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Graylog StyleLint config for web interface plugin authors",
   "main": "index.js",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is pinning `yarn` as package manager for the integrated packages, so dependabot does not fall back to `npm@6`, which has been [deprecated](https://github.blog/changelog/2025-01-20-dependabot-will-no-longer-support-npm-v6/#:~:text=As%20of%20January%2020th%2C%202025,a%20supported%20release%20of%20NPM.)

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.