### PR TITLE
Do not enable auto-refresh for events page by default.

### DIFF
--- a/graylog2-web-interface/src/components/events/EventsRefreshProvider.tsx
+++ b/graylog2-web-interface/src/components/events/EventsRefreshProvider.tsx
@@ -29,7 +29,7 @@ const noop = () => {};
 const EventsRefreshProvider = ({ children = undefined }: React.PropsWithChildren<{}>) => {
   const defaultInterval = useDefaultInterval();
   const defaultRefreshConfig: RefreshConfig = useMemo(
-    () => ({ enabled: true, interval: durationToMS(defaultInterval) }),
+    () => ({ enabled: false, interval: durationToMS(defaultInterval) }),
     [defaultInterval],
   );
 

--- a/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventsRefreshControls.tsx
@@ -72,7 +72,7 @@ const EventsRefreshControls = () => {
       isLoadingMinimumInterval={isLoadingMinimumInterval}
       minimumRefreshInterval={minimumRefreshInterval}
       defaultInterval={defaultInterval}
-      humanName="Evets"
+      humanName="Events"
       onToggle={onToggle}
       onSelectInterval={onSelectInterval}
     />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the auto-refresh on the Events/Security to start paused, requiring the user to explicitly enable it.

/nocl Changing unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.