### PR TITLE
Improve extendability of `QueryString` type.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
@@ -41,7 +41,7 @@ import { useStore } from 'stores/connect';
 import Store from 'logic/local-storage/Store';
 import { MultiSelect, TimeUnitInput, SearchFiltersFormControls, TimezoneSelect } from 'components/common';
 import Query from 'views/logic/queries/Query';
-import type { RelativeTimeRangeWithEnd, ElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { RelativeTimeRangeWithEnd } from 'views/logic/queries/Query';
 import Search from 'views/logic/search/Search';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { Alert, ButtonToolbar, ControlLabel, FormGroup, HelpBlock, Input } from 'components/bootstrap';
@@ -64,6 +64,7 @@ import { indicesInWarmTier, isSearchingWarmTier } from 'views/components/searchb
 import type { FiltersType } from 'views/types';
 import { defaultCompare } from 'logic/DefaultCompare';
 import type { EventDefinitionValidation } from 'components/event-definitions/types';
+import type { QueryString } from 'views/logic/queries/types';
 
 import EditQueryParameterModal from '../event-definition-form/EditQueryParameterModal';
 import commonStyles from '../common/commonStyles.css';
@@ -144,7 +145,7 @@ const FilterForm = ({ currentUser, eventDefinition, onChange, streams, validatio
 
   const validateQueryString = useCallback(
     (
-      queryString: ElasticsearchQueryString | string,
+      queryString: QueryString | string,
       streamIds: Array<string>,
       timeRange: RelativeTimeRangeWithEnd,
       timezone: string,

--- a/graylog2-web-interface/src/util/MessagesExportUtils.ts
+++ b/graylog2-web-interface/src/util/MessagesExportUtils.ts
@@ -18,9 +18,10 @@ import { fetchFile } from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import ApiRoutes from 'routing/ApiRoutes';
-import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { createLinkAndDownload } from 'util/FileDownloadUtils';
+import type { QueryString } from 'views/logic/queries/types';
 
 export type ExportPayload = {
   timerange?: TimeRange | undefined | null;

--- a/graylog2-web-interface/src/views/components/WidgetQueryOverride.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryOverride.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 
-import type { ElasticsearchQueryString } from 'views/logic/queries/Query';
 import { Button } from 'components/bootstrap';
+import type { QueryString } from 'views/logic/queries/types';
 
 import BasicQueryInput from './searchbar/queryinput/AsyncBasicQueryInput';
 
@@ -64,7 +64,7 @@ const ResetButton = styled(Button)`
 `;
 
 type Props = {
-  value: ElasticsearchQueryString;
+  value: QueryString;
   onReset: () => void;
 };
 

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContext.tsx
@@ -16,9 +16,10 @@
  */
 import * as React from 'react';
 
-import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
+import type { QueryString } from 'views/logic/queries/types';
 
 export type Drilldown = {
   query: QueryString;

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.tsx
@@ -21,12 +21,13 @@ import { mount } from 'wrappedEnzyme';
 import { asMock } from 'helpers/mocking';
 import View from 'views/logic/views/View';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
-import type { TimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import Query, { createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import useViewType from 'views/hooks/useViewType';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
+import type { QueryString } from 'views/logic/queries/types';
 
 import DrilldownContextProvider from './DrilldownContextProvider';
 import DrilldownContext from './DrilldownContext';
@@ -36,7 +37,7 @@ jest.mock('views/logic/queries/useCurrentQuery');
 jest.mock('views/hooks/useGlobalOverride');
 
 describe('DrilldownContextProvider', () => {
-  const Consumer = (_props: { streams: Array<string>; timerange: TimeRange; query: ElasticsearchQueryString }) => null;
+  const Consumer = (_props: { streams: Array<string>; timerange: TimeRange; query: QueryString }) => null;
 
   const TestComponent = () => {
     const { streams, timerange, query } = useContext(DrilldownContext);

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -25,7 +25,7 @@ import type { TitleType } from 'views/stores/TitleTypes';
 import { exportSearchMessages, exportSearchTypeMessages } from 'util/MessagesExportUtils';
 import type { ViewStateMap, ViewType } from 'views/logic/views/View';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
-import type { AbsoluteTimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import View from 'views/logic/views/View';
 import ViewState from 'views/logic/views/ViewState';
 import ParameterBinding from 'views/logic/parameters/ParameterBinding';
@@ -46,6 +46,7 @@ import useSearchExecutionState from 'views/hooks/useSearchExecutionState';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { usePlugin } from 'views/test/testPlugins';
 import startDownload from 'views/components/export/startDownload';
+import type { QueryString } from 'views/logic/queries/types';
 
 import type { Props as ExportModalProps } from './ExportModal';
 import ExportModal from './ExportModal';
@@ -130,7 +131,7 @@ describe('ExportModal', () => {
       from: '2020-01-01T12:18:17.827Z',
       to: '2020-01-01T12:23:17.827Z',
     };
-    const globalQuery: ElasticsearchQueryString = { type: 'elasticsearch', query_string: 'source:$mainSource$' };
+    const globalQuery: QueryString = { type: 'elasticsearch', query_string: 'source:$mainSource$' };
     const globalOverride = new GlobalOverride(effectiveTimeRange, globalQuery);
     const executionState = new SearchExecutionState(parameterBindings, globalOverride);
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/validateQuery.ts
@@ -17,22 +17,22 @@
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
-import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
 import generateId from 'logic/generateId';
 import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
+import type { QueryString } from 'views/logic/queries/types';
 
 export type ValidationQuery = {
-  queryString: ElasticsearchQueryString | string;
+  queryString: QueryString | string;
   timeRange?: TimeRange | undefined;
   streams?: Array<string>;
   streamCategories?: Array<string>;
-  filter?: ElasticsearchQueryString | string;
+  filter?: QueryString | string;
   validation_mode?: 'QUERY' | 'SEARCH_FILTER';
 };
 
-const queryExists = (query: string | ElasticsearchQueryString) =>
-  typeof query === 'object' ? !!query.query_string : !!query;
+const queryExists = (query: string | QueryString) => (typeof query === 'object' ? !!query.query_string : !!query);
 
 export const validateQuery = (
   { queryString, timeRange, streams, streamCategories, filter, ...rest }: ValidationQuery,

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
@@ -17,14 +17,15 @@
 import * as React from 'react';
 import { asElement, render, screen } from 'wrappedTestingLibrary';
 
-import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { QueryString } from 'views/logic/queries/types';
 
 import ReplaySearchButton from './ReplaySearchButton';
 
 type OptionalOverrides = {
   streams?: Array<string>;
-  query?: ElasticsearchQueryString;
+  query?: QueryString;
   timerange?: TimeRange;
 };
 

--- a/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
+++ b/graylog2-web-interface/src/views/logic/NormalizeSearchURLQueryParams.ts
@@ -16,7 +16,8 @@
  */
 import { useMemo } from 'react';
 
-import type { TimeRange, FilterType, ElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { TimeRange, FilterType } from 'views/logic/queries/Query';
+import type { QueryString } from 'views/logic/queries/types';
 import {
   filtersForQuery,
   categoryFiltersForQuery,
@@ -79,7 +80,7 @@ type NormalizedSearchURLQueryParams = {
   timeRange: TimeRange | undefined;
   streamsFilter: FilterType | undefined;
   streamCategoriesFilter: FilterType | undefined;
-  queryString: ElasticsearchQueryString | undefined;
+  queryString: QueryString | undefined;
 };
 
 const normalizeSearchURLQueryParams = (query: RawQuery): NormalizedSearchURLQueryParams => {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.ts
@@ -18,8 +18,9 @@ import { Map } from 'immutable';
 
 import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
-import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type { FiltersType } from 'views/types';
+import type { QueryString } from 'views/logic/queries/types';
 
 import AggregationWidgetConfig from './AggregationWidgetConfig';
 

--- a/graylog2-web-interface/src/views/logic/queries/Query.ts
+++ b/graylog2-web-interface/src/views/logic/queries/Query.ts
@@ -20,6 +20,7 @@ import isDeepEqual from 'stores/isDeepEqual';
 import generateId from 'logic/generateId';
 import type { FiltersType, SearchFilter } from 'views/types';
 import type { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
+import type { QueryString, ElasticsearchQueryString } from 'views/logic/queries/types';
 
 import type { SearchType } from './SearchType';
 
@@ -46,11 +47,6 @@ export type QueryJson = {
   filter?: { [key: string]: any };
   filters?: Array<SearchFilter>;
   search_types: any;
-};
-
-export type ElasticsearchQueryString = {
-  type: 'elasticsearch';
-  query_string: string;
 };
 
 export const createElasticsearchQueryString = (query = ''): ElasticsearchQueryString => ({
@@ -143,8 +139,6 @@ export const filtersToStreamCategorySet = (
 
   return filters.map(filtersToStreamCategorySet).reduce((prev, cur) => prev.merge(cur), Immutable.Set());
 };
-
-export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
 

--- a/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryGenerator.ts
@@ -18,10 +18,11 @@ import { OrderedMap } from 'immutable';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DEFAULT_TIMERANGE } from 'views/Constants';
-import type { TimeRange, ElasticsearchQueryString, QueryId, FilterType } from 'views/logic/queries/Query';
+import type { TimeRange, QueryId, FilterType } from 'views/logic/queries/Query';
 import Query, { createElasticsearchQueryString, newFiltersForQuery } from 'views/logic/queries/Query';
 import generateId from 'logic/generateId';
 import type { SearchFilter } from 'components/event-definitions/event-definitions-types';
+import type { QueryString } from 'views/logic/queries/types';
 
 export default (
   streamId?: string | string[],
@@ -29,7 +30,7 @@ export default (
   // eslint-disable-next-line default-param-last
   id: QueryId | undefined = generateId(),
   timeRange?: TimeRange,
-  queryString?: ElasticsearchQueryString,
+  queryString?: QueryString,
   searchFilters?: SearchFilter[],
 ): Query => {
   // eslint-disable-next-line no-nested-ternary

--- a/graylog2-web-interface/src/views/logic/queries/SearchType.ts
+++ b/graylog2-web-interface/src/views/logic/queries/SearchType.ts
@@ -18,8 +18,9 @@ import type MessageSortConfig from 'views/logic/searchtypes/messages/MessageSort
 import type SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import type { Decorator } from 'views/components/messagelist/decorators/Types';
 import type { SearchFilter } from 'views/types';
+import type { QueryString } from 'views/logic/queries/types';
 
-import type { ElasticsearchQueryString, TimeRange } from './Query';
+import type { TimeRange } from './Query';
 
 type AutoInterval = {
   type: 'auto';
@@ -46,7 +47,7 @@ type SearchTypeBase = {
   filters: Array<SearchFilter> | undefined;
   id: string;
   name: string | undefined | null;
-  query: ElasticsearchQueryString | undefined | null;
+  query: QueryString | undefined | null;
   timerange: TimeRange | undefined | null;
   type: string;
   streams: Array<string>;

--- a/graylog2-web-interface/src/views/logic/queries/types.ts
+++ b/graylog2-web-interface/src/views/logic/queries/types.ts
@@ -1,0 +1,9 @@
+export type ElasticsearchQueryString = {
+  type: 'elasticsearch';
+  query_string: string;
+};
+export interface PluggableQueryString {
+  'elasticsearch': ElasticsearchQueryString;
+}
+
+export type QueryString = PluggableQueryString[keyof PluggableQueryString];

--- a/graylog2-web-interface/src/views/logic/queries/types.ts
+++ b/graylog2-web-interface/src/views/logic/queries/types.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
 export type ElasticsearchQueryString = {
   type: 'elasticsearch';
   query_string: string;

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.ts
@@ -19,7 +19,9 @@ import type { Moment } from 'moment';
 import moment from 'moment';
 import trim from 'lodash/trim';
 
-import type { QueryString, TimeRange } from '../queries/Query';
+import type { QueryString } from 'views/logic/queries/types';
+
+import type { TimeRange } from '../queries/Query';
 
 export type SearchTypeOptions<T = any> = {
   [searchTypeId: string]: T;

--- a/graylog2-web-interface/src/views/logic/search/SearchLink.ts
+++ b/graylog2-web-interface/src/views/logic/search/SearchLink.ts
@@ -18,9 +18,10 @@ import * as Immutable from 'immutable';
 import URI from 'urijs';
 
 import Routes from 'routing/Routes';
-import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import { timeRangeToQueryParameter } from 'views/logic/TimeRange';
 import { addToQuery, escape } from 'views/logic/queries/QueryHelper';
+import type { QueryString } from 'views/logic/queries/types';
 
 type InternalState = {
   id: string;

--- a/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateSavedSearch.ts
@@ -17,15 +17,16 @@
 import { useMemo } from 'react';
 
 import View from 'views/logic/views/View';
-import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import ViewGenerator from 'views/logic/views/ViewGenerator';
 import type Parameter from 'views/logic/parameters/Parameter';
+import type { QueryString } from 'views/logic/queries/types';
 
 type Props = {
   streamId?: string | string[];
   streamCategory?: string | string[];
   timeRange?: TimeRange;
-  queryString?: ElasticsearchQueryString;
+  queryString?: QueryString;
   parameters?: Array<Parameter>;
 };
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -19,12 +19,7 @@ import * as Immutable from 'immutable';
 import uniq from 'lodash/uniq';
 
 import View from 'views/logic/views/View';
-import type {
-  AbsoluteTimeRange,
-  ElasticsearchQueryString,
-  RelativeTimeRangeStartOnly,
-  TimeRange,
-} from 'views/logic/queries/Query';
+import type { AbsoluteTimeRange, RelativeTimeRangeStartOnly, TimeRange } from 'views/logic/queries/Query';
 import type { Event } from 'components/events/events/types';
 import type { EventDefinition, SearchFilter } from 'components/event-definitions/event-definitions-types';
 import QueryGenerator from 'views/logic/queries/QueryGenerator';
@@ -51,6 +46,7 @@ import { concatQueryStrings, escape, predicate } from 'views/logic/queries/Query
 import HighlightingRule, { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { exprToConditionMapper } from 'views/logic/ExpressionConditionMappers';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
+import type { QueryString } from 'views/logic/queries/types';
 
 const AGGREGATION_WIDGET_HEIGHT = 3;
 
@@ -229,7 +225,7 @@ export const ViewGenerator = async ({
   streams: string | string[] | undefined | null;
   streamCategories: string | string[] | undefined | null;
   timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly;
-  queryString: ElasticsearchQueryString;
+  queryString: QueryString;
   aggregations: Array<EventDefinitionAggregation>;
   groupBy: Array<string>;
   queryParameters: Array<ParameterJson>;
@@ -281,7 +277,7 @@ export const UseCreateViewForEvent = ({
         type: 'relative',
         range: (eventDefinition?.config?.search_within_ms ?? 0) / 1000,
       };
-  const queryString: ElasticsearchQueryString = {
+  const queryString: QueryString = {
     type: 'elasticsearch',
     query_string: eventData
       ? concatQueryStrings([eventQueryString, queryStringFromGrouping])

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.ts
@@ -14,9 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { TimeRange, ElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';
 import type Parameter from 'views/logic/parameters/Parameter';
+import type { QueryString } from 'views/logic/queries/types';
 
 import View from './View';
 import ViewStateGenerator from './ViewStateGenerator';
@@ -37,7 +38,7 @@ export default async ({
   streamId?: string | string[];
   streamCategory?: string | string[];
   timeRange?: TimeRange;
-  queryString?: ElasticsearchQueryString;
+  queryString?: QueryString;
   parameters?: Array<Parameter>;
 }) => {
   const query = QueryGenerator(streamId, streamCategory, undefined, timeRange, queryString);

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.ts
@@ -19,12 +19,13 @@ import { Map } from 'immutable';
 import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
 import type { FiltersType } from 'views/types';
+import type { QueryString } from 'views/logic/queries/types';
 
 import Widget from './Widget';
 import MessagesWidgetConfig from './MessagesWidgetConfig';
 import type { WidgetState } from './Widget';
 
-import type { QueryString, TimeRange } from '../queries/Query';
+import type { TimeRange } from '../queries/Query';
 
 export default class MessagesWidget extends Widget {
   constructor(

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -17,11 +17,12 @@
 import { Map, List } from 'immutable';
 import * as Immutable from 'immutable';
 
-import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import type { TimeRange } from 'views/logic/queries/Query';
 import { singleton } from 'logic/singleton';
 import generateId from 'logic/generateId';
 import isDeepEqual from 'stores/isDeepEqual';
 import type { FiltersType, SearchFilter } from 'views/types';
+import type { QueryString } from 'views/logic/queries/types';
 
 export type WidgetState = {
   id: string;

--- a/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
@@ -20,7 +20,8 @@ import Widget from 'views/logic/widgets/Widget';
 import type { WidgetState } from 'views/logic/widgets/Widget';
 import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
-import type { TimeRange, QueryString } from 'views/logic/queries/Query';
+import type { QueryString } from 'views/logic/queries/types';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type { FiltersType } from 'views/types';
 
 import EventsWidgetConfig from './EventsWidgetConfig';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are making it possible to extend the `QueryString` type.
The type is being used for the `query` attribute of the `Query` class.

Here is an example how to extend it:

```
declare module 'views/logic/queries/types' {
  interface PluggableQueryString {
    custom_type?: {
      'type': 'custom_type';
      'query_string': string;
    };
  }
}
```

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9755
/nocl