### PR TITLE
Fixed markdown view sanitation

### DIFF
--- a/changelog/unreleased/ghsa-76vf-mpmx-777j.toml
+++ b/changelog/unreleased/ghsa-76vf-mpmx-777j.toml
@@ -1,2 +1,4 @@
 type = "s"
 message = "Disallow HTML in the Event Definition Remediation Steps field. [GHSA-76vf-mpmx-777j](https://github.com/Graylog2/graylog2-server/security/advisories/GHSA-76vf-mpmx-777j)"
+
+pulls=["22211"]

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackV1.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackV1.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.zafarkhaja.semver.Version;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +30,7 @@ import org.graylog2.contentpacks.model.constraints.Constraint;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.parameters.Parameter;
+import org.graylog2.security.html.HTMLSanitizerConverter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -69,6 +71,7 @@ public abstract class ContentPackV1 implements ContentPack {
 
     @JsonView(ContentPackView.HttpView.class)
     @JsonProperty(FIELD_DESCRIPTION)
+    @JsonSerialize(converter = HTMLSanitizerConverter.class)
     public abstract String description();
 
     @JsonView(ContentPackView.HttpView.class)

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/LegacyContentPack.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/LegacyContentPack.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.bson.types.ObjectId;
@@ -29,6 +30,7 @@ import org.graylog2.contentpacks.model.constraints.Constraint;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.parameters.Parameter;
+import org.graylog2.security.html.HTMLSanitizerConverter;
 
 import javax.annotation.Nullable;
 import java.net.URI;
@@ -69,6 +71,7 @@ public abstract class LegacyContentPack implements ContentPack {
 
     @JsonView(ContentPackView.HttpView.class)
     @JsonProperty(FIELD_DESCRIPTION)
+    @JsonSerialize(converter = HTMLSanitizerConverter.class)
     public abstract String description();
 
     @JsonView(ContentPackView.HttpView.class)

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -27,7 +27,7 @@ const Markdown = ({ text }: Props) => {
   const markdown = useMemo(() => DOMPurify.sanitize(marked(text ?? '', { async: false }), { USE_PROFILES: { html: false } }), [text]);
 
   // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: markdown }} />;
+  return <div role="heading" aria-level={1} dangerouslySetInnerHTML={{ __html: markdown }} />;
 };
 
 export default Markdown;

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -24,10 +24,13 @@ type Props = {
 };
 
 const Markdown = ({ text }: Props) => {
-  const markdown = useMemo(() => DOMPurify.sanitize(marked(text ?? '', { async: false }), { USE_PROFILES: { html: false } }), [text]);
+  // Remove dangerous HTML
+  const sanitizedText = DOMPurify.sanitize(text ?? '', { USE_PROFILES: { html: false } });
+  // Remove dangerous markdown
+  const markdown = useMemo(() => DOMPurify.sanitize(marked(sanitizedText, { async: false })), [sanitizedText]);
 
   // eslint-disable-next-line react/no-danger
-  return <div role="heading" aria-level={1} dangerouslySetInnerHTML={{ __html: markdown }} />;
+  return <div dangerouslySetInnerHTML={{ __html: markdown }} />;
 };
 
 export default Markdown;

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/BaseEditor.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/BaseEditor.tsx
@@ -51,7 +51,12 @@ function MDBaseEditor({
   onBlur = undefined
 }: Props) {
   const handleOnBlur = React.useCallback(() => {
-    const sanitizedValue = DOMPurify.sanitize(value, { USE_PROFILES: { html: false } });
+    // Remove dangerous markdown
+    const sanitizedValue = DOMPurify.sanitize(
+      // Remove dangerous HTML
+      DOMPurify.sanitize(value, { USE_PROFILES: { html: false } })
+    );
+
     if (onBlur) onBlur(sanitizedValue);
     else onChange(sanitizedValue);
   }, [onBlur, onChange, value]);

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
@@ -17,7 +17,6 @@
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import styled from 'styled-components';
-import DOMPurify from 'dompurify';
 
 import { Button } from 'components/bootstrap';
 import { Icon } from 'components/common';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed markdown view sanitation which was dropping all HTML generated from the markdown.

/nocl

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/9963

## Description
<!--- Describe your changes in detail -->
This PR fixes the sanitation of the markdown value passed to Markdown component and Preview. Also it takes care of fixing failing tests and unused import

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.