### PR TITLE
fix: Ensure metadata is cleaned up when deleting an index set, even if indices are retained

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -119,10 +119,17 @@ public class Indices {
 
     public void delete(String indexName) {
         Optional<WarmIndexInfo> snapshotInfoOptional = indicesAdapter.getWarmIndexInfo(indexName);
-        indicesAdapter.delete(indexName);
-
-        eventBus.post(IndicesDeletedEvent.create(indexName));
+        deleteIndex(indexName);
+        fireIndexDeletedEvents(indexName);
         snapshotInfoOptional.ifPresent(snapshotInfo -> eventBus.post(new WarmIndexDeletedEvent(snapshotInfo)));
+    }
+
+    public void deleteIndex(String indexName) {
+        indicesAdapter.delete(indexName);
+    }
+
+    public void fireIndexDeletedEvents(String indexName) {
+        eventBus.post(IndicesDeletedEvent.create(indexName));
     }
 
     public void close(String indexName) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where deleting an index set without deleting the backing indices leaves orphaned metadata. This metadata then causes duplicate key errors when creating new index sets with the same prefix.  The fix ensures that metadata is always deleted when an index set is removed, regardless of whether the indices are also deleted.
#22113 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

