### PR TITLE
Fix overreporting of WhoIs redirect errors

### DIFF
--- a/changelog/unreleased/issue-20571.toml
+++ b/changelog/unreleased/issue-20571.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Suppress repeated error logging for Whois lookup adapter when following redirects."
+
+issues = ["20571"]
+pulls = ["21838"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
@@ -56,7 +56,8 @@ public class WhoisIpLookup {
         try {
             return run(this.defaultRegistry, ip);
         } catch (WhoisLookupException e) {
-            // Find first exception in the chain.
+            // Since recursive calls are used to follow redirects, extract the root cause of the exception to find the
+            // initial error, and then rethrow it only once.
             final WhoisLookupException rootCause = (WhoisLookupException) e.getCause();
             final InternetRegistry causeRegistry = rootCause.getRegistry();
             final String error = f("Could not lookup WHOIS information for [%s] at [%s].", ip, causeRegistry);

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
@@ -128,7 +128,7 @@ public class WhoisIpLookup {
             return new WhoisIpLookupResult(parser.getOrganization(), parser.getCountryCode());
         } catch (IOException e) {
             LOG.error("Could not lookup WHOIS information for [{}] at [{}].", ip, registry.toString());
-            throw e;
+            return null;
         } finally {
             if (whoisClient.isConnected()) {
                 whoisClient.disconnect();

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
@@ -59,9 +59,9 @@ public class WhoisIpLookup {
             // Since recursive calls are used to follow redirects, extract the root cause of the exception to find the
             // initial error, and then rethrow it only once.
             final WhoisLookupException rootCause = (WhoisLookupException) e.getCause();
-            final InternetRegistry causeRegistry = rootCause.getRegistry();
-            final String error = f("Could not lookup WHOIS information for [%s] at [%s].", ip, causeRegistry);
-            final WhoisLookupException whoisLookupException = new WhoisLookupException(error, e.getCause(), causeRegistry);
+            final InternetRegistry rootCauseRegistry = rootCause.getRegistry();
+            final String error = f("Could not lookup WHOIS information for [%s] at [%s].", ip, rootCauseRegistry);
+            final WhoisLookupException whoisLookupException = new WhoisLookupException(error, e.getCause(), rootCauseRegistry);
             if (!LOG.isTraceEnabled()) {
                 LOG.error(error);
             }

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
@@ -61,7 +61,14 @@ public class WhoisIpLookup {
             final InternetRegistry causeRegistry = rootCause.getRegistry();
             final String error = f("Could not lookup WHOIS information for [%s] at [%s].", ip, causeRegistry);
             final WhoisLookupException whoisLookupException = new WhoisLookupException(error, e.getCause(), causeRegistry);
-            LOG.error(error, whoisLookupException);
+            if (!LOG.isTraceEnabled()) {
+                LOG.error(error);
+            }
+            else {
+                // Only include stack trace in debug mode. Avoids spamming logs with stack traces, since the stacktrace
+                // was not included in the past.
+                LOG.error(error, whoisLookupException);
+            }
             throw whoisLookupException;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisLookupException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisLookupException.java
@@ -1,0 +1,19 @@
+package org.graylog.plugins.threatintel.whois.ip;
+
+public class WhoisLookupException extends Exception {
+    private final InternetRegistry registry;
+
+    public WhoisLookupException(Throwable cause, InternetRegistry registry) {
+        super(cause);
+        this.registry = registry;
+    }
+
+    public WhoisLookupException(String message, Throwable cause, InternetRegistry registry) {
+        super(message, cause);
+        this.registry = registry;
+    }
+
+    public InternetRegistry getRegistry() {
+        return registry;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisLookupException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisLookupException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.threatintel.whois.ip;
 
 public class WhoisLookupException extends Exception {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix https://github.com/Graylog2/graylog2-server/issues/20571.

Fix over-reporting of error which occur during redirect chains. Previously, the `ERROR` log statement would be logged once for the erroring call, then it would be rethrown as the recursive call unwinded for every call below in the stack, resulting in extraneous error log statements. Now, the error logging is only being done once at the top-level for first erroring call.

For example:
> WhoisIpLookup - Could not lookup WHOIS information for [<IP>] at [LACNIC].

Also includes the proper lookup error in the look table response as well. 

```
{
  "single_value": "Lookup Error: Could not lookup WHOIS information for [<IP>] at [LACNIC].",
  "multi_value": {
    "value": "Lookup Error: Could not lookup WHOIS information for [<IP>] at [LACNIC]."
  },
  "string_list_value": null,
  "has_error": false,
  "ttl": 9223372036854776000
}
```

The exception still needs to be thrown in the `run` method, to ensure we are able to capture and log it (and return it in lookup error result). So, the the top-level error handling was added to dig out and surface only the cause error that initiated the exception.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/Graylog2/graylog2-server/issues/20571

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is a little tricky to test, since it requires testing whois lookups in cases where errors occur while following a redirect loop. The error condition can be simulated by reducing the timeout configured with the input.

See the support issue referenced below in the history for an example of an IP to use. With higher timeouts, the lookup should be successful. With lower timeouts (e.g. 250ms), only one error should logged (instead of the two as mentioned in the issue).