### PR TITLE
Gather metrics from shared scheduler thread pools

### DIFF
--- a/changelog/unreleased/pr-21454.toml
+++ b/changelog/unreleased/pr-21454.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Added metrics to the shared "scheduler" and "daemonScheduler" thread pools."
+
+pulls = ["21454"]

--- a/changelog/unreleased/pr-21454.toml
+++ b/changelog/unreleased/pr-21454.toml
@@ -1,4 +1,4 @@
 type = "a"
-message = "Added metrics to the shared "scheduler" and "daemonScheduler" thread pools."
+message = "Added metrics to the shared \"scheduler\" and \"daemonScheduler\" thread pools."
 
 pulls = ["21454"]

--- a/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
@@ -43,7 +43,7 @@ public class Periodicals {
     private static final Logger LOG = LoggerFactory.getLogger(Periodicals.class);
 
     private final List<Periodical> periodicals;
-    private final Map<Periodical, ScheduledFuture> futures;
+    private final Map<Periodical, ScheduledFuture<?>> futures;
     private final ScheduledExecutorService scheduler;
     private final ScheduledExecutorService daemonScheduler;
 
@@ -138,7 +138,7 @@ public class Periodicals {
     /**
      * @return a copy of the map of all executor futures
      */
-    public Map<Periodical, ScheduledFuture> getFutures() {
+    public Map<Periodical, ScheduledFuture<?>> getFutures() {
         return Maps.newHashMap(futures);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/Periodicals.java
@@ -18,6 +18,9 @@ package org.graylog2.periodical;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.periodical.Periodical;
 import org.slf4j.Logger;
@@ -34,6 +37,7 @@ import java.util.stream.Collectors;
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
  */
+@Singleton
 public class Periodicals {
 
     private static final Logger LOG = LoggerFactory.getLogger(Periodicals.class);
@@ -43,7 +47,9 @@ public class Periodicals {
     private final ScheduledExecutorService scheduler;
     private final ScheduledExecutorService daemonScheduler;
 
-    public Periodicals(ScheduledExecutorService scheduler, ScheduledExecutorService daemonScheduler) {
+    @Inject
+    public Periodicals(@Named("scheduler") ScheduledExecutorService scheduler,
+                       @Named("daemonScheduler") ScheduledExecutorService daemonScheduler) {
         this.scheduler = scheduler;
         this.daemonScheduler = daemonScheduler;
         this.periodicals = Lists.newArrayList();

--- a/graylog2-server/src/main/resources/prometheus-exporter.yml
+++ b/graylog2-server/src/main/resources/prometheus-exporter.yml
@@ -1345,3 +1345,23 @@ metric_mappings:
 
   - metric_name: "data_warehouse_journal_written_messages"
     match_pattern: "org.graylog.plugins.datawarehouse.output.journal.writtenMessages"
+
+  - metric_name: "shared_thread_pools_daemon_scheduler_executor"
+    match_pattern: "org.graylog2.shared-thread-pools.scheduled-daemon-executor.*"
+    wildcard_extract_labels:
+      - "type"
+
+  - metric_name: "shared_thread_pools_daemon_scheduler_executor_scheduled"
+    match_pattern: "org.graylog2.shared-thread-pools.scheduled-daemon-executor.scheduled.*"
+    wildcard_extract_labels:
+      - "type"
+
+  - metric_name: "shared_thread_pools_scheduler_executor_scheduled"
+    match_pattern: "org.graylog2.shared-thread-pools.scheduled-executor.*"
+    wildcard_extract_labels:
+      - "type"
+
+  - metric_name: "shared_thread_pools_scheduler_executor_scheduled"
+    match_pattern: "org.graylog2.shared-thread-pools.scheduled-executor.scheduled.*"
+    wildcard_extract_labels:
+      - "type"


### PR DESCRIPTION
Instruments the shared "scheduler" and "daemonScheduler" thread pools to gather metrics.

This was a TODO in the code that I stumbled upon. There is no immediate need for this, but it might help to gain some insight into the runtime behaviour.
