### PR TITLE
Add missing class loader to `ObjectMapperModule` creation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/GraylogNodeModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/GraylogNodeModule.java
@@ -36,6 +36,7 @@ import org.graylog2.shared.bindings.ObjectMapperModule;
 import org.graylog2.shared.bindings.SchedulerBindings;
 import org.graylog2.shared.bindings.ServerStatusBindings;
 import org.graylog2.shared.bindings.providers.EventBusProvider;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 
 import java.util.Set;
 
@@ -45,9 +46,11 @@ import java.util.Set;
  */
 public class GraylogNodeModule extends Graylog2Module {
     private final GraylogNodeConfiguration configuration;
+    private final ChainingClassLoader chainingClassLoader;
 
-    public GraylogNodeModule(final GraylogNodeConfiguration configuration) {
+    public GraylogNodeModule(final GraylogNodeConfiguration configuration, final ChainingClassLoader chainingClassLoader) {
         this.configuration = configuration;
+        this.chainingClassLoader = chainingClassLoader;
     }
 
     @Override
@@ -55,7 +58,7 @@ public class GraylogNodeModule extends Graylog2Module {
         bind(GraylogNodeConfiguration.class).toInstance(configuration);
         if (configuration.withMongoDb()) {
             install(new MongoDbConnectionModule());
-            install(new ObjectMapperModule());
+            install(new ObjectMapperModule(chainingClassLoader));
         }
         if (configuration.withScheduler()) {
             install(new SchedulerBindings());

--- a/graylog2-server/src/main/java/org/graylog2/commands/AbstractNodeCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/AbstractNodeCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractNodeCommand extends CmdLineTool<GraylogNodeConfigu
 
     public AbstractNodeCommand(final String commandName, final GraylogNodeConfiguration configuration) {
         super(commandName, configuration);
-        this.nodeModule = new GraylogNodeModule(configuration);
+        this.nodeModule = new GraylogNodeModule(configuration, chainingClassLoader);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
@@ -32,6 +32,11 @@ import static java.util.Objects.requireNonNull;
 public class ObjectMapperModule extends Graylog2Module {
     private final ClassLoader classLoader;
 
+    @VisibleForTesting
+    public ObjectMapperModule() {
+        this(ObjectMapperModule.class.getClassLoader());
+    }
+
     public ObjectMapperModule(ClassLoader classLoader) {
         this.classLoader = requireNonNull(classLoader);
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
@@ -32,11 +32,6 @@ import static java.util.Objects.requireNonNull;
 public class ObjectMapperModule extends Graylog2Module {
     private final ClassLoader classLoader;
 
-    @VisibleForTesting
-    public ObjectMapperModule() {
-        this(ObjectMapperModule.class.getClassLoader());
-    }
-
     public ObjectMapperModule(ClassLoader classLoader) {
         this.classLoader = requireNonNull(classLoader);
     }


### PR DESCRIPTION
The ObjectMapperModule needs the chaining class loader to find classes from plugins.

This broke in the node types refactoring in pull request #20181. (commit b4e1e075f9a18382c55add16ad0bf1265c462fc3)

~Also, remove the unused no-argument constructor in `ObjectMapperModule` to avoid future accidents.~ The no-argument constructor is actually used in tests.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9768
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9996

/nocl Fixing unreleased refactoring