### PR TITLE
Make Alerts & Events histogram collapsible.

### DIFF
--- a/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
+++ b/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
@@ -28,11 +28,18 @@ import useColumnRenderers from 'components/events/events/ColumnRenderers';
 import EventsRefreshControls from 'components/events/events/EventsRefreshControls';
 import QueryHelper from 'components/common/QueryHelper';
 import EventsHistogram from 'components/events/EventsHistogram';
+import type { MiddleSectionProps } from 'components/common/PaginatedEntityTable/PaginatedEntityTable';
+import EventsMetrics from 'components/events/EventsMetrics';
 
 const additionalSearchFields = {
   key: 'The key of the event',
 };
 
+const Metrics = ({ searchParams, setFilters }: MiddleSectionProps) => (
+  <EventsMetrics>
+    <EventsHistogram searchParams={searchParams} setFilters={setFilters} />
+  </EventsMetrics>
+);
 const EventsEntityTable = () => {
   const { stream_id: streamId } = useQuery();
 
@@ -61,7 +68,7 @@ const EventsEntityTable = () => {
       columnRenderers={columnRenderers}
       bulkSelection={bulkSelection}
       topRightCol={<EventsRefreshControls />}
-      middleSection={EventsHistogram}
+      middleSection={Metrics}
     />
   );
 };

--- a/graylog2-web-interface/src/components/events/EventsMetrics.tsx
+++ b/graylog2-web-interface/src/components/events/EventsMetrics.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+import styled, { css } from 'styled-components';
+
+import IconButton from 'components/common/IconButton';
+
+const Container = styled.div(
+  ({ theme }) => css`
+    margin: 5px 0;
+    padding: 5px;
+    background-color: ${theme.colors.background.secondaryNav};
+  `,
+);
+const HeadlineContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+type Props = React.PropsWithChildren<{}>;
+const EventsMetrics = ({ children = undefined }: Props) => {
+  const [expanded, setExpanded] = useState(true);
+  const expandTitle = `${expanded ? 'Collapse' : 'Expand'} Metrics`;
+  const expandIcon = expanded ? 'unfold_less' : 'unfold_more';
+  const onClick = useCallback(() => setExpanded((_expanded) => !_expanded), []);
+
+  return (
+    <Container>
+      <HeadlineContainer>
+        <h2>Metrics</h2>
+        <IconButton title={expandTitle} name={expandIcon} onClick={onClick} />
+      </HeadlineContainer>
+      {expanded ? children : null}
+    </Container>
+  );
+};
+export default EventsMetrics;

--- a/graylog2-web-interface/src/components/events/EventsMetrics.tsx
+++ b/graylog2-web-interface/src/components/events/EventsMetrics.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/components/events/EventsMetrics.tsx
+++ b/graylog2-web-interface/src/components/events/EventsMetrics.tsx
@@ -3,6 +3,10 @@ import { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import IconButton from 'components/common/IconButton';
+import useUpdateUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUpdateUserLayoutPreferences';
+import useTableFetchContext from 'components/common/PaginatedEntityTable/useTableFetchContext';
+import useUserLayoutPreferences from 'components/common/EntityDataTable/hooks/useUserLayoutPreferences';
+import Spinner from 'components/common/Spinner';
 
 const Container = styled.div(
   ({ theme }) => css`
@@ -16,12 +20,24 @@ const HeadlineContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
 `;
-type Props = React.PropsWithChildren<{}>;
-const EventsMetrics = ({ children = undefined }: Props) => {
-  const [expanded, setExpanded] = useState(true);
+type EventsMetricsProps = React.PropsWithChildren<{
+  expanded: boolean;
+  onExpandToggle: (expanded: boolean) => void;
+}>;
+const EventsMetrics = ({ children = undefined, expanded: initialExpanded, onExpandToggle }: EventsMetricsProps) => {
+  const [expanded, setExpanded] = useState<boolean>(initialExpanded);
   const expandTitle = `${expanded ? 'Collapse' : 'Expand'} Metrics`;
   const expandIcon = expanded ? 'unfold_less' : 'unfold_more';
-  const onClick = useCallback(() => setExpanded((_expanded) => !_expanded), []);
+  const onClick = useCallback(
+    () =>
+      setExpanded((_expanded) => {
+        const newValue = !_expanded;
+        onExpandToggle(newValue);
+
+        return newValue;
+      }),
+    [onExpandToggle],
+  );
 
   return (
     <Container>
@@ -33,4 +49,26 @@ const EventsMetrics = ({ children = undefined }: Props) => {
     </Container>
   );
 };
-export default EventsMetrics;
+
+type Props = React.PropsWithChildren<{}>;
+const EventsMetricsBarrier = ({ children = undefined }: Props) => {
+  const { entityTableId } = useTableFetchContext();
+  const { mutate: updatePreferences } = useUpdateUserLayoutPreferences(entityTableId);
+  const { data, isInitialLoading: isLoadingPreferences } = useUserLayoutPreferences<{ showMetrics: boolean }>(
+    entityTableId,
+  );
+  const onExpandToggle = useCallback(
+    (expanded: boolean) => updatePreferences({ customPreferences: { showMetrics: expanded } }),
+    [updatePreferences],
+  );
+
+  return isLoadingPreferences ? (
+    <Spinner />
+  ) : (
+    <EventsMetrics expanded={data.customPreferences?.showMetrics ?? true} onExpandToggle={onExpandToggle}>
+      {children}
+    </EventsMetrics>
+  );
+};
+
+export default EventsMetricsBarrier;

--- a/graylog2-web-interface/src/components/events/EventsMetrics.tsx
+++ b/graylog2-web-interface/src/components/events/EventsMetrics.tsx
@@ -26,9 +26,7 @@ import Spinner from 'components/common/Spinner';
 
 const Container = styled.div(
   ({ theme }) => css`
-    margin: 5px 0;
-    padding: 5px;
-    background-color: ${theme.colors.background.secondaryNav};
+    margin: ${theme.spacings.xs} 0;
   `,
 );
 const HeadlineContainer = styled.div`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding a collapse/expand button for the Alerts & Events histogram widget, persisting the state in the current user's table preferences.

/nocl WIP Feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.