### PR TITLE
Refactor timestamp formatting for maintainability

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -519,7 +519,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
         }
     }
 
-    private void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
+    public void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
         addTimestampField(FIELD_TIMESTAMP, newTimeStamp);
         addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -521,7 +521,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
 
     private void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
         addTimestampField(FIELD_TIMESTAMP, newTimeStamp);
-        addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, newTimeStamp);
+        addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
     }
 
     private DateTime convertToDateTime(@Nonnull Object value) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -19,6 +19,7 @@ package org.graylog2.plugin;
 import com.codahale.metrics.Meter;
 import com.eaio.uuid.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
@@ -519,6 +520,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
         }
     }
 
+    @VisibleForTesting
     public void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
         addTimestampField(FIELD_TIMESTAMP, newTimeStamp);
         addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
@@ -600,7 +602,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
         addField(key, value, false);
     }
 
-    public void addTimestampField(final String key, final DateTime value) {
+    private void addTimestampField(final String key, final DateTime value) {
         addField(key, buildElasticSearchTimeFormat(value.withZone(UTC)), false);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -520,8 +520,8 @@ public class Message implements Messages, Indexable, Acknowledgeable {
     }
 
     private void updateTimeStamp(DateTime oldTimeStamp, DateTime newTimeStamp) {
-        addField(FIELD_TIMESTAMP, buildElasticSearchTimeFormat(newTimeStamp.withZone(UTC)));
-        addField(FIELD_GL2_ORIGINAL_TIMESTAMP, buildElasticSearchTimeFormat(oldTimeStamp.withZone(UTC)));
+        addTimestampField(FIELD_TIMESTAMP, newTimeStamp);
+        addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, newTimeStamp);
     }
 
     private DateTime convertToDateTime(@Nonnull Object value) {
@@ -598,6 +598,10 @@ public class Message implements Messages, Indexable, Acknowledgeable {
 
     public void addField(final String key, final Object value) {
         addField(key, value, false);
+    }
+
+    public void addTimestampField(final String key, final DateTime value) {
+        addField(key, buildElasticSearchTimeFormat(value.withZone(UTC)), false);
     }
 
     private void addRequiredField(final String key, final Object value) {
@@ -909,7 +913,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
     public void setReceiveTime(DateTime receiveTime) {
         if (receiveTime != null) {
             this.receiveTime = receiveTime;
-            addField(FIELD_GL2_RECEIVE_TIMESTAMP, buildElasticSearchTimeFormat(receiveTime.withZone(UTC)));
+            addTimestampField(FIELD_GL2_RECEIVE_TIMESTAMP, receiveTime);
         }
     }
 
@@ -928,7 +932,7 @@ public class Message implements Messages, Indexable, Acknowledgeable {
     public void setProcessingTime(DateTime processingTime) {
         if (processingTime != null) {
             this.processingTime = processingTime;
-            addField(FIELD_GL2_PROCESSING_TIMESTAMP, buildElasticSearchTimeFormat(processingTime.withZone(UTC)));
+            addTimestampField(FIELD_GL2_PROCESSING_TIMESTAMP, processingTime);
             if (getReceiveTime() != null) {
                 final long duration = processingTime.getMillis() - getReceiveTime().getMillis();
                 addField(FIELD_GL2_PROCESSING_DURATION_MS, Ints.saturatedCast(duration));

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -325,17 +325,22 @@ public class MessageTest {
     }
 
     @Test
-    public void testProcessingAndReceiveTimestoESObject() {
+    public void testOtherTimestoESObject() {
         final DateTime receiveTime = Tools.nowUTC();
 
         message.setReceiveTime(receiveTime);
         final DateTime processingTime = receiveTime.plusSeconds(1);
         message.setProcessingTime(processingTime);
+        final DateTime originalTime = receiveTime.plusSeconds(2);
+        final DateTime updatedTime = receiveTime.plusSeconds(3);
+        message.updateTimeStamp(originalTime, updatedTime);
         final Map<String, Object> elasticSearchObject = message.toElasticSearchObject(objectMapper, invalidTimestampMeter);
 
         assertThat(elasticSearchObject.get(Message.FIELD_GL2_RECEIVE_TIMESTAMP)).isEqualTo(Tools.buildElasticSearchTimeFormat(receiveTime));
         assertThat(elasticSearchObject.get(Message.FIELD_GL2_PROCESSING_TIMESTAMP)).isEqualTo(Tools.buildElasticSearchTimeFormat(processingTime));
         assertThat(elasticSearchObject.get(Message.FIELD_GL2_PROCESSING_DURATION_MS)).isEqualTo(1000);
+        assertThat(elasticSearchObject.get(Message.FIELD_GL2_ORIGINAL_TIMESTAMP)).isEqualTo(Tools.buildElasticSearchTimeFormat(originalTime));
+        assertThat(elasticSearchObject.get(Message.FIELD_TIMESTAMP)).isEqualTo(Tools.buildElasticSearchTimeFormat(updatedTime));
     }
 
     @Test


### PR DESCRIPTION
/nocl internal

<!--- Provide a general summary of your changes in the Title above -->
Introduce a utility method for adding message fields of type `DateTime`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's easy to forget to format the `DateTime` value for OS/ES, since the existing `addField` method happily accepts the `DateTime`; and depending on how dynamic indexing is configured, it may not even show up in testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Functionally equivalent change.
