### PR TITLE
Generate proper menu item for "Replay Search" event action.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/replay-search/LinkToReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/LinkToReplaySearch.tsx
@@ -20,13 +20,27 @@ import React from 'react';
 import Routes from 'routing/Routes';
 import { ReplaySearchButtonComponent } from 'views/components/widgets/ReplaySearchButton';
 import useParams from 'routing/useParams';
+import MenuItem from 'components/bootstrap/menuitem/MenuItem';
 
-const LinkToReplaySearch = ({ isEvent = false, id = undefined, onClick = undefined }: { id?: string, isEvent?: boolean, onClick?: () => void }) => {
-  const { definitionId } = useParams<{ alertId?: string, definitionId?: string }>();
-  const searchLink = isEvent ? Routes.ALERTS.replay_search(id) : Routes.ALERTS.DEFINITIONS.replay_search(id || definitionId);
+type Props = {
+  id?: string;
+  isEvent?: boolean;
+  onClick?: () => void;
+  isMenuitem?: boolean;
+};
+const LinkToReplaySearch = ({ isEvent = false, id = undefined, onClick = undefined, isMenuitem = false }: Props) => {
+  const { definitionId } = useParams<{ alertId?: string; definitionId?: string }>();
+  const searchLink = isEvent
+    ? Routes.ALERTS.replay_search(id)
+    : Routes.ALERTS.DEFINITIONS.replay_search(id || definitionId);
 
   return (
-    <ReplaySearchButtonComponent searchLink={searchLink} onClick={onClick}>Replay search</ReplaySearchButtonComponent>
+    <ReplaySearchButtonComponent
+      searchLink={searchLink}
+      onClick={onClick}
+      component={isMenuitem ? MenuItem : undefined}>
+      Replay search
+    </ReplaySearchButtonComponent>
   );
 };
 

--- a/graylog2-web-interface/src/components/events/events/hooks/useEventAction.tsx
+++ b/graylog2-web-interface/src/components/events/events/hooks/useEventAction.tsx
@@ -27,11 +27,23 @@ const useEventAction = (event: Event) => {
   const sendEventActionTelemetry = useSendEventActionTelemetry();
   const hasReplayInfo = !!event.replay_info;
 
-  const moreActions = useMemo(() => [
-    hasReplayInfo ? <MenuItem key="replay_info"><LinkToReplaySearch onClick={() => sendEventActionTelemetry('REPLAY_SEARCH', false)} id={event.id} isEvent /></MenuItem> : null,
-    pluggableActions.length && hasReplayInfo ? <MenuItem divider key="divider" /> : null,
-    pluggableActions.length ? pluggableActions : null,
-  ].filter(Boolean), [sendEventActionTelemetry, event.id, hasReplayInfo, pluggableActions]);
+  const moreActions = useMemo(
+    () =>
+      [
+        hasReplayInfo ? (
+          <LinkToReplaySearch
+            key="replay-search"
+            isMenuitem
+            onClick={() => sendEventActionTelemetry('REPLAY_SEARCH', false)}
+            id={event.id}
+            isEvent
+          />
+        ) : null,
+        pluggableActions.length && hasReplayInfo ? <MenuItem divider key="divider" /> : null,
+        pluggableActions.length ? pluggableActions : null,
+      ].filter(Boolean),
+    [sendEventActionTelemetry, event.id, hasReplayInfo, pluggableActions],
+  );
 
   return { moreActions, pluggableActionModals };
 };

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -35,7 +35,7 @@ const NeutralLink = styled.a`
   align-items: center;
   color: inherit;
   text-decoration: none;
-  
+
   &:hover {
     text-decoration: none;
   }
@@ -72,29 +72,61 @@ const buildSearchLink = (
   return searchLink;
 };
 
-export const ReplaySearchButtonComponent = ({ searchLink, children, onClick }: { children?: React.ReactNode, searchLink: string, onClick?: () => void }) => {
+const iconName = 'play_arrow' as const;
+
+type CustomComponentProps = React.PropsWithChildren<{
+  href?: string;
+  title?: string;
+  onClick?: React.MouseEventHandler<unknown>;
+  target?: string;
+  rel?: string;
+}>;
+
+export const ReplaySearchButtonComponent = ({
+  searchLink,
+  children = undefined,
+  onClick = undefined,
+  component: Component = NeutralLink,
+}: {
+  children?: React.ReactNode;
+  searchLink: string;
+  onClick?: () => void;
+  component?: React.ComponentType<CustomComponentProps>;
+}) => {
   const title = 'Replay search';
 
   return (
-    <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
-      {children
-        ? <>{children} <StyledIcon name="play_arrow" /></>
-        : <IconButton name="play_arrow" focusable={false} title={title} />}
-    </NeutralLink>
+    <Component href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
+      {children ? (
+        <>
+          {children} <StyledIcon name={iconName} />
+        </>
+      ) : (
+        <IconButton name={iconName} focusable={false} title={title} />
+      )}
+    </Component>
   );
 };
 
 type Props = {
-  queryString?: string | undefined,
-  timerange?: TimeRange | undefined,
-  streams?: string[] | undefined,
-  streamCategories?: string[] | undefined,
-  parameters?: Immutable.Set<Parameter>,
-  children?: React.ReactNode,
-  parameterBindings?: ParameterBindings,
+  queryString?: string | undefined;
+  timerange?: TimeRange | undefined;
+  streams?: string[] | undefined;
+  streamCategories?: string[] | undefined;
+  parameters?: Immutable.Set<Parameter>;
+  children?: React.ReactNode;
+  parameterBindings?: ParameterBindings;
 };
 
-const ReplaySearchButton = ({ queryString, timerange, streams, streamCategories, parameters, children, parameterBindings }: Props) => {
+const ReplaySearchButton = ({
+  queryString = undefined,
+  timerange = undefined,
+  streams = undefined,
+  streamCategories = undefined,
+  parameters = undefined,
+  children = undefined,
+  parameterBindings = undefined,
+}: Props) => {
   const sessionId = useMemo(() => `replay-search-${generateId()}`, []);
   const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, streamCategories, parameters);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR turns the simple `a`-element used for the menu item of the "Replay Search" action into a proper `MenuItem`-element with `href`/`onClick` props. This fixes issues with the action only being triggered when the text is clicked, but not when the rest of the hover area is clicked.

Fixes Graylog2/graylog-plugin-enterprise#9646

/nocl Fixes unreleased code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.