### PR TITLE
Fix when widget title input in widget edit mode looses cursor position on change 6.1

### DIFF
--- a/changelog/unreleased/issue-21145.toml
+++ b/changelog/unreleased/issue-21145.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix when widget title input in widget edit mode looses cursor position on change"
+
+pulls = ["21327"]
+issues = ["21145"]

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -96,7 +96,7 @@ const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading, edit
           <TitleInput type="text"
                       id="widget-title"
                       onChange={(e) => onRename(e.target.value)}
-                      value={title}
+                      defaultValue={title}
                       required />
         </TitleInputWrapper>
       ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Note: this is a backport of #21327
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
fix: #21145 

we might need backports to 6.1 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

