### PR TITLE
Add upgrade notes for files API removal

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,11 @@ Upgrading to Graylog 6.2.x
 
 ## Breaking Changes
 
+* The `files:read` and `files:create` permissions have been removed. These permissions were used in the Graylog
+  Enterprise plugin for the generic `/plugins/org.graylog.plugins.files/*` REST API endpoints, which have also been
+  removed. Existing Graylog users would only have these permissions assigned if explicitly granted through custom,
+  user-initiated calls to the "Users" REST API.
+
 ### Plugins
 * This release includes Java API changes which might require plugin authors to adjust their code. Please check
   [Java API Changes](#java-api-changes) for details.
@@ -52,6 +57,6 @@ DBService classes' new streaming methods require streams to be closed after usin
 
 The following REST API changes have been made.
 
-| Endpoint                                         | Description                                                                                                                     |
-|--------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `GET /tbd`                                       | tbd                                                                                                                             |
+| Endpoint                               | Description                         |
+|----------------------------------------|-------------------------------------|
+| `/plugins/org.graylog.plugins.files/*` | removed (Graylog Enterprise plugin) |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,11 +3,6 @@ Upgrading to Graylog 6.2.x
 
 ## Breaking Changes
 
-* The `files:read` and `files:create` permissions have been removed. These permissions were used in the Graylog
-  Enterprise plugin for the generic `/plugins/org.graylog.plugins.files/*` REST API endpoints, which have also been
-  removed. Existing Graylog users would only have these permissions assigned if explicitly granted through custom,
-  user-initiated calls to the "Users" REST API.
-
 ### Plugins
 * This release includes Java API changes which might require plugin authors to adjust their code. Please check
   [Java API Changes](#java-api-changes) for details.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -56,4 +56,4 @@ The following REST API changes have been made.
 |-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | `GET /plugins/org.graylog.integrations/aws/inputs/available_services` | Remove unused endpoint.                                                                 |
 | `GET /plugins/org.graylog.integrations/aws/inputs/permissions`        | Removed permissions endpoint in favor of maintaining permissions in official docs site. |
-| `/plugins/org.graylog.plugins.files/*`                                | removed (Graylog Enterprise plugin)                                                     |
+| `/plugins/org.graylog.plugins.files/*`                                | Removed (Graylog Enterprise plugin).                                                    |


### PR DESCRIPTION
Upgrade notes for changes to the Enterprise plugin in https://github.com/Graylog2/graylog-plugin-enterprise/pull/9808.

/nocl
