### PR TITLE
Allow disabling type checking in dev server to save memory.

### DIFF
--- a/graylog2-web-interface/webpack.preflight.ts
+++ b/graylog2-web-interface/webpack.preflight.ts
@@ -33,6 +33,7 @@ const BUILD_PATH = path.resolve(ROOT_PATH, 'target/preflight/build');
 const TARGET = process.env.npm_lifecycle_event || 'build';
 process.env.BABEL_ENV = TARGET;
 const mode = TARGET.startsWith('build') ? 'production' : 'development';
+const disableTsc = process.env.disable_tsc === 'true';
 
 const apiUrl = process.env.GRAYLOG_API_URL ?? DEFAULT_API_URL;
 
@@ -74,10 +75,12 @@ if (mode === 'development') {
       hot: false,
       liveReload: true,
       compress: true,
-      proxy: [{
-        context: ['/api'],
-        target: apiUrl,
-      }],
+      proxy: [
+        {
+          context: ['/api'],
+          target: apiUrl,
+        },
+      ],
     },
     devtool: 'cheap-module-source-map',
     output: {
@@ -88,7 +91,7 @@ if (mode === 'development') {
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
       }),
-      new ForkTsCheckerWebpackPlugin(),
+      ...(disableTsc ? [] : [new ForkTsCheckerWebpackPlugin()]),
     ],
   });
 }
@@ -97,9 +100,11 @@ if (mode === 'production') {
   webpackConfig = merge(baseConfig, {
     optimization: {
       moduleIds: 'deterministic',
-      minimizer: [new EsbuildPlugin({
-        target: supportedBrowsers,
-      })],
+      minimizer: [
+        new EsbuildPlugin({
+          target: supportedBrowsers,
+        }),
+      ],
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/graylog2-web-interface/webpack/core.js
+++ b/graylog2-web-interface/webpack/core.js
@@ -24,6 +24,8 @@ const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin');
 
 const UniqueChunkIdPlugin = require('./UniqueChunkIdPlugin');
 
+const disableTsc = process.env.disable_tsc === 'true';
+
 const getCssLoaderOptions = (target) => {
   // Development
   if (target === 'start') {
@@ -160,11 +162,15 @@ const config = (target, appPath, rootPath, webInterfaceRoot, supportedBrowsers) 
         new webpack.DefinePlugin({
           DEVELOPMENT: true,
         }),
-        new ForkTsCheckerWebpackPlugin({
-          typescript: {
-            memoryLimit: 4096,
-          },
-        }),
+        ...(disableTsc
+          ? []
+          : [
+              new ForkTsCheckerWebpackPlugin({
+                typescript: {
+                  memoryLimit: 4096,
+                },
+              }),
+            ]),
       ],
     });
   }
@@ -196,9 +202,11 @@ const config = (target, appPath, rootPath, webInterfaceRoot, supportedBrowsers) 
           },
         },
         moduleIds: 'deterministic',
-        minimizer: [new EsbuildPlugin({
-          target: supportedBrowsers,
-        })],
+        minimizer: [
+          new EsbuildPlugin({
+            target: supportedBrowsers,
+          }),
+        ],
       },
       plugins: [
         new webpack.DefinePlugin({


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->s

This PR adds a `disable_tsc` environment variable for `yarn start`, which disables type-checking. This is useful, when `tsc` is used through the IDE or separately (e.g. using `tsc --watch`) and no double type-checking is wanted.

/nocl Relevant for dev only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.