### PR TITLE
Do not use internal state for widget comparison in events widget.

### DIFF
--- a/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
@@ -61,7 +61,7 @@ export default class EventsWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof EventsWidget) {
-      return widgetAttributesForComparison.every((key) => isDeepEqual(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isDeepEqual(this[key], other[key]));
     }
 
     return false;
@@ -69,7 +69,7 @@ export default class EventsWidget extends Widget {
 
   equalsForSearch(other: any) {
     if (other instanceof EventsWidget) {
-      return widgetAttributesForComparison.every((key) => isEqualForSearch(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isEqualForSearch(this[key], other[key]));
     }
 
     return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/22161. The comparison of `this._value[key]` and `other[key]` was not working, because  `this._value[key]` is referencing the internal state, while `other[key]` references the public methods and their keys vary.

Related to https://github.com/Graylog2/graylog2-server/issues/22153

/nocl - a change log is included in the original PR and its changes have not been released yet.