### PR TITLE
Add escape character handling to key_value pipeline function

### DIFF
--- a/changelog/unreleased/pr-21456.toml
+++ b/changelog/unreleased/pr-21456.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added escape character handling to the key_value pipeline rule."
+
+pulls = ["21456"]
+issues = ["graylog-plugin-enterprise#9552"]

--- a/changelog/unreleased/pr-21456.toml
+++ b/changelog/unreleased/pr-21456.toml
@@ -1,5 +1,5 @@
 type = "added"
-message = "Added escape character handling to the key_value pipeline rule."
+message = "Added escape character handling to the key_value pipeline function."
 
 pulls = ["21456"]
 issues = ["graylog-plugin-enterprise#9552"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -133,6 +133,8 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
     }
 
     private static class DelimiterCharMatcher extends CharMatcher {
+        private static final CharMatcher BASE_MATCHER = new DelimiterCharMatcher('"')
+                .and(new DelimiterCharMatcher('\''));
         private final char wrapperChar;
 
         private boolean inWrapper = false;
@@ -144,9 +146,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
          * @return a char matcher that can handle double and single quotes
          */
         static CharMatcher withQuoteHandling(CharMatcher charMatcher) {
-            return new DelimiterCharMatcher('"')
-                    .and(new DelimiterCharMatcher('\''))
-                    .and(charMatcher);
+            return BASE_MATCHER.and(charMatcher);
         }
 
         /**
@@ -157,8 +157,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
          * @return a char matcher that can handle double, single quotes, and escape characters
          */
         static CharMatcher withQuoteAndEscapeHandling(CharMatcher charMatcher) {
-            return new DelimiterCharMatcher('"')
-                    .and(new DelimiterCharMatcher('\''))
+            return BASE_MATCHER
                     .and(new NotEscapedCharMatcher())
                     .and(charMatcher);
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -154,7 +154,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
          * or after the escape char '\'.
          *
          * @param charMatcher the char matcher
-         * @return a char matcher that can handle double and single quotes
+         * @return a char matcher that can handle double, single quotes, and escape characters
          */
         static CharMatcher withQuoteAndEscapeHandling(CharMatcher charMatcher) {
             return new DelimiterCharMatcher('"')

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -133,8 +133,6 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
     }
 
     private static class DelimiterCharMatcher extends CharMatcher {
-        private static final CharMatcher BASE_MATCHER = new DelimiterCharMatcher('"')
-                .and(new DelimiterCharMatcher('\''));
         private final char wrapperChar;
 
         private boolean inWrapper = false;
@@ -146,7 +144,9 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
          * @return a char matcher that can handle double and single quotes
          */
         static CharMatcher withQuoteHandling(CharMatcher charMatcher) {
-            return BASE_MATCHER.and(charMatcher);
+            return new DelimiterCharMatcher('"')
+                    .and(new DelimiterCharMatcher('\''))
+                    .and(charMatcher);
         }
 
         /**
@@ -157,7 +157,8 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
          * @return a char matcher that can handle double, single quotes, and escape characters
          */
         static CharMatcher withQuoteAndEscapeHandling(CharMatcher charMatcher) {
-            return BASE_MATCHER
+            return new DelimiterCharMatcher('"')
+                    .and(new DelimiterCharMatcher('\''))
                     .and(new NotEscapedCharMatcher())
                     .and(charMatcher);
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValueTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValueTest.java
@@ -137,4 +137,25 @@ class KeyValueTest {
 
         assertThat(result).containsExactlyInAnyOrderEntriesOf(expectedResult);
     }
+
+    @Test
+    void testEscapeHandling() {
+        final Map<String, Expression> arguments = Map.of(
+                "value", new StringExpression(new CommonToken(0), "field1=value1,dn=CN=Network Automation User\\,OU=Service Accounts\\,OU=GR\\,OU=Region\\,DC=company\\,DC=local,field3=value3"),
+                "kv_delimiters", new StringExpression(new CommonToken(0), "="),
+                "delimiters", new StringExpression(new CommonToken(0), ","),
+                "allow_dup_keys", new BooleanExpression(new CommonToken(0), true),
+                "use_escape_char", new BooleanExpression(new CommonToken(0), true),
+                "handle_dup_keys", new StringExpression(new CommonToken(0), ",")
+        );
+
+        Map<String, String> result = classUnderTest.evaluate(new FunctionArgs(classUnderTest, arguments), evaluationContext);
+
+        Map<String, String> expectedResult = new HashMap<>();
+        expectedResult.put("field1", "value1");
+        expectedResult.put("dn", "CN=Network Automation User\\,OU=Service Accounts\\,OU=GR\\,OU=Region\\,DC=company\\,DC=local");
+        expectedResult.put("field3", "value3");
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(expectedResult);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a new `use_escape_char` parameter that turns on escape character handling for values in the `key_value` pipeline function.

- Added this feature as an optional parameter to avoid changing any existing usages of the `key_value` function.
- Only works on the outer splitter to allow values to contain escaped delimiter chars - ie, trying to use an escape char in the key doesn't work. Not sure that use case would make sense anyway but open to feedback.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes Graylog2/graylog-plugin-enterprise#9552

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

