### PR TITLE
Bump software.amazon.kinesis:amazon-kinesis-client from 2.6.0 to 2.6.1

### DIFF
--- a/changelog/unreleased/pr-21538.toml
+++ b/changelog/unreleased/pr-21538.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Upgrade AWS Kinesis client libary to version 6.1.0 to fix potential shard processing issues."
+
+issues = ["21451"]
+pulls = ["21538"]

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
         <aws-java-sdk-1.version>1.12.675</aws-java-sdk-1.version>
         <aws-java-sdk-2.version>2.30.4</aws-java-sdk-2.version>
-        <aws-kinesis-client.version>2.6.0</aws-kinesis-client.version>
+        <aws-kinesis-client.version>2.6.1</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.2.0</aws-msk-iam-auth.version>
         <!-- When bumping bouncycastle.version, check if the explicit management for bcutil-jdk18on can/must be removed. -->
         <bouncycastle.version>1.80</bouncycastle.version>


### PR DESCRIPTION
Release Notes: https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.6.1

Refs #21451

Needs a backport to at least `6.1`. 