### PR TITLE
DataLake: Clean up data lake search jobs on startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -35,6 +35,7 @@ import org.graylog.plugins.views.migrations.V20200730000000_AddGl2MessageIdField
 import org.graylog.plugins.views.migrations.V20240605120000_RemoveUnitFieldFromSearchDocuments;
 import org.graylog.plugins.views.migrations.V20240626143000_CreateDashboardsView;
 import org.graylog.plugins.views.migrations.V20240704100700_DashboardAddLastUpdated;
+import org.graylog.plugins.views.migrations.V20250224150000_SearchJobStateCleanupOnStartup;
 import org.graylog.plugins.views.providers.ExportBackendProvider;
 import org.graylog.plugins.views.providers.QuerySuggestionsProvider;
 import org.graylog.plugins.views.search.SearchRequirements;
@@ -258,6 +259,7 @@ public class ViewsBindings extends ViewsModule {
         addMigration(V20240605120000_RemoveUnitFieldFromSearchDocuments.class);
         addMigration(V20240626143000_CreateDashboardsView.class);
         addMigration(V20240704100700_DashboardAddLastUpdated.class);
+        addMigration(V20250224150000_SearchJobStateCleanupOnStartup.class);
 
         addAuditEventTypes(ViewsAuditEventTypes.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20250224150000_SearchJobStateCleanupOnStartup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20250224150000_SearchJobStateCleanupOnStartup.java
@@ -1,0 +1,61 @@
+package org.graylog.plugins.views.migrations;
+
+import com.google.common.collect.Sets;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import jakarta.inject.Inject;
+import org.graylog.plugins.views.search.db.SearchJobService;
+import org.graylog.plugins.views.search.errors.SearchError;
+import org.graylog.plugins.views.search.errors.SimpleSearchError;
+import org.graylog.plugins.views.search.jobs.SearchJobState;
+import org.graylog.plugins.views.search.jobs.SearchJobStateService;
+import org.graylog.plugins.views.search.jobs.SearchJobStatus;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.migrations.Migration;
+import org.graylog2.plugin.system.NodeId;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.graylog.plugins.views.search.jobs.SearchJobState.STATUS_FIELD;
+
+/**
+ * This migration runs at every startup to clean SearchJobs up that were running while Graylog stopped/restarted
+ * and moves them into an error state so that they can be restarted manually by the user.
+ */
+public class V20250224150000_SearchJobStateCleanupOnStartup extends Migration {
+
+    private final MongoCollection<SearchJobState> collection;
+    private final SearchJobStateService searchJobStateService;
+    private final SearchJobService searchJobService;
+    private final NodeId nodeId;
+
+    @Inject
+    public V20250224150000_SearchJobStateCleanupOnStartup(final MongoCollections mongoCollections,
+                                                          final SearchJobStateService searchJobStateService,
+                                                          final SearchJobService searchJobService,
+                                                          final NodeId nodeId) {
+        this.collection = mongoCollections.collection(SearchJobStateService.COLLECTION_NAME, SearchJobState.class);
+        this.searchJobStateService = searchJobStateService;
+        this.searchJobService = searchJobService;
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2025-02-24T15:00:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        // find all jobs in state "RUNNING" on startup
+        collection.find(Filters.eq(STATUS_FIELD, SearchJobStatus.RUNNING)).forEach(job -> {
+            // if this job is supposed to run on this node and it is not in the cache, it can't be a running job and should be moved to error state
+            if(job.identifier().executingNodeId().equals(nodeId.getNodeId()) && (searchJobService.getFromCache(job.id()) == null)) {
+                final var j = job.toBuilder().status(SearchJobStatus.ERROR).errors(Sets.union(job.errors(), Set.of(new SimpleSearchError("Job has been canceled because this Graylog node restarted.", true)))).build();
+                searchJobStateService.update(j);
+            }
+        });
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.jobs;
 
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
@@ -32,6 +33,7 @@ import org.graylog2.database.utils.MongoUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

On GL startup, check if there are search-jobs in `RUNNING` state on the given node that are also not in the query cache. These jobs need to be moved into `ERROR` state as they were running before the node was shut down/restarted and will not finish. This way the user can see that it was aborted (including the reason).
We do not automatically restart the job as it's possible that the given job was the reason that the node went down (in case of an automatic restart from monitoring etc.)

/nocl as it's not yet released functionality.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

