### PR TITLE
Set default User-Agent in HTTP client to "Graylog"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -85,6 +85,9 @@ public abstract class BaseConfiguration extends PathConfiguration implements Com
     @Parameter("disable_native_system_stats_collector")
     private boolean disableNativeSystemStatsCollector = false;
 
+    @Parameter(value = "http_user_agent")
+    private String httpUserAgent = "Graylog";
+
     @Parameter(value = "http_proxy_uri")
     private URI httpProxyUri;
 
@@ -177,6 +180,10 @@ public abstract class BaseConfiguration extends PathConfiguration implements Com
 
     public boolean isDisableNativeSystemStatsCollector() {
         return disableNativeSystemStatsCollector;
+    }
+
+    public String getHttpUserAgent() {
+        return httpUserAgent;
     }
 
     public URI getHttpProxyUri() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -18,9 +18,15 @@ package org.graylog2.shared.bindings.providers;
 
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.base.Splitter;
+import com.google.common.net.HttpHeaders;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
 import okhttp3.Authenticator;
 import okhttp3.Challenge;
 import okhttp3.Credentials;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -31,12 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Provider;
-import jakarta.inject.Singleton;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -51,6 +51,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Provider for a configured {@link okhttp3.OkHttpClient}.
  *
+ * @see org.graylog2.plugin.BaseConfiguration#getHttpUserAgent()
  * @see org.graylog2.plugin.BaseConfiguration#getHttpConnectTimeout()
  * @see org.graylog2.plugin.BaseConfiguration#getHttpReadTimeout()
  * @see org.graylog2.plugin.BaseConfiguration#getHttpWriteTimeout()
@@ -59,6 +60,25 @@ import static java.util.Objects.requireNonNull;
 @Singleton
 public class OkHttpClientProvider implements Provider<OkHttpClient> {
     private static final Logger LOG = LoggerFactory.getLogger(OkHttpClientProvider.class);
+
+    static class UserAgentInterceptor implements Interceptor {
+        private final String userAgent;
+
+        public UserAgentInterceptor(String userAgent) {
+            this.userAgent = userAgent;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request originalRequest = chain.request();
+            Request newRequest = originalRequest.newBuilder()
+                    .header(HttpHeaders.USER_AGENT, userAgent)
+                    .build();
+            return chain.proceed(newRequest);
+        }
+    }
+
+    protected final String userAgent;
     protected final Duration connectTimeout;
     protected final Duration readTimeout;
     protected final Duration writeTimeout;
@@ -67,12 +87,14 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
     private final ProxySelectorProvider proxySelectorProvider;
 
     @Inject
-    public OkHttpClientProvider(@Named("http_connect_timeout") Duration connectTimeout,
+    public OkHttpClientProvider(@Named("http_user_agent") String userAgent,
+                                @Named("http_connect_timeout") Duration connectTimeout,
                                 @Named("http_read_timeout") Duration readTimeout,
                                 @Named("http_write_timeout") Duration writeTimeout,
                                 @Named("http_proxy_uri") @Nullable URI httpProxyUri,
                                 TrustManagerAndSocketFactoryProvider trustManagerAndSocketFactoryProvider,
                                 ProxySelectorProvider proxySelectorProvider) {
+        this.userAgent = requireNonNull(userAgent);
         this.connectTimeout = requireNonNull(connectTimeout);
         this.readTimeout = requireNonNull(readTimeout);
         this.writeTimeout = requireNonNull(writeTimeout);
@@ -85,6 +107,7 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
     public OkHttpClient get() {
         final OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
                 .retryOnConnectionFailure(true)
+                .addInterceptor(new UserAgentInterceptor(userAgent))
                 .connectTimeout(connectTimeout.getQuantity(), connectTimeout.getUnit())
                 .writeTimeout(writeTimeout.getQuantity(), writeTimeout.getUnit())
                 .readTimeout(readTimeout.getQuantity(), readTimeout.getUnit());

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -291,11 +291,11 @@ public class OkHttpClientProviderTest {
         final ProxySelectorProvider proxyProvider = new ProxySelectorProvider(server.url("/").uri(), null);
         ProxySelectorProvider spyProxyProvider = Mockito.spy(proxyProvider);
         final OkHttpClientProvider provider = new OkHttpClientProvider(
+                "GraylogTest",
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
-                server.url("/").uri(),
-                null, spyProxyProvider);
+                server.url("/").uri(), null, spyProxyProvider);
 
         OkHttpClientProvider spyClientProvider = Mockito.spy(provider);
 
@@ -310,6 +310,14 @@ public class OkHttpClientProviderTest {
                 .hasSize(1)
                 .first()
                 .matches(proxy -> proxy.equals(testProxy));
+    }
+
+    @Test
+    public void testUserAgent() throws IOException, InterruptedException {
+        server.enqueue(successfulMockResponse());
+        client(server.url("/").uri()).newCall(request()).execute();
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getHeader(HttpHeaders.USER_AGENT)).isEqualTo("GraylogTest");
     }
 
     private MockResponse successfulMockResponse() {
@@ -334,11 +342,11 @@ public class OkHttpClientProviderTest {
 
     private OkHttpClient client(URI proxyURI) {
         final OkHttpClientProvider provider = new OkHttpClientProvider(
+                "GraylogTest",
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
-                proxyURI,
-                null, new ProxySelectorProvider(proxyURI, null));
+                proxyURI, null, new ProxySelectorProvider(proxyURI, null));
 
         return provider.get();
     }

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ParameterizedHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/ParameterizedHttpClientProviderTest.java
@@ -142,11 +142,11 @@ public class ParameterizedHttpClientProviderTest {
 
     private OkHttpClientProvider client(URI proxyURI) {
         final OkHttpClientProvider provider = new OkHttpClientProvider(
+                "GraylogTest",
                 Duration.milliseconds(500L),
                 Duration.milliseconds(500L),
                 Duration.milliseconds(500L),
-                proxyURI,
-                null, null);
+                proxyURI, null, null);
 
         return provider;
     }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -624,6 +624,10 @@ mongodb_max_connections = 1000
 # This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
 #transport_email_web_interface_url = https://graylog.example.com
 
+# The User-Agent header for outgoing HTTP connections.
+# Default: Graylog
+#http_user_agent = Graylog
+
 # The default connect timeout for outgoing HTTP connections.
 # Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
 # Default: 5s


### PR DESCRIPTION
## Description

Introduce a new `http_user_agent` config option, with `Graylog` as the default value.

## Motivation and Context

When sending alert notifications, the Graylog server includes the HTTP client name (`okhttp`) and version in the `User-Agent` header. This information can be used by attackers to fingerprint the Graylog server’s HTTP client and craft targeted exploits. 

This PR changes the default `User-Agent` to `Graylog`.

## How Has This Been Tested?

- Added test case to `OkHttpClientProviderTest`
- Manual HTTP notification tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl