### PR TITLE
Add permission change information to data node migration

### DIFF
--- a/changelog/unreleased/pr-21959.toml
+++ b/changelog/unreleased/pr-21959.toml
@@ -1,0 +1,5 @@
+type = "c"
+message = "More concise information on when/how to change permissions for the OpenSearch data directory in the Data Node migration wizard. ."
+
+issues = ["Graylog2/graylog-plugin-enterprise#9231"]
+pulls = ["21959"]

--- a/graylog2-web-interface/src/components/datanode/migrations/common/InPlaceMigrationInfo.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/common/InPlaceMigrationInfo.tsx
@@ -41,8 +41,8 @@ const InPlaceMigrationInfo = () => (
       For In-Place migrations, please ensure the configuration of your Data Nodes in <code>datanode.conf</code>,
       specifically the <code>opensearch_data_location</code> configuration option, points to the correct existing
       OpenSearch data directory on every node.<br />
-      During the time of the migration, both the Data Node's and the OpenSearch's system user will need to be able to
-      access and write to the data directory. To ensure this, you can run for example<br />
+      During the time of the migration, both the Data Node&apos;s and the OpenSearch&apos;s system user will need
+      to be able to access and write to the data directory. To ensure this, you can run for example<br />
       <code>sudo chmod -R 757 &lt;your_data_directory&gt;</code>
     </Panel.Body>
   </StyledPanel>

--- a/graylog2-web-interface/src/components/datanode/migrations/common/InPlaceMigrationInfo.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/common/InPlaceMigrationInfo.tsx
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, {css} from 'styled-components';
 
-import { Panel } from 'components/bootstrap';
+import {Panel} from 'components/bootstrap';
 
 export const StyledPanel = styled(Panel)<{ bsStyle: string }>(
   ({ bsStyle = 'default', theme }) => css`
@@ -40,7 +40,10 @@ const InPlaceMigrationInfo = () => (
     <Panel.Body>
       For In-Place migrations, please ensure the configuration of your Data Nodes in <code>datanode.conf</code>,
       specifically the <code>opensearch_data_location</code> configuration option, points to the correct existing
-      OpenSearch data directory on every node.
+      OpenSearch data directory on every node.<br />
+      During the time of the migration, both the Data Node's and the OpenSearch's system user will need to be able to
+      access and write to the data directory. To ensure this, you can run for example<br />
+      <code>sudo chmod -R 757 &lt;your_data_directory&gt;</code>
     </Panel.Body>
   </StyledPanel>
 );

--- a/graylog2-web-interface/src/components/datanode/migrations/in-place/StopMessageProcessing.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/in-place/StopMessageProcessing.tsx
@@ -18,10 +18,10 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import MigrationStepTriggerButtonToolbar from 'components/datanode/migrations/common/MigrationStepTriggerButtonToolbar';
-import type { MigrationStepComponentProps } from 'components/datanode/Types';
-import { Panel } from 'components/bootstrap';
-import { Icon } from 'components/common';
-import { StyledPanel } from 'components/datanode/migrations/MigrationWelcomeStep';
+import type {MigrationStepComponentProps} from 'components/datanode/Types';
+import {Panel} from 'components/bootstrap';
+import {Icon} from 'components/common';
+import {StyledPanel} from 'components/datanode/migrations/MigrationWelcomeStep';
 
 const StyledHelpPanel = styled(StyledPanel)`
   margin-top: 30px;
@@ -40,9 +40,13 @@ const StopMessageProcessing = ({ currentStep, onTriggerStep, hideActions }: Migr
       <Panel.Body>
         <p>Please stop your OpenSearch cluster before proceeding.</p>
         <p>
-          If you are migrating existing OpenSearch data by pointing the data node to its data directory, make sure that
-          the user running the data node (usually graylog-datanode) has permissions to write to the data directory set
-          in the data node configuration.
+          If you are migrating existing OpenSearch data by pointing the data node to its data directory, make sure to
+          change the owner of the data directory to the user running the data node (usually graylog-datanode) and
+          reset the correct permissions, e.g. by running
+        </p>
+        <p>
+          <code>sudo chown -R graylog-datanode:graylog-datanode &lt;your_data_directory&gt;</code><br />
+          <code>sudo chmod -R 750 &lt;your_data_directory&gt;</code>
         </p>
       </Panel.Body>
     </StyledHelpPanel>


### PR DESCRIPTION
## Description
Adds more information on when/how to change permissions for the OpenSearch data directory in the Data Node migration wizard. 

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/9231

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/5116f132-f874-4b86-9aac-37d1e419657c)

![image](https://github.com/user-attachments/assets/4e9e80b9-1d39-41ab-8a30-da9180c3c5a9)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

