### PR TITLE
Remove warning when checking if a feature flag is on

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/featureflag/ImmutableFeatureFlags.java
+++ b/graylog2-server/src/main/java/org/graylog2/featureflag/ImmutableFeatureFlags.java
@@ -48,7 +48,7 @@ class ImmutableFeatureFlags implements FeatureFlags {
     public boolean isOn(String feature) {
         FeatureFlag flag = getFlag(feature);
         if (flag == null) {
-            LOG.warn("Feature flag '{}' is not set. Fall back to default value 'false'", feature);
+            LOG.debug("Feature flag '{}' is not set. Fall back to default value 'false'", feature);
             return false;
         }
         return flag.isOn();

--- a/graylog2-server/src/main/java/org/graylog2/featureflag/ImmutableFeatureFlags.java
+++ b/graylog2-server/src/main/java/org/graylog2/featureflag/ImmutableFeatureFlags.java
@@ -48,7 +48,6 @@ class ImmutableFeatureFlags implements FeatureFlags {
     public boolean isOn(String feature) {
         FeatureFlag flag = getFlag(feature);
         if (flag == null) {
-            LOG.debug("Feature flag '{}' is not set. Fall back to default value 'false'", feature);
             return false;
         }
         return flag.isOn();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the warning that appears when checking if a feature flag is on in backend code (with `FeatureFlags.isOn()`). 

```
WARN: Feature flag 'my_feature_flag' is not set. Fall back to default value 'false'.
```

Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10264

## Motivation/Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/10264 for additional motivation.

/nocl logging-level change