### PR TITLE
Fix comparison of messages widget to avoid unnecessary refresh. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-22153.toml
+++ b/changelog/unreleased/issue-22153.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix comparison of messages widget to avoid unnecessary refresh."
+
+pulls = ["22161"]
+issues = ["22153"]

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.ts
@@ -23,7 +23,7 @@ import type { FiltersType } from 'views/types';
 
 import AggregationWidgetConfig from './AggregationWidgetConfig';
 
-import Widget from '../widgets/Widget';
+import Widget, { widgetAttributesForComparison } from '../widgets/Widget';
 
 export default class AggregationWidget extends Widget {
   constructor(id: string, config: AggregationWidgetConfig, filter?: string, timerange?: TimeRange, query?: QueryString, streams?: Array<string>, streamCategories?: Array<string>, filters?: FiltersType) {
@@ -54,7 +54,7 @@ export default class AggregationWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof AggregationWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isDeepEqual(this[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isDeepEqual(this[key], other[key]));
     }
 
     return false;
@@ -62,7 +62,7 @@ export default class AggregationWidget extends Widget {
 
   equalsForSearch(other: any) {
     if (other instanceof AggregationWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isEqualForSearch(this[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isEqualForSearch(this[key], other[key]));
     }
 
     return false;

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.ts
@@ -20,7 +20,7 @@ import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
 import type { FiltersType } from 'views/types';
 
-import Widget from './Widget';
+import Widget, { widgetAttributesForComparison } from './Widget';
 import MessagesWidgetConfig from './MessagesWidgetConfig';
 import type { WidgetState } from './Widget';
 
@@ -48,7 +48,7 @@ export default class MessagesWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof MessagesWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isDeepEqual(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isDeepEqual(this[key], other[key]));
     }
 
     return false;
@@ -60,7 +60,7 @@ export default class MessagesWidget extends Widget {
 
   equalsForSearch(other: any) {
     if (other instanceof MessagesWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isEqualForSearch(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isEqualForSearch(this[key], other[key]));
     }
 
     return false;

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.ts
@@ -35,9 +35,9 @@ export type WidgetState = {
   stream_categories: Array<string>;
 };
 
-type DeserializesWidgets = {
-  fromJSON: (value) => Widget;
-};
+interface DeserializesWidgets {
+  fromJSON: (value: any) => Widget;
+}
 
 const isNullish = (o: any) => (o === null || o === undefined);
 
@@ -272,6 +272,17 @@ class Builder {
     return new Widget(id, type, config, filter, timerange, query, streams, streamCategories, filters);
   }
 }
+
+export const widgetAttributesForComparison: Array<keyof Widget> = [
+  'id',
+  'config',
+  'filter',
+  'timerange',
+  'query',
+  'streams',
+  'streamCategories',
+  'filters',
+];
 
 Widget.Builder = Builder;
 

--- a/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
@@ -16,7 +16,7 @@
  */
 import { Map } from 'immutable';
 
-import Widget from 'views/logic/widgets/Widget';
+import Widget, { widgetAttributesForComparison } from 'views/logic/widgets/Widget';
 import type { WidgetState } from 'views/logic/widgets/Widget';
 import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
@@ -52,7 +52,7 @@ export default class EventsWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof EventsWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isDeepEqual(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isDeepEqual(this._value[key], other[key]));
     }
 
     return false;
@@ -60,7 +60,7 @@ export default class EventsWidget extends Widget {
 
   equalsForSearch(other: any) {
     if (other instanceof EventsWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams', 'stream_categories', 'filters'].every((key) => isEqualForSearch(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isEqualForSearch(this._value[key], other[key]));
     }
 
     return false;

--- a/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/events/EventsWidget.ts
@@ -52,7 +52,7 @@ export default class EventsWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof EventsWidget) {
-      return widgetAttributesForComparison.every((key) => isDeepEqual(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isDeepEqual(this[key], other[key]));
     }
 
     return false;
@@ -60,7 +60,7 @@ export default class EventsWidget extends Widget {
 
   equalsForSearch(other: any) {
     if (other instanceof EventsWidget) {
-      return widgetAttributesForComparison.every((key) => isEqualForSearch(this._value[key], other[key]));
+      return widgetAttributesForComparison.every((key) => isEqualForSearch(this[key], other[key]));
     }
 
     return false;

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.ts
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.ts
@@ -17,12 +17,12 @@
 import isEqualWith from 'lodash/isEqualWith';
 import isFunction from 'lodash/isFunction';
 
-const hasFn = (obj, fn) => (obj && obj[fn] && isFunction(obj[fn]));
-const hasEquals = (obj) => hasFn(obj, 'equals');
-const hasEqualsForSearch = (obj) => hasFn(obj, 'equalsForSearch');
-const isImmutable = (obj) => hasFn(obj, 'toJS');
+const hasFn = (obj: any, fn: string) => (obj && obj[fn] && isFunction(obj[fn]));
+const hasEquals = (obj: any) => hasFn(obj, 'equals');
+const hasEqualsForSearch = (obj: any) => hasFn(obj, 'equalsForSearch');
+const isImmutable = (obj: any) => hasFn(obj, 'toJS');
 
-const _isEqual = (first, second) => {
+const _isEqual = (first: any, second: any) => {
   if (hasEqualsForSearch(first)) {
     return first.equalsForSearch(second);
   }


### PR DESCRIPTION
**Note:** This is a backport of #22161 & #22226 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an issue with widgets, where resizing a widget resulted in an unnecessary search execution due to the widget comparison function returning a wrong result. This is related to the introduction of the `streamCategories` attribute, which is referenced incorrectly in the comparison function, due to different casing between the internal state and public methods of the class.

Fixes #22153.

/prd Graylog2/graylog-plugin-enterprise#10268

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.