### PR TITLE
Allow longer TTL when creating a new token.

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -349,6 +349,10 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.threeten</groupId>
+            <artifactId>threeten-extra</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.graylog2.repackaged</groupId>

--- a/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationDeserializer.java
@@ -1,0 +1,25 @@
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.threeten.extra.PeriodDuration;
+
+import java.io.IOException;
+
+public class PeriodDurationDeserializer extends StdDeserializer<PeriodDuration> {
+
+    public PeriodDurationDeserializer() {
+        super(PeriodDuration.class);
+    }
+
+    @Override
+    public PeriodDuration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        if (p.currentTokenId() == JsonTokenId.ID_STRING) {
+            return PeriodDuration.parse(p.getText().trim());
+        }
+        throw ctxt.wrongTokenException(p, handledType(), JsonToken.VALUE_STRING, "expected String");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationDeserializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationSerializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationSerializer.java
@@ -1,0 +1,21 @@
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.threeten.extra.PeriodDuration;
+
+import java.io.IOException;
+
+public class PeriodDurationSerializer extends StdSerializer<PeriodDuration> {
+
+    public PeriodDurationSerializer() {
+        super(PeriodDuration.class);
+    }
+
+    @Override
+    public void serialize(PeriodDuration value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        final String stringified = value.toString();
+        gen.writeString(stringified);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationSerializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/PeriodDurationSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.users;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -101,10 +102,10 @@ import org.graylog2.users.UserOverviewDTO;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.extra.PeriodDuration;
 
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -711,8 +712,8 @@ public class UsersResource extends RestResource {
         return TokenList.create(tokenList.build());
     }
 
-    public record GenerateTokenTTL(Optional<Duration> tokenTTL) {
-        public Duration getTTL(Supplier<Duration> defaultSupplier) {
+    public record GenerateTokenTTL(@JsonProperty Optional<PeriodDuration> tokenTTL) {
+        public PeriodDuration getTTL(Supplier<PeriodDuration> defaultSupplier) {
             return this.tokenTTL.orElseGet(defaultSupplier);
         }
     }
@@ -736,7 +737,7 @@ public class UsersResource extends RestResource {
         if (body == null) {
             body = new GenerateTokenTTL(Optional.empty());
         }
-        final AccessToken accessToken = accessTokenService.create(futureOwner.getName(), name, body.getTTL(() -> clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens()));
+        final AccessToken accessToken = accessTokenService.create(futureOwner.getName(), name, body.getTTL(() -> PeriodDuration.of(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens())));
 
         return Token.create(accessToken.getId(), accessToken.getName(), accessToken.getToken(), accessToken.getLastAccess());
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -737,7 +737,7 @@ public class UsersResource extends RestResource {
         if (body == null) {
             body = new GenerateTokenTTL(Optional.empty());
         }
-        final AccessToken accessToken = accessTokenService.create(futureOwner.getName(), name, body.getTTL(() -> PeriodDuration.of(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens())));
+        final AccessToken accessToken = accessTokenService.create(futureOwner.getName(), name, body.getTTL(() -> clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens()));
 
         return Token.create(accessToken.getId(), accessToken.getName(), accessToken.getToken(), accessToken.getLastAccess());
     }

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
@@ -22,9 +22,9 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.rest.models.SortOrder;
 import org.graylog2.search.SearchQuery;
 import org.joda.time.DateTime;
+import org.threeten.extra.PeriodDuration;
 
 import javax.annotation.Nullable;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +40,7 @@ public interface AccessTokenService extends PersistedService {
     List<AccessToken> loadAll(String username);
 
     /**
-     * Please use {@link #create(String, String, Duration)} instead.
+     * Please use {@link #create(String, String, PeriodDuration)} instead.
      * Internally, the above-mentioned method is called with the currently configured default ttl.
      *
      * @deprecated
@@ -48,7 +48,7 @@ public interface AccessTokenService extends PersistedService {
     @Deprecated(since = "6.2.0")
     AccessToken create(String username, String name);
 
-    AccessToken create(String username, String name, Duration ttl);
+    AccessToken create(String username, String name, PeriodDuration ttl);
 
     DateTime touch(AccessToken accessToken) throws ValidationException;
 

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -48,11 +48,12 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.extra.PeriodDuration;
 
 import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.time.Duration;
+import java.time.Period;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,12 +144,12 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
     @Override
     public AccessToken create(String username, String name) {
-        final Duration defaultTTL = configService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens();
+        final PeriodDuration defaultTTL = PeriodDuration.of(configService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens());
         return create(username, name, defaultTTL);
     }
 
     @Override
-    public AccessToken create(String username, String name, Duration ttl) {
+    public AccessToken create(String username, String name, PeriodDuration ttl) {
         Map<String, Object> fields = Maps.newHashMap();
         AccessTokenImpl accessToken;
         String id = null;
@@ -163,7 +164,9 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
             fields.put(AccessTokenImpl.USERNAME, username);
             fields.put(AccessTokenImpl.NAME, name);
             fields.put(AccessTokenImpl.CREATED_AT, nowUTC);
-            fields.put(AccessTokenImpl.EXPIRES_AT, nowUTC.plus(ttl.toMillis()));
+            // This is kind of ugly, as we're still using joda-time. Once we're with java.time, one can use "nowUtc.plus(ttl)".
+            // Until then, we need to add all fields of the period and the duration separately:
+            fields.put(AccessTokenImpl.EXPIRES_AT, addTtlPeriodDuration(nowUTC, ttl));
             fields.put(AccessTokenImpl.LAST_ACCESS, Tools.dateTimeFromDouble(0)); // aka never.
             accessToken = new AccessTokenImpl(fields);
             try {
@@ -179,6 +182,11 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
             throw new IllegalStateException("Could not create unique access token, tried 10 times. This is bad.");
         }
         return accessToken;
+    }
+
+    private DateTime addTtlPeriodDuration(DateTime dt, PeriodDuration ttl) {
+        final Period p = ttl.getPeriod();
+        return dt.plusYears(p.getYears()).plusMonths(p.getMonths()).plusDays(p.getDays()).plus(ttl.getDuration().toMillis());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -144,7 +144,7 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
     @Override
     public AccessToken create(String username, String name) {
-        final PeriodDuration defaultTTL = PeriodDuration.of(configService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens());
+        final PeriodDuration defaultTTL = configService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES).defaultTTLForNewTokens();
         return create(username, name, defaultTTL);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/config/ObjectMapperConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/config/ObjectMapperConfiguration.java
@@ -45,6 +45,8 @@ import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
 import org.graylog2.jackson.JacksonModelValidator;
 import org.graylog2.jackson.JodaDurationCompatSerializer;
 import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
+import org.graylog2.jackson.PeriodDurationDeserializer;
+import org.graylog2.jackson.PeriodDurationSerializer;
 import org.graylog2.jackson.SemverDeserializer;
 import org.graylog2.jackson.SemverRequirementDeserializer;
 import org.graylog2.jackson.SemverRequirementSerializer;
@@ -59,6 +61,7 @@ import org.graylog2.shared.jackson.SizeSerializer;
 import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.joda.time.Duration;
 import org.joda.time.Period;
+import org.threeten.extra.PeriodDuration;
 
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -102,6 +105,7 @@ public class ObjectMapperConfiguration {
                         .addSerializer(new SemverSerializer())
                         .addSerializer(new SemverRequirementSerializer())
                         .addSerializer(Duration.class, new JodaDurationCompatSerializer())
+                        .addSerializer(new PeriodDurationSerializer())
                         .addSerializer(GRN.class, new ToStringSerializer())
                         .addSerializer(EncryptedValue.class, new EncryptedValueSerializer())
                         .addDeserializer(Version.class, new VersionDeserializer())
@@ -109,6 +113,7 @@ public class ObjectMapperConfiguration {
                         .addDeserializer(Requirement.class, new SemverRequirementDeserializer())
                         .addDeserializer(GRN.class, new GRNDeserializer(grnRegistry))
                         .addDeserializer(EncryptedValue.class, new EncryptedValueDeserializer(encryptedValueService))
+                        .addDeserializer(PeriodDuration.class, new PeriodDurationDeserializer())
                         .setDeserializerModifier(inputConfigurationBeanDeserializerModifier)
                         .setSerializerModifier(JacksonModelValidator.getBeanSerializerModifier())
                 );

--- a/graylog2-server/src/main/java/org/graylog2/users/UserConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.Version;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -35,9 +36,9 @@ public abstract class UserConfiguration {
     //Starting with graylog version 6.2, external users are not allowed to own access tokens by default.
     // Before this version, it is allowed, to not introduce a breaking change:
     // Similarly, starting from version 6.2, creation of tokens is restricted to admins only:
-    public static final UserConfiguration DEFAULT_VALUES = create(false, Duration.of(8, ChronoUnit.HOURS), IS_BEFORE_VERSION_6_2, !IS_BEFORE_VERSION_6_2, Duration.ofDays(30));
+    public static final UserConfiguration DEFAULT_VALUES = create(false, Duration.of(8, ChronoUnit.HOURS), IS_BEFORE_VERSION_6_2, !IS_BEFORE_VERSION_6_2, PeriodDuration.of(Duration.ofDays(30)));
     //In case the installation is upgraded, we apply some less strict defaults:
-    public static final UserConfiguration DEFAULT_VALUES_FOR_UPGRADE = create(false, Duration.of(8, ChronoUnit.HOURS), IS_BEFORE_VERSION_6_2, false, Duration.ofDays(30));
+    public static final UserConfiguration DEFAULT_VALUES_FOR_UPGRADE = create(false, Duration.of(8, ChronoUnit.HOURS), IS_BEFORE_VERSION_6_2, false, PeriodDuration.of(Duration.ofDays(30)));
 
     @JsonProperty("enable_global_session_timeout")
     public abstract boolean enableGlobalSessionTimeout();
@@ -52,7 +53,7 @@ public abstract class UserConfiguration {
     public abstract boolean restrictAccessTokenToAdmins();
 
     @JsonProperty("default_ttl_for_new_tokens")
-    public abstract Duration defaultTTLForNewTokens();
+    public abstract PeriodDuration defaultTTLForNewTokens();
 
     @JsonCreator
     public static UserConfiguration create(
@@ -60,7 +61,7 @@ public abstract class UserConfiguration {
             @JsonProperty("global_session_timeout_interval") Duration globalSessionTimeoutInterval,
             @JsonProperty("allow_access_token_for_external_user") boolean allowAccessTokenForExternalUsers,
             @JsonProperty("restrict_access_token_to_admins") boolean restrictAccessTokensToAdmins,
-            @JsonProperty("default_ttl_for_new_tokens") Duration defaultTTLForNewTokens) {
+            @JsonProperty("default_ttl_for_new_tokens") PeriodDuration defaultTTLForNewTokens) {
         return new AutoValue_UserConfiguration(enableGlobalSessionTimeout, globalSessionTimeoutInterval,
                 allowAccessTokenForExternalUsers, restrictAccessTokensToAdmins, defaultTTLForNewTokens);
     }

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
@@ -19,39 +19,29 @@ package org.graylog2.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.threeten.extra.PeriodDuration;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(Parameterized.class)
 public class PeriodDurationDeserializerTest {
     private final ObjectMapper mapper = new ObjectMapperProvider().get();
 
-    private final String serializedInput;
-    private final String expected;
-
-    public PeriodDurationDeserializerTest(String serializedInput, String expected) {
-        this.serializedInput = serializedInput;
-        this.expected = expected;
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of("\"P1Y\"", "P1Y"),
+                Arguments.of("\"PT12H\"", "PT12H"),
+                Arguments.of("\"P1YT12H\"", "P1YT12H")
+        );
     }
 
-    @Parameterized.Parameters(name = "Deserializing \"{0}\" should result in PeriodDuration.parse(\"{1}\").")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"\"P1Y\"", "P1Y"},
-                {"\"PT12H\"", "PT12H"},
-                {"\"P1YT12H\"", "P1YT12H"}
-        });
-    }
-
-    @Test
-    public void testDeserialize() throws JsonProcessingException {
+    @ParameterizedTest(name = "Deserializing \"{0}\" should result in PeriodDuration.parse(\"{1}\").")
+    @MethodSource("data")
+    void testDeserialize(String serializedInput, String expected) throws JsonProcessingException {
         final PeriodDuration deserialized = mapper.readValue(serializedInput, PeriodDuration.class);
         final PeriodDuration expectedInstance = PeriodDuration.parse(expected);
         assertThat(deserialized).isEqualTo(expectedInstance);

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationDeserializerTest.java
@@ -1,0 +1,43 @@
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.threeten.extra.PeriodDuration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(Parameterized.class)
+public class PeriodDurationDeserializerTest {
+    private final ObjectMapper mapper = new ObjectMapperProvider().get();
+
+    private final String serializedInput;
+    private final String expected;
+
+    public PeriodDurationDeserializerTest(String serializedInput, String expected) {
+        this.serializedInput = serializedInput;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters(name = "Deserializing \"{0}\" should result in PeriodDuration.parse(\"{1}\").")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"\"P1Y\"", "P1Y"},
+                {"\"PT12H\"", "PT12H"},
+                {"\"P1YT12H\"", "P1YT12H"}
+        });
+    }
+
+    @Test
+    public void testDeserialize() throws JsonProcessingException {
+        final PeriodDuration deserialized = mapper.readValue(serializedInput, PeriodDuration.class);
+        final PeriodDuration expectedInstance = PeriodDuration.parse(expected);
+        assertThat(deserialized).isEqualTo(expectedInstance);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
@@ -1,0 +1,43 @@
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.threeten.extra.PeriodDuration;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(Parameterized.class)
+public class PeriodDurationSerializerTest {
+    private final ObjectMapper mapper = new ObjectMapperProvider().get();
+
+    private final String input;
+    private final String expectedSerialized;
+
+    public PeriodDurationSerializerTest(String input, String expectedSerialized) {
+        this.input = input;
+        this.expectedSerialized = expectedSerialized;
+    }
+
+    @Parameterized.Parameters(name = "Input \"{0}\" serializes to \"{1}\"")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"P1Y", "\"P1Y\""},
+                {"PT12H", "\"PT12H\""},
+                {"P1YT12H", "\"P1YT12H\""}
+        });
+    }
+
+    @Test
+    public void testSerialization() throws JsonProcessingException {
+        final PeriodDuration instance = PeriodDuration.parse(input);
+        final String serialized = mapper.writeValueAsString(instance);
+        assertThat(serialized).isEqualTo(expectedSerialized);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog2.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/PeriodDurationSerializerTest.java
@@ -19,39 +19,29 @@ package org.graylog2.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.threeten.extra.PeriodDuration;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@RunWith(Parameterized.class)
 public class PeriodDurationSerializerTest {
     private final ObjectMapper mapper = new ObjectMapperProvider().get();
 
-    private final String input;
-    private final String expectedSerialized;
-
-    public PeriodDurationSerializerTest(String input, String expectedSerialized) {
-        this.input = input;
-        this.expectedSerialized = expectedSerialized;
+    public static Stream<Arguments> data() {
+        return Stream.of(
+                Arguments.of("P1Y", "\"P1Y\""),
+                Arguments.of("PT12H", "\"PT12H\""),
+                Arguments.of("P1YT12H", "\"P1YT12H\"")
+        );
     }
 
-    @Parameterized.Parameters(name = "Input \"{0}\" serializes to \"{1}\"")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"P1Y", "\"P1Y\""},
-                {"PT12H", "\"PT12H\""},
-                {"P1YT12H", "\"P1YT12H\""}
-        });
-    }
-
-    @Test
-    public void testSerialization() throws JsonProcessingException {
+    @ParameterizedTest(name = "Input \"{0}\" serializes to \"{1}\"")
+    @MethodSource("data")
+    void testSerialization(String input, String expectedSerialized) throws JsonProcessingException {
         final PeriodDuration instance = PeriodDuration.parse(input);
         final String serialized = mapper.writeValueAsString(instance);
         assertThat(serialized).isEqualTo(expectedSerialized);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20250206105400_TokenManagementConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20250206105400_TokenManagementConfigurationTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 public class V20250206105400_TokenManagementConfigurationTest {
     //We prepare some existing config with explicitly updated values, so we can safely check they're not touched by the migration:
-    private final UserConfiguration existingConfig = UserConfiguration.create(true, Duration.of(10, ChronoUnit.HOURS), true, false, Duration.ofDays(7));
+    private final UserConfiguration existingConfig = UserConfiguration.create(true, Duration.of(10, ChronoUnit.HOURS), true, false, PeriodDuration.of(Duration.ofDays(7)));
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20250219134200_DefaultTTLForNewTokensTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20250219134200_DefaultTTLForNewTokensTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 public class V20250219134200_DefaultTTLForNewTokensTest {
     //We prepare some existing config with explicitly updated values, so we can safely check they're not touched by the migration:
-    private final UserConfiguration existingConfig = UserConfiguration.create(true, Duration.of(10, ChronoUnit.HOURS), true, false, Duration.ofDays(7));
+    private final UserConfiguration existingConfig = UserConfiguration.create(true, Duration.of(10, ChronoUnit.HOURS), true, false, PeriodDuration.of(Duration.ofDays(7)));
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UserResourceGenerateTokenAccessTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UserResourceGenerateTokenAccessTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.Parameterized;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -192,7 +193,7 @@ public class UserResourceGenerateTokenAccessTest {
         when(subject.isPermitted(USERS_TOKENCREATE + ":" + USERNAME)).thenReturn(isPermitted);
         if (!isAdmin) {
             when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
-                    .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), confAllowExternal, confDenyNonAdmins, Duration.ofDays(30)));
+                    .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), confAllowExternal, confDenyNonAdmins, PeriodDuration.of(Duration.ofDays(30))));
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -160,11 +161,11 @@ public class UsersResourceTest {
         final Token expected = createTokenAndPrepareMocks(userProps, false);
 
         try {
-            final Token actual = usersResource.generateNewToken(USERNAME, UsersResourceTest.TOKEN_NAME, new UsersResource.GenerateTokenTTL(Optional.of(Duration.ofDays(30))));
+            final Token actual = usersResource.generateNewToken(USERNAME, UsersResourceTest.TOKEN_NAME, new UsersResource.GenerateTokenTTL(Optional.of(PeriodDuration.of(Duration.ofDays(30)))));
             assertEquals(expected, actual);
         } finally {
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
-            verify(accessTokenService).create(USERNAME, UsersResourceTest.TOKEN_NAME, Duration.ofDays(30));
+            verify(accessTokenService).create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verify(clusterConfigService).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
@@ -181,7 +182,7 @@ public class UsersResourceTest {
         } finally {
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             //Before calling the service, the configuration for the default TTL is already loaded in the resource:
-            verify(accessTokenService).create(USERNAME, UsersResourceTest.TOKEN_NAME, Duration.ofDays(30));
+            verify(accessTokenService).create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verify(clusterConfigService, times(2)).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
@@ -209,13 +210,13 @@ public class UsersResourceTest {
         final Token expected = createTokenAndPrepareMocks(userProps, true);
 
         try {
-            final Token actual = usersResource.generateNewToken(USERNAME, TOKEN_NAME, new UsersResource.GenerateTokenTTL(Optional.of(Duration.ofDays(30))));
+            final Token actual = usersResource.generateNewToken(USERNAME, TOKEN_NAME, new UsersResource.GenerateTokenTTL(Optional.of(PeriodDuration.of(Duration.ofDays(30)))));
             assertEquals(expected, actual);
         } finally {
             verify(subject).getPrincipal();
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verify(clusterConfigService, times(2)).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
-            verify(accessTokenService).create(USERNAME, TOKEN_NAME, Duration.ofDays(30));
+            verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
     }
@@ -232,7 +233,7 @@ public class UsersResourceTest {
             verify(subject).getPrincipal();
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verify(clusterConfigService, times(2)).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
-            verify(accessTokenService).create(USERNAME, TOKEN_NAME, Duration.ofDays(30));
+            verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
     }
@@ -251,7 +252,7 @@ public class UsersResourceTest {
             verify(subject).getPrincipal();
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + adminUserName);
             verify(clusterConfigService).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
-            verify(accessTokenService).create(USERNAME, TOKEN_NAME, Duration.ofDays(30));
+            verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
     }
@@ -298,7 +299,7 @@ public class UsersResourceTest {
         when(subject.isPermitted(USERS_TOKENCREATE + ":" + callingUserName)).thenReturn(true);
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
                 .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), false, false, Duration.ofDays(30)));
-        when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, Duration.ofDays(30))).thenReturn(accessToken);
+        when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
 
         return Token.create(tokenId.toHexString(), TOKEN_NAME, token, lastAccess);
 
@@ -325,7 +326,7 @@ public class UsersResourceTest {
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
                 .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), allowExternalUser, false, Duration.ofDays(30)));
         if (accessToken != null) {
-            when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, Duration.ofDays(30))).thenReturn(accessToken);
+            when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
@@ -298,7 +298,7 @@ public class UsersResourceTest {
         when(userManagementService.loadById(USERNAME)).thenReturn(userImplFactory.create(owningUser));
         when(subject.isPermitted(USERS_TOKENCREATE + ":" + callingUserName)).thenReturn(true);
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
-                .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), false, false, Duration.ofDays(30)));
+                .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), false, false, PeriodDuration.of(Duration.ofDays(30))));
         when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
 
         return Token.create(tokenId.toHexString(), TOKEN_NAME, token, lastAccess);
@@ -324,7 +324,7 @@ public class UsersResourceTest {
         when(userManagementService.loadById(USERNAME)).thenReturn(user);
         when(subject.isPermitted(USERS_TOKENCREATE + ":" + USERNAME)).thenReturn(true);
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
-                .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), allowExternalUser, false, Duration.ofDays(30)));
+                .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), allowExternalUser, false, PeriodDuration.of(Duration.ofDays(30))));
         if (accessToken != null) {
             when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
         }

--- a/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.Duration;
 import java.util.List;
@@ -142,7 +143,7 @@ public class AccessTokenServiceImplTest {
         final int ttlInDays = 30;
 
         assertEquals(0, accessTokenService.loadAll(username).size());
-        final AccessToken token = accessTokenService.create(username, tokenname, Duration.ofDays(ttlInDays));
+        final AccessToken token = accessTokenService.create(username, tokenname, PeriodDuration.of(Duration.ofDays(ttlInDays)));
 
         assertEquals(1, accessTokenService.loadAll(username).size());
         assertNotNull("Should have returned token", token);
@@ -152,6 +153,34 @@ public class AccessTokenServiceImplTest {
         assertNotNull("\"CreatedAt\" should not be null", token.getCreatedAt());
         assertNotNull("\"ExpiresAt\" should not be null", token.getExpiresAt());
         assertEquals("Expiration-timestamp should be " + ttlInDays + " days after creation-timestamp", token.getCreatedAt().plusDays(ttlInDays), token.getExpiresAt());
+        verifyNoMoreInteractions(paginatedAccessTokenEntityService, configService);
+    }
+
+    @Test
+    public void testCreateWithOddTTL() {
+        final String username = "admin";
+        final String tokenname = "web";
+
+        assertEquals(0, accessTokenService.loadAll(username).size());
+        final AccessToken token = accessTokenService.create(username, tokenname, PeriodDuration.parse("P1Y1M1DT1H1M1S"));
+
+        final List<AccessToken> accessTokens = accessTokenService.loadAll(username);
+        assertEquals(1, accessTokens.size());
+        assertNotNull("Should have returned token", token);
+        assertEquals("Username before and after saving should be equal", username, token.getUserName());
+        assertEquals("Token before and after saving should be equal", tokenname, token.getName());
+        assertNotNull("Token should not be null", token.getToken());
+        assertNotNull("\"CreatedAt\" should not be null", token.getCreatedAt());
+        assertNotNull("\"ExpiresAt\" should not be null", token.getExpiresAt());
+        //Comparing the period between the creation and expiration of the token: It should be 1 year, 1 month, 1 day, 1 hour, 1 minute and 1 second, as defined above:
+        org.joda.time.Period validDuring = new org.joda.time.Period(token.getCreatedAt(), token.getExpiresAt());
+        assertEquals(1, validDuring.getYears());
+        assertEquals(1, validDuring.getMonths());
+        assertEquals(1, validDuring.getDays());
+        assertEquals(1, validDuring.getHours());
+        assertEquals(1, validDuring.getMinutes());
+        assertEquals(1, validDuring.getSeconds());
+        assertEquals(0, validDuring.getMillis());
         verifyNoMoreInteractions(paginatedAccessTokenEntityService, configService);
     }
 
@@ -182,7 +211,7 @@ public class AccessTokenServiceImplTest {
 
         assertThat(accessTokenService.loadAll(username)).isEmpty();
 
-        final AccessToken token = accessTokenService.create(username, tokenName, Duration.ofDays(30));
+        final AccessToken token = accessTokenService.create(username, tokenName, PeriodDuration.of(Duration.ofDays(30)));
 
         assertThat(accessTokenService.loadAll(username)).hasSize(1);
 
@@ -232,7 +261,7 @@ public class AccessTokenServiceImplTest {
         assertNull(accessTokenService.load(tokenString));
         assertEquals(0, accessTokenService.loadAll(username).size());
 
-        final AccessToken token = accessTokenService.create(username, tokenname, Duration.ofDays(30));
+        final AccessToken token = accessTokenService.create(username, tokenname, PeriodDuration.of(Duration.ofDays(30)));
         token.setToken(tokenString);
 
         accessTokenService.save(token);
@@ -251,7 +280,7 @@ public class AccessTokenServiceImplTest {
     @MongoDBFixtures("accessTokensSingleToken.json")
     public void testExceptionForMultipleTokens() {
         final AccessToken existingToken = accessTokenService.load("foobar");
-        final AccessToken newToken = accessTokenService.create("user", "foobar", Duration.ofDays(30));
+        final AccessToken newToken = accessTokenService.create("user", "foobar", PeriodDuration.of(Duration.ofDays(30)));
         newToken.setToken(existingToken.getToken());
         assertThatThrownBy(() -> accessTokenService.save(newToken))
                 .isInstanceOfSatisfying(MongoException.class, e ->

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
         <streamex.version>0.8.3</streamex.version>
         <swagger.version>1.6.15</swagger.version>
         <syslog4j.version>0.9.61</syslog4j.version>
+        <threeten-extra.version>1.8.0</threeten-extra.version>
         <ulid.version>8.3.0</ulid.version>
         <unboundid-ldap.version>7.0.2</unboundid-ldap.version>
         <uuid.version>3.2.1</uuid.version>
@@ -492,6 +493,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcutil-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.threeten</groupId>
+                <artifactId>threeten-extra</artifactId>
+                <version>${threeten-extra.version}</version>
             </dependency>
 
             <!-- test -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #22015.
When creating a token with a TTL specifying months or even years, the creation fails.

## Description
<!--- Describe your changes in detail -->
Before, the TTL was accepted as a `java.time.Duration`, which only handles durations up to days. It isn't made for anything coarser than that. So after checking with @bernd , the TTL is now accepted as `org.threeten.extra.PeriodDuration`, which allows any combination of time-units (year, month, day, hour, minute, second). So with this, the TTL's configuration became more flexible too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are unit-tests and I've also checked on my local server both via UI and curl.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl
