### PR TITLE
Ban bouncycastle jdk15on dependencies

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -483,6 +483,14 @@
                         <groupId>org.apache.directory.api</groupId>
                         <artifactId>api-ldap-schema-data</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -719,6 +719,10 @@
                                         <exclude>javax.inject:*</exclude>
                                         <exclude>javax.ws.rs:javax.*</exclude>
                                         <exclude>com.fasterxml.jackson.jaxrs:*</exclude>
+                                        <!-- Ban bouncycastle jdk15on dependencies. We are using jdk18on equivalents instead. -->
+                                        <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                        <exclude>org.bouncycastle:bcpkix-jdk15on</exclude>
+                                        <exclude>org.bouncycastle:bcutil-jdk15on</exclude>
                                     </excludes>
                                 </bannedDependencies>
                                 <banDuplicatePomDependencyVersions/>


### PR DESCRIPTION
We are using jdk18on dependencies and don't want jdk15on dependencies to be pulled in accidentally. These would usually be rather outdated, and we don't want to take care of version bumps for the jdk15on dependencies.

/nocl

