### PR TITLE
Memoize initial form values to avoid reset of widget config. (`6.1`)

### DIFF
--- a/changelog/unreleased/pr-22151.toml
+++ b/changelog/unreleased/pr-22151.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Avoid resetting widget editor on slow network connections."
+
+issues=["Graylog2/graylog-plugin-enterprise#6663"]
+pulls=["22151"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/AggregationWizard.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import styled from 'styled-components';
 
 import type { EditWidgetComponentProps } from 'views/types';
@@ -101,7 +102,7 @@ const validateForm = (formValues: WidgetConfigFormValues) => {
 };
 
 const AggregationWizard = ({ onChange, config, children, onSubmit, onCancel }: EditWidgetComponentProps<AggregationWidgetConfig> & { children: React.ReactElement }) => {
-  const initialFormValues = _initialFormValues(config);
+  const initialFormValues = useMemo(() => _initialFormValues(config), [config]);
 
   return (
     <WidgetConfigForm onSubmit={(formValues: WidgetConfigFormValues) => _onSubmit(formValues, onChange, config)}


### PR DESCRIPTION
**Note:** This is a backport of #22151 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing a usage of useMemo to avoid a reset of the widget config when the component is rerendering before the config change has bubbled upwards to the state.

Fixes Graylog2/graylog-plugin-enterprise#6663
Fixes Graylog2/support#12

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.