### PR TITLE
Extract views logic from general redux store logic.

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/replay-search/AggregationConditions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/AggregationConditions.tsx
@@ -22,11 +22,11 @@ import { StaticColor } from 'views/logic/views/formatting/highlighting/Highlight
 import { ColorPickerPopover, Icon } from 'components/common';
 import { DEFAULT_CUSTOM_HIGHLIGHT_RANGE } from 'views/Constants';
 import { conditionToExprMapper, exprToConditionMapper } from 'views/logic/ExpressionConditionMappers';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 import { updateHighlightingRule, createHighlightingRules } from 'views/logic/slices/highlightActions';
 import { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import NoAttributeProvided from 'components/event-definitions/replay-search/NoAttributeProvided';
 import useReplaySearchContext from 'components/event-definitions/replay-search/hooks/useReplaySearchContext';
 
@@ -50,10 +50,10 @@ const ColorComponent = styled.div`
   cursor: pointer;
 `;
 
-const useHighlightingRules = () => useAppSelector(selectHighlightingRules);
+const useHighlightingRules = () => useViewsSelector(selectHighlightingRules);
 
 const AggregationConditions = () => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const { alertId, definitionId } = useReplaySearchContext();
   const { aggregations } = useAlertAndEventDefinitionData(alertId, definitionId);
   const highlightingRules = useHighlightingRules();

--- a/graylog2-web-interface/src/pages/DelegatedSearchPage.jsx
+++ b/graylog2-web-interface/src/pages/DelegatedSearchPage.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import PluggableStoreProvider from '../components/PluggableStoreProvider';
+import ViewsStoreProvider from '../views/stores/ViewsStoreProvider';
 
 export default (props) => {
   const components =
@@ -28,8 +28,8 @@ export default (props) => {
   const Component = components[0];
 
   return (
-    <PluggableStoreProvider>
+    <ViewsStoreProvider>
       <Component {...props} />
-    </PluggableStoreProvider>
+    </ViewsStoreProvider>
   );
 };

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -30,7 +30,7 @@ import WindowDimensionsContextProvider from 'contexts/WindowDimensionsContextPro
 import { InputsActions } from 'stores/inputs/InputsStore';
 import { NodesActions } from 'stores/nodes/NodesStore';
 import { isLocalNode } from 'views/hooks/useIsLocalNode';
-import PluggableStoreProvider from 'components/PluggableStoreProvider';
+import ViewsStoreProvider from 'views/stores/ViewsStoreProvider';
 import View from 'views/logic/views/View';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import SingleMessageFieldTypesProvider from 'views/components/fieldtypes/SingleMessageFieldTypesProvider';
@@ -98,7 +98,7 @@ const ShowMessagePage = ({ message, messageId, index }: ShowMessagePageProps) =>
     const fieldTypesStreams = messageStreams.filter((streamId) => streamsMap.has(streamId));
 
     return (
-      <PluggableStoreProvider view={view} initialQuery="none" isNew={false} executionState={executionState}>
+      <ViewsStoreProvider view={view} initialQuery="none" isNew={false} executionState={executionState}>
         <DocumentTitle title={`Message ${messageId} on ${index}`}>
           <Row className="content" id="sticky-augmentations-container">
             <Col md={12}>
@@ -123,7 +123,7 @@ const ShowMessagePage = ({ message, messageId, index }: ShowMessagePageProps) =>
             </Col>
           </Row>
         </DocumentTitle>
-      </PluggableStoreProvider>
+      </ViewsStoreProvider>
     );
   }
 

--- a/graylog2-web-interface/src/store.ts
+++ b/graylog2-web-interface/src/store.ts
@@ -15,17 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { configureStore } from '@reduxjs/toolkit';
-import type { PluggableReducer } from 'graylog-web-plugin';
+import type { Reducer, UnknownAction, ReducersMapObject } from 'redux';
 
-import type { RootState } from 'views/types';
-import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
+export type PluggableReducer<T> = {
+  key: keyof T;
+  reducer: Reducer<T[keyof T], UnknownAction>;
+};
 
-const createStore = (
-  reducers: PluggableReducer[],
-  initialState: Partial<RootState>,
-  searchExecutors: SearchExecutors,
-) => {
-  const reducer = Object.fromEntries(reducers.map((r) => [r.key, r.reducer]));
+const createStore = <T>(reducers: Array<PluggableReducer<T>>, initialState: Partial<T>, extraArgument?: unknown) => {
+  const reducer = Object.fromEntries(reducers.map((r) => [r.key, r.reducer])) as ReducersMapObject<T, UnknownAction>;
 
   return configureStore({
     reducer,
@@ -35,7 +33,7 @@ const createStore = (
         serializableCheck: false,
         immutableCheck: false,
         thunk: {
-          extraArgument: { searchExecutors },
+          extraArgument,
         },
       }),
   });

--- a/graylog2-web-interface/src/stores/useAppDispatch.ts
+++ b/graylog2-web-interface/src/stores/useAppDispatch.ts
@@ -18,7 +18,7 @@ import { useDispatch } from 'react-redux';
 
 import type createStore from 'store';
 
-export type AppDispatch = ReturnType<typeof createStore>['dispatch'];
-const useAppDispatch: () => AppDispatch = useDispatch;
+export type AppDispatch<T extends object> = ReturnType<typeof createStore<T>>['dispatch'];
+const useAppDispatch: <T extends object>() => AppDispatch<T> = useDispatch;
 
 export default useAppDispatch;

--- a/graylog2-web-interface/src/stores/useAppSelector.ts
+++ b/graylog2-web-interface/src/stores/useAppSelector.ts
@@ -16,7 +16,5 @@
  */
 import { useSelector } from 'react-redux';
 
-import type { RootState } from 'views/types';
-
-const useAppSelector = <R>(fn: (state: RootState) => R) => useSelector<RootState, R>(fn);
+const useAppSelector = <R, T>(fn: (state: T) => R) => useSelector<T, R>(fn);
 export default useAppSelector;

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -35,8 +35,8 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import CopyPageToDashboard from 'views/logic/views/CopyPageToDashboard';
 import { loadAsDashboard, loadDashboard } from 'views/logic/views/Actions';
 import createSearch from 'views/logic/slices/createSearch';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { selectView, selectActiveQuery } from 'views/logic/slices/viewSelectors';
 import fetchSearch from 'views/logic/views/fetchSearch';
@@ -251,7 +251,7 @@ const addPageToDashboard =
   };
 
 const _onCopyToDashboard =
-  (selectedDashboardId: string | undefined | null) => async (_dispatch: AppDispatch, getState: GetState) => {
+  (selectedDashboardId: string | undefined | null) => async (_dispatch: ViewsDispatch, getState: GetState) => {
     const view = selectView(getState());
     const queryId = selectActiveQuery(getState());
 
@@ -291,7 +291,7 @@ const AdaptableQueryTabs = ({
   const [lockedTab, setLockedTab] = useState<QueryId>();
   const [showConfigurationModal, setShowConfigurationModal] = useState<boolean>(false);
   const [showCopyToDashboardModal, setShowCopyToDashboardModal] = useState<boolean>(false);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const history = useHistory();
   const sendTelemetry = useSendTelemetry();
   const queriesConfigBtn = useRef(null);

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.tsx
@@ -27,7 +27,7 @@ import TitleTypes from 'views/stores/TitleTypes';
 import EditableTitle from 'views/components/common/EditableTitle';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 import FindNewActiveQueryId from 'views/logic/views/FindNewActiveQuery';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { setQueriesOrder, mergeQueryTitles } from 'views/logic/slices/viewSlice';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -83,7 +83,7 @@ const AdaptableQueryTabsConfiguration = ({ show, setShow, queriesList, activeQue
   const widgetIds = useWidgetIds();
   const [nextQueriesList, setNextQueriesList] = useState<Immutable.OrderedSet<PageListItem>>(queriesList);
   const disablePageDelete = nextQueriesList.size <= 1;
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const sendTelemetry = useSendTelemetry();
   const onConfirmPagesConfiguration = useCallback(() => {
     const isActiveQueryDeleted = !nextQueriesList.find(({ id }) => id === activeQueryId);

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -24,7 +24,7 @@ import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import usePluginEntities from 'hooks/usePluginEntities';
 import generateId from 'logic/generateId';
 import useView from 'views/hooks/useView';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -74,7 +74,7 @@ type Props = {
 const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
   const creators = usePluginEntities('widgetCreators');
   const view = useView();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
 

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -34,7 +34,7 @@ import { executePluggableDashboardDuplicationHandler as executePluggableDuplicat
 import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useView from 'views/hooks/useView';
 import useIsNew from 'views/hooks/useIsNew';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { updateView } from 'views/logic/slices/viewSlice';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -78,7 +78,7 @@ const DashboardActionsMenu = () => {
       </MenuItem>
     </>
   );
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const history = useHistory();
   const pluggableDashboardActions = usePluginEntities('views.components.dashboardActions');
   const modalRefs = useRef({});

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -51,7 +51,7 @@ import {
   SearchInputAndValidationContainer,
 } from 'views/components/searchbar/SearchBarLayout';
 import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { setGlobalOverride, execute } from 'views/logic/slices/searchExecutionSlice';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
 import useHandlerContext from 'views/components/useHandlerContext';
@@ -125,7 +125,7 @@ const DashboardSearchBar = () => {
   const { config } = useSearchConfiguration();
   const { timerange, query: { query_string: queryString = '' } = {} } = useGlobalOverride() ?? {};
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const handlerContext = useHandlerContext();
   const { restartAutoRefresh } = useAutoRefresh();
   const submitForm = useCallback(

--- a/graylog2-web-interface/src/views/components/DebugOverlay.tsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 
 import { Modal, Button } from 'components/bootstrap';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 
 type Props = {
   onClose: () => void;
@@ -26,7 +26,7 @@ type Props = {
 };
 
 const DebugOverlay = ({ show, onClose }: Props) => {
-  const fullState = useAppSelector((state) => state);
+  const fullState = useViewsSelector((state) => state);
 
   return (
     <BootstrapModalWrapper showModal={show} onHide={onClose}>

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.tsx
@@ -35,8 +35,8 @@ import type { InterpolationMode } from 'views/logic/aggregationbuilder/visualiza
 import { Alert, Button, Row, Col } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
 import { TIMESTAMP_FIELD } from 'views/Constants';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { updateViewState } from 'views/logic/slices/viewSlice';
 import { execute } from 'views/logic/slices/searchExecutionSlice';
 import type { WidgetPositions, GetState } from 'views/types';
@@ -147,7 +147,7 @@ const _updateExistingWidgetPos = (existingPositions: WidgetPositions, rowOffset:
 };
 
 const _migrateWidgets =
-  (legacyCharts: Array<LegacyFieldChart>) => async (_dispatch: AppDispatch, getState: GetState) => {
+  (legacyCharts: Array<LegacyFieldChart>) => async (_dispatch: ViewsDispatch, getState: GetState) => {
     const { defaultHeight } = widgetDefinition(AggregationWidget.type);
     const currentView = selectActiveViewState(getState());
     const activeQuery = selectActiveQuery(getState());
@@ -198,7 +198,7 @@ const _migrateWidgets =
   };
 
 const _onMigrate = async (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   legacyCharts: Array<LegacyFieldChart>,
   setMigrating: (migrating: boolean) => void,
   setMigrationFinished: (finished: boolean) => void,
@@ -223,7 +223,7 @@ const MigrateFieldCharts = () => {
   const [migrationFinished, setMigrationFinished] = useState(!!Store.get(FIELD_CHARTS_MIGRATED_KEY));
   const legacyCharts: Array<LegacyFieldChart> = values(Store.get(FIELD_CHARTS_KEY));
   const chartAmount = legacyCharts.length;
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const onMigrate = useCallback(
     () => _onMigrate(dispatch, legacyCharts, setMigrating, setMigrationFinished),
     [dispatch, legacyCharts],

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -26,7 +26,7 @@ import useQueryTitles from 'views/hooks/useQueryTitles';
 import useViewMetadata from 'views/hooks/useViewMetadata';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery, removeQuery } from 'views/logic/slices/viewSlice';
 
 jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
@@ -50,7 +50,7 @@ const viewMetadata = {
 jest.mock('views/hooks/useQueryIds');
 jest.mock('views/hooks/useQueryTitles');
 jest.mock('views/hooks/useViewMetadata');
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/logic/slices/viewSlice', () => ({
   ...jest.requireActual('views/logic/slices/viewSlice'),
@@ -92,7 +92,7 @@ describe('QueryBar', () => {
 
   it('allows changing tab', async () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<QueryBar />);
 
@@ -105,7 +105,7 @@ describe('QueryBar', () => {
 
   it('allows closing current tab', async () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     const setDashboard = jest.fn();
 
     render(

--- a/graylog2-web-interface/src/views/components/QueryBar.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.tsx
@@ -23,8 +23,8 @@ import ConfirmDeletingDashboardPage from 'views/logic/views/ConfirmDeletingDashb
 import useQueryIds from 'views/hooks/useQueryIds';
 import useQueryTitles from 'views/hooks/useQueryTitles';
 import useViewMetadata from 'views/hooks/useViewMetadata';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery, createQuery, removeQuery } from 'views/logic/slices/viewSlice';
 import useWidgetIds from 'views/components/useWidgetIds';
 import { setTitle } from 'views/logic/slices/titlesActions';
@@ -37,7 +37,7 @@ const onRemovePage = async (
   activeQueryId: string,
   queries: Immutable.OrderedSet<string>,
   widgetIds: Immutable.Map<string, Immutable.List<string>>,
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
 ) => {
   if (queries.size === 1) {
     return Promise.resolve();
@@ -58,7 +58,7 @@ const QueryBar = () => {
   const { activeQuery: activeQueryId, id: dashboardId } = useViewMetadata();
   const { setDashboardPage } = useContext(DashboardPageContext);
   const widgetIds = useWidgetIds();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   const onSelectPage = useCallback(
     (pageId: string) => {

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -45,10 +45,10 @@ import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import useCurrentUser from 'hooks/useCurrentUser';
 import SynchronizeUrl from 'views/components/SynchronizeUrl';
 import useView from 'views/hooks/useView';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { cancelExecutedJob, execute } from 'views/logic/slices/searchExecutionSlice';
 import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import useParameters from 'views/hooks/useParameters';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useViewTitle from 'views/hooks/useViewTitle';
@@ -91,7 +91,7 @@ const SearchArea = styled(PageContentLayout)(() => {
 });
 
 const ConnectedSidebar = (props: Omit<React.ComponentProps<typeof Sidebar>, 'results' | 'title'>) => {
-  const results = useAppSelector(selectCurrentQueryResults);
+  const results = useViewsSelector(selectCurrentQueryResults);
   const title = useViewTitle();
 
   return <Sidebar results={results} title={title} {...props} />;
@@ -119,7 +119,7 @@ const ViewAdditionalContextProvider = ({ children }: { children: React.ReactNode
 ViewAdditionalContextProvider.displayName = 'ViewAdditionalContextProvider';
 
 const useOnWindowUnload = () => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   return useEffect(() => {
     const handleLeavePage = () => dispatch(cancelExecutedJob());
@@ -137,7 +137,7 @@ type Props = {
 };
 
 const Search = ({ forceSideBarPinned = false }: Props) => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const refreshSearch = useCallback(() => dispatch(execute()), [dispatch]);
   const {
     sidebar: { isShown: showSidebar },

--- a/graylog2-web-interface/src/views/components/SearchBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.tsx
@@ -26,7 +26,7 @@ import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
 import OriginalSearchBar from './SearchBar';
@@ -55,7 +55,7 @@ jest.mock('views/components/searchbar/queryvalidation/validateQuery', () =>
 
 jest.mock('views/logic/debounceWithPromise', () => (fn: any) => fn);
 jest.mock('views/logic/queries/useCurrentQuery');
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 jest.mock('views/hooks/useAutoRefresh');
 
 const query = MockQuery.builder()
@@ -91,7 +91,7 @@ describe('SearchBar', () => {
 
   it('should refresh search, when search is performed and there are no changes.', async () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<SearchBar />);
 

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -64,8 +64,8 @@ import {
 import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
 import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 import useQueryFilters from 'views/logic/queries/useQueryFilters';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { execute } from 'views/logic/slices/searchExecutionSlice';
 import { updateQuery } from 'views/logic/slices/viewSlice';
 import useHandlerContext from 'views/components/useHandlerContext';
@@ -92,7 +92,7 @@ const StreamsAndRefresh = styled.div`
 `;
 
 const defaultOnSubmit = async (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   values: SearchBarFormValues,
   pluggableSearchBarControls: Array<() => SearchBarControl>,
   currentQuery: Query,
@@ -162,7 +162,7 @@ const _validateQueryString = (
 
 type Props = {
   onSubmit?: (
-    dispatch: AppDispatch,
+    dispatch: ViewsDispatch,
     update: SearchBarFormValues,
     pluggableSearchBarControls: Array<() => SearchBarControl>,
     query: Query,
@@ -198,7 +198,7 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
   const queryFilters = useQueryFilters();
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const { restartAutoRefresh } = useAutoRefresh();
   const _onSubmit = useCallback(
     (values: SearchBarFormValues) =>

--- a/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
+++ b/graylog2-web-interface/src/views/components/SynchronizeUrl.tsx
@@ -18,23 +18,23 @@ import { useEffect } from 'react';
 
 import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState } from 'views/types';
 import { selectView } from 'views/logic/slices/viewSelectors';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectSearchExecutionState } from 'views/logic/slices/searchExecutionSelectors';
 import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 
 const bindSearchParamsFromQueryThunk =
-  (query: { [key: string]: unknown }) => (_dispatch: AppDispatch, getState: () => RootState) => {
+  (query: { [key: string]: unknown }) => (_dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
     const executionState = selectSearchExecutionState(getState());
     bindSearchParamsFromQuery({ view, query, retry: () => Promise.resolve(), executionState });
   };
 
 const useBindSearchParamsFromQuery = (query: { [key: string]: unknown }) => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   useEffect(() => {
     dispatch(bindSearchParamsFromQueryThunk(query));

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -127,7 +127,7 @@ type GridProps = {
   width: number;
 };
 
-const Grid = ({ children, locked, onPositionsChange, onSyncLayout, positions, width }: GridProps) => {
+const Grid = ({ children, locked, onPositionsChange, onSyncLayout = undefined, positions, width }: GridProps) => {
   const { focusedWidget } = useContext(WidgetFocusContext);
 
   return (

--- a/graylog2-web-interface/src/views/components/WidgetGrid.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.tsx
@@ -28,7 +28,7 @@ import type { FocusContextState } from 'views/components/contexts/WidgetFocusCon
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import ElementDimensions from 'components/common/ElementDimensions';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewStates, selectIsDirty } from 'views/logic/slices/viewSelectors';
 import type Widget from 'views/logic/widgets/Widget';
 import findGaps from 'views/components/GridGaps';
@@ -36,8 +36,8 @@ import generateId from 'logic/generateId';
 import NewWidgetPlaceholder from 'views/components/NewWidgetPlaceholder';
 import CreateNewWidgetModal from 'views/components/CreateNewWidgetModal';
 import isDeepEqual from 'stores/isDeepEqual';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { updateWidgetPositions, updateWidgetPosition } from 'views/logic/slices/widgetActions';
 import { setIsDirty } from 'views/logic/slices/viewSlice';
 
@@ -110,7 +110,7 @@ const selectWidgetPositions = createSelector(selectViewStates, (viewStates) =>
 );
 
 const useWidgetsAndPositions = (): [ReturnType<typeof useWidgets>, WidgetPositions] => {
-  const initialPositions = useAppSelector(selectWidgetPositions);
+  const initialPositions = useViewsSelector(selectWidgetPositions);
   const widgets = useWidgets();
 
   const positions = useMemo(() => generatePositions(widgets, initialPositions), [widgets, initialPositions]);
@@ -152,7 +152,7 @@ const MAXIMUM_GRID_SIZE = 12;
 const convertPosition = ({ col, row, height, width }: BackendWidgetPosition) =>
   new WidgetPosition(col, row, height, width >= MAXIMUM_GRID_SIZE ? Infinity : width);
 
-const onPositionChange = (dispatch: AppDispatch, newPosition: BackendWidgetPosition) => {
+const onPositionChange = (dispatch: ViewsDispatch, newPosition: BackendWidgetPosition) => {
   const { id } = newPosition;
   const widgetPosition = convertPosition(newPosition);
 
@@ -160,7 +160,7 @@ const onPositionChange = (dispatch: AppDispatch, newPosition: BackendWidgetPosit
 };
 
 const _onPositionsChange = (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   newPositions: Array<BackendWidgetPosition>,
   setLastUpdate: (newValue: string) => void,
 ) => {
@@ -174,7 +174,7 @@ const _onPositionsChange = (
 
 const _onSyncLayout =
   (positions: WidgetPositions, newPositions: Array<BackendWidgetPosition>) =>
-  (dispatch: AppDispatch, getState: GetState) => {
+  (dispatch: ViewsDispatch, getState: GetState) => {
     const isDirty = selectIsDirty(getState());
     const widgetPositions = Object.fromEntries(
       newPositions.map((newPosition) => [newPosition.id, convertPosition(newPosition)]),
@@ -208,7 +208,7 @@ const WidgetGrid = () => {
   const { focusedWidget } = useContext(WidgetFocusContext);
   const [lastUpdate, setLastUpdate] = useState<string>(undefined);
   const preventDoubleUpdate = useRef<BackendWidgetPosition[]>();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   const [widgets, positions] = useWidgetsAndPositions();
 

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -51,10 +51,10 @@ import useUserDateTime from 'hooks/useUserDateTime';
 import { SEARCH_BAR_GAP, TimeRangeRow, SearchQueryRow } from 'views/components/searchbar/SearchBarLayout';
 import PluggableCommands from 'views/components/searchbar/queryinput/PluggableCommands';
 import useGlobalOverride from 'views/hooks/useGlobalOverride';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { updateWidget } from 'views/logic/slices/widgetActions';
 import { execute, setGlobalOverrideQuery, setGlobalOverrideTimerange } from 'views/logic/slices/searchExecutionSlice';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import useHandlerContext from 'views/components/useHandlerContext';
 import useView from 'views/hooks/useView';
 import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
@@ -99,7 +99,7 @@ export const updateWidgetSearchControls = (widget, { timerange, streams, streamC
     .build();
 
 const onSubmit = async (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   values: CombinedSearchBarFormValues,
   pluggableSearchBarControls: Array<() => SearchBarControl>,
   widget: Widget,
@@ -125,9 +125,9 @@ const onSubmit = async (
   return dispatch(execute());
 };
 
-const resetTimeRangeOverride = (dispatch: AppDispatch) =>
+const resetTimeRangeOverride = (dispatch: ViewsDispatch) =>
   dispatch(setGlobalOverrideTimerange(undefined)).then(() => dispatch(execute()));
-const resetQueryOverride = (dispatch: AppDispatch) =>
+const resetQueryOverride = (dispatch: ViewsDispatch) =>
   dispatch(setGlobalOverrideQuery(undefined)).then(() => dispatch(execute()));
 
 const useBindApplySearchControlsChanges = (formRef) => {
@@ -214,7 +214,7 @@ const WidgetQueryControls = ({ availableStreams }: Props) => {
     [globalOverride, pluggableSearchBarControls, userTimezone, handlerContext],
   );
   const initialValues = useInitialFormValues(widget);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const _onSubmit = useCallback(
     (values: CombinedSearchBarFormValues) => onSubmit(dispatch, values, pluggableSearchBarControls, widget),
     [dispatch, pluggableSearchBarControls, widget],

--- a/graylog2-web-interface/src/views/components/actions/Action.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/Action.test.tsx
@@ -24,7 +24,7 @@ import type { ActionContexts, RootState } from 'views/types';
 import asMock from 'helpers/mocking/AsMock';
 import usePluginEntities from 'hooks/usePluginEntities';
 import FieldType from 'views/logic/fieldtypes/FieldType';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import mockDispatch from 'views/test/mockDispatch';
 import { createSearch } from 'fixtures/searches';
 import useExternalValueActions from 'views/hooks/useExternalValueActions';
@@ -32,7 +32,7 @@ import useExternalValueActions from 'views/hooks/useExternalValueActions';
 import Action from './Action';
 
 jest.mock('hooks/usePluginEntities', () => jest.fn(() => []));
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/hooks/useExternalValueActions');
 
@@ -40,7 +40,7 @@ describe('Action', () => {
   beforeEach(() => {
     const view = createSearch();
     const dispatch = mockDispatch({ view: { view, activeQuery: 'query-id-1' } } as RootState);
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     asMock(useExternalValueActions).mockReturnValue({
       isLoading: false,

--- a/graylog2-web-interface/src/views/components/actions/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionDropdown.tsx
@@ -25,8 +25,8 @@ import type {
   ActionHandlerArguments,
   ActionComponents,
 } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { Spinner } from 'components/common';
 import useExternalValueActions from 'views/hooks/useExternalValueActions';
 
@@ -44,7 +44,7 @@ const StyledListItem = styled.li`
 `;
 
 const filterVisibleActions = (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   handlerArgs: Props['handlerArgs'],
   actions: Array<ActionDefinition> | undefined = [],
 ) =>
@@ -57,7 +57,7 @@ const filterVisibleActions = (
 const useInternalActions = (type: Props['type'], handlerArgs: Props['handlerArgs']) => {
   const valueActions = usePluginEntities('valueActions');
   const fieldActions = usePluginEntities('fieldActions');
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   if (type === 'value') {
     return filterVisibleActions(dispatch, handlerArgs, valueActions);
@@ -72,7 +72,7 @@ const useInternalActions = (type: Props['type'], handlerArgs: Props['handlerArgs
 
 const useExternalActions = (type: Props['type'], handlerArgs: Props['handlerArgs']) => {
   const { isLoading, isError, externalValueActions } = useExternalValueActions();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   if (type !== 'value') {
     return { isLoading, isError, externalValueActions: [] };

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.tsx
@@ -21,7 +21,7 @@ import type { FieldName, FieldValue } from 'views/logic/fieldtypes/FieldType';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 import type { QueryId } from 'views/logic/queries/Query';
 import generateId from 'logic/generateId';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 
 export type ActionComponentProps = {
   onClose: () => void;
@@ -63,7 +63,7 @@ type ActionDefinitionBase<Contexts> = {
 
 export type ThunkActionHandler<T> = (
   args: ActionHandlerArguments<T>,
-) => (dispatch: AppDispatch, getState: GetState) => unknown | Promise<unknown>;
+) => (dispatch: ViewsDispatch, getState: GetState) => unknown | Promise<unknown>;
 
 type FunctionHandlerAction<Contexts> = {
   handler: ActionHandler<Contexts>;
@@ -94,7 +94,7 @@ export function isExternalLinkAction<T>(action: ActionDefinition<T>): action is 
 }
 
 export function createHandlerFor<T>(
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   action: ActionDefinitionBase<T> & HandlerAction<T>,
   setActionComponents: SetActionComponents,
 ): ActionHandler<T> {

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.test.tsx
@@ -25,12 +25,12 @@ import { createSearch } from 'fixtures/searches';
 import mockDispatch from 'views/test/mockDispatch';
 import type { RootState } from 'views/types';
 import { asMock } from 'helpers/mocking';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import wrapWithMenu from 'helpers/components/wrapWithMenu';
 
 import OriginalActionMenuItem from './ActionMenuItem';
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 const ActionMenuItem = wrapWithMenu(OriginalActionMenuItem);
 
@@ -66,7 +66,7 @@ describe('ActionMenuItem', () => {
   beforeEach(() => {
     const view = createSearch();
     const dispatch = mockDispatch({ view: { view, activeQuery: 'query-id-1' } } as RootState);
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
   });
 
   it('should display help text for actions with handler', () => {

--- a/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionMenuItem.tsx
@@ -33,7 +33,7 @@ import type {
 } from 'views/components/actions/ActionHandler';
 import { createHandlerFor, isExternalLinkAction } from 'views/components/actions/ActionHandler';
 import HoverForHelp from 'components/common/HoverForHelp';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -139,7 +139,7 @@ const ActionHandlerItem = ({
   onMenuToggle,
 }: ActionHandlerItemProps) => {
   const { unsetWidgetFocusing } = useContext(WidgetFocusContext);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
 
@@ -191,7 +191,7 @@ const ActionMenuItem = ({
   onMenuToggle,
 }: Props) => {
   const { isEnabled = () => true } = action;
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const actionDisabled = dispatch((_dispatch, getState) => !isEnabled(handlerArgs, getState));
   const { field } = handlerArgs;
 

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -22,9 +22,9 @@ import URI from 'urijs';
 import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewStates } from 'views/logic/slices/viewSelectors';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery } from 'views/logic/slices/viewSlice';
 
 const _clearURI = (query: string) => new URI(query).removeSearch('page');
@@ -40,8 +40,8 @@ const _updateQueryParams = (newPage: string | undefined, query: string) => {
 };
 
 const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPage }) => {
-  const states = useAppSelector(selectViewStates);
-  const dispatch = useAppDispatch();
+  const states = useViewsSelector(selectViewStates);
+  const dispatch = useViewsDispatch();
 
   useEffect(() => {
     const nextPage = uriParams.page;

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -28,7 +28,7 @@ import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import type { SearchExecutionResult } from 'views/types';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import executeSearch from 'views/logic/slices/executeJobResult';
 import generateId from 'logic/generateId';
 
@@ -101,7 +101,7 @@ describe('DefaultFieldTypesProvider', () => {
     );
 
     const TriggerRefresh = () => {
-      const dispatch = useAppDispatch();
+      const dispatch = useViewsDispatch();
 
       return (
         <button type="button" onClick={() => dispatch(execute())}>

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.tsx
@@ -16,12 +16,12 @@
  */
 import * as React from 'react';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 
 import HighlightingRulesContext from './HighlightingRulesContext';
 
-const useHighlightingRules = () => useAppSelector(selectHighlightingRules);
+const useHighlightingRules = () => useViewsSelector(selectHighlightingRules);
 
 const HighlightingRulesProvider = ({ children }: { children: React.ReactElement }): React.ReactElement => {
   const highlightingRules = useHighlightingRules();

--- a/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import SearchExplainContext from 'views/components/contexts/SearchExplainContext';
 import type { SearchExplainContextType, WidgetExplain } from 'views/components/contexts/SearchExplainContext';
 import { buildSearchExecutionState } from 'views/logic/slices/executeJobResult';
@@ -31,9 +31,9 @@ import useViewType from 'views/hooks/useViewType';
 import View from 'views/logic/views/View';
 
 const SearchExplainContextProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
-  const view = useAppSelector(selectView);
-  const executionState = useAppSelector(selectSearchExecutionState);
-  const widgetsToSearch = useAppSelector(selectWidgetsToSearch);
+  const view = useViewsSelector(selectView);
+  const executionState = useViewsSelector(selectSearchExecutionState);
+  const widgetsToSearch = useViewsSelector(selectWidgetsToSearch);
   const [searchExplain, setSearchExplain] = useState<SearchExplainContextType['explainedSearch'] | undefined>(
     undefined,
   );

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageAutoRefreshProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageAutoRefreshProvider.tsx
@@ -19,13 +19,13 @@ import { useCallback } from 'react';
 
 import AutoRefreshProvider from 'views/components/contexts/AutoRefreshProvider';
 import { execute } from 'views/logic/slices/searchExecutionSlice';
-import useAppDispatch from 'stores/useAppDispatch';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectJobIds } from 'views/logic/slices/searchExecutionSelectors';
 
 const SearchPageAutoRefreshProvider = ({ children }: React.PropsWithChildren) => {
-  const dispatch = useAppDispatch();
-  const jobIds = useAppSelector(selectJobIds);
+  const dispatch = useViewsDispatch();
+  const jobIds = useViewsSelector(selectJobIds);
 
   const onRefresh = useCallback(() => {
     if (!jobIds) {

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.test.tsx
@@ -26,7 +26,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { allMessagesTable } from 'views/logic/Widgets';
 import { createViewWithWidgets } from 'fixtures/searches';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { Button } from 'components/bootstrap';
 
 const mockNavigate = jest.fn();
@@ -40,7 +40,7 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 const emptyLocation = {
   pathname: '',
@@ -63,7 +63,7 @@ describe('WidgetFocusProvider', () => {
 
   beforeEach(() => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     asMock(useLocation).mockReturnValue(emptyLocation);
   });
 
@@ -204,7 +204,7 @@ describe('WidgetFocusProvider', () => {
 
   it('does not trigger setting widgets to search initially', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     asMock(useLocation).mockReturnValue(emptyLocation);
     renderSUT(jest.fn());
 

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFocusProvider.tsx
@@ -23,7 +23,7 @@ import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import useWidgets from 'views/hooks/useWidgets';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { execute, setWidgetsToSearch } from 'views/logic/slices/searchExecutionSlice';
 import type { HistoryFunction } from 'routing/useHistory';
 import useHistory from 'routing/useHistory';
@@ -86,7 +86,7 @@ const emptyFocusContext: FocusContextState = {
 };
 
 const useSyncStateWithQueryParams = ({ focusedWidget, focusUriParams, setFocusedWidget, widgetIds }: SyncStateArgs) => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   useEffect(() => {
     const nextFocusedWidget = {

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.tsx
@@ -24,7 +24,7 @@ import Query from 'views/logic/queries/Query';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { asMock } from 'helpers/mocking';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery } from 'views/logic/slices/viewSlice';
 
 import OriginalCycleQueryTab from './CycleQueryTab';
@@ -44,7 +44,7 @@ const CycleQueryTab = ({
   </TestStoreProvider>
 );
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/logic/slices/viewSlice', () => ({
   ...jest.requireActual('views/logic/slices/viewSlice'),
@@ -71,7 +71,7 @@ describe('CycleQueryTab', () => {
 
   it('should not switch to anything before interval', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
 
@@ -82,7 +82,7 @@ describe('CycleQueryTab', () => {
 
   it('should switch to next tab after interval', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
 
@@ -93,7 +93,7 @@ describe('CycleQueryTab', () => {
 
   it('should switch to first tab if current one is the last', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="baz" interval={1} tabs={[0, 1, 2]} />);
 
@@ -104,7 +104,7 @@ describe('CycleQueryTab', () => {
 
   it('should switch to next tab skipping gaps after interval', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="foo" interval={1} tabs={[0, 2]} />);
 
@@ -115,7 +115,7 @@ describe('CycleQueryTab', () => {
 
   it('should switch to next tab defaulting to all tabs if `tabs` prop` is left out', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="foo" tabs={[1]} interval={1} />);
 
@@ -126,7 +126,7 @@ describe('CycleQueryTab', () => {
 
   it('triggers tab change after the correct interval has passed', async () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     render(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
 
@@ -137,7 +137,7 @@ describe('CycleQueryTab', () => {
 
   it('does not trigger after unmounting', () => {
     const dispatch = jest.fn();
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     const { unmount } = render(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
 

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.tsx
@@ -26,7 +26,7 @@ type Props = {
   tabs?: Array<number> | undefined | null;
 };
 
-const CycleQueryTab = ({ interval, tabs }: Props) => {
+const CycleQueryTab = ({ interval, tabs = undefined }: Props) => {
   const view = useView();
   const activeQuery = useActiveQueryId();
   const dispatch = useViewsDispatch();

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.tsx
@@ -16,7 +16,7 @@
  */
 import { useEffect } from 'react';
 
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery } from 'views/logic/slices/viewSlice';
 import useView from 'views/hooks/useView';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
@@ -29,7 +29,7 @@ type Props = {
 const CycleQueryTab = ({ interval, tabs }: Props) => {
   const view = useView();
   const activeQuery = useActiveQueryId();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   useEffect(() => {
     const cycleInterval = setInterval(() => {

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -31,7 +31,7 @@ import type { Events } from 'views/logic/searchtypes/events/EventHandler';
 import type SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { updateWidgetConfig } from 'views/logic/slices/widgetActions';
 import useWidgetUnits from 'views/components/visualizations/hooks/useWidgetUnits';
 
@@ -148,7 +148,7 @@ const DataTable = ({
   const widget = useContext(WidgetContext);
   useEffect(onRenderComplete, [onRenderComplete]);
   const [rowPivotColumnsWidth, setRowPivotColumnsWidth] = useState<{ [key: string]: number }>({});
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   const onSetColumnsWidth = useCallback(
     ({ field, offsetWidth }: { field: string; offsetWidth: number }) => {

--- a/graylog2-web-interface/src/views/components/messagelist/FormatAssetList.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/FormatAssetList.tsx
@@ -20,10 +20,10 @@ import usePluginEntities from 'hooks/usePluginEntities';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 import AddToQueryHandler from 'views/logic/valueactions/AddToQueryHandler';
-import useAppDispatch from 'stores/useAppDispatch';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 
-const handleAddToQuery = (dispatch: AppDispatch, queryId: string, id: string, fieldType: FieldType) => {
+const handleAddToQuery = (dispatch: ViewsDispatch, queryId: string, id: string, fieldType: FieldType) => {
   const field: string = 'associated_assets';
 
   return dispatch(AddToQueryHandler({ queryId, field, value: id, type: fieldType }));
@@ -32,7 +32,7 @@ const handleAddToQuery = (dispatch: AppDispatch, queryId: string, id: string, fi
 const FormatAssetList = ({ associated_assets, fieldType }: { associated_assets: string[]; fieldType: FieldType }) => {
   const pluggableAssetListComponent = usePluginEntities('views.components.assetInformationActions');
   const queryId = useActiveQueryId();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   const assetsList = React.useMemo(
     () =>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.tsx
@@ -22,7 +22,7 @@ import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { asMock } from 'helpers/mocking';
 import createSearch from 'views/logic/slices/createSearch';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewStates } from 'views/logic/slices/viewSelectors';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 
@@ -31,7 +31,7 @@ import QueryTitle from './QueryTitle';
 jest.mock('views/logic/slices/createSearch');
 
 const QueryCount = () => {
-  const queries = useAppSelector(selectViewStates);
+  const queries = useViewsSelector(selectViewStates);
   const activeQuery = useActiveQueryId();
 
   return (

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.tsx
@@ -22,7 +22,7 @@ import { MenuItem } from 'components/bootstrap';
 import type { QueryId } from 'views/logic/queries/Query';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
 import type ViewState from 'views/logic/views/ViewState';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { duplicateQuery } from 'views/logic/slices/viewSlice';
 
 import QueryActionDropdown from './QueryActionDropdown';
@@ -59,7 +59,7 @@ const QueryTitle = ({
 }: Props) => {
   const [titleValue, setTitleValue] = useState(title);
   const { setDashboardPage } = useContext(DashboardPageContext);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   useEffect(() => {
     setTitleValue(title);

--- a/graylog2-web-interface/src/views/components/searchbar/SaveDashboardButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SaveDashboardButton.tsx
@@ -20,7 +20,7 @@ import { useCallback } from 'react';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import SaveViewButton from 'views/components/searchbar/SaveViewButton';
 import useHotkey from 'hooks/useHotkey';
 import useView from 'views/hooks/useView';
@@ -36,7 +36,7 @@ const SaveDashboardButton = ({ userIsAllowedToEdit, openSaveAsModal }: Props) =>
   const view = useView();
   const isNewView = useIsNew();
   const sendTelemetry = useSendTelemetry();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const hasUndeclaredParameters = useHasUndeclaredParameters();
   const _onSaveView = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_SAVED, {

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -40,7 +40,7 @@ import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useIsDirty from 'views/hooks/useIsDirty';
 import useIsNew from 'views/hooks/useIsNew';
 import useView from 'views/hooks/useView';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { loadView, updateView } from 'views/logic/slices/viewSlice';
 import type FetchError from 'logic/errors/FetchError';
 import useHistory from 'routing/useHistory';
@@ -117,7 +117,7 @@ const SearchActionsMenu = () => {
   const [showMetadataEdit, setShowMetadataEdit] = useState(false);
   const [showShareSearch, setShowShareSearch] = useState(false);
   const currentTitle = view?.title ?? '';
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const onUpdateView = useCallback((newView: View) => dispatch(updateView(newView)), [dispatch]);
 
   const loaded = isNew === false;

--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.test.tsx
@@ -21,7 +21,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import userEvent from '@testing-library/user-event';
 
 import { asMock } from 'helpers/mocking';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { createSearch } from 'fixtures/searches';
 import mockDispatch from 'views/test/mockDispatch';
 import type { RootState } from 'views/types';
@@ -67,13 +67,13 @@ const plugin = {
   },
 };
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 describe('AddWidgetButton', () => {
   beforeEach(() => {
     const view = createSearch();
     const dispatch = mockDispatch({ view: { view, activeQuery: 'query-id-1' } } as RootState);
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     PluginStore.register(plugin);
   });
 

--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
@@ -24,8 +24,8 @@ import useLocation from 'routing/useLocation';
 import { Button } from 'components/bootstrap';
 import type View from 'views/logic/views/View';
 import generateId from 'logic/generateId';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -53,7 +53,7 @@ export type CreatorProps = {
   view: View;
 };
 type CreatorType = 'preset' | 'generic' | 'investigations' | 'events';
-type CreatorFunction = () => (dispatch: AppDispatch, getState: GetState) => unknown;
+type CreatorFunction = () => (dispatch: ViewsDispatch, getState: GetState) => unknown;
 
 type FunctionalCreator = {
   func: CreatorFunction;
@@ -90,7 +90,7 @@ const CreateMenuItem = ({
 }) => {
   const location = useLocation();
   const sendTelemetry = useSendTelemetry();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const disabled = creator.useCondition?.() === false;
 
   const createHandlerFor = () => {

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -24,7 +24,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 
 import HighlightingRule from './HighlightingRule';
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/logic/slices/highlightActions', () => ({
   updateHighlightingRule: jest.fn(() => Promise.resolve()),

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/ViewsHighlightingRules.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/ViewsHighlightingRules.tsx
@@ -25,7 +25,7 @@ import {
 import HighlightingRules from 'views/components/sidebar/highlighting/HighlightingRules';
 import type { Value, Condition, Color } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import type HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 
 const DESCRIPTION =
   'Search terms and field values can be highlighted. Highlighting your search query in the results can be enabled/disabled in the graylog server config.\n' +
@@ -33,7 +33,7 @@ const DESCRIPTION =
   'If a term or a value has more than one rule, the first matching rule is used.';
 
 const ViewsHighlightingRules = () => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const onUpdateRules = useCallback(
     (newRules: Array<HighlightingRule>) => dispatch(updateHighlightingRules(newRules)).then(() => {}),
     [dispatch],

--- a/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.test.tsx
@@ -24,12 +24,12 @@ import { testView2, undoRedoTestStore } from 'fixtures/undoRedo';
 import RedoNavItem from 'views/components/sidebar/redo/RedoNavItem';
 import mockDispatch from 'views/test/mockDispatch';
 import type { RootState } from 'views/types';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { redo } from 'views/logic/slices/undoRedoActions';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/logic/slices/undoRedoActions', () => ({
   ...jest.requireActual('views/logic/slices/undoRedoActions'),
@@ -48,7 +48,7 @@ describe('<RedoNavItem />', () => {
   const dispatch = mockDispatch({ view: { view: testView2, activeQuery: 'query-id-1' } } as RootState);
 
   beforeEach(() => {
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     jest.clearAllMocks();
   });
 

--- a/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/redo/RedoNavItem.tsx
@@ -17,8 +17,8 @@
 import React, { useCallback } from 'react';
 
 import NavItem from 'views/components/sidebar/NavItem';
-import useAppDispatch from 'stores/useAppDispatch';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectUndoRedoAvailability } from 'views/logic/slices/undoRedoSelectors';
 import { redo } from 'views/logic/slices/undoRedoActions';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -33,8 +33,8 @@ const TITLE = 'Redo';
 
 const RedoNavItem = ({ sidebarIsPinned }: { sidebarIsPinned: boolean }) => {
   const viewType = useViewType();
-  const dispatch = useAppDispatch();
-  const { isRedoAvailable } = useAppSelector(selectUndoRedoAvailability);
+  const dispatch = useViewsDispatch();
+  const { isRedoAvailable } = useViewsSelector(selectUndoRedoAvailability);
   const sendTelemetry = useSendTelemetry();
   const location = useLocation();
 

--- a/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.test.tsx
@@ -24,12 +24,12 @@ import { testView2, undoRedoTestStore } from 'fixtures/undoRedo';
 import UndoNavItem from 'views/components/sidebar/undo/UndoNavItem';
 import mockDispatch from 'views/test/mockDispatch';
 import type { RootState } from 'views/types';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { undo } from 'views/logic/slices/undoRedoActions';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 jest.mock('views/logic/slices/undoRedoActions', () => ({
   ...jest.requireActual('views/logic/slices/undoRedoActions'),
@@ -48,7 +48,7 @@ describe('<UndoNavItem />', () => {
   const dispatch = mockDispatch({ view: { view: testView2, activeQuery: 'query-id-1' } } as RootState);
 
   beforeEach(() => {
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     jest.clearAllMocks();
   });
 

--- a/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/undo/UndoNavItem.tsx
@@ -17,8 +17,8 @@
 import React, { useCallback } from 'react';
 
 import NavItem from 'views/components/sidebar/NavItem';
-import useAppDispatch from 'stores/useAppDispatch';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectUndoRedoAvailability } from 'views/logic/slices/undoRedoSelectors';
 import { undo } from 'views/logic/slices/undoRedoActions';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -33,8 +33,8 @@ const TITLE = 'Undo';
 
 const UndoNavItem = ({ sidebarIsPinned }: { sidebarIsPinned: boolean }) => {
   const viewType = useViewType();
-  const dispatch = useAppDispatch();
-  const { isUndoAvailable } = useAppSelector(selectUndoRedoAvailability);
+  const dispatch = useViewsDispatch();
+  const { isUndoAvailable } = useViewsSelector(selectUndoRedoAvailability);
   const sendTelemetry = useSendTelemetry();
   const location = useLocation();
 

--- a/graylog2-web-interface/src/views/components/useHandlerContext.ts
+++ b/graylog2-web-interface/src/views/components/useHandlerContext.ts
@@ -18,12 +18,12 @@ import { createSelector } from '@reduxjs/toolkit';
 
 import { selectView } from 'views/logic/slices/viewSelectors';
 import { selectSearchExecutionState } from 'views/logic/slices/searchExecutionSelectors';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 
 const selectHandlerContext = createSelector(selectView, selectSearchExecutionState, (view, executionState) => ({
   view,
   executionState,
 }));
 
-const useHandlerContext = () => useAppSelector(selectHandlerContext);
+const useHandlerContext = () => useViewsSelector(selectHandlerContext);
 export default useHandlerContext;

--- a/graylog2-web-interface/src/views/components/useWidgetIds.ts
+++ b/graylog2-web-interface/src/views/components/useWidgetIds.ts
@@ -16,12 +16,12 @@
  */
 import { createSelector } from '@reduxjs/toolkit';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewStates } from 'views/logic/slices/viewSelectors';
 
 const selectWidgetIdsByQuery = createSelector(selectViewStates, (viewState) =>
   viewState.map((state) => state.widgets.map((widget) => widget.id).toList()).toMap(),
 );
-const useWidgetIds = () => useAppSelector(selectWidgetIdsByQuery);
+const useWidgetIds = () => useViewsSelector(selectWidgetIdsByQuery);
 
 export default useWidgetIds;

--- a/graylog2-web-interface/src/views/components/useWidgetResults.ts
+++ b/graylog2-web-interface/src/views/components/useWidgetResults.ts
@@ -22,7 +22,7 @@ import type Widget from 'views/logic/widgets/Widget';
 import type { WidgetMapping } from 'views/logic/views/types';
 import type QueryResult from 'views/logic/QueryResult';
 import type SearchError from 'views/logic/SearchError';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectSearchExecutionResult } from 'views/logic/slices/searchExecutionSelectors';
 import { selectActiveQuery, selectWidget } from 'views/logic/slices/viewSelectors';
 
@@ -84,6 +84,6 @@ const selectWidgetResults = (widgetId: string) =>
     },
   );
 
-const useWidgetResults = (widgetId: string) => useAppSelector(selectWidgetResults(widgetId));
+const useWidgetResults = (widgetId: string) => useViewsSelector(selectWidgetResults(widgetId));
 
 export default useWidgetResults;

--- a/graylog2-web-interface/src/views/components/views/ExecutionInfo.tsx
+++ b/graylog2-web-interface/src/views/components/views/ExecutionInfo.tsx
@@ -18,12 +18,12 @@ import React from 'react';
 import numeral from 'numeral';
 import isEmpty from 'lodash/isEmpty';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
 import { Timestamp } from 'components/common';
 
 const ExecutionInfo = () => {
-  const result = useAppSelector(selectCurrentQueryResults);
+  const result = useViewsSelector(selectCurrentQueryResults);
 
   if (isEmpty(result)) {
     return <i>No query executed yet.</i>;

--- a/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewHeader.tsx
@@ -27,7 +27,7 @@ import View from 'views/logic/views/View';
 import Routes from 'routing/Routes';
 import useViewTitle from 'views/hooks/useViewTitle';
 import useView from 'views/hooks/useView';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import FavoriteIcon from 'views/components/FavoriteIcon';
 import { updateView } from 'views/logic/slices/viewSlice';
 import useIsNew from 'views/hooks/useIsNew';
@@ -146,7 +146,7 @@ const ViewHeader = () => {
 
   const { alertId, definitionId, type } = useReplaySearchContext();
   const { definitionTitle } = useAlertAndEventDefinitionData(alertId, definitionId);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const _onSaveView = useCallback(
     async (updatedView: View) => {
       await dispatch(onSaveView(updatedView));

--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.ts
@@ -18,13 +18,13 @@
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import View from 'views/logic/views/View';
 import { adjustFormat, toUTCFromTz } from 'util/DateTime';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { setGlobalOverrideTimerange, execute } from 'views/logic/slices/searchExecutionSlice';
 import { setTimerange } from 'views/logic/slices/viewSlice';
 import type { GetState } from 'views/types';
 import { selectActiveQuery, selectViewType } from 'views/logic/slices/viewSelectors';
 
-const onZoom = (from: string, to: string, userTz: string) => (dispatch: AppDispatch, getState: GetState) => {
+const onZoom = (from: string, to: string, userTz: string) => (dispatch: ViewsDispatch, getState: GetState) => {
   const activeQuery = selectActiveQuery(getState());
   const viewType = selectViewType(getState());
   const newTimeRange: AbsoluteTimeRange = {

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.test.tsx
@@ -30,7 +30,7 @@ import asMock from 'helpers/mocking/AsMock';
 import ChartColorContext from './ChartColorContext';
 
 jest.mock('views/logic/queries/useCurrentQueryId', () => () => 'active-query-id');
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 jest.mock('views/hooks/useExternalValueActions');
 
 const colors = ColorMapper.create();

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -25,7 +25,7 @@ import useUserDateTime from 'hooks/useUserDateTime';
 import type { AxisType } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 import { DEFAULT_AXIS_TYPE } from 'views/logic/aggregationbuilder/visualizations/XYVisualization';
 import assertUnreachable from 'logic/assertUnreachable';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 
 import GenericPlot from './GenericPlot';
 import type { ChartColor, ChartConfig, PlotLayout } from './GenericPlot';
@@ -96,7 +96,7 @@ const XYPlot = ({
   }
 
   const layout: Partial<PlotLayout> = { ...defaultLayout, ...plotLayout };
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const _onZoom = useCallback(
     config.isTimeline

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -77,12 +77,12 @@ const XYPlot = ({
   axisType = DEFAULT_AXIS_TYPE,
   config,
   chartData,
-  effectiveTimerange,
+  effectiveTimerange = undefined,
   setChartColor = defaultSetColor,
   height,
   width,
   plotLayout = {},
-  onZoom,
+  onZoom = undefined,
 }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
   const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: mapAxisType(axisType) } as const;

--- a/graylog2-web-interface/src/views/components/widgets/ExtraDropdownWidgetActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ExtraDropdownWidgetActions.tsx
@@ -20,7 +20,7 @@ import { useContext, useMemo } from 'react';
 import type Widget from 'views/logic/widgets/Widget';
 import { MenuItem } from 'components/bootstrap';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import useWidgetActions from 'views/components/widgets/useWidgetActions';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -34,7 +34,7 @@ type Props = {
 const ExtraDropdownWidgetActions = ({ widget }: Props) => {
   const widgetFocusContext = useContext(WidgetFocusContext);
   const pluginWidgetActions = useWidgetActions();
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
   const extraWidgetActions = useMemo(

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -28,7 +28,7 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import { InputsActions, InputsStore } from 'stores/inputs/InputsStore';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import useCurrentSearchTypesResults from 'views/components/widgets/useCurrentSearchTypesResults';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { finishedLoading } from 'views/logic/slices/searchExecutionSlice';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import SearchResult from 'views/logic/SearchResult';
@@ -75,7 +75,7 @@ const dummySearchJobResults = {
 jest.mock('views/hooks/useActiveQueryId');
 jest.mock('views/components/widgets/useCurrentSearchTypesResults');
 jest.mock('views/components/widgets/reexecuteSearchTypes');
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 describe('MessageList', () => {
   const config = MessagesWidgetConfig.builder().fields([]).build();
@@ -199,7 +199,7 @@ describe('MessageList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
     const secondPageSize = 10;
 
@@ -227,7 +227,7 @@ describe('MessageList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     const secondPageSize = 10;
 
     render(<SimpleMessageList data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }} />);
@@ -251,7 +251,7 @@ describe('MessageList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     const secondPageSize = 10;
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.tsx
@@ -31,7 +31,7 @@ import WindowDimensionsContextProvider from 'contexts/WindowDimensionsContextPro
 import { InputsActions } from 'stores/inputs/InputsStore';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import useCurrentSearchTypesResults from 'views/components/widgets/useCurrentSearchTypesResults';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
 import useOnSearchExecution from 'views/hooks/useOnSearchExecution';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
@@ -110,7 +110,7 @@ const MessageList = ({
   const activeQueryId = useActiveQueryId();
   const searchTypes = useCurrentSearchTypesResults();
   const scrollContainerRef = useResetScrollPositionOnPageChange(currentPage);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   useResetPaginationOnSearchExecution(setPagination, currentPage);
   useRenderCompletionCallback();
 

--- a/graylog2-web-interface/src/views/components/widgets/SearchQueryExecutionInfoHelper.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SearchQueryExecutionInfoHelper.tsx
@@ -23,7 +23,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { Icon, Timestamp } from 'components/common';
 import { Table } from 'components/bootstrap';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
 import type { MessageResult, SearchTypeResult, SearchTypeResultTypes } from 'views/types';
 import type { SearchTypeIds } from 'views/logic/views/types';
@@ -112,7 +112,7 @@ const HelpPopover = ({ widgetExecutionData }: { widgetExecutionData: WidgetExecu
 const SearchQueryExecutionInfoHelper = ({ currentWidgetMapping, children }: Props) => {
   const [open, setOpen] = useState(false);
   const interactive = useContext(InteractiveContext);
-  const result = useAppSelector(selectCurrentQueryResults);
+  const result = useViewsSelector(selectCurrentQueryResults);
   const currentWidgetSearchType = useMemo<SearchTypeResultTypes[keyof SearchTypeResultTypes]>(() => {
     const searchTypeId = currentWidgetMapping?.toJS()?.[0];
 

--- a/graylog2-web-interface/src/views/components/widgets/Types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/Types.ts
@@ -18,7 +18,7 @@ import type * as React from 'react';
 
 import type { WidgetFocusContextType } from 'views/components/contexts/WidgetFocusContext';
 import type Widget from 'views/logic/widgets/Widget';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 
 export type Contexts = {
@@ -28,7 +28,7 @@ export type Contexts = {
 export type WidgetAction = (
   w: Widget,
   contexts: Contexts,
-) => (dispatch: AppDispatch, getState: GetState) => Promise<unknown>;
+) => (dispatch: ViewsDispatch, getState: GetState) => Promise<unknown>;
 
 type WidgetActionPositionType = 'menu' | 'dropdown';
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import type { BackendWidgetPosition, WidgetResults, GetState } from 'views/types';
 import { widgetDefinition } from 'views/logic/Widgets';
-import type WidgetModel from 'views/logic/widgets/Widget';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
@@ -61,7 +60,7 @@ import InteractiveContext from '../contexts/InteractiveContext';
 
 export type Props = {
   id: string;
-  widget: WidgetModel;
+  widget: WidgetType;
   editing?: boolean;
   title: string;
   position: WidgetPosition;
@@ -175,7 +174,7 @@ export const EditWrapper = ({
   onCancelEdit,
   onWidgetConfigChange,
   type,
-  showQueryControls,
+  showQueryControls = undefined,
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -32,8 +32,8 @@ import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import useWidgetResults from 'views/components/useWidgetResults';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { updateWidget, updateWidgetConfig } from 'views/logic/slices/widgetActions';
 import { selectActiveQuery } from 'views/logic/slices/viewSelectors';
 import { setTitle } from 'views/logic/slices/titlesActions';
@@ -179,7 +179,7 @@ export const EditWrapper = ({
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const onSubmitEdit = useCallback(
     (newWidget: WidgetType, hasChanges: boolean) => {
       if (hasChanges) {
@@ -215,7 +215,7 @@ export const EditWrapper = ({
   );
 };
 
-const setWidgetTitle = (widgetId: string, newTitle: string) => async (dispatch: AppDispatch, getState: GetState) => {
+const setWidgetTitle = (widgetId: string, newTitle: string) => async (dispatch: ViewsDispatch, getState: GetState) => {
   const activeQuery = selectActiveQuery(getState());
 
   return dispatch(setTitle(activeQuery, 'widget', widgetId, newTitle));
@@ -228,7 +228,7 @@ const Widget = ({ id, editing = false, widget, title, position, onPositionsChang
   const [loading, setLoading] = useState(false);
   const [oldWidget, setOldWidget] = useState(editing ? widget : undefined);
   const { focusedWidget, setWidgetEditing, unsetWidgetEditing } = useContext(WidgetFocusContext);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
 

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -37,8 +37,8 @@ import iterateConfirmationHooks from 'views/hooks/IterateConfirmationHooks';
 import DrilldownContext from 'views/components/contexts/DrilldownContext';
 import useView from 'views/hooks/useView';
 import createSearch from 'views/logic/slices/createSearch';
-import type { AppDispatch } from 'stores/useAppDispatch';
-import useAppDispatch from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery, updateView } from 'views/logic/slices/viewSlice';
 import { duplicateWidget, removeWidget } from 'views/logic/slices/widgetActions';
 import fetchSearch from 'views/logic/views/fetchSearch';
@@ -103,7 +103,7 @@ const _onCreateNewDashboard = async (view: View, widgetId: string, history: Hist
 };
 
 const _onMoveWidgetToPage = async (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   view: View,
   setShowMoveWidgetToTab: (show: boolean) => void,
   widgetId: string,
@@ -129,7 +129,7 @@ const defaultOnDeleteWidget = async (_widget: Widget, _view: View, title: string
   // eslint-disable-next-line no-alert
   window.confirm(`Are you sure you want to remove the widget "${title}"?`);
 
-const _onDelete = (widget: Widget, view: View, title: string) => async (dispatch: AppDispatch) => {
+const _onDelete = (widget: Widget, view: View, title: string) => async (dispatch: ViewsDispatch) => {
   const pluggableWidgetDeletionHooks = PluginStore.exports('views.hooks.confirmDeletingWidget');
 
   const result = await iterateConfirmationHooks(
@@ -142,7 +142,7 @@ const _onDelete = (widget: Widget, view: View, title: string) => async (dispatch
   return result === true ? dispatch(removeWidget(widget.id)) : Promise.resolve();
 };
 
-const _onDuplicate = (widgetId: string, unsetWidgetFocusing: () => void, title: string) => (dispatch: AppDispatch) =>
+const _onDuplicate = (widgetId: string, unsetWidgetFocusing: () => void, title: string) => (dispatch: ViewsDispatch) =>
   dispatch(duplicateWidget(widgetId, title)).then(() => unsetWidgetFocusing());
 
 type Props = {
@@ -161,7 +161,7 @@ const WidgetActionsMenu = ({ isFocused, onPositionsChange, position, title, togg
   const [showCopyToDashboard, setShowCopyToDashboard] = useState(false);
   const [showExport, setShowExport] = useState(false);
   const [showMoveWidgetToTab, setShowMoveWidgetToTab] = useState(false);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const history = useHistory();
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();

--- a/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.test.tsx
@@ -28,7 +28,7 @@ import ChartColorContext from '../visualizations/ChartColorContext';
 import type { ChangeColorFunction, ChartColorMap } from '../visualizations/ChartColorContext';
 
 jest.mock('views/components/widgets/useColorRules');
-jest.mock('stores/useAppDispatch', () => () => jest.fn());
+jest.mock('views/stores/useViewsDispatch', () => () => jest.fn());
 
 jest.mock('views/logic/slices/widgetActions', () => ({
   setChartColor: jest.fn(),

--- a/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetColorContext.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useMemo } from 'react';
 
 import ColorMapper from 'views/components/visualizations/ColorMapper';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { setChartColor } from 'views/logic/slices/widgetActions';
 
 import useColorRules from './useColorRules';
@@ -40,7 +40,7 @@ const WidgetColorContext = ({ children, id }: Props) => {
 
     return colorRulesForWidgetBuilder.build();
   }, [colorRules, id]);
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
 
   const contextValue = useMemo(() => {
     const setColor = (name: string, color: string) => {

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 
 import { events as eventsFixtures } from 'fixtures/events';
 import asMock from 'helpers/mocking/AsMock';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { finishedLoading } from 'views/logic/slices/searchExecutionSlice';
 import SearchResult from 'views/logic/SearchResult';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
@@ -44,7 +44,7 @@ const dummySearchJobResults = {
   results: {},
 };
 jest.mock('views/components/widgets/reexecuteSearchTypes');
-jest.mock('stores/useAppDispatch');
+jest.mock('views/stores/useViewsDispatch');
 
 describe('EventsList', () => {
   const config = EventsWidgetConfig.createDefault();
@@ -115,7 +115,7 @@ describe('EventsList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     const searchTypePayload = { [data.id]: { page: 2, per_page: 10 } };
     const secondPageSize = 10;
 
@@ -143,7 +143,7 @@ describe('EventsList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
     const secondPageSize = 10;
 
     render(<SimpleEventsList data={{ ...data, totalResults: 10 + secondPageSize }} />);
@@ -167,7 +167,7 @@ describe('EventsList', () => {
         widgetMapping: Immutable.Map(),
       }),
     );
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    asMock(useViewsDispatch).mockReturnValue(dispatch);
 
     const secondPageSize = 10;
 

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsList.tsx
@@ -22,7 +22,7 @@ import type { WidgetComponentProps } from 'views/types';
 import { PaginatedList } from 'components/common';
 import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
-import useAppDispatch from 'stores/useAppDispatch';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
 import type EventsWidgetConfig from 'views/logic/widgets/events/EventsWidgetConfig';
 import type { EventsListResult } from 'views/components/widgets/events/types';
 import type EventsWidgetSortConfig from 'views/logic/widgets/events/EventsWidgetSortConfig';
@@ -62,7 +62,7 @@ const useHandlePageChange = (
   setLoadingState: (loading: boolean) => void,
   setPagination: (pagination: Pagination) => void,
 ) => {
-  const dispatch = useAppDispatch();
+  const dispatch = useViewsDispatch();
   const { stopAutoRefresh } = useAutoRefresh();
 
   return useCallback(

--- a/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
+++ b/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
@@ -17,7 +17,7 @@
 import type { SearchTypeOptions } from 'views/logic/search/GlobalOverride';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import type { TimeRange } from 'views/logic/queries/Query';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState, SearchExecutionResult, ExtraArguments } from 'views/types';
 import { selectView } from 'views/logic/slices/viewSelectors';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
@@ -30,7 +30,7 @@ import { executeWithExecutionState } from 'views/logic/slices/searchExecutionSli
 
 const reexecuteSearchTypes =
   (searchTypes: SearchTypeOptions, effectiveTimerange?: TimeRange) =>
-  (dispatch: AppDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
+  (dispatch: ViewsDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
     const state = getState();
     const globalOverride = selectGlobalOverride(state);
     const globalQuery = globalOverride?.query;

--- a/graylog2-web-interface/src/views/components/widgets/useCurrentSearchTypesResults.ts
+++ b/graylog2-web-interface/src/views/components/widgets/useCurrentSearchTypesResults.ts
@@ -17,10 +17,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 
 const selectCurrentSearchTypeResults = createSelector(selectCurrentQueryResults, (result) => result?.searchTypes);
 
-const useCurrentSearchTypesResults = () => useAppSelector(selectCurrentSearchTypeResults);
+const useCurrentSearchTypesResults = () => useViewsSelector(selectCurrentSearchTypeResults);
 
 export default useCurrentSearchTypesResults;

--- a/graylog2-web-interface/src/views/hooks/useActiveViewState.ts
+++ b/graylog2-web-interface/src/views/hooks/useActiveViewState.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectActiveViewState } from 'views/logic/slices/viewSelectors';
 
-const useActiveViewState = () => useAppSelector(selectActiveViewState);
+const useActiveViewState = () => useViewsSelector(selectActiveViewState);
 
 export default useActiveViewState;

--- a/graylog2-web-interface/src/views/hooks/useGlobalOverride.ts
+++ b/graylog2-web-interface/src/views/hooks/useGlobalOverride.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectGlobalOverride } from 'views/logic/slices/searchExecutionSelectors';
 
-const useGlobalOverride = () => useAppSelector(selectGlobalOverride);
+const useGlobalOverride = () => useViewsSelector(selectGlobalOverride);
 
 export default useGlobalOverride;

--- a/graylog2-web-interface/src/views/hooks/useIsLoading.ts
+++ b/graylog2-web-interface/src/views/hooks/useIsLoading.ts
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 
-const useIsLoading = () => useAppSelector((state) => state.searchExecution.isLoading);
+const useIsLoading = () => useViewsSelector((state) => state.searchExecution.isLoading);
 
 export default useIsLoading;

--- a/graylog2-web-interface/src/views/hooks/useIsNew.ts
+++ b/graylog2-web-interface/src/views/hooks/useIsNew.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectIsNew } from 'views/logic/slices/viewSelectors';
 
-const useIsNew = () => useAppSelector(selectIsNew);
+const useIsNew = () => useViewsSelector(selectIsNew);
 
 export default useIsNew;

--- a/graylog2-web-interface/src/views/hooks/useOnSearchExecution.ts
+++ b/graylog2-web-interface/src/views/hooks/useOnSearchExecution.ts
@@ -16,11 +16,11 @@
  */
 import { useEffect, useRef } from 'react';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectSearchJobId } from 'views/logic/slices/searchExecutionSelectors';
 
 const useOnSearchExecution = (fn: () => void) => {
-  const searchResultId = useAppSelector(selectSearchJobId);
+  const searchResultId = useViewsSelector(selectSearchJobId);
   const lastSearchResultId = useRef<string | undefined>();
 
   useEffect(() => {

--- a/graylog2-web-interface/src/views/hooks/useParameters.ts
+++ b/graylog2-web-interface/src/views/hooks/useParameters.ts
@@ -16,7 +16,7 @@
  */
 import { createSelector } from '@reduxjs/toolkit';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectParameterBindings } from 'views/logic/slices/searchExecutionSelectors';
 import { selectParameters } from 'views/logic/slices/viewSelectors';
 
@@ -26,6 +26,6 @@ const selectParametersAndBindings = createSelector(
   (parameterBindings, parameters) => ({ parameterBindings, parameters }),
 );
 
-const useParameters = () => useAppSelector(selectParametersAndBindings);
+const useParameters = () => useViewsSelector(selectParametersAndBindings);
 
 export default useParameters;

--- a/graylog2-web-interface/src/views/hooks/useParametersMap.ts
+++ b/graylog2-web-interface/src/views/hooks/useParametersMap.ts
@@ -17,7 +17,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import * as Immutable from 'immutable';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import type Parameter from 'views/logic/parameters/Parameter';
 import { selectParameters } from 'views/logic/slices/viewSelectors';
 
@@ -25,5 +25,5 @@ const selectParametersMap = createSelector(selectParameters, (parameters = Immut
   Immutable.Map<string, Parameter>(parameters.map((p) => [p.name, p])),
 );
 
-const useParametersMap = () => useAppSelector(selectParametersMap);
+const useParametersMap = () => useViewsSelector(selectParametersMap);
 export default useParametersMap;

--- a/graylog2-web-interface/src/views/hooks/useQueryIds.ts
+++ b/graylog2-web-interface/src/views/hooks/useQueryIds.ts
@@ -16,10 +16,10 @@
  */
 import { createSelector } from '@reduxjs/toolkit';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectSearchQueries } from 'views/logic/slices/viewSelectors';
 
 const selectQueryIds = createSelector(selectSearchQueries, (queries) => queries.map((q) => q.id).toOrderedSet());
-const useQueryIds = () => useAppSelector(selectQueryIds);
+const useQueryIds = () => useViewsSelector(selectQueryIds);
 
 export default useQueryIds;

--- a/graylog2-web-interface/src/views/hooks/useQueryTitles.ts
+++ b/graylog2-web-interface/src/views/hooks/useQueryTitles.ts
@@ -16,7 +16,7 @@
  */
 import { createSelector } from '@reduxjs/toolkit';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewStates } from 'views/logic/slices/viewSelectors';
 
 const selectQueryTitles = createSelector(selectViewStates, (viewStates) =>
@@ -26,6 +26,6 @@ const selectQueryTitles = createSelector(selectViewStates, (viewStates) =>
     .toMap(),
 );
 
-const useQueryTitles = () => useAppSelector(selectQueryTitles);
+const useQueryTitles = () => useViewsSelector(selectQueryTitles);
 
 export default useQueryTitles;

--- a/graylog2-web-interface/src/views/hooks/useSearchExecutionState.ts
+++ b/graylog2-web-interface/src/views/hooks/useSearchExecutionState.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectSearchExecutionState } from 'views/logic/slices/searchExecutionSelectors';
 
-const useSearchExecutionState = () => useAppSelector(selectSearchExecutionState);
+const useSearchExecutionState = () => useViewsSelector(selectSearchExecutionState);
 
 export default useSearchExecutionState;

--- a/graylog2-web-interface/src/views/hooks/useSearchResult.ts
+++ b/graylog2-web-interface/src/views/hooks/useSearchResult.ts
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectSearchExecutionResult } from 'views/logic/slices/searchExecutionSelectors';
 
-const useSearchResult = () => useAppSelector(selectSearchExecutionResult);
+const useSearchResult = () => useViewsSelector(selectSearchExecutionResult);
 export default useSearchResult;

--- a/graylog2-web-interface/src/views/hooks/useView.ts
+++ b/graylog2-web-interface/src/views/hooks/useView.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectView } from 'views/logic/slices/viewSelectors';
 
-const useView = () => useAppSelector(selectView);
+const useView = () => useViewsSelector(selectView);
 
 export default useView;

--- a/graylog2-web-interface/src/views/hooks/useViewMetadata.ts
+++ b/graylog2-web-interface/src/views/hooks/useViewMetadata.ts
@@ -16,7 +16,7 @@
  */
 import { createSelector } from '@reduxjs/toolkit';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectActiveQuery, selectView } from 'views/logic/slices/viewSelectors';
 import type View from 'views/logic/views/View';
 
@@ -32,6 +32,6 @@ const selectViewMetadata = createSelector(selectActiveQuery, selectView, (active
     : {},
 );
 
-const useViewMetadata = () => useAppSelector(selectViewMetadata);
+const useViewMetadata = () => useViewsSelector(selectViewMetadata);
 
 export default useViewMetadata;

--- a/graylog2-web-interface/src/views/hooks/useViewTitle.ts
+++ b/graylog2-web-interface/src/views/hooks/useViewTitle.ts
@@ -17,12 +17,12 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import viewTitle from 'views/logic/views/ViewTitle';
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectView, selectViewType } from 'views/logic/slices/viewSelectors';
 
 const selectViewTitle = createSelector(selectView, selectViewType, (view, viewType) =>
   viewTitle(view?.title, viewType),
 );
-const useViewTitle = () => useAppSelector(selectViewTitle);
+const useViewTitle = () => useViewsSelector(selectViewTitle);
 
 export default useViewTitle;

--- a/graylog2-web-interface/src/views/hooks/useViewType.ts
+++ b/graylog2-web-interface/src/views/hooks/useViewType.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectViewType } from 'views/logic/slices/viewSelectors';
 
-const useViewType = () => useAppSelector(selectViewType);
+const useViewType = () => useViewsSelector(selectViewType);
 
 export default useViewType;

--- a/graylog2-web-interface/src/views/hooks/useWidget.ts
+++ b/graylog2-web-interface/src/views/hooks/useWidget.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectWidget } from 'views/logic/slices/viewSelectors';
 
-const useWidget = (widgetId: string) => useAppSelector(selectWidget(widgetId));
+const useWidget = (widgetId: string) => useViewsSelector(selectWidget(widgetId));
 
 export default useWidget;

--- a/graylog2-web-interface/src/views/hooks/useWidgets.ts
+++ b/graylog2-web-interface/src/views/hooks/useWidgets.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectWidgets } from 'views/logic/slices/viewSelectors';
 
-const useWidgets = () => useAppSelector(selectWidgets);
+const useWidgets = () => useViewsSelector(selectWidgets);
 
 export default useWidgets;

--- a/graylog2-web-interface/src/views/logic/creatoractions/AddCustomAggregation.ts
+++ b/graylog2-web-interface/src/views/logic/creatoractions/AddCustomAggregation.ts
@@ -20,7 +20,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import DataTable from 'views/components/datatable';
 import type { CreatorProps } from 'views/components/sidebar/create/AddWidgetButton';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 import type { GetState } from 'views/types';
 import { selectView } from 'views/logic/slices/viewSelectors';
@@ -32,7 +32,7 @@ export const CreateCustomAggregation = ({ view }: CreatorProps) =>
     .config(AggregationWidgetConfig.builder().rowPivots([]).series([]).visualization(DataTable.type).build())
     .build();
 
-export default () => (dispatch: AppDispatch, getState: GetState) => {
+export default () => (dispatch: ViewsDispatch, getState: GetState) => {
   const view = selectView(getState());
 
   return dispatch(addWidget(CreateCustomAggregation({ view })));

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageCountActionHandler.ts
@@ -19,7 +19,7 @@ import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget'
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Series from 'views/logic/aggregationbuilder/Series';
 import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 
 export const CreateMessageCount = () => {
@@ -31,6 +31,6 @@ export const CreateMessageCount = () => {
     .build();
 };
 
-const AddMessageCountActionHandler = () => (dispatch: AppDispatch) => dispatch(addWidget(CreateMessageCount()));
+const AddMessageCountActionHandler = () => (dispatch: ViewsDispatch) => dispatch(addWidget(CreateMessageCount()));
 
 export default AddMessageCountActionHandler;

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddMessageTableActionHandler.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 
 import MessagesWidget from '../widgets/MessagesWidget';
@@ -29,4 +29,4 @@ export const CreateMessagesWidget = () =>
     )
     .build();
 
-export default () => (dispatch: AppDispatch) => dispatch(addWidget(CreateMessagesWidget()));
+export default () => (dispatch: ViewsDispatch) => dispatch(addWidget(CreateMessagesWidget()));

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToAllTablesActionHandler.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { ActionHandlerArguments } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { updateWidgets } from 'views/logic/slices/widgetActions';
 import type { GetState } from 'views/types';
 import { selectWidgets } from 'views/logic/slices/viewSelectors';
@@ -23,7 +23,7 @@ import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 
 const AddToAllTablesActionHandler =
   ({ field }: ActionHandlerArguments<{}>) =>
-  async (dispatch: AppDispatch, getState: GetState) => {
+  async (dispatch: ViewsDispatch, getState: GetState) => {
     const widgets = selectWidgets(getState());
     const newWidgets = widgets
       .map((widget) => {

--- a/graylog2-web-interface/src/views/logic/fieldactions/AddToTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AddToTableActionHandler.ts
@@ -17,14 +17,14 @@
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import type Widget from 'views/logic/widgets/Widget';
 import type { ActionHandlerCondition, ActionHandlerArguments } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { updateWidgetConfig } from 'views/logic/slices/widgetActions';
 
 type Contexts = { widget: Widget };
 
 const AddToTableActionHandler =
   ({ field, contexts: { widget } }: ActionHandlerArguments<{ widget?: Widget }>) =>
-  (dispatch: AppDispatch) => {
+  (dispatch: ViewsDispatch) => {
     const newFields = [].concat(widget.config.fields, [field]);
     const newConfig = widget.config.toBuilder().fields(newFields).build();
 

--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.ts
@@ -21,14 +21,14 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Series from 'views/logic/aggregationbuilder/Series';
 import DataTable from 'views/components/datatable';
 import type { ThunkActionHandler } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 
 import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 
 const AggregateActionHandler: ThunkActionHandler<{ widget?: Widget }> =
   ({ field, type, contexts: { widget = Widget.empty() } }) =>
-  (dispatch: AppDispatch) => {
+  (dispatch: ViewsDispatch) => {
     const newWidgetBuilder = AggregationWidget.builder()
       .newId()
       .config(

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.ts
@@ -21,7 +21,7 @@ import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget'
 import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
 import { TIMESTAMP_FIELD } from 'views/Constants';
 import type { ThunkActionHandler } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 
 import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
@@ -30,7 +30,7 @@ import { FieldTypes } from '../fieldtypes/FieldType';
 
 const ChartActionHandler: ThunkActionHandler<{ widget?: Widget }> =
   ({ field, contexts: { widget: origWidget = Widget.empty() } }) =>
-  (dispatch: AppDispatch) => {
+  (dispatch: ViewsDispatch) => {
     const series = isFunction(field) ? Series.forFunction(field) : Series.forFunction(`avg(${field})`);
     const config = AggregationWidgetConfig.builder()
       .rowPivots([pivotForField(TIMESTAMP_FIELD, FieldTypes.DATE())])

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.ts
@@ -19,7 +19,7 @@ import Widget from 'views/logic/widgets/Widget';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import Series from 'views/logic/aggregationbuilder/Series';
 import TitleTypes from 'views/stores/TitleTypes';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { addWidget } from 'views/logic/slices/widgetActions';
 import { setTitle } from 'views/logic/slices/titlesActions';
@@ -33,7 +33,7 @@ const NONNUMERIC_FIELD_SERIES = ['count', 'card'];
 
 const handler =
   ({ field, type, contexts: { widget: origWidget = Widget.empty() } }: ActionHandlerArguments<{ widget?: Widget }>) =>
-  (dispatch: AppDispatch, getState: GetState) => {
+  (dispatch: ViewsDispatch, getState: GetState) => {
     const activeQuery = selectActiveQuery(getState());
     const series = (type && type.isNumeric() ? NUMERIC_FIELD_SERIES : NONNUMERIC_FIELD_SERIES)
       .map((f) => {

--- a/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromAllTablesActionHandler.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { ActionHandlerArguments } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { selectWidgets } from 'views/logic/slices/viewSelectors';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
@@ -23,7 +23,7 @@ import { updateWidgets } from 'views/logic/slices/widgetActions';
 
 const RemoveFromAllTablesActionHandler =
   ({ field }: ActionHandlerArguments<{}>) =>
-  (dispatch: AppDispatch, getState: GetState) => {
+  (dispatch: ViewsDispatch, getState: GetState) => {
     const widgets = selectWidgets(getState());
     const newWidgets = widgets
       .map((widget) => {

--- a/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromTableActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/fieldactions/RemoveFromTableActionHandler.ts
@@ -16,7 +16,7 @@
  */
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import type Widget from 'views/logic/widgets/Widget';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { updateWidgetConfig } from 'views/logic/slices/widgetActions';
 import type { ActionHandlerArguments } from 'views/components/actions/ActionHandler';
 
@@ -26,7 +26,7 @@ type Contexts = { widget: Widget };
 
 const RemoveFromTableActionHandler =
   ({ field, contexts: { widget } }: ActionHandlerArguments<Contexts>) =>
-  (dispatch: AppDispatch) => {
+  (dispatch: ViewsDispatch) => {
     const newFields = widget.config.fields.filter((f) => f !== field);
     const newConfig = widget.config.toBuilder().fields(newFields).build();
 

--- a/graylog2-web-interface/src/views/logic/parameters/useHasUndeclaredParameters.ts
+++ b/graylog2-web-interface/src/views/logic/parameters/useHasUndeclaredParameters.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectHasUndeclaredParameters } from 'views/logic/slices/searchMetadataSelectors';
 
-const useHasUndeclaredParameters = () => useAppSelector(selectHasUndeclaredParameters);
+const useHasUndeclaredParameters = () => useViewsSelector(selectHasUndeclaredParameters);
 
 export default useHasUndeclaredParameters;

--- a/graylog2-web-interface/src/views/logic/queries/useCurrentQuery.ts
+++ b/graylog2-web-interface/src/views/logic/queries/useCurrentQuery.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectCurrentQuery } from 'views/logic/slices/viewSelectors';
 
-const useCurrentQuery = () => useAppSelector(selectCurrentQuery);
+const useCurrentQuery = () => useViewsSelector(selectCurrentQuery);
 
 export default useCurrentQuery;

--- a/graylog2-web-interface/src/views/logic/queries/useCurrentQueryId.ts
+++ b/graylog2-web-interface/src/views/logic/queries/useCurrentQueryId.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import { selectActiveQuery } from 'views/logic/slices/viewSelectors';
 
-const useCurrentQueryId = () => useAppSelector(selectActiveQuery);
+const useCurrentQueryId = () => useViewsSelector(selectActiveQuery);
 
 export default useCurrentQueryId;

--- a/graylog2-web-interface/src/views/logic/queries/useQueryFilters.ts
+++ b/graylog2-web-interface/src/views/logic/queries/useQueryFilters.ts
@@ -18,7 +18,7 @@ import * as Immutable from 'immutable';
 import { createSelector } from '@reduxjs/toolkit';
 import { useMemo } from 'react';
 
-import useAppSelector from 'stores/useAppSelector';
+import useViewsSelector from 'views/stores/useViewsSelector';
 import type { QueryId } from 'views/logic/queries/Query';
 import type Query from 'views/logic/queries/Query';
 import { selectSearchQueries } from 'views/logic/slices/viewSelectors';
@@ -27,7 +27,7 @@ const selectQueriesAsMap = createSelector(selectSearchQueries, (queries) =>
   Immutable.OrderedMap<QueryId, Query>(queries.map((q) => [q.id, q])),
 );
 
-const useQueries = () => useAppSelector(selectQueriesAsMap);
+const useQueries = () => useViewsSelector(selectQueriesAsMap);
 
 const useQueryFilters = () => {
   const queries = useQueries();

--- a/graylog2-web-interface/src/views/logic/searchbar/pluggableSearchBarControlsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/searchbar/pluggableSearchBarControlsHandler.ts
@@ -21,7 +21,7 @@ import type { SearchBarControl, CombinedSearchBarFormValues, HandlerContext } fr
 import usePluginEntities from 'hooks/usePluginEntities';
 import type Widget from 'views/logic/widgets/Widget';
 import type Query from 'views/logic/queries/Query';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 
 const executeSafely = <T extends () => ReturnType<T>>(
   fn: T,
@@ -70,9 +70,9 @@ export const useInitialDashboardWidgetValues = (currentWidget: Widget) => {
 };
 
 const executeSubmitHandler = async <T>(
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   values: CombinedSearchBarFormValues,
-  submitHandlers: Array<(values: CombinedSearchBarFormValues, dispatch: AppDispatch, entity?: T) => Promise<T>>,
+  submitHandlers: Array<(values: CombinedSearchBarFormValues, dispatch: ViewsDispatch, entity?: T) => Promise<T>>,
   currentEntity?: T,
 ): Promise<T> => {
   let updatedEntity = currentEntity;
@@ -98,7 +98,7 @@ const executeSubmitHandler = async <T>(
 };
 
 export const executeSearchSubmitHandler = (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   values: CombinedSearchBarFormValues,
   pluggableSearchBarControls: Array<() => SearchBarControl>,
   currentQuery?: Query,
@@ -111,7 +111,7 @@ export const executeSearchSubmitHandler = (
 };
 
 export const executeDashboardWidgetSubmitHandler = (
-  dispatch: AppDispatch,
+  dispatch: ViewsDispatch,
   values: CombinedSearchBarFormValues,
   pluggableSearchBarControls: Array<() => SearchBarControl>,
   currentWidget: Widget,

--- a/graylog2-web-interface/src/views/logic/slices/highlightActions.ts
+++ b/graylog2-web-interface/src/views/logic/slices/highlightActions.ts
@@ -16,7 +16,7 @@
  */
 import type { Condition } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import HighlightingRule, { randomColor } from 'views/logic/views/formatting/highlighting/HighlightingRule';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { selectActiveViewState, selectActiveQuery } from 'views/logic/slices/viewSelectors';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
@@ -25,7 +25,7 @@ import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 import type { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 
 export const updateHighlightingRules =
-  (rules: Array<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
+  (rules: Array<HighlightingRule>) => async (dispatch: ViewsDispatch, getState: GetState) => {
     const activeQuery = selectActiveQuery(getState());
     const currentViewState = selectActiveViewState(getState());
     const { formatting = FormattingSettings.empty() } = currentViewState;
@@ -38,7 +38,8 @@ export const updateHighlightingRules =
   };
 
 export const updateHighlightingRule =
-  (rule: HighlightingRule, payload: Partial<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
+  (rule: HighlightingRule, payload: Partial<HighlightingRule>) =>
+  async (dispatch: ViewsDispatch, getState: GetState) => {
     const highlightingRules = selectHighlightingRules(getState());
 
     if (Object.entries(payload).length === 0) {
@@ -56,7 +57,7 @@ export const updateHighlightingRule =
     return dispatch(updateHighlightingRules(newHighlightingRules));
   };
 
-export const addHighlightingRule = (rule: HighlightingRule) => async (dispatch: AppDispatch, getState: GetState) => {
+export const addHighlightingRule = (rule: HighlightingRule) => async (dispatch: ViewsDispatch, getState: GetState) => {
   const activeViewState = selectActiveViewState(getState());
   const { formatting = FormattingSettings.empty() } = activeViewState;
 
@@ -64,14 +65,14 @@ export const addHighlightingRule = (rule: HighlightingRule) => async (dispatch: 
 };
 
 export const addHighlightingRules =
-  (rules: Array<HighlightingRule>) => async (dispatch: AppDispatch, getState: GetState) => {
+  (rules: Array<HighlightingRule>) => async (dispatch: ViewsDispatch, getState: GetState) => {
     const activeViewState = selectActiveViewState(getState());
     const { formatting = FormattingSettings.empty() } = activeViewState;
 
     return dispatch(updateHighlightingRules([...formatting.highlighting, ...rules]));
   };
 
-export const createHighlightingRule = (field: string, value: any) => async (dispatch: AppDispatch) => {
+export const createHighlightingRule = (field: string, value: any) => async (dispatch: ViewsDispatch) => {
   const newRule = HighlightingRule.builder().field(field).value(value).color(randomColor()).build();
 
   return dispatch(addHighlightingRule(newRule));
@@ -79,7 +80,7 @@ export const createHighlightingRule = (field: string, value: any) => async (disp
 
 export const createHighlightingRules =
   (rules: Array<{ field: string; value: any; condition?: Condition; color?: StaticColor }>) =>
-  async (dispatch: AppDispatch) => {
+  async (dispatch: ViewsDispatch) => {
     const newRules = rules.map(({ field, value, color, condition }) =>
       HighlightingRule.builder()
         .field(field)
@@ -92,10 +93,11 @@ export const createHighlightingRules =
     return dispatch(addHighlightingRules(newRules));
   };
 
-export const removeHighlightingRule = (rule: HighlightingRule) => async (dispatch: AppDispatch, getState: GetState) => {
-  const highlightingRules = selectHighlightingRules(getState());
+export const removeHighlightingRule =
+  (rule: HighlightingRule) => async (dispatch: ViewsDispatch, getState: GetState) => {
+    const highlightingRules = selectHighlightingRules(getState());
 
-  const newHighlightingRules = highlightingRules.filter((r) => r !== rule);
+    const newHighlightingRules = highlightingRules.filter((r) => r !== rule);
 
-  return dispatch(updateHighlightingRules(newHighlightingRules));
-};
+    return dispatch(updateHighlightingRules(newHighlightingRules));
+  };

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -28,7 +28,7 @@ import type {
   ExtraArguments,
   JobIdsState,
 } from 'views/types';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { SearchParser } from 'views/logic/slices/searchMetadataSlice';
 import { parseSearch } from 'views/logic/slices/searchMetadataSlice';
 import type View from 'views/logic/views/View';
@@ -147,7 +147,7 @@ export type SearchExecutors = {
 
 export const cancelExecutedJob =
   () =>
-  (dispatch: AppDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
+  (dispatch: ViewsDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
     const state = getState();
     const jobIds = selectJobIds(state);
 
@@ -165,7 +165,7 @@ export const executeWithExecutionState =
     executionState: SearchExecutionState,
     searchExecutors: SearchExecutors,
   ) =>
-  (dispatch: AppDispatch, getState: GetState) =>
+  (dispatch: ViewsDispatch, getState: GetState) =>
     dispatch(parseSearch(view.search, searchExecutors.parse))
       .then(() => {
         dispatch(loading());
@@ -192,7 +192,7 @@ export const executeWithExecutionState =
 
 export const execute =
   () =>
-  (dispatch: AppDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
+  (dispatch: ViewsDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
     const state = getState();
     const view = selectView(state);
     const executionState = selectSearchExecutionState(state);
@@ -202,7 +202,7 @@ export const execute =
   };
 
 export const setGlobalOverrideQuery =
-  (queryString: string) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryString: string) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const globalOverride = selectGlobalOverride(getState()) ?? GlobalOverride.empty();
     const newGlobalOverride = globalOverride.toBuilder().query(createElasticsearchQueryString(queryString)).build();
 
@@ -210,7 +210,7 @@ export const setGlobalOverrideQuery =
   };
 
 export const setGlobalOverrideTimerange =
-  (timerange: TimeRange) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (timerange: TimeRange) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const globalOverride = selectGlobalOverride(getState()) ?? GlobalOverride.empty();
     const newGlobalOverride = globalOverride.toBuilder().timerange(timerange).build();
 
@@ -218,7 +218,7 @@ export const setGlobalOverrideTimerange =
   };
 
 export const setGlobalOverride =
-  (queryString: string, timerange: TimeRange) => (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryString: string, timerange: TimeRange) => (dispatch: ViewsDispatch, getState: () => RootState) => {
     const globalOverride = selectGlobalOverride(getState()) ?? GlobalOverride.empty();
     const newGlobalOverride = globalOverride
       .toBuilder()
@@ -229,15 +229,16 @@ export const setGlobalOverride =
     return dispatch(searchExecutionSlice.actions.updateGlobalOverride(newGlobalOverride));
   };
 
-export const declareParameters = (newParameters: ParameterMap) => async (dispatch: AppDispatch, getState: GetState) => {
-  const parameters = selectParameters(getState()).toArray();
-  const newParametersArray = newParameters.valueSeq().toArray();
-  await dispatch(searchExecutionSlice.actions.addParameterBindings(newParametersArray));
+export const declareParameters =
+  (newParameters: ParameterMap) => async (dispatch: ViewsDispatch, getState: GetState) => {
+    const parameters = selectParameters(getState()).toArray();
+    const newParametersArray = newParameters.valueSeq().toArray();
+    await dispatch(searchExecutionSlice.actions.addParameterBindings(newParametersArray));
 
-  return dispatch(setParameters([...parameters, ...newParametersArray]));
-};
+    return dispatch(setParameters([...parameters, ...newParametersArray]));
+  };
 
-export const removeParameter = (parameterName: string) => async (dispatch: AppDispatch, getState: GetState) => {
+export const removeParameter = (parameterName: string) => async (dispatch: ViewsDispatch, getState: GetState) => {
   const parameters = selectParameters(getState());
   const newParameters = parameters.filter((p) => p.name !== parameterName).toArray();
   const parameterBindings = selectParameterBindings(getState());
@@ -249,7 +250,7 @@ export const removeParameter = (parameterName: string) => async (dispatch: AppDi
 };
 
 export const updateParameter =
-  (parameterName: string, newParameter: Parameter) => async (dispatch: AppDispatch, getState: GetState) => {
+  (parameterName: string, newParameter: Parameter) => async (dispatch: ViewsDispatch, getState: GetState) => {
     const parameters = selectParameters(getState());
     const newParameters = parameters.map((p) => (p.name === parameterName ? newParameter : p)).toArray();
     const parameterBindings = selectParameterBindings(getState());

--- a/graylog2-web-interface/src/views/logic/slices/searchMetadataSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchMetadataSlice.ts
@@ -18,7 +18,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 import type SearchMetadata from 'views/logic/search/SearchMetadata';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type Search from 'views/logic/search/Search';
 
 const searchMetadataSlice = createSlice({
@@ -47,7 +47,7 @@ export const searchMetadataSliceReducer = searchMetadataSlice.reducer;
 
 export type SearchParser = (search: Search) => Promise<SearchMetadata>;
 
-export const parseSearch = (search: Search, parse: SearchParser) => async (dispatch: AppDispatch) => {
+export const parseSearch = (search: Search, parse: SearchParser) => async (dispatch: ViewsDispatch) => {
   dispatch(loading());
 
   return parse(search).then((result) => dispatch(finishedLoading(result)));

--- a/graylog2-web-interface/src/views/logic/slices/titlesActions.ts
+++ b/graylog2-web-interface/src/views/logic/slices/titlesActions.ts
@@ -15,22 +15,23 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { TitleType, TitlesMap } from 'views/stores/TitleTypes';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { selectViewState } from 'views/logic/slices/viewSelectors';
 import { updateViewState } from 'views/logic/slices/viewSlice';
 import { selectTitles } from 'views/logic/slices/titlesSelectors';
 
-export const updateTitles = (id: string, newTitles: TitlesMap) => async (dispatch: AppDispatch, getState: GetState) => {
-  const viewState = selectViewState(id)(getState());
-  const newViewState = viewState.toBuilder().titles(newTitles).build();
+export const updateTitles =
+  (id: string, newTitles: TitlesMap) => async (dispatch: ViewsDispatch, getState: GetState) => {
+    const viewState = selectViewState(id)(getState());
+    const newViewState = viewState.toBuilder().titles(newTitles).build();
 
-  return dispatch(updateViewState(id, newViewState));
-};
+    return dispatch(updateViewState(id, newViewState));
+  };
 
 export const setTitle =
   (queryId: string, type: TitleType, id: string, title: string) =>
-  async (dispatch: AppDispatch, getState: GetState) => {
+  async (dispatch: ViewsDispatch, getState: GetState) => {
     const viewState = selectViewState(queryId)(getState());
     const titles = selectTitles(queryId)(getState());
     const newTitles = titles.setIn([type, id], title);

--- a/graylog2-web-interface/src/views/logic/slices/undoRedoActions.tsx
+++ b/graylog2-web-interface/src/views/logic/slices/undoRedoActions.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState, ViewState } from 'views/types';
 import { selectRootUndoRedo, selectUndoRedoAvailability } from 'views/logic/slices/undoRedoSelectors';
 import { isViewWidgetsEqualForSearch, selectQuery, updateView } from 'views/logic/slices/viewSlice';
@@ -34,7 +34,7 @@ const viewHandler = (
     currentView,
   }: {
     hasToPushRevision: boolean;
-    dispatch: AppDispatch;
+    dispatch: ViewsDispatch;
     currentView: View;
   },
 ): Promise<unknown> =>
@@ -46,7 +46,7 @@ const viewHandler = (
     return dispatch(updateView(state.view, shouldRecreateSearch, { hasToPushRevision }));
   });
 
-export const undo = () => async (dispatch: AppDispatch, getState: () => RootState) => {
+export const undo = () => async (dispatch: ViewsDispatch, getState: () => RootState) => {
   const rootState = getState();
   const { revisions, currentRevision } = selectRootUndoRedo(rootState);
   const { isUndoAvailable } = selectUndoRedoAvailability(rootState);
@@ -62,7 +62,7 @@ export const undo = () => async (dispatch: AppDispatch, getState: () => RootStat
   }
 };
 
-export const redo = () => async (dispatch: AppDispatch, getState: () => RootState) => {
+export const redo = () => async (dispatch: ViewsDispatch, getState: () => RootState) => {
   const rootState = getState();
   const { revisions, currentRevision } = selectRootUndoRedo(rootState);
   const { view: currentView } = selectRootView(rootState);

--- a/graylog2-web-interface/src/views/logic/slices/undoRedoSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/undoRedoSlice.ts
@@ -17,7 +17,7 @@
 
 import { createSlice } from '@reduxjs/toolkit';
 
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState } from 'views/types';
 import { selectRootUndoRedo } from 'views/logic/slices/undoRedoSelectors';
 
@@ -55,7 +55,7 @@ export const { setRevisions, setCurrentRevision } = undoRedoSlice.actions;
 
 export const pushIntoRevisions =
   (revisionItem: RevisionItem, setAsLastRevision: boolean = true) =>
-  async (dispatch: AppDispatch, getState: () => RootState) => {
+  async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const { revisions, currentRevision } = selectRootUndoRedo(getState());
     const isLast = currentRevision === revisions.length;
     // if we are in the middle of the buffer, we have to remove all items after current;

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -18,7 +18,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import * as Immutable from 'immutable';
 
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { ViewState, RootState, GetState } from 'views/types';
 import type { QueryId, TimeRange } from 'views/logic/queries/Query';
 import type ViewStateType from 'views/logic/views/ViewState';
@@ -102,7 +102,7 @@ const _recreateSearch = async (newView: View) => {
   return updatedView.toBuilder().search(updatedSearch).build();
 };
 
-export const selectQuery = (activeQuery: string) => async (dispatch: AppDispatch, getState: () => RootState) => {
+export const selectQuery = (activeQuery: string) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
   const currentActiveQuery = selectActiveQuery(getState());
   dispatch(setActiveQuery(activeQuery));
 
@@ -113,7 +113,7 @@ export const selectQuery = (activeQuery: string) => async (dispatch: AppDispatch
 
 export const loadView =
   (newView: View, recreateSearch: boolean = false) =>
-  async (dispatch: AppDispatch, getState: () => RootState) => {
+  async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
 
     if (recreateSearch || !isViewWidgetsEqualForSearch(view, newView)) {
@@ -132,7 +132,7 @@ const defaultUpdateViewOptions = { hasToPushRevision: true };
 
 export const updateView =
   (newView: View, recreateSearch: boolean = false, options: UpdateViewOptions = defaultUpdateViewOptions) =>
-  async (dispatch: AppDispatch, getState: () => RootState) => {
+  async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const state = getState();
     const view = selectView(state);
 
@@ -158,7 +158,7 @@ export const updateView =
   };
 
 export const updateQueries =
-  (newQueries: Immutable.OrderedSet<Query>) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (newQueries: Immutable.OrderedSet<Query>) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
     const { search } = view;
     const newSearch = search.toBuilder().newId().queries(newQueries).build();
@@ -174,7 +174,7 @@ export const updateQueries =
   };
 
 export const addQuery =
-  (query: Query, viewState: ViewStateType) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (query: Query, viewState: ViewStateType) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const state = getState();
     const view = selectView(state);
     const { search } = view;
@@ -192,7 +192,7 @@ export const addQuery =
   };
 
 export const updateQuery =
-  (queryId: QueryId, query: Query) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryId: QueryId, query: Query) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const state = getState();
     const view = selectView(state);
     const { queries } = view.search;
@@ -203,7 +203,7 @@ export const updateQuery =
     return dispatch(updateView(newView, true));
   };
 
-export const removeQuery = (queryId: string) => async (dispatch: AppDispatch, getState: () => RootState) => {
+export const removeQuery = (queryId: string) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
   const state = getState();
   const view = selectView(state);
   const activeQuery = selectActiveQuery(state);
@@ -219,14 +219,14 @@ export const removeQuery = (queryId: string) => async (dispatch: AppDispatch, ge
   await dispatch(updateView(newView, true));
 };
 
-export const createQuery = () => async (dispatch: AppDispatch, getState: () => RootState) => {
+export const createQuery = () => async (dispatch: ViewsDispatch, getState: () => RootState) => {
   const viewType = selectViewType(getState());
   const [query, state] = await NewQueryActionHandler(viewType);
 
   return dispatch(addQuery(query, state));
 };
 
-export const duplicateQuery = (queryId: string) => async (dispatch: AppDispatch, getState: GetState) => {
+export const duplicateQuery = (queryId: string) => async (dispatch: ViewsDispatch, getState: GetState) => {
   const newId = generateId();
   const viewState = selectViewState(queryId)(getState());
   const newViewState = viewState.duplicate();
@@ -240,7 +240,7 @@ export const duplicateQuery = (queryId: string) => async (dispatch: AppDispatch,
 };
 
 export const setQueriesOrder =
-  (queryIds: Immutable.OrderedSet<string>) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryIds: Immutable.OrderedSet<string>) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const queries = selectSearchQueries(getState());
     const newQueries = queryIds.map((id) => queries.find((q) => q.id === id)).toOrderedSet();
 
@@ -249,7 +249,7 @@ export const setQueriesOrder =
 
 export const mergeQueryTitles =
   (newQueryTitles: { queryId: QueryId; titlesMap: TitlesMap }[]) =>
-  async (dispatch: AppDispatch, getState: () => RootState) => {
+  async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
     let newState = view.state;
 
@@ -272,7 +272,7 @@ export const mergeQueryTitles =
   };
 
 export const setQueryString =
-  (queryId: QueryId, newQueryString: string) => (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryId: QueryId, newQueryString: string) => (dispatch: ViewsDispatch, getState: () => RootState) => {
     const query = selectQueryById(queryId)(getState());
     const newQuery = query.toBuilder().query(createElasticsearchQueryString(newQueryString)).build();
 
@@ -280,7 +280,7 @@ export const setQueryString =
   };
 
 export const setTimerange =
-  (queryId: QueryId, timerange: TimeRange) => (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryId: QueryId, timerange: TimeRange) => (dispatch: ViewsDispatch, getState: () => RootState) => {
     const query = selectQueryById(queryId)(getState());
     const newQuery = query.toBuilder().timerange(timerange).build();
 
@@ -288,7 +288,7 @@ export const setTimerange =
   };
 
 export const updateQueryString =
-  (queryId: string, newQueryString: string) => (dispatch: AppDispatch, getState: () => RootState) => {
+  (queryId: string, newQueryString: string) => (dispatch: ViewsDispatch, getState: () => RootState) => {
     const viewType = selectViewType(getState());
 
     if (viewType === View.Type.Search) {
@@ -299,7 +299,7 @@ export const updateQueryString =
   };
 
 export const updateViewState =
-  (id: QueryId, newViewState: ViewStateType) => (dispatch: AppDispatch, getState: () => RootState) => {
+  (id: QueryId, newViewState: ViewStateType) => (dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
     const newState = view.state.set(id, newViewState);
     const newView = view.toBuilder().state(newState).build();
@@ -308,7 +308,7 @@ export const updateViewState =
   };
 
 export const setParameters =
-  (newParameters: Array<Parameter>) => async (dispatch: AppDispatch, getState: () => RootState) => {
+  (newParameters: Array<Parameter>) => async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const view = selectView(getState());
     const search = selectSearch(getState());
     const newSearch = search.toBuilder().parameters(newParameters).build();

--- a/graylog2-web-interface/src/views/logic/slices/widgetActions.ts
+++ b/graylog2-web-interface/src/views/logic/slices/widgetActions.ts
@@ -17,7 +17,7 @@
 import * as Immutable from 'immutable';
 
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState, WidgetPositions } from 'views/types';
 import { selectWidgetPositions } from 'views/logic/slices/widgetSelectors';
 import {
@@ -36,7 +36,7 @@ import GenerateNextPosition from 'views/logic/views/GenerateNextPosition';
 import normalizeViewState from 'views/logic/views/normalizeViewState';
 
 export const updateWidgetPositions =
-  (newWidgetPositions: WidgetPositions) => (dispatch: AppDispatch, getState: GetState) => {
+  (newWidgetPositions: WidgetPositions) => (dispatch: ViewsDispatch, getState: GetState) => {
     const activeQuery = selectActiveQuery(getState());
     const activeViewState = selectActiveViewState(getState());
     const newViewState = activeViewState.toBuilder().widgetPositions(newWidgetPositions).build();
@@ -45,14 +45,14 @@ export const updateWidgetPositions =
   };
 
 export const updateWidgetPosition =
-  (id: string, newWidgetPosition: WidgetPosition) => (dispatch: AppDispatch, getState: GetState) => {
+  (id: string, newWidgetPosition: WidgetPosition) => (dispatch: ViewsDispatch, getState: GetState) => {
     const widgetPositions = selectWidgetPositions(getState());
     const newWidgetPositions = { ...widgetPositions, [id]: newWidgetPosition };
 
     return dispatch(updateWidgetPositions(newWidgetPositions));
   };
 
-export const updateWidgets = (newWidgets: Immutable.List<Widget>) => (dispatch: AppDispatch, getState: GetState) => {
+export const updateWidgets = (newWidgets: Immutable.List<Widget>) => (dispatch: ViewsDispatch, getState: GetState) => {
   const activeQuery = selectActiveQuery(getState());
   const activeViewState = selectActiveViewState(getState());
   const newViewState = activeViewState.toBuilder().widgets(newWidgets).build();
@@ -62,26 +62,27 @@ export const updateWidgets = (newWidgets: Immutable.List<Widget>) => (dispatch: 
   return dispatch(updateViewState(activeQuery, newViewStateNormalized));
 };
 
-export const addWidget = (widget: Widget, position?: WidgetPosition) => (dispatch: AppDispatch, getState: GetState) => {
-  if (widget.id === undefined) {
-    throw new Error('Unable to add widget without id to query.');
-  }
+export const addWidget =
+  (widget: Widget, position?: WidgetPosition) => (dispatch: ViewsDispatch, getState: GetState) => {
+    if (widget.id === undefined) {
+      throw new Error('Unable to add widget without id to query.');
+    }
 
-  const widgets = selectWidgets(getState());
-  const widgetPositions = Immutable.Map(selectWidgetPositions(getState()));
-  const newWidgets = widgets.push(widget);
-  const newWidgetPositions = position
-    ? widgetPositions.set(widget.id, position)
-    : GenerateNextPosition(widgetPositions, newWidgets.toArray());
+    const widgets = selectWidgets(getState());
+    const widgetPositions = Immutable.Map(selectWidgetPositions(getState()));
+    const newWidgets = widgets.push(widget);
+    const newWidgetPositions = position
+      ? widgetPositions.set(widget.id, position)
+      : GenerateNextPosition(widgetPositions, newWidgets.toArray());
 
-  const activeQuery = selectActiveQuery(getState());
-  const activeViewState = selectActiveViewState(getState());
-  const newViewState = activeViewState.toBuilder().widgetPositions(newWidgetPositions).widgets(newWidgets).build();
+    const activeQuery = selectActiveQuery(getState());
+    const activeViewState = selectActiveViewState(getState());
+    const newViewState = activeViewState.toBuilder().widgetPositions(newWidgetPositions).widgets(newWidgets).build();
 
-  return dispatch(updateViewState(activeQuery, newViewState));
-};
+    return dispatch(updateViewState(activeQuery, newViewState));
+  };
 
-export const updateWidget = (id: string, updatedWidget: Widget) => (dispatch: AppDispatch, getState: GetState) => {
+export const updateWidget = (id: string, updatedWidget: Widget) => (dispatch: ViewsDispatch, getState: GetState) => {
   const widgets = selectWidgets(getState());
   const newWidgets = widgets.map((widget) => (widget.id === id ? updatedWidget : widget)).toList();
 
@@ -89,7 +90,7 @@ export const updateWidget = (id: string, updatedWidget: Widget) => (dispatch: Ap
 };
 
 export const updateWidgetConfig =
-  (id: string, newWidgetConfig: WidgetConfig) => (dispatch: AppDispatch, getState: GetState) => {
+  (id: string, newWidgetConfig: WidgetConfig) => (dispatch: ViewsDispatch, getState: GetState) => {
     const widget = selectWidget(id)(getState());
     const newWidget = widget.toBuilder().config(newWidgetConfig).build();
 
@@ -97,7 +98,7 @@ export const updateWidgetConfig =
   };
 
 export const duplicateWidget =
-  (widgetId: string, widgetTitle: string) => async (dispatch: AppDispatch, getState: GetState) => {
+  (widgetId: string, widgetTitle: string) => async (dispatch: ViewsDispatch, getState: GetState) => {
     const widget = selectWidget(widgetId)(getState());
 
     if (!widget) {
@@ -113,7 +114,7 @@ export const duplicateWidget =
     );
   };
 
-export const removeWidget = (widgetId: string) => async (dispatch: AppDispatch, getState: GetState) => {
+export const removeWidget = (widgetId: string) => async (dispatch: ViewsDispatch, getState: GetState) => {
   const widgets = selectWidgets(getState());
   const newWidgets = widgets.filter((widget) => widget.id !== widgetId).toList();
 
@@ -121,7 +122,7 @@ export const removeWidget = (widgetId: string) => async (dispatch: AppDispatch, 
 };
 
 export const setChartColor =
-  (widgetId: string, name: string, color: string) => (dispatch: AppDispatch, getState: GetState) => {
+  (widgetId: string, name: string, color: string) => (dispatch: ViewsDispatch, getState: GetState) => {
     const widget = selectWidget(widgetId)(getState());
     const formattingSettings: WidgetFormattingSettings =
       widget?.config?.formattingSettings ?? WidgetFormattingSettings.empty();

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -18,7 +18,7 @@ import type FieldType from 'views/logic/fieldtypes/FieldType';
 import { escape, addToQuery, formatTimestamp, predicate } from 'views/logic/queries/QueryHelper';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState } from 'views/types';
 
 const formatNewQuery = (oldQuery: string, field: string, value: string | number, type: FieldType) => {
@@ -36,7 +36,7 @@ type Arguments = {
 
 const AddToQueryHandler =
   ({ queryId, field, value = '', type }: Arguments) =>
-  async (dispatch: AppDispatch, getState: () => RootState) => {
+  async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const oldQuery = selectQueryString(queryId)(getState());
     const newQuery = formatNewQuery(oldQuery, field, value, type);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { escape, addToQuery, predicate, not } from 'views/logic/queries/QueryHelper';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState } from 'views/types';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
@@ -34,7 +34,7 @@ type Args = {
 
 const ExcludeFromQueryHandler =
   ({ queryId, field, value }: Args) =>
-  (dispatch: AppDispatch, getState: () => RootState) => {
+  (dispatch: ViewsDispatch, getState: () => RootState) => {
     const oldQuery = selectQueryString(queryId)(getState());
     const newQuery = formatNewQuery(oldQuery, field, value);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/HighlightValueHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/HighlightValueHandler.ts
@@ -15,14 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { ActionHandlerCondition, ActionHandlerArguments } from 'views/components/actions/ActionHandler';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { createHighlightingRule } from 'views/logic/slices/highlightActions';
 import type { GetState } from 'views/types';
 import { selectHighlightingRules } from 'views/logic/slices/highlightSelectors';
 
 const HighlightValueHandler =
   ({ field, value }: ActionHandlerArguments) =>
-  (dispatch: AppDispatch) => {
+  (dispatch: ViewsDispatch) => {
     if (value === undefined) {
       return Promise.reject(new Error('Unable to add highlighting for missing value.'));
     }

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.ts
@@ -17,7 +17,7 @@
 import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
 import { escape, addToQuery, predicate } from 'views/logic/queries/QueryHelper';
 import TitleTypes from 'views/stores/TitleTypes';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { GetState } from 'views/types';
 import { addWidget } from 'views/logic/slices/widgetActions';
 import { setTitle } from 'views/logic/slices/titlesActions';
@@ -48,7 +48,7 @@ const extractFieldsFromValuePath = (valuePath: ValuePath): Array<string> =>
 
 const ShowDocumentsHandler =
   ({ contexts: { valuePath, widget } }: Arguments) =>
-  (dispatch: AppDispatch, getState: GetState) => {
+  (dispatch: ViewsDispatch, getState: GetState) => {
     const activeQuery = selectActiveQuery(getState());
     const mergedObject = Object.fromEntries(valuePath.flatMap(Object.entries));
     const widgetQuery = widget && widget.query ? widget.query.query_string : '';

--- a/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveNewDashboard.ts
@@ -20,12 +20,12 @@ import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import { loadDashboard } from 'views/logic/views/Actions';
 import type { HistoryFunction } from 'routing/useHistory';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { setIsDirty, setIsNew } from 'views/logic/slices/viewSlice';
 
 import type View from './View';
 
-export default (view: View, history: HistoryFunction) => async (dispatch: AppDispatch) => {
+export default (view: View, history: HistoryFunction) => async (dispatch: ViewsDispatch) => {
   try {
     const savedView = await ViewManagementActions.create(view);
 

--- a/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
@@ -17,7 +17,7 @@
 import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import type View from 'views/logic/views/View';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { setIsNew, setIsDirty } from 'views/logic/slices/viewSlice';
 import type FetchError from 'logic/errors/FetchError';
 
@@ -26,7 +26,7 @@ const _extractErrorMessage = (error: FetchError) =>
     ? error.additional.body.message
     : error;
 
-export default (view: View) => async (dispatch: AppDispatch) => {
+export default (view: View) => async (dispatch: ViewsDispatch) => {
   try {
     await ViewManagementActions.update(view);
     dispatch(setIsNew(false));

--- a/graylog2-web-interface/src/views/logic/widgets/events/AddEventsWidgetActionHandler.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/AddEventsWidgetActionHandler.ts
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { addWidget } from 'views/logic/slices/widgetActions';
 
 import EventsWidgetConfig from './EventsWidgetConfig';
@@ -23,4 +23,4 @@ import EventsWidget from './EventsWidget';
 export const CreateEventsWidget = () =>
   EventsWidget.builder().newId().config(EventsWidgetConfig.createDefault()).build();
 
-export default () => async (dispatch: AppDispatch) => dispatch(addWidget(CreateEventsWidget()));
+export default () => async (dispatch: ViewsDispatch) => dispatch(addWidget(CreateEventsWidget()));

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -27,7 +27,7 @@ import { DocumentTitle, Spinner } from 'components/common';
 import type View from 'views/logic/views/View';
 import useProcessHooksForView from 'views/logic/views/UseProcessHooksForView';
 import useQuery from 'routing/useQuery';
-import PluggableStoreProvider from 'components/PluggableStoreProvider';
+import ViewsStoreProvider from 'views/stores/ViewsStoreProvider';
 import useViewTitle from 'views/hooks/useViewTitle';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { HistoryFunction } from 'routing/useHistory';
@@ -81,7 +81,7 @@ const SearchPage = ({
   const { view, executionState } = result;
 
   return view ? (
-    <PluggableStoreProvider
+    <ViewsStoreProvider
       view={view}
       executionState={executionState}
       isNew={isNew}
@@ -101,7 +101,7 @@ const SearchPage = ({
           </NewViewLoaderContext.Provider>
         </DashboardPageContextProvider>
       </SearchPageTitle>
-    </PluggableStoreProvider>
+    </ViewsStoreProvider>
   ) : (
     <Spinner />
   );

--- a/graylog2-web-interface/src/views/stores/ViewsStoreProvider.tsx
+++ b/graylog2-web-interface/src/views/stores/ViewsStoreProvider.tsx
@@ -53,7 +53,7 @@ const useInitialState = (
   undoRedoState: UndoRedoState,
   view: View,
   isNew: boolean,
-  activeQuery,
+  activeQuery: string,
   executionState: SearchExecutionState,
   result?: Props['result'],
 ): Partial<RootState> =>
@@ -81,25 +81,25 @@ const useInitialState = (
     [executionState, isNew, view],
   );
 
-const PluggableStoreProvider = ({
+const ViewsStoreProvider = ({
   initialQuery,
-  children,
+  children = undefined,
   isNew,
   view,
   executionState,
-  undoRedoState,
-  result,
+  undoRedoState = undefined,
+  result = undefined,
 }: React.PropsWithChildren<Props>) => {
   const reducers = usePluginEntities('views.reducers');
   const activeQuery = useActiveQuery(initialQuery, view);
   const initialState = useInitialState(undoRedoState, view, isNew, activeQuery, executionState, result);
   const searchExecutors = useSearchExecutors();
   const store = useMemo(
-    () => createStore(reducers, initialState, searchExecutors),
+    () => createStore<RootState>(reducers, initialState, { searchExecutors }),
     [initialState, reducers, searchExecutors],
   );
 
   return <Provider store={store}>{children}</Provider>;
 };
 
-export default PluggableStoreProvider;
+export default ViewsStoreProvider;

--- a/graylog2-web-interface/src/views/stores/useViewsDispatch.ts
+++ b/graylog2-web-interface/src/views/stores/useViewsDispatch.ts
@@ -14,9 +14,13 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useViewsSelector from 'views/stores/useViewsSelector';
-import { selectIsDirty } from 'views/logic/slices/viewSelectors';
 
-const useIsDirty = () => useViewsSelector(selectIsDirty);
+import type { RootState } from 'views/types';
+import type { AppDispatch } from 'stores/useAppDispatch';
+import useAppDispatch from 'stores/useAppDispatch';
 
-export default useIsDirty;
+export type ViewsDispatch = AppDispatch<RootState>;
+
+const useViewsDispatch = useAppDispatch<RootState>;
+
+export default useViewsDispatch;

--- a/graylog2-web-interface/src/views/stores/useViewsSelector.ts
+++ b/graylog2-web-interface/src/views/stores/useViewsSelector.ts
@@ -14,9 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import useViewsSelector from 'views/stores/useViewsSelector';
-import { selectIsDirty } from 'views/logic/slices/viewSelectors';
+import type { RootState } from 'views/types';
+import useAppSelector from 'stores/useAppSelector';
 
-const useIsDirty = () => useViewsSelector(selectIsDirty);
-
-export default useIsDirty;
+const useViewsSelector = <R>(fn: (state: RootState) => R) => useAppSelector<R, RootState>(fn);
+export default useViewsSelector;

--- a/graylog2-web-interface/src/views/test/TestStoreProvider.tsx
+++ b/graylog2-web-interface/src/views/test/TestStoreProvider.tsx
@@ -21,7 +21,7 @@ import ViewsStoreProvider from 'views/stores/ViewsStoreProvider';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 
 const TestStoreProvider = ({
-  children,
+  children = undefined,
   undoRedoState,
   ...rest
 }: React.PropsWithChildren<Partial<React.ComponentProps<typeof ViewsStoreProvider>>>) => {

--- a/graylog2-web-interface/src/views/test/TestStoreProvider.tsx
+++ b/graylog2-web-interface/src/views/test/TestStoreProvider.tsx
@@ -17,28 +17,28 @@
 import * as React from 'react';
 
 import { createSearch } from 'fixtures/searches';
-import PluggableStoreProvider from 'components/PluggableStoreProvider';
+import ViewsStoreProvider from 'views/stores/ViewsStoreProvider';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 
 const TestStoreProvider = ({
   children,
   undoRedoState,
   ...rest
-}: React.PropsWithChildren<Partial<React.ComponentProps<typeof PluggableStoreProvider>>>) => {
+}: React.PropsWithChildren<Partial<React.ComponentProps<typeof ViewsStoreProvider>>>) => {
   const view = rest.view ?? createSearch();
   const isNew = rest.isNew ?? false;
   const initialQuery = rest.initialQuery ?? 'query-id-1';
   const executionState = rest.executionState ?? SearchExecutionState.empty();
 
   return (
-    <PluggableStoreProvider
+    <ViewsStoreProvider
       undoRedoState={undoRedoState}
       view={view}
       initialQuery={initialQuery}
       isNew={isNew}
       executionState={executionState}>
       {children}
-    </PluggableStoreProvider>
+    </ViewsStoreProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/test/mockDispatch.ts
+++ b/graylog2-web-interface/src/views/test/mockDispatch.ts
@@ -17,7 +17,7 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 
 import type { RootState, ExtraArguments, SearchExecutionResult } from 'views/types';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import { asMock } from 'helpers/mocking';
 import { createSearch } from 'fixtures/searches';
 import type View from 'views/logic/views/View';
@@ -33,12 +33,12 @@ const mockSearchExecutors: SearchExecutors = {
   cancelJob: async () => null,
 };
 
-type ActionFn = (d: AppDispatch, getState: () => RootState, extraArgs?: ExtraArguments) => UnknownAction;
+type ActionFn = (d: ViewsDispatch, getState: () => RootState, extraArgs?: ExtraArguments) => UnknownAction;
 
 const isActionFn = (fn: UnknownAction | ActionFn): fn is ActionFn => typeof fn === 'function';
 
 const mockDispatch = (state: RootState = defaultState) => {
-  const dispatch: AppDispatch = jest.fn();
+  const dispatch: ViewsDispatch = jest.fn();
 
   asMock(dispatch).mockImplementation((fn) =>
     isActionFn(fn) ? fn(dispatch, () => state, { searchExecutors: mockSearchExecutors }) : fn,
@@ -49,7 +49,7 @@ const mockDispatch = (state: RootState = defaultState) => {
 
 export const mockDispatchForView = (view: View, initialQuery: string = 'query-id-1') => {
   const state = { ...defaultState, view: { view, activeQuery: initialQuery } } as RootState;
-  const dispatch: AppDispatch = jest.fn();
+  const dispatch: ViewsDispatch = jest.fn();
 
   asMock(dispatch).mockImplementation((fn) => (isActionFn(fn) ? fn(dispatch, () => state) : fn));
 

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -18,7 +18,6 @@
 import type React from 'react';
 import type * as Immutable from 'immutable';
 import type { FormikErrors } from 'formik';
-import type { Reducer, AnyAction } from '@reduxjs/toolkit';
 
 import type { ExportPayload } from 'util/MessagesExportUtils';
 import type { IconName } from 'components/common/Icon';
@@ -62,6 +61,7 @@ import type { SearchExecutors } from 'views/logic/slices/searchExecutionSlice';
 import type { JobIds } from 'views/stores/SearchJobs';
 import type { FilterComponents, Attributes } from 'views/components/widgets/overview-configuration/filters/types';
 import type { Event } from 'components/events/events/types';
+import type { PluggableReducer } from 'store';
 
 export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]
   ? ElementType
@@ -477,10 +477,7 @@ export interface ExtraArguments {
 
 export type GetState = () => RootState;
 
-export type ViewsReducer = {
-  key: keyof RootState;
-  reducer: Reducer<RootState[keyof RootState], AnyAction>;
-};
+export type ViewsReducer = PluggableReducer<RootState>;
 
 export type Widgets = Immutable.OrderedMap<string, Widget>;
 

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -52,7 +52,7 @@ import type { CustomCommand, CustomCommandContext } from 'views/components/searc
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import type SearchMetadata from 'views/logic/search/SearchMetadata';
-import type { AppDispatch } from 'stores/useAppDispatch';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type SearchResult from 'views/logic/SearchResult';
 import type { WidgetMapping } from 'views/logic/views/types';
 import type Parameter from 'views/logic/parameters/Parameter';
@@ -395,12 +395,12 @@ export interface SearchBarControl {
   id: string;
   onSearchSubmit?: <T extends Query | undefined>(
     values: CombinedSearchBarFormValues,
-    dispatch: AppDispatch,
+    dispatch: ViewsDispatch,
     currentQuery?: T,
   ) => Promise<T>;
   onDashboardWidgetSubmit: (
     values: CombinedSearchBarFormValues,
-    dispatch: AppDispatch,
+    dispatch: ViewsDispatch,
     currentWidget: Widget,
   ) => Promise<Widget | void>;
   onValidate?: (values: CombinedSearchBarFormValues, context?: HandlerContext) => FormikErrors<{}>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change `src/store`, `src/useAppDispatch` and `src/useAppSelector` contained views specific logic. To be able to reuse these general redux abstractions in other parts of the app, which are not related to views, we extracted the views related code.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9788
/nocl