### PR TITLE
Improve position of widget stretch icon

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useCallback } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import Spinner from 'components/common/Spinner';
 import { widgetDefinition } from 'views/logic/Widgets';
@@ -26,12 +26,12 @@ import useLocation from 'routing/useLocation';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 
-const StyledIconButton = styled(IconButton)<{ $stretched: boolean }>(({ $stretched }) => css`
+const StyledIconButton = styled(IconButton)`
   span {
     position: relative;
-    left: ${$stretched ? '-1px' : 0};
+    left: -1px;
   }
-`);
+`;
 
 type PositionType = {
   col: number,
@@ -79,7 +79,6 @@ const WidgetHorizontalStretch = ({ onStretch, position, widgetId, widgetType }: 
     <StyledIconButton onClick={onClick}
                       name={icon}
                       title={title}
-                      $stretched={stretched}
                       rotation={90} />
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is a small follow-up for https://github.com/Graylog2/graylog2-server/pull/21482.

Before:
![image](https://github.com/user-attachments/assets/e696229c-5659-4a56-91eb-0fd0d99d69cf)

After:
![image](https://github.com/user-attachments/assets/e63a8143-f8fc-4025-8b25-5e2dd88b6d7e)

/nocl