### PR TITLE
Escape response headers in API browser

### DIFF
--- a/changelog/unreleased/pr-21795.toml
+++ b/changelog/unreleased/pr-21795.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix escaping of response headers in API browser."
+
+pulls = ["21795"]

--- a/graylog2-server/src/main/resources/swagger/swagger-ui.js
+++ b/graylog2-server/src/main/resources/swagger/swagger-ui.js
@@ -1751,7 +1751,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       $(".request_url", $(this.el)).html("<pre>" + data.request.url + "</pre>");
       $(".response_code", $(this.el)).html("<pre>" + data.status + "</pre>");
       $(".response_body", $(this.el)).html(response_body);
-      $(".response_headers", $(this.el)).html("<pre>" + JSON.stringify(data.getHeaders()) + "</pre>");
+      $(".response_headers", $(this.el)).html("<pre>" + Handlebars.Utils.escapeExpression(JSON.stringify(data.getHeaders())) + "</pre>");
       $(".response", $(this.el)).slideDown();
       $(".response_hider", $(this.el)).show();
       $(".response_throbber", $(this.el)).hide();


### PR DESCRIPTION
In the API browser, response headers are displayed as JSON when a request was executed. If a response header contains HTML characters, it was potentially breaking the page.

We are now applying additional HTML escaping.