### PR TITLE
Using msearch for Pagination

### DIFF
--- a/changelog/unreleased/pr-22162.toml
+++ b/changelog/unreleased/pr-22162.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Use msearch instead of search to avoid creating too long HTTP request lines for getting the next chunk in pagination calls"
+
+issues = ["21554"]
+pulls = ["22162"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationResultES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/PaginationResultES7.java
@@ -45,7 +45,7 @@ public class PaginationResultES7 extends ChunkedQueryResultES7 {
 
     @Override
     @Nullable
-    protected SearchResponse nextSearchResult() throws IOException {
+    protected SearchResponse nextSearchResult() {
         final SearchSourceBuilder initialQuery = initialSearchRequest.source();
         final SearchHit[] hits = lastSearchResponse.getHits().getHits();
         if (hits == null || hits.length == 0) {
@@ -53,8 +53,7 @@ public class PaginationResultES7 extends ChunkedQueryResultES7 {
         }
         initialQuery.searchAfter(hits[hits.length - 1].getSortValues());
         initialSearchRequest.source(initialQuery);
-        return client.executeWithIOException((c, requestOptions) -> c.search(initialSearchRequest, requestOptions),
-                "Unable to retrieve next chunk from search: ");
+        return client.search(initialSearchRequest, "Unable to retrieve next chunk from search: ");
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationResultOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/PaginationResultOS2.java
@@ -45,7 +45,7 @@ public class PaginationResultOS2 extends ChunkedQueryResultOS2 {
 
     @Override
     @Nullable
-    protected SearchResponse nextSearchResult() throws IOException {
+    protected SearchResponse nextSearchResult() {
         final SearchSourceBuilder initialQuery = initialSearchRequest.source();
         final SearchHit[] hits = lastSearchResponse.getHits().getHits();
         if (hits == null || hits.length == 0) {
@@ -53,8 +53,7 @@ public class PaginationResultOS2 extends ChunkedQueryResultOS2 {
         }
         initialQuery.searchAfter(hits[hits.length - 1].getSortValues());
         initialSearchRequest.source(initialQuery);
-        return client.executeWithIOException((c, requestOptions) -> c.search(initialSearchRequest, requestOptions),
-                "Unable to retrieve next chunk from search: ");
+        return client.search(initialSearchRequest, "Unable to retrieve next chunk from search: ");
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this change, getting the next chunk would result in a GET call to the indexer which was error prone if the HTTP line (e.g. if there were many indices) got longer than the specification would allow. Wrapping this into the correct call that uses a `msearch` in the backend solves this.

fixes #21554


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual test by hardcoding the batch size to 5 (instead of 500) and creating an Event. On triggering the event, checking the flow with the debugger.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

