### PR TITLE
Add support for quoted (default) MongoDB search term values in SearchQueryParser

### DIFF
--- a/changelog/unreleased/issue-21565.toml
+++ b/changelog/unreleased/issue-21565.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix issue preventing quoted entity search values from finding exact matches on various pages throughout Graylog."
+
+issues = ["21565"]
+pulls = ["21567"]

--- a/changelog/unreleased/issue-21565.toml
+++ b/changelog/unreleased/issue-21565.toml
@@ -1,5 +1,5 @@
 type = "fixed"
-message = "Fix issue preventing quoted entity search values from finding exact matches on various pages throughout Graylog."
+message = "Fixed issue preventing quoted entity search values from finding exact matches on various pages throughout Graylog."
 
 issues = ["21565"]
 pulls = ["21567"]

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -79,10 +79,10 @@ public class SearchQueryParser {
 
     // Pattern to split a search query into individual parsable elements terms.
     private static final String TERM_SPLIT_PATTERN =
-            "(\\S+:(=|=~|<|<=|>|>=)?'(?:[^'\\\\]|\\\\.)*')|" + // Field-specific terms with single-quotes: title:'value'
-                    "(\\S+:(=|=~|<|<=|>|>=)?\"(?:[^\"\\\\]|\\\\.)*\")|" + // Field-specific terms with double-quotes title:"value"
-                    "['\"][^\\\\]*?(?:\\\\.[^\\\\]*)*?['\"]|" + // Single quoted value: "value one"
-                    "\\S+:(=|=~|<|<=|>|>=)?\\S+|" + // Field-specific terms without quotes title:value
+            "(\\S+:(=|=~|<|<=|>|>=)?'(?:[^'\\\\]|\\\\.)*')|" + // Split field-specific terms with single-quotes: title:'value'
+                    "(\\S+:(=|=~|<|<=|>|>=)?\"(?:[^\"\\\\]|\\\\.)*\")|" + // Split field-specific terms with double-quotes title:"value"
+                    "['\"][^\\\\]*?(?:\\\\.[^\\\\]*)*?['\"]|" + // Split single quoted value: "value one"
+                    "\\S+:(=|=~|<|<=|>|>=)?\\S+|" + // Split field-specific terms without quotes title:value
                     "\\S+"; // Split the words of any other string value
 
     // This needs to be updated if more operators are added

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -77,8 +77,16 @@ public class SearchQueryParser {
     private static final Splitter FIELD_VALUE_SPLITTER = Splitter.on(":").limit(2).omitEmptyStrings().trimResults();
     private static final Splitter VALUE_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
 
+    // Pattern to split a search query into individual parsable elements terms.
+    private static final String TERM_SPLIT_PATTERN =
+            "(\\S+:(=|=~|<|<=|>|>=)?'(?:[^'\\\\]|\\\\.)*')|" + // Field-specific terms with single-quotes: title:'value'
+                    "(\\S+:(=|=~|<|<=|>|>=)?\"(?:[^\"\\\\]|\\\\.)*\")|" + // Field-specific terms with double-quotes title:"value"
+                    "['\"][^\\\\]*?(?:\\\\.[^\\\\]*)*?['\"]|" + // Single quoted value: "value one"
+                    "\\S+:(=|=~|<|<=|>|>=)?\\S+|" + // Field-specific terms without quotes title:value
+                    "\\S+"; // Split the words of any other string value
+
     // This needs to be updated if more operators are added
-    private static final Pattern QUERY_SPLITTER_PATTERN = Pattern.compile("(\\S+:(=|=~|<|<=|>|>=)?'(?:[^'\\\\]|\\\\.)*')|(\\S+:(=|=~|<|<=|>|>=)?\"(?:[^\"\\\\]|\\\\.)*\")|\\S+|\\S+:(=|=~|<|<=|>|>=)?\\S+");
+    private static final Pattern QUERY_SPLITTER_PATTERN = Pattern.compile(TERM_SPLIT_PATTERN);
     private static final String INVALID_ENTRY_MESSAGE = "Chunk [%s] is not a valid entry";
     private static final String QUOTE_REPLACE_REGEX = "^[\"']|[\"']$";
     public static final SearchQueryOperator DEFAULT_STRING_OPERATOR = SearchQueryOperators.REGEXP;

--- a/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
@@ -32,6 +32,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -291,6 +292,31 @@ public class SearchQueryParserTest {
         assertThat(queryMap.get("name")).containsOnly(new SearchQueryParser.FieldValue("Bobby", false));
         assertThat(queryMap.get("breed")).containsOnly(new SearchQueryParser.FieldValue("terrier", false));
         assertThat(searchQuery.hasDisallowedKeys()).isFalse();
+    }
+
+    @Test
+    void unquotedEmptyFieldPrefixSingleSearchTerm() {
+        final SearchQueryParser parser = new SearchQueryParser("name", Set.of(), "");
+        // Verify unquoted term is split into two search values.
+        final SearchQuery searchQuery = parser.parse("Bobby testerson");
+        final Multimap<String, SearchQueryParser.FieldValue> queryMap = searchQuery.getQueryMap();
+        assertThat(queryMap.keySet().size()).isEqualTo(1);
+        final Collection<SearchQueryParser.FieldValue> values = queryMap.get("name");
+        assertThat(values.size()).isEqualTo(2);
+        assertThat(values).contains(new SearchQueryParser.FieldValue("Bobby", false));
+        assertThat(values).contains(new SearchQueryParser.FieldValue("testerson", false));
+    }
+
+    @Test
+    void quotedEmptyFieldPrefixSingleSearchTerm() {
+        final SearchQueryParser parser = new SearchQueryParser("name", Set.of(), "");
+        // Verify quoted term is maintained as a single search value.
+        final SearchQuery searchQuery = parser.parse("\"Bobby testerson\"");
+        final Multimap<String, SearchQueryParser.FieldValue> queryMap = searchQuery.getQueryMap();
+        assertThat(queryMap.keySet().size()).isEqualTo(1);
+        final Collection<SearchQueryParser.FieldValue> values = queryMap.get("name");
+        assertThat(values.size()).isEqualTo(1);
+        assertThat(values).containsOnly(new SearchQueryParser.FieldValue("Bobby testerson", false));
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for quoted default search terms (those that don't specifically indicate a field name) when performing entity searches on various pages throughout the application where the MongoDB `SearchQueryParser` is used. The underlaying problem is explained in detail in the source issue https://github.com/Graylog2/graylog2-server/issues/21565. 

TLDR: When multi-word entity search terms are provided in quotes (e.g. `"My Event Definition"`), they will no longer be split into separate search terms by word. This prevents an excessive number of results from being returned, which can be confusing (and not what I think folks will expect). The words are still split into separate terms when no quotes are supplied. 

This also adds consistency with how field-specific terms work and respect quotes. For example, currently, when searching for `title:"My Event Definition"`, only the whole quoted value is searched. It seems to follow that non-field specific values should work the same way.

Note that I am not a regex expert, but I did try to break-up the long splitting expression into chunks with corresponding documentation to improve maintainability. Please let me know if anyone has advice for improving the expression

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/Graylog2/graylog2-server/issues/21565  

This issue was discovered while providing support assistance. I have also noticed this in the past, so I thought this was a good chance to dig-into it and see if we can improve quoted search term handling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There is pretty extensive unit test coverage for `SearchQueryParser`. I've added two tests for the new cases and confirmed that over cases still pass. I also have done some smoke-testing when searching for Event Definitions, and it seems to work fine.

## Screen Shots
![image](https://github.com/user-attachments/assets/008d1a2b-bd71-4c89-8ac3-2cae81f41a15)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

