### PR TITLE
AWS Kinesis/Cloudwatch input: Refer to official docs site for needed permissions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -52,6 +52,8 @@ DBService classes' new streaming methods require streams to be closed after usin
 
 The following REST API changes have been made.
 
-| Endpoint                                         | Description                                                                                                                     |
-|--------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `GET /tbd`                                       | tbd                                                                                                                             |
+| Endpoint                                                              | Description                                                                             |
+|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `GET /plugins/org.graylog.integrations/aws/inputs/available_services` | Remove unused endpoint.                                                                 |
+| `GET /plugins/org.graylog.integrations/aws/inputs/permissions`        | Removed permissions endpoint in favor of maintaining permissions in official docs site. |
+| `GET /tbd`                                                            | tbd                                                                                     |

--- a/changelog/unreleased/pr-21755.toml
+++ b/changelog/unreleased/pr-21755.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Refer to official AWS Kinesis/Cloudwatch input for permissions on first page of input setup."
+
+pulls = ["21755"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -20,8 +20,16 @@ import com.codahale.metrics.annotation.Timed;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
@@ -29,9 +37,7 @@ import org.graylog.integrations.aws.AWSPermissions;
 import org.graylog.integrations.aws.resources.requests.AWSInputCreateRequest;
 import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
-import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
 import org.graylog.integrations.aws.resources.responses.KinesisHealthCheckResponse;
-import org.graylog.integrations.aws.resources.responses.KinesisPermissionsResponse;
 import org.graylog.integrations.aws.resources.responses.LogGroupsResponse;
 import org.graylog.integrations.aws.resources.responses.RegionsResponse;
 import org.graylog.integrations.aws.resources.responses.StreamsResponse;
@@ -46,26 +52,9 @@ import org.graylog2.rest.resources.system.inputs.AbstractInputsResource;
 import org.graylog2.shared.inputs.MessageInputFactory;
 import org.graylog2.shared.security.RestPermissions;
 
-import jakarta.inject.Inject;
-
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Web endpoints for the AWS integration.
- * Full base URL for requests in this class: http://api/plugins/org.graylog.integrations/aws/
- */
 @Api(value = "AWS", description = "AWS integrations")
 @Path("/aws")
 @RequiresAuthentication
@@ -93,30 +82,6 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @RequiresPermissions(AWSPermissions.AWS_READ)
     public RegionsResponse getAwsRegions() {
         return awsService.getAvailableRegions();
-    }
-
-    @GET
-    @Timed
-    @Path("/available_services")
-    @ApiResponses(value = {
-            @ApiResponse(code = 500, message = AWSService.POLICY_ENCODING_ERROR),
-    })
-    @ApiOperation(value = "Get all available AWS services")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
-    public AvailableServiceResponse getAvailableServices() {
-        return awsService.getAvailableServices();
-    }
-
-    @GET
-    @Timed
-    @Path("/permissions")
-    @ApiResponses(value = {
-            @ApiResponse(code = 500, message = AWSService.POLICY_ENCODING_ERROR),
-    })
-    @ApiOperation(value = "Get the permissions required for the AWS Kinesis setup and for the Kinesis auto-setup.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
-    public KinesisPermissionsResponse getPermissions() {
-        return awsService.getPermissions();
     }
 
     @POST

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
@@ -77,7 +77,7 @@ public class AWSServiceTest {
     @Before
     public void setUp() {
 
-        awsService = new AWSService(inputService, messageInputFactory, nodeId, new ObjectMapperProvider().get());
+        awsService = new AWSService(inputService, messageInputFactory, nodeId);
     }
 
     @Test
@@ -122,7 +122,6 @@ public class AWSServiceTest {
 
     @Test
     public void regionTest() {
-
         List<AWSRegion> regions = awsService.getAvailableRegions().regions();
 
         // Use a loop presence check.
@@ -138,45 +137,5 @@ public class AWSServiceTest {
         assertTrue(regions.stream().anyMatch(r -> r.displayValue().equals("Europe (Stockholm): eu-north-1")));
         // AWS periodically adds regions. The number should generally only increase. No need to check exact number.
         assertTrue("There should be at least 34 total regions.", regions.size() >= 34);
-    }
-
-    @Test
-    public void testAvailableServices() {
-
-        AvailableServiceResponse services = awsService.getAvailableServices();
-
-        // There should be one service.
-        assertEquals(1, services.total());
-        assertEquals(1, services.services().size());
-
-        // CloudWatch should be in the list of available services.
-        assertTrue(services.services().stream().anyMatch(s -> s.name().equals("CloudWatch")));
-
-        // Verify that some of the needed actions are present.
-        String policy = services.services().get(0).policy();
-        assertTrue(policy.contains("cloudwatch"));
-        assertTrue(policy.contains("dynamodb"));
-        assertTrue(policy.contains("ec2"));
-        assertTrue(policy.contains("elasticloadbalancing"));
-        assertTrue(policy.contains("kinesis"));
-    }
-
-    @Test
-    public void testPermissions() {
-
-        final KinesisPermissionsResponse permissions = awsService.getPermissions();
-
-        // Verify that the setup policy contains some needed permissions.
-        assertTrue(permissions.setupPolicy().contains("cloudwatch"));
-        assertTrue(permissions.setupPolicy().contains("dynamodb"));
-        assertTrue(permissions.setupPolicy().contains("ec2"));
-        assertTrue(permissions.setupPolicy().contains("elasticloadbalancing"));
-        assertTrue(permissions.setupPolicy().contains("kinesis"));
-
-        // Verify that the auto-setup policy contains some needed permissions.
-        assertTrue(permissions.autoSetupPolicy().contains("CreateStream"));
-        assertTrue(permissions.autoSetupPolicy().contains("DescribeSubscriptionFilters"));
-        assertTrue(permissions.autoSetupPolicy().contains("PutRecord"));
-        assertTrue(permissions.autoSetupPolicy().contains("RegisterStreamConsumer"));
     }
 }

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/SidebarPermissions.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/SidebarPermissions.tsx
@@ -14,112 +14,21 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useState } from 'react';
-import styled, { css } from 'styled-components';
+import React from 'react';
 
-import { Panel } from 'components/bootstrap';
-import useFetch from 'integrations/aws/common/hooks/useFetch';
-import { ApiRoutes } from 'integrations/aws/common/Routes';
-import Icon from 'components/common/Icon';
-
-type PoliciesProps = {
-  title: string;
-  note: string;
-  policy: any;
-};
-
-function Policies({ title, note, policy }: PoliciesProps) {
-  const [opened, setOpened] = useState(false);
-
-  const toggleOpen = () => {
-    setOpened(!opened);
-  };
-
-  return (
-    <div>
-      <Header onClick={toggleOpen}>
-        <HeaderContent>
-          <Title>
-            {opened ? 'Hide' : 'Show'} {title}
-          </Title>
-          <Note>{note}</Note>
-        </HeaderContent>
-
-        <IconContainer $opened={opened}>
-          <Icon name="arrow_right_alt" size="2x" />
-        </IconContainer>
-      </Header>
-
-      <Policy opened={opened}>{JSON.stringify(policy, null, 2)}</Policy>
-    </div>
-  );
-}
+import {Panel} from 'components/bootstrap';
+import {ExternalLink} from 'components/common';
 
 export default function SidebarPermissions() {
-  const [permissionsStatus] = useFetch(ApiRoutes.INTEGRATIONS.AWS.PERMISSIONS);
 
   return (
     <Panel bsStyle="info" header={<span>AWS Policy Permissions</span>}>
       <p>
-        Please verify that you have granted your AWS IAM user sufficient permissions. You can use the following policies
-        for reference.
+        Please refer to the{' '}
+        <ExternalLink href="https://go2docs.graylog.org/current/getting_in_log_data/aws_kinesis_cloudwatch_input.html">official documentation</ExternalLink>
+        {' '}for information on required AWS permissions.<br />
       </p>
 
-      {!permissionsStatus.loading && permissionsStatus.data && (
-        <>
-          <Policies
-            title="Recommended Policy"
-            note="To be able to use all available functionality for Kinesis setup."
-            policy={JSON.parse(permissionsStatus.data.setup_policy)}
-          />
-
-          <Policies
-            title="Least Privilege Policy"
-            note="Doesn't include Kinesis auto-subscription controls."
-            policy={JSON.parse(permissionsStatus.data.auto_setup_policy)}
-          />
-        </>
-      )}
     </Panel>
   );
 }
-
-const Header = styled.header`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-`;
-
-const HeaderContent = styled.div`
-  flex-grow: 1;
-`;
-
-const IconContainer = styled.span<{ $opened: boolean }>(
-  ({ $opened }) => css`
-    transform: rotate(${$opened ? '90deg' : '0deg'});
-    transition: transform 150ms ease-in-out;
-  `,
-);
-
-const Policy = styled.pre<{ opened: boolean }>(
-  ({ opened }) => css`
-    overflow: hidden;
-    max-height: ${opened ? '1000px' : '0'};
-    opacity: ${opened ? '1' : '0'};
-    transition:
-      max-height 150ms ease-in-out,
-      opacity 150ms ease-in-out,
-      margin 150ms ease-in-out,
-      padding 150ms ease-in-out;
-    margin-bottom: ${opened ? '12px' : '0'};
-    padding: ${opened ? '9.5px' : '0'};
-  `,
-);
-
-const Title = styled.h4`
-  font-weight: bold;
-`;
-
-const Note = styled.p`
-  font-style: italic;
-`;

--- a/graylog2-web-interface/src/integrations/aws/common/Routes.ts
+++ b/graylog2-web-interface/src/integrations/aws/common/Routes.ts
@@ -29,7 +29,6 @@ const AwsRoutes = {
 const ApiRoutes = {
   INTEGRATIONS: {
     AWS: {
-      PERMISSIONS: '/plugins/org.graylog.integrations/aws/permissions',
       REGIONS: '/plugins/org.graylog.integrations/aws/regions',
       CLOUDWATCH: {
         GROUPS: '/plugins/org.graylog.integrations/aws/cloudwatch/log_groups',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove inline permissions that were displayed on the right of the setup wizard for the AWS Kinesis/Cloudwatch input. The permissions were not fully correct (contained some extraneous permissions). This PR removes them and instead refers the user to the official Graylog docs (the preferred location for maintaining needed permissions and setup details). Additional permissions information will be added to the corresponding docs page in the 6.2 timeframe.

https://go2docs.graylog.org/current/getting_in_log_data/aws_kinesis_cloudwatch_input.html

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to the first page of the AWS Kinesis/Cloudwatch input setup and verify that the new 

![image](https://github.com/user-attachments/assets/8956109b-0d08-4ecd-af73-62e80f448cec)

## Screenshots
Previously, the permissions were explicitly listed as shown below. These were replaced with the above panel.
![image](https://github.com/user-attachments/assets/3013a2bc-f62e-4f61-aad4-4794d10e50dd)
