### PR TITLE
Hide plotly notifier when zooming.

### DIFF
--- a/changelog/unreleased/issue-20833.toml
+++ b/changelog/unreleased/issue-20833.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Hiding zoom-out notifier when zooming in on graph."
+
+issues = ["20833"]
+pulls = ["21850"]

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useContext, useMemo, useCallback } from 'react';
-import styled, { css, useTheme, createGlobalStyle } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 import merge from 'lodash/merge';
 import type { Layout } from 'plotly.js';
 
@@ -55,12 +55,6 @@ const StyledPlot = styled(Plot)(
     }
   `,
 );
-
-const DisableNotifier = createGlobalStyle`
-  div.plotly-notifier {
-    visibility: hidden;
-  }
-`;
 
 export type OnClickMarkerEvent = {
   x: string;
@@ -120,7 +114,7 @@ const nonInteractiveLayout = {
 
 const style = { height: '100%', width: '100%' };
 
-const config = { displayModeBar: false, doubleClick: false as const, responsive: true };
+const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false };
 
 const usePlotLayout = (layout: Partial<Layout>) => {
   const theme = useTheme();
@@ -269,21 +263,18 @@ const GenericPlot = ({
   }, [onRenderComplete, onAfterPlot]);
 
   return (
-    <>
-      <DisableNotifier />
-      <StyledPlot
-        data={plotChartData}
-        useResizeHandler
-        layout={plotLayout}
-        style={style}
-        onAfterPlot={_onAfterPlot}
-        onClick={interactive ? _onMarkerClick : () => false}
-        onHover={_onHoverMarker}
-        onUnhover={onUnhoverMarker}
-        onRelayout={interactive ? _onRelayout : () => {}}
-        config={config}
-      />
-    </>
+    <StyledPlot
+      data={plotChartData}
+      useResizeHandler
+      layout={plotLayout}
+      style={style}
+      onAfterPlot={_onAfterPlot}
+      onClick={interactive ? _onMarkerClick : () => false}
+      onHover={_onHoverMarker}
+      onUnhover={onUnhoverMarker}
+      onRelayout={interactive ? _onRelayout : () => {}}
+      config={config}
+    />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -114,7 +114,7 @@ const nonInteractiveLayout = {
 
 const style = { height: '100%', width: '100%' };
 
-const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false };
+const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false } as const;
 
 const usePlotLayout = (layout: Partial<Layout>) => {
   const theme = useTheme();

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -209,7 +209,7 @@ const usePlotChartData = (
 const GenericPlot = ({
   chartData,
   layout = {},
-  setChartColor,
+  setChartColor = undefined,
   onClickMarker = () => {},
   onHoverMarker = () => {},
   onUnhoverMarker = () => {},

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useContext, useMemo, useCallback } from 'react';
-import styled, { css, useTheme } from 'styled-components';
+import styled, { css, useTheme, createGlobalStyle } from 'styled-components';
 import merge from 'lodash/merge';
 import type { Layout } from 'plotly.js';
 
@@ -35,10 +35,6 @@ export type PlotLayout = Layout;
 
 const StyledPlot = styled(Plot)(
   ({ theme }) => css`
-    div.plotly-notifier {
-      visibility: hidden;
-    }
-
     .customPopover .popover-content {
       padding: 0;
     }
@@ -59,6 +55,12 @@ const StyledPlot = styled(Plot)(
     }
   `,
 );
+
+const DisableNotifier = createGlobalStyle`
+  div.plotly-notifier {
+    visibility: hidden;
+  }
+`;
 
 export type OnClickMarkerEvent = {
   x: string;
@@ -267,18 +269,21 @@ const GenericPlot = ({
   }, [onRenderComplete, onAfterPlot]);
 
   return (
-    <StyledPlot
-      data={plotChartData}
-      useResizeHandler
-      layout={plotLayout}
-      style={style}
-      onAfterPlot={_onAfterPlot}
-      onClick={interactive ? _onMarkerClick : () => false}
-      onHover={_onHoverMarker}
-      onUnhover={onUnhoverMarker}
-      onRelayout={interactive ? _onRelayout : () => {}}
-      config={config}
-    />
+    <>
+      <DisableNotifier />
+      <StyledPlot
+        data={plotChartData}
+        useResizeHandler
+        layout={plotLayout}
+        style={style}
+        onAfterPlot={_onAfterPlot}
+        onClick={interactive ? _onMarkerClick : () => false}
+        onHover={_onHoverMarker}
+        onUnhover={onUnhoverMarker}
+        onRelayout={interactive ? _onRelayout : () => {}}
+        config={config}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is hiding the notifier that is shown when zooming in on a graph.

Fixes #20833.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.