### PR TITLE
New configuration to (dis-)allow external users create access tokens

### DIFF
--- a/changelog/unreleased/issue-21322.toml
+++ b/changelog/unreleased/issue-21322.toml
@@ -1,0 +1,5 @@
+type="a"
+message="Added new Configuration to define default for allowing access tokens for external users."
+
+issues=["21322"]
+pulls=["21438"]

--- a/graylog2-server/src/main/java/org/graylog2/users/UserConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.plugin.Version;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -29,18 +30,26 @@ import java.time.temporal.ChronoUnit;
 @AutoValue
 @WithBeanGetter
 public abstract class UserConfiguration {
-    public static final UserConfiguration DEFAULT_VALUES = create(false, Duration.of(8, ChronoUnit.HOURS));
+    private static final boolean IS_BEFORE_VERSION_6_2 = !Version.CURRENT_CLASSPATH.sameOrHigher(Version.from(6, 2, 0));
+
+    //Starting with graylog version 6.2, external users are not allowed to own access tokens by default.
+    // Before this version, it is allowed, to not introduce a breaking change:
+    public static final UserConfiguration DEFAULT_VALUES = create(false, Duration.of(8, ChronoUnit.HOURS), IS_BEFORE_VERSION_6_2);
 
     @JsonProperty("enable_global_session_timeout")
     public abstract boolean enableGlobalSessionTimeout();
 
     @JsonProperty("global_session_timeout_interval")
-    public abstract java.time.Duration globalSessionTimeoutInterval();
+    public abstract Duration globalSessionTimeoutInterval();
+
+    @JsonProperty("allow_access_token_for_external_user")
+    public abstract boolean allowAccessTokenForExternalUsers();
 
     @JsonCreator
     public static UserConfiguration create(
             @JsonProperty("enable_global_session_timeout") boolean enableGlobalSessionTimeout,
-            @JsonProperty("global_session_timeout_interval") java.time.Duration globalSessionTimeoutInterval) {
-        return new AutoValue_UserConfiguration(enableGlobalSessionTimeout, globalSessionTimeoutInterval);
+            @JsonProperty("global_session_timeout_interval") Duration globalSessionTimeoutInterval,
+            @JsonProperty("allow_access_token_for_external_user") boolean allowAccessTokenForExternalUsers) {
+        return new AutoValue_UserConfiguration(enableGlobalSessionTimeout, globalSessionTimeoutInterval, allowAccessTokenForExternalUsers);
     }
 }


### PR DESCRIPTION
Fixes #21403 
<!--- Provide a general summary of your changes in the Title above -->
Add a new configuration-entry to manage creation of access-tokens for external users.

## Description
<!--- Describe your changes in detail -->
The configuration's value is considered when a user wants to create a new access token. For internal users, it doesn't make a difference, for external ones, it would forbid creating a token if set to `false`. Otherwise, external users are also allowed to create access tokens.

Starting with graylog 6.2, the configuration is set to not allow external users creating an access token. Before that version, it is allowed, to prevent a breaking change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are test-cases covering all three options (internal user, external with setting being `true` and external user with setting being `false`).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

