### PR TITLE
Introduce a queue in InputEventListener to prevent input state races

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputEventListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputEventListenerTest.java
@@ -38,6 +38,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.concurrent.Executors;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -77,7 +79,7 @@ public class InputEventListenerTest {
     @Before
     public void setUp() throws Exception {
         final EventBus eventBus = new EventBus(this.getClass().getSimpleName());
-        listener = new InputEventListener(eventBus, inputLauncher, inputRegistry, inputService, nodeId, leaderElectionService, persistedInputs, serverStatus);
+        listener = new InputEventListener(eventBus, inputLauncher, inputRegistry, inputService, nodeId, leaderElectionService, persistedInputs, serverStatus, Executors.newSingleThreadScheduledExecutor());
     }
 
     @Test


### PR DESCRIPTION
## Description

Use a queue to prevent overlapping input state changes.

## Motivation and Context

Thread-safety issues can be triggered by rapidly restarting an input via API calls. (e.g., with an AMQP input to produce dangling consumers).

## How Has This Been Tested?

Locally, firing input start/stop requests in quick succession.

## Screenshots (if appropriate):

Using the queue, parallel starting and stopping of the input (here: an AMQP input) runs without errors. See video:

https://github.com/user-attachments/assets/5a9181a5-edde-4366-ad3a-021e30f104ec

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

