### PR TITLE
No need to verify existence of search related to search job

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchJobDTO.java
@@ -107,11 +107,6 @@ public record SearchJobDTO(
     }
 
     public static SearchJobDTO fromSearchJobState(final SearchJobState searchJob) {
-        //TODO: bring back when deprecated method in DataWarehouseQueryResource is gone
-//        if (loadedSearch.isEmpty()) {
-//            //TODO: less hardcore error handling?
-//            throw new IllegalStateException("Search Job stored in the database references missing Search");
-//        }
         final SearchJobStatus status = searchJob.status();
         final ExecutionInfo executionInfo = new ExecutionInfo(
                 status != RUNNING,


### PR DESCRIPTION
## Description
No need to verify existence of search related to search job.
/nocl

## Motivation and Context
FE does not use search ID stored in search job to fetch a search.
Each execution results in the creation of a new search.
Even if the search job is linked to a search that is gone, we should not take any immediate actions, throw exceptions etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

