### PR TITLE
Implement helper function to mock `window.confirm` in tests.

### DIFF
--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
@@ -33,7 +33,7 @@ import mockEntityShareState, {
 } from 'fixtures/entityShareState';
 import ActiveShare from 'logic/permissions/ActiveShare';
 import { EntityShareStore, EntityShareActions } from 'stores/permissions/EntityShareStore';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import EntityShareModal from './EntityShareModal';
 

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
@@ -33,6 +33,7 @@ import mockEntityShareState, {
 } from 'fixtures/entityShareState';
 import ActiveShare from 'logic/permissions/ActiveShare';
 import { EntityShareStore, EntityShareActions } from 'stores/permissions/EntityShareStore';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import EntityShareModal from './EntityShareModal';
 
@@ -155,16 +156,7 @@ describe('EntityShareModal', () => {
   });
 
   describe('grantee selector', () => {
-    let oldConfirm;
-
-    beforeEach(() => {
-      oldConfirm = window.confirm;
-      window.confirm = jest.fn(() => true);
-    });
-
-    afterEach(() => {
-      window.confirm = oldConfirm;
-    });
+    useWindowConfirmMock();
 
     describe('adds new selected grantee', () => {
       const addGrantee = async ({ newGrantee, capability }) => {

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
@@ -23,7 +23,7 @@ import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 import { adminUser } from 'fixtures/users';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import ActionsCell from './ActionsCell';
 

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.tsx
@@ -23,6 +23,7 @@ import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { AuthzRolesActions } from 'stores/roles/AuthzRolesStore';
 import { adminUser } from 'fixtures/users';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import ActionsCell from './ActionsCell';
 
@@ -65,17 +66,7 @@ describe('ActionsCell', () => {
   );
 
   describe('role deletion', () => {
-    let oldConfirm;
-
-    beforeEach(() => {
-      oldConfirm = window.confirm;
-      window.confirm = jest.fn(() => true);
-    });
-
-    afterEach(() => {
-      window.confirm = oldConfirm;
-      jest.clearAllMocks();
-    });
+    useWindowConfirmMock();
 
     it('should be possible if role is not built in', async () => {
       asMock(useCurrentUser).mockReturnValue(

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
@@ -28,7 +28,7 @@ import { indexSets } from 'fixtures/indexSets';
 import { asMock } from 'helpers/mocking';
 import ApiRoutes from 'routing/ApiRoutes';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn());
 jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
@@ -28,6 +28,7 @@ import { indexSets } from 'fixtures/indexSets';
 import { asMock } from 'helpers/mocking';
 import ApiRoutes from 'routing/ApiRoutes';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 jest.mock('logic/rest/FetchProvider', () => jest.fn());
 jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');
@@ -138,9 +139,7 @@ describe('StreamsOverview BulkActionsRow', () => {
   });
 
   describe('delete action', () => {
-    beforeEach(() => {
-      window.confirm = jest.fn(() => true);
-    });
+    useWindowConfirmMock();
 
     const deleteStreams = async () => {
       await userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -24,7 +24,7 @@ import { paginatedUsers, alice, bob, admin as adminOverview } from 'fixtures/use
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
 import { UsersActions } from 'stores/users/UsersStore';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import UsersOverview from './UsersOverview';
 

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.tsx
@@ -24,6 +24,7 @@ import { paginatedUsers, alice, bob, admin as adminOverview } from 'fixtures/use
 import asMock from 'helpers/mocking/AsMock';
 import mockAction from 'helpers/mocking/MockAction';
 import { UsersActions } from 'stores/users/UsersStore';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import UsersOverview from './UsersOverview';
 
@@ -110,16 +111,8 @@ describe('UsersOverview', () => {
     const modifiableUsersList = Immutable.List([modifiableUser]);
     const readOnlyUser = alice.toBuilder().readOnly(true).build();
     const readOnlyUsersList = Immutable.List([readOnlyUser]);
-    let oldConfirm;
 
-    beforeEach(() => {
-      oldConfirm = window.confirm;
-      window.confirm = jest.fn(() => true);
-    });
-
-    afterEach(() => {
-      window.confirm = oldConfirm;
-    });
+    useWindowConfirmMock();
 
     it(
       'be able to delete a modifiable user',

--- a/graylog2-web-interface/src/preflight/App.test.tsx
+++ b/graylog2-web-interface/src/preflight/App.test.tsx
@@ -19,6 +19,7 @@ import { screen, renderPreflight } from 'wrappedTestingLibrary';
 
 import fetch from 'logic/rest/FetchProvider';
 import { asMock } from 'helpers/mocking';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import App from './App';
 
@@ -58,13 +59,11 @@ jest.mock('preflight/util/UserNotification', () => ({
 }));
 
 describe('App', () => {
-  let windowConfirm;
   let windowLocation;
 
-  beforeAll(() => {
-    windowConfirm = window.confirm;
-    window.confirm = jest.fn(() => true);
+  useWindowConfirmMock();
 
+  beforeAll(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { reload: jest.fn() },
@@ -76,7 +75,6 @@ describe('App', () => {
   });
 
   afterAll(() => {
-    window.confirm = windowConfirm;
     Object.defineProperty(window, 'location', { configurable: true, value: windowLocation });
   });
 

--- a/graylog2-web-interface/src/preflight/App.test.tsx
+++ b/graylog2-web-interface/src/preflight/App.test.tsx
@@ -19,7 +19,7 @@ import { screen, renderPreflight } from 'wrappedTestingLibrary';
 
 import fetch from 'logic/rest/FetchProvider';
 import { asMock } from 'helpers/mocking';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import App from './App';
 

--- a/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
@@ -21,7 +21,7 @@ import DataNodesOverview from 'preflight/components/Setup/DataNodesOverview';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import { asMock } from 'helpers/mocking';
 import { dataNodes } from 'fixtures/dataNodes';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 jest.mock('preflight/hooks/useDataNodes');
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));

--- a/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/Setup/DataNodesOverview.test.tsx
@@ -21,12 +21,13 @@ import DataNodesOverview from 'preflight/components/Setup/DataNodesOverview';
 import useDataNodes from 'preflight/hooks/useDataNodes';
 import { asMock } from 'helpers/mocking';
 import { dataNodes } from 'fixtures/dataNodes';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 jest.mock('preflight/hooks/useDataNodes');
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
 
 describe('DataNodesOverview', () => {
-  let oldConfirm;
+  useWindowConfirmMock();
 
   beforeEach(() => {
     asMock(useDataNodes).mockReturnValue({
@@ -35,13 +36,6 @@ describe('DataNodesOverview', () => {
       isInitialLoading: false,
       error: undefined,
     });
-
-    oldConfirm = window.confirm;
-    window.confirm = jest.fn(() => true);
-  });
-
-  afterEach(() => {
-    window.confirm = oldConfirm;
   });
 
   it('should list available data nodes', async () => {

--- a/graylog2-web-interface/src/preflight/components/WaitingForStartup.test.tsx
+++ b/graylog2-web-interface/src/preflight/components/WaitingForStartup.test.tsx
@@ -28,8 +28,6 @@ describe('WaitingForStartup', () => {
   let windowLocation;
 
   beforeAll(() => {
-    window.confirm = jest.fn(() => true);
-
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: { reload: jest.fn() },

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -24,7 +24,7 @@ import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabs
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { setQueriesOrder, mergeQueryTitles } from 'views/logic/slices/viewSlice';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 jest.mock('views/logic/slices/viewSlice', () => ({
   ...jest.requireActual('views/logic/slices/viewSlice'),

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -24,6 +24,7 @@ import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabs
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { setQueriesOrder, mergeQueryTitles } from 'views/logic/slices/viewSlice';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 jest.mock('views/logic/slices/viewSlice', () => ({
   ...jest.requireActual('views/logic/slices/viewSlice'),
@@ -32,18 +33,7 @@ jest.mock('views/logic/slices/viewSlice', () => ({
 }));
 
 describe('AdaptableQueryTabsConfiguration', () => {
-  let oldConfirm;
-
-  beforeEach(() => {
-    oldConfirm = window.confirm;
-    window.confirm = jest.fn(() => true);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    window.confirm = oldConfirm;
-  });
-
+  useWindowConfirmMock();
   useViewsPlugin();
 
   const renderConfiguration = () =>

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -28,7 +28,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery, removeQuery } from 'views/logic/slices/viewSlice';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 jest.mock('views/logic/queries/useCurrentQueryId', () => () => 'bar');

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -28,6 +28,7 @@ import useViewsPlugin from 'views/test/testViewsPlugin';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsDispatch from 'views/stores/useViewsDispatch';
 import { selectQuery, removeQuery } from 'views/logic/slices/viewSlice';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 jest.mock('hooks/useElementDimensions', () => () => ({ width: 1024, height: 768 }));
 jest.mock('views/logic/queries/useCurrentQueryId', () => () => 'bar');
@@ -65,21 +66,13 @@ const QueryBar = () => (
 );
 
 describe('QueryBar', () => {
-  let oldWindowConfirm;
-
+  useWindowConfirmMock();
   useViewsPlugin();
 
   beforeEach(() => {
-    oldWindowConfirm = window.confirm;
-    window.confirm = jest.fn(() => true);
-
     asMock(useQueryIds).mockReturnValue(queries);
     asMock(useQueryTitles).mockReturnValue(queryTitles);
     asMock(useViewMetadata).mockReturnValue(viewMetadata);
-  });
-
-  afterEach(() => {
-    window.confirm = oldWindowConfirm;
   });
 
   it('renders existing tabs', async () => {

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
@@ -22,7 +22,7 @@ import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import { asMock } from 'helpers/mocking';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import BulkActions from './BulkActions';
 

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/BulkActions.test.tsx
@@ -22,6 +22,7 @@ import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import { asMock } from 'helpers/mocking';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import BulkActions from './BulkActions';
 
@@ -57,9 +58,9 @@ describe('DashboardsOverview BulkActionsRow', () => {
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   };
 
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
+  useWindowConfirmMock();
 
+  beforeEach(() => {
     asMock(useSelectedEntities).mockReturnValue(useSelectedEntitiesResponse);
   });
 

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -30,7 +30,7 @@ import { adminUser } from 'fixtures/users';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
 import type { ContextValue } from 'components/common/PaginatedEntityTable/TableFetchContext';
 import TableFetchContext from 'components/common/PaginatedEntityTable/TableFetchContext';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 jest.mock('hooks/useCurrentUser');
 jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -30,6 +30,7 @@ import { adminUser } from 'fixtures/users';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
 import type { ContextValue } from 'components/common/PaginatedEntityTable/TableFetchContext';
 import TableFetchContext from 'components/common/PaginatedEntityTable/TableFetchContext';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 jest.mock('hooks/useCurrentUser');
 jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');
@@ -62,8 +63,6 @@ const DashboardActions = ({
 );
 
 describe('DashboardActions', () => {
-  let oldWindowConfirm;
-
   const simpleDashboard = simpleView();
   const menuIsHidden = () => expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 
@@ -73,9 +72,9 @@ describe('DashboardActions', () => {
     await waitFor(() => menuIsHidden());
   };
 
+  useWindowConfirmMock();
+
   beforeEach(() => {
-    oldWindowConfirm = window.confirm;
-    window.confirm = jest.fn();
     asMock(useCurrentUser).mockReturnValue(adminUser);
 
     asMock(useSelectedEntities).mockReturnValue({
@@ -85,10 +84,6 @@ describe('DashboardActions', () => {
       deselectEntity: () => {},
       toggleEntitySelect: () => {},
     });
-  });
-
-  afterEach(() => {
-    window.confirm = oldWindowConfirm;
   });
 
   it('does not delete dashboard when user clicks cancel', async () => {

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -54,7 +54,7 @@ const mockSearchParams = {
 const mockContextValue = { searchParams: mockSearchParams, refetch: jest.fn(), attributes: [] };
 
 const DashboardActions = ({
-  contextValue,
+  contextValue = undefined,
   ...props
 }: React.ComponentProps<typeof OriginalDashboardActions> & { contextValue?: ContextValue }) => (
   <TableFetchContext.Provider value={contextValue ?? mockContextValue}>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
@@ -22,7 +22,7 @@ import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import { asMock } from 'helpers/mocking';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import BulkActions from './BulkActions';
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/BulkActions.test.tsx
@@ -22,6 +22,7 @@ import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import { asMock } from 'helpers/mocking';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import BulkActions from './BulkActions';
 
@@ -36,7 +37,7 @@ jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');
 
 describe('SavedSearches BulkActions', () => {
   const openActionsDropdown = async () => {
-    await userEvent.click(
+    userEvent.click(
       await screen.findByRole('button', {
         name: /bulk actions/i,
       }),
@@ -47,9 +48,9 @@ describe('SavedSearches BulkActions', () => {
     userEvent.click(await screen.findByRole('menuitem', { name: /delete/i }));
   };
 
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
+  useWindowConfirmMock();
 
+  beforeEach(() => {
     asMock(useSelectedEntities).mockReturnValue({
       selectedEntities: [],
       setSelectedEntities: () => {},

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -28,6 +28,7 @@ import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences';
 import { adminUser } from 'fixtures/users';
 import useCurrentUser from 'hooks/useCurrentUser';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import SavedSearchesModal from './SavedSearchesModal';
 
@@ -74,6 +75,7 @@ jest.mock('routing/Routes', () => ({
 }));
 
 describe('SavedSearchesModal', () => {
+  useWindowConfirmMock();
   const defaultPaginatedSearches = createPaginatedSearches();
 
   beforeEach(() => {
@@ -150,7 +152,6 @@ describe('SavedSearchesModal', () => {
     });
 
     it('should call `onDelete` if saved search is deleted', async () => {
-      window.confirm = jest.fn(() => true);
       const onDelete = jest.fn(() => Promise.resolve());
 
       render(

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -28,7 +28,7 @@ import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences';
 import { adminUser } from 'fixtures/users';
 import useCurrentUser from 'hooks/useCurrentUser';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import SavedSearchesModal from './SavedSearchesModal';
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -21,7 +21,7 @@ import userEvent from '@testing-library/user-event';
 import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import useViewsPlugin from 'views/test/testViewsPlugin';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import HighlightingRule from './HighlightingRule';
 

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.test.tsx
@@ -21,6 +21,7 @@ import userEvent from '@testing-library/user-event';
 import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
 import useViewsPlugin from 'views/test/testViewsPlugin';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import HighlightingRule from './HighlightingRule';
 
@@ -93,17 +94,9 @@ describe('HighlightingRule', () => {
   });
 
   describe('rule removal:', () => {
-    let oldConfirm = null;
     const findDeleteIcon = () => screen.findByTitle('Remove this Highlighting Rule');
 
-    beforeEach(async () => {
-      oldConfirm = window.confirm;
-      window.confirm = jest.fn(() => false);
-    });
-
-    afterEach(() => {
-      window.confirm = oldConfirm;
-    });
+    useWindowConfirmMock();
 
     it('asks for confirmation before rule is removed', async () => {
       render(<SUT />);

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -41,6 +41,7 @@ import useViewType from 'views/hooks/useViewType';
 import fetchSearch from 'views/logic/views/fetchSearch';
 import useWidgetResults from 'views/components/useWidgetResults';
 import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
+import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
 
 import WidgetActionsMenu from './WidgetActionsMenu';
 
@@ -301,16 +302,7 @@ describe('<WidgetActionsMenu />', () => {
   });
 
   describe('delete action', () => {
-    let oldWindowConfirm;
-
-    beforeEach(() => {
-      oldWindowConfirm = window.confirm;
-      window.confirm = jest.fn();
-    });
-
-    afterEach(() => {
-      window.confirm = oldWindowConfirm;
-    });
+    useWindowConfirmMock();
 
     it('should delete widget when no deletion hook is installed and prompt is confirmed', async () => {
       asMock(window.confirm).mockReturnValue(true);

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -41,7 +41,7 @@ import useViewType from 'views/hooks/useViewType';
 import fetchSearch from 'views/logic/views/fetchSearch';
 import useWidgetResults from 'views/components/useWidgetResults';
 import TestFieldTypesContextProvider from 'views/components/contexts/TestFieldTypesContextProvider';
-import { useWindowConfirmMock } from 'helpers/mocking/WindowMock';
+import useWindowConfirmMock from 'helpers/mocking/useWindowConfirmMock';
 
 import WidgetActionsMenu from './WidgetActionsMenu';
 

--- a/graylog2-web-interface/test/helpers/mocking/WindowMock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/WindowMock.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line import/prefer-default-export
+export const useWindowConfirmMock = () => {
+  let originalWindowConfirm;
+
+  beforeEach(() => {
+    originalWindowConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+  });
+
+  afterEach(() => {
+    window.confirm = originalWindowConfirm;
+  });
+};

--- a/graylog2-web-interface/test/helpers/mocking/WindowMock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/WindowMock.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
 // eslint-disable-next-line import/prefer-default-export
 export const useWindowConfirmMock = () => {
   let originalWindowConfirm;

--- a/graylog2-web-interface/test/helpers/mocking/useWindowConfirmMock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/useWindowConfirmMock.ts
@@ -15,8 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-// eslint-disable-next-line import/prefer-default-export
-export const useWindowConfirmMock = () => {
+const useWindowConfirmMock = () => {
   let originalWindowConfirm;
 
   beforeEach(() => {
@@ -28,3 +27,5 @@ export const useWindowConfirmMock = () => {
     window.confirm = originalWindowConfirm;
   });
 };
+
+export default useWindowConfirmMock;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a `useWindowConfirm` helper function to easily and properly mock `window.confirm` in tests.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9858
/nocl