### PR TITLE
Avoid using hook in `useMemo`.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
+++ b/graylog2-web-interface/src/components/navigation/MainNavbar.tsx
@@ -105,12 +105,13 @@ const useNavigationItems = () => {
   const { permissions } = useCurrentUser();
   const { activePerspective } = useActivePerspective();
   const allNavigationItems = usePluginEntities('navigation');
+  const navigationItems = useMemo(() => mergeDuplicateDropdowns(allNavigationItems), [allNavigationItems]);
+
+  const securityLicenseInvalid = !pluginLicenseValid(navigationItems, DEFAULT_SECURITY_NAV_ITEM.description);
 
   return useMemo(() => {
-    const navigationItems = mergeDuplicateDropdowns(allNavigationItems);
     const enterpriseMenuIsMissing = !pluginMenuItemExists(navigationItems, DEFAULT_ENTERPRISE_NAV_ITEM.description);
     const securityMenuIsMissing = !pluginMenuItemExists(navigationItems, DEFAULT_SECURITY_NAV_ITEM.description);
-    const securityLicenseInvalid = !pluginLicenseValid(navigationItems, DEFAULT_SECURITY_NAV_ITEM.description);
     const isPermittedToEnterpriseOrSecurity = isPermitted(permissions, ['licenseinfos:read']);
 
     if (enterpriseMenuIsMissing && isPermittedToEnterpriseOrSecurity) {
@@ -134,7 +135,7 @@ const useNavigationItems = () => {
     const itemsForActivePerspective = filterByPerspective(navigationItems, activePerspective?.id);
 
     return sortItemsByPosition(itemsForActivePerspective);
-  }, [activePerspective, allNavigationItems, permissions]);
+  }, [activePerspective?.id, navigationItems, permissions, securityLicenseInvalid]);
 };
 
 const MainNavbar = ({ pathname }: { pathname: string }) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is avoiding a warning logged due to using a custom hook in a `useMemo` clause:

<details>

```
Warning: Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. You can only call Hooks at the top level of your React function. For more information, see https://reactjs.org/link/rules-of-hooks Error Component Stack
    at MainNavbar (MainNavbar.tsx:140:1)
    at div (<anonymous>)
    at Transition (Transition.js:133:30)
    at Collapse (Collapse.js:156:35)
    at NavbarCollapse (NavbarCollapse.js:34:29)
    at div (<anonymous>)
    at Grid (Grid.js:49:29)
    at nav (<anonymous>)
    at Navbar (Navbar.js:155:30)
    at UncontrolledComponent (uncontrollable.js:44:37)
    at O (styled-components.browser.esm.js:32:23503)
    at Navigation.tsx:43:1
    at NavigationContainer (Navigation.tsx:97:1)
    at div (<anonymous>)
    at O (styled-components.browser.esm.js:32:23503)
    at ScratchpadProvider (ScratchpadProvider.tsx:30:1)
    at CustomHotkeysProvider (HotkeysProvider.tsx:89:1)
    at BoundHotkeysProxyProviderProvider (react-hotkeys-hook.esm.js:256:1)
    at HotkeysProvider (react-hotkeys-hook.esm.js:288:1)
    at HotkeysProvider (HotkeysProvider.tsx:133:1)
    at PerspectivesProvider (PerspectivesProvider.tsx:83:1)
    at QueryParamProviderInner (QueryParamProvider.js:28:3)
    at ReactRouter6Adapter (index.js:9:1)
    at QueryParamProvider (QueryParamProvider.js:47:3)
    at DefaultQueryParamProvider (DefaultQueryParamProvider.tsx:22:1)
    at App (<anonymous>)
    at LicenseCheckProvider (LicenseCheckProvider.tsx:30:1)
    at ErrorBoundary (react-error-boundary.development.esm.js:12:1)
    at GlobalContextProviders (GlobalContextProviders.tsx:26:1)
    at RenderedRoute (index.js:578:5)
    at RenderErrorBoundary (index.js:525:5)
    at DataRoutes (index.js:607:1)
    at Router (index.js:1213:15)
    at RouterProvider (index.js:391:1)
    at RouterErrorBoundary (RouterErrorBoundary.tsx:36:1)
    at AppRouter (AppRouter.tsx:148:1)
    at InputsProvider (InputsProvider.tsx:36:1)
    at NodesProvider.tsx:25:1
    at NodesProvider (NodesProvider.tsx:34:1)
    at StreamsProvider (StreamsProvider.tsx:31:1)
    at ConnectStoresWrapper (connect.tsx:128:1)
    at TelemetryProvider (TelemetryProvider.tsx:59:1)
    at Xe (styled-components.browser.esm.js:32:20310)
    at MantineThemeProvider (MantineThemeProvider.mjs:30:3)
    at MantineProvider (MantineProvider.mjs:31:3)
    at GraylogThemeProvider (GraylogThemeProvider.tsx:34:1)
    at CurrentUserPreferencesProvider (CurrentUserPreferencesProvider.tsx:23:1)
    at StaticTimezoneProvider (UserDateTimeProvider.tsx:49:1)
    at CurrentUserDateTimeProvider (UserDateTimeProvider.tsx:65:1)
    at UserDateTimeProvider (UserDateTimeProvider.tsx:72:1)
    at CurrentUserProvider (CurrentUserProvider.tsx:31:1)
    at ThemeAndUserProvider (ThemeAndUserProvider.tsx:26:1)
    at QueryClientProvider (QueryClientProvider.mjs:48:3)
    at DefaultQueryClientProvider (DefaultQueryClientProvider.tsx:42:1)
    at LoggedInPage (<anonymous>)
    at Suspense (<anonymous>)
    at ErrorBoundary (react-error-boundary.development.esm.js:12:1)
    at AppFacade (AppFacade.tsx:48:1)
    at QueryClientProvider (QueryClientProvider.mjs:48:3)
    at LoginQueryClientProvider (LoginQueryClientProvider.tsx:39:1)
    at PostHogProvider (index.js:36:1)
    at TelemetryInit (TelemetryInit.tsx:54:1)
```

</details>

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.