### PR TITLE
Using msearch instead of search to avoid errors when the HTTP request parameters exceed the allowed maximum

### DIFF
--- a/changelog/unreleased/pr-22158.toml
+++ b/changelog/unreleased/pr-22158.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fix 'Caught an unhandled exception while executing event processor' when search request to OpenSearch has to many indices."
+
+issues = ["21554"]
+pulls = ["22158"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationES7.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.results.MultiChunkResultRetriever;
 import org.graylog2.indexer.results.ResultMessageFactory;
 import org.graylog2.indexer.searches.ChunkCommand;
 
+import java.util.List;
 import java.util.Set;
 
 public class PaginationES7 implements MultiChunkResultRetriever {
@@ -46,8 +47,13 @@ public class PaginationES7 implements MultiChunkResultRetriever {
     public ChunkedResult retrieveChunkedResult(final ChunkCommand chunkCommand) {
         final SearchSourceBuilder searchQuery = searchRequestFactory.create(chunkCommand);
         final SearchRequest request = buildSearchRequest(searchQuery, chunkCommand.indices());
-        final SearchResponse result = client.search(request, "Unable to perform search-after pagination search");
-        return new PaginationResultES7(resultMessageFactory, client, request, result, searchQuery.toString(), chunkCommand.fields(), chunkCommand.limit().orElse(-1));
+        // doing a msearch so that it results in a POST so we don't have to deal with possible errors where the request exceeds HTTP parameter lengths
+        final var result = client.msearch(List.of(request), "Unable to perform search-after pagination search");
+        if(result.size() != 1) {
+            // we put in one request, so we expect exactly one result to come back
+            throw new RuntimeException("MSearch with one request should result in exactly one result, but was: " + result.size());
+        }
+        return new PaginationResultES7(resultMessageFactory, client, request, result.get(0).getResponse(), searchQuery.toString(), chunkCommand.fields(), chunkCommand.limit().orElse(-1));
     }
 
     private SearchRequest buildSearchRequest(final SearchSourceBuilder query,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prior to this PR, when a lot of indices were selected for the operation, it could exceed the maximum allowed parameter lengths in an HTTP request. With an msearch, these data is sent via a POST instead.

fixes #21554 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

