### PR TITLE
Fix missing Query Parameters in Event Definitions in Content Packs (6.0)

### DIFF
--- a/changelog/unreleased/pr-21349.toml
+++ b/changelog/unreleased/pr-21349.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix missing Query Parameters in Event Definitions in Content Packs."
+
+issues = ["Graylog2/graylog-plugin-enterprise#9274"]
+pulls = ["21349"]

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/AggregationEventProcessorConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/AggregationEventProcessorConfigEntity.java
@@ -27,6 +27,7 @@ import com.google.common.graph.MutableGraph;
 import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.events.processor.aggregation.AggregationConditions;
 import org.graylog.events.processor.aggregation.AggregationEventProcessorConfig;
+import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.entities.Entity;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.graylog2.contentpacks.facades.StreamReferenceFacade.resolveStreamEntity;
@@ -53,6 +55,7 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
     public static final String TYPE_NAME = "aggregation-v1";
 
     private static final String FIELD_QUERY = "query";
+    private static final String FIELD_QUERY_PARAMETERS = "query_parameters";
     private static final String FIELD_FILTERS = "filters";
     private static final String FIELD_STREAMS = "streams";
     private static final String FIELD_GROUP_BY = "group_by";
@@ -64,6 +67,10 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
 
     @JsonProperty(FIELD_QUERY)
     public abstract ValueReference query();
+
+    @Nullable
+    @JsonProperty(FIELD_QUERY_PARAMETERS)
+    public abstract ImmutableSet<Parameter> queryParameters();
 
     @JsonProperty(FIELD_FILTERS)
     public abstract List<UsedSearchFilter> filters();
@@ -108,6 +115,9 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
 
         @JsonProperty(FIELD_QUERY)
         public abstract Builder query(ValueReference query);
+
+        @JsonProperty(FIELD_QUERY_PARAMETERS)
+        public abstract Builder queryParameters(Set<Parameter> queryParameters);
 
         @JsonProperty
         public abstract Builder filters(List<UsedSearchFilter> filters);
@@ -157,6 +167,7 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
         return AggregationEventProcessorConfig.builder()
                 .type(type())
                 .query(query().asString(parameters))
+                .queryParameters(queryParameters())
                 .streams(streamSet)
                 .filters(ImmutableList.copyOf(filters()))
                 .groupBy(groupBy())

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -80,6 +80,7 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
     @JsonProperty(FIELD_QUERY)
     public abstract String query();
 
+    @Nullable
     @JsonProperty(FIELD_QUERY_PARAMETERS)
     public abstract ImmutableSet<Parameter> queryParameters();
 
@@ -277,6 +278,7 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         return AggregationEventProcessorConfigEntity.builder()
                 .type(type())
                 .query(ValueReference.of(query()))
+                .queryParameters(queryParameters())
                 .filters(ImmutableList.copyOf(filters()))
                 .streams(streamRefs)
                 .groupBy(groupBy())
@@ -297,6 +299,11 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
                     .build();
             mutableGraph.putEdge(entityDescriptor, depStream);
         });
+        // attribute is tagged @Nullable, so do a null check first
+        if(queryParameters() != null) {
+            queryParameters().forEach(parameter -> parameter.resolveNativeEntity(entityDescriptor, mutableGraph));
+        }
+        filters().forEach(filter -> filter.resolveNativeEntity(entityDescriptor, mutableGraph));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -303,7 +303,6 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         if(queryParameters() != null) {
             queryParameters().forEach(parameter -> parameter.resolveNativeEntity(entityDescriptor, mutableGraph));
         }
-        filters().forEach(filter -> filter.resolveNativeEntity(entityDescriptor, mutableGraph));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Parameter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Parameter.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Maps;
+import org.graylog2.contentpacks.ContentPackable;
+import org.graylog2.contentpacks.EntityDescriptorIds;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -41,7 +43,7 @@ import java.util.Objects;
         property = Parameter.TYPE_FIELD,
         visible = true,
         defaultImpl = ValueParameter.class)
-public interface Parameter {
+public interface Parameter extends ContentPackable<Parameter> {
     String TYPE_FIELD = "type";
 
     @JsonProperty(TYPE_FIELD)
@@ -73,6 +75,10 @@ public interface Parameter {
     Binding binding();
 
     Parameter applyBindings(Map<String,  Parameter.Binding> bindings);
+
+    default Parameter toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        return this;
+    }
 
     interface Builder<SELF> {
         @JsonProperty(TYPE_FIELD)

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -76,6 +76,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
     @VisibleForTesting
     Entity exportNativeEntity(LookupTableDto lookupTableDto, EntityDescriptorIds entityDescriptorIds) {
         final String tableId = entityDescriptorIds.get(EntityDescriptor.create(lookupTableDto.id(), ModelTypes.LOOKUP_TABLE_V1))
+                .or(() -> entityDescriptorIds.get(EntityDescriptor.create(lookupTableDto.name(), ModelTypes.LOOKUP_TABLE_V1)))
                 .orElseThrow(() -> new ContentPackException("Couldn't find lookup table entity " + lookupTableDto.id()));
         final String cacheId = entityDescriptorIds.get(cacheDescriptor(lookupTableDto.cacheId()))
                 .orElseThrow(() -> new ContentPackException("Couldn't find lookup cache entity " + lookupTableDto.cacheId()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**backport of https://github.com/Graylog2/graylog2-server/pull/21349**

Prior to this PR, when exporting an event definition into a content pack, parameter definitions were missing from the content pack and so could not be restored on import. This PR fixes the bug.

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9274

This change also selects a dependent Lookup Table + Cache & Adapter 

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9877

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

