### PR TITLE
Silence unneeded Azure SDK internal logging

### DIFF
--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -28,12 +28,13 @@
         <Logger name="org.apache.kafka.clients.producer.ProducerConfig" level="warn"/>
         <!-- Silence useless session validation messages -->
         <Logger name="org.apache.shiro.session.mgt.AbstractValidatingSessionManager" level="warn"/>
-        <!-- Silence Azure SDK messages -->
+        <!-- Silence informational Azure SDK messages -->
         <Logger name="com.azure" level="warn"/>
         <Logger name="reactor.core.publisher.Operators" level="off"/>
         <Logger name="com.azure.messaging.eventhubs.PartitionPumpManager" level="off"/>
         <Logger name="com.azure.core.amqp.implementation.ReactorReceiver" level="off"/>
         <Logger name="com.azure.core.amqp.implementation.ReactorDispatcher" level="off"/>
+        <Logger name="com.azure.core.amqp.implementation.MessageFlux" level="off"/>
         <!-- Silence Apache Hadoop/Avro log chatter -->
         <Logger name="org.apache.hadoop" level="warn"/>
         <Logger name="org.apache.parquet.hadoop.InternalParquetRecordReader" level="warn"/>


### PR DESCRIPTION
https://github.com/Graylog2/graylog-plugin-enterprise/pull/9544 updates the Azure SDK, and some additional internal unneeded SDK log messages (for `MessageFlux`) are now surfacing during successful multi-Graylog node partition load balancing operations. This PR silences those, since we have our own partition change logging. 

When starting up a second Graylog node and a partition is transitioned to that node:
```
2025-02-06 14:17:15,010 INFO : org.graylog.enterprise.integrations.azure.external.AzureLogsProcessor - Input [[Azure Event Hubs/Event Hubs/67a3eecc62e4bb171b9760dd]] is now receiving on partition [0].
2025-02-06 14:17:15,610 WARN : com.azure.core.amqp.implementation.MessageFlux - {"az.sdk.message":"Setting next mediator and waiting for activation.","messageFlux":"mf_b4fd2c_1738873035023","connectionId":"MF_bb77fc_1738873035024","linkName":"0_b3f8e7_1738873035023","entityPath":"secdev-test/ConsumerGroups/$default/Partitions/0"}
2025-02-06 14:17:15,677 WARN : com.azure.core.amqp.implementation.MessageFlux - {"az.sdk.message":"The mediator is active.","messageFlux":"mf_b4fd2c_1738873035023","connectionId":"MF_bb77fc_1738873035024","linkName":"0_b3f8e7_1738873035023","entityPath":"secdev-test/ConsumerGroups/$default/Partitions/0"}
2025-02-06 14:17:50,115 WARN : com.azure.core.amqp.implementation.MessageFlux - {"az.sdk.message":"Receiver emitted terminal error.","exception":"New receiver '8b249262-90f5-40a2-b06e-2f1bcd61d187' with higher epoch of '0' is created hence current receiver 'e81eb66c-2a7a-4ec6-bf67-1115a2d63b21' with epoch '0' is getting disconnected. If you are recreating the receiver, make sure a higher epoch is used. TrackingId:bd8e2e5200008b56001fba4967a518cb_G45_B1, SystemTracker:secdev:eventhub:secdev-test~16383|$default, Timestamp:2025-02-06T20:17:50, errorContext[NAMESPACE: secdev.servicebus.windows.net. ERROR CONTEXT: N/A, PATH: secdev-test/ConsumerGroups/$default/Partitions/0, REFERENCE_ID: 0_b3f8e7_1738873035023, LINK_CREDIT: 500]","messageFlux":"mf_b4fd2c_1738873035023","connectionId":"MF_bb77fc_1738873035024","linkName":"0_b3f8e7_1738873035023","entityPath":"secdev-test/ConsumerGroups/$default/Partitions/0"}
2025-02-06 14:17:50,134 WARN : com.azure.core.amqp.implementation.MessageFlux - {"az.sdk.message":"Terminal error signal from Upstream|Receiver arrived at MessageFlux.","exception":"New receiver '8b249262-90f5-40a2-b06e-2f1bcd61d187' with higher epoch of '0' is created hence current receiver 'e81eb66c-2a7a-4ec6-bf67-1115a2d63b21' with epoch '0' is getting disconnected. If you are recreating the receiver, make sure a higher epoch is used. TrackingId:bd8e2e5200008b56001fba4967a518cb_G45_B1, SystemTracker:secdev:eventhub:secdev-test~16383|$default, Timestamp:2025-02-06T20:17:50, errorContext[NAMESPACE: secdev.servicebus.windows.net. ERROR CONTEXT: N/A, PATH: secdev-test/ConsumerGroups/$default/Partitions/0, REFERENCE_ID: 0_b3f8e7_1738873035023, LINK_CREDIT: 500]","messageFlux":"mf_b4fd2c_1738873035023","connectionId":"MF_bb77fc_1738873035024","linkName":"0_b3f8e7_1738873035023","entityPath":"secdev-test/ConsumerGroups/$default/Partitions/0"}
2025-02-06 14:17:50,135 WARN : com.azure.core.amqp.implementation.MessageFlux - {"az.sdk.message":"MessageFlux reached a terminal error-state, signaling it downstream.","exception":"New receiver '8b249262-90f5-40a2-b06e-2f1bcd61d187' with higher epoch of '0' is created hence current receiver 'e81eb66c-2a7a-4ec6-bf67-1115a2d63b21' with epoch '0' is getting disconnected. If you are recreating the receiver, make sure a higher epoch is used. TrackingId:bd8e2e5200008b56001fba4967a518cb_G45_B1, SystemTracker:secdev:eventhub:secdev-test~16383|$default, Timestamp:2025-02-06T20:17:50, errorContext[NAMESPACE: secdev.servicebus.windows.net. ERROR CONTEXT: N/A, PATH: secdev-test/ConsumerGroups/$default/Partitions/0, REFERENCE_ID: 0_b3f8e7_1738873035023, LINK_CREDIT: 500]","messageFlux":"mf_b4fd2c_1738873035023","connectionId":"MF_bb77fc_1738873035024","linkName":"0_b3f8e7_1738873035023","entityPath":"secdev-test/ConsumerGroups/$default/Partitions/0"}
2025-02-06 14:17:50,138 INFO : org.graylog.enterprise.integrations.azure.external.AzureLogsProcessor - Input [[Azure Event Hubs/Event Hubs/67a3eecc62e4bb171b9760dd]] lost ownership of partition [0]. The partition ownership was likely taken by another Graylog node to help balance the receiving load.
2025-02-06 14:17:50,143 INFO : org.graylog.enterprise.integrations.azure.external.AzureLogsProcessor - Input [[Azure Event Hubs/Event Hubs/67a3eecc62e4bb171b9760dd]] has stopped receiving on partition [0].
```

/nocl logging change for dependency update
