### PR TITLE
Add dependency array to useCreateSavedSearch hook 6.1

### DIFF
--- a/changelog/unreleased/issue-20465.toml
+++ b/changelog/unreleased/issue-20465.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed the issue when the streams link in the message table was not working on the streams page."
+
+issues=["20465"]
+pulls = ["21338"]

--- a/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
@@ -21,22 +21,25 @@ import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Qu
 import ViewGenerator from 'views/logic/views/ViewGenerator';
 import type Parameter from 'views/logic/parameters/Parameter';
 
+type Props = {
+  streamId?: string | string[],
+  streamCategory?: string | string[],
+  timeRange?: TimeRange,
+  queryString?: ElasticsearchQueryString,
+  parameters?: Array<Parameter>,
+}
+
+type Deps = Array<Props[keyof Props]> | [];
 const useCreateSavedSearch = ({
   streamId,
   streamCategory,
   timeRange,
   queryString,
   parameters,
-}:{
-  streamId?: string | string[],
-  streamCategory?: string | string[],
-  timeRange?: TimeRange,
-  queryString?: ElasticsearchQueryString,
-  parameters?: Array<Parameter>,
-}) => useMemo(
+}:Props, deps: Deps = []) => useMemo(
   () => ViewGenerator({ type: View.Type.Search, streamId, streamCategory, timeRange, queryString, parameters }),
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  [],
+  deps,
 );
 
 export default useCreateSavedSearch;

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.tsx
@@ -86,19 +86,20 @@ describe('StreamSearchPage', () => {
       queryString: undefined,
       streamId: 'stream-id-1',
       timeRange: undefined,
-    }));
+    }, [streamId]));
   });
 
-  it('should recreate view when streamId passed from props changes', async () => {
+  it('should rerender hook when streamId passed from props changes', async () => {
     const { rerender } = render(<SimpleStreamSearchPage />);
 
     await waitFor(() => expect(useCreateSavedSearch).toHaveBeenCalledWith({
       queryString: undefined,
       streamId: 'stream-id-1',
       timeRange: undefined,
-    }));
+    }, [streamId]));
 
-    asMock(useParams).mockReturnValue({ streamId: 'stream-id-2' });
+    const secondStream = 'stream-id-2';
+    asMock(useParams).mockReturnValue({ streamId: secondStream });
 
     rerender(<SimpleStreamSearchPage />);
 
@@ -106,7 +107,7 @@ describe('StreamSearchPage', () => {
       queryString: undefined,
       streamId: 'stream-id-2',
       timeRange: undefined,
-    }));
+    }, [secondStream]));
   });
 
   describe('loading another view', () => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.tsx
@@ -35,7 +35,7 @@ const StreamSearchPage = () => {
   }
 
   const { timeRange, queryString } = useSearchURLQueryParams();
-  const viewPromise = useCreateSavedSearch({ streamId, timeRange, queryString });
+  const viewPromise = useCreateSavedSearch({ streamId, timeRange, queryString }, [streamId]);
   const view = useCreateSearch(viewPromise);
 
   const _loadNewView = useCallback(() => loadNewViewForStream(history, streamId), [history, streamId]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
NOTE: This PR is backport https://github.com/Graylog2/graylog2-server/pull/21338

## Description
<!--- Describe your changes in detail -->
Issue #20465 happens because the `useMemo` inside the `useCreateSavedSearch`  hook doesn't have dependencies of `streamId` in the dependencies array. That was done to not recreate the view when on the search page some parameters change (e.g. streams from query params). In the case of the streams search page we have to recreate the view when the stream id from params changes. To solve the issue we can add deps array to `useCreateSavedSearch`  hook  which we pass to `useMemo`

## Motivation and Context
fix: #20465 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

