### PR TITLE
Fix display of encrypted configuration values for inputs

### DIFF
--- a/changelog/unreleased/pr-21927.toml
+++ b/changelog/unreleased/pr-21927.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix display of encrypted configuration values for inputs."
+
+pulls = ["21927"]

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.tsx
@@ -88,8 +88,7 @@ const EncryptedField = ({ id, value, name }: { id: string; value: EncryptedField
 
 const PasswordField = ({ id, name }: { id: string; name: string }) => (
   <li key={`${id}-${name}`}>
-    <div className="key">{name}:</div>
-    <div className="value">{PASSWORD_PLACEHOLDER}</div>
+    <div className="key">{name}:</div> <div className="value">{PASSWORD_PLACEHOLDER}</div>
   </li>
 );
 
@@ -115,12 +114,12 @@ const Configuration = ({
       const value = config[key];
       const requestedConfiguration = typeDefinition?.requested_configuration?.[key];
 
-      if (isPasswordField(requestedConfiguration)) {
-        return <PasswordField id={_id} name={key} />;
-      }
-
       if (requestedConfiguration && 'is_encrypted' in requestedConfiguration && requestedConfiguration.is_encrypted) {
         return <EncryptedField id={_id} value={value as EncryptedFieldValue<unknown>} name={key} />;
+      }
+
+      if (isPasswordField(requestedConfiguration)) {
+        return <PasswordField id={_id} name={key} />;
       }
 
       if (requestedConfiguration?.type === 'inline_binary') {


### PR DESCRIPTION
Fix the display of encrypted input values that also have the IS_PASSWORD attribute. We now first check if a field is an encrypted value before checking the IS_PASSWORD status.

This fixes an issue where an empty encrypted input value was shown as `****` instead of `<empty>` on the inputs page.

Also, add a space between the input label and the masked value for password fields.

## Screenshots

### Before

Set and unset values look the same.

![2025-03-10_10-37](https://github.com/user-attachments/assets/7844d400-683e-4f38-92ee-e3e881510e63)

### After

Unset value:

![2025-03-10_10-37_1](https://github.com/user-attachments/assets/3a3bab38-1829-4f16-a0a9-8945ea00a13e)

Set value:

![2025-03-10_10-38](https://github.com/user-attachments/assets/c157dc1b-7ddd-473c-9316-2286bf0a9795)
