### PR TITLE
IndexerDiscoveryProvider will provide only AVAILABLE datanodes to prevent hitting starting indexers

### DIFF
--- a/changelog/unreleased/issue-21896.toml
+++ b/changelog/unreleased/issue-21896.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "IndexerDiscoveryProvider is now providing only AVAILABLE data nodes to prevent hitting starting indexers."
+
+pulls = ["22128"]
+issues = ["21896"]

--- a/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/IndexerDiscoveryProvider.java
@@ -31,6 +31,7 @@ import org.graylog2.bootstrap.preflight.PreflightConfigResult;
 import org.graylog2.bootstrap.preflight.PreflightConfigService;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodeStatus;
 import org.graylog2.cluster.nodes.NodeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,6 +139,7 @@ public class IndexerDiscoveryProvider implements Provider<List<URI>> {
 
     private List<URI> discover() {
         return nodeService.allActive().values().stream()
+                .filter(n -> n.getDataNodeStatus() == DataNodeStatus.AVAILABLE) // avoid providing transport address of not fully initialized nodes
                 .map(Node::getTransportAddress)
                 .filter(address -> address != null && !address.isBlank())
                 .map(URI::create)


### PR DESCRIPTION
During opensearch startup in data nodes, there is a short phase where opensearch is already listening on 9200 port but returning plaintext error, telling it's starting now. If we read this page in VersionProbe, we'll fail to parse it as json and print ugly error message.

To prevent this, IndexerDiscoveryProvider will use only fully initialized datanodes, where opensearch is already fully started and returns valid responses. 

## Motivation and Context
Fixes #21896

## How Has This Been Tested?
Existing set of integration tests
:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

