### PR TITLE
Fix/9778 markdown editor sanitize string value

### DIFF
--- a/changelog/unreleased/issue-9778.toml
+++ b/changelog/unreleased/issue-9778.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Added value sanitation to MarkdownEditor component"
+
+issues = ["Graylog2/graylog-plugin-enterprise#9778"]
+pulls = [""]

--- a/changelog/unreleased/issue-9778.toml
+++ b/changelog/unreleased/issue-9778.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Added value sanitation to MarkdownEditor component"
 
 issues = ["Graylog2/graylog-plugin-enterprise#9778"]
-pulls = [""]
+pulls = ["21786", "Graylog2/graylog-plugin-enterprise#9830"]

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/Editor.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import styled, { css } from 'styled-components';
+import DOMPurify from 'dompurify';
 
 import { SourceCodeEditor, Icon } from 'components/common';
 
@@ -84,7 +85,7 @@ type Props = {
   onFullMode?: (fullMode: boolean) => void;
 };
 
-function Editor({ id, value, height, readOnly = false, onChange, onFullMode }: Props) {
+function Editor({ id = undefined, value, height, readOnly = false, onChange, onFullMode = () => {} }: Props) {
   const [localValue, setLocalValue] = React.useState<string>(value);
   const [showPreview, setShowPreview] = React.useState<boolean>(false);
   const [fullView, setFullView] = React.useState<boolean>(false);
@@ -96,10 +97,11 @@ function Editor({ id, value, height, readOnly = false, onChange, onFullMode }: P
     if (onFullMode) onFullMode(fullMode);
   };
 
-  const handleOnChange = (newValue: string) => {
-    setLocalValue(newValue);
-    onChange(newValue);
-  };
+  const handleOnChange = React.useCallback((newValue: string) => {
+    const sanitizedValue = DOMPurify.sanitize(newValue);
+    setLocalValue(sanitizedValue);
+    onChange(sanitizedValue);
+  }, [onChange]);
 
   return (
     <>
@@ -128,13 +130,13 @@ function Editor({ id, value, height, readOnly = false, onChange, onFullMode }: P
           </EditorStyles>
         )}
         <Preview value={localValue} height={height} show={showPreview} />
-        <ExpandIcon data-testid="expand-icon" name="expand" onClick={() => handleOnFullMode(true)} />
+        <ExpandIcon data-testid="expand-icon" name="expand_content" size="sm" onClick={() => handleOnFullMode(true)} />
       </div>
       {fullView && (
         <EditorModal
+          show
           value={localValue}
           readOnly={readOnly}
-          show={fullView}
           onChange={handleOnChange}
           onClose={() => handleOnFullMode(false)}
         />

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
+import DOMPurify from 'dompurify';
 
 import { Button } from 'components/bootstrap';
 import { Icon, SourceCodeEditor } from 'components/common';
@@ -78,15 +79,16 @@ const EditorWrapper = styled.div`
 `;
 
 type Props = {
-  value: string;
-  readOnly?: boolean;
-  show: boolean;
-  onChange: (newValue: string) => void;
-  onClose: () => void;
-  onDone?: (newValue?: string) => void;
+  value: string,
+  readOnly?: boolean,
+  show: boolean,
+  onChange: (newValue: string) => void,
+  onClose: () => void,
+  onDone?: (newValue?: string) => void,
+  helpBlock?: React.ReactNode,
 };
 
-function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone }: Props) {
+function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone = () => {}, helpBlock = undefined }: Props) {
   const [height, setHeight] = React.useState<number>(0);
   const [localValue, setLocalValue] = React.useState<string>(value);
 
@@ -97,13 +99,11 @@ function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone 
 
   React.useEffect(() => setLocalValue(value), [value]);
 
-  const handleOnChange = React.useCallback(
-    (newValue: string) => {
-      setLocalValue(newValue);
-      onChange(newValue);
-    },
-    [onChange],
-  );
+  const handleOnChange = React.useCallback((newValue: string) => {
+    const sanitizedValue = DOMPurify.sanitize(newValue);
+    setLocalValue(sanitizedValue);
+    onChange(sanitizedValue);
+  }, [onChange]);
 
   const handleOnDone = React.useCallback(() => {
     if (onDone) onDone(localValue);
@@ -119,6 +119,7 @@ function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone 
               <h2 style={{ marginBottom: '1rem' }}>Markdown Editor</h2>
               <CloseIcon name="close" onClick={() => onClose()} />
             </Row>
+            {helpBlock && <Row>{helpBlock}</Row>}
             <Row id="editor-body">
               {height > 0 && (
                 <>
@@ -143,14 +144,12 @@ function EditorModal({ value, readOnly = false, onChange, show, onClose, onDone 
             </Row>
             <Row style={{ justifyContent: 'flex-end', marginTop: '1rem' }}>
               <Button onClick={() => onClose()}>Cancel</Button>
-              <Button bsStyle="success" onClick={handleOnDone}>
-                Done
-              </Button>
+              <Button bsStyle="success" onClick={handleOnDone}>Done</Button>
             </Row>
           </Content>
         </Backdrop>
       ) : null,
-    [show, height, localValue, readOnly, onClose, handleOnDone, handleOnChange],
+    [show, height, localValue, readOnly, onClose, handleOnDone, handleOnChange, helpBlock],
   );
 
   return <>{ReactDom.createPortal(Component, document.body)}</>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates to MarkdownEditor component. Sanitize value with DOMPurify to prevent XSS attacks.

closes: Graylog2/graylog-plugin-enterprise#9778

## Description
<!--- Describe your changes in detail -->
This PR adds `DOMPurify.sanitize()` to MarkdownEditor to prevent users to be able to execute XSS attacks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve product security

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

