### PR TITLE
change query to find indices in range to an equal search for deflecto…

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -104,16 +104,20 @@ public class MongoIndexRangeService implements IndexRangeService {
 
     @Override
     public SortedSet<IndexRange> find(DateTime begin, DateTime end) {
+        if(end.isBefore(begin)) {
+            throw new RuntimeException("Calculation of IndexRanges error: end time (" + end + ") is earlier than begin time (" + begin + ")");
+        }
         final var query = or(
                 and(
                         exists("start", false),  // "start" has been used by the old index ranges in MongoDB
                         lte(IndexRange.FIELD_BEGIN, end.getMillis()),
                         gte(IndexRange.FIELD_END, begin.getMillis())
                 ),
+                // or find current deflector indices (these have begin/end 0)
                 and(
                         exists("start", false),  // "start" has been used by the old index ranges in MongoDB
-                        lte(IndexRange.FIELD_BEGIN, 0L),
-                        gte(IndexRange.FIELD_END, 0L)
+                        eq(IndexRange.FIELD_BEGIN, 0L),
+                        eq(IndexRange.FIELD_END, 0L)
                 )
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -116,9 +116,24 @@ public class MongoIndexRangeServiceTest {
         final SortedSet<IndexRange> indexRanges = indexRangeService.find(begin, end);
 
         assertThat(indexRanges).containsExactly(
+                MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000008"), "graylog_deflect", new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 6, 0, 0, DateTimeZone.UTC), 42),
                 MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000002"), "graylog_2", new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 3, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 3, 0, 0, DateTimeZone.UTC), 42),
                 MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000003"), "graylog_3", new DateTime(2015, 1, 3, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 4, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 4, 0, 0, DateTimeZone.UTC), 42),
-                MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000004"), "graylog_4", new DateTime(2015, 1, 4, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 5, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 5, 0, 0, DateTimeZone.UTC), 42)
+                MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000004"), "graylog_4", new DateTime(2015, 1, 4, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 5, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 5, 0, 0, DateTimeZone.UTC), 42),
+                MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000006"), "graylog_6", new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 6, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 6, 0, 0, DateTimeZone.UTC), 42)
+        );
+    }
+
+    @Test
+    @MongoDBFixtures("MongoIndexRangeServiceTest-distinct.json")
+    public void findReturnsOnlyDeflectorIndex() throws Exception {
+        // looking at a timerange that contains no other indices so only the deflector is returned
+        final DateTime begin = new DateTime(2017, 1, 1, 0, 0, DateTimeZone.UTC);
+        final DateTime end = new DateTime(2017, 11, 1, 0, 0, DateTimeZone.UTC);
+        final SortedSet<IndexRange> indexRanges = indexRangeService.find(begin, end);
+
+        assertThat(indexRanges).containsExactly(
+                MongoIndexRange.create(new ObjectId("55e0261a0cc6980000000008"), "graylog_deflect", new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 6, 0, 0, DateTimeZone.UTC), 42)
         );
     }
 

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest-distinct.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest-distinct.json
@@ -49,6 +49,36 @@
       "begin": 1420416000000,
       "end": 1420502400000,
       "took_ms": 42
+    },
+    {
+      "_id": {
+        "$oid": "55e0261a0cc6980000000006"
+      },
+      "index_name": "graylog_6",
+      "calculated_at": 1420502400000,
+      "begin": 0,
+      "end": 1420502400000,
+      "took_ms": 42
+    },
+    {
+      "_id": {
+        "$oid": "55e0261a0cc6980000000007"
+      },
+      "index_name": "graylog_7",
+      "calculated_at": 1420502400000,
+      "begin": 2120502400000,
+      "end": 2420502400000,
+      "took_ms": 42
+    },
+    {
+      "_id": {
+        "$oid": "55e0261a0cc6980000000008"
+      },
+      "index_name": "graylog_deflect",
+      "calculated_at": 1420502400000,
+      "begin": 0,
+      "end": 0,
+      "took_ms": 42
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If you have an index that has messages with a timestamp `1970-01-01 00:00` but that has already been rotated (`index_range` has `begin == 0` and `end != 0`), it was still found as a valid index for certain operations by the former, now changed query clause that was supposed to only find deflector indices (`begin == 0` and `end == 0`).

I added more tests to reflect those situations.

Also, if you query with a `end` time before `begin` time now, an exception is thrown because of an invalid time range.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

