### PR TITLE
Apply OS formatter to new date field

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -520,8 +520,8 @@ public class Message implements Messages, Indexable, Acknowledgeable {
     }
 
     private void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
-        addField(FIELD_TIMESTAMP, newTimeStamp);
-        addField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
+        addField(FIELD_TIMESTAMP, buildElasticSearchTimeFormat(newTimeStamp.withZone(UTC)));
+        addField(FIELD_GL2_ORIGINAL_TIMESTAMP, buildElasticSearchTimeFormat(oldTimeStamp.withZone(UTC)));
     }
 
     private DateTime convertToDateTime(@Nonnull Object value) {


### PR DESCRIPTION
/nocl fix to unreleased feature

<!--- Provide a general summary of your changes in the Title above -->
Apply ES/OS formatter to `DateTime` value 

## Description
<!--- Describe your changes in detail -->
The default format of a Joda `DateTime` value is `uuuu-MM-ddTHH:mm:ss.SSSZ`
OS/ES expects `uuuu-MM-dd HH:mm:ss.SSS`

Apply `ES_DATE_FORMAT_FORMATTER` when assigning `DateTime` to a `Date` message field.
This was missing in timestamp normalization PR #21429 

Note: The problem may not manifest in testing until the indexset is rotated. 
