### PR TITLE
Throw error if attribute is not registered when fetching titles.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityFilters/hooks/useFiltersWithTitle.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/hooks/useFiltersWithTitle.ts
@@ -131,6 +131,11 @@ const _allFiltersWithTitle = (
 ): Filters =>
   urlQueryFilters.entrySeq().reduce((col, [attributeId, filterValues]) => {
     const relatedAttribute = attributesMetaData?.find(({ id }) => id === attributeId);
+    if (!relatedAttribute) {
+      throw new Error(
+        `Found value for attribute "${attributeId}", which is not in list of registered attributes: ${attributesMetaData?.map(({ id }) => id).join(', ')} - typo in attribute name?`,
+      );
+    }
     const filtersWithTitle: Array<Filter> = filterValues.map((value) => {
       const title = filterTitle(
         relatedAttribute,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a small improvement for working with paginated entity data table, so that when an attribute filter is set, but when retrieving titles, the attribute id is not in the list of registered attributes, an error will be thrown. 

Previously, it was handled gracefully at this point, but threw a seemingly unrelated exception later. This is very confusing when the underlying error is e.g. a misspelling of the attribute name. Throwing an explicit error here makes debugging much easier.

/nocl Internal addition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.