### PR TITLE
Deprecate PersistedServiceImpl

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/PersistedServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PersistedServiceImpl.java
@@ -42,6 +42,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Legacy implementation of PersistedService.
+ *
+ * <p>This implementation is being phased out in favor of Jackson-based MongoDB serialization.
+ * New code should use MongoCollections instead of this class.</p>
+ *
+ * @see org.graylog2.database.MongoCollections
+ */
+@Deprecated(since = "6.2.0", forRemoval = true)
 public class PersistedServiceImpl implements PersistedService {
     private static final Logger LOG = LoggerFactory.getLogger(PersistedServiceImpl.class);
     public final MongoConnection mongoConnection;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/database/PersistedService.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/database/PersistedService.java
@@ -23,6 +23,19 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Interface for persistent data services.
+ *
+ * <p><strong>IMPLEMENTATION NOTICE:</strong> This interface is considered legacy code and should not be
+ * implemented by new services. Existing implementations and callers can continue using it without
+ * changes. For new persistence services, please use the MongoDB storage based on Jackson serialization
+ * via {@code MongoCollections} instead.</p>
+ *
+ * <p>The traditional MongoDB access in this interface will be phased out in favor of the more
+ * type-safe Jackson-based serialization approach.</p>
+ *
+ * @see org.graylog2.database.MongoCollections
+ */
 public interface PersistedService {
     <T extends Persisted> int destroy(T model);
 


### PR DESCRIPTION
Deprecating `PersistedServiceImpl` to encourage developers to move away from it.

I decided against deprecating `PersistedService` itself because that would generate deprecation warnings for callers.

/nocl
