### PR TITLE
Allow specifying `onClickMarker` for `XYPlot`.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -28,9 +28,10 @@ import assertUnreachable from 'logic/assertUnreachable';
 import useViewsDispatch from 'views/stores/useViewsDispatch';
 
 import GenericPlot from './GenericPlot';
-import type { ChartColor, ChartConfig, PlotLayout } from './GenericPlot';
+import type { ChartConfig, PlotLayout } from './GenericPlot';
 import OnZoom from './OnZoom';
 
+type GenericPlotProps = React.ComponentProps<typeof GenericPlot>;
 export type Props = {
   axisType?: AxisType;
   config: AggregationWidgetConfig;
@@ -41,9 +42,10 @@ export type Props = {
   };
   height: number;
   width: number;
-  setChartColor?: (config: ChartConfig, color: ColorMapper) => ChartColor;
+  setChartColor?: GenericPlotProps['setChartColor'];
   plotLayout?: Partial<PlotLayout>;
   onZoom?: (from: string, to: string, userTimezone: string) => boolean;
+  onClickMarker?: GenericPlotProps['onClickMarker'];
 };
 
 const yLegendPosition = (containerHeight: number) => {
@@ -83,6 +85,7 @@ const XYPlot = ({
   width,
   plotLayout = {},
   onZoom = undefined,
+  onClickMarker = undefined,
 }: Props) => {
   const { formatTime, userTimezone } = useUserDateTime();
   const yaxis = { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: mapAxisType(axisType) } as const;
@@ -124,7 +127,7 @@ const XYPlot = ({
 
   return (
     <PlotLegend config={config} chartData={chartData} height={height} width={width}>
-      <GenericPlot chartData={chartData} layout={layout} onZoom={_onZoom} setChartColor={setChartColor} />
+      <GenericPlot chartData={chartData} layout={layout} onZoom={_onZoom} setChartColor={setChartColor} onClickMarker={onClickMarker} />
     </PlotLegend>
   );
 };

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { mount } from 'wrappedEnzyme';
+import { render, waitFor } from 'wrappedTestingLibrary';
 
 import mockComponent from 'helpers/mocking/MockComponent';
 import asMock from 'helpers/mocking/AsMock';
@@ -33,8 +33,9 @@ import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import { createSearch } from 'fixtures/searches';
 import { setTimerange } from 'views/logic/slices/viewSlice';
+import GenericPlot from 'views/components/visualizations/GenericPlot';
 
-jest.mock('../GenericPlot', () => mockComponent('GenericPlot'));
+jest.mock('../GenericPlot', () => jest.fn(mockComponent('GenericPlot')));
 jest.mock('views/logic/queries/useCurrentQuery');
 jest.mock('views/logic/queries/useCurrentQueryId');
 jest.mock('views/hooks/useViewType');
@@ -88,96 +89,109 @@ describe('XYPlot', () => {
     asMock(useCurrentQuery).mockReturnValue(defaultCurrentQuery);
     asMock(useCurrentQueryId).mockReturnValue(defaultCurrentQuery.id);
     asMock(useViewType).mockReturnValue(View.Type.Search);
+    jest.clearAllMocks();
   });
 
   it('renders generic X/Y-Plot when no timeline config is passed', () => {
     const emptyConfig = AggregationWidgetConfig.builder().build();
     const timerange = { from: 'foo', to: 'bar', type: 'absolute' };
-    const wrapper = mount(<SimpleXYPlot effectiveTimerange={timerange} config={emptyConfig} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot effectiveTimerange={timerange} config={emptyConfig} />);
 
-    expect(genericPlot).toHaveProp('layout', {
-      yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: 'linear' },
-      xaxis: { fixedrange: true },
-      hovermode: 'x',
-      legend: { y: -0.14 },
-    });
+    expect(GenericPlot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layout: {
+          yaxis: { fixedrange: true, rangemode: 'tozero', tickformat: ',~r', type: 'linear' },
+          xaxis: { fixedrange: true },
+          hovermode: 'x',
+          legend: { y: -0.14 },
+        },
+        chartData: expect.anything(),
+      }),
+      expect.anything(),
+    );
 
-    expect(genericPlot).toHaveProp('chartData', chartData);
-
-    genericPlot.get(0).props.onZoom('from', 'to');
+    const { onZoom } = asMock(GenericPlot).mock.calls[0][0];
+    onZoom('from', 'to');
 
     expect(setTimerange).not.toHaveBeenCalled();
   });
 
-  it('adds zoom handler for timeline plot', () => {
+  it('adds zoom handler for timeline plot', async () => {
     const timerange = { from: '2018-10-12T02:04:21.723Z', to: '2018-10-12T10:04:21.723Z', type: 'absolute' };
-    const wrapper = mount(<SimpleXYPlot effectiveTimerange={timerange} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot effectiveTimerange={timerange} />);
 
-    expect(genericPlot).toHaveProp(
-      'layout',
+    expect(GenericPlot).toHaveBeenCalledWith(
       expect.objectContaining({
-        xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
+        'layout': expect.objectContaining({
+          xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
+        }),
       }),
+      {},
     );
 
-    genericPlot.get(0).props.onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
+    const { onZoom } = asMock(GenericPlot).mock.calls[0][0];
+    onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
 
-    expect(setTimerange).toHaveBeenCalledWith('dummyquery', {
-      type: 'absolute',
-      from: '2018-10-12T04:04:21.723+00:00',
-      to: '2018-10-12T08:04:21.723+00:00',
+    await waitFor(() => {
+      expect(setTimerange).toHaveBeenCalledWith('dummyquery', {
+        type: 'absolute',
+        from: '2018-10-12T04:04:21.723+00:00',
+        to: '2018-10-12T08:04:21.723+00:00',
+      });
     });
   });
 
   it('uses effective time range from pivot result if all messages are selected', () => {
     const timerange = { from: '2018-10-12T02:04:21.723Z', to: '2018-10-12T10:04:21.723Z', type: 'absolute' };
     const currentQueryForAllMessages = defaultCurrentQuery.toBuilder().timerange(ALL_MESSAGES_TIMERANGE).build();
-    const wrapper = mount(<SimpleXYPlot effectiveTimerange={timerange} currentQuery={currentQueryForAllMessages} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot effectiveTimerange={timerange} currentQuery={currentQueryForAllMessages} />);
 
-    expect(genericPlot).toHaveProp(
-      'layout',
+    expect(GenericPlot).toHaveBeenCalledWith(
       expect.objectContaining({
-        xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
+        'layout': expect.objectContaining({
+          xaxis: { range: ['2018-10-12T04:04:21.723+02:00', '2018-10-12T12:04:21.723+02:00'], type: 'date' },
+        }),
       }),
+      {},
     );
   });
 
   it('sets correct plot legend position for small containers', () => {
-    const wrapper = mount(<SimpleXYPlot height={140} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot height={140} />);
 
-    expect(genericPlot).toHaveProp(
-      'layout',
+    expect(GenericPlot).toHaveBeenCalledWith(
       expect.objectContaining({
-        legend: { y: -0.6 },
+        'layout': expect.objectContaining({
+          legend: { y: -0.6 },
+        }),
       }),
+      {},
     );
   });
 
   it('sets correct plot legend position for containers with medium height', () => {
-    const wrapper = mount(<SimpleXYPlot height={350} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot height={350} />);
 
-    expect(genericPlot).toHaveProp(
-      'layout',
+    expect(GenericPlot).toHaveBeenCalledWith(
       expect.objectContaining({
-        legend: { y: -0.2 },
+        'layout': expect.objectContaining({
+          legend: { y: -0.2 },
+        }),
       }),
+      {},
     );
   });
 
   it('sets correct plot legend position for containers with huge height', () => {
-    const wrapper = mount(<SimpleXYPlot height={700} />);
-    const genericPlot = wrapper.find('GenericPlot');
+    render(<SimpleXYPlot height={700} />);
 
-    expect(genericPlot).toHaveProp(
-      'layout',
+    expect(GenericPlot).toHaveBeenCalledWith(
       expect.objectContaining({
-        legend: { y: -0.14 },
+        'layout': expect.objectContaining({
+          legend: { y: -0.14 },
+        }),
       }),
+      {},
     );
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -194,4 +194,13 @@ describe('XYPlot', () => {
       {},
     );
   });
+
+  it('allows passing `onClickMarker` callback', async () => {
+    const onClick = jest.fn();
+    render(<SimpleXYPlot onClickMarker={onClick} />);
+    const { onClickMarker } = asMock(GenericPlot).mock.calls[0][0];
+    onClickMarker({ x: 'Foo', y: '23' });
+
+    expect(onClick).toHaveBeenCalledWith({ x: 'Foo', y: '23' });
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows passing an `onClickMarker` prop to the `XYPlot` component which is passed through to `GenericPlot`, enabling a consumer of the component to define a callback that is called when an element in the chart is clicked.

/nocl Internal Refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.