### PR TITLE
Safer extraction of search response in field type retrieval.

### DIFF
--- a/changelog/unreleased/pr-22095.toml
+++ b/changelog/unreleased/pr-22095.toml
@@ -1,0 +1,4 @@
+type="a"
+message="Better error reporting for low-level failures during field type retrieval."
+
+pulls=["22095"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -184,7 +184,7 @@ public class ElasticsearchClient {
                 : RequestOptions.DEFAULT;
     }
 
-    private ElasticsearchException exceptionFrom(Exception e, String errorMessage) {
+    public static ElasticsearchException exceptionFrom(Exception e, String errorMessage) {
         if (e instanceof ElasticsearchException elasticsearchException) {
             if (isIndexNotFoundException(elasticsearchException)) {
                 throw IndexNotFoundException.create(errorMessage + elasticsearchException.getResourceId(), elasticsearchException.getIndex().getName());
@@ -211,7 +211,7 @@ public class ElasticsearchClient {
         return new ElasticsearchException(errorMessage, e);
     }
 
-    private boolean isInvalidWriteTargetException(ElasticsearchException elasticsearchException) {
+    private static boolean isInvalidWriteTargetException(ElasticsearchException elasticsearchException) {
         try {
             final ParsedElasticsearchException parsedException = ParsedElasticsearchException.from(elasticsearchException.getMessage());
             return parsedException.reason().startsWith("no write index is defined for alias");
@@ -220,7 +220,7 @@ public class ElasticsearchClient {
         }
     }
 
-    private boolean isMasterNotDiscoveredException(ElasticsearchException elasticsearchException) {
+    private static boolean isMasterNotDiscoveredException(ElasticsearchException elasticsearchException) {
         try {
             final ParsedElasticsearchException parsedException = ParsedElasticsearchException.from(elasticsearchException.getMessage());
             return parsedException.type().equals("master_not_discovered_exception")
@@ -230,15 +230,15 @@ public class ElasticsearchClient {
         }
     }
 
-    private boolean isIndexNotFoundException(ElasticsearchException elasticsearchException) {
+    private static boolean isIndexNotFoundException(ElasticsearchException elasticsearchException) {
         return elasticsearchException.getMessage().contains("index_not_found_exception");
     }
 
-    private boolean isMapperParsingExceptionException(ElasticsearchException openSearchException) {
+    private static boolean isMapperParsingExceptionException(ElasticsearchException openSearchException) {
         return openSearchException.getMessage().contains("mapper_parsing_exception");
     }
 
-    private boolean isBatchSizeTooLargeException(ElasticsearchException elasticsearchException) {
+    private static boolean isBatchSizeTooLargeException(ElasticsearchException elasticsearchException) {
         if (elasticsearchException instanceof ElasticsearchStatusException statusException) {
             if (statusException.getCause() instanceof ResponseException responseException) {
                 return (responseException.getResponse().getStatusLine().getStatusCode() == 429);

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -184,29 +184,29 @@ public class ElasticsearchClient {
                 : RequestOptions.DEFAULT;
     }
 
-    public static ElasticsearchException exceptionFrom(Exception e, String errorMessage) {
+    public static RuntimeException exceptionFrom(Exception e, String errorMessage) {
         if (e instanceof ElasticsearchException elasticsearchException) {
             if (isIndexNotFoundException(elasticsearchException)) {
-                throw IndexNotFoundException.create(errorMessage + elasticsearchException.getResourceId(), elasticsearchException.getIndex().getName());
+                return IndexNotFoundException.create(errorMessage + elasticsearchException.getResourceId(), elasticsearchException.getIndex().getName());
             }
             if (isMasterNotDiscoveredException(elasticsearchException)) {
-                throw new MasterNotDiscoveredException();
+                return new MasterNotDiscoveredException();
             }
             if (isInvalidWriteTargetException(elasticsearchException)) {
                 final Matcher matcher = invalidWriteTarget.matcher(elasticsearchException.getMessage());
                 if (matcher.find()) {
                     final String target = matcher.group("target");
-                    throw InvalidWriteTargetException.create(target);
+                    return InvalidWriteTargetException.create(target);
                 }
             }
             if (isBatchSizeTooLargeException(elasticsearchException)) {
-                throw new BatchSizeTooLargeException(elasticsearchException.getMessage());
+                return new BatchSizeTooLargeException(elasticsearchException.getMessage());
             }
             if (isMapperParsingExceptionException(elasticsearchException)) {
-                throw new MapperParsingException(elasticsearchException.getMessage());
+                return new MapperParsingException(elasticsearchException.getMessage());
             }
         } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
-            throw new BatchSizeTooLargeException(e.getMessage());
+            return new BatchSizeTooLargeException(e.getMessage());
         }
         return new ElasticsearchException(errorMessage, e);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/fieldtypes/streams/StreamsForFieldRetrieverES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/fieldtypes/streams/StreamsForFieldRetrieverES7.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.storage.elasticsearch7.fieldtypes.streams;
 
+import jakarta.inject.Inject;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
@@ -28,8 +29,6 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.Search
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog2.indexer.fieldtypes.streamfiltered.esadapters.StreamsForFieldRetriever;
 import org.graylog2.plugin.Message;
-
-import jakarta.inject.Inject;
 
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +60,7 @@ public class StreamsForFieldRetrieverES7 implements StreamsForFieldRetriever {
                     if (item.isFailure()) {
                         throw ElasticsearchClient.exceptionFrom(item.getFailure(), "Error while retrieving field types");
                     }
-                    return retrieveStreamsFromAggregationInResponse(item.getResponse())
+                    return retrieveStreamsFromAggregationInResponse(item.getResponse());
                 })
                 .toList();
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/fieldtypes/streams/StreamsForFieldRetrieverES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/fieldtypes/streams/StreamsForFieldRetrieverES7.java
@@ -57,7 +57,12 @@ public class StreamsForFieldRetrieverES7 implements StreamsForFieldRetriever {
 
 
         final List<Set<String>> streamsPerField = multiSearchResponse.stream()
-                .map(item -> retrieveStreamsFromAggregationInResponse(item.getResponse()))
+                .map(item -> {
+                    if (item.isFailure()) {
+                        throw ElasticsearchClient.exceptionFrom(item.getFailure(), "Error while retrieving field types");
+                    }
+                    return retrieveStreamsFromAggregationInResponse(item.getResponse())
+                })
                 .toList();
 
         Map<String, Set<String>> result = new HashMap<>(fieldNames.size());

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
@@ -184,29 +184,29 @@ public class OpenSearchClient {
                 : RequestOptions.DEFAULT;
     }
 
-    public static OpenSearchException exceptionFrom(Exception e, String errorMessage) {
+    public static RuntimeException exceptionFrom(Exception e, String errorMessage) {
         if (e instanceof OpenSearchException openSearchException) {
             if (isIndexNotFoundException(openSearchException)) {
-                throw IndexNotFoundException.create(errorMessage + openSearchException.getResourceId(), openSearchException.getIndex().getName());
+                return IndexNotFoundException.create(errorMessage + openSearchException.getResourceId(), openSearchException.getIndex().getName());
             }
             if (isMasterNotDiscoveredException(openSearchException)) {
-                throw new MasterNotDiscoveredException();
+                return new MasterNotDiscoveredException();
             }
             if (isInvalidWriteTargetException(openSearchException)) {
                 final Matcher matcher = invalidWriteTarget.matcher(openSearchException.getMessage());
                 if (matcher.find()) {
                     final String target = matcher.group("target");
-                    throw InvalidWriteTargetException.create(target);
+                    return InvalidWriteTargetException.create(target);
                 }
             }
             if (isBatchSizeTooLargeException(openSearchException)) {
-                throw new BatchSizeTooLargeException(openSearchException.getMessage());
+                return new BatchSizeTooLargeException(openSearchException.getMessage());
             }
             if (isMapperParsingExceptionException(openSearchException)) {
-                throw new MapperParsingException(openSearchException.getMessage());
+                return new MapperParsingException(openSearchException.getMessage());
             }
         } else if (e instanceof IOException && e.getCause() instanceof ContentTooLongException) {
-            throw new BatchSizeTooLargeException(e.getMessage());
+            return new BatchSizeTooLargeException(e.getMessage());
         }
         return new OpenSearchException(errorMessage, e);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/OpenSearchClient.java
@@ -184,7 +184,7 @@ public class OpenSearchClient {
                 : RequestOptions.DEFAULT;
     }
 
-    private OpenSearchException exceptionFrom(Exception e, String errorMessage) {
+    public static OpenSearchException exceptionFrom(Exception e, String errorMessage) {
         if (e instanceof OpenSearchException openSearchException) {
             if (isIndexNotFoundException(openSearchException)) {
                 throw IndexNotFoundException.create(errorMessage + openSearchException.getResourceId(), openSearchException.getIndex().getName());
@@ -211,7 +211,7 @@ public class OpenSearchClient {
         return new OpenSearchException(errorMessage, e);
     }
 
-    private boolean isInvalidWriteTargetException(OpenSearchException openSearchException) {
+    private static boolean isInvalidWriteTargetException(OpenSearchException openSearchException) {
         try {
             final ParsedOpenSearchException parsedException = ParsedOpenSearchException.from(openSearchException.getMessage());
             return parsedException.reason().startsWith("no write index is defined for alias");
@@ -220,7 +220,7 @@ public class OpenSearchClient {
         }
     }
 
-    private boolean isMasterNotDiscoveredException(OpenSearchException openSearchException) {
+    private static boolean isMasterNotDiscoveredException(OpenSearchException openSearchException) {
         try {
             final ParsedOpenSearchException parsedException = ParsedOpenSearchException.from(openSearchException.getMessage());
             return parsedException.type().equals("master_not_discovered_exception")
@@ -230,15 +230,15 @@ public class OpenSearchClient {
         }
     }
 
-    private boolean isIndexNotFoundException(OpenSearchException openSearchException) {
+    private static boolean isIndexNotFoundException(OpenSearchException openSearchException) {
         return openSearchException.getMessage().contains("index_not_found_exception");
     }
 
-    private boolean isMapperParsingExceptionException(OpenSearchException openSearchException) {
+    private static boolean isMapperParsingExceptionException(OpenSearchException openSearchException) {
         return openSearchException.getMessage().contains("mapper_parsing_exception");
     }
 
-    private boolean isBatchSizeTooLargeException(OpenSearchException openSearchException) {
+    private static boolean isBatchSizeTooLargeException(OpenSearchException openSearchException) {
         if (openSearchException instanceof OpenSearchStatusException statusException) {
             if (statusException.getCause() instanceof ResponseException responseException) {
                 return (responseException.getResponse().getStatusLine().getStatusCode() == 429);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is modifying low-level field types retrieval in a way that an individual error of the multi-search request does not result in a `NullPointerException`, but throws a proper exception before when the response is a failure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.