### PR TITLE
Bump software.amazon.kinesis:amazon-kinesis-client from 2.6.0 to 2.6.1 (6.1)

### DIFF
--- a/changelog/unreleased/pr-21538.toml
+++ b/changelog/unreleased/pr-21538.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Upgrade AWS Kinesis client libary to version 6.1.0 to fix potential shard processing issues."
+
+issues = ["21451"]
+pulls = ["21538"]

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
         <aws-java-sdk-1.version>1.12.675</aws-java-sdk-1.version>
         <aws-java-sdk-2.version>2.28.6</aws-java-sdk-2.version>
-        <aws-kinesis-client.version>2.6.0</aws-kinesis-client.version>
+        <aws-kinesis-client.version>2.6.1</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.2.0</aws-msk-iam-auth.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <byte-buddy.version>1.15.3</byte-buddy.version>


### PR DESCRIPTION
Note: this is a backport of #21538.

Release Notes: https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.6.1

Refs https://github.com/Graylog2/graylog2-server/issues/21451