### PR TITLE
fix: ensure tokenTtl is reset to default value after form submission

### DIFF
--- a/graylog2-web-interface/src/components/users/CreateTokenForm.tsx
+++ b/graylog2-web-interface/src/components/users/CreateTokenForm.tsx
@@ -46,7 +46,6 @@ const CreateTokenForm = ({ creatingToken = false, disableForm = false, onCreate 
     event.preventDefault();
     onCreate({ tokenName, tokenTtl });
     setTokenName('');
-    setTokenTtl('');
   };
 
   const ttlValidator = (milliseconds: number) => milliseconds >= 60000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes the issue where creating a second token for a user fails because tokenTtl is reset to an empty string instead of the default value
#22164 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

