### PR TITLE
Create a utility function for BSON ObjectID generation.

### DIFF
--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.tsx
@@ -340,7 +340,7 @@ const RuleBuilder = () => {
                 <StyledPanelBody>
                   {rule.rule_builder.conditions.map((condition, index) => (
                     <RuleBuilderBlock
-                      key={index}
+                      key={condition.id}
                       blockDict={conditionsDict || []}
                       block={condition}
                       order={index}
@@ -375,7 +375,7 @@ const RuleBuilder = () => {
                 <StyledPanelBody>
                   {rule.rule_builder.actions.map((action, index) => (
                     <RuleBuilderBlock
-                      key={index}
+                      key={action.id}
                       blockDict={actionsDict || []}
                       block={action}
                       order={index}

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.tsx
@@ -16,7 +16,6 @@
  */
 import React, { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
-import ObjectID from 'bson-objectid';
 
 import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
@@ -27,6 +26,7 @@ import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import generateObjectId from 'logic/generateObjectId';
 
 import RuleBuilderProvider from './RuleBuilderProvider';
 import RuleBuilderBlock from './RuleBuilderBlock';
@@ -171,7 +171,7 @@ const RuleBuilder = () => {
 
   const addBlock = async (type: BlockType, block: RuleBlock, orderIndex?: number) => {
     let ruleToAdd: RuleBuilderRule;
-    const blockId = new ObjectID().toString();
+    const blockId = generateObjectId();
 
     if (type === 'condition') {
       const newConditions = rule.rule_builder.conditions;

--- a/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRulesFields.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRulesFields.tsx
@@ -18,7 +18,6 @@ import * as React from 'react';
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useFormikContext } from 'formik';
-import ObjectID from 'bson-objectid';
 
 import Errors from 'components/rules/rule-builder/Errors';
 import { ConfirmDialog } from 'components/common';
@@ -27,6 +26,7 @@ import RuleBuilderBlock from 'components/rules/rule-builder/RuleBuilderBlock';
 import { Panel, Radio } from 'components/bootstrap';
 import type { StreamOutputFilterRule } from 'components/streams/StreamDetails/output-filter/Types';
 import useStreamOutputRuleBuilder, { fetchValidateRule } from 'components/streams/hooks/useStreamOutputRuleBuilder';
+import generateObjectId from 'logic/generateObjectId';
 
 type Props = {
   type: BlockType;
@@ -84,7 +84,7 @@ const FilterRulesFields = ({ type }: Props) => {
         ...values,
         rule: {
           ...values.rule,
-          conditions: [...(values.rule?.conditions || []), { ...block, id: new ObjectID().toString() }],
+          conditions: [...(values.rule?.conditions || []), { ...block, id: generateObjectId() }],
         },
       };
       validateAndUpdateFormValues(ruleToValidate);

--- a/graylog2-web-interface/src/logic/generateObjectId.ts
+++ b/graylog2-web-interface/src/logic/generateObjectId.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import ObjectID from 'bson-objectid';
+
+// Returns a new BSON ObjectID, which are used for documents in MongoDB.
+const generateObjectId = () => new ObjectID().toString();
+
+export default generateObjectId;

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -39,12 +39,7 @@ import DashboardActionsMenu from './DashboardActionsMenu';
 jest.mock('views/logic/views/OnSaveViewAction', () => jest.fn(() => () => {}));
 jest.mock('views/hooks/useSaveViewFormControls');
 jest.mock('hooks/useCurrentUser');
-
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-dashboard-id'),
-  })),
-);
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-dashboard-id'));
 
 jest.mock('views/stores/ViewManagementStore', () => ({
   ViewManagementActions: {

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -68,7 +68,13 @@ describe('DashboardActionsMenu', () => {
     .createdAt(new Date('2019-10-16T14:38:44.681Z'))
     .build();
 
-  const SUT = ({ providerOverrides, view = mockView }: { providerOverrides?: Partial<LayoutState>; view?: View }) => (
+  const SUT = ({
+    providerOverrides = undefined,
+    view = mockView,
+  }: {
+    providerOverrides?: Partial<LayoutState>;
+    view?: View;
+  }) => (
     <TestStoreProvider view={view}>
       <HotkeysProvider>
         <SearchPageLayoutProvider value={providerOverrides}>

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.tsx
@@ -17,12 +17,12 @@
 import React from 'react';
 import jQuery from 'jquery';
 import styled, { css } from 'styled-components';
-import ObjectID from 'bson-objectid';
 
 import { ConfigurationForm } from 'components/configurationforms';
 import type { ConfigurationFormData } from 'components/configurationforms';
 import { Select } from 'components/common';
 import type { DecoratorType, Decorator } from 'views/components/messagelist/decorators/Types';
+import generateObjectId from 'logic/generateObjectId';
 
 import InlineForm from './InlineForm';
 import PopoverHelp from './PopoverHelp';
@@ -86,7 +86,7 @@ class AddDecoratorButton extends React.Component<Props, State> {
     const { stream, nextOrder, onCreate } = this.props;
 
     const request = {
-      id: new ObjectID().toString(),
+      id: generateObjectId(),
       stream,
       type: data.type,
       config: data.configuration,

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.test.tsx
@@ -49,12 +49,7 @@ jest.mock('views/hooks/useSaveViewFormControls');
 jest.mock('routing/useHistory');
 jest.mock('hooks/useCurrentUser');
 jest.mock('views/logic/views/OnSaveViewAction', () => jest.fn(() => () => {}));
-
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-search-id'),
-  })),
-);
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-search-id'));
 
 jest.mock('views/stores/ViewManagementStore', () => ({
   ViewManagementActions: {

--- a/graylog2-web-interface/src/views/logic/search/Search.ts
+++ b/graylog2-web-interface/src/views/logic/search/Search.ts
@@ -16,7 +16,8 @@
  */
 
 import * as Immutable from 'immutable';
-import ObjectID from 'bson-objectid';
+
+import generateObjectId from 'logic/generateObjectId';
 
 import Query from '../queries/Query';
 import Parameter from '../parameters/Parameter';
@@ -113,7 +114,7 @@ class Builder {
   }
 
   newId(): Builder {
-    return this.id(new ObjectID().toString());
+    return this.id(generateObjectId());
   }
 
   queries(value: Array<Query> | QuerySet): Builder {

--- a/graylog2-web-interface/src/views/logic/views/CopyPageToDashboard.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyPageToDashboard.test.ts
@@ -28,12 +28,7 @@ import Parameter from '../parameters/Parameter';
 jest.useFakeTimers().setSystemTime(1577836800000); // 2020-01-01 00:00:00.000
 
 jest.mock('logic/generateId', () => jest.fn(() => 'dead-beef'));
-
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-search-id'),
-  })),
-);
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-search-id'));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.ts
@@ -24,12 +24,7 @@ import ValueParameter from '../parameters/ValueParameter';
 import Parameter from '../parameters/Parameter';
 
 jest.mock('logic/generateId', () => jest.fn(() => 'dead-beef'));
-
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-search-id'),
-  })),
-);
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-search-id'));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.ts
@@ -26,12 +26,7 @@ import ValueParameter from '../parameters/ValueParameter';
 import Search from '../search/Search';
 
 jest.mock('logic/generateId', () => jest.fn(() => 'dead-beef'));
-
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-search-id'),
-  })),
-);
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-search-id'));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.ts
@@ -25,13 +25,8 @@ import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import Parameter from '../parameters/Parameter';
 import ValueParameter from '../parameters/ValueParameter';
 
-jest.mock('bson-objectid', () =>
-  jest.fn(() => ({
-    toString: jest.fn(() => 'new-search-id'),
-  })),
-);
-
 jest.mock('logic/generateId', () => jest.fn(() => 'dead-beef'));
+jest.mock('logic/generateObjectId', () => jest.fn(() => 'new-search-id'));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { renderHook } from 'wrappedTestingLibrary/hooks';
-import ObjectID from 'bson-objectid';
 
 import {
   mockedMappedAggregation,
@@ -33,6 +32,7 @@ import generateId from 'logic/generateId';
 import asMock from 'helpers/mocking/AsMock';
 import type View from 'views/logic/views/View';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import generateObjectId from 'logic/generateObjectId';
 
 const counter = () => {
   let index = 0;
@@ -105,9 +105,8 @@ jest.mock('graylog-web-plugin/plugin', () => ({
   PluginStore: { exports: jest.fn(() => [{ type: 'aggregation', defaults: {} }]) },
 }));
 
+jest.mock('logic/generateObjectId', () => jest.fn());
 jest.mock('logic/generateId', () => jest.fn());
-
-jest.mock('bson-objectid', () => jest.fn());
 
 const mock_color = StaticColor.create('#ffffff');
 
@@ -139,13 +138,7 @@ describe('UseCreateViewForEvent', () => {
 
   it('should create view with 2 aggregation widgets and one summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdTwoAggregations);
-
-    asMock(ObjectID).mockImplementation(
-      () =>
-        ({
-          toString: () => mockedObjectIdTwoAggregations(),
-        }) as ObjectID,
-    );
+    asMock(generateObjectId).mockImplementation(mockedObjectIdTwoAggregations);
 
     const { result } = renderHook(() =>
       UseCreateViewForEvent({
@@ -161,13 +154,7 @@ describe('UseCreateViewForEvent', () => {
 
   it('should create view with 1 aggregation widgets and without summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdOneAggregation);
-
-    asMock(ObjectID).mockImplementation(
-      () =>
-        ({
-          toString: () => mockedObjectIdOneAggregation(),
-        }) as ObjectID,
-    );
+    asMock(generateObjectId).mockImplementation(mockedObjectIdOneAggregation);
 
     const { result } = renderHook(() =>
       UseCreateViewForEvent({
@@ -183,13 +170,7 @@ describe('UseCreateViewForEvent', () => {
 
   it('should create view with 1 aggregation widgets when aggregation has no fields and grouping by', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdOneAggregationNoFields);
-
-    asMock(ObjectID).mockImplementation(
-      () =>
-        ({
-          toString: () => mockedObjectIdOneAggregationNoFields(),
-        }) as ObjectID,
-    );
+    asMock(generateObjectId).mockImplementation(mockedObjectIdOneAggregationNoFields);
 
     const { result } = renderHook(() =>
       UseCreateViewForEvent({

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinitions.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinitions.test.ts
@@ -118,7 +118,7 @@ describe('UseCreateViewForEventDefinition', () => {
 
   it('should create view with 2 aggregation widgets and one summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdTwoAggregations);
-    asMock(generateObjectId).mockReturnValue(mockedObjectIdTwoAggregations());
+    asMock(generateObjectId).mockImplementation(mockedObjectIdTwoAggregations);
 
     const { result } = renderHook(() =>
       UseCreateViewForEventDefinition({
@@ -133,7 +133,7 @@ describe('UseCreateViewForEventDefinition', () => {
 
   it('should create view with 1 aggregation widgets and without summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdOneAggregation);
-    asMock(generateObjectId).mockReturnValue(mockedObjectIdOneAggregation());
+    asMock(generateObjectId).mockImplementation(mockedObjectIdOneAggregation);
 
     const { result } = renderHook(() =>
       UseCreateViewForEventDefinition({

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinitions.test.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEventDefinitions.test.ts
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { renderHook } from 'wrappedTestingLibrary/hooks';
-import ObjectID from 'bson-objectid';
 
 import {
   mockedMappedAggregation,
@@ -29,6 +28,7 @@ import generateId from 'logic/generateId';
 import asMock from 'helpers/mocking/AsMock';
 import type View from 'views/logic/views/View';
 import { StaticColor } from 'views/logic/views/formatting/highlighting/HighlightingColor';
+import generateObjectId from 'logic/generateObjectId';
 
 const counter = () => {
   let index = 0;
@@ -86,8 +86,8 @@ jest.mock('graylog-web-plugin/plugin', () => ({
 }));
 
 jest.mock('logic/generateId', () => jest.fn());
+jest.mock('logic/generateObjectId', () => jest.fn());
 
-jest.mock('bson-objectid', () => jest.fn());
 const mock_color = StaticColor.create('#ffffff');
 
 jest.mock('views/logic/views/formatting/highlighting/HighlightingRule', () => ({
@@ -118,13 +118,7 @@ describe('UseCreateViewForEventDefinition', () => {
 
   it('should create view with 2 aggregation widgets and one summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdTwoAggregations);
-
-    asMock(ObjectID).mockImplementation(
-      () =>
-        ({
-          toString: () => mockedObjectIdTwoAggregations(),
-        }) as ObjectID,
-    );
+    asMock(generateObjectId).mockReturnValue(mockedObjectIdTwoAggregations());
 
     const { result } = renderHook(() =>
       UseCreateViewForEventDefinition({
@@ -139,13 +133,7 @@ describe('UseCreateViewForEventDefinition', () => {
 
   it('should create view with 1 aggregation widgets and without summary', async () => {
     asMock(generateId).mockImplementation(mockedGenerateIdOneAggregation);
-
-    asMock(ObjectID).mockImplementation(
-      () =>
-        ({
-          toString: () => mockedObjectIdOneAggregation(),
-        }) as ObjectID,
-    );
+    asMock(generateObjectId).mockReturnValue(mockedObjectIdOneAggregation());
 
     const { result } = renderHook(() =>
       UseCreateViewForEventDefinition({

--- a/graylog2-web-interface/src/views/logic/views/View.ts
+++ b/graylog2-web-interface/src/views/logic/views/View.ts
@@ -16,10 +16,10 @@
  */
 import * as Immutable from 'immutable';
 import flatten from 'lodash/flatten';
-import ObjectID from 'bson-objectid';
 
 import type Widget from 'views/logic/widgets/Widget';
 import defaultTitle from 'views/components/defaultTitle';
+import generateObjectId from 'logic/generateObjectId';
 
 import ViewState from './ViewState';
 import type { WidgetMapping } from './types';
@@ -302,7 +302,7 @@ class Builder {
   }
 
   newId(): Builder {
-    return this.id(new ObjectID().toString());
+    return this.id(generateObjectId());
   }
 
   title(value: string): Builder {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This PR creates the utility function `generateObjectId` to generate BSON ObjectIDs.
We can use the abstraction in the frontend instead of interacting with the library directly.

This approach is similar to the utility function `generateId`, which generates a `uuid`.

The abstraction makes it easier to mock the id generation in tests and it would make it easier to switch to a different library in the future.

When I tried to mock `bson-objectid` in tests for a plugin I got the following error `Cannot find module 'bson-objectid'`. Using utility function avoids this problem.

/nocl