### PR TITLE
Make `latest` metric preserve type in frontend. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-21833.toml
+++ b/changelog/unreleased/issue-21833.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Make `latest` metric preserve field type of field used in frontend."
+
+pulls = ["21833"]
+issues = ["21837"]

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.ts
@@ -21,7 +21,7 @@ import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import FieldType, { FieldTypes } from './FieldType';
 import FieldTypeMapping from './FieldTypeMapping';
 
-const typePreservingFunctions = ['avg', 'min', 'max', 'percentile'];
+const typePreservingFunctions = ['avg', 'min', 'max', 'percentile', 'latest'];
 const constantTypeFunctions = {
   card: FieldTypes.LONG,
   count: FieldTypes.LONG,


### PR DESCRIPTION
**Note:** This is a backport of #21837 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR makes the `latest` metric preserve the type of the field it uses in the frontend. This fixes e.g. issues with timestamps not being formatted in the current user's timezone.

Fixes #21833

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.