### PR TITLE
always retry index creation with default settings/mappings

### DIFF
--- a/changelog/unreleased/pr-22155.toml
+++ b/changelog/unreleased/pr-22155.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Always retry index creation with default settings/mappings for restore or retrieval."
+
+issues = ["Graylog2/graylog-plugin-enterprise#10126"]
+pulls = ["22155"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -36,7 +36,6 @@ import org.graylog2.indexer.IndexMappingTemplate;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexTemplateNotFoundException;
-import org.graylog2.indexer.MapperParsingException;
 import org.graylog2.indexer.indexset.CustomFieldMappings;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetMappingTemplate;
@@ -249,7 +248,7 @@ public class Indices {
 
             indicesAdapter.create(indexName, settings, mappings);
         } catch (Exception e) {
-            if ((indexSettings != null || indexMapping != null) && e instanceof MapperParsingException) {
+            if ((indexSettings != null || indexMapping != null)) {
                 LOG.info("Couldn't create index {}. Error: {}. Fall back to default settings/mappings and retry.", indexName, e.getMessage(), e);
                 return create(indexName, indexSet, null, null);
             }


### PR DESCRIPTION
Previously, we retried index creation with the default index settings/mappings only when `MapperParsingException` was thrown. The error described in this issue(Graylog2/graylog-plugin-enterprise#10126) throws another exception so we now do the retry on any exception. The retry currently only takes place for archive restore and data lake retrieval.
closes Graylog2/graylog-plugin-enterprise#10126

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


