### PR TITLE
Allowing to pass and store custom entity table preferences.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
@@ -19,8 +19,13 @@ package org.graylog2.rest.resources.entities.preferences.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 public record EntityListPreferences(@JsonProperty("displayed_attributes") List<String> displayedAttributes,
                                     @JsonProperty("per_page") Integer perPage,
-                                    @JsonProperty("sort") SortPreferences sort) {
+                                    @JsonProperty("sort") SortPreferences sort,
+                                    @JsonProperty("custom_preferences") Map<String, Object> customPreferences) {
+    public static EntityListPreferences create(List<String> displayedAttributes, Integer perPage, SortPreferences sort) {
+        return new EntityListPreferences(displayedAttributes, perPage, sort, Map.of());
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
@@ -69,7 +69,7 @@ class EntityListPreferencesCleanerOnUserDeletionTest {
                 .build();
         service.save(StoredEntityListPreferences.builder()
                 .preferencesId(preferenceId1)
-                .preferences(new EntityListPreferences(List.of(), 42, null))
+                .preferences(EntityListPreferences.create(List.of(), 42, null))
                 .build());
 
         final StoredEntityListPreferencesId preferenceId2 = StoredEntityListPreferencesId.builder()
@@ -78,7 +78,7 @@ class EntityListPreferencesCleanerOnUserDeletionTest {
                 .build();
         service.save(StoredEntityListPreferences.builder()
                 .preferencesId(preferenceId2)
-                .preferences(new EntityListPreferences(List.of(), 42, null))
+                .preferences(EntityListPreferences.create(List.of(), 42, null))
                 .build());
 
         //verify they are present

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -71,7 +71,7 @@ public class EntityListPreferencesServiceImplTest {
     public void performsSaveAndGetOperationsCorrectly() {
         final StoredEntityListPreferences existingPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(new EntityListPreferences(List.of("title", "description"), 42, new SingleFieldSortPreferences("title", ASC)))
+                .preferences(EntityListPreferences.create(List.of("title", "description"), 42, new SingleFieldSortPreferences("title", ASC)))
                 .build();
 
         //save
@@ -89,7 +89,7 @@ public class EntityListPreferencesServiceImplTest {
         //update with save
         StoredEntityListPreferences updatedPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(new EntityListPreferences(List.of("title", "description", "owner"), 13, new SingleFieldSortPreferences("title", DESC)))
+                .preferences(EntityListPreferences.create(List.of("title", "description", "owner"), 13, new SingleFieldSortPreferences("title", DESC)))
                 .build();
         saved = toTest.save(updatedPreference);
         assertTrue(saved);
@@ -101,7 +101,7 @@ public class EntityListPreferencesServiceImplTest {
         //update with some values cleaned
         updatedPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(new EntityListPreferences(List.of("title", "description", "owner"), null, null))
+                .preferences(EntityListPreferences.create(List.of("title", "description", "owner"), null, null))
                 .build();
         saved = toTest.save(updatedPreference);
         assertTrue(saved);

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/__mocks__/useUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/__mocks__/useUserLayoutPreferences.ts
@@ -1,0 +1,12 @@
+import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
+
+import type originalUseUserLayoutPreferences from '../useUserLayoutPreferences';
+
+const useUserLayoutPreferences = jest.fn(
+  (): ReturnType<typeof originalUseUserLayoutPreferences> => ({
+    data: layoutPreferences,
+    isInitialLoading: false,
+    refetch: () => {},
+  }),
+);
+export default useUserLayoutPreferences;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/__mocks__/useUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/__mocks__/useUserLayoutPreferences.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 
 import type originalUseUserLayoutPreferences from '../useUserLayoutPreferences';

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.test.tsx
@@ -45,14 +45,6 @@ describe('useUserSearchFilterQuery hook', () => {
     defaultDisplayedAttributes: ['title'],
   };
 
-  beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({
-      data: layoutPreferences,
-      isInitialLoading: false,
-      refetch: () => {},
-    });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTableLayout.test.tsx
@@ -46,7 +46,11 @@ describe('useUserSearchFilterQuery hook', () => {
   };
 
   beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({
+      data: layoutPreferences,
+      isInitialLoading: false,
+      refetch: () => {},
+    });
   });
 
   afterEach(() => {
@@ -71,7 +75,7 @@ describe('useUserSearchFilterQuery hook', () => {
   });
 
   it('should return defaults when there are no user layout preferences', async () => {
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: undefined, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({ data: undefined, isInitialLoading: false, refetch: () => {} });
 
     const { result } = renderHook(
       () =>
@@ -93,6 +97,7 @@ describe('useUserSearchFilterQuery hook', () => {
     asMock(useUserLayoutPreferences).mockReturnValue({
       data: { perPage: layoutPreferences.perPage },
       isInitialLoading: false,
+      refetch: () => {},
     });
     const { result } = renderHook(
       () =>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.test.tsx
@@ -41,7 +41,11 @@ jest.mock('./useUserLayoutPreferences');
 
 describe('useUserSearchFilterQuery hook', () => {
   beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({
+      data: layoutPreferences,
+      isInitialLoading: false,
+      refetch: () => {},
+    });
   });
 
   afterEach(() => {
@@ -63,7 +67,11 @@ describe('useUserSearchFilterQuery hook', () => {
   });
 
   it('should allow partial update of user layout preferences', async () => {
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({
+      data: layoutPreferences,
+      isInitialLoading: false,
+      refetch: () => {},
+    });
     const { result, waitFor } = renderHook(() => useUpdateUserLayoutPreferences('streams'), { wrapper });
 
     result.current.mutate({ perPage: 100 });

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.test.tsx
@@ -19,11 +19,8 @@ import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 
 import { layoutPreferences, layoutPreferencesJSON } from 'fixtures/entityListLayoutPreferences';
-import asMock from 'helpers/mocking/AsMock';
 import fetch from 'logic/rest/FetchProvider';
 import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences';
-
-import useUserLayoutPreferences from './useUserLayoutPreferences';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -40,14 +37,6 @@ jest.mock('util/UserNotification', () => ({ error: jest.fn() }));
 jest.mock('./useUserLayoutPreferences');
 
 describe('useUserSearchFilterQuery hook', () => {
-  beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({
-      data: layoutPreferences,
-      isInitialLoading: false,
-      refetch: () => {},
-    });
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -67,11 +56,6 @@ describe('useUserSearchFilterQuery hook', () => {
   });
 
   it('should allow partial update of user layout preferences', async () => {
-    asMock(useUserLayoutPreferences).mockReturnValue({
-      data: layoutPreferences,
-      isInitialLoading: false,
-      refetch: () => {},
-    });
     const { result, waitFor } = renderHook(() => useUpdateUserLayoutPreferences('streams'), { wrapper });
 
     result.current.mutate({ perPage: 100 });

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
@@ -34,9 +34,9 @@ const preferencesToJSON = <T>({
   custom_preferences: customPreferences,
 });
 
-const useUpdateUserLayoutPreferences = (entityTableId: string) => {
+const useUpdateUserLayoutPreferences = <T>(entityTableId: string) => {
   const { data: userLayoutPreferences = {}, refetch } = useUserLayoutPreferences(entityTableId);
-  const mutationFn = (newPreferences: TableLayoutPreferences) =>
+  const mutationFn = (newPreferences: TableLayoutPreferences<T>) =>
     fetch(
       'POST',
       qualifyUrl(`/entitylists/preferences/${entityTableId}`),

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
@@ -47,7 +47,7 @@ const useUpdateUserLayoutPreferences = <T>(entityTableId: string) => {
     onError: (error) => {
       UserNotification.error(`Updating table layout preferences failed with error: ${error}`);
     },
-    onMutate: refetch,
+    onSuccess: refetch,
   });
 
   return { mutate };

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences.ts
@@ -47,7 +47,7 @@ const useUpdateUserLayoutPreferences = <T>(entityTableId: string) => {
     onError: (error) => {
       UserNotification.error(`Updating table layout preferences failed with error: ${error}`);
     },
-    onSuccess: refetch,
+    onSuccess: () => refetch(),
   });
 
   return { mutate };

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUserLayoutPreferences.ts
@@ -27,16 +27,20 @@ const preferencesFromJSON = ({
   displayed_attributes,
   sort,
   per_page,
+  custom_preferences,
 }: TableLayoutPreferencesJSON): TableLayoutPreferences => ({
   displayedAttributes: displayed_attributes,
   sort: sort ? { attributeId: sort.field, direction: sort.order } : undefined,
   perPage: per_page,
+  customPreferences: custom_preferences,
 });
 const fetchUserLayoutPreferences = (entityId: string) =>
   fetch('GET', qualifyUrl(`/entitylists/preferences/${entityId}`)).then((res) => preferencesFromJSON(res ?? {}));
 
-const useUserLayoutPreferences = (entityId: string): { data: TableLayoutPreferences; isInitialLoading: boolean } => {
-  const { data, isInitialLoading } = useQuery(
+const useUserLayoutPreferences = <T>(
+  entityId: string,
+): { data: TableLayoutPreferences<T>; isInitialLoading: boolean; refetch: () => void } => {
+  const { data, isInitialLoading, refetch } = useQuery(
     ['table-layout', entityId],
     () =>
       defaultOnError(
@@ -52,6 +56,7 @@ const useUserLayoutPreferences = (entityId: string): { data: TableLayoutPreferen
   return {
     data: data ?? INITIAL_DATA,
     isInitialLoading,
+    refetch,
   };
 };
 

--- a/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/types.ts
@@ -51,19 +51,21 @@ export type ColumnRenderers<Entity extends EntityBase, Meta = unknown> = {
   types?: { [type: string]: ColumnRenderer<Entity, Meta> };
 };
 
-export type TableLayoutPreferences = {
+export type TableLayoutPreferences<T = { [key: string]: unknown }> = {
   displayedAttributes?: Array<string>;
   sort?: Sort;
   perPage?: number;
+  customPreferences?: T;
 };
 
-export type TableLayoutPreferencesJSON = {
+export type TableLayoutPreferencesJSON<T = { [key: string]: unknown }> = {
   displayed_attributes?: Array<string>;
   sort?: {
     field: string;
     order: 'asc' | 'desc';
   };
   per_page?: number;
+  custom_preferences?: T;
 };
 
 export type ExpandedSectionRenderer<Entity> = {

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfilesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/ProfilesList.test.tsx
@@ -63,6 +63,7 @@ describe('IndexSetFieldTypesList', () => {
         displayedAttributes: ['name', 'description', 'type', 'custom_field_mappings'],
       },
       isInitialLoading: false,
+      refetch: () => {},
     });
 
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
@@ -100,6 +100,7 @@ describe('IndexSetFieldTypesList', () => {
         displayedAttributes: ['field_name', 'origin', 'is_reserved', 'type'],
       },
       isInitialLoading: false,
+      refetch: () => {},
     });
 
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamsOverview.test.tsx
@@ -87,6 +87,7 @@ describe('StreamsOverview', () => {
     asMock(useUserLayoutPreferences).mockReturnValue({
       data: { ...layoutPreferences, displayedAttributes: ['title', 'description', 'rules'] },
       isInitialLoading: false,
+      refetch: () => {},
     });
 
     asMock(useStreamRuleTypes).mockReturnValue({ data: streamRuleTypes });

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
@@ -82,6 +82,7 @@ describe('IndexSetFieldTypesPage', () => {
         displayedAttributes: ['field_name', 'origin', 'is_reserved', 'type'],
       },
       isInitialLoading: false,
+      refetch: () => {},
     });
 
     asMock(useFieldTypesForMappings).mockReturnValue({

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.test.tsx
@@ -22,8 +22,6 @@ import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import { asMock } from 'helpers/mocking';
 import useFetchEntities from 'components/common/PaginatedEntityTable/useFetchEntities';
-import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
-import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import DefaultQueryParamProvider from 'routing/DefaultQueryParamProvider';
 
 import DashboardsOverview from './DashboardsOverview';
@@ -105,11 +103,6 @@ describe('DashboardsOverview', () => {
   );
 
   beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({
-      data: layoutPreferences,
-      isInitialLoading: false,
-      refetch: () => {},
-    });
     asMock(useFetchEntities).mockReturnValue(loadDashboardsResponse(0));
     asMock(useQueryParam).mockImplementation(() => [undefined, () => {}]);
   });

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/DashboardsOverview.test.tsx
@@ -105,7 +105,11 @@ describe('DashboardsOverview', () => {
   );
 
   beforeEach(() => {
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({
+      data: layoutPreferences,
+      isInitialLoading: false,
+      refetch: () => {},
+    });
     asMock(useFetchEntities).mockReturnValue(loadDashboardsResponse(0));
     asMock(useQueryParam).mockImplementation(() => [undefined, () => {}]);
   });

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -85,7 +85,11 @@ describe('SavedSearchesModal', () => {
       isInitialLoading: false,
     });
 
-    asMock(useUserLayoutPreferences).mockReturnValue({ data: layoutPreferences, isInitialLoading: false });
+    asMock(useUserLayoutPreferences).mockReturnValue({
+      data: layoutPreferences,
+      isInitialLoading: false,
+      refetch: () => {},
+    });
     asMock(useUpdateUserLayoutPreferences).mockReturnValue({ mutate: () => {} });
     asMock(useCurrentUser).mockReturnValue(adminUser);
   });

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -23,8 +23,6 @@ import asMock from 'helpers/mocking/AsMock';
 import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import useSavedSearches from 'views/hooks/useSavedSearches';
-import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
-import { layoutPreferences } from 'fixtures/entityListLayoutPreferences';
 import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences';
 import { adminUser } from 'fixtures/users';
 import useCurrentUser from 'hooks/useCurrentUser';
@@ -85,11 +83,6 @@ describe('SavedSearchesModal', () => {
       isInitialLoading: false,
     });
 
-    asMock(useUserLayoutPreferences).mockReturnValue({
-      data: layoutPreferences,
-      isInitialLoading: false,
-      refetch: () => {},
-    });
     asMock(useUpdateUserLayoutPreferences).mockReturnValue({ mutate: () => {} });
     asMock(useCurrentUser).mockReturnValue(adminUser);
   });

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.test.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldTypeModal.test.tsx
@@ -178,6 +178,7 @@ describe('ChangeFieldTypeModal', () => {
         displayedAttributes: ['index_set_title', 'stream_titles', 'types'],
       },
       isInitialLoading: false,
+      refetch: () => {},
     });
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extending the user entity table prefences to allow frontend components to store arbitrary preferences for specific tables as well.

/nocl Internal extension.
/prd Graylog2/graylog-plugin-enterprise#9942

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.