### PR TITLE
Replacing query map in field types context with list of fields of current query.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -43,6 +43,7 @@ jest.mock(
 
 const fieldTypes: FieldTypes = {
   all: Immutable.List(),
+  currentQuery: Immutable.List(),
   queryFields: Immutable.Map(),
 };
 const SimpleWidgetGrid = ({ view }: { view?: View }) => (

--- a/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.test.tsx
@@ -15,18 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import Widget from 'views/components/widgets/Widget';
 import _Widget from 'views/logic/widgets/Widget';
-import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import type View from 'views/logic/views/View';
 import { createViewWithWidgets } from 'fixtures/searches';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import WidgetGrid from './WidgetGrid';
 
@@ -41,16 +39,11 @@ jest.mock(
       children,
 );
 
-const fieldTypes: FieldTypes = {
-  all: Immutable.List(),
-  currentQuery: Immutable.List(),
-  queryFields: Immutable.Map(),
-};
-const SimpleWidgetGrid = ({ view }: { view?: View }) => (
+const SimpleWidgetGrid = ({ view = undefined }: { view?: View }) => (
   <TestStoreProvider view={view}>
-    <FieldTypesContext.Provider value={fieldTypes}>
+    <TestFieldTypesContextProvider>
       <WidgetGrid />
-    </FieldTypesContext.Provider>
+    </TestFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
@@ -32,7 +32,7 @@ const widgetConfig = AggregationWidgetConfig.builder().visualization(DataTable.t
 
 jest.mock('views/hooks/useAggregationFunctions');
 
-const fieldTypes = { all: simpleFields(), queryFields: simpleQueryFields('queryId') };
+const fieldTypes = { all: simpleFields(), currentQuery: simpleFields(), queryFields: simpleQueryFields('queryId') };
 
 describe('AggregationWizard', () => {
   const renderSUT = (props: Partial<React.ComponentProps<typeof AggregationWizard>> = {}) =>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.test.tsx
@@ -19,12 +19,12 @@ import * as Immutable from 'immutable';
 import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
-import { simpleFields, simpleQueryFields } from 'fixtures/fields';
+import { simpleFields } from 'fixtures/fields';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
+import { SimpleFieldTypesContextProvider } from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import AggregationWizard from './AggregationWizard';
 
@@ -32,13 +32,11 @@ const widgetConfig = AggregationWidgetConfig.builder().visualization(DataTable.t
 
 jest.mock('views/hooks/useAggregationFunctions');
 
-const fieldTypes = { all: simpleFields(), currentQuery: simpleFields(), queryFields: simpleQueryFields('queryId') };
-
 describe('AggregationWizard', () => {
   const renderSUT = (props: Partial<React.ComponentProps<typeof AggregationWizard>> = {}) =>
     render(
       <TestStoreProvider>
-        <FieldTypesContext.Provider value={fieldTypes}>
+        <SimpleFieldTypesContextProvider fields={simpleFields().toArray()}>
           <AggregationWizard
             onChange={() => {}}
             onCancel={() => {}}
@@ -50,7 +48,7 @@ describe('AggregationWizard', () => {
             {...props}>
             <div>The Visualization</div>
           </AggregationWizard>
-        </FieldTypesContext.Provider>
+        </SimpleFieldTypesContextProvider>
       </TestStoreProvider>,
     );
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/FieldSelect.tsx
@@ -16,18 +16,15 @@
  */
 import * as React from 'react';
 import { useContext } from 'react';
-import Immutable from 'immutable';
 
 import FieldSelectBase from 'views/components/aggregationwizard/FieldSelectBase';
-import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
 type Props = Omit<React.ComponentProps<typeof FieldSelectBase>, 'options'>;
 
 const FieldSelect = (props: Props) => {
-  const activeQuery = useActiveQueryId();
   const fieldTypes = useContext(FieldTypesContext);
-  const fieldOptions = fieldTypes.queryFields.get(activeQuery, Immutable.List()).toArray();
+  const fieldOptions = fieldTypes.currentQuery?.toArray() ?? [];
 
   return <FieldSelectBase options={fieldOptions} {...props} />;
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.corevisualizations.test.tsx
@@ -26,21 +26,15 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import AreaVisualization from 'views/components/visualizations/area/AreaVisualization';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import Series from 'views/logic/aggregationbuilder/Series';
-import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import { createSearch } from 'fixtures/searches';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 const testTimeout = applyTimeoutMultiplier(30000);
 
 const widgetConfig = AggregationWidgetConfig.builder().visualization('table').build();
-
-const fieldTypes: FieldTypes = {
-  all: Immutable.List([]),
-  queryFields: Immutable.Map(),
-};
 
 const selectEventConfig = { container: document.body };
 
@@ -50,7 +44,7 @@ const view = createSearch();
 
 const SimpleAggregationWizard = (props: Partial<React.ComponentProps<typeof AggregationWizard>>) => (
   <TestStoreProvider view={view} isNew initialQuery="query-id-1">
-    <FieldTypesContext.Provider value={fieldTypes}>
+    <TestFieldTypesContextProvider>
       <AggregationWizard
         config={widgetConfig}
         editing
@@ -62,7 +56,7 @@ const SimpleAggregationWizard = (props: Partial<React.ComponentProps<typeof Aggr
         {...props}>
         <span>The visualization</span>
       </AggregationWizard>
-    </FieldTypesContext.Provider>
+    </TestFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -51,7 +51,7 @@ const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
 const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
 const fieldTypeMapping3 = new FieldTypeMapping('timestamp', FieldTypes.DATE());
 const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2, fieldTypeMapping3]);
-const fieldTypes = { all: fields, queryFields: Immutable.Map({ queryId: fields }) };
+const fieldTypes = { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: fields }) };
 
 const plugin: PluginRegistration = { exports: { visualizationTypes: [dataTable] } };
 
@@ -83,6 +83,7 @@ describe('AggregationWizard', () => {
   type Props = Partial<React.ComponentProps<typeof AggregationWizard>> & {
     fieldTypesList?: {
       all: FieldTypeMappingsList;
+      currentQuery: FieldTypeMappingsList;
       queryFields: Map<string, FieldTypeMappingsList>;
     };
   };
@@ -153,7 +154,10 @@ describe('AggregationWizard', () => {
       const onChange = jest.fn();
       const queryFieldTypeMapping = new FieldTypeMapping('status_code', fieldType);
       const queryFields = Immutable.List([queryFieldTypeMapping]);
-      renderSUT({ onChange, fieldTypesList: { all: fields, queryFields: Immutable.Map({ queryId: queryFields }) } });
+      renderSUT({
+        onChange,
+        fieldTypesList: { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: queryFields }) },
+      });
 
       await addGrouping();
       await selectField('status_code');
@@ -179,7 +183,11 @@ describe('AggregationWizard', () => {
 
       renderSUT({
         onChange,
-        fieldTypesList: { all: Immutable.List([]), queryFields: Immutable.Map({ queryId: Immutable.List([]) }) },
+        fieldTypesList: {
+          all: Immutable.List(),
+          currentQuery: Immutable.List(),
+          queryFields: Immutable.Map({ queryId: Immutable.List([]) }),
+        },
         config: initialConfig,
       });
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -22,7 +22,6 @@ import userEvent from '@testing-library/user-event';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
-import type { Map } from 'immutable';
 
 import { asMock } from 'helpers/mocking';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -84,7 +83,6 @@ describe('AggregationWizard', () => {
     fieldTypesList?: {
       all: FieldTypeMappingsList;
       currentQuery: FieldTypeMappingsList;
-      queryFields: Map<string, FieldTypeMappingsList>;
     };
   };
 
@@ -153,10 +151,10 @@ describe('AggregationWizard', () => {
     async () => {
       const onChange = jest.fn();
       const queryFieldTypeMapping = new FieldTypeMapping('status_code', fieldType);
-      const queryFields = Immutable.List([queryFieldTypeMapping]);
+      const queryFields = fields.push(queryFieldTypeMapping);
       renderSUT({
         onChange,
-        fieldTypesList: { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: queryFields }) },
+        fieldTypesList: { all: fields, currentQuery: queryFields },
       });
 
       await addGrouping();
@@ -186,7 +184,6 @@ describe('AggregationWizard', () => {
         fieldTypesList: {
           all: Immutable.List(),
           currentQuery: Immutable.List(),
-          queryFields: Immutable.Map({ queryId: Immutable.List([]) }),
         },
         config: initialConfig,
       });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -45,7 +45,7 @@ const fieldType = new FieldType('field_type', ['numeric'], []);
 const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
 const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
 const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2]);
-const fieldTypes = { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: fields }) };
+const fieldTypes = { all: fields, currentQuery: fields };
 
 jest.mock('views/hooks/useAggregationFunctions');
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -45,7 +45,7 @@ const fieldType = new FieldType('field_type', ['numeric'], []);
 const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
 const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
 const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2]);
-const fieldTypes = { all: fields, queryFields: Immutable.Map({ queryId: fields }) };
+const fieldTypes = { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: fields }) };
 
 jest.mock('views/hooks/useAggregationFunctions');
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -45,7 +45,7 @@ const fieldType = new FieldType('field_type', ['numeric'], []);
 const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
 const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
 const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2]);
-const fieldTypes = { all: fields, queryFields: Immutable.Map({ queryId: fields }) };
+const fieldTypes = { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: fields }) };
 
 const pivot0 = Pivot.createValues([fieldTypeMapping1.name]);
 const pivot1 = Pivot.createValues([fieldTypeMapping2.name]);

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.sort.test.tsx
@@ -27,13 +27,13 @@ import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import DataTable from 'views/components/datatable';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
 import Series from 'views/logic/aggregationbuilder/Series';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
+import { SimpleFieldTypesContextProvider } from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import AggregationWizard from '../AggregationWizard';
 
@@ -44,8 +44,7 @@ const extendedTimeout = applyTimeoutMultiplier(30000);
 const fieldType = new FieldType('field_type', ['numeric'], []);
 const fieldTypeMapping1 = new FieldTypeMapping('took_ms', fieldType);
 const fieldTypeMapping2 = new FieldTypeMapping('http_method', fieldType);
-const fields = Immutable.List([fieldTypeMapping1, fieldTypeMapping2]);
-const fieldTypes = { all: fields, currentQuery: fields, queryFields: Immutable.Map({ queryId: fields }) };
+const fields = [fieldTypeMapping1, fieldTypeMapping2];
 
 const pivot0 = Pivot.createValues([fieldTypeMapping1.name]);
 const pivot1 = Pivot.createValues([fieldTypeMapping2.name]);
@@ -92,7 +91,7 @@ const sortByTookMsDesc = async (sortElementContainerId: Matcher, option: string 
 const renderSUT = (props = {}) =>
   render(
     <TestStoreProvider>
-      <FieldTypesContext.Provider value={fieldTypes}>
+      <SimpleFieldTypesContextProvider fields={fields}>
         <AggregationWizard
           onChange={() => {}}
           onCancel={() => {}}
@@ -104,7 +103,7 @@ const renderSUT = (props = {}) =>
           {...props}>
           <span>The Visualization</span>
         </AggregationWizard>
-      </FieldTypesContext.Provider>
+      </SimpleFieldTypesContextProvider>
     </TestStoreProvider>,
   );
 

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
@@ -73,7 +73,6 @@ export const toTimeGrouping = (grouping: GroupByFormValues): DateGrouping => {
 
 export const onGroupingFieldsChange = ({
   fieldTypes,
-  activeQueryId,
   groupingIndex,
   grouping,
   newFields,
@@ -97,9 +96,9 @@ export const onGroupingFieldsChange = ({
     return;
   }
 
-  const groupingHasValuesField = fieldTypes.queryFields
-    .get(activeQueryId, fieldTypes.all)
-    .some(({ name, type }) => newFields.includes(name) && type.type !== 'date');
+  const groupingHasValuesField = fieldTypes.currentQuery.some(
+    ({ name, type }) => newFields.includes(name) && type.type !== 'date',
+  );
   const newGroupingType = groupingHasValuesField ? ValuesType : DateType;
 
   if (grouping.type === newGroupingType) {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
@@ -95,6 +95,7 @@ const SUT = ({ initialValues = {} }: { initialValues: WidgetConfigFormValues }) 
     <FieldTypesContext.Provider
       value={{
         all: Immutable.List(fieldTypes),
+        currentQuery: Immutable.List(fieldTypes),
         queryFields: Immutable.Map({
           queryId: Immutable.List(fieldTypes),
         }),

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
@@ -84,6 +84,7 @@ const fieldTypes = [
   FieldTypeMapping.create('field-not-allowed-1', FieldType.create('number', [Properties.FullTextSearch])),
 ];
 
+// eslint-disable-next-line react/require-default-props
 const SUT = ({ initialValues = {} }: { initialValues: WidgetConfigFormValues }) => (
   <TestStoreProvider>
     <SimpleFieldTypesContextProvider fields={fieldTypes}>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricsConfiguration.test.tsx
@@ -15,11 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import * as Immutable from 'immutable';
 import { Formik, Form } from 'formik';
 import { render, screen } from 'wrappedTestingLibrary';
 
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { asMock } from 'helpers/mocking';
@@ -31,6 +29,7 @@ import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import useFeature from 'hooks/useFeature';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import MetricsConfiguration from 'views/components/aggregationwizard/metric/MetricsConfiguration';
+import { SimpleFieldTypesContextProvider } from 'views/components/contexts/TestFieldTypesContextProvider';
 
 jest.mock('hooks/useFeature');
 jest.mock('views/hooks/useAggregationFunctions');
@@ -78,34 +77,22 @@ const generateNotAllowedMetricsWithoutField = (): Array<MetricFormValues> =>
 
 const fieldTypes = [
   FieldTypeMapping.create('field-allowed-0', FieldType.create('number', [Properties.Numeric])),
-
   FieldTypeMapping.create('field-allowed-1', FieldType.create('number', [Properties.Numeric])),
-
   FieldTypeMapping.create('field-allowed-2', FieldType.create('number', [Properties.FullTextSearch])),
-
   FieldTypeMapping.create('field-allowed-3', FieldType.create('number', [Properties.FullTextSearch])),
-
   FieldTypeMapping.create('field-not-allowed-0', FieldType.create('number', [Properties.Numeric])),
-
   FieldTypeMapping.create('field-not-allowed-1', FieldType.create('number', [Properties.FullTextSearch])),
 ];
 
 const SUT = ({ initialValues = {} }: { initialValues: WidgetConfigFormValues }) => (
   <TestStoreProvider>
-    <FieldTypesContext.Provider
-      value={{
-        all: Immutable.List(fieldTypes),
-        currentQuery: Immutable.List(fieldTypes),
-        queryFields: Immutable.Map({
-          queryId: Immutable.List(fieldTypes),
-        }),
-      }}>
+    <SimpleFieldTypesContextProvider fields={fieldTypes}>
       <Formik initialValues={initialValues} onSubmit={() => {}}>
         <Form>
           <MetricsConfiguration />
         </Form>
       </Formik>
-    </FieldTypesContext.Provider>
+    </SimpleFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.test.tsx
@@ -65,27 +65,28 @@ describe('DefaultFieldTypesProvider', () => {
 
     expect(consume).toHaveBeenCalledWith({
       all: Immutable.List(),
-      queryFields: Immutable.Map({ foobar: Immutable.List() }),
+      currentQuery: Immutable.List(),
     });
   });
 
   it('provides field types of field types store', () => {
+    const fields = simpleFields();
+
     asMock(useCurrentQuery).mockReturnValue(
       Query.builder()
         .id('queryId')
         .filter(filtersForQuery(['dummyStream']))
         .build(),
     );
+    const queryFields = simpleQueryFields('foo').get('foo');
 
     asMock(useFieldTypes).mockImplementation((streams) =>
-      streams.length === 0
-        ? { data: simpleFields().toArray(), refetch }
-        : { data: simpleQueryFields('foo').get('foo').toArray(), refetch },
+      streams.length === 0 ? { data: fields.toArray(), refetch } : { data: queryFields.toArray(), refetch },
     );
 
     const consume = renderSUT();
 
-    const fieldTypes = { all: simpleFields(), queryFields: simpleQueryFields('queryId') };
+    const fieldTypes = { all: fields, currentQuery: queryFields };
 
     expect(consume).toHaveBeenCalledWith(fieldTypes);
   });

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -26,7 +26,6 @@ import useOnSearchExecution from 'views/hooks/useOnSearchExecution';
 
 import FieldTypesContext from './FieldTypesContext';
 
-const defaultId = '';
 const defaultTimeRange: RelativeTimeRange = { type: 'relative', from: 300 };
 
 const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement }) => {
@@ -40,14 +39,10 @@ const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement 
     [],
     currentQuery?.timerange || defaultTimeRange,
   );
-  const queryFields = useMemo(
-    () => Immutable.Map({ [currentQuery?.id || defaultId]: Immutable.List(currentFieldTypes) }),
-    [currentFieldTypes, currentQuery?.id],
-  );
   const all = useMemo(() => Immutable.List(allFieldTypes ?? []), [allFieldTypes]);
   const fieldTypes = useMemo(
-    () => ({ all, queryFields, currentQuery: Immutable.List(currentFieldTypes) }),
-    [all, currentFieldTypes, queryFields],
+    () => ({ all, currentQuery: Immutable.List(currentFieldTypes) }),
+    [all, currentFieldTypes],
   );
 
   useOnSearchExecution(() => {

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -45,7 +45,10 @@ const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement 
     [currentFieldTypes, currentQuery?.id],
   );
   const all = useMemo(() => Immutable.List(allFieldTypes ?? []), [allFieldTypes]);
-  const fieldTypes = useMemo(() => ({ all, queryFields }), [all, queryFields]);
+  const fieldTypes = useMemo(
+    () => ({ all, queryFields, currentQuery: Immutable.List(currentFieldTypes) }),
+    [all, currentFieldTypes, queryFields],
+  );
 
   useOnSearchExecution(() => {
     refreshCurrentTypes();

--- a/graylog2-web-interface/src/views/components/contexts/FieldTypesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/FieldTypesContext.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type { List, Map } from 'immutable';
+import type { List } from 'immutable';
 
 import { singleton } from 'logic/singleton';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
@@ -24,7 +24,6 @@ type FieldTypeMappingsList = List<FieldTypeMapping>;
 export type FieldTypes = {
   all: FieldTypeMappingsList;
   currentQuery: FieldTypeMappingsList;
-  queryFields: Map<string, FieldTypeMappingsList>;
 };
 
 const FieldTypesContext = React.createContext<FieldTypes | undefined>(undefined);

--- a/graylog2-web-interface/src/views/components/contexts/FieldTypesContext.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/FieldTypesContext.tsx
@@ -23,6 +23,7 @@ import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 type FieldTypeMappingsList = List<FieldTypeMapping>;
 export type FieldTypes = {
   all: FieldTypeMappingsList;
+  currentQuery: FieldTypeMappingsList;
   queryFields: Map<string, FieldTypeMappingsList>;
 };
 

--- a/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import * as Immutable from 'immutable';
+
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
+
+const fieldTypes = {
+  all: Immutable.List<FieldTypeMapping>(),
+  currentQuery: Immutable.List<FieldTypeMapping>(),
+  queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
+};
+
+const TestFieldTypesContextProvider = ({ children }: React.PropsWithChildren<{}>) => (
+  <FieldTypesContext.Provider value={fieldTypes}>{children}</FieldTypesContext.Provider>
+);
+
+export default TestFieldTypesContextProvider;

--- a/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import * as Immutable from 'immutable';
 

--- a/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
@@ -4,14 +4,18 @@ import * as Immutable from 'immutable';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 
-const fieldTypes = {
-  all: Immutable.List<FieldTypeMapping>(),
-  currentQuery: Immutable.List<FieldTypeMapping>(),
-  queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
+export const SimpleFieldTypesContextProvider = ({
+  children = undefined,
+  fields,
+}: React.PropsWithChildren<{ fields: FieldTypeMapping[] }>) => {
+  const fieldList = Immutable.List(fields);
+  const value = { all: fieldList, currentQuery: fieldList };
+
+  return <FieldTypesContext.Provider value={value}>{children}</FieldTypesContext.Provider>;
 };
 
-const TestFieldTypesContextProvider = ({ children }: React.PropsWithChildren<{}>) => (
-  <FieldTypesContext.Provider value={fieldTypes}>{children}</FieldTypesContext.Provider>
+const TestFieldTypesContextProvider = ({ children = undefined }: React.PropsWithChildren<{}>) => (
+  <SimpleFieldTypesContextProvider fields={[]}>{children}</SimpleFieldTypesContextProvider>
 );
 
 export default TestFieldTypesContextProvider;

--- a/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/TestFieldTypesContextProvider.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import * as Immutable from 'immutable';
 
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
@@ -24,8 +25,11 @@ export const SimpleFieldTypesContextProvider = ({
   children = undefined,
   fields,
 }: React.PropsWithChildren<{ fields: FieldTypeMapping[] }>) => {
-  const fieldList = Immutable.List(fields);
-  const value = { all: fieldList, currentQuery: fieldList };
+  const value = useMemo(() => {
+    const fieldList = Immutable.List(fields);
+
+    return { all: fieldList, currentQuery: fieldList };
+  }, [fields]);
 
   return <FieldTypesContext.Provider value={value}>{children}</FieldTypesContext.Provider>;
 };

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.test.tsx
@@ -47,10 +47,10 @@ describe('WidgetFieldTypesContextProvider', () => {
       <WidgetContext.Provider value={widget}>
         <WidgetFieldTypesContextProvider>
           <FieldTypesContext.Consumer>
-            {({ all, queryFields }) => (
+            {({ all, currentQuery }) => (
               <>
                 <span>Got {all.size} field type(s)</span>
-                <span>and {queryFields.get('deadbeef').size} field type(s) for query</span>
+                <span>and {currentQuery.size} field type(s) for query</span>
               </>
             )}
           </FieldTypesContext.Consumer>

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
@@ -37,6 +37,7 @@ const WidgetFieldTypesContextProvider = ({ children }: Props) => {
 
     return {
       all: fieldTypesList,
+      currentQuery: fieldTypesList,
       queryFields: Immutable.Map({ [query.id]: fieldTypesList }),
     };
   }, [fieldTypes, query.id]);

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
@@ -21,7 +21,6 @@ import * as Immutable from 'immutable';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
-import useCurrentQuery from 'views/logic/queries/useCurrentQuery';
 
 type Props = {
   children: React.ReactNode;
@@ -29,7 +28,6 @@ type Props = {
 
 const WidgetFieldTypesContextProvider = ({ children }: Props) => {
   const { timerange, streams } = useContext(WidgetContext);
-  const query = useCurrentQuery();
   const { data: fieldTypes } = useFieldTypes(streams, timerange);
 
   const fieldTypesContextValue = useMemo(() => {
@@ -39,7 +37,7 @@ const WidgetFieldTypesContextProvider = ({ children }: Props) => {
       all: fieldTypesList,
       currentQuery: fieldTypesList,
     };
-  }, [fieldTypes, query.id]);
+  }, [fieldTypes]);
 
   return <FieldTypesContext.Provider value={fieldTypesContextValue}>{children}</FieldTypesContext.Provider>;
 };

--- a/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/WidgetFieldTypesContextProvider.tsx
@@ -38,7 +38,6 @@ const WidgetFieldTypesContextProvider = ({ children }: Props) => {
     return {
       all: fieldTypesList,
       currentQuery: fieldTypesList,
-      queryFields: Immutable.Map({ [query.id]: fieldTypesList }),
     };
   }, [fieldTypes, query.id]);
 

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -39,7 +39,6 @@ import {
   viewWithoutWidget,
 } from 'views/components/export/Fixtures';
 import { createWidget } from 'views/logic/WidgetTestHelpers';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useViewType from 'views/hooks/useViewType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useSearchExecutionState from 'views/hooks/useSearchExecutionState';
@@ -47,6 +46,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import { usePlugin } from 'views/test/testPlugins';
 import startDownload from 'views/components/export/startDownload';
 import type { QueryString } from 'views/logic/queries/types';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import type { Props as ExportModalProps } from './ExportModal';
 import ExportModal from './ExportModal';
@@ -114,13 +114,13 @@ describe('ExportModal', () => {
     ...props
   }: SimpleExportModalProps) => (
     <TestStoreProvider>
-      <FieldTypesContext.Provider value={{ all: Immutable.List(), queryFields: Immutable.Map() }}>
+      <TestFieldTypesContextProvider>
         <ExportModal
           view={view ?? viewWithoutWidget(viewType)}
           closeModal={closeModal}
           {...(props as ExportModalProps)}
         />
-      </FieldTypesContext.Provider>
+      </TestFieldTypesContextProvider>
     </TestStoreProvider>
   );
 

--- a/graylog2-web-interface/src/views/components/export/ExportSettings.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportSettings.test.tsx
@@ -68,6 +68,7 @@ const pluginExports = {
 const fields = Immutable.List([FieldTypeMapping.create('foo', FieldType.create('long'))]);
 const fieldTypes: FieldTypes = {
   all: fields,
+  currentQuery: fields,
   queryFields: Immutable.Map({ 'view-query-id': fields }),
 };
 

--- a/graylog2-web-interface/src/views/components/export/ExportSettings.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportSettings.test.tsx
@@ -25,12 +25,11 @@ import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
-import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
 import { asMock } from 'helpers/mocking';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { usePlugin } from 'views/test/testPlugins';
+import { SimpleFieldTypesContextProvider } from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import { viewWithoutWidget, stateWithOneWidget } from './Fixtures';
 import ExportSettings from './ExportSettings';
@@ -65,20 +64,15 @@ const pluginExports = {
   },
 };
 
-const fields = Immutable.List([FieldTypeMapping.create('foo', FieldType.create('long'))]);
-const fieldTypes: FieldTypes = {
-  all: fields,
-  currentQuery: fields,
-  queryFields: Immutable.Map({ 'view-query-id': fields }),
-};
+const fields = [FieldTypeMapping.create('foo', FieldType.create('long'))];
 
 const SimpleExportSettings = (props: Omit<React.ComponentProps<typeof ExportSettings>, 'fields'>) => (
   <TestStoreProvider>
-    <FieldTypesContext.Provider value={fieldTypes}>
+    <SimpleFieldTypesContextProvider fields={fields}>
       <Formik initialValues={{ selectedFields: [] }} onSubmit={() => {}}>
         {() => <ExportSettings {...props} />}
       </Formik>
-    </FieldTypesContext.Provider>
+    </SimpleFieldTypesContextProvider>
   </TestStoreProvider>
 );
 const customWidget = Widget.builder().id('widget-id-1').type('custom').build();

--- a/graylog2-web-interface/src/views/components/fieldtypes/SingleMessageFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/SingleMessageFieldTypesProvider.tsx
@@ -31,7 +31,7 @@ export const SingleMessageFieldTypesProvider = ({ streams, timestamp, children }
   const types = useMemo(() => {
     const fieldTypesList = Immutable.List(fieldTypes);
 
-    return { all: fieldTypesList, currentQuery: fieldTypesList, queryFields: Immutable.Map({ query: fieldTypesList }) };
+    return { all: fieldTypesList, currentQuery: fieldTypesList };
   }, [fieldTypes]);
 
   return <FieldTypesContext.Provider value={types}>{children}</FieldTypesContext.Provider>;

--- a/graylog2-web-interface/src/views/components/fieldtypes/SingleMessageFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/SingleMessageFieldTypesProvider.tsx
@@ -31,7 +31,7 @@ export const SingleMessageFieldTypesProvider = ({ streams, timestamp, children }
   const types = useMemo(() => {
     const fieldTypesList = Immutable.List(fieldTypes);
 
-    return { all: fieldTypesList, queryFields: Immutable.Map({ query: fieldTypesList }) };
+    return { all: fieldTypesList, currentQuery: fieldTypesList, queryFields: Immutable.Map({ query: fieldTypesList }) };
   }, [fieldTypes]);
 
   return <FieldTypesContext.Provider value={types}>{children}</FieldTypesContext.Provider>;

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
@@ -30,8 +30,6 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import type { NewViewLoaderContextType } from 'views/logic/NewViewLoaderContext';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import * as ViewsPermissions from 'views/Permissions';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import useSaveViewFormControls from 'views/hooks/useSaveViewFormControls';
 import useCurrentUser from 'hooks/useCurrentUser';
 import useView from 'views/hooks/useView';
@@ -43,6 +41,7 @@ import useHistory from 'routing/useHistory';
 import mockHistory from 'helpers/mocking/mockHistory';
 import OnSaveViewAction from 'views/logic/views/OnSaveViewAction';
 import HotkeysProvider from 'contexts/HotkeysProvider';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import SearchActionsMenu from './SearchActionsMenu';
 
@@ -89,11 +88,6 @@ describe('SearchActionsMenu', () => {
 
   const defaultView = createView();
 
-  const fieldTypes = {
-    all: Immutable.List<FieldTypeMapping>(),
-    queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
-  };
-
   type SimpleSearchActionsMenuProps = {
     loadNewView?: NewViewLoaderContextType;
     onLoadView?: ViewLoaderContextType;
@@ -106,13 +100,13 @@ describe('SearchActionsMenu', () => {
   }: SimpleSearchActionsMenuProps) => (
     <TestStoreProvider>
       <HotkeysProvider>
-        <FieldTypesContext.Provider value={fieldTypes}>
+        <TestFieldTypesContextProvider>
           <ViewLoaderContext.Provider value={onLoadView}>
             <NewViewLoaderContext.Provider value={loadNewView}>
               <SearchActionsMenu {...props} />
             </NewViewLoaderContext.Provider>
           </ViewLoaderContext.Provider>
-        </FieldTypesContext.Provider>
+        </TestFieldTypesContextProvider>
       </HotkeysProvider>
     </TestStoreProvider>
   );

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.test.tsx
@@ -27,7 +27,11 @@ import FieldsOverview from './FieldsOverview';
 jest.mock('views/hooks/useActiveQueryId');
 
 describe('<FieldsOverview />', () => {
-  const fieldTypesStoreState = { all: simpleFields(), queryFields: simpleQueryFields('aQueryId') };
+  const fieldTypesStoreState = {
+    all: simpleFields(),
+    currentQuery: simpleFields(),
+    queryFields: simpleQueryFields('aQueryId'),
+  };
   const SimpleFieldsOverview = () => (
     <FieldTypesContext.Provider value={fieldTypesStoreState}>
       <FieldsOverview />

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.tsx
@@ -22,7 +22,6 @@ import type { List as ImmutableList } from 'immutable';
 import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import { Button } from 'components/bootstrap';
-import useActiveQueryId from 'views/hooks/useActiveQueryId';
 
 import List from './List';
 import FieldGroup from './FieldGroup';
@@ -129,20 +128,15 @@ const FieldsOverview = ({ allFields, activeQueryFields }: Props) => {
   );
 };
 
-const FieldsOverviewWithContext = (props) => {
-  const activeQuery = useActiveQueryId();
+const FieldsOverviewWithContext = (props: Omit<Props, 'allFields' | 'activeQueryFields'>) => (
+  <FieldTypesContext.Consumer>
+    {(fieldTypes) => {
+      const allFields = fieldTypes?.all;
+      const activeQueryFields = fieldTypes?.currentQuery;
 
-  return (
-    <FieldTypesContext.Consumer>
-      {(fieldTypes) => {
-        const allFields = fieldTypes?.all;
-        const queryFields = fieldTypes?.queryFields;
-        const activeQueryFields = queryFields?.get(activeQuery, allFields);
-
-        return <FieldsOverview {...props} allFields={allFields} activeQueryFields={activeQueryFields} />;
-      }}
-    </FieldTypesContext.Consumer>
-  );
-};
+      return <FieldsOverview {...props} allFields={allFields} activeQueryFields={activeQueryFields} />;
+    }}
+  </FieldTypesContext.Consumer>
+);
 
 export default FieldsOverviewWithContext;

--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.tsx
@@ -65,7 +65,7 @@ const List = ({ filter, activeQueryFields, allFields, currentGroup }: Props) => 
   }
 
   const fieldFilter = filter
-    ? (field) => field.name.toLocaleUpperCase().includes(filter.toLocaleUpperCase())
+    ? (field: { name: string }) => field.name.toLocaleUpperCase().includes(filter.toLocaleUpperCase())
     : () => true;
   const fieldsToShow = _fieldsToShow(activeQueryFields, allFields, currentGroup);
   const fieldList = fieldsToShow.filter(fieldFilter).sortBy((field) => field.name.toLocaleUpperCase());

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -42,6 +42,7 @@ const ruleWithValueZero = rule.toBuilder().value(0).build();
 describe('HighlightForm', () => {
   const fieldTypes: FieldTypes = {
     all: Immutable.List([FieldTypeMapping.create('foob', FieldType.create('long', [Properties.Numeric]))]),
+    currentQuery: Immutable.List<FieldTypeMapping>(),
     queryFields: Immutable.Map(),
   };
   const SUT = (props: Partial<React.ComponentProps<typeof HighlightForm>>) => (

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightForm.test.tsx
@@ -17,17 +17,15 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
-import * as Immutable from 'immutable';
 
 import HighlightForm from 'views/components/sidebar/highlighting/HighlightForm';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
-import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType, { Properties } from 'views/logic/fieldtypes/FieldType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
+import { SimpleFieldTypesContextProvider } from 'views/components/contexts/TestFieldTypesContextProvider';
 
 const rule = HighlightingRule.builder()
   .color(StaticColor.create('#333333'))
@@ -40,16 +38,12 @@ const ruleWithValueFalse = rule.toBuilder().value(false).build();
 const ruleWithValueZero = rule.toBuilder().value(0).build();
 
 describe('HighlightForm', () => {
-  const fieldTypes: FieldTypes = {
-    all: Immutable.List([FieldTypeMapping.create('foob', FieldType.create('long', [Properties.Numeric]))]),
-    currentQuery: Immutable.List<FieldTypeMapping>(),
-    queryFields: Immutable.Map(),
-  };
+  const fields = [FieldTypeMapping.create('foob', FieldType.create('long', [Properties.Numeric]))];
   const SUT = (props: Partial<React.ComponentProps<typeof HighlightForm>>) => (
     <TestStoreProvider>
-      <FieldTypesContext.Provider value={fieldTypes}>
+      <SimpleFieldTypesContextProvider fields={fields}>
         <HighlightForm onClose={() => {}} rule={undefined} onSubmit={() => Promise.resolve()} {...props} />
-      </FieldTypesContext.Provider>
+      </SimpleFieldTypesContextProvider>
     </TestStoreProvider>
   );
 

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -196,7 +196,10 @@ const InteractiveLegend = ({ config, fieldTypes, labelFields, labels }: LegendCo
     .sort(stringLenSort)
     .map((value) => <TableCell key={value} value={value} labelFields={_labelFields} fieldTypes={fieldTypes} />);
 
-  const result = chunk(tableCells, 5).map((cells, index) => <LegendRow key={index}>{cells}</LegendRow>);
+  const result = chunk(tableCells, 5).map((cells, index) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <LegendRow key={index}>{cells}</LegendRow>
+  ));
 
   return (
     <LegendContainer>

--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -30,7 +30,6 @@ import { EVENT_COLOR, eventsDisplayName } from 'views/logic/searchtypes/events/E
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
 import type { FieldTypes } from 'views/components/contexts/FieldTypesContext';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import type { ChartDefinition } from 'views/components/visualizations/ChartData';
 import { keySeparator, humanSeparator } from 'views/Constants';
 import useMapKeys from 'views/components/visualizations/useMapKeys';
@@ -126,7 +125,6 @@ const columnPivotsToFields = (config: Props['config']) => config?.columnPivots?.
 type TableCellProps = {
   value: string;
   fieldTypes: FieldTypes;
-  activeQuery: string;
   labelFields: string[];
 };
 
@@ -172,11 +170,10 @@ const LegendEntry = ({ value, labelsWithField }: LegendEntryProps) => {
   );
 };
 
-const TableCell = ({ value, fieldTypes, activeQuery, labelFields }: TableCellProps) => {
+const TableCell = ({ value, fieldTypes, labelFields }: TableCellProps) => {
   const labelsWithField = value.split(keySeparator).map((label, idx) => {
     const field = labelFields[idx];
-    const fieldType =
-      fieldTypes?.queryFields?.get(activeQuery)?.find((type) => type.name === field)?.type ?? FieldType.Unknown;
+    const fieldType = fieldTypes?.currentQuery?.find((type) => type.name === field)?.type ?? FieldType.Unknown;
 
     return { label, field, type: fieldType };
   });
@@ -189,24 +186,15 @@ const TableCell = ({ value, fieldTypes, activeQuery, labelFields }: TableCellPro
 };
 
 type LegendComponentProps = Pick<Props, 'config' | 'labelFields'> & {
-  activeQuery: string;
   fieldTypes: FieldTypes;
   labels: Array<string>;
 };
 
-const InteractiveLegend = ({ activeQuery, config, fieldTypes, labelFields, labels }: LegendComponentProps) => {
+const InteractiveLegend = ({ config, fieldTypes, labelFields, labels }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
   const tableCells = labels
     .sort(stringLenSort)
-    .map((value) => (
-      <TableCell
-        key={value}
-        value={value}
-        labelFields={_labelFields}
-        fieldTypes={fieldTypes}
-        activeQuery={activeQuery}
-      />
-    ));
+    .map((value) => <TableCell key={value} value={value} labelFields={_labelFields} fieldTypes={fieldTypes} />);
 
   const result = chunk(tableCells, 5).map((cells, index) => <LegendRow key={index}>{cells}</LegendRow>);
 
@@ -223,7 +211,7 @@ const FlexLegendContainer = styled.div`
   flex-wrap: wrap;
 `;
 
-const NoninteractiveLegend = ({ activeQuery, config, fieldTypes, labels, labelFields }: LegendComponentProps) => {
+const NoninteractiveLegend = ({ config, fieldTypes, labels, labelFields }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);
 
   return (
@@ -231,8 +219,7 @@ const NoninteractiveLegend = ({ activeQuery, config, fieldTypes, labels, labelFi
       {labels.map((value) => {
         const labelsWithField = value.split(keySeparator).map((label, idx) => {
           const field = _labelFields[idx];
-          const fieldType =
-            fieldTypes?.queryFields?.get(activeQuery)?.find((type) => type.name === field)?.type ?? FieldType.Unknown;
+          const fieldType = fieldTypes?.currentQuery?.find((type) => type.name === field)?.type ?? FieldType.Unknown;
 
           return { label, field, type: fieldType };
         });
@@ -260,7 +247,6 @@ const PlotLegend = ({
   const { limitHeight } = useContext(WidgetRenderingContext);
 
   const labels = labelMapper(chartData);
-  const activeQuery = useActiveQueryId();
   const Container = limitHeight ? FixedContainer : VariableContainer;
 
   if (!neverHide && !focusedWidget?.editing && series.length <= 1 && columnPivots.length <= 0) {
@@ -276,13 +262,7 @@ const PlotLegend = ({
   return (
     <Container $height={height} $width={width}>
       {children}
-      <LegendComponent
-        activeQuery={activeQuery}
-        config={config}
-        fieldTypes={fieldTypes}
-        labelFields={labelFields}
-        labels={labels}
-      />
+      <LegendComponent config={config} fieldTypes={fieldTypes} labelFields={labelFields} labels={labels} />
     </Container>
   );
 };

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -77,12 +77,12 @@ const XYPlot = ({
   axisType = DEFAULT_AXIS_TYPE,
   config,
   chartData,
-  effectiveTimerange,
+  effectiveTimerange = undefined,
   setChartColor = defaultSetColor,
   height,
   width,
   plotLayout = {},
-  onZoom,
+  onZoom = undefined,
 }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
   const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: mapAxisType(axisType) } as const;

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -24,9 +24,8 @@ import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import AppConfig from 'util/AppConfig';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import { effectiveTimerange, simpleChartData } from './AreaVisualization.fixtures';
 
@@ -43,13 +42,9 @@ jest.mock('util/AppConfig', () => ({
 
 const AreaVisualization = (props: React.ComponentProps<typeof OriginalAreaVisualization>) => (
   <TestStoreProvider>
-    <FieldTypesContext.Provider
-      value={{
-        all: Immutable.List(),
-        queryFields: Immutable.Map({ 'query-id-1': Immutable.List<FieldTypeMapping>() }),
-      }}>
+    <TestFieldTypesContextProvider>
       <OriginalAreaVisualization {...props} />
-    </FieldTypesContext.Provider>
+    </TestFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -40,6 +40,7 @@ jest.mock('util/AppConfig', () => ({
   isCloud: jest.fn(() => false),
 }));
 
+// eslint-disable-next-line react/require-default-props
 const AreaVisualization = (props: React.ComponentProps<typeof OriginalAreaVisualization>) => (
   <TestStoreProvider>
     <TestFieldTypesContextProvider>

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -34,6 +34,7 @@ import HeatmapVisualization from '../HeatmapVisualization';
 
 jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
 
+// eslint-disable-next-line react/require-default-props
 const WrappedHeatMap = (props: React.ComponentProps<typeof HeatmapVisualization>) => (
   <TestStoreProvider>
     <TestFieldTypesContextProvider>

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.tsx
@@ -26,8 +26,7 @@ import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import HeatmapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/HeatmapVisualizationConfig';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import * as fixtures from './HeatmapVisualization.fixtures';
 
@@ -37,13 +36,9 @@ jest.mock('../../GenericPlot', () => mockComponent('GenericPlot'));
 
 const WrappedHeatMap = (props: React.ComponentProps<typeof HeatmapVisualization>) => (
   <TestStoreProvider>
-    <FieldTypesContext.Provider
-      value={{
-        all: Immutable.List(),
-        queryFields: Immutable.Map({ 'query-id-1': Immutable.List<FieldTypeMapping>() }),
-      }}>
+    <TestFieldTypesContextProvider>
       <HeatmapVisualization {...props} />
-    </FieldTypesContext.Provider>
+    </TestFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/__tests__/PieVisualization.test.tsx
@@ -24,11 +24,10 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useExternalValueActions from 'views/hooks/useExternalValueActions';
 import asMock from 'helpers/mocking/AsMock';
 import AppConfig from 'util/AppConfig';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import { oneRowPivotOneColumnPivot, oneRowPivot } from './fixtures';
 
@@ -43,11 +42,7 @@ const effectiveTimerange = {
 jest.mock('views/hooks/useExternalValueActions');
 const SimplePieVisualization = (props: Pick<React.ComponentProps<typeof PieVisualization>, 'config' | 'data'>) => (
   <TestStoreProvider>
-    <FieldTypesContext.Provider
-      value={{
-        all: Immutable.List(),
-        queryFields: Immutable.Map({ 'query-id-1': Immutable.List<FieldTypeMapping>() }),
-      }}>
+    <TestFieldTypesContextProvider>
       <PieVisualization
         effectiveTimerange={effectiveTimerange}
         fields={Immutable.List()}
@@ -58,7 +53,7 @@ const SimplePieVisualization = (props: Pick<React.ComponentProps<typeof PieVisua
         onChange={() => {}}
         {...props}
       />
-    </FieldTypesContext.Provider>
+    </TestFieldTypesContextProvider>
   </TestStoreProvider>
 );
 

--- a/graylog2-web-interface/src/views/components/visualizations/useMapKeys.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useMapKeys.ts
@@ -19,7 +19,6 @@ import { useCallback, useContext, useMemo } from 'react';
 import type { KeyMapper } from 'views/components/visualizations/TransformKeys';
 import StreamsContext from 'contexts/StreamsContext';
 import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import type { Key } from 'views/logic/searchtypes/pivot/PivotHandler';
 import useInputs from 'hooks/useInputs';
 import useNodeSummaries from 'hooks/useNodeSummaries';
@@ -32,11 +31,7 @@ const useMapKeys = (): KeyMapper => {
   const nodes = useNodeSummaries();
   const inputs = useInputs();
   const fieldTypes = useContext(FieldTypesContext);
-  const activeQuery = useActiveQueryId();
-  const currentFields = useMemo(
-    () => fieldTypes?.queryFields?.get(activeQuery),
-    [activeQuery, fieldTypes?.queryFields],
-  );
+  const currentFields = useMemo(() => fieldTypes?.currentQuery, [fieldTypes?.currentQuery]);
 
   return useCallback(
     (key: Key, field: string) => {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.aggregations.test.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import * as Immutable from 'immutable';
 import { render, waitFor, screen, within, act } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import userEvent from '@testing-library/user-event';
@@ -36,13 +35,13 @@ import useViewType from 'views/hooks/useViewType';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { updateWidget } from 'views/logic/slices/widgetActions';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import Widget from './Widget';
 import type { Props as WidgetComponentProps } from './Widget';
 
 import WidgetContext from '../contexts/WidgetContext';
 import WidgetFocusContext from '../contexts/WidgetFocusContext';
-import FieldTypesContext from '../contexts/FieldTypesContext';
 
 const testTimeout = applyTimeoutMultiplier(60000);
 const mockedUnixTime = 1577836800000; // 2020-01-01 00:00:00.000
@@ -116,7 +115,7 @@ describe('Aggregation Widget', () => {
 
   const AggregationWidget = ({ widget: propsWidget = dataTableWidget, ...props }: AggregationWidgetProps) => (
     <TestStoreProvider>
-      <FieldTypesContext.Provider value={{ all: Immutable.List(), queryFields: Immutable.Map() }}>
+      <TestFieldTypesContextProvider>
         <WidgetFocusContext.Provider value={widgetFocusContextState}>
           <WidgetContext.Provider value={propsWidget}>
             <Widget
@@ -129,7 +128,7 @@ describe('Aggregation Widget', () => {
             />
           </WidgetContext.Provider>
         </WidgetFocusContext.Provider>
-      </FieldTypesContext.Provider>
+      </TestFieldTypesContextProvider>
     </TestStoreProvider>
   );
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import * as Immutable from 'immutable';
 import { render, waitFor, fireEvent, screen } from 'wrappedTestingLibrary';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
 
@@ -26,10 +25,10 @@ import useWidgetResults from 'views/components/useWidgetResults';
 import SearchError from 'views/logic/SearchError';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import { duplicateWidget, updateWidgetConfig, updateWidget } from 'views/logic/slices/widgetActions';
-import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { usePlugin } from 'views/test/testPlugins';
 import SearchExplainContext from 'views/components/contexts/SearchExplainContext';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import Widget from './Widget';
 import type { Props as WidgetComponentProps } from './Widget';
@@ -37,7 +36,6 @@ import type { Props as WidgetComponentProps } from './Widget';
 import WidgetContext from '../contexts/WidgetContext';
 import type { WidgetFocusContextType } from '../contexts/WidgetFocusContext';
 import WidgetFocusContext from '../contexts/WidgetFocusContext';
-import FieldTypesContext from '../contexts/FieldTypesContext';
 
 jest.mock('../searchbar/queryinput/QueryInput');
 jest.mock('./WidgetHeader', () => 'widget-header');
@@ -118,11 +116,6 @@ describe('<Widget />', () => {
 
   const widget = WidgetModel.builder().newId().type('dummy').config({ queryId: 'query-id-1' }).build();
 
-  const fieldTypes = {
-    all: Immutable.List<FieldTypeMapping>(),
-    queryFields: Immutable.Map<string, Immutable.List<FieldTypeMapping>>(),
-  };
-
   type DummyWidgetProps = Partial<WidgetComponentProps> & {
     focusedWidget?: WidgetFocusContextType['focusedWidget'];
     setWidgetFocusing?: WidgetFocusContextType['setWidgetFocusing'];
@@ -150,7 +143,7 @@ describe('<Widget />', () => {
   }: DummyWidgetProps) => (
     <TestStoreProvider>
       <SearchExplainContext.Provider value={searchExplainContext(searchedIndices)}>
-        <FieldTypesContext.Provider value={fieldTypes}>
+        <TestFieldTypesContextProvider>
           <WidgetFocusContext.Provider
             value={{ focusedWidget, setWidgetFocusing, setWidgetEditing, unsetWidgetFocusing, unsetWidgetEditing }}>
             <WidgetContext.Provider value={propsWidget}>
@@ -164,7 +157,7 @@ describe('<Widget />', () => {
               />
             </WidgetContext.Provider>
           </WidgetFocusContext.Provider>
-        </FieldTypesContext.Provider>
+        </TestFieldTypesContextProvider>
       </SearchExplainContext.Provider>
     </TestStoreProvider>
   );
@@ -268,7 +261,7 @@ describe('<Widget />', () => {
     const unknownWidget = WidgetModel.builder().newId().type('i-dont-know-this-widget-type').config({}).build();
     const UnknownWidget = (props: Partial<React.ComponentProps<typeof Widget>>) => (
       <TestStoreProvider>
-        <FieldTypesContext.Provider value={fieldTypes}>
+        <TestFieldTypesContextProvider>
           <WidgetContext.Provider value={unknownWidget}>
             <Widget
               widget={unknownWidget}
@@ -280,7 +273,7 @@ describe('<Widget />', () => {
               {...props}
             />
           </WidgetContext.Provider>
-        </FieldTypesContext.Provider>
+        </TestFieldTypesContextProvider>
       </TestStoreProvider>
     );
 

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -21,7 +21,6 @@ import styled from 'styled-components';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import type { BackendWidgetPosition, WidgetResults, GetState } from 'views/types';
 import { widgetDefinition } from 'views/logic/Widgets';
-import type WidgetModel from 'views/logic/widgets/Widget';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
@@ -61,7 +60,7 @@ import InteractiveContext from '../contexts/InteractiveContext';
 
 export type Props = {
   id: string;
-  widget: WidgetModel;
+  widget: WidgetType;
   editing?: boolean;
   title: string;
   position: WidgetPosition;
@@ -171,7 +170,7 @@ export const EditWrapper = ({
   onCancelEdit,
   onWidgetConfigChange,
   type,
-  showQueryControls,
+  showQueryControls = undefined,
 }: EditWrapperProps) => {
   const EditComponent = useMemo(() => _editComponentForType(type), [type]);
   const hasOwnSubmitButton = _hasOwnEditSubmitButton(type);

--- a/graylog2-web-interface/src/views/components/widgets/Widget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.tsx
@@ -82,12 +82,8 @@ const _hasOwnEditSubmitButton = (type: string) => widgetDefinition(type).hasEdit
 
 const useQueryFieldTypes = () => {
   const fieldTypes = useContext(FieldTypesContext);
-  const queryId = useActiveQueryId();
 
-  return useMemo(
-    () => fieldTypes.queryFields.get(queryId, fieldTypes.all),
-    [fieldTypes.all, fieldTypes.queryFields, queryId],
-  );
+  return useMemo(() => fieldTypes.currentQuery, [fieldTypes.currentQuery]);
 };
 
 const WidgetFooter = styled.div`

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -32,7 +32,6 @@ import CopyWidgetToDashboard from 'views/logic/views/CopyWidgetToDashboard';
 import ViewState from 'views/logic/views/ViewState';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import { loadDashboard } from 'views/logic/views/Actions';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import useDashboards from 'views/components/dashboard/hooks/useDashboards';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
@@ -41,6 +40,7 @@ import { duplicateWidget, removeWidget } from 'views/logic/slices/widgetActions'
 import useViewType from 'views/hooks/useViewType';
 import fetchSearch from 'views/logic/views/fetchSearch';
 import useWidgetResults from 'views/components/useWidgetResults';
+import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
 
 import WidgetActionsMenu from './WidgetActionsMenu';
 
@@ -119,8 +119,7 @@ describe('<WidgetActionsMenu />', () => {
     ...props
   }: DummyWidgetProps) => (
     <TestStoreProvider view={view} initialQuery="query-id">
-      <FieldTypesContext.Provider
-        value={{ all: Immutable.List(), currentQuery: Immutable.List(), queryFields: Immutable.Map() }}>
+      <TestFieldTypesContextProvider>
         <WidgetFocusContext.Provider
           value={{
             setWidgetFocusing,
@@ -140,7 +139,7 @@ describe('<WidgetActionsMenu />', () => {
             />
           </WidgetContext.Provider>
         </WidgetFocusContext.Provider>
-      </FieldTypesContext.Provider>
+      </TestFieldTypesContextProvider>
     </TestStoreProvider>
   );
 

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -119,7 +119,8 @@ describe('<WidgetActionsMenu />', () => {
     ...props
   }: DummyWidgetProps) => (
     <TestStoreProvider view={view} initialQuery="query-id">
-      <FieldTypesContext.Provider value={{ all: Immutable.List(), queryFields: Immutable.Map() }}>
+      <FieldTypesContext.Provider
+        value={{ all: Immutable.List(), currentQuery: Immutable.List(), queryFields: Immutable.Map() }}>
         <WidgetFocusContext.Provider
           value={{
             setWidgetFocusing,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is refactoring the field types context of the frontend in order to simplify it. Before this PR, it held a map of query ids -> field types (named `queryFields`). The use case it was used for all the time was to retrieve the field types of the current query. Therefore, this query map was removed and replaced with a simple prop (`currentQuery`) holding a list of field types for the current query.

Additionally, tests were simplified by providing two providers for this context to be used in tests:

  - `TestFieldTypesContextProvider`: providing a context with empty field types, to be used for testing components which require the presence of the context but do not interact with field types.
  - `SimpleFieldTypesContextProvider`: can be used by providing an array of field mappings through the `fields` prop to construct a context where all fields and fields of the current query are identical.

/nocl Internal refactoring.
/prd Graylog2/graylog-plugin-enterprise#9807

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.