### PR TITLE
ISW - Restructure create stream form to avoid tooltip overlap

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.SetupRouting.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.SetupRouting.test.tsx
@@ -164,7 +164,7 @@ const getStreamCreateFormFields = async () => {
     hidden: true,
   });
 
-  const indexSetSelect = await screen.findByLabelText('Index Set');
+  const indexSetSelect = await screen.findByLabelText('Select Index Set');
 
   const removeMatchesCheckbox = await screen.findByRole('checkbox', {
     name: /Remove matches from/i,

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/components/CreateStreamForm.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/components/CreateStreamForm.tsx
@@ -39,9 +39,23 @@ type Props = {
   prevShouldCreateNewPipeline?: OpenStepsData['SETUP_ROUTING']['shouldCreateNewPipeline'];
 };
 
+const SubHeadline = styled.h4(
+  ({ theme }) => css`
+    margin-top: ${theme.spacings.md};
+    margin-bottom: ${theme.spacings.xs};
+  `,
+);
+
+const IndexSetInfoText = styled.p(
+  ({ theme }) => css`
+    margin-top: ${theme.spacings.xs};
+    margin-bottom: ${theme.spacings.md};
+  `,
+);
+
 const NewIndexSetButton = styled(Button)(
   ({ theme }) => css`
-    margin-bottom: ${theme.spacings.xs};
+    margin-bottom: ${theme.spacings.md};
   `,
 );
 
@@ -102,22 +116,6 @@ const CreateStreamForm = ({
             id="description"
             help="What kind of messages are routed into this stream?"
           />
-          <SelectedIndexSetAlert indexSets={indexSets} selectedIndexSetId={values.index_set_id} />
-
-          <IndexSetSelect
-            indexSets={indexSets}
-            help={
-              <>
-                Messages that match this stream will be written to the configured Index Set. Index Sets are used to
-                rationally partition data to allow faster searches.
-                <br />
-                We recommend creating a new Index Set for each Input type.
-              </>
-            }
-          />
-          <RecommendedTooltip opened withArrow position="right" label="Recommended!">
-            <NewIndexSetButton onClick={handleNewIndexSetClick}>Create a new Index Set</NewIndexSetButton>
-          </RecommendedTooltip>
           <FormikInput
             label={<>Remove matches from &lsquo;Default Stream&rsquo;</>}
             help={<span>Don&apos;t assign messages that match this stream to the &lsquo;Default Stream&rsquo;.</span>}
@@ -132,6 +130,18 @@ const CreateStreamForm = ({
             id="create_new_pipeline"
             type="checkbox"
           />
+          <SubHeadline>Selet Index Set</SubHeadline>
+          <SelectedIndexSetAlert indexSets={indexSets} selectedIndexSetId={values.index_set_id} />
+          <IndexSetInfoText>
+            Messages that match this stream will be written to the configured Index Set. Index Sets are used to
+            rationally partition data to allow faster searches.
+            <br />
+            We recommend creating a new Index Set for each Input type.
+          </IndexSetInfoText>
+          <RecommendedTooltip opened withArrow position="right" label="Recommended!">
+            <NewIndexSetButton onClick={handleNewIndexSetClick}>Create a new Index Set</NewIndexSetButton>
+          </RecommendedTooltip>
+          <IndexSetSelect label="Select Index Set" indexSets={indexSets} />
 
           <Row>
             <ButtonCol md={12}>

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/components/SelectedIndexSetAlert.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/components/SelectedIndexSetAlert.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import styled from 'styled-components';
 
 import { Alert, Col, Row } from 'components/bootstrap';
 import useStreamsByIndexSet from 'components/inputs/InputSetupWizard/hooks/useStreamsByIndexSet';
@@ -24,6 +25,11 @@ type Props = {
   selectedIndexSetId?: string;
   indexSets: Array<IndexSet>;
 };
+
+const StyledAlert = styled(Alert)`
+  margin-top: 0;
+  margin-bottom: 0;
+`;
 
 const SelectedIndexSetAlert = ({ selectedIndexSetId = undefined, indexSets }: Props) => {
   const { data: streamsByIndexSetIdData } = useStreamsByIndexSet(selectedIndexSetId, !!selectedIndexSetId);
@@ -46,13 +52,13 @@ const SelectedIndexSetAlert = ({ selectedIndexSetId = undefined, indexSets }: Pr
     return (
       <Row>
         <Col md={12}>
-          <Alert title="Default Index Set selected" bsStyle="info">
+          <StyledAlert title="Default Index Set selected" bsStyle="info">
             You have selected the Default Index Set.
             <br />
             We recommend against this: as the potential recipient of messages of many different formats (any message
             with no routing, via the Default Stream), the Default Index Set is susceptible to reaching the maximum
             per-Index field limit of the search backend if used extensively.
-          </Alert>
+          </StyledAlert>
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/components/streams/IndexSetSelect.tsx
+++ b/graylog2-web-interface/src/components/streams/IndexSetSelect.tsx
@@ -25,10 +25,12 @@ import type { IndexSet } from 'stores/indices/IndexSetsStore';
 type Props = {
   indexSets: Array<IndexSet>;
   help?: React.ReactElement | string;
+  label?: React.ReactElement | string;
 };
 
 const IndexSetSelect = ({
   indexSets,
+  label = 'Index Set',
   help = 'Messages that match this stream will be written to the configured index set.',
 }: Props) => {
   const indexSetOptions = useMemo(
@@ -45,7 +47,7 @@ const IndexSetSelect = ({
   return (
     <Field name="index_set_id">
       {({ field: { name, value, onChange, onBlur }, meta: { error, touched } }) => (
-        <Input label="Index Set" help={help} id={name} error={error && touched ? error : undefined}>
+        <Input label={label} help={help} id={name} error={error && touched ? error : undefined}>
           <Select
             onBlur={onBlur}
             onChange={(newValue: number) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Part of https://github.com/Graylog2/graylog2-server/issues/22147
/nocl

As there is no easy fix to do this due to the way z-index works, especially with children & parents we decided to restructure the form instead.
With the new form structure it is easier to understand for the user and the button with the tooltip is placed above the select.
There is the edge case that when the height is too small, the tooltip overlay will still overlap with the select as it opens to the top instead.
I agreed with @tellistone that it is okay due to time constraint.
However, we should eventually look at issues like that and how we handle z-index in our code base (especially with the new mantine components).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot 2025-04-02 at 13 25 22](https://github.com/user-attachments/assets/6c35ea8d-3ea2-45bd-9d5b-e914b12ecd12)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

