### PR TITLE
Service method for execution state retrieval of active job for a user

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStateService.java
@@ -203,4 +203,22 @@ public class SearchJobStateService {
             return Optional.empty();
         }
     }
+
+    public Optional<SearchJobExecutionState> getExecutionStateForLatestUserJob(final String user) {
+        final Document doc = collection.find(Filters.eq(OWNER_FIELD, user), Document.class)
+                .projection(include(STATUS_FIELD, PROGRESS_FIELD))
+                .sort(Sorts.descending(CREATED_AT_FIELD))
+                .first();
+        if (doc != null) {
+            return Optional.of(
+                    new SearchJobExecutionState(
+                            SearchJobStatus.valueOf(doc.get(STATUS_FIELD, String.class)),
+                            doc.getInteger(PROGRESS_FIELD, 0)
+                    )
+            );
+        } else {
+            return Optional.empty();
+        }
+
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStatus.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/jobs/SearchJobStatus.java
@@ -19,7 +19,6 @@ package org.graylog.plugins.views.search.jobs;
 public enum SearchJobStatus {
     RUNNING,
     DONE,
-    CANCELLATION_REQUESTED,
     CANCELLED,
     TIMEOUT,
     EXPIRED,

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/jobs/SearchJobStateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/jobs/SearchJobStateServiceTest.java
@@ -230,15 +230,17 @@ public class SearchJobStateServiceTest {
                         "bob",
                         "dcae52e4-777e-4e3f-8e69-61df7a607016"))
                 .result(noResult("0000000000000042"))
-                .status(SearchJobStatus.RUNNING)
-                .progress(42)
+                .status(SearchJobStatus.TIMEOUT)
+                .progress(47)
                 .createdAt(DateTime.parse("2020-01-01T11:11:11"))
                 .updatedAt(DateTime.now(DateTimeZone.UTC))
                 .build());
 
         assertTrue(toTest.getLatestForUser("andy").isEmpty()); //Andy has no search jobs
         assertEquals("677fd86ae6db8b71a8e10003", toTest.getLatestForUser("bob").get().identifier().searchId()); //Bob has only one, we choose it
+        assertEquals(Optional.of(new SearchJobExecutionState(SearchJobStatus.TIMEOUT, 47)), toTest.getExecutionStateForLatestUserJob("bob"));
         assertEquals("677fd86ae6db8b71a8e10002", toTest.getLatestForUser("john").get().identifier().searchId()); //John has 2, we choose the one with the latest "created at" date
+        assertEquals(Optional.of(new SearchJobExecutionState(SearchJobStatus.RUNNING, 42)), toTest.getExecutionStateForLatestUserJob("john"));
 
     }
 


### PR DESCRIPTION
## Description
Service method for execution state retrieval of active job for a user.
Additionally, unused state has been removed from `SearchJobStatus`.
/nocl

## Motivation and Context
FE will need a new endpoint to provide this small piece of information, instead of fetching everything we know about the job.

## How Has This Been Tested?
Unit tests have been modified accordingly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

