### PR TITLE
Hide plotly notifier when zooming. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-20833.toml
+++ b/changelog/unreleased/issue-20833.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Hiding zoom-out notifier when zooming in on graph."
+
+issues = ["20833"]
+pulls = ["21850"]

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -237,18 +237,16 @@ const GenericPlot = ({ chartData, layout, setChartColor, onClickMarker, onHoverM
   }, [onRenderComplete, onAfterPlot]);
 
   return (
-    <StyledPlot
-      data={plotChartData}
-      useResizeHandler
-      layout={plotLayout}
-      style={style}
-      onAfterPlot={_onAfterPlot}
-      onClick={interactive ? _onMarkerClick : () => false}
-      onHover={_onHoverMarker}
-      onUnhover={onUnhoverMarker}
-      onRelayout={interactive ? _onRelayout : () => {}}
-      config={config}
-    />
+    <StyledPlot data={plotChartData}
+                useResizeHandler
+                layout={plotLayout}
+                style={style}
+                onAfterPlot={_onAfterPlot}
+                onClick={interactive ? _onMarkerClick : () => false}
+                onHover={_onHoverMarker}
+                onUnhover={onUnhoverMarker}
+                onRelayout={interactive ? _onRelayout : () => {}}
+                config={config} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -33,20 +33,17 @@ import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
 export type PlotLayout = Layout
 
-const StyledPlot = styled(Plot)(({ theme }) => css`
-  div.plotly-notifier {
-    visibility: hidden;
-  }
-
-  .customPopover .popover-content {
-    padding: 0;
-  }
-  
-  .hoverlayer .hovertext {
-    rect {
-      fill: ${theme.colors.global.contentBackground} !important;
-      opacity: 0.9 !important;
+const StyledPlot = styled(Plot)(
+  ({ theme }) => css`
+    .customPopover .popover-content {
+      padding: 0;
     }
+
+    .hoverlayer .hovertext {
+      rect {
+        fill: ${theme.colors.global.contentBackground} !important;
+        opacity: 0.9 !important;
+      }
 
     .name {
       fill: ${theme.colors.global.textDefault} !important;
@@ -116,7 +113,7 @@ const nonInteractiveLayout = {
 
 const style = { height: '100%', width: '100%' };
 
-const config = { displayModeBar: false, doubleClick: false as const, responsive: true };
+const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false };
 
 const usePlotLayout = (layout: Partial<Layout>) => {
   const theme = useTheme();
@@ -240,16 +237,18 @@ const GenericPlot = ({ chartData, layout, setChartColor, onClickMarker, onHoverM
   }, [onRenderComplete, onAfterPlot]);
 
   return (
-    <StyledPlot data={plotChartData}
-                useResizeHandler
-                layout={plotLayout}
-                style={style}
-                onAfterPlot={_onAfterPlot}
-                onClick={interactive ? _onMarkerClick : () => false}
-                onHover={_onHoverMarker}
-                onUnhover={onUnhoverMarker}
-                onRelayout={interactive ? _onRelayout : () => {}}
-                config={config} />
+    <StyledPlot
+      data={plotChartData}
+      useResizeHandler
+      layout={plotLayout}
+      style={style}
+      onAfterPlot={_onAfterPlot}
+      onClick={interactive ? _onMarkerClick : () => false}
+      onHover={_onHoverMarker}
+      onUnhover={onUnhoverMarker}
+      onRelayout={interactive ? _onRelayout : () => {}}
+      config={config}
+    />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -113,7 +113,7 @@ const nonInteractiveLayout = {
 
 const style = { height: '100%', width: '100%' };
 
-const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false };
+const config = { displayModeBar: false, doubleClick: false, responsive: true, showTips: false } as const;
 
 const usePlotLayout = (layout: Partial<Layout>) => {
   const theme = useTheme();


### PR DESCRIPTION
**Note:** This is a backport of #21850 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is hiding the notifier that is shown when zooming in on a graph.

Fixes #20833.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.