### PR TITLE
Improve certificate generation

### DIFF
--- a/changelog/unreleased/pr-21943.toml
+++ b/changelog/unreleased/pr-21943.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "Generated certificates now use 4096 bit keys."
+
+issues = ["graylog-plugin-enterprise#9951"]
+pulls = ["21943"]

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
@@ -35,6 +35,7 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Date;
+import java.util.UUID;
 
 import static org.graylog.security.certutil.CertConstants.KEY_GENERATION_ALGORITHM;
 import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
@@ -47,8 +48,7 @@ public class CertificateGenerator {
 
         final X500Name name = getX500Name(request.cnName());
 
-        // TODO: cert serial number?
-        BigInteger serialNumber = BigInteger.valueOf(System.currentTimeMillis());
+        BigInteger serialNumber = new BigInteger(UUID.randomUUID().toString().replace("-", ""), 16);
         Instant validFrom = Instant.now();
 
         Instant validUntil = validFrom.plus(request.validity());

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
@@ -42,6 +42,7 @@ import static org.graylog.security.certutil.CertConstants.SIGNING_ALGORITHM;
 public class CertificateGenerator {
     public static KeyPair generate(CertRequest request) throws Exception {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_GENERATION_ALGORITHM);
+        keyGen.initialize(4096);
         java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
 
         final X500Name name = getX500Name(request.cnName());


### PR DESCRIPTION
## Description
This extends the key size used in certificate generation to 4096 bits.

Additionally, the generated serial number is now derived from a UUID to better prevent possible collisions and lower predicability.

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/9951 

## How Has This Been Tested?
Integration tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

