### PR TITLE
Increase visibility of GeoLocationInformation Latitude and Longitude fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
@@ -28,8 +28,8 @@ import javax.annotation.Nullable;
 @AutoValue
 @JsonDeserialize(builder = GeoLocationInformation.Builder.class)
 public abstract class GeoLocationInformation {
-    private static final String FIELD_LATITUDE = "latitude";
-    private static final String FIELD_LONGITUDE = "longitude";
+    public static final String FIELD_LATITUDE = "latitude";
+    public static final String FIELD_LONGITUDE = "longitude";
     private static final String FIELD_COUNTRY_ISO_CODE = "country_iso_code";
     private static final String FIELD_COUNTRY_NAME = "country_name";
     private static final String FIELD_CITY_NAME = "city_name";


### PR DESCRIPTION
Increase visibility of GeoLocationInformation Latitude and Longitude constant fields.

See https://github.com/Graylog2/graylog-plugin-enterprise/pull/10001 for additional context. 

/nocl No functionality change.