### PR TITLE
Use nativeLibPath in data node

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -35,6 +35,7 @@ import org.graylog.datanode.configuration.DatanodeDirectories;
 import org.graylog2.CommonNodeConfiguration;
 import org.graylog2.Configuration.SafeClassesValidator;
 import org.graylog2.configuration.Documentation;
+import org.graylog2.configuration.NativeLibPathConfiguration;
 import org.graylog2.plugin.Tools;
 import org.graylog2.shared.SuppressForbidden;
 import org.slf4j.Logger;
@@ -58,7 +59,7 @@ import java.util.Set;
  * Helper class to hold configuration of DataNode
  */
 @SuppressWarnings("FieldMayBeFinal")
-public class Configuration implements CommonNodeConfiguration {
+public class Configuration implements CommonNodeConfiguration, NativeLibPathConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
     public static final String TRANSPORT_CERTIFICATE_PASSWORD_PROPERTY = "transport_certificate_password";
     public static final String HTTP_CERTIFICATE_PASSWORD_PROPERTY = "http_certificate_password";

--- a/data-node/src/main/java/org/graylog/datanode/bootstrap/DatanodeBootstrap.java
+++ b/data-node/src/main/java/org/graylog/datanode/bootstrap/DatanodeBootstrap.java
@@ -66,6 +66,11 @@ public abstract class DatanodeBootstrap extends AbstractNodeCommand {
     protected abstract void startNodeRegistration(Injector injector);
 
     @Override
+    protected void beforeStart() {
+        super.beforeStart();
+    }
+
+    @Override
     protected void beforeInjectorCreation(Set<Plugin> plugins) {
         runPreFlightChecks(plugins);
     }

--- a/graylog2-server/src/main/java/org/graylog2/GraylogNodeConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/GraylogNodeConfiguration.java
@@ -18,6 +18,7 @@ package org.graylog2;
 
 import org.graylog2.plugin.ServerStatus;
 
+import java.nio.file.Path;
 import java.util.Set;
 
 /**
@@ -77,4 +78,5 @@ public interface GraylogNodeConfiguration {
     boolean isMessageRecordingsEnabled();
 
     boolean isCloud();
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -48,6 +48,7 @@ import org.graylog2.cluster.leader.LeaderElectionService;
 import org.graylog2.cluster.preflight.GraylogServerProvisioningBindings;
 import org.graylog2.commands.AbstractNodeCommand;
 import org.graylog2.configuration.IndexerDiscoveryModule;
+import org.graylog2.configuration.NativeLibPathConfiguration;
 import org.graylog2.configuration.PathConfiguration;
 import org.graylog2.migrations.Migration;
 import org.graylog2.migrations.MigrationType;
@@ -142,9 +143,6 @@ public abstract class ServerBootstrap extends AbstractNodeCommand {
         if (!isNoPidFile()) {
             savePidFile(getPidFile());
         }
-
-        // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
-        setNettyNativeDefaults(parseAndGetPathConfiguration(configFile));
     }
 
     @Override
@@ -300,21 +298,6 @@ public abstract class ServerBootstrap extends AbstractNodeCommand {
                 (binder) -> binder.bind(ChainingClassLoader.class).toInstance(chainingClassLoader),
                 binder -> preflightCheckModules.forEach(binder::install),
                 this::featureFlagsBinding);
-    }
-
-    private void setNettyNativeDefaults(PathConfiguration pathConfiguration) {
-        // Give netty a better spot than /tmp to unpack its tcnative libraries
-        if (System.getProperty("io.netty.native.workdir") == null) {
-            System.setProperty("io.netty.native.workdir", pathConfiguration.getNativeLibDir().toAbsolutePath().toString());
-        }
-        // The jna.tmpdir should reside in the native lib dir. (See: https://github.com/Graylog2/graylog2-server/issues/21223)
-        if (System.getProperty("jna.tmpdir") == null) {
-            System.setProperty("jna.tmpdir", pathConfiguration.getNativeLibDir().toAbsolutePath().resolve("jna").toString());
-        }
-        // Don't delete the native lib after unpacking, as this confuses needrestart(1) on some distributions
-        if (System.getProperty("io.netty.native.deleteLibAfterLoading") == null) {
-            System.setProperty("io.netty.native.deleteLibAfterLoading", "false");
-        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/configuration/NativeLibPathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/NativeLibPathConfiguration.java
@@ -1,0 +1,9 @@
+package org.graylog2.configuration;
+
+import java.nio.file.Path;
+
+public interface NativeLibPathConfiguration {
+
+    Path getNativeLibDir();
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.SortedSet;
 
-public class PathConfiguration extends PluginPathConfiguration {
+public class PathConfiguration extends PluginPathConfiguration implements NativeLibPathConfiguration {
     public static final String ALLOWED_AUXILIARY_PATHS = "allowed_auxiliary_paths";
 
     protected static final Path DEFAULT_BIN_DIR = Paths.get("bin");


### PR DESCRIPTION
## Description
Fixes using the nativeLib directory in data node for setting the ZStd temp folder and netty defaults.

## Motivation and Context
fixes https://github.com/Graylog2/graylog2-server/issues/22097

## How Has This Been Tested?
Existing integration tests, locally to see if libraries are changed/used.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

