### PR TITLE
Bypass pipeline mutability check for default pipeline

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineService.java
@@ -24,7 +24,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface PipelineService {
-    PipelineDao save(PipelineDao pipeline);
+    default PipelineDao save(PipelineDao pipeline) {
+        return save(pipeline, true);
+    }
+
+    PipelineDao save(PipelineDao pipeline, boolean checkMutability);
 
     PipelineDao load(String id) throws NotFoundException;
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineService.java
@@ -69,6 +69,11 @@ public class InMemoryPipelineService implements PipelineService {
     }
 
     @Override
+    public PipelineDao save(PipelineDao pipeline, boolean checkMutability) {
+        return save(pipeline);
+    }
+
+    @Override
     public PipelineDao load(String id) throws NotFoundException {
         final PipelineDao pipeline = store.get(id);
         if (pipeline == null) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -69,13 +69,15 @@ public class MongoDbPipelineService implements PipelineService {
     }
 
     @Override
-    public PipelineDao save(PipelineDao pipeline) {
+    public PipelineDao save(PipelineDao pipeline, boolean checkMutability) {
         scopedEntityMongoUtils.ensureValidScope(pipeline);
 
         final var pipelineId = pipeline.id();
         final PipelineDao savedPipeline;
         if (pipelineId != null) {
-            scopedEntityMongoUtils.ensureMutability(pipeline);
+            if (checkMutability) {
+                scopedEntityMongoUtils.ensureMutability(pipeline);
+            }
             collection.replaceOne(idEq(pipelineId), pipeline, new ReplaceOptions().upsert(true));
             savedPipeline = pipeline;
         } else {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
@@ -248,10 +248,6 @@ public class PipelineResource extends RestResource implements PluginRestResource
         return PipelineUtils.update(pipelineService, pipelineRuleParser, id, update, true);
     }
 
-    public PipelineSource forceUpdate(String id, PipelineSource update, boolean checkMutability) throws NotFoundException {
-        return PipelineUtils.update(pipelineService, pipelineRuleParser, id, update, checkMutability);
-    }
-
     public record RoutingRequest(
             @JsonProperty(value = "input_id", required = true) String inputId,
             @JsonProperty(value = "stream_id", required = true) String streamId,

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
@@ -245,7 +245,11 @@ public class PipelineResource extends RestResource implements PluginRestResource
                                  @ApiParam(name = "pipeline", required = true) @NotNull PipelineSource update) throws NotFoundException {
         checkPermission(PipelineRestPermissions.PIPELINE_EDIT, id);
         checkReservedName(update);
-        return PipelineUtils.update(pipelineService, pipelineRuleParser, id, update);
+        return PipelineUtils.update(pipelineService, pipelineRuleParser, id, update, true);
+    }
+
+    public PipelineSource forceUpdate(String id, PipelineSource update, boolean checkMutability) throws NotFoundException {
+        return PipelineUtils.update(pipelineService, pipelineRuleParser, id, update, checkMutability);
     }
 
     public record RoutingRequest(
@@ -284,7 +288,7 @@ public class PipelineResource extends RestResource implements PluginRestResource
             pipelineSource = pipelineSource.toBuilder()
                     .source(PipelineUtils.createPipelineString(pipelineSource))
                     .build();
-            update(pipelineDao.id(), pipelineSource);
+            PipelineUtils.update(pipelineService, pipelineRuleParser, pipelineDao.id(), pipelineSource, false);
         } else {
             log.info(f("Routing for input <%s> already exists - skipping", request.inputId()));
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineUtils.java
@@ -42,7 +42,8 @@ public class PipelineUtils {
     public static PipelineSource update(PipelineService pipelineService,
                                         PipelineRuleParser pipelineRuleParser,
                                         String id,
-                                        PipelineSource update) throws NotFoundException {
+                                        PipelineSource update,
+                                        boolean checkMutability) throws NotFoundException {
         final PipelineDao dao = pipelineService.load(id);
         final Pipeline pipeline;
         try {
@@ -59,7 +60,7 @@ public class PipelineUtils {
 
         final PipelineDao savedPipeline;
         try {
-            savedPipeline = pipelineService.save(toSave);
+            savedPipeline = pipelineService.save(toSave, checkMutability);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage(), e);
             throw new BadRequestException(e.getMessage());

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
@@ -177,7 +177,7 @@ public class InputRoutingService {
         try {
             PipelineDao pipelineDao = pipelineService.loadByName(GL_INPUT_ROUTING_PIPELINE);
             String pipelineSource = pipelineDao.source().replace(oldTitle, newTitle);
-            pipelineService.save(pipelineDao.toBuilder().source(pipelineSource).build());
+            pipelineService.save(pipelineDao.toBuilder().source(pipelineSource).build(), false);
         } catch (NotFoundException e) {
             log.warn("Unable to load pipeline {}", GL_INPUT_ROUTING_PIPELINE, e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
@@ -211,7 +211,7 @@ public class InputRoutingService {
             pipelineSource = pipelineSource.toBuilder()
                     .source(PipelineUtils.createPipelineString(pipelineSource))
                     .build();
-            PipelineUtils.update(pipelineService, pipelineRuleParser, pipelineDao.id(), pipelineSource);
+            PipelineUtils.update(pipelineService, pipelineRuleParser, pipelineDao.id(), pipelineSource, false);
         } catch (NotFoundException e) {
             log.warn("Unable to load pipeline {}", GL_INPUT_ROUTING_PIPELINE, e);
         }


### PR DESCRIPTION
/nocl 
/prd Graylog2/graylog-plugin-enterprise#9735

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mutability checking for pipelines was too strict - we still need to be able to update the default pipeline when we add system-generated routing rules.
