### PR TITLE
Implementing endpoint for retrieving alerts/events histogram.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -32,11 +32,10 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.ToXCo
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ParsedAutoDateHistogram;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.FieldSortBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.SortOrder;
@@ -56,6 +55,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -63,7 +63,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
@@ -155,7 +154,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
         final var termsAggregation = AggregationBuilders.terms(termsAggregationName)
                 .field(EventDto.FIELD_ALERT);
 
-        searchSourceBuilder.aggregation(termsAggregation.subAggregation(histogramAggregation));
+        searchSourceBuilder.aggregation(histogramAggregation.subAggregation(termsAggregation));
 
         final Set<String> indices = affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices;
         final SearchRequest searchRequest = new SearchRequest(indices.toArray(new String[0]))
@@ -169,26 +168,22 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
 
         final SearchResponse searchResult = client.search(searchRequest, "Unable to perform search query");
 
-        final ParsedTerms termsResult = searchResult.getAggregations().get(termsAggregationName);
+        final ParsedAutoDateHistogram histogramResult = searchResult.getAggregations().get(histogramAggregationName);
+        final var histogramBuckets = histogramResult.getBuckets();
 
-        final var alerts = extractBuckets(termsResult, "true");
-        final var events = extractBuckets(termsResult, "false");
+        final var alerts = new ArrayList<MoreSearch.Histogram.Bucket>(histogramBuckets.size());
+        final var events = new ArrayList<MoreSearch.Histogram.Bucket>(histogramBuckets.size());
+
+        histogramBuckets.forEach(bucket -> {
+            final var parsedTerms = (ParsedTerms) bucket.getAggregations().get(termsAggregationName);
+            final var dateTime = (ZonedDateTime) bucket.getKey();
+            final var alertCount = Optional.ofNullable(parsedTerms.getBucketByKey("true")).map(MultiBucketsAggregation.Bucket::getDocCount).orElse(0L);
+            final var eventCount = Optional.ofNullable(parsedTerms.getBucketByKey("false")).map(MultiBucketsAggregation.Bucket::getDocCount).orElse(0L);
+            alerts.add(new MoreSearch.Histogram.Bucket(dateTime, alertCount));
+            events.add(new MoreSearch.Histogram.Bucket(dateTime, eventCount));
+        });
 
         return new MoreSearch.Histogram(new MoreSearch.Histogram.EventsBuckets(events, alerts));
-    }
-
-    private List<MoreSearch.Histogram.Bucket> extractBuckets(ParsedTerms termsResult, String key) {
-        return Optional.ofNullable(termsResult.getBucketByKey(key))
-                .map(Terms.Bucket::getAggregations)
-                .map(b -> (ParsedAutoDateHistogram) b.get(histogramAggregationName))
-                .map(b -> b.getBuckets().stream())
-                .orElse(Stream.empty())
-                .map(this::createBucket)
-                .toList();
-    }
-
-    private MoreSearch.Histogram.Bucket createBucket(Histogram.Bucket bucket) {
-        return new MoreSearch.Histogram.Bucket((ZonedDateTime) bucket.getKey(), bucket.getDocCount());
     }
 
     private QueryBuilder createQuery(String queryString, TimeRange timerange, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -31,6 +31,12 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.Indice
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.xcontent.ToXContent;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ParsedAutoDateHistogram;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.FieldSortBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.SortOrder;
@@ -47,12 +53,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
@@ -64,6 +73,8 @@ import static org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.Qu
 public class MoreSearchAdapterES7 implements MoreSearchAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(MoreSearchAdapterES7.class);
     public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.LENIENT_EXPAND_OPEN;
+    private static final String termsAggregationName = "alert_type";
+    private static final String histogramAggregationName = "histogram";
     private final ES7ResultMessageFactory resultMessageFactory;
     private final ElasticsearchClient client;
     private final Boolean allowLeadingWildcard;
@@ -87,24 +98,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
     public MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices,
                                          Sorting sorting, int page, int perPage, Set<String> eventStreams,
                                          String filterString, Set<String> forbiddenSourceStreams) {
-        final QueryBuilder query = (queryString.isEmpty() || queryString.equals("*")) ?
-                matchAllQuery() :
-                queryStringQuery(queryString).allowLeadingWildcard(allowLeadingWildcard);
-
-        final BoolQueryBuilder filter = boolQuery()
-                .filter(query)
-                .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
-                .filter(requireNonNull(TimeRangeQueryFactory.create(timerange)));
-
-        if (!isNullOrEmpty(filterString)) {
-            filter.filter(queryStringQuery(filterString));
-        }
-
-        if (!forbiddenSourceStreams.isEmpty()) {
-            // If an event has any stream in "source_streams" that the calling search user is not allowed to access,
-            // the event must not be in the search result.
-            filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
-        }
+        final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
                 .query(filter)
@@ -139,6 +133,82 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
                 .usedIndexNames(affectedIndices)
                 .executedQuery(searchSourceBuilder.toString())
                 .build();
+    }
+
+    @Override
+    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, TimeRange timerange, Set<String> affectedIndices,
+                                               Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+        final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams);
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(filter)
+                .size(0)
+                .trackTotalHits(true);
+
+        final var histogramAggregation = new AutoDateHistogramAggregationBuilder(histogramAggregationName)
+                .field(EventDto.FIELD_EVENT_TIMESTAMP)
+                .setNumBuckets(buckets);
+
+        final var termsAggregation = AggregationBuilders.terms(termsAggregationName)
+                .field(EventDto.FIELD_ALERT);
+
+        searchSourceBuilder.aggregation(termsAggregation.subAggregation(histogramAggregation));
+
+        final Set<String> indices = affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices;
+        final SearchRequest searchRequest = new SearchRequest(indices.toArray(new String[0]))
+                .source(searchSourceBuilder)
+                .indicesOptions(INDICES_OPTIONS);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
+            LOG.debug("Execute search: {}", searchRequest);
+        }
+
+        final SearchResponse searchResult = client.search(searchRequest, "Unable to perform search query");
+
+        final ParsedTerms termsResult = searchResult.getAggregations().get(termsAggregationName);
+
+        final var alerts = extractBuckets(termsResult, "true");
+        final var events = extractBuckets(termsResult, "false");
+
+        return new MoreSearch.Histogram(new MoreSearch.Histogram.EventsBuckets(events, alerts));
+    }
+
+    private List<MoreSearch.Histogram.Bucket> extractBuckets(ParsedTerms termsResult, String key) {
+        return Optional.ofNullable(termsResult.getBucketByKey(key))
+                .map(Terms.Bucket::getAggregations)
+                .map(b -> (ParsedAutoDateHistogram) b.get(histogramAggregationName))
+                .map(b -> b.getBuckets().stream())
+                .orElse(Stream.empty())
+                .map(this::createBucket)
+                .toList();
+    }
+
+    private MoreSearch.Histogram.Bucket createBucket(Histogram.Bucket bucket) {
+        return new MoreSearch.Histogram.Bucket((ZonedDateTime) bucket.getKey(), bucket.getDocCount());
+    }
+
+    private QueryBuilder createQuery(String queryString, TimeRange timerange, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+        final QueryBuilder query = (queryString.isEmpty() || queryString.equals("*"))
+                ? matchAllQuery()
+                : queryStringQuery(queryString).allowLeadingWildcard(allowLeadingWildcard);
+
+        final BoolQueryBuilder filter = boolQuery()
+                .filter(query)
+                .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
+                .filter(requireNonNull(TimeRangeQueryFactory.create(timerange)));
+
+        if (!isNullOrEmpty(filterString)) {
+            filter.filter(queryStringQuery(filterString));
+        }
+
+        if (!forbiddenSourceStreams.isEmpty()) {
+            // If an event has any stream in "source_streams" that the calling search user is not allowed to access,
+            // the event must not be in the search result.
+            filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
+        }
+
+        return filter;
     }
 
     private List<FieldSortBuilder> createSorting(Sorting sorting) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -47,12 +47,14 @@ import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.ChunkCommand;
 import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -136,8 +138,8 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
     }
 
     @Override
-    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, TimeRange timerange, Set<String> affectedIndices,
-                                               Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+                                               Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams, ZoneId timeZone) {
         final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
@@ -147,6 +149,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
 
         final var histogramAggregation = new AutoDateHistogramAggregationBuilder(histogramAggregationName)
                 .field(EventDto.FIELD_EVENT_TIMESTAMP)
+                .timeZone(timeZone)
                 .setNumBuckets(buckets);
 
         final var termsAggregation = AggregationBuilders.terms(termsAggregationName)

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -47,12 +47,14 @@ import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.ChunkCommand;
 import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -137,8 +139,8 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
     }
 
     @Override
-    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, TimeRange timerange, Set<String> affectedIndices,
-                                               Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+                                               Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams, ZoneId timeZone) {
         final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams);
 
         final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
@@ -148,6 +150,7 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
 
         final var histogramAggregation = new AutoDateHistogramAggregationBuilder(histogramAggregationName)
                 .field(EventDto.FIELD_EVENT_TIMESTAMP)
+                .timeZone(timeZone)
                 .setNumBuckets(buckets);
 
         final var termsAggregation = AggregationBuilders.terms(termsAggregationName)

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
@@ -36,10 +36,13 @@ import org.graylog.events.search.EventsSearchResult;
 import org.graylog.events.search.EventsSearchService;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +78,12 @@ public class EventsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Build histogram of events over time")
     @NoAuditEvent("Doesn't change any data, only searches for events")
     public EventsHistogramResult histogram(@ApiParam(name = "JSON body") final EventsSearchParameters request) {
-        return searchService.histogram(firstNonNull(request, EventsSearchParameters.empty()), getSubject());
+        final var timezone = Optional.ofNullable(getCurrentUser())
+                .map(User::getTimeZone)
+                .map(DateTimeZone::getID)
+                .map(ZoneId::of)
+                .orElse(ZoneId.of("UTC"));
+        return searchService.histogram(firstNonNull(request, EventsSearchParameters.empty()), getSubject(), timezone);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.events.event.EventDto;
+import org.graylog.events.search.EventsHistogramResult;
 import org.graylog.events.search.EventsSearchFilter;
 import org.graylog.events.search.EventsSearchParameters;
 import org.graylog.events.search.EventsSearchResult;
@@ -67,6 +68,14 @@ public class EventsResource extends RestResource implements PluginRestResource {
     @NoAuditEvent("Doesn't change any data, only searches for events")
     public EventsSearchResult search(@ApiParam(name = "JSON body") final EventsSearchParameters request) {
         return searchService.search(firstNonNull(request, EventsSearchParameters.empty()), getSubject());
+    }
+
+    @POST
+    @Path("/histogram")
+    @ApiOperation("Build histogram of events over time")
+    @NoAuditEvent("Doesn't change any data, only searches for events")
+    public EventsHistogramResult histogram(@ApiParam(name = "JSON body") final EventsSearchParameters request) {
+        return searchService.histogram(firstNonNull(request, EventsSearchParameters.empty()), getSubject());
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsHistogramResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.events.search;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public record EventsHistogramResult(EventsBuckets buckets) {
+    public static EventsHistogramResult fromResult(MoreSearch.Histogram result) {
+        final var events = result.buckets().events().stream()
+                .map(event -> new Bucket(event.startDate(), event.count()))
+                .toList();
+        final var alerts = result.buckets().alerts().stream()
+                .map(alert -> new Bucket(alert.startDate(), alert.count()))
+                .toList();
+
+        return new EventsHistogramResult(new EventsBuckets(events, alerts));
+    }
+
+    public record EventsBuckets(List<Bucket> events, List<Bucket> alerts) {}
+
+    public record Bucket(ZonedDateTime startDate, Long count) {}
+}

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
@@ -67,7 +67,7 @@ public class EventsSearchService {
         return String.format(Locale.ROOT, "%s:%s", EventDto.FIELD_EVENT_DEFINITION_ID, id);
     }
 
-    public EventsSearchResult search(EventsSearchParameters parameters, Subject subject) {
+    private String buildFilter(EventsSearchParameters parameters) {
         final var filterBuilder = new ArrayList<String>();
         // Make sure we only filter for actual events and ignore anything else that might be in the event
         // indices. (fixes an issue when users store non-event messages in event indices)
@@ -116,9 +116,14 @@ public class EventsSearchService {
                 break;
         }
 
-        final String filter = filterBuilder.stream()
+        return filterBuilder.stream()
                 .map(query -> "(" + query + ")")
                 .collect(joiningQueriesWithAND);
+    }
+
+    public EventsSearchResult search(EventsSearchParameters parameters, Subject subject) {
+        final var filter = buildFilter(parameters);
+
         final ImmutableSet<String> eventStreams = ImmutableSet.of(DEFAULT_EVENTS_STREAM_ID, DEFAULT_SYSTEM_EVENTS_STREAM_ID);
         final MoreSearch.Result result = moreSearch.eventSearch(parameters, filter, eventStreams, forbiddenSourceStreams(subject));
 
@@ -148,6 +153,15 @@ public class EventsSearchService {
                 .usedIndices(result.usedIndexNames())
                 .context(context)
                 .build();
+    }
+
+    public EventsHistogramResult histogram(EventsSearchParameters parameters, Subject subject) {
+        final var filter = buildFilter(parameters);
+
+        final ImmutableSet<String> eventStreams = ImmutableSet.of(DEFAULT_EVENTS_STREAM_ID, DEFAULT_SYSTEM_EVENTS_STREAM_ID);
+        final var result = moreSearch.histogram(parameters, filter, eventStreams, forbiddenSourceStreams(subject));
+
+        return EventsHistogramResult.fromResult(result);
     }
 
     private String createTimeRangeFilter(TimeRange aggregationTimerange) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
@@ -30,6 +30,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamService;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -155,11 +156,11 @@ public class EventsSearchService {
                 .build();
     }
 
-    public EventsHistogramResult histogram(EventsSearchParameters parameters, Subject subject) {
+    public EventsHistogramResult histogram(EventsSearchParameters parameters, Subject subject, ZoneId timeZone) {
         final var filter = buildFilter(parameters);
 
         final ImmutableSet<String> eventStreams = ImmutableSet.of(DEFAULT_EVENTS_STREAM_ID, DEFAULT_SYSTEM_EVENTS_STREAM_ID);
-        final var result = moreSearch.histogram(parameters, filter, eventStreams, forbiddenSourceStreams(subject));
+        final var result = moreSearch.histogram(parameters, filter, eventStreams, forbiddenSourceStreams(subject), timeZone);
 
         return EventsHistogramResult.fromResult(result);
     }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -36,6 +36,7 @@ import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -99,6 +100,35 @@ public class MoreSearch {
                     .build();
         }
         return moreSearchAdapter.eventSearch(queryString, parameters.timerange(), affectedIndices, sorting, parameters.page(), parameters.perPage(), eventStreams, filterString, forbiddenSourceStreams);
+    }
+
+    /**
+     * Creates a histogram over events for the given parameters.
+     *
+     * @param parameters             event search parameters
+     * @param filterString           filter string
+     * @param eventStreams           event streams to search in
+     * @param forbiddenSourceStreams forbidden source streams
+     * @return the result
+     */
+    // TODO: We cannot use Searches#search() at the moment because that method cannot handle multiple streams. (because of Searches#extractStreamId())
+    //       We also cannot use the new search code at the moment because it doesn't do pagination.
+    Histogram histogram(EventsSearchParameters parameters, String filterString, Set<String> eventStreams, Set<String> forbiddenSourceStreams) {
+        checkArgument(parameters != null, "parameters cannot be null");
+        checkArgument(!eventStreams.isEmpty(), "eventStreams cannot be empty");
+        checkArgument(forbiddenSourceStreams != null, "forbiddenSourceStreams cannot be null");
+
+        final Sorting.Direction sortDirection = parameters.sortDirection() == EventsSearchParameters.SortDirection.ASC ? Sorting.Direction.ASC : Sorting.Direction.DESC;
+        final Sorting sorting = parameters.sortUnmappedType()
+                .map(unmappedType -> new Sorting(parameters.sortBy(), sortDirection, unmappedType))
+                .orElse(new Sorting(parameters.sortBy(), sortDirection));
+        final String queryString = parameters.query().trim();
+        final Set<String> affectedIndices = getAffectedIndices(eventStreams, parameters.timerange());
+
+        if (affectedIndices == null || affectedIndices.isEmpty()) {
+            return Histogram.empty();
+        }
+        return moreSearchAdapter.eventHistogram(10, queryString, parameters.timerange(), affectedIndices, eventStreams, filterString, forbiddenSourceStreams);
     }
 
     private Set<String> getAffectedIndices(Set<String> streamIds, TimeRange timeRange) {
@@ -231,4 +261,15 @@ public class MoreSearch {
             public abstract Result build();
         }
     }
+
+    public record Histogram(EventsBuckets buckets) {
+        public static Histogram empty() {
+            return new Histogram(new EventsBuckets(List.of(), List.of()));
+        }
+
+        public record EventsBuckets(List<Bucket> events, List<Bucket> alerts) {}
+
+        public record Bucket(ZonedDateTime startDate, Long count) {}
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -20,20 +20,26 @@ import org.graylog.events.processor.EventProcessorException;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.Sorting;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public interface MoreSearchAdapter {
-    MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
+    MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting,
+                                  int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
 
-    MoreSearch.Histogram eventHistogram(int buckets, String queryString, TimeRange timerange, Set<String> affectedIndices, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
+    MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+                                        Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams,
+                                        ZoneId timeZone);
 
     interface ScrollEventsCallback {
         void accept(List<ResultMessage> results, AtomicBoolean requestContinue) throws EventProcessorException;
     }
 
-    void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, List<UsedSearchFilter> filters, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
+    void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams,
+                      List<UsedSearchFilter> filters, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public interface MoreSearchAdapter {
     MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
 
+    MoreSearch.Histogram eventHistogram(int buckets, String queryString, TimeRange timerange, Set<String> affectedIndices, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
+
     interface ScrollEventsCallback {
         void accept(List<ResultMessage> results, AtomicBoolean requestContinue) throws EventProcessorException;
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing a backpoint (`/events/histogram`), which is expecting the same parameters as the paginated search endpoint for events, returning a histogram for the occurence of events & alerts over time. It returns a maximum of 30 buckets for the given time range, picking appropriate time units for bucket intervals, trying to align them with calendrical units.

/nocl Part of a unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.