### PR TITLE
Define position in navigation for enterprise and security nav item.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/DefaultEnterpriseNavItem.ts
+++ b/graylog2-web-interface/src/components/navigation/DefaultEnterpriseNavItem.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import { DASHBOARDS_LINK_TITLE } from 'components/navigation/bindings';
+import Routes from 'routing/Routes';
+
+const DefaultEnterpriseNavItem = {
+  description: 'Enterprise',
+  position: { after: DASHBOARDS_LINK_TITLE },
+  path: Routes.SYSTEM.ENTERPRISE,
+};
+
+export default DefaultEnterpriseNavItem;

--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -21,13 +21,13 @@ import type { PluginNavigation } from 'graylog-web-plugin';
 
 import { Nav } from 'components/bootstrap';
 import { isPermitted } from 'util/PermissionsMixin';
-import Routes, { ENTERPRISE_ROUTE_DESCRIPTION, SECURITY_ROUTE_DESCRIPTION } from 'routing/Routes';
 import filterByPerspective from 'components/perspectives/util/filterByPerspective';
 import useCurrentUser from 'hooks/useCurrentUser';
 import useActivePerspective from 'components/perspectives/hooks/useActivePerspective';
 import usePluginEntities from 'hooks/usePluginEntities';
-import { navigation as securityNavigation } from 'components/security/bindings';
 import NavigationItem from 'components/navigation/NavigationItem';
+import { DEFAULT_SECURITY_NAV_ITEM } from 'components/security/bindings';
+import DEFAULT_ENTERPRISE_NAV_ITEM from 'components/navigation/DefaultEnterpriseNavItem';
 
 const _existingDropdownItemIndex = (
   existingNavigationItems: Array<PluginNavigation>,
@@ -108,17 +108,14 @@ const useNavigationItems = () => {
 
   return useMemo(() => {
     const navigationItems = mergeDuplicateDropdowns(allNavigationItems);
-    const enterpriseMenuIsMissing = !pluginMenuItemExists(navigationItems, ENTERPRISE_ROUTE_DESCRIPTION);
-    const securityMenuIsMissing = !pluginMenuItemExists(navigationItems, SECURITY_ROUTE_DESCRIPTION);
-    const securityLicenseInvalid = !pluginLicenseValid(navigationItems, SECURITY_ROUTE_DESCRIPTION);
+    const enterpriseMenuIsMissing = !pluginMenuItemExists(navigationItems, DEFAULT_ENTERPRISE_NAV_ITEM.description);
+    const securityMenuIsMissing = !pluginMenuItemExists(navigationItems, DEFAULT_SECURITY_NAV_ITEM.description);
+    const securityLicenseInvalid = !pluginLicenseValid(navigationItems, DEFAULT_SECURITY_NAV_ITEM.description);
     const isPermittedToEnterpriseOrSecurity = isPermitted(permissions, ['licenseinfos:read']);
 
     if (enterpriseMenuIsMissing && isPermittedToEnterpriseOrSecurity) {
       // no enterprise plugin menu, so we will add one
-      navigationItems.push({
-        path: Routes.SYSTEM.ENTERPRISE,
-        description: ENTERPRISE_ROUTE_DESCRIPTION,
-      });
+      navigationItems.push(DEFAULT_ENTERPRISE_NAV_ITEM);
     }
 
     if ((securityMenuIsMissing && isPermittedToEnterpriseOrSecurity) || securityLicenseInvalid) {
@@ -126,12 +123,12 @@ const useNavigationItems = () => {
       if (!securityMenuIsMissing) {
         // remove the existing security menu item
         navigationItems.splice(
-          navigationItems.findIndex((item) => item.description === SECURITY_ROUTE_DESCRIPTION),
+          navigationItems.findIndex((item) => item.description === DEFAULT_SECURITY_NAV_ITEM.description),
           1,
         );
       }
 
-      navigationItems.push(securityNavigation);
+      navigationItems.push(DEFAULT_SECURITY_NAV_ITEM);
     }
 
     const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective?.id);

--- a/graylog2-web-interface/src/components/navigation/bindings.ts
+++ b/graylog2-web-interface/src/components/navigation/bindings.ts
@@ -23,6 +23,7 @@ import AppConfig from 'util/AppConfig';
 
 export const SYSTEM_DROPDOWN_TITLE = 'System';
 export const SEARCH_LINK_TITLE = 'Search';
+export const DASHBOARDS_LINK_TITLE = 'Dashboards';
 
 const navigationBindings: PluginExports = {
   navigation: [
@@ -40,7 +41,7 @@ const navigationBindings: PluginExports = {
     },
     {
       path: Routes.DASHBOARDS,
-      description: 'Dashboards',
+      description: DASHBOARDS_LINK_TITLE,
     },
     {
       description: SYSTEM_DROPDOWN_TITLE,

--- a/graylog2-web-interface/src/components/security/bindings.ts
+++ b/graylog2-web-interface/src/components/security/bindings.ts
@@ -16,15 +16,17 @@
  */
 import type { PluginExports } from 'graylog-web-plugin/plugin';
 
-import Routes, { SECURITY_PATH, SECURITY_ROUTE_DESCRIPTION } from 'routing/Routes';
+import Routes, { SECURITY_PATH } from 'routing/Routes';
 import SecurityPageEntry from 'components/security/SecurityPageEntry';
+import DEFAULT_ENTERPRISE_NAV_ITEM from 'components/navigation/DefaultEnterpriseNavItem';
 
 const routes = [
   { path: `${SECURITY_PATH}/*`, component: SecurityPageEntry, parentComponent: ({ children }) => children },
 ];
 
-export const navigation = {
-  description: SECURITY_ROUTE_DESCRIPTION,
+export const DEFAULT_SECURITY_NAV_ITEM = {
+  description: 'Security',
+  position: { after: DEFAULT_ENTERPRISE_NAV_ITEM.description },
   children: [
     { path: Routes.SECURITY.OVERVIEW, description: 'Overview' },
     { path: Routes.SECURITY.USER_ACTIVITY, description: 'User Activity' },

--- a/graylog2-web-interface/src/routing/Routes.ts
+++ b/graylog2-web-interface/src/routing/Routes.ts
@@ -465,13 +465,6 @@ const pluginRoute = (routeKey: string, throwError: boolean = true) => {
 
 const getPluginRoute = (routeKey: string) => pluginRoute(routeKey, false);
 
-/**
- * Exported constants for using strings to check if a plugin is registered by its description.
- *
- */
-export const ENTERPRISE_ROUTE_DESCRIPTION = 'Enterprise';
-export const SECURITY_ROUTE_DESCRIPTION = 'Security';
-
 const defaultExport = Object.assign(qualifiedRoutes, { pluginRoute, getPluginRoute, unqualified });
 
 export default defaultExport;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the order of navigation items in the DOM is based on the order items get registered in the plugin store.
With this PR we are making use of the functionality added with https://github.com/Graylog2/graylog2-server/pull/21827 to define specific positions for the enterprise and security nav item.

/nocl
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9887