### PR TITLE
Improve ExpiredTokenCleaner

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/ExpiredTokenCleaner.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ExpiredTokenCleaner.java
@@ -59,13 +59,13 @@ public class ExpiredTokenCleaner extends Periodical {
 
         for (AccessTokenService.ExpiredToken token : expiredTokens) {
             ImmutableMap.Builder<String, Object> ctxBuilder = ImmutableMap.builder();
-            ctxBuilder.put(AccessTokenImpl.NAME, token.tokenName()).put("userId", token.userId());
+            ctxBuilder.put(AccessTokenImpl.NAME, token.tokenName()).put("userId", token.userId()).put("username", token.username());
             try {
                 this.tokenService.deleteById(token.id());
-                LOG.info("Successfully removed expired token \"{}\" (id: {}) for user <{}>.", token.tokenName(), token.id(), token.userId());
+                LOG.info("Successfully removed expired token \"{}\" (id: {}) for user <{}> (id <{}>).", token.tokenName(), token.id(), token.username(), token.userId());
                 this.auditEventSender.success(AuditActor.system(nodeId), USER_ACCESS_TOKEN_DELETE, ctxBuilder.build());
             } catch (Exception e) {
-                LOG.warn("Failed to remove expired token \"{}\" (id: {}) for user <{}>", token.tokenName(), token.id(), token.userId(), e);
+                LOG.warn("Failed to remove expired token \"{}\" (id: {}) for user <{}> (id <{}>).", token.tokenName(), token.id(), token.username(), token.userId(), e);
                 ctxBuilder.put("Failure", e.getMessage());
                 this.auditEventSender.failure(AuditActor.system(nodeId), USER_ACCESS_TOKEN_DELETE, ctxBuilder.build());
             }

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenService.java
@@ -86,7 +86,8 @@ public interface AccessTokenService extends PersistedService {
      * @param id        ID of the token.
      * @param tokenName Name of the token.
      * @param expiresAt Expiration date/time of the token.
-     * @param userId    ID of the owning user.
+     * @param userId    ID of the owning user. Can be null, in case the token belongs to a user which doesn't exist in the database.
+     * @param username  The username of the owner.
      */
-    record ExpiredToken(String id, String tokenName, DateTime expiresAt, String userId) {}
+    record ExpiredToken(String id, String tokenName, DateTime expiresAt, String userId, String username) {}
 }

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -27,6 +27,7 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.UnwindOptions;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
@@ -57,6 +58,7 @@ import java.time.Period;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -67,8 +69,11 @@ import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Aggregates.sort;
 import static com.mongodb.client.model.Aggregates.unwind;
+import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Projections.fields;
 import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Sorts.orderBy;
 
 /**
  * Provides access to access tokens in the database.
@@ -194,7 +199,7 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
         try {
             return lastAccessCache.get(accessToken.getId());
         } catch (ExecutionException e) {
-            LOG.debug("Ignoring error: " + e.getMessage());
+            LOG.debug("Ignoring error: {}", e.getMessage());
             return null;
         }
     }
@@ -273,18 +278,19 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
         final List<Bson> pipeline = List.of(
                 //Search fot tokens whose EXPIRES_AT is less than or equal to now:
-                match(new Document(AccessTokenImpl.EXPIRES_AT, new Document("$lte", expiredBefore.toDate()))),
+                match(lte(AccessTokenImpl.EXPIRES_AT, expiredBefore.toDate())),
                 // Sort by expiration date:
-                sort(new Document(AccessTokenImpl.EXPIRES_AT, 1)),
+                sort(orderBy(ascending(AccessTokenImpl.EXPIRES_AT))),
                 // Join in the user-collection on the username as "userDetails":
                 lookup(UserImpl.COLLECTION_NAME, AccessTokenImpl.USERNAME, UserImpl.USERNAME, join),
-                // Have a dedicated Doc for each user-id - we're working with a 1:1 relationship here, so it's safe:
-                unwind("$" + join),
+                // Have a dedicated Doc for each user-id. In case the user doesn't exist, we still keep the entire entry:
+                unwind("$" + join, new UnwindOptions().preserveNullAndEmptyArrays(true)),
                 // Load only token-id, expiration date and user-id:
                 project(fields(
                         include(AccessTokenImpl.ID_FIELD),
                         include(AccessTokenImpl.NAME),
                         include(AccessTokenImpl.EXPIRES_AT),
+                        include(AccessTokenImpl.USERNAME),
                         include(joinId)
                 ))
         );
@@ -293,12 +299,14 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
         final AggregateIterable<Document> aggregateIt = tokenColl.aggregate(pipeline);
         try (var stream = StreamSupport.stream(aggregateIt.spliterator(), false)) {
             return stream.map(d -> {
-                        final Document userDetails = d.get(join, Document.class);
+                final Optional<Document> userDetails = Optional.ofNullable(d.get(join, Document.class));
                         return new ExpiredToken(
                                 d.getObjectId(AccessTokenImpl.ID_FIELD).toString(),
                                 d.getString(AccessTokenImpl.NAME),
                                 new DateTime(d.getDate(AccessTokenImpl.EXPIRES_AT)).withZone(DateTimeZone.UTC),
-                                userDetails.getObjectId("_id").toString()
+                                //Return null for non-existing users, but definitely append the username from the token itself:
+                                userDetails.map(ud -> ud.getObjectId("_id").toString()).orElse(null),
+                                d.getString(AccessTokenImpl.USERNAME)
                         );
                     }
             ).toList();

--- a/graylog2-server/src/test/java/org/graylog2/periodical/ExpiredTokenCleanerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ExpiredTokenCleanerTest.java
@@ -2,6 +2,22 @@
  * Copyright (C) 2020 Graylog, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the Server Side License, version 1,
  * as published by MongoDB, Inc.
  *

--- a/graylog2-server/src/test/java/org/graylog2/periodical/ExpiredTokenCleanerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ExpiredTokenCleanerTest.java
@@ -2,15 +2,15 @@
  * Copyright (C) 2020 Graylog, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the Server Side Public License, version 1,
+ * it under the terms of the Server Side License, version 1,
  * as published by MongoDB, Inc.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * Server Side Public License for more details.
+ * Server Side License for more details.
  *
- * You should have received a copy of the Server Side Public License
+ * You should have received a copy of the Server Side License
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
@@ -23,12 +23,11 @@ import org.graylog2.security.AccessTokenImpl;
 import org.graylog2.security.AccessTokenService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -37,14 +36,13 @@ import java.util.Map;
 import static org.graylog2.audit.AuditEventTypes.USER_ACCESS_TOKEN_DELETE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class ExpiredTokenCleanerTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
+@ExtendWith(MockitoExtension.class)
+class ExpiredTokenCleanerTest {
 
     @Mock
     private AccessTokenService tokenService;
@@ -59,15 +57,15 @@ public class ExpiredTokenCleanerTest {
 
     private ExpiredTokenCleaner expiredTokenCleaner;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         expiredTokenCleaner = new ExpiredTokenCleaner(tokenService, auditEventSender, nodeId);
         mocks = new Object[]{tokenService, auditEventSender, nodeId};
-        when(nodeId.getNodeId()).thenReturn("nodeId1");
+        lenient().when(nodeId.getNodeId()).thenReturn("nodeId1");
     }
 
     @Test
-    public void doNothingIfNoTokenHasExpired() {
+    void doNothingIfNoTokenHasExpired() {
         when(tokenService.findExpiredTokens(any())).thenReturn(Collections.emptyList());
 
         expiredTokenCleaner.doRun();
@@ -77,7 +75,7 @@ public class ExpiredTokenCleanerTest {
     }
 
     @Test
-    public void sendAuditEventIfExpiredTokenIsDeletedSuccessfully() {
+    void sendAuditEventIfExpiredTokenIsDeletedSuccessfully() {
         final int id = 1;
         when(tokenService.findExpiredTokens(any())).thenReturn(List.of(mkToken(id)));
 
@@ -92,7 +90,7 @@ public class ExpiredTokenCleanerTest {
     }
 
     @Test
-    public void sendAuditEventIfExpiredTokenFailsToBeDeleted() {
+    void sendAuditEventIfExpiredTokenFailsToBeDeleted() {
         final int id = 2;
         final String errorMsg = "Boooom!";
         when(tokenService.findExpiredTokens(any())).thenReturn(List.of(mkToken(id)));
@@ -114,13 +112,13 @@ public class ExpiredTokenCleanerTest {
     private final DateTime baseDateTime = new DateTime(2020, 1, 1, 0, 0, DateTimeZone.UTC);
 
     private AccessTokenService.ExpiredToken mkToken(int id) {
-        return new AccessTokenService.ExpiredToken(String.valueOf(id), "token" + id, baseDateTime.plusDays(id), "user" + id);
+        return new AccessTokenService.ExpiredToken(String.valueOf(id), "token" + id, baseDateTime.plusDays(id), "user" + id, "username" + id);
     }
 
 
     private Map<String, Object> expectedContext(int id, String errorMsg) {
         ImmutableMap.Builder<String, Object> ctx = ImmutableMap.builder();
-        ctx.put(AccessTokenImpl.NAME, "token" + id).put("userId", "user" + id);
+        ctx.put(AccessTokenImpl.NAME, "token" + id).put("userId", "user" + id).put("username", "username" + id);
         if (errorMsg != null) {
             ctx.put("Failure", errorMsg);
         }

--- a/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
@@ -304,8 +304,8 @@ public class AccessTokenServiceImplTest {
         final List<AccessTokenService.ExpiredToken> expiredTokens = accessTokenService.findExpiredTokens(Tools.nowUTC());
         final List<AccessTokenService.ExpiredToken> expected =
                 List.of(
-                        new AccessTokenService.ExpiredToken("54e3deadbeefdeadbeefaffe", "web", DateTime.parse("2015-03-14T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf"),
-                        new AccessTokenService.ExpiredToken("54f9deadbeefdeadbeefaffe", "rest", DateTime.parse("2015-03-15T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf")
+                        new AccessTokenService.ExpiredToken("54e3deadbeefdeadbeefaffe", "web", DateTime.parse("2015-03-14T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf", "user"),
+                        new AccessTokenService.ExpiredToken("54f9deadbeefdeadbeefaffe", "rest", DateTime.parse("2015-03-15T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf", "user")
                 );
 
         assertThat(expiredTokens).isNotEmpty();

--- a/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AccessTokenServiceImplTest.java
@@ -305,7 +305,7 @@ public class AccessTokenServiceImplTest {
         final List<AccessTokenService.ExpiredToken> expected =
                 List.of(
                         new AccessTokenService.ExpiredToken("54e3deadbeefdeadbeefaffe", "web", DateTime.parse("2015-03-14T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf", "user"),
-                        new AccessTokenService.ExpiredToken("54f9deadbeefdeadbeefaffe", "rest", DateTime.parse("2015-03-15T16:00:00.000Z"), "679918ce5cc8a61bb95c95bf", "user")
+                        new AccessTokenService.ExpiredToken("54f9deadbeefdeadbeefaffe", "rest", DateTime.parse("2015-03-15T16:00:00.000Z"), null, "deleted_user")
                 );
 
         assertThat(expiredTokens).isNotEmpty();

--- a/graylog2-server/src/test/resources/org/graylog2/security/findExpiredTokens_severalExpired.json
+++ b/graylog2-server/src/test/resources/org/graylog2/security/findExpiredTokens_severalExpired.json
@@ -16,7 +16,7 @@
       "_id": {
         "$oid": "54f9deadbeefdeadbeefaffe"
       },
-      "username": "user",
+      "username": "deleted_user",
       "token": "anothertoken",
       "NAME": "rest",
       "last_access": {


### PR DESCRIPTION
Also find/return/delete expired tokens for admin (which doesn't have an entry in the users-collection.

<!--- Provide a general summary of your changes in the Title above -->
Fixes #22087
The `ExpiredTokenCleaner` didn't find tokens for the admin (which doesn't have an entry in the `users`-collection, so the "join" didn't return anything. The cleanup-job not cleaning up properly is not an option, otherwise we would have to rename it.

## Description
<!--- Describe your changes in detail -->
Finding expired tokens now also returns the entries without corresponding entries in the `users`-collection and adds the user-name on top of the user-id (which is nullable due to this) to the audit-context, so that it is still clean, whose token was deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The existing unit-tests have been adapted accordingly and I've run the job locally several times.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl
