### PR TITLE
Fixing field type render for input and nodes field.

### DIFF
--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.test.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.test.tsx
@@ -21,12 +21,22 @@ import asMock from 'helpers/mocking/AsMock';
 import TypeSpecificValue from 'views/components/TypeSpecificValue';
 import FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';
 import useFeature from 'hooks/useFeature';
+import usePluginEntities from 'hooks/usePluginEntities';
+import FieldTypeValueRenderer from 'views/components/fieldtypes/FieldTypeValueRenderer';
+import useInputs from 'hooks/useInputs';
+import FieldType from 'views/logic/fieldtypes/FieldType';
 
 jest.mock('hooks/useFeature');
+jest.mock('hooks/usePluginEntities');
+jest.mock('hooks/useInputs');
 
 describe('TypeSpecificValue', () => {
   beforeEach(() => {
     asMock(useFeature).mockReturnValue(true);
+
+    asMock(usePluginEntities).mockImplementation(
+      (entityKey) => ({ fieldTypeValueRenderer: FieldTypeValueRenderer, forwarder: [] })[entityKey],
+    );
   });
 
   it('should render prettified value if unit defined', async () => {
@@ -45,5 +55,24 @@ describe('TypeSpecificValue', () => {
     render(<TypeSpecificValue field="field1" value={6543.21} />);
 
     await screen.findByText(6543.21);
+  });
+
+  it('should render input titles for input field', async () => {
+    asMock(useInputs).mockReturnValue({
+      'input-id-1': {
+        id: 'input-id-1',
+        title: 'Input 1',
+        type: 'type',
+        global: false,
+        name: 'inputName',
+        created_at: '',
+        creator_user_id: 'creatorId',
+        static_fields: {},
+        attributes: {},
+      },
+    });
+    render(<TypeSpecificValue field="gl2_source_input" value="input-id-1" type={new FieldType('input', [], [])} />);
+
+    await screen.findByText('Input 1');
   });
 });

--- a/graylog2-web-interface/src/views/components/fieldtypes/FieldTypeValueRenderer.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/FieldTypeValueRenderer.tsx
@@ -36,8 +36,8 @@ const FieldTypeValueRenderer: PluginExports['fieldTypeValueRenderer'] = [
     type: 'boolean',
     render: (value, field, Component) => <Component value={String(value)} field={field} />,
   },
-  { type: 'input', render: (_flied, value) => <InputField value={String(value)} /> },
-  { type: 'node', render: (_flied, value) => <NodeField value={String(value)} /> },
+  { type: 'input', render: (value) => <InputField value={String(value)} /> },
+  { type: 'node', render: (value) => <NodeField value={String(value)} /> },
   {
     type: 'streams',
     render: (value: string | Array<string>) => <StreamsField value={value} />,

--- a/graylog2-web-interface/src/views/components/fieldtypes/InputField.tsx
+++ b/graylog2-web-interface/src/views/components/fieldtypes/InputField.tsx
@@ -31,7 +31,7 @@ const useForwarderInput = (inputId: string, enabled: boolean) => {
     isError,
     isLoading,
   } = useQuery(['forwarder', 'input', inputId], () => fetchForwarderInput(inputId), {
-    enabled: fetchForwarderInput && enabled,
+    enabled: !!fetchForwarderInput && enabled,
   });
 
   return isLoading || isError ? undefined : forwarderInput;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is fixing a regression introduced with https://github.com/Graylog2/graylog2-server/pull/21865, which displayed the field name instead of the input name for `gl2_source_input` field values.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9980

/nocl

