### PR TITLE
Fix line-height of dropdown buttons in main navbar.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -35,7 +35,6 @@ const DropdownTrigger = styled.button<{ $active: boolean }>(
     border: 0;
     padding: 0 15px;
     min-height: ${NAV_ITEM_HEIGHT};
-    line-height: ${theme.fonts.lineHeight.body};
 
     &:hover,
     &:focus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This small fix unifies the line-height of links and dropdown buttons in the main navbar. Before this change the dropdown buttons had a slightly different line-height.

Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/bf1eaa21-4019-45b4-b5dc-16d23d0bbc67" />

After:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/fb638042-cba2-42ca-99fe-94b3cd58be21" />


/nocl