### PR TITLE
Add missing JadConfig converters resulting in server startup failure.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -411,7 +411,7 @@ public abstract class CmdLineTool<NodeConfiguration extends GraylogNodeConfigura
      * For example `root_timezone = America/Chicago`.
      * <p>
      * The converters must be added to each instance of JadConfig before calling `JadConfig.process()` or else
-     * configuration value parsing might fail.
+     * configuration value parsing might fail which could halt server startup.
      */
     private void addConverters(JadConfig config) {
         config.addConverterFactory(new GuavaConverterFactory());


### PR DESCRIPTION
Fixes halted server startup due to the below exception when the `root_timezone` server property is specified. The issue was introduced in https://github.com/Graylog2/graylog2-server/pull/22224, where a new `JadConfig` instance was constructed without adding the needed converters to support `DateTimeZone` and presumably other joda-related server config properties. 

The fix adds the required converters to the new instance as well.

Big thanks to @kingzacko1 for discovering the issue and helping to root it out.

```
2025-04-04 14:12:35,054 ERROR: org.graylog2.bootstrap.CmdLineTool - Invalid configuration
com.github.joschi.jadconfig.ParameterException: Couldn't set field rootTimeZone
	at com.github.joschi.jadconfig.JadConfig.processClassField(JadConfig.java:202) ~[jadconfig-0.15.0.jar:?]
	at com.github.joschi.jadconfig.JadConfig.processClassFields(JadConfig.java:143) ~[jadconfig-0.15.0.jar:?]
	at com.github.joschi.jadconfig.JadConfig.process(JadConfig.java:103) ~[jadconfig-0.15.0.jar:?]
	at org.graylog2.bootstrap.CmdLineTool.processConfiguration(CmdLineTool.java:552) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.parseAndGetNativeLibPathConfiguration(CmdLineTool.java:405) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.doRun(CmdLineTool.java:294) [classes/:?]
	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:285) [classes/:?]
	at org.graylog2.bootstrap.Main.main(Main.java:57) [classes/:?]
Caused by: java.lang.IllegalArgumentException: Can not set org.joda.time.DateTimeZone field org.graylog2.Configuration.rootTimeZone to java.lang.String
	at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167) ~[?:?]
	at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171) ~[?:?]
	at java.base/jdk.internal.reflect.UnsafeObjectFieldAccessorImpl.set(UnsafeObjectFieldAccessorImpl.java:81) ~[?:?]
	at java.base/java.lang.reflect.Field.set(Field.java:799) ~[?:?]
	at com.github.joschi.jadconfig.JadConfig.processClassField(JadConfig.java:200) ~[jadconfig-0.15.0.jar:?]
	... 7 more
```

/nocl unreleased bug