### PR TITLE
Providing entity table id through table context.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -164,7 +164,11 @@ const PaginatedEntityTable = <T extends EntityBase, M = unknown>({
   } = paginatedEntities;
 
   return (
-    <TableFetchContextProvider refetch={refetch} searchParams={fetchOptions} attributes={attributes}>
+    <TableFetchContextProvider
+      refetch={refetch}
+      searchParams={fetchOptions}
+      attributes={attributes}
+      entityTableId={tableLayout.entityTableId}>
       <PaginatedList pageSize={layoutConfig.pageSize} showPageSizeSelect={false} totalItems={total}>
         <SearchRow>
           <SearchForm

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContext.ts
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContext.ts
@@ -23,6 +23,7 @@ export type ContextValue = {
   searchParams: SearchParams;
   refetch: () => void;
   attributes: Array<Attribute>;
+  entityTableId: string;
 };
 
 const TableFetchContext = React.createContext<ContextValue | undefined>(undefined);

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContextProvider.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContextProvider.tsx
@@ -28,7 +28,13 @@ type Props = React.PropsWithChildren<{
   entityTableId: string;
 }>;
 
-const TableFetchContextProvider = ({ children, searchParams, refetch, attributes, entityTableId }: Props) => {
+const TableFetchContextProvider = ({
+  children = undefined,
+  searchParams,
+  refetch,
+  attributes,
+  entityTableId,
+}: Props) => {
   const contextValue = useMemo(
     () => ({
       searchParams,

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContextProvider.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/TableFetchContextProvider.tsx
@@ -25,16 +25,18 @@ type Props = React.PropsWithChildren<{
   attributes: Array<Attribute>;
   refetch: () => void;
   searchParams: SearchParams;
+  entityTableId: string;
 }>;
 
-const TableFetchContextProvider = ({ children, searchParams, refetch, attributes }: Props) => {
+const TableFetchContextProvider = ({ children, searchParams, refetch, attributes, entityTableId }: Props) => {
   const contextValue = useMemo(
     () => ({
       searchParams,
       refetch,
       attributes,
+      entityTableId,
     }),
-    [searchParams, refetch, attributes],
+    [searchParams, refetch, attributes, entityTableId],
   );
 
   return <TableFetchContext.Provider value={contextValue}>{children}</TableFetchContext.Provider>;

--- a/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
+++ b/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
@@ -28,7 +28,12 @@ import IndexerClusterHealth from 'components/indexers/IndexerClusterHealth';
 
 const ClusterConfigurationPage = () => {
   const clusterNodes = useClusterNodes();
-  const searchParams: SearchParams = { query: '', page: 1, pageSize: 0, sort: { attributeId: 'hostname', direction: 'asc' } };
+  const searchParams: SearchParams = {
+    query: '',
+    page: 1,
+    pageSize: 0,
+    sort: { attributeId: 'hostname', direction: 'asc' },
+  };
 
   return (
     <DocumentTitle title="Cluster Configuration">
@@ -36,10 +41,10 @@ const ClusterConfigurationPage = () => {
       <div>
         <PageHeader title="Cluster Configuration">
           <span>
-            This page provides a real-time overview of the nodes in your Graylog cluster.
-            You can pause message processing at any time. The process buffers will not accept any new messages until
-            you resume it. If the message journal is enabled for a node, which it is by default, incoming messages
-            will be persisted to disk, even when processing is disabled.
+            This page provides a real-time overview of the nodes in your Graylog cluster. You can pause message
+            processing at any time. The process buffers will not accept any new messages until you resume it. If the
+            message journal is enabled for a node, which it is by default, incoming messages will be persisted to disk,
+            even when processing is disabled.
           </span>
         </PageHeader>
         <HideOnCloud>
@@ -50,7 +55,11 @@ const ClusterConfigurationPage = () => {
             <h2>Nodes</h2>
           </Col>
           <Col md={12}>
-            <TableFetchContextProvider refetch={clusterNodes.refetchDatanodes} searchParams={searchParams} attributes={[]}>
+            <TableFetchContextProvider
+              refetch={clusterNodes.refetchDatanodes}
+              searchParams={searchParams}
+              attributes={[]}
+              entityTableId="cluster-configuration">
               <ClusterConfigurationListView clusterNodes={clusterNodes} />
             </TableFetchContextProvider>
           </Col>

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardActions.test.tsx
@@ -51,7 +51,12 @@ const mockSearchParams = {
   },
 } as const;
 
-const mockContextValue = { searchParams: mockSearchParams, refetch: jest.fn(), attributes: [] };
+const mockContextValue = {
+  searchParams: mockSearchParams,
+  refetch: jest.fn(),
+  attributes: [],
+  entityTableId: 'entity-table',
+};
 
 const DashboardActions = ({
   contextValue = undefined,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the `TableFetchContext` and its providers with the entity table id. This makes it easier to e.g. consume table preferences in child components of the paginated data table.

/nocl Internal refactoring.
/prd Graylog2/graylog-plugin-enterprise#9939

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.