### PR TITLE
Query time limit ignored for Data Lake search types

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/validation/TimeRangeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/validation/TimeRangeValidator.java
@@ -26,6 +26,7 @@ import org.graylog.plugins.views.search.errors.QueryError;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.searchtypes.DataLakeSearchType;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
@@ -52,6 +53,7 @@ public class TimeRangeValidator implements SearchValidator {
 
         final Stream<SearchError> searchTypeErrors = query.searchTypes()
                 .stream()
+                .filter(searchType -> !(searchType instanceof DataLakeSearchType)) //Data Lake search types are not limited by this configuration setting
                 .flatMap(searchType -> validateSearchType(query, searchType, config).map(Stream::of).orElseGet(Stream::empty));
         return Stream.concat(queryError.map(Stream::of).orElseGet(Stream::empty), searchTypeErrors);
     }


### PR DESCRIPTION
## Description
Query time limit ignored for Data Lake search types.
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10122
/nocl

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/10122

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

