### PR TITLE
Mark Palo Alto Networks v8 and v9 inputs as deprecated

### DIFF
--- a/changelog/unreleased/pr-21579.toml
+++ b/changelog/unreleased/pr-21579.toml
@@ -1,4 +1,4 @@
 type = "d"
-message = "Deprecated Palo Alto version 8.x and 9.x inputs"
+message = "Deprecated Palo Alto Networks version 8.x and 9.x inputs"
 
 pulls = ["21579"]

--- a/changelog/unreleased/pr-21579.toml
+++ b/changelog/unreleased/pr-21579.toml
@@ -1,0 +1,4 @@
+type = "d"
+message = "Deprecated Palo Alto version 8.x and 9.x inputs"
+
+pulls = ["21579"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
@@ -38,7 +38,7 @@ import static org.graylog.integrations.inputs.paloalto.PaloAltoCodec.CK_TRAFFIC_
 
 public class PaloAltoTCPInput extends MessageInput {
 
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v8.x) (deprecated)";
+    public static final String NAME = "Palo Alto Networks TCP v8.x (deprecated)";
 
     private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTCPInput.class);
 

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
@@ -38,7 +38,7 @@ import static org.graylog.integrations.inputs.paloalto.PaloAltoCodec.CK_TRAFFIC_
 
 public class PaloAltoTCPInput extends MessageInput {
 
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v8.x)";
+    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v8.x) (deprecated)";
 
     private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTCPInput.class);
 

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
@@ -35,7 +35,7 @@ import jakarta.inject.Inject;
 public class PaloAlto9xInput extends MessageInput {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xInput.class);
 
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9+)";
+    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9+) (deprecated)";
 
     @Inject
     public PaloAlto9xInput(@Assisted Configuration configuration,

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
@@ -35,7 +35,7 @@ import jakarta.inject.Inject;
 public class PaloAlto9xInput extends MessageInput {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xInput.class);
 
-    public static final String NAME = "Palo Alto Networks TCP v9+ (deprecated)";
+    public static final String NAME = "Palo Alto Networks TCP v9.x (deprecated)";
 
     @Inject
     public PaloAlto9xInput(@Assisted Configuration configuration,

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
@@ -35,7 +35,7 @@ import jakarta.inject.Inject;
 public class PaloAlto9xInput extends MessageInput {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xInput.class);
 
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9+) (deprecated)";
+    public static final String NAME = "Palo Alto Networks TCP v9+ (deprecated)";
 
     @Inject
     public PaloAlto9xInput(@Assisted Configuration configuration,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mark Palo Alto version 8 and 9 inputs as deprecated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9629

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Started input and verified `(deprecation)` appears in title. Note that I adjusted the title to avoid it wrapping and to two sets of parentheses.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/71da5067-51e1-4713-9e09-85e9fdd4f750)
