### PR TITLE
Preparing tests for `user-event` v14.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/EntityFilters.test.tsx
@@ -314,8 +314,8 @@ describe('<EntityFilters />', () => {
       const timeRangeForm = await screen.findByTestId('time-range-form');
 
       const fromInput = within(timeRangeForm).getByRole('textbox', { name: /from/i });
-      userEvent.clear(fromInput);
-      userEvent.paste(fromInput, '2020-01-01 00:55:00.000');
+      await userEvent.clear(fromInput);
+      await userEvent.type(fromInput, '2020-01-01 00:55:00.000');
 
       const submitButton = within(timeRangeForm).getByRole('button', {
         name: /create filter/i,

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.test.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render, screen, act } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
 import Editor from './Editor';
@@ -53,11 +53,10 @@ describe('MarkdownEditor', () => {
 
     const editor = await screen.findByRole('textbox');
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    await act(async () => {
-      await userEvent.paste(editor, '# this would be a title');
-    });
+    await userEvent.paste(editor, '# this would be a title');
 
-    expect(onChange).toHaveBeenLastCalledWith('# this would be a title');
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith('# this would be a title');
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.test.tsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.test.tsx
@@ -103,8 +103,8 @@ describe('<TimeUnitInput />', () => {
 
     const timeInput = await findTimeInput();
 
-    userEvent.clear(timeInput);
-    userEvent.paste(timeInput, '42');
+    await userEvent.clear(timeInput);
+    await userEvent.type(timeInput, '42');
 
     await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(42, 'SECONDS', true));
   });

--- a/graylog2-web-interface/src/components/rules/RuleForm.test.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.test.tsx
@@ -124,7 +124,7 @@ describe('RuleForm', () => {
 
     expect(rawMessageInput).toHaveValue('');
 
-    await userEvent.paste(rawMessageInput, ruleInput);
+    await userEvent.type(rawMessageInput, ruleInput);
     const runSimulationButton = await screen.findByRole('button', { name: 'Run rule simulation' });
 
     await waitFor(() => {

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.test.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.test.tsx
@@ -76,10 +76,10 @@ describe('RuleBuilder', () => {
     const titleInput = await screen.findByLabelText('Title');
     const descriptionInput = await screen.findByLabelText('Description');
 
-    userEvent.paste(titleInput, title);
-    userEvent.paste(descriptionInput, description);
+    await userEvent.type(titleInput, title);
+    await userEvent.type(descriptionInput, description);
     const createRuleButton = await screen.findByRole('button', { name: 'Create rule' });
-    userEvent.click(createRuleButton);
+    await userEvent.click(createRuleButton);
 
     expect(createRule).toHaveBeenCalledWith({
       title,
@@ -88,7 +88,7 @@ describe('RuleBuilder', () => {
     });
   });
 
-  it('should update Title and Description', () => {
+  it('should update Title and Description', async () => {
     const updateRule = jest.fn();
     const title = 'title';
     const description = 'description';
@@ -111,10 +111,10 @@ describe('RuleBuilder', () => {
     const titleInput = getByLabelText('Title');
     const descriptionInput = getByLabelText('Description');
 
-    userEvent.paste(titleInput, title);
-    userEvent.paste(descriptionInput, description);
+    await userEvent.type(titleInput, title);
+    await userEvent.type(descriptionInput, description);
     const updateRuleButton = getByRole('button', { name: 'Update rule' });
-    userEvent.click(updateRuleButton);
+    await userEvent.click(updateRuleButton);
 
     expect(updateRule).toHaveBeenCalledWith({
       title,

--- a/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/ViewsQueryInput.test.tsx
@@ -41,7 +41,7 @@ class Completer {
   shouldShowCompletions: () => true;
 }
 
-describe('QueryInput', () => {
+describe('ViewsQueryInput', () => {
   const findQueryInput = () => screen.findByRole('textbox');
 
   const SimpleQueryInput = (props: Partial<React.ComponentProps<typeof ViewsQueryInput>>) => (
@@ -73,18 +73,23 @@ describe('QueryInput', () => {
     const onChange = jest.fn();
     render(<SimpleQueryInput onChange={onChange} />);
 
-    userEvent.paste(await findQueryInput(), 'the query');
+    const queryInput = await findQueryInput();
+    queryInput.focus();
+    await userEvent.paste(queryInput, 'the query');
 
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ target: { value: 'the query', name: 'search-query' } });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({ target: { value: 'the query', name: 'search-query' } });
+    });
   });
 
   it('triggers onBlur when input is blurred', async () => {
     const onBlur = jest.fn();
     render(<SimpleQueryInput onBlur={onBlur} />);
 
-    userEvent.paste(await findQueryInput(), 'the query');
-    userEvent.tab();
+    const queryInput = await findQueryInput();
+    queryInput.focus();
+    await userEvent.type(queryInput, 'the query');
+    await userEvent.tab();
 
     expect(onBlur).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is preparing tests for `user-event` v14, by replacing calls to `userEvent.paste` with `userEvent.type`, wherever possible. In v14, the API of `paste` is changing and not taking an element anymore, it should be used anyway only if `type` is not applicable.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.