### PR TITLE
Threat Coverage Widget: searching for Sigma Rules filters for only potentially matching Rules

### DIFF
--- a/changelog/unreleased/pr-21835.toml
+++ b/changelog/unreleased/pr-21835.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Adding an interface to tag inputs for enterprise functionality, extracting scripting API methods into a service for reuse"
+
+pulls = ["21835", "graylog-plugin-enterprise#9869"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto11/PaloAlto11xCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto11/PaloAlto11xCodec.java
@@ -30,6 +30,7 @@ import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
+import org.graylog2.plugin.inputs.DefinesEventSourceProduct;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
@@ -46,7 +47,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
-public class PaloAlto11xCodec implements Codec {
+public class PaloAlto11xCodec implements Codec, DefinesEventSourceProduct {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto11xCodec.class);
     static final String CK_STORE_FULL_MESSAGE = "store_full_message";
     static final String CK_TIMEZONE = "timezone";
@@ -104,7 +105,7 @@ public class PaloAlto11xCodec implements Codec {
         }
 
         Message message = messageFactory.createMessage(payload, source, timestamp);
-        message.addField(EventFields.EVENT_SOURCE_PRODUCT, EVENT_SOURCE_PRODUCT_NAME);
+        message.addField(EventFields.EVENT_SOURCE_PRODUCT, getEventSourceProduct());
         message.addField(VendorFields.VENDOR_SUBTYPE, panType);
         // Store full message if configured.
         if (configuration.getBoolean(CK_STORE_FULL_MESSAGE)) {
@@ -135,6 +136,11 @@ public class PaloAlto11xCodec implements Codec {
     @Override
     public Configuration getConfiguration() {
         return this.configuration;
+    }
+
+    @Override
+    public String getEventSourceProduct() {
+        return EVENT_SOURCE_PRODUCT_NAME;
     }
 
     @FactoryClass

--- a/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -28,6 +28,7 @@ import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
+import org.graylog2.plugin.inputs.DefinesEventSourceProduct;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
@@ -53,7 +54,7 @@ import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.THREA
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.TRAFFIC;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.USERID;
 
-public class PaloAlto9xCodec implements Codec {
+public class PaloAlto9xCodec implements Codec, DefinesEventSourceProduct {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xCodec.class);
 
     static final String CK_STORE_FULL_MESSAGE = "store_full_message";
@@ -126,7 +127,7 @@ public class PaloAlto9xCodec implements Codec {
                     }
             }
 
-            message.addField(EventFields.EVENT_SOURCE_PRODUCT, "PAN");
+            message.addField(EventFields.EVENT_SOURCE_PRODUCT, getEventSourceProduct());
 
             // Store full message if configured.
             if (configuration.getBoolean(CK_STORE_FULL_MESSAGE)) {
@@ -150,6 +151,11 @@ public class PaloAlto9xCodec implements Codec {
     @Override
     public Configuration getConfiguration() {
         return this.configuration;
+    }
+
+    @Override
+    public String getEventSourceProduct() {
+        return "PAN";
     }
 
     @FactoryClass

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
@@ -28,7 +28,7 @@ public class ScriptingApiModule extends ViewsModule {
     @Override
     protected void configure() {
         addSystemRestResource(ScriptingApiResource.class);
-        bind(ScriptingApiServiceImpl.class).to(ScriptingApiServiceImpl.class).asEagerSingleton();
+        bind(ScriptingApiService.class).to(ScriptingApiServiceImpl.class).asEagerSingleton();
         jerseyAdditionalComponentsBinder().addBinding().toInstance(TabularResponseWriter.class);
 
         final Multibinder<FieldDecorator> fieldDecoratorBinder = Multibinder.newSetBinder(binder(), FieldDecorator.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiModule.java
@@ -28,6 +28,7 @@ public class ScriptingApiModule extends ViewsModule {
     @Override
     protected void configure() {
         addSystemRestResource(ScriptingApiResource.class);
+        bind(ScriptingApiServiceImpl.class).to(ScriptingApiServiceImpl.class).asEagerSingleton();
         jerseyAdditionalComponentsBinder().addBinding().toInstance(TabularResponseWriter.class);
 
         final Multibinder<FieldDecorator> fieldDecoratorBinder = Multibinder.newSetBinder(binder(), FieldDecorator.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiResource.java
@@ -48,6 +48,7 @@ import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesReques
 import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
 import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.utilities.StringUtils;
@@ -103,7 +104,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
 
             //Step 2: execute search as we usually do
             final SearchJob searchJob = searchExecutor.executeSync(search, searchUser, ExecutionState.empty());
-            postAuditEvent(searchJob);
+            postAuditEvent(searchJob, searchUser.getUser());
 
             //Step 3: take complex response and try to map it to simpler, tabular form
             return messagesTabularResponseCreator.mapToResponse(messagesRequestSpec, searchJob, searchUser, getSubject());
@@ -158,7 +159,7 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
 
             //Step 2: execute search as we usually do
             final SearchJob searchJob = searchExecutor.executeSync(search, searchUser, ExecutionState.empty());
-            postAuditEvent(searchJob);
+            postAuditEvent(searchJob, searchUser.getUser());
 
             //Step 3: take complex response and try to map it to simpler, tabular form
             return aggregationTabularResponseCreator.mapToResponse(aggregationRequestSpec, searchJob, searchUser);
@@ -193,8 +194,8 @@ public class ScriptingApiResource extends RestResource implements PluginRestReso
         }
     }
 
-    private void postAuditEvent(SearchJob searchJob) {
-        final SearchJobExecutionEvent searchJobExecutionEvent = SearchJobExecutionEvent.create(getCurrentUser(), searchJob, DateTime.now(DateTimeZone.UTC));
+    private void postAuditEvent(SearchJob searchJob, User user) {
+        final SearchJobExecutionEvent searchJobExecutionEvent = SearchJobExecutionEvent.create(user, searchJob, DateTime.now(DateTimeZone.UTC));
         this.serverEventBus.post(searchJobExecutionEvent);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiService.java
@@ -1,0 +1,13 @@
+package org.graylog.plugins.views.search.rest.scriptingapi;
+
+import org.apache.shiro.subject.Subject;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.scriptingapi.mapping.QueryFailedException;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
+
+public interface ScriptingApiService {
+    TabularResponse executeQuery(MessagesRequestSpec messagesRequestSpec, SearchUser searchUser, Subject subject) throws QueryFailedException;
+    TabularResponse executeAggregation(AggregationRequestSpec aggregationRequestSpec, SearchUser searchUser) throws QueryFailedException;
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest.scriptingapi;
 
 import org.apache.shiro.subject.Subject;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiServiceImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.views.search.rest.scriptingapi;
 
 import com.google.common.eventbus.EventBus;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/ScriptingApiServiceImpl.java
@@ -1,0 +1,72 @@
+package org.graylog.plugins.views.search.rest.scriptingapi;
+
+import com.google.common.eventbus.EventBus;
+import jakarta.inject.Inject;
+import org.apache.shiro.subject.Subject;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.engine.SearchExecutor;
+import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.rest.ExecutionState;
+import org.graylog.plugins.views.search.rest.scriptingapi.mapping.AggregationTabularResponseCreator;
+import org.graylog.plugins.views.search.rest.scriptingapi.mapping.MessagesTabularResponseCreator;
+import org.graylog.plugins.views.search.rest.scriptingapi.mapping.QueryFailedException;
+import org.graylog.plugins.views.search.rest.scriptingapi.mapping.SearchRequestSpecToSearchMapper;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
+import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
+import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
+import org.graylog2.plugin.database.users.User;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+
+public class ScriptingApiServiceImpl implements ScriptingApiService {
+    private final SearchExecutor searchExecutor;
+    private final SearchRequestSpecToSearchMapper searchCreator;
+    private final MessagesTabularResponseCreator messagesTabularResponseCreator;
+    private final AggregationTabularResponseCreator aggregationTabularResponseCreator;
+    private final EventBus serverEventBus;
+
+    @Inject
+    public ScriptingApiServiceImpl(final SearchExecutor searchExecutor,
+                                   final SearchRequestSpecToSearchMapper searchCreator,
+                                   final MessagesTabularResponseCreator messagesTabularResponseCreator,
+                                   final AggregationTabularResponseCreator aggregationTabularResponseCreator,
+                                   final EventBus serverEventBus) {
+        this.searchExecutor = searchExecutor;
+        this.searchCreator = searchCreator;
+        this.messagesTabularResponseCreator = messagesTabularResponseCreator;
+        this.aggregationTabularResponseCreator = aggregationTabularResponseCreator;
+        this.serverEventBus = serverEventBus;
+    }
+
+    public TabularResponse executeQuery(MessagesRequestSpec messagesRequestSpec, SearchUser searchUser, Subject subject) throws QueryFailedException {
+        //Step 1: map simple request to more complex search
+        Search search = searchCreator.mapToSearch(messagesRequestSpec, searchUser);
+
+        //Step 2: execute search as we usually do
+        final SearchJob searchJob = searchExecutor.executeSync(search, searchUser, ExecutionState.empty());
+        postAuditEvent(searchJob, searchUser.getUser());
+
+        //Step 3: take complex response and try to map it to simpler, tabular form
+        return messagesTabularResponseCreator.mapToResponse(messagesRequestSpec, searchJob, searchUser, subject);
+    }
+
+    public TabularResponse executeAggregation(AggregationRequestSpec aggregationRequestSpec, SearchUser searchUser) throws QueryFailedException {
+        //Step 1: map simple request to more complex search
+        Search search = searchCreator.mapToSearch(aggregationRequestSpec, searchUser);
+
+        //Step 2: execute search as we usually do
+        final SearchJob searchJob = searchExecutor.executeSync(search, searchUser, ExecutionState.empty());
+        postAuditEvent(searchJob, searchUser.getUser());
+
+        //Step 3: take complex response and try to map it to simpler, tabular form
+        return aggregationTabularResponseCreator.mapToResponse(aggregationRequestSpec, searchJob, searchUser);
+    }
+
+    private void postAuditEvent(SearchJob searchJob, User user) {
+        final SearchJobExecutionEvent searchJobExecutionEvent = SearchJobExecutionEvent.create(user, searchJob, DateTime.now(DateTimeZone.UTC));
+        this.serverEventBus.post(searchJobExecutionEvent);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/DefinesEventSourceProduct.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/DefinesEventSourceProduct.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.plugin.inputs;
 
 public interface DefinesEventSourceProduct {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/DefinesEventSourceProduct.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/DefinesEventSourceProduct.java
@@ -1,0 +1,10 @@
+package org.graylog2.plugin.inputs;
+
+public interface DefinesEventSourceProduct {
+    /**
+     * Every codec except the general Syslog/GELF codecs set this attribute and we start to depend on
+     * it in code, so we make this a mandatory getter
+     * @return
+     */
+    String getEventSourceProduct();
+}

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -89,7 +89,7 @@ new_report_creation=on
 remote_reindex_migration=off
 
 # Enable preview of data warehouse data
-data_warehouse_search=off
+data_warehouse_search=on
 
 # Enable preview of input setup wizard
 setup_mode=off

--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -89,7 +89,7 @@ new_report_creation=on
 remote_reindex_migration=off
 
 # Enable preview of data warehouse data
-data_warehouse_search=on
+data_warehouse_search=off
 
 # Enable preview of input setup wizard
 setup_mode=off


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this change, all Sigma Rules where shown with the given search parameters.
Now, we additionally filter to only list Sigma Rules that match the configured `event_source_product` field contents
- defined by an input
- defined by a static field on an input
- in messages indexed in the recent past in the indexer

So that in the FE we can only show the Sigma Rules to enable that make sense in context of your system configuration.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

