### PR TITLE
Make system routing pipeline immutable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineDao.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineDao.java
@@ -19,15 +19,18 @@ package org.graylog.plugins.pipelineprocessor.db;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.graylog2.database.MongoEntity;
+import org.graylog2.database.entities.DefaultEntityScope;
+import org.graylog2.database.entities.ScopedEntity;
 import org.joda.time.DateTime;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
 
+import static org.graylog.plugins.pipelineprocessor.rest.PipelineResource.GL_INPUT_ROUTING_PIPELINE;
+
 @AutoValue
-public abstract class PipelineDao implements MongoEntity {
+public abstract class PipelineDao extends ScopedEntity {
     public static final String FIELD_ID = "id";
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_DESCRIPTION = "description";
@@ -61,13 +64,20 @@ public abstract class PipelineDao implements MongoEntity {
 
     @JsonCreator
     public static PipelineDao create(@Id @ObjectId @JsonProperty(FIELD_ID) @Nullable String id,
+                                     @JsonProperty(FIELD_SCOPE) @Nullable String scope,
                                      @JsonProperty(FIELD_TITLE) String title,
                                      @JsonProperty(FIELD_DESCRIPTION) @Nullable String description,
                                      @JsonProperty(FIELD_SOURCE) String source,
                                      @Nullable @JsonProperty(FIELD_CREATED_AT) DateTime createdAt,
                                      @Nullable @JsonProperty(FIELD_MODIFIED_AT) DateTime modifiedAt) {
+        if (title.equalsIgnoreCase(GL_INPUT_ROUTING_PIPELINE)) {
+            scope = SystemPipelineScope.NAME;
+        } else if (scope == null) {
+            scope = DefaultEntityScope.NAME;
+        }
         return builder()
                 .id(id)
+                .scope(scope)
                 .title(title)
                 .description(description)
                 .source(source)
@@ -77,7 +87,7 @@ public abstract class PipelineDao implements MongoEntity {
     }
 
     @AutoValue.Builder
-    public abstract static class Builder {
+    public abstract static class Builder extends ScopedEntity.AbstractBuilder<Builder> {
         public abstract PipelineDao build();
 
         public abstract Builder id(String id);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/SystemPipelineScope.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/SystemPipelineScope.java
@@ -14,19 +14,25 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog2.database.entities;
+package org.graylog.plugins.pipelineprocessor.db;
 
-import org.graylog.plugins.pipelineprocessor.db.SystemPipelineScope;
-import org.graylog2.plugin.PluginModule;
+import org.graylog2.database.entities.EntityScope;
 
-public class ScopedEntitiesModule extends PluginModule {
+public class SystemPipelineScope extends EntityScope {
+    public static final String NAME = "GRAYLOG_SYSTEM_PIPELINE_SCOPE";
+
     @Override
-    protected void configure() {
-
-        addEntityScope(DefaultEntityScope.class);
-        addEntityScope(SystemPipelineScope.class);
-
-        addSystemRestResource(EntityScopeResource.class);
+    public String getName() {
+        return NAME;
     }
 
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public boolean isDeletable() {
+        return false;
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
@@ -88,7 +88,7 @@ class MessageCreationLoopPreventionTest extends BaseParserTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         """
                                 pipeline "pipeline"
                                 stage 0 match all

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -129,7 +129,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"creates message\";\n" +
@@ -158,7 +158,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"true\";\n" +
@@ -188,7 +188,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"true\";\n" +
@@ -219,7 +219,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match either\n" +
                                 "    rule \"true\";\n" +
@@ -250,7 +250,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match either\n" +
                                 "    rule \"false\";\n" +
@@ -280,7 +280,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match pass\n" +
                                 "    rule \"true\";\n" +
@@ -311,7 +311,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match pass\n" +
                                 "    rule \"false\";\n" +
@@ -347,7 +347,7 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(ImmutableList.of(
-                PipelineDao.create("p1", "title1", "description",
+                PipelineDao.create("p1", null, "title1", "description",
                         "pipeline \"pipeline1\"\n" +
                                 "stage 0 match pass\n" +
                                 "    rule \"1-a\";\n" +
@@ -357,7 +357,7 @@ public class PipelineInterpreterTest {
                                 "end\n",
                         Tools.nowUTC(),
                         null),
-                PipelineDao.create("p2", "title2", "description",
+                PipelineDao.create("p2", null, "title2", "description",
                         "pipeline \"pipeline2\"\n" +
                                 "stage 0 match pass\n" +
                                 "    rule \"2-a\";\n" +
@@ -445,7 +445,7 @@ public class PipelineInterpreterTest {
         );
 
         final PipelineService pipelineService = new InMemoryPipelineService(new ClusterEventBus());
-        pipelineService.save(PipelineDao.create("cde", "title", "description",
+        pipelineService.save(PipelineDao.create("cde", null, "title", "description",
                 "pipeline \"pipeline\"\n" +
                         "stage 0 match all\n" +
                         "    rule \"match_all\";\n" +
@@ -538,7 +538,7 @@ public class PipelineInterpreterTest {
                         "end", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"broken_condition\";\n" +
@@ -583,7 +583,7 @@ public class PipelineInterpreterTest {
                         "end", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"broken_statement\";\n" +
@@ -629,7 +629,7 @@ public class PipelineInterpreterTest {
                         "end", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
-                PipelineDao.create("p1", "title", "description",
+                PipelineDao.create("p1", null, "title", "description",
                         "pipeline \"pipeline\"\n" +
                                 "stage 0 match all\n" +
                                 "    rule \"valid_rule\";\n" +

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
+import org.graylog.plugins.pipelineprocessor.db.SystemPipelineScope;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
@@ -50,6 +51,8 @@ import org.graylog2.contentpacks.model.entities.PipelineEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.database.entities.DefaultEntityScope;
+import org.graylog2.database.entities.EntityScopeService;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
@@ -93,16 +96,19 @@ public class PipelineFacadeTest {
     @Mock
     private StreamService streamService;
 
+    private EntityScopeService entityScopeService;
     private PipelineFacade facade;
 
     @Before
     @SuppressForbidden("Using Executors.newSingleThreadExecutor() is okay in tests")
-    public void setUp() throws Exception {
+    public void setUp() {
+        entityScopeService = new EntityScopeService(Set.of(new DefaultEntityScope(), new SystemPipelineScope()));
+
         final ClusterEventBus clusterEventBus = new ClusterEventBus("cluster-event-bus", Executors.newSingleThreadExecutor());
 
         final MongoCollections mongoCollections = new MongoCollections(new MongoJackObjectMapperProvider(objectMapper),
                 mongodb.mongoConnection());
-        pipelineService = new MongoDbPipelineService(mongoCollections, clusterEventBus);
+        pipelineService = new MongoDbPipelineService(mongoCollections, entityScopeService, clusterEventBus);
         connectionsService = new MongoDbPipelineStreamConnectionsService(mongoCollections, clusterEventBus);
 
         facade = new PipelineFacade(objectMapper, pipelineService, connectionsService, pipelineRuleParser, ruleService, streamService);
@@ -238,12 +244,20 @@ public class PipelineFacadeTest {
     public void delete() throws NotFoundException {
         final PipelineDao pipelineDao = pipelineService.load("5a85c4854b900afd5d662be3");
 
-        assertThat(pipelineService.loadAll()).hasSize(1);
+        assertThat(pipelineService.loadAll()).hasSize(2);
         facade.delete(pipelineDao);
-        assertThat(pipelineService.loadAll()).isEmpty();
+        assertThat(pipelineService.loadAll()).hasSize(1);
 
         assertThatThrownBy(() -> pipelineService.load("5a85c4854b900afd5d662be3"))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @MongoDBFixtures("PipelineFacadeTest/pipelines.json")
+    public void deleteSystemPipeline() throws NotFoundException {
+        final PipelineDao pipelineDao = pipelineService.load("5a85c4854b900afd5d662be4");
+        assertThatThrownBy(() -> facade.delete(pipelineDao))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -311,14 +325,20 @@ public class PipelineFacadeTest {
     @Test
     @MongoDBFixtures("PipelineFacadeTest/pipelines.json")
     public void listEntityExcerpts() {
-        final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
+        final EntityExcerpt expectedEntityExcerpt1 = EntityExcerpt.builder()
                 .id(ModelId.of("5a85c4854b900afd5d662be3"))
                 .type(ModelTypes.PIPELINE_V1)
                 .title("Test")
                 .build();
+        final EntityExcerpt expectedEntityExcerpt2 = EntityExcerpt.builder()
+                .id(ModelId.of("5a85c4854b900afd5d662be4"))
+                .type(ModelTypes.PIPELINE_V1)
+                .title("All Messages Routing")
+                .build();
+        final Set<EntityExcerpt> expected = Set.of(expectedEntityExcerpt1, expectedEntityExcerpt2);
 
         final Set<EntityExcerpt> entityExcerpts = facade.listEntityExcerpts();
-        assertThat(entityExcerpts).containsOnly(expectedEntityExcerpt);
+        assertThat(entityExcerpts).isEqualTo(expected);
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/facades/PipelineFacadeTest/pipelines.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/facades/PipelineFacadeTest/pipelines.json
@@ -13,6 +13,21 @@
       "modified_at": {
         "$date": "2018-04-24T12:37:31.592Z"
       }
+    },
+    {
+      "_id": {
+        "$oid": "5a85c4854b900afd5d662be4"
+      },
+      "_scope": "GRAYLOG_SYSTEM_PIPELINE_SCOPE",
+      "title": "All Messages Routing",
+      "description": "GL generated pipeline",
+      "source": "pipeline \"All Messages Routing\"\nstage 0 match either\nrule \"debug\"\nrule \"no-op\"\nend",
+      "created_at": {
+        "$date": "2018-02-15T17:33:57.125Z"
+      },
+      "modified_at": {
+        "$date": "2018-04-24T12:37:31.592Z"
+      }
     }
   ],
   "pipeline_processor_pipelines_streams": [


### PR DESCRIPTION
/nocl part of Input Setup Wizard
Resolves #Graylog2/graylog-plugin-enterprise/issues/9589 

## Description
<!--- Describe your changes in detail -->
Extend pipeline to be a scoped entity.
The system routing pipeline `"All Messages Routing"` is rendered immutable by assigning it the scope `SystemPipelineScope`.
See issue for more details.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ad hoc and unit test.