### PR TITLE
AmqpTransport: Log root cause of IOException, if possible

### DIFF
--- a/changelog/unreleased/pr-21764.toml
+++ b/changelog/unreleased/pr-21764.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "AmqpTransport: Log root cause of IOException, if possible"
+
+issues = [""]
+pulls = ["21764"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
@@ -55,6 +55,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.graylog2.shared.utilities.ExceptionUtils.getRootCause;
+
 public class AmqpTransport extends ThrottleableTransport2 {
     public static final String CK_HOSTNAME = "broker_hostname";
     public static final String CK_PORT = "broker_port";
@@ -215,7 +217,7 @@ public class AmqpTransport extends ThrottleableTransport2 {
             } catch (TimeoutException e) {
                 inputFailureRecorder.setFailing(getClass(), "Timeout while opening new AMQP connection", e);
             } catch (IOException e) {
-                inputFailureRecorder.setFailing(getClass(), "Error while opening new AMQP connection", e);
+                inputFailureRecorder.setFailing(getClass(), "Error while opening new AMQP connection", getRootCause(e));
             } catch (Exception e) {
                 inputFailureRecorder.setFailing(getClass(), "Could not launch AMQP consumer.", e);
             }


### PR DESCRIPTION
## Description

Log the root cause of an IOException in the AMQP Transport, if possible.

## Motivation and Context

The root cause can provide essential information to troubleshoot an AMQP problem, e.g., if incompatible queue settings are being used (in which case the [new passive queue declaration option](https://github.com/Graylog2/graylog2-server/pull/20270) could be the solution).

## How Has This Been Tested?

Manually started an AMQP input against a local RabbitMQ, using various settings to provoke channel errors.

Example output:
```
Error while opening new AMQP connection: (channel error; protocol method: #method<channel.close> (reply-code=406, reply-text=PRECONDITION_FAILED - inequivalent arg 'x-max-length' for queue "log-messages' in vhost'/': received none but current is the value '10' of type 'long', class-id=50,
method-id=10))
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

