### PR TITLE
Memoize initial form values to avoid reset of widget config.

### DIFF
--- a/changelog/unreleased/pr-22151.toml
+++ b/changelog/unreleased/pr-22151.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Avoid resetting widget editor on slow network connections."
+
+issues=["Graylog2/graylog-plugin-enterprise#6663"]
+pulls=["22151"]

--- a/graylog2-web-interface/src/pages/DelegatedSearchPage.jsx
+++ b/graylog2-web-interface/src/pages/DelegatedSearchPage.jsx
@@ -14,22 +14,19 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useMemo } from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import ViewsStoreProvider from '../views/stores/ViewsStoreProvider';
-
-export default (props) => {
-  const components =
-    PluginStore.exports('pages')
-      .map((c) => c.search || {})
-      .map((c) => c.component)
-      .filter((c) => c) || [];
-  const Component = components[0];
-
-  return (
-    <ViewsStoreProvider>
-      <Component {...props} />
-    </ViewsStoreProvider>
+export default () => {
+  const [Component] = useMemo(
+    () =>
+      PluginStore.exports('pages')
+        .map((c) => c.search || {})
+        .map((c) => c.component)
+        .filter((c) => c) ?? [],
+    [],
   );
+
+  return <Component />;
 };

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import styled from 'styled-components';
 
 import type { EditWidgetComponentProps } from 'views/types';
@@ -118,7 +119,7 @@ const AggregationWizard = ({
   children,
   onCancel,
 }: EditWidgetComponentProps<AggregationWidgetConfig> & { children: React.ReactElement }) => {
-  const initialFormValues = _initialFormValues(config);
+  const initialFormValues = useMemo(() => _initialFormValues(config), [config]);
 
   return (
     <WidgetConfigForm

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingsConfiguration.tsx
@@ -79,7 +79,7 @@ const GroupingsConfiguration = () => {
   } = useFormikContext<WidgetConfigFormValues>();
   const disableColumnRollup = !groupBy?.groupings?.find(({ direction }) => direction === 'column');
   const removeGrouping = useCallback(
-    (index) => () => {
+    (index: number) => () => {
       setValues(GroupingElement.onRemove(index, values));
     },
     [setValues, values],

--- a/graylog2-web-interface/src/views/components/widgets/telemety.ts
+++ b/graylog2-web-interface/src/views/components/widgets/telemety.ts
@@ -16,6 +16,7 @@
  */
 
 // This file contains telemetry functions which are used in multiple components
+import { useCallback } from 'react';
 
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
@@ -26,34 +27,43 @@ export const useSendWidgetEditTelemetry = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
 
-  return () =>
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_EDIT_TOGGLED, {
-      app_pathname: getPathnameWithoutId(pathname),
-      app_section: 'search-widget',
-      app_action_value: 'widget-edit-button',
-    });
+  return useCallback(
+    () =>
+      sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_EDIT_TOGGLED, {
+        app_pathname: getPathnameWithoutId(pathname),
+        app_section: 'search-widget',
+        app_action_value: 'widget-edit-button',
+      }),
+    [pathname, sendTelemetry],
+  );
 };
 
 export const useSendWidgetEditCancelTelemetry = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
 
-  return () =>
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_EDIT_CANCEL_CLICKED, {
-      app_pathname: getPathnameWithoutId(pathname),
-      app_section: 'search-widget',
-      app_action_value: 'widget-edit-cancel-button',
-    });
+  return useCallback(
+    () =>
+      sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_EDIT_CANCEL_CLICKED, {
+        app_pathname: getPathnameWithoutId(pathname),
+        app_section: 'search-widget',
+        app_action_value: 'widget-edit-cancel-button',
+      }),
+    [pathname, sendTelemetry],
+  );
 };
 
 export const useSendWidgetConfigUpdateTelemetry = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
 
-  return () =>
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_CONFIG_UPDATED, {
-      app_pathname: getPathnameWithoutId(pathname),
-      app_section: 'search-widget',
-      app_action_value: 'widget-edit-update-button',
-    });
+  return useCallback(
+    () =>
+      sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_ACTION.WIDGET_CONFIG_UPDATED, {
+        app_pathname: getPathnameWithoutId(pathname),
+        app_section: 'search-widget',
+        app_action_value: 'widget-edit-update-button',
+      }),
+    [pathname, sendTelemetry],
+  );
 };


### PR DESCRIPTION
**Note:** This needs a backport to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing a usage of `useMemo` to avoid a reset of the widget config when the component is rerendering before the config change has bubbled upwards to the state.

Fixes Graylog2/graylog-plugin-enterprise#6663
Fixes Graylog2/support#12

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.