### PR TITLE
SearchJobStateService extended to allow reset of latest search job

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
@@ -72,17 +72,24 @@ public class SearchJobStateService {
         );
     }
 
-    public boolean resetLatestForUser(final String user) {
-        return getLatestForUser(user).map(activeQuerySearchJobState ->
-                        update(
-                                activeQuerySearchJobState.toBuilder()
-                                        .status(SearchJobStatus.RESET)
-                                        .result(null)
-                                        .errors(Set.of())
-                                        .build()
-                        )
-                )
-                .orElse(false);
+    /**
+     * Reset latest/active search job for a given user.
+     *
+     * @param user Current user
+     * @return {@link Optional<SearchJobState>} object representing state of latest/active search job before the reset.
+     */
+    public Optional<SearchJobState> resetLatestForUser(final String user) {
+        return getLatestForUser(user).map(activeQuerySearchJobState -> {
+                    update(
+                            activeQuerySearchJobState.toBuilder()
+                                    .status(SearchJobStatus.RESET)
+                                    .result(null)
+                                    .errors(Set.of())
+                                    .build()
+                    );
+                    return activeQuerySearchJobState;
+                }
+        );
     }
 
     public boolean delete(final String id) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
@@ -32,6 +32,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
@@ -69,6 +70,19 @@ public class SearchJobStateService {
                         .sort(Sorts.descending(CREATED_AT_FIELD))
                         .first()
         );
+    }
+
+    public boolean resetLatestForUser(final String user) {
+        return getLatestForUser(user).map(activeQuerySearchJobState ->
+                        update(
+                                activeQuerySearchJobState.toBuilder()
+                                        .status(SearchJobStatus.RESET)
+                                        .result(null)
+                                        .errors(Set.of())
+                                        .build()
+                        )
+                )
+                .orElse(false);
     }
 
     public boolean delete(final String id) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/jobs/SearchJobStateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/jobs/SearchJobStateServiceTest.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -160,9 +159,11 @@ public class SearchJobStateServiceTest {
                 .updatedAt(DateTime.now(DateTimeZone.UTC))
                 .build());
 
-        assertFalse(toTest.resetLatestForUser("jose")); //no active query for Jose
+        assertTrue(toTest.resetLatestForUser("jose").isEmpty()); //no active query for Jose
 
-        assertTrue(toTest.resetLatestForUser("john"));
+        final Optional<SearchJobState> previousState = toTest.resetLatestForUser("john");
+        assertTrue(previousState.isPresent());
+        assertEquals(savedSearchJobState, previousState.get());
         final Optional<SearchJobState> latestForJohn = toTest.getLatestForUser("john");
         assertTrue(latestForJohn.isPresent());
         assertEquals(SearchJobStatus.RESET, latestForJohn.get().status());


### PR DESCRIPTION
## Description
SearchJobStateService extended to allow reset of latest search job.
/nocl (new/unreleased functionality)

## Motivation and Context
FE needs a way to reset latest search jobs

## How Has This Been Tested?
With new unit test and manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

