### PR TITLE
Placing eslint disable statements back at right positions.

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.tsx
@@ -57,8 +57,7 @@ const SubmitAllError = ({ error, backendId }: { error: FetchError; backendId: st
       <Alert
         bsStyle="danger"
         style={{ wordBreak: 'break-word' }}
-        title={`Failed to ${backendId ? 'edit' : 'create'} authentication service`}
-      >
+        title={`Failed to ${backendId ? 'edit' : 'create'} authentication service`}>
         {error?.message && (
           <>
             {error.message}
@@ -221,8 +220,8 @@ const _onSubmitAll = (
       });
 
   if (stepsState.authBackendMeta.backendGroupSyncIsActive && !formValues.synchronizeGroups) {
-    // eslint-disable-next-line no-alert
     if (
+      // eslint-disable-next-line no-alert
       window.confirm('Do you really want to remove the group synchronization config for this authentication service?')
     ) {
       return _submit();
@@ -379,8 +378,7 @@ const BackendWizard = ({
       horizontal
       justified
       onStepChange={_setActiveStepKey}
-      steps={steps}
-    >
+      steps={steps}>
       <Sidebar prepareSubmitPayload={_getSubmitPayload} />
     </Wizard>
   );

--- a/graylog2-web-interface/src/components/common/Section.tsx
+++ b/graylog2-web-interface/src/components/common/Section.tsx
@@ -101,20 +101,18 @@ const Section = ({
             <FlexWrapper
               onClick={(e) => {
                 e.stopPropagation();
-              }}
-            >
+              }}>
               {headerLeftSection}
             </FlexWrapper>
           )}
         </FlexWrapper>
         <FlexWrapper>
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
           {actions && (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
             <div
               onClick={(e) => {
                 e.stopPropagation();
-              }}
-            >
+              }}>
               {actions}
             </div>
           )}
@@ -125,8 +123,7 @@ const Section = ({
               onClick={toggle}
               data-testid="collapseButton"
               title={`Toggle ${title.toLowerCase()} section`}
-              disabled={disableCollapseButton}
-            >
+              disabled={disableCollapseButton}>
               <Icon size="sm" name={opened ? 'keyboard_arrow_up' : 'keyboard_arrow_down'} />
             </Button>
           )}

--- a/graylog2-web-interface/src/components/common/ace/theme-graylog.js
+++ b/graylog2-web-interface/src/components/common/ace/theme-graylog.js
@@ -26,8 +26,8 @@ ace.define('ace/theme/graylog', ['require', 'exports', 'module', 'ace/lib/dom'],
   dom.importCssString(exports.cssText, exports.cssClass);
 });
 
+// eslint-disable-next-line func-names
 (function () {
-  // eslint-disable-line func-names
   ace.require(['ace/theme/graylog'], (m) => {
     if (typeof module === 'object' && typeof exports === 'object' && module) {
       module.exports = m;

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeLogsDialog.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeLogsDialog.tsx
@@ -64,9 +64,9 @@ const DataNodeLogsDialog = ({ show, hostname, onHide }: Props) => {
           {logs[logsType] ? (
             <LogsContainer>
               <table>
-                {/* eslint-disable-next-line react/no-array-index-key */}
                 <tbody>
                   {logs[logsType]?.map((log, key) => (
+                    // eslint-disable-next-line react/no-array-index-key
                     <tr key={key}>
                       <td>{log}</td>
                     </tr>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.tsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.tsx
@@ -155,8 +155,8 @@ class GrokPatterns extends React.Component<
   };
 
   confirmedRemove = (pattern) => {
-    // eslint-disable-next-line no-alert
     if (
+      // eslint-disable-next-line no-alert
       window.confirm(
         `Really delete the grok pattern ${pattern.name}?\nIt will be removed from the system and unavailable for any extractor. If it is still in use by extractors those will fail to work.`,
       )
@@ -198,8 +198,7 @@ class GrokPatterns extends React.Component<
                 style={{ marginRight: 5 }}
                 bsStyle="danger"
                 bsSize="xs"
-                onClick={() => this.confirmedRemove(pattern)}
-              >
+                onClick={() => this.confirmedRemove(pattern)}>
                 Delete
               </Button>
             </IfPermitted>
@@ -236,8 +235,7 @@ class GrokPatterns extends React.Component<
                 />
               </ButtonToolbar>
             </IfPermitted>
-          }
-        >
+          }>
           <span>
             This is a list of grok patterns you can use in your Graylog grok extractors. You can add your own manually
             or import a whole list of patterns from a so called pattern file.

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.tsx
@@ -25,8 +25,8 @@ import { IndexRangesActions } from 'stores/indices/IndexRangesStore';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 
 const _onRecalculateIndexRange = (indexSetId: string) => {
-  // eslint-disable-next-line no-alert
   if (
+    // eslint-disable-next-line no-alert
     window.confirm(
       'This will recalculate index ranges for this index set using a background system job. Do you want to proceed?',
     )
@@ -36,8 +36,8 @@ const _onRecalculateIndexRange = (indexSetId: string) => {
 };
 
 const _onCycleDeflector = (indexSetId: string) => {
-  // eslint-disable-next-line no-alert
   if (
+    // eslint-disable-next-line no-alert
     window.confirm('This will manually cycle the current active write index on this index set. Do you want to proceed?')
   ) {
     DeflectorActions.cycle(indexSetId).then(() => {

--- a/graylog2-web-interface/src/components/inputs/InputThroughput.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputThroughput.tsx
@@ -268,8 +268,8 @@ class InputThroughput extends React.Component<Props, State> {
               <br />
             </span>
           )}
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
           {!isNaN(writtenBytes1Sec) && input.global && (
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid
             <a href="" onClick={this._toggleShowDetails}>
               {showDetails ? 'Hide' : 'Show'} details
             </a>

--- a/graylog2-web-interface/src/components/nodes/NodesActions.tsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.tsx
@@ -40,8 +40,8 @@ class NodesActions extends React.Component<
   _toggleMessageProcessing = () => {
     const { systemOverview, node } = this.props;
 
-    // eslint-disable-next-line no-alert
     if (
+      // eslint-disable-next-line no-alert
       window.confirm(
         `You are about to ${systemOverview.is_processing ? 'pause' : 'resume'} message processing in this node. Are you sure?`,
       )

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
@@ -72,8 +72,8 @@ const EntityShareModal = ({
     if (selectedGranteeId) {
       const selectedGrantee = entityShareState?.availableGrantees.find((grantee) => grantee.id === selectedGranteeId);
 
-      // eslint-disable-next-line no-alert
       if (
+        // eslint-disable-next-line no-alert
         !window.confirm(
           `${selectedGrantee.title ? `"${selectedGrantee.title}"` : 'An entity (name not found)'} got selected but was never added as a collaborator. Do you want to continue anyway?`,
         )
@@ -105,8 +105,7 @@ const EntityShareModal = ({
         <>
           Sharing {entityTypeTitle ?? entityType}: <i>{entityTitle}</i>
         </>
-      }
-    >
+      }>
       {entityShareState && entityShareState.entity === entityGRN ? (
         <EntityShareSettings
           description={description}

--- a/graylog2-web-interface/src/components/security/SecurityPageEntry.tsx
+++ b/graylog2-web-interface/src/components/security/SecurityPageEntry.tsx
@@ -24,10 +24,10 @@ const SecurityPageEntry = () => {
   const securityPagePlugins = usePluginEntities('securityPage');
 
   if (securityPagePlugins?.length) {
-    // eslint-disable-next-line react/no-array-index-key
     return (
       <>
         {securityPagePlugins.map((Page, index) => (
+          // eslint-disable-next-line react/no-array-index-key
           <Page key={index} />
         ))}
       </>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -188,9 +188,9 @@ const ConfigurationForm = ({
 
     nextFormData.collector_id = nextId;
 
-    // eslint-disable-next-line no-alert
     if (
       !nextFormData.template ||
+      // eslint-disable-next-line no-alert
       window.confirm('Do you want to use the default template for the selected Configuration?')
     ) {
       _onTemplateChange(defaultTemplate);

--- a/graylog2-web-interface/src/components/simulator/SimulationTrace.tsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationTrace.tsx
@@ -39,8 +39,8 @@ const SimulationTrace = ({ simulationResults }: Props) => {
   simulationTrace.forEach((trace, idx) => {
     // eslint-disable-next-line react/no-array-index-key
     traceEntries.push(<dt key={`${trace.time}-${idx}-title`}>{NumberUtils.formatNumber(trace.time)} &#956;s</dt>);
-    // eslint-disable-next-line react/no-array-index-key
     traceEntries.push(
+      // eslint-disable-next-line react/no-array-index-key
       <dd key={`${trace}-${idx}-description`}>
         <span>{trace.message}</span>
       </dd>,

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.tsx
@@ -70,8 +70,8 @@ const BulkActions = ({ indexSets }: Props) => {
   );
 
   const onDelete = useCallback(() => {
-    // eslint-disable-next-line no-alert
     if (
+      // eslint-disable-next-line no-alert
       window.confirm(`Do you really want to remove ${selectedItemsAmount} ${descriptor}? This action cannot be undone.`)
     ) {
       fetch('POST', qualifyUrl(ApiRoutes.StreamsApiController.bulk_delete().url), { entity_ids: selectedEntities })

--- a/graylog2-web-interface/src/generator/emit.ts
+++ b/graylog2-web-interface/src/generator/emit.ts
@@ -250,8 +250,8 @@ const emitBlock = (
     true,
   );
 
-  // eslint-disable-next-line no-nested-ternary
   const body =
+    // eslint-disable-next-line no-nested-ternary
     formDataParameters.length > 0
       ? ts.factory.createIdentifier('formData')
       : bodyParameter

--- a/graylog2-web-interface/src/preflight/components/ResumeStartupButton.tsx
+++ b/graylog2-web-interface/src/preflight/components/ResumeStartupButton.tsx
@@ -40,9 +40,9 @@ const ResumeStartupButton = ({
   const { data: dataNodes } = useDataNodes();
 
   const onResumeStartup = useCallback(() => {
-    // eslint-disable-next-line no-alert
     if (
       dataNodes?.length ||
+      // eslint-disable-next-line no-alert
       window.confirm(
         'Are you sure you want to resume startup without a running Graylog data node? This will cause the configuration to fall back to using an Opensearch instance on localhost:9200.',
       )

--- a/graylog2-web-interface/src/util/NumberFormatting.test.ts
+++ b/graylog2-web-interface/src/util/NumberFormatting.test.ts
@@ -18,8 +18,8 @@ import { formatNumber, formatPercentage, formatTrend } from './NumberFormatting'
 
 // eslint-disable-next-line jest/valid-expect
 const expectFormattedNumber = (num: number) => expect(formatNumber(num));
-// eslint-disable-next-line jest/valid-expect
 const expectFormattedTrend = (num: number, options?: Parameters<typeof formatTrend>[1]) =>
+  // eslint-disable-next-line jest/valid-expect
   expect(formatTrend(num, options));
 // eslint-disable-next-line jest/valid-expect
 const expectFormattedPercentage = (num: number) => expect(formatPercentage(num / 100));

--- a/graylog2-web-interface/src/util/deprecationNotice.js
+++ b/graylog2-web-interface/src/util/deprecationNotice.js
@@ -18,8 +18,8 @@ import AppConfig from './AppConfig';
 
 export const DEPRECATION_NOTICE = 'Graylog Deprecation Notice:';
 
-// eslint-disable-next-line no-console
 const deprecationNotice = (deprecatedMessage) =>
+  // eslint-disable-next-line no-console
   AppConfig.gl2DevMode() && console.warn(DEPRECATION_NOTICE, deprecatedMessage);
 
 export default deprecationNotice;

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -168,8 +168,8 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
     [activeQueryId, dashboardId, disablePageDelete, sendTelemetry, widgetIds],
   );
 
-  // eslint-disable-next-line react/no-unused-prop-types
   const customListItemRender = useCallback(
+    // eslint-disable-next-line react/no-unused-prop-types
     ({ item }: { item: PageListItem }) => (
       <ListItem item={item} onUpdateTitle={onUpdateTitle} onRemove={removePage} disableDelete={disablePageDelete} />
     ),
@@ -182,8 +182,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
       title="Update Dashboard Pages Configuration"
       onConfirm={onConfirmPagesConfiguration}
       onCancel={onPagesConfigurationModalClose}
-      confirmButtonText="Update configuration"
-    >
+      confirmButtonText="Update configuration">
       <>
         <h3>Order</h3>
         <p>

--- a/graylog2-web-interface/src/views/components/HeaderElements.tsx
+++ b/graylog2-web-interface/src/views/components/HeaderElements.tsx
@@ -23,11 +23,10 @@ const HeaderElements = () => {
 
   return (
     <>
-      {headerElements
+      {headerElements.map((Component, idx) => (
         // eslint-disable-next-line react/no-array-index-key
-        .map((Component, idx) => (
-          <Component key={idx} />
-        ))}
+        <Component key={idx} />
+      ))}
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/QueryBarElements.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBarElements.tsx
@@ -23,11 +23,10 @@ const QueryBarElements = () => {
 
   return (
     <>
-      {queryBarElements
+      {queryBarElements.map((Component, idx) => (
         // eslint-disable-next-line react/no-array-index-key
-        .map((Component, idx) => (
-          <Component key={idx} />
-        ))}
+        <Component key={idx} />
+      ))}
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.tsx
@@ -34,8 +34,8 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import { MoreActions } from 'components/common/EntityDataTable';
 import { useTableFetchContext } from 'components/common/PaginatedEntityTable';
 
-// eslint-disable-next-line no-alert
 const defaultDashboardDeletionHook = async (view: View) =>
+  // eslint-disable-next-line no-alert
   window.confirm(`Are you sure you want to delete "${view.title}"?`);
 
 const _extractErrorMessage = (error: FetchError) =>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TabKeywordTimeRange.test.tsx
@@ -43,8 +43,7 @@ const TabKeywordTimeRange = ({
         ? { timeRangeTabs: { keyword: { keyword: 'validation error' } } }
         : {}
     }
-    validateOnMount
-  >
+    validateOnMount>
     <Form>
       <OriginalTabKeywordTimeRange {...(props as React.ComponentProps<typeof TabKeywordTimeRange>)} />
     </Form>
@@ -71,8 +70,8 @@ describe('TabKeywordTimeRange', () => {
     return formGroup && formGroup.className.includes('has-error') ? 'error' : null;
   };
 
-  // eslint-disable-next-line testing-library/no-unnecessary-act
   const changeInput = async (input, value) =>
+    // eslint-disable-next-line testing-library/no-unnecessary-act
     act(async () => {
       const { name } = asElement(input, HTMLInputElement);
 

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.tsx
@@ -30,9 +30,9 @@ import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 // without CurrentUser & UserPreferences
 jest.mock('components/bootstrap/Popover');
 
-// eslint-disable-next-line global-require
 jest.mock(
   'views/components/visualizations/plotly/AsyncPlot',
+  // eslint-disable-next-line global-require
   () => require('views/components/visualizations/plotly/Plot').default,
 );
 jest.mock('components/common/ColorPicker', () => 'color-picker');

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -90,8 +90,8 @@ const _trendDirection = (delta: number, trendPreference: TrendPreference): Trend
   }
 };
 
-// eslint-disable-next-line no-nested-ternary
 const _trendIcon = (delta: number) =>
+  // eslint-disable-next-line no-nested-ternary
   delta === 0 ? 'arrow_circle_right' : delta > 0 ? 'arrow_circle_up' : 'arrow_circle_down';
 
 const diff = (current: number | undefined, previous: number | undefined): [number, number] => {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.tsx
@@ -69,10 +69,10 @@ type MarkerProps = {
 };
 
 const Marker = ({ coordinates, value, min, max, radiusSize, increment, color, name, keys }: MarkerProps) => {
-  // eslint-disable-next-line no-restricted-globals
   const formattedCoordinates = coordinates
     .split(',')
     .map((component) => Number(component))
+    // eslint-disable-next-line no-restricted-globals
     .filter((n) => !isNaN(n));
 
   if (formattedCoordinates.length !== 2) {
@@ -95,8 +95,7 @@ const Marker = ({ coordinates, value, min, max, radiusSize, increment, color, na
       color={color.hex()}
       fillColor={color.hex()}
       weight={2}
-      opacity={0.8}
-    >
+      opacity={0.8}>
       <Popup>
         <dl>
           <dt>Name</dt>
@@ -242,8 +241,7 @@ class MapVisualization extends React.Component<MapVisualizationProps> {
               whenReady={this._handleMapReady}
               zoom={viewport.zoom}
               zoomAnimation={interactive}
-              zoomControl={interactive}
-            >
+              zoomControl={interactive}>
               <MapEvents onViewportChanged={onChange} />
               <TileLayer url={url} attribution={attribution} eventHandlers={{ load: this._handleTilesReady }} />
               {markers}

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -125,8 +125,8 @@ const _onMoveWidgetToPage = async (
   }
 };
 
-// eslint-disable-next-line no-alert
 const defaultOnDeleteWidget = async (_widget: Widget, _view: View, title: string) =>
+  // eslint-disable-next-line no-alert
   window.confirm(`Are you sure you want to remove the widget "${title}"?`);
 
 const _onDelete = (widget: Widget, view: View, title: string) => async (dispatch: AppDispatch) => {

--- a/graylog2-web-interface/src/views/components/widgets/useWidgetExportActionComponent.ts
+++ b/graylog2-web-interface/src/views/components/widgets/useWidgetExportActionComponent.ts
@@ -24,10 +24,10 @@ const useWidgetExportActionComponent = (widget: Widget) => {
   const widgetExportAction =
     exportActions &&
     exportActions
-      // eslint-disable-next-line react-hooks/rules-of-hooks
       .filter(
         ({ action, useCondition }) =>
           typeof useCondition === 'function' &&
+          // eslint-disable-next-line react-hooks/rules-of-hooks
           useCondition() &&
           action &&
           (typeof action.isHidden !== 'function' || !action.isHidden(widget)),

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
@@ -41,8 +41,8 @@ export type RawQuery = (TimeRangeQueryParameter | { relative?: string }) &
   StreamsQuery &
   StreamCategoryQuery & { q?: string };
 
-// eslint-disable-next-line no-nested-ternary
 const normalizeTimeRange = (query: {} | TimeRangeQueryParameter): TimeRange | undefined =>
+  // eslint-disable-next-line no-nested-ternary
   query && 'rangetype' in query
     ? timeRangeFromQueryParameter(query)
     : 'relative' in query

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -131,8 +131,8 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   const byStreamCategory = matchesDecoratorStreamCategories(streamCategories);
   const streamDecorators = decorators?.length ? decorators.filter(byStreamId) : [];
   const streamCategoryDecorators = decorators?.length ? decorators.filter(byStreamCategory) : [];
-  // eslint-disable-next-line no-nested-ternary
   const allDecorators =
+    // eslint-disable-next-line no-nested-ternary
     streamDecorators.length && streamCategoryDecorators.length
       ? [...streamDecorators, ...streamCategoryDecorators]
       : streamDecorators.length

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.ts
@@ -74,8 +74,8 @@ const _defaultWidgets: DefaultWidgets = {
     const byStreamCategory = matchesDecoratorStreamCategories(streamCategory);
     const streamDecorators = decorators ? decorators.filter(byStreamId) : [];
     const streamCategoryDecorators = decorators?.length ? decorators.filter(byStreamCategory) : [];
-    // eslint-disable-next-line no-nested-ternary
     const allDecorators =
+      // eslint-disable-next-line no-nested-ternary
       streamDecorators.length && streamCategoryDecorators.length
         ? [...streamDecorators, ...streamCategoryDecorators]
         : streamDecorators.length


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #21515, `prettier` was doing the initial reformatting of our code, leading to misplaced `eslint-disable` statements. Due to these being not effective at their new positions, the next automated linter fixing job (#21631) would remove them.

Therefore, this PR is placing these statements at their correct positions again, avoiding automated removal.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.