### PR TITLE
Revert "Close QueryValidation popover on outside click (#21347)"

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -202,7 +202,7 @@ const QueryValidation = () => {
   };
 
   return (
-    <Popover onChange={toggleShow} opened={hasExplanations && showExplanation} position="bottom" width={500} withArrow>
+    <Popover opened={hasExplanations && showExplanation} position="bottom" width={500} withArrow>
       <Popover.Target>
         <Container ref={explanationTriggerRef}>
           {hasExplanations ? (


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This reverts commit 80cdf4dc62a3399f6734f7874bc2345e0b694d39. The PR is breaking parameter support, because declaring a parameter from the popover will break on the first click in the parameter declaration modal.

/nocl Reverting unreleased change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.