### PR TITLE
From now on, admin cannot cancel/load other users' jobs via Search API

### DIFF
--- a/changelog/unreleased/pr-21932.toml
+++ b/changelog/unreleased/pr-21932.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Admin user can no longer cancel search jobs of other users."
+
+issues = ["Graylog2/graylog-plugin-enterprise#9926"]
+pulls = ["21932"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchJobService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchJobService.java
@@ -43,6 +43,6 @@ public interface SearchJobService {
     boolean isInCache(final String jobId);
 
     default boolean hasPermissionToAccessJob(final SearchUser searchUser, final String jobOwner) {
-        return jobOwner.equals(searchUser.username()) || searchUser.isAdmin();
+        return jobOwner.equals(searchUser.username());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/InMemorySearchJobServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/InMemorySearchJobServiceTest.java
@@ -57,15 +57,6 @@ public class InMemorySearchJobServiceTest {
     }
 
     @Test
-    public void testAdminCanLoadJobOfDifferentUser() {
-        final SearchJob jannettesJob = toTest.create(Search.builder().build(), "Jannette", NO_CANCELLATION);
-        final Optional<SearchJobDTO> retrievedJob = toTest.load(jannettesJob.getId(), adminUser("Clara"));
-        Assertions.assertThat(retrievedJob)
-                .isPresent()
-                .hasValue(SearchJobDTO.fromSearchJob(jannettesJob));
-    }
-
-    @Test
     public void testReturnsEmptyOptionalWhenTryingToLoadNonExistingJob() {
         final Optional<SearchJobDTO> retrievedJob = toTest.load("Guadalajara!", null);
         Assertions.assertThat(retrievedJob)
@@ -78,9 +69,4 @@ public class InMemorySearchJobServiceTest {
                 .build();
     }
 
-    private SearchUser adminUser(final String username) {
-        return TestSearchUser.builder()
-                .withUser(u -> u.withUsername(username).isLocalAdmin(true))
-                .build();
-    }
 }


### PR DESCRIPTION
## Description
From now on, admin cannot cancel/load other users' jobs via Search API.
/jpd Graylog2/graylog-plugin-enterprise#9937

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/9926

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

