### PR TITLE
Allow calling search status endpoint with pagination parameters (FE).

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
+++ b/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
@@ -56,17 +56,17 @@ const reexecuteSearchTypes =
     };
 
     return dispatch(
-      executeWithExecutionState(
-        view.search,
+      executeWithExecutionState({
+        search: view.search,
         activeQuery,
-        [],
+        searchTypesToSearch: [],
         executionState,
-        {
+        searchExecutors: {
           ...searchExecutors,
           resultMapper: handleSearchResult,
         },
-        view.widgetMapping,
-      ),
+        widgetMapping: view.widgetMapping,
+      }),
     );
   };
 

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -141,8 +141,6 @@ export type SearchExecutors = {
     searchTypesToSearch: string[],
     executionStateParam: SearchExecutionState,
     keepQueries?: string[],
-    page?: number,
-    perPage?: number,
   ) => Promise<JobIds>;
   executeJobResult: (params: {
     jobIds: JobIds;
@@ -224,7 +222,7 @@ export const executeWithExecutionState =
         dispatch(loading());
         dispatch(cancelExecutedJob());
 
-        return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery], page, perPage);
+        return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery]);
       })
       .then((jobIds: JobIds) => dispatch(executeSearchJob({ searchExecutors, jobIds, widgetMapping, page, perPage })));
 

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -14,8 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import * as Immutable from 'immutable';
 import trim from 'lodash/trim';
 
@@ -41,10 +41,10 @@ import {
   selectParameterBindings,
 } from 'views/logic/slices/searchExecutionSelectors';
 import type { TimeRange } from 'views/logic/queries/Query';
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 import ParameterBinding from 'views/logic/parameters/ParameterBinding';
 import type Parameter from 'views/logic/parameters/Parameter';
 import type { ParameterMap } from 'views/logic/parameters/Parameter';
-import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 import type { JobIds } from 'views/stores/SearchJobs';
 import type Search from 'views/logic/search/Search';
 import { setParameters } from 'views/logic/slices/viewSlice';
@@ -58,7 +58,7 @@ const searchExecutionSlice = createSlice({
     isLoading: false,
     result: undefined,
     jobIds: null,
-  } as SearchExecution,
+  },
   reducers: {
     loading: (state) => ({
       ...state,
@@ -141,8 +141,15 @@ export type SearchExecutors = {
     searchTypesToSearch: string[],
     executionStateParam: SearchExecutionState,
     keepQueries?: string[],
+    page?: number,
+    perPage?: number,
   ) => Promise<JobIds>;
-  executeJobResult: (jobIds: JobIds, widgetMapping?: WidgetMapping) => Promise<SearchExecutionResult>;
+  executeJobResult: (params: {
+    jobIds: JobIds;
+    widgetMapping?: WidgetMapping;
+    page?: number;
+    perPage?: number;
+  }) => Promise<SearchExecutionResult>;
   cancelJob: (jobIds: JobIds) => Promise<null>;
 };
 
@@ -161,54 +168,98 @@ export const cancelExecutedJob =
     return Promise.resolve();
   };
 
+export const executeSearchJob =
+  ({
+    jobIds,
+    widgetMapping,
+    page,
+    perPage,
+  }: {
+    jobIds: JobIds;
+    widgetMapping?: WidgetMapping;
+    page?: number;
+    perPage?: number;
+  }) =>
+  (dispatch: ViewsDispatch, _getState, { searchExecutors }: { searchExecutors: SearchExecutors }) => {
+    dispatch(setJobIds(jobIds));
+    dispatch(loading());
+
+    return searchExecutors
+      .executeJobResult({ jobIds, widgetMapping, page, perPage })
+      .then(searchExecutors.resultMapper)
+      .then((result) => {
+        dispatch(setJobIds(null));
+        const isCanceled = result?.result?.result?.execution?.cancelled;
+        if (isCanceled) return dispatch(stopLoading());
+
+        return dispatch(finishedLoading(result));
+      });
+  };
+
 export const executeWithExecutionState =
-  (
-    search: Search,
-    activeQuery: string,
-    searchTypesToSearch: Array<string>,
-    executionState: SearchExecutionState,
-    searchExecutors: SearchExecutors,
-    widgetMapping?: WidgetMapping,
-  ) =>
+  ({
+    search,
+    activeQuery,
+    searchTypesToSearch,
+    executionState,
+    searchExecutors,
+    widgetMapping,
+    page,
+    perPage,
+  }: {
+    search: Search;
+    activeQuery: string;
+    searchTypesToSearch: Array<string>;
+    executionState: SearchExecutionState;
+    searchExecutors: SearchExecutors;
+    widgetMapping?: WidgetMapping;
+    page?: number;
+    perPage?: number;
+  }) =>
   (dispatch: ViewsDispatch) =>
     dispatch(parseSearch(search, searchExecutors.parse))
       .then(() => {
         dispatch(loading());
         dispatch(cancelExecutedJob());
 
-        return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery]);
+        return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery], page, perPage);
       })
       .then((jobIds: JobIds) => {
         dispatch(setJobIds(jobIds));
 
-        return searchExecutors
-          .executeJobResult(jobIds, widgetMapping)
-          .then(searchExecutors.resultMapper)
-          .then((result) => {
-            dispatch(setJobIds(null));
-            const isCanceled = result?.result?.result?.execution?.cancelled;
-            if (isCanceled) return dispatch(stopLoading());
-
-            return dispatch(finishedLoading(result));
-          });
+        return dispatch(executeSearchJob({ jobIds, widgetMapping, page, perPage }));
       });
 
 export const execute =
-  (search: Search, activeQuery: string, widgetMapping?: WidgetMapping) =>
+  ({
+    search,
+    activeQuery,
+    widgetMapping,
+    page,
+    perPage,
+  }: {
+    search: Search;
+    activeQuery: string;
+    widgetMapping?: WidgetMapping;
+    page?: number;
+    perPage?: number;
+  }) =>
   (dispatch: ViewsDispatch, getState: () => RootState, { searchExecutors }: ExtraArguments) => {
     const state = getState();
     const executionState = selectSearchExecutionState(state);
     const searchTypesToSearch = selectSearchTypesToSearch(state);
 
     return dispatch(
-      executeWithExecutionState(
+      executeWithExecutionState({
         search,
         activeQuery,
         searchTypesToSearch,
         executionState,
         searchExecutors,
         widgetMapping,
-      ),
+        page,
+        perPage,
+      }),
     );
   };
 

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -174,13 +174,15 @@ export const executeSearchJob =
     widgetMapping,
     page,
     perPage,
+    searchExecutors,
   }: {
     jobIds: JobIds;
     widgetMapping?: WidgetMapping;
     page?: number;
     perPage?: number;
+    searchExecutors: SearchExecutors;
   }) =>
-  (dispatch: ViewsDispatch, _getState, { searchExecutors }: { searchExecutors: SearchExecutors }) => {
+  (dispatch: ViewsDispatch, _getState) => {
     dispatch(setJobIds(jobIds));
     dispatch(loading());
 
@@ -224,11 +226,7 @@ export const executeWithExecutionState =
 
         return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery], page, perPage);
       })
-      .then((jobIds: JobIds) => {
-        dispatch(setJobIds(jobIds));
-
-        return dispatch(executeSearchJob({ jobIds, widgetMapping, page, perPage }));
-      });
+      .then((jobIds: JobIds) => dispatch(executeSearchJob({ searchExecutors, jobIds, widgetMapping, page, perPage })));
 
 export const execute =
   ({

--- a/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/viewSlice.ts
@@ -107,7 +107,7 @@ export const executeActiveQuery = () => (dispatch: ViewsDispatch, getState: () =
   const search = selectSearch(getState());
   const activeQuery = selectActiveQuery(getState());
 
-  return dispatch(execute(search, activeQuery, view.widgetMapping));
+  return dispatch(execute({ search, activeQuery, widgetMapping: view.widgetMapping }));
 };
 
 export const selectQuery = (activeQuery: string) => async (dispatch: ViewsDispatch, getState: () => RootState) => {

--- a/graylog2-web-interface/src/views/stores/SearchJobs.ts
+++ b/graylog2-web-interface/src/views/stores/SearchJobs.ts
@@ -28,8 +28,10 @@ const startJobUrl = (id: string) => URLUtils.qualifyUrl(`/views/search/${id}/exe
 const cancelJobUrl = (nodeId: string, jobId: string) =>
   URLUtils.qualifyUrl(`/views/searchjobs/${nodeId}/${jobId}/cancel`);
 
-const pollJobUrl = (nodeId: string, jobId: string) =>
-  URLUtils.qualifyUrl(`/views/searchjobs/${nodeId}/${jobId}/status`);
+const pollJobUrl = (nodeId: string, jobId: string, page?: number, perPage?: number) =>
+  URLUtils.qualifyUrl(
+    `/views/searchjobs/${nodeId}/${jobId}/status${page && perPage ? `?page=${page}&per_page=${perPage}` : ''}`,
+  );
 
 type ExecutionInfoType = {
   done: boolean;
@@ -61,8 +63,16 @@ export function runStartJob(search: Search, executionState: SearchExecutionState
   return fetch('POST', startJobUrl(search.id), JSON.stringify(executionState));
 }
 
-export function runPollJob({ nodeId, asyncSearchId }: JobIds): Promise<SearchJobType | null> {
-  return fetch('GET', pollJobUrl(nodeId, asyncSearchId));
+export function runPollJob({
+  jobIds: { nodeId, asyncSearchId },
+  page,
+  perPage,
+}: {
+  jobIds: JobIds;
+  page?: number;
+  perPage?: number;
+}): Promise<SearchJobType | null> {
+  return fetch('GET', pollJobUrl(nodeId, asyncSearchId, page, perPage));
 }
 
 export function runCancelJob({ nodeId, asyncSearchId }: JobIds): Promise<null> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We recently extended the search job status endpoint with the option to add a `page` and `per_page` parameter https://github.com/Graylog2/graylog2-server/pull/21797. They can be added to query paginated results of message list search types.

With this PR we make use of these parameters in the frontend.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9847
/nocl
