### PR TITLE
Bump json-smart transitive dependency to version 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,14 @@
                 <artifactId>json-path</artifactId>
                 <version>${json-path.version}</version>
             </dependency>
+            <!-- Manage json-smart to version >= 2.5.2 to address CVE-2024-57699. json-smart is only used as a
+                 transitive dependency (e.g. for json-path), so when updating the version here, check if we still need
+                 to manage the version ourselves. -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.5.2</version>
+            </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>


### PR DESCRIPTION
Manages `net.minidev:json-smart` to version 2.5.2 to ensure a non-vulnerable version is used as a transitive dependency.

Addresses CVE-2024-57699
See also https://github.com/advisories/GHSA-pq2g-wx69-c263