### PR TITLE
Use time range limit defined in `TimeRangeFilter` props for time range preset dropdown.

### DIFF
--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
@@ -69,7 +69,6 @@ const contextSettings = {
   showDropdownButton: false,
   showPresetsButton: false,
   showAddToQuickListButton: false,
-  ignoreLimitDurationInTimeRangeDropdown: true,
 };
 
 const TimeRangePresetFormItem = ({ idx, id, timerange, description, onChange, onRemove, limitDuration }: ItemProps) => {
@@ -136,12 +135,6 @@ const TimeRangePresetForm = ({
     [onUpdate, options],
   );
 
-  const { config } = useSearchConfiguration();
-  const limitDuration = useMemo(
-    () => moment.duration(config?.query_time_range_limit).asSeconds() ?? 0,
-    [config?.query_time_range_limit],
-  );
-
   const onRemove = useCallback(
     (idx: number) => {
       const newState = options.delete(idx);
@@ -166,7 +159,6 @@ const TimeRangePresetForm = ({
       }),
     );
   }, [onUpdate, options]);
-
   const customContentRender = useCallback(
     ({ item: { id, description, timerange }, index }) => (
       <TimeRangePresetFormItem
@@ -176,10 +168,10 @@ const TimeRangePresetForm = ({
         onChange={onChange}
         timerange={timerange}
         description={description}
-        limitDuration={limitDuration}
+        limitDuration={undefined}
       />
     ),
-    [limitDuration, onChange, onRemove],
+    [onChange, onRemove],
   );
 
   return (

--- a/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangePresetForm.tsx
@@ -15,8 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import type { Dispatch } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import moment from 'moment/moment';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import Immutable from 'immutable';
 import debounce from 'lodash/debounce';
@@ -27,7 +26,6 @@ import type { TimeRange } from 'views/logic/queries/Query';
 import TimeRangeFilter from 'views/components/searchbar/time-range-filter';
 import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import generateId from 'logic/generateId';
-import useSearchConfiguration from 'hooks/useSearchConfiguration';
 
 export type TimeRangePreset = {
   timerange: TimeRange;
@@ -168,7 +166,7 @@ const TimeRangePresetForm = ({
         onChange={onChange}
         timerange={timerange}
         description={description}
-        limitDuration={undefined}
+        limitDuration={0}
       />
     ),
     [onChange, onRemove],

--- a/graylog2-web-interface/src/views/components/contexts/TimeRangeInputSettingsContext.ts
+++ b/graylog2-web-interface/src/views/components/contexts/TimeRangeInputSettingsContext.ts
@@ -22,14 +22,12 @@ type TimeRangeInputSettings = {
   showDropdownButton: boolean;
   showPresetsButton: boolean;
   showAddToQuickListButton: boolean;
-  ignoreLimitDurationInTimeRangeDropdown: boolean;
 };
 
 const defaultValue = {
   showDropdownButton: true,
   showPresetsButton: true,
   showAddToQuickListButton: true,
-  ignoreLimitDurationInTimeRangeDropdown: false,
 };
 
 const TimeRangeInputSettingsContext = React.createContext<TimeRangeInputSettings>(defaultValue);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
@@ -110,6 +110,7 @@ const TimeRangeFilter = ({
       <FlexContainer className={className} ref={containerRef}>
         {showDropdownButton && (
           <TimeRangeFilterButtons
+            limitDuration={limitDuration}
             disabled={disabled}
             toggleShow={toggleShow}
             onPresetSelectOpen={hideTimeRangeDropDown}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
@@ -29,7 +29,7 @@ jest.mock('stores/configurations/ConfigurationsStore', () => ({
 }));
 
 jest.mock('hooks/useSearchConfiguration', () => () => ({
-  config: { ...mockSearchClusterConfig, query_time_range_limit: undefined },
+  config: mockSearchClusterConfig,
   refresh: () => {},
 }));
 
@@ -52,6 +52,7 @@ describe('TimeRangeFilterButtons', () => {
   const SUTTimeRangeFilterButtons = ({ onSubmit = () => {}, ...props }: SUTProps) => (
     <Formik initialValues={{ selectedFields: [] }} onSubmit={onSubmit}>
       <TimeRangeFilterButtons
+        limitDuration={undefined}
         toggleShow={() => {}}
         onPresetSelectOpen={() => {}}
         setCurrentTimeRange={() => {}}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.test.tsx
@@ -52,7 +52,7 @@ describe('TimeRangeFilterButtons', () => {
   const SUTTimeRangeFilterButtons = ({ onSubmit = () => {}, ...props }: SUTProps) => (
     <Formik initialValues={{ selectedFields: [] }} onSubmit={onSubmit}>
       <TimeRangeFilterButtons
-        limitDuration={undefined}
+        limitDuration={0}
         toggleShow={() => {}}
         onPresetSelectOpen={() => {}}
         setCurrentTimeRange={() => {}}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilterButtons.tsx
@@ -34,6 +34,7 @@ type Props = {
   toggleShow: () => void;
   showPresetDropdown?: boolean;
   submitOnPresetChange?: boolean;
+  limitDuration: number;
 };
 
 const StyledRangePresetDropdown = styled(RangePresetDropdown)`
@@ -53,6 +54,7 @@ const TimeRangeFilterButtons = ({
   setCurrentTimeRange,
   showPresetDropdown = true,
   toggleShow,
+  limitDuration,
   submitOnPresetChange = true,
 }: Props) => {
   const { submitForm, isValid } = useFormikContext();
@@ -80,6 +82,7 @@ const TimeRangeFilterButtons = ({
       <TimeRangePickerButton hasError={hasErrorOnMount} disabled={disabled} onClick={_onClick} />
       {showPresetDropdown && (
         <StyledRangePresetDropdown
+          limitDuration={limitDuration}
           disabled={disabled}
           displayTitle={false}
           onChange={selectRelativeTimeRangePreset}

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
@@ -44,7 +44,7 @@ describe('TimeRangePresetDropdown', () => {
     });
 
     const onSelectOption = jest.fn();
-    render(<TimeRangePresetDropdown onChange={onSelectOption} limitDuration={undefined} />);
+    render(<TimeRangePresetDropdown onChange={onSelectOption} limitDuration={0} />);
 
     await openTimeRangePresetSelect();
     await screen.findByRole('menuitem', { name: /15 minutes/i });

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.test.tsx
@@ -44,7 +44,7 @@ describe('TimeRangePresetDropdown', () => {
     });
 
     const onSelectOption = jest.fn();
-    render(<TimeRangePresetDropdown onChange={onSelectOption} />);
+    render(<TimeRangePresetDropdown onChange={onSelectOption} limitDuration={undefined} />);
 
     await openTimeRangePresetSelect();
     await screen.findByRole('menuitem', { name: /15 minutes/i });
@@ -64,10 +64,10 @@ describe('TimeRangePresetDropdown', () => {
   });
 
   it('filtrate options by limit', async () => {
+    const limitDuration = 36000; // 6 Minutes
     asMock(useSearchConfiguration).mockReturnValue({
       config: {
         ...mockSearchClusterConfig,
-        query_time_range_limit: 'PT6M',
         quick_access_timerange_presets: [
           {
             id: '639843f5-049a-4532-8a54-102da850b7f1',
@@ -93,7 +93,7 @@ describe('TimeRangePresetDropdown', () => {
 
     const onSelectOption = jest.fn();
 
-    render(<TimeRangePresetDropdown onChange={onSelectOption} />);
+    render(<TimeRangePresetDropdown onChange={onSelectOption} limitDuration={limitDuration} />); //
 
     await openTimeRangePresetSelect();
 

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangePresetDropdown.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import moment from 'moment';
 import styled, { css } from 'styled-components';
 
@@ -109,17 +109,13 @@ const preparePresetOptions = async (
   ];
 };
 
-const usePresetOptions = (disabled: boolean) => {
+const usePresetOptions = (disabled: boolean, limitDuration: number) => {
   const { config } = useSearchConfiguration();
   const [presetOptions, setPresetOptions] = useState<Array<PresetOption> | undefined>();
-  const timeRangeLimit = useMemo(
-    () => moment.duration(config?.query_time_range_limit).asSeconds(),
-    [config?.query_time_range_limit],
-  );
 
   const onSetOptions = useCallback(async () => {
-    setPresetOptions(await preparePresetOptions(config?.quick_access_timerange_presets, timeRangeLimit, disabled));
-  }, [config?.quick_access_timerange_presets, disabled, timeRangeLimit]);
+    setPresetOptions(await preparePresetOptions(config?.quick_access_timerange_presets, limitDuration, disabled));
+  }, [config?.quick_access_timerange_presets, disabled, limitDuration]);
 
   return { options: presetOptions, setOptions: onSetOptions };
 };
@@ -132,24 +128,26 @@ type Props = {
   header?: string;
   disabled?: boolean;
   onChange?: (timerange: TimeRange) => void;
+  limitDuration: number;
 };
 
 const TimeRangePresetDropdown = ({
   disabled = false,
-  onChange,
+  limitDuration,
+  onChange = undefined,
   onToggle: onToggleProp,
-  className,
+  className = undefined,
   displayTitle = true,
   bsSize = 'small',
-  header,
+  header = undefined,
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const { formatTime } = useUserDateTime();
   const location = useLocation();
-  const { options, setOptions: setDropdownOptions } = usePresetOptions(disabled);
+  const { options, setOptions: setDropdownOptions } = usePresetOptions(disabled, limitDuration);
 
   const _onChange = useCallback(
-    (timerange: any) => {
+    (timerange: TimeRange) => {
       if (timerange !== null && timerange !== undefined) {
         onChange(onInitializingTimerange(timerange, formatTime));
       }

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -251,7 +251,7 @@ const TimeRangePicker = ({
               <NestedForm>
                 <Row>
                   <Col md={12}>
-                    <TimeRangePresetRow />
+                    <TimeRangePresetRow limitDuration={limitDuration} />
                     <TimeRangeTabs limitDuration={limitDuration} validTypes={validTypes} />
                   </Col>
                 </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -148,14 +148,9 @@ const TimeRangePicker = ({
   setCurrentTimeRange,
   validTypes = allTimeRangeTypes,
   position,
-  limitDuration: configLimitDuration,
+  limitDuration,
   withinPortal = true,
 }: Props) => {
-  const { ignoreLimitDurationInTimeRangeDropdown } = useContext(TimeRangeInputSettingsContext);
-  const limitDuration = useMemo(
-    () => (ignoreLimitDurationInTimeRangeDropdown ? 0 : configLimitDuration),
-    [configLimitDuration, ignoreLimitDurationInTimeRangeDropdown],
-  );
   const { formatTime, userTimezone } = useUserDateTime();
   const sendTelemetry = useSendTelemetry();
   const location = useLocation();

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePicker.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Formik } from 'formik';
 import styled, { css } from 'styled-components';
 import moment from 'moment';
@@ -31,7 +31,6 @@ import validateTimeRange from 'views/components/TimeRangeValidation';
 import type { DateTime } from 'util/DateTime';
 import useUserDateTime from 'hooks/useUserDateTime';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
-import TimeRangeInputSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/time-range-picker/TimeRangePresetRow.tsx
@@ -43,7 +43,11 @@ const normalizePresetTimeRange = (timeRange: TimeRange) => {
   return timeRange;
 };
 
-const TimeRangePresetRow = () => {
+type Props = {
+  limitDuration: number;
+};
+
+const TimeRangePresetRow = ({ limitDuration }: Props) => {
   const { showAddToQuickListButton } = useContext(TimeRangeInputSettingsContext);
   const { showPresetsButton } = useContext(TimeRangeInputSettingsContext);
   const { values, setValues } = useFormikContext<TimeRangePickerFormValues>();
@@ -70,7 +74,7 @@ const TimeRangePresetRow = () => {
           <SaveTimeRangeAsPresetButton />
         </IfPermitted>
       )}
-      {showPresetsButton && <TimeRangePresetDropdown onChange={onSetPreset} />}
+      {showPresetsButton && <TimeRangePresetDropdown limitDuration={limitDuration} onChange={onSetPreset} />}
     </Container>
   );
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the query time range limit in the search date time picker was based on the `limitDuration` prop of the `TimeRangeFilter` component.

![image](https://github.com/user-attachments/assets/82aab842-109e-42c9-b11c-2cf5b6f5e568)

While the time range limit, which is being used to filter the preset dropdown was provided by the `useSearchConfig` hook.

![image](https://github.com/user-attachments/assets/31c0f88f-7023-41e2-b017-cce4b1f2679d)

We started using the time range picker on other pages were we want to ignore the search configuration. To achieve this we are now no longer consuming the `useSearchConfig` hook in the `RangePresetDropdown`, but the `limitDuration` prop from the parent `TimeRangeFilter` component.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10198
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/10224
/nocl