### PR TITLE
Add basic skeleton component which can be used as placeholder for loading content.

### DIFF
--- a/graylog2-web-interface/src/components/common/Skeleton.md
+++ b/graylog2-web-interface/src/components/common/Skeleton.md
@@ -1,0 +1,11 @@
+### Basic
+
+```tsx
+<Skeleton height={10} width={100} />
+```
+
+### With relative width
+
+```tsx
+<Skeleton height={10} width="70%" />
+```

--- a/graylog2-web-interface/src/components/common/Skeleton.tsx
+++ b/graylog2-web-interface/src/components/common/Skeleton.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { Skeleton as MantineSkeleton } from '@mantine/core';
+import styled, { css } from 'styled-components';
+
+const StyledSkeleton = styled(MantineSkeleton)(
+  ({ theme }) => css`
+    &:after {
+      background-color: ${theme.colors.gray[80]};
+    }
+  `,
+);
+
+const Skeleton = (props: Pick<React.ComponentProps<typeof MantineSkeleton>, 'className' | 'height' | 'width'>) => (
+  <StyledSkeleton {...props} radius="xl" />
+);
+
+export default Skeleton;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -103,6 +103,7 @@ export { default as ReadOnlyFormGroup } from './ReadOnlyFormGroup';
 export { default as RelativeTime } from './RelativeTime';
 export { default as RingProgress } from './RingProgress';
 export { default as ScrollButton } from './ScrollButton';
+export { default as Skeleton } from './Skeleton';
 export { default as SearchForm } from './SearchForm';
 export { default as Section } from './Section';
 export { default as Select } from './Select';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a simple skeleton component which can be used as placeholder for loading content.
It is based on https://mantine.dev/core/skeleton.

/nocl