### PR TITLE
Consistent Time Range handling in Alerts & Events histogram.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -144,7 +144,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
     }
 
     @Override
-    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+    public MoreSearch.Histogram eventHistogram(String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
                                                Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams, ZoneId timeZone,
                                                Map<String, Set<String>> extraFilters) {
         final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams, extraFilters);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -25,6 +25,7 @@ import org.graylog.events.processor.EventProcessorException;
 import org.graylog.events.search.MoreSearch;
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
@@ -34,7 +35,9 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuil
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ExtendedBounds;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ParsedAutoDateHistogram;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -47,6 +50,7 @@ import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.ChunkCommand;
 import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
@@ -108,6 +112,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
                 .from((page - 1) * perPage)
                 .size(perPage)
                 .trackTotalHits(true);
+
         final var sortBuilders = createSorting(sorting);
         sortBuilders.forEach(searchSourceBuilder::sort);
 
@@ -149,10 +154,22 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
                 .size(0)
                 .trackTotalHits(true);
 
-        final var histogramAggregation = new AutoDateHistogramAggregationBuilder(histogramAggregationName)
+        final var autoInterval = AutoInterval.create();
+        final var interval = autoInterval.toDateInterval(timerange);
+
+        final var histogramAggregation = new DateHistogramAggregationBuilder(histogramAggregationName)
                 .field(EventDto.FIELD_EVENT_TIMESTAMP)
                 .timeZone(timeZone)
-                .setNumBuckets(buckets);
+                .minDocCount(0)
+                .extendedBounds(new ExtendedBounds(Tools.buildElasticSearchTimeFormat(timerange.from()), Tools.buildElasticSearchTimeFormat(timerange.to())));
+
+        final var dateInterval = new DateHistogramInterval(interval.getQuantity().toString() + interval.getUnit());
+
+        if (interval.getQuantity().intValue() > 1) {
+            histogramAggregation.fixedInterval(dateInterval);
+        } else {
+            histogramAggregation.calendarInterval(dateInterval);
+        }
 
         final var termsAggregation = AggregationBuilders.terms(termsAggregationName)
                 .field(EventDto.FIELD_ALERT);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -144,7 +144,7 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
     }
 
     @Override
-    public MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+    public MoreSearch.Histogram eventHistogram(String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
                                                Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams,
                                                ZoneId timeZone, Map<String, Set<String>> extraFilters) {
         final var filter = createQuery(queryString, timerange, eventStreams, filterString, forbiddenSourceStreams, extraFilters);
@@ -162,7 +162,7 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
                 .timeZone(timeZone)
                 .minDocCount(0)
                 .extendedBounds(new LongBounds(Tools.buildElasticSearchTimeFormat(timerange.from()), Tools.buildElasticSearchTimeFormat(timerange.to())));
-        
+
         final var dateInterval = new DateHistogramInterval(interval.getQuantity().toString() + interval.getUnit());
 
         if (interval.getQuantity().intValue() > 1) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -128,7 +128,7 @@ public class MoreSearch {
         if (affectedIndices == null || affectedIndices.isEmpty()) {
             return Histogram.empty(effectiveTimeRange);
         }
-        return moreSearchAdapter.eventHistogram(30, queryString, effectiveTimeRange, affectedIndices, eventStreams,
+        return moreSearchAdapter.eventHistogram(queryString, effectiveTimeRange, affectedIndices, eventStreams,
                 filterString, forbiddenSourceStreams, timeZone, parameters.filter().extraFilters());
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -38,7 +38,7 @@ public interface MoreSearchAdapter {
                                   int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams,
                                   Map<String, Set<String>> extraFilters);
 
-    MoreSearch.Histogram eventHistogram(int buckets, String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
+    MoreSearch.Histogram eventHistogram(String queryString, AbsoluteRange timerange, Set<String> affectedIndices,
                                         Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams,
                                         ZoneId timeZone, Map<String, Set<String>> extraFilters);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving the Alerts & Events histogram in two ways:

  - Always set range of graph to selected time range. This prevents a bug, where the removal of a time range filter does not reset the time range in the graph.
  - Return empty buckets before and after first/last data present in aggregation

This provides a more consistent handling & presentation of the configured time range for the user.

/nocl Unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

### Before:
![image](https://github.com/user-attachments/assets/bec37322-3ad5-4e4a-83fd-1ed764ceda2b)
Range of Graph is zoomed in to the range where data is available

### After:
![image](https://github.com/user-attachments/assets/266254e2-ef67-4c3d-8f76-f30fdfdbcc39)
Range of Graph is still defaulting to six months even, when no early data is available

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.