### PR TITLE
Update regex to handle special chars

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
@@ -48,7 +48,7 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 public class InputRoutingService {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InputRoutingService.class);
     private static final String GL_ROUTING_RULE_PREFIX = "gl_route_";
-    private static final Pattern GL_ROUTING_RULE_REGEX = Pattern.compile(GL_ROUTING_RULE_PREFIX + "(\\w+)\\[(\\w+)\\]_to_(\\w+)");
+    private static final Pattern GL_ROUTING_RULE_REGEX = Pattern.compile(GL_ROUTING_RULE_PREFIX + "(.+)\\[(\\w+)\\]_to_(.+)");
 
     private final RuleService ruleService;
     private final InputService inputService;
@@ -132,7 +132,7 @@ public class InputRoutingService {
     }
 
     private String createSystemRuleRegex(String inputId, String inputName) {
-        return GL_ROUTING_RULE_PREFIX + inputName + "\\[" + inputId + "\\]_to_.*";
+        return GL_ROUTING_RULE_PREFIX + Pattern.quote(inputName) + "\\[" + inputId + "\\]_to_.*";
     }
 
     private String replaceInputName(String ruleName, String oldInputName, String newInputName) {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputRoutingService.java
@@ -130,7 +130,8 @@ public class InputRoutingService {
     }
 
     private String sanitize(String s) {
-        return s.replace('\"', '*');
+        return s.replace('\"', '*')
+                .replace('\\', '*');
     }
 
     private boolean isSystemRulePattern(String ruleName) {


### PR DESCRIPTION
/nocl 
Resolves #22023

<!--- Provide a general summary of your changes in the Title above -->
Update regex matching to handle special characters in the names of inputs and streams.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The handler for renamed/deleted inputs choked on input or stream names with special chars. This prevented proper updating of the related pipeline and routing rule.
