### PR TITLE
SearchType.Result proper deserialization

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -85,6 +85,7 @@ import org.graylog.plugins.views.search.rest.remote.SearchJobsStatusResource;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.events.EventList;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSort;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSort;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
@@ -190,6 +191,11 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(MessageList.class);
         registerJacksonSubtype(Pivot.class);
         registerJacksonSubtype(EventList.class);
+
+        //search type results
+        registerJacksonSubtype(PivotResult.class, Pivot.NAME);
+        registerJacksonSubtype(MessageList.Result.class, MessageList.NAME);
+        registerJacksonSubtype(EventList.Result.class, EventList.NAME);
 
         // pivot specs
         registerJacksonSubtype(Values.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
@@ -126,6 +126,11 @@ public interface SearchType extends ContentPackable<SearchTypeEntity>, Exportabl
      * <p>
      * The frontend components then make use of the structured data to display it.
      */
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.EXISTING_PROPERTY,
+            property = "type",
+            visible = true)
     interface Result {
         @JsonProperty("id")
         String id();


### PR DESCRIPTION
## Description
SearchType.Result proper deserialization.
/nocl

## Motivation and Context
So far, we seemed to serialize `SearchType.Result` instances to JSON, but never deserialize them back.
With a move towards storing results of search job in MongoDB, we need proper deserialization as well.
Despite the fact that only `IcebergRowsList.Result` is needed at this point, I am adding support for all `SearchType.Result` subclasses.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

