### PR TITLE
Removing `Ctrl-Space` from noop handler in query input.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -297,7 +297,7 @@ const QueryInput = React.forwardRef<Editor, Props>(
         // The following will disable the mentioned hotkeys.
         {
           name: 'Do nothing',
-          bindKey: { win: 'Ctrl-Space|Ctrl-Shift-Space', mac: 'Ctrl-Space|Ctrl-Shift-Space' },
+          bindKey: { win: 'Ctrl-Shift-Space', mac: 'Ctrl-Space|Ctrl-Shift-Space' },
           exec: () => {},
         },
       ],

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/QueryInput.tsx
@@ -212,10 +212,14 @@ const useShowHotkeysInOverview = () => {
 };
 
 type Props = BaseProps & {
+  // eslint-disable-next-line react/require-default-props
   commands?: Array<Command>;
+  // eslint-disable-next-line react/require-default-props
   disableExecution?: boolean;
+  // eslint-disable-next-line react/require-default-props
   isValidating?: boolean;
   name: string;
+  // eslint-disable-next-line react/require-default-props
   onBlur?: (query: string) => void;
   onChange: (changeEvent: { target: { value: string; name: string } }) => Promise<string>;
   onExecute: (query: string) => void;
@@ -232,9 +236,9 @@ const QueryInput = React.forwardRef<Editor, Props>(
       error,
       height,
       inputId,
-      isValidating,
+      isValidating = undefined,
       maxLines,
-      onBlur,
+      onBlur = undefined,
       onChange,
       onExecute: onExecuteProp,
       placeholder = '',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The noop handler defined for `react-ace` in the `QueryInput` component was clashing with the newly defined `Ctrl-Space` hotkey on linux in #21336. This PR is removing it to unblock `Ctrl-Space` for the auto-completion on Linux.

/nocl Fixes unreleased change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.