### PR TITLE
Don't include test dependencies in Data Node artifact

### DIFF
--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -731,7 +731,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeScope>compile</includeScope>
+                            <includeScope>runtime</includeScope>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>

--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -731,6 +731,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
+                            <includeScope>compile</includeScope>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>


### PR DESCRIPTION
Only include "runtime" scope in copy-dependencies configuration.

This shaves 40 MB from the artifact.

/nocl