### PR TITLE
Replace react-bootstrap modal with mantine modal

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 
 import ModalSubmit from 'components/common/ModalSubmit';
 
+import type { ModalSize } from './Modal';
 import Modal from './Modal';
 import BootstrapModalWrapper from './BootstrapModalWrapper';
 
@@ -29,6 +30,7 @@ type Props = {
   confirmButtonDisabled?: boolean;
   onConfirm: (e: React.BaseSyntheticEvent) => void;
   onCancel: () => void;
+  size?: ModalSize;
   children: React.ReactNode;
 };
 

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
@@ -48,7 +48,7 @@ const BootstrapModalConfirm = ({
   ...restProps
 }: Props) => (
   <BootstrapModalWrapper showModal={showModal} onHide={onCancel} role="alertdialog" {...restProps}>
-    <Modal.Header closeButton>
+    <Modal.Header>
       <Modal.Title>{title}</Modal.Title>
     </Modal.Header>
 

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
@@ -47,7 +47,7 @@ const BootstrapModalConfirm = ({
   onConfirm,
   ...restProps
 }: Props) => (
-  <BootstrapModalWrapper showModal={showModal} onHide={onCancel} role="alertdialog" {...restProps}>
+  <BootstrapModalWrapper showModal={showModal} onHide={onCancel} {...restProps}>
     <Modal.Header>
       <Modal.Title>{title}</Modal.Title>
     </Modal.Header>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.tsx
@@ -35,14 +35,14 @@ describe('BootstrapModalForm', () => {
   it('does not show modal form when show property is false', async () => {
     render(renderModalForm(false));
 
-    expect(screen.queryByTitle('Sample Form')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Sample Form/i })).not.toBeInTheDocument();
     expect(screen.queryByText('42')).not.toBeInTheDocument();
   });
 
   it('shows modal form when show property is true', async () => {
     render(renderModalForm(true));
 
-    await screen.findByTitle('Sample Form');
+    await screen.findByRole('heading', { name: /Sample Form/i });
     await screen.findByText('42');
   });
 

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
@@ -14,9 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useMemo, useRef } from 'react';
+import React, { useRef } from 'react';
 import $ from 'jquery';
-import isString from 'lodash/isString';
 
 import ModalSubmit from 'components/common/ModalSubmit';
 
@@ -41,13 +40,13 @@ type Props = {
  * has, and providing form validation using HTML5 and our custom validation.
  */
 const BootstrapModalForm = ({
-  backdrop,
+  backdrop = undefined,
   submitButtonDisabled = false,
   formProps = {},
-  bsSize,
+  bsSize = undefined,
   show,
   submitButtonText = 'Submit',
-  onSubmitForm,
+  onSubmitForm = undefined,
   onCancel,
   title,
   children,

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
@@ -88,7 +88,7 @@ const BootstrapModalForm = ({
       onHide={onCancel}
       title={_title}
       {...restProps}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
       <form ref={form} onSubmit={submit} {...formProps} data-testid="modal-form">

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
@@ -88,7 +88,7 @@ const BootstrapModalForm = ({
       onHide={onCancel}
       title={_title}
       {...restProps}>
-      <Modal.Header>
+      <Modal.Header closeButton>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
       <form ref={form} onSubmit={submit} {...formProps} data-testid="modal-form">

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
@@ -34,7 +34,6 @@ type Props = {
   onCancel: () => void;
   title: string | React.ReactNode;
   children: React.ReactNode;
-  modalTitle?: string | undefined;
 };
 
 /**
@@ -52,7 +51,6 @@ const BootstrapModalForm = ({
   onCancel,
   title,
   children,
-  modalTitle,
   ...restProps
 }: Props) => {
   const form = useRef(null);
@@ -78,16 +76,8 @@ const BootstrapModalForm = ({
 
   const body = <div className="container-fluid">{children}</div>;
 
-  const _title = useMemo<string | undefined>(() => (isString(title) ? title : modalTitle), [modalTitle, title]);
-
   return (
-    <BootstrapModalWrapper
-      bsSize={bsSize}
-      showModal={show}
-      backdrop={backdrop}
-      onHide={onCancel}
-      title={_title}
-      {...restProps}>
+    <BootstrapModalWrapper bsSize={bsSize} showModal={show} backdrop={backdrop} onHide={onCancel} {...restProps}>
       <Modal.Header>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.tsx
@@ -24,7 +24,7 @@ import Modal from './Modal';
 import BootstrapModalWrapper from './BootstrapModalWrapper';
 
 type Props = {
-  backdrop?: boolean | 'static' | undefined;
+  backdrop?: boolean;
   submitButtonDisabled?: boolean;
   formProps?: object;
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
@@ -88,7 +88,7 @@ const BootstrapModalForm = ({
       onHide={onCancel}
       title={_title}
       {...restProps}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
       <form ref={form} onSubmit={submit} {...formProps} data-testid="modal-form">

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
@@ -28,16 +28,8 @@ type Props = {
   children: React.ReactNode;
 };
 
-const BootstrapModalWrapper = ({
-  showModal,
-  children,
-  onHide,
-  bsSize,
-  backdrop,
-  role = 'dialog',
-  ...restProps
-}: Props) => (
-  <Modal show={showModal} onHide={onHide} bsSize={bsSize} backdrop={backdrop} role={role} {...restProps}>
+const BootstrapModalWrapper = ({ showModal, children, onHide, bsSize, backdrop, ...restProps }: Props) => (
+  <Modal show={showModal} onHide={onHide} bsSize={bsSize} backdrop={backdrop} {...restProps}>
     {children}
   </Modal>
 );

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
@@ -20,7 +20,7 @@ import Modal from './Modal';
 
 type Props = {
   title?: string | undefined;
-  backdrop?: boolean | 'static' | undefined;
+  backdrop?: boolean;
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
   showModal: boolean;
   role?: string;
@@ -33,7 +33,7 @@ const BootstrapModalWrapper = ({
   children,
   onHide,
   bsSize,
-  backdrop = 'static',
+  backdrop,
   role = 'dialog',
   ...restProps
 }: Props) => (

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
@@ -19,17 +19,15 @@ import React from 'react';
 import Modal from './Modal';
 
 type Props = {
-  title?: string | undefined;
   backdrop?: boolean;
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
   showModal: boolean;
-  role?: string;
   onHide: () => void;
   children: React.ReactNode;
 };
 
-const BootstrapModalWrapper = ({ showModal, children, onHide, bsSize, backdrop, ...restProps }: Props) => (
-  <Modal show={showModal} onHide={onHide} bsSize={bsSize} backdrop={backdrop} {...restProps}>
+const BootstrapModalWrapper = ({ showModal, children, onHide, bsSize, backdrop }: Props) => (
+  <Modal show={showModal} onHide={onHide} bsSize={bsSize} backdrop={backdrop}>
     {children}
   </Modal>
 );

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.tsx
@@ -26,7 +26,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-const BootstrapModalWrapper = ({ showModal, children, onHide, bsSize, backdrop }: Props) => (
+const BootstrapModalWrapper = ({ showModal, children, onHide, bsSize = undefined, backdrop = undefined }: Props) => (
   <Modal show={showModal} onHide={onHide} bsSize={bsSize} backdrop={backdrop}>
     {children}
   </Modal>

--- a/graylog2-web-interface/src/components/bootstrap/Modal.md
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.md
@@ -10,7 +10,7 @@ const ModalExample = () => {
       <Button onClick={toggleShow}>Open Modal</Button>
 
       <Modal show={show} onHide={toggleShow}>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Lorem Ipsum Presents:</Modal.Title>
         </Modal.Header>
 

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -31,6 +31,9 @@ const ModalContent = styled(MantineModal.Content)`
 
 const sizeForMantine = (size: BsSize) => {
   switch (size) {
+    case 'sm':
+    case 'small':
+      return 'md';
     case 'lg':
     case 'large':
       return 'xl';
@@ -43,13 +46,21 @@ type Props = {
   onHide: () => void;
   children: React.ReactNode;
   show?: boolean;
-  bsSize?: 'lg' | 'large' | 'small';
+  bsSize?: 'lg' | 'large' | 'sm' | 'small';
   enforceFocus?: boolean;
+  backdrop?: boolean;
 };
 
-const Modal = ({ onHide, show = false, children, bsSize = undefined, enforceFocus = false }: Props) => (
+const Modal = ({
+  onHide,
+  show = false,
+  children,
+  bsSize = undefined,
+  enforceFocus = false,
+  backdrop = true,
+}: Props) => (
   <MantineModal.Root opened={show} onClose={onHide} size={sizeForMantine(bsSize)} trapFocus={enforceFocus}>
-    <ModalOverlay />
+    {backdrop && <ModalOverlay />}
     <ModalContent>{children}</ModalContent>
   </MantineModal.Root>
 );

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -15,11 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
 import { Modal as MantineModal } from '@mantine/core';
 import styled from 'styled-components';
 
 import type { BsSize } from 'components/bootstrap/types';
+
+export type ModalSize = 'lg' | 'large' | 'sm' | 'small';
 
 const ModalOverlay = styled(MantineModal.Overlay)`
   z-index: 1040;
@@ -46,7 +47,7 @@ type Props = {
   onHide: () => void;
   children: React.ReactNode;
   show?: boolean;
-  bsSize?: 'lg' | 'large' | 'sm' | 'small';
+  bsSize?: ModalSize;
   enforceFocus?: boolean;
   backdrop?: boolean;
   closable?: boolean;

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -53,12 +53,7 @@ const Modal = ({ onHide, show = false, children, bsSize = undefined }: Props) =>
   </MantineModal.Root>
 );
 
-Modal.Header = ({ children, closeButton }: { children: React.ReactNode; closeButton: boolean }) => (
-  <MantineModal.Header>
-    {children}
-    {closeButton && <MantineModal.CloseButton />}
-  </MantineModal.Header>
-);
+Modal.Header = ({ children }: { children: React.ReactNode }) => <MantineModal.Header>{children}</MantineModal.Header>;
 
 Modal.Title = styled(MantineModal.Title)`
   font-size: ${({ theme }) => theme.fonts.size.h2};

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -43,36 +43,43 @@ const sizeForMantine = (size: BsSize) => {
 };
 
 type Props = {
-  onHide: () => void;
+  onHide?: () => void;
   children: React.ReactNode;
   show?: boolean;
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
   enforceFocus?: boolean;
   backdrop?: boolean;
-  closeOnEscape?: boolean;
 };
 
 const Modal = ({
-  onHide,
+  onHide = undefined,
   show = false,
   children,
   bsSize = undefined,
   enforceFocus = false,
   backdrop = true,
-  closeOnEscape = true,
-}: Props) => (
-  <MantineModal.Root
-    opened={show}
-    onClose={onHide}
-    size={sizeForMantine(bsSize)}
-    trapFocus={enforceFocus}
-    closeOnEscape={closeOnEscape}>
-    {backdrop && <ModalOverlay />}
-    <ModalContent>{children}</ModalContent>
-  </MantineModal.Root>
-);
+}: Props) => {
+  const closable = typeof onHide === 'function';
 
-Modal.Header = ({ children }: { children: React.ReactNode }) => <MantineModal.Header>{children}</MantineModal.Header>;
+  return (
+    <MantineModal.Root
+      opened={show}
+      onClose={onHide}
+      size={sizeForMantine(bsSize)}
+      trapFocus={enforceFocus}
+      closeOnEscape={closable}>
+      {backdrop && <ModalOverlay />}
+      <ModalContent>{children}</ModalContent>
+    </MantineModal.Root>
+  );
+};
+
+Modal.Header = ({ children, showCloseButton = true }: { children: React.ReactNode; showCloseButton?: boolean }) => (
+  <MantineModal.Header>
+    {children}
+    {showCloseButton && <MantineModal.CloseButton />}
+  </MantineModal.Header>
+);
 
 Modal.Title = styled(MantineModal.Title)`
   font-size: ${({ theme }) => theme.fonts.size.h2};

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -40,7 +40,12 @@ const Modal = ({ onHide, show = false, children }: Props) => (
   </MantineModal.Root>
 );
 
-Modal.Header = MantineModal.Header;
+Modal.Header = ({ children, closeButton }: { children: React.ReactNode; closeButton: boolean }) => (
+  <MantineModal.Header>
+    {children}
+    {closeButton && <MantineModal.CloseButton />}
+  </MantineModal.Header>
+);
 
 Modal.Title = styled(MantineModal.Title)`
   font-size: ${({ theme }) => theme.fonts.size.h2};

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -19,6 +19,8 @@ import * as React from 'react';
 import { Modal as MantineModal } from '@mantine/core';
 import styled from 'styled-components';
 
+import type { BsSize } from 'components/bootstrap/types';
+
 const ModalOverlay = styled(MantineModal.Overlay)`
   z-index: 1030;
 `;
@@ -27,14 +29,25 @@ const ModalContent = styled(MantineModal.Content)`
   z-index: 1031;
 `;
 
+const sizeForMantine = (size: BsSize) => {
+  switch (size) {
+    case 'lg':
+    case 'large':
+      return 'xl';
+    default:
+      return 'lg';
+  }
+};
+
 type Props = {
   onHide: () => void;
   children: React.ReactNode;
   show?: boolean;
+  bsSize?: 'lg' | 'large';
 };
 
-const Modal = ({ onHide, show = false, children }: Props) => (
-  <MantineModal.Root opened={show} onClose={onHide} size="lg">
+const Modal = ({ onHide, show = false, children, bsSize = undefined }: Props) => (
+  <MantineModal.Root opened={show} onClose={onHide} size={sizeForMantine(bsSize)}>
     <ModalOverlay />
     <ModalContent>{children}</ModalContent>
   </MantineModal.Root>

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -14,92 +14,40 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { Modal as BootstrapModal } from 'react-bootstrap';
-import styled, { css } from 'styled-components';
+import { Modal as MantineModal } from '@mantine/core';
+import styled from 'styled-components';
 
-const Dialog = css`
-  margin-top: 55px;
-
-  .modal-content {
-    background-color: ${({ theme }) => theme.colors.global.contentBackground};
-    border-color: ${({ theme }) => theme.colors.variant.light.default};
-    height: 100%;
-  }
+const ModalOverlay = styled(MantineModal.Overlay)`
+  z-index: 1030;
 `;
 
-const Header = css`
-  border-bottom-color: ${({ theme }) => theme.colors.variant.light.default};
-
-  button.close {
-    color: currentColor;
-  }
+const ModalContent = styled(MantineModal.Content)`
+  z-index: 1031;
 `;
 
-const Title = css`
-  font-size: ${({ theme }) => theme.fonts.size.h3};
+type Props = {
+  onHide: () => void;
+  children: React.ReactNode;
+  show?: boolean;
+};
+
+const Modal = ({ onHide, show = false, children }: Props) => (
+  <MantineModal.Root opened={show} onClose={onHide} size="lg">
+    <ModalOverlay />
+    <ModalContent>{children}</ModalContent>
+  </MantineModal.Root>
+);
+
+Modal.Header = MantineModal.Header;
+
+Modal.Title = styled(MantineModal.Title)`
+  font-size: ${({ theme }) => theme.fonts.size.h2};
 `;
 
-const Footer = css`
-  border-top-color: ${({ theme }) => theme.colors.variant.light.default};
-`;
-
-const Body = css`
-  .form-group {
-    margin-bottom: 5px;
-  }
-`;
-
-const Modal = styled(BootstrapModal)`
-  .modal-backdrop {
-    height: 100000%; /* yes, really. this fixes the backdrop being cut off when the page is scrolled. */
-    z-index: 1030;
-  }
-
-  form {
-    margin-bottom: 0;
-  }
-
-  .modal-dialog {
-    ${Dialog}
-  }
-
-  .modal-header {
-    ${Header}
-  }
-
-  .modal-footer {
-    ${Footer}
-  }
-
-  .modal-title {
-    ${Title}
-  }
-
-  .modal-body {
-    ${Body}
-  }
-`;
-
-Modal.Dialog = styled(BootstrapModal.Dialog)`
-  ${Dialog}
-`;
-
-Modal.Header = styled(BootstrapModal.Header)`
-  ${Header}
-`;
-
-Modal.Title = styled(BootstrapModal.Title)`
-  ${Title}
-`;
-
-Modal.Body = styled(BootstrapModal.Body)`
-  ${Body}
-`;
-
-Modal.Footer = styled(BootstrapModal.Footer)`
-  ${Footer}
-`;
+Modal.Body = MantineModal.Body;
+Modal.Footer = MantineModal.Body;
 
 /** @component */
 export default Modal;

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { Modal as MantineModal } from '@mantine/core';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import type { BsSize } from 'components/bootstrap/types';
 
@@ -29,6 +29,12 @@ const ModalOverlay = styled(MantineModal.Overlay)`
 const ModalContent = styled(MantineModal.Content)`
   z-index: 1050;
 `;
+
+const ModalRoot = styled(MantineModal.Root)(
+  ({ theme }) => css`
+    --mantine-color-body: ${theme.colors.global.contentBackground};
+  `,
+);
 
 const sizeForMantine = (size: BsSize) => {
   switch (size) {
@@ -62,7 +68,7 @@ const Modal = ({
   backdrop = true,
   closable = true,
 }: Props) => (
-  <MantineModal.Root
+  <ModalRoot
     opened={show}
     onClose={onHide}
     size={sizeForMantine(bsSize)}
@@ -70,7 +76,7 @@ const Modal = ({
     closeOnEscape={closable}>
     {backdrop && <ModalOverlay />}
     <ModalContent>{children}</ModalContent>
-  </MantineModal.Root>
+  </ModalRoot>
 );
 
 Modal.Header = ({ children, showCloseButton = true }: { children: React.ReactNode; showCloseButton?: boolean }) => (

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -43,11 +43,12 @@ type Props = {
   onHide: () => void;
   children: React.ReactNode;
   show?: boolean;
-  bsSize?: 'lg' | 'large';
+  bsSize?: 'lg' | 'large' | 'small';
+  enforceFocus?: boolean;
 };
 
-const Modal = ({ onHide, show = false, children, bsSize = undefined }: Props) => (
-  <MantineModal.Root opened={show} onClose={onHide} size={sizeForMantine(bsSize)}>
+const Modal = ({ onHide, show = false, children, bsSize = undefined, enforceFocus = false }: Props) => (
+  <MantineModal.Root opened={show} onClose={onHide} size={sizeForMantine(bsSize)} trapFocus={enforceFocus}>
     <ModalOverlay />
     <ModalContent>{children}</ModalContent>
   </MantineModal.Root>

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -22,11 +22,11 @@ import styled from 'styled-components';
 import type { BsSize } from 'components/bootstrap/types';
 
 const ModalOverlay = styled(MantineModal.Overlay)`
-  z-index: 1030;
+  z-index: 1040;
 `;
 
 const ModalContent = styled(MantineModal.Content)`
-  z-index: 1031;
+  z-index: 1050;
 `;
 
 const sizeForMantine = (size: BsSize) => {

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -49,6 +49,7 @@ type Props = {
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
   enforceFocus?: boolean;
   backdrop?: boolean;
+  closeOnEscape?: boolean;
 };
 
 const Modal = ({
@@ -58,8 +59,14 @@ const Modal = ({
   bsSize = undefined,
   enforceFocus = false,
   backdrop = true,
+  closeOnEscape = true,
 }: Props) => (
-  <MantineModal.Root opened={show} onClose={onHide} size={sizeForMantine(bsSize)} trapFocus={enforceFocus}>
+  <MantineModal.Root
+    opened={show}
+    onClose={onHide}
+    size={sizeForMantine(bsSize)}
+    trapFocus={enforceFocus}
+    closeOnEscape={closeOnEscape}>
     {backdrop && <ModalOverlay />}
     <ModalContent>{children}</ModalContent>
   </MantineModal.Root>
@@ -74,5 +81,4 @@ Modal.Title = styled(MantineModal.Title)`
 Modal.Body = MantineModal.Body;
 Modal.Footer = MantineModal.Body;
 
-/** @component */
 export default Modal;

--- a/graylog2-web-interface/src/components/bootstrap/Modal.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Modal.tsx
@@ -43,36 +43,34 @@ const sizeForMantine = (size: BsSize) => {
 };
 
 type Props = {
-  onHide?: () => void;
+  onHide: () => void;
   children: React.ReactNode;
   show?: boolean;
   bsSize?: 'lg' | 'large' | 'sm' | 'small';
   enforceFocus?: boolean;
   backdrop?: boolean;
+  closable?: boolean;
 };
 
 const Modal = ({
-  onHide = undefined,
+  onHide,
   show = false,
   children,
   bsSize = undefined,
   enforceFocus = false,
   backdrop = true,
-}: Props) => {
-  const closable = typeof onHide === 'function';
-
-  return (
-    <MantineModal.Root
-      opened={show}
-      onClose={onHide}
-      size={sizeForMantine(bsSize)}
-      trapFocus={enforceFocus}
-      closeOnEscape={closable}>
-      {backdrop && <ModalOverlay />}
-      <ModalContent>{children}</ModalContent>
-    </MantineModal.Root>
-  );
-};
+  closable = true,
+}: Props) => (
+  <MantineModal.Root
+    opened={show}
+    onClose={onHide}
+    size={sizeForMantine(bsSize)}
+    trapFocus={enforceFocus}
+    closeOnEscape={closable}>
+    {backdrop && <ModalOverlay />}
+    <ModalContent>{children}</ModalContent>
+  </MantineModal.Root>
+);
 
 Modal.Header = ({ children, showCloseButton = true }: { children: React.ReactNode; showCloseButton?: boolean }) => (
   <MantineModal.Header>

--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -26,7 +26,7 @@ const StyledModal = styled(Modal)`
 
 type Props = {
   show?: boolean;
-  onConfirm: (event) => void;
+  onConfirm: () => void;
   onCancel?: () => void;
   title: string | React.ReactNode;
   children: React.ReactNode;

--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -53,7 +53,7 @@ const ConfirmDialog = ({
 
   return (
     <StyledModal show={show} onHide={onHide}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
 

--- a/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/PermissionsConfig.tsx
@@ -118,7 +118,7 @@ const PermissionsConfig = () => {
             <Formik onSubmit={saveConfig} initialValues={config}>
               {({ isSubmitting }) => (
                 <Form>
-                  <Modal.Header closeButton>
+                  <Modal.Header>
                     <Modal.Title id="dialog_label">{modalTitle}</Modal.Title>
                   </Modal.Header>
 

--- a/graylog2-web-interface/src/components/configurations/UserConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/UserConfig.tsx
@@ -133,7 +133,7 @@ const UserConfig = () => {
             <Formik onSubmit={saveConfig} initialValues={formConfig}>
               {({ isSubmitting, values, setFieldValue }) => (
                 <Form>
-                  <Modal.Header closeButton>
+                  <Modal.Header>
                     <Modal.Title id="dialog_label">{modalTitle}</Modal.Title>
                   </Modal.Header>
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.tsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.tsx
@@ -115,7 +115,7 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
 
   return (
     <BootstrapModalWrapper showModal={show} onHide={_onCancel}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{modalTitle}</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/components/configurations/message-processors/ProcessingConfigModalForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/message-processors/ProcessingConfigModalForm.tsx
@@ -93,7 +93,7 @@ const ProcessingConfigModalForm = ({ closeModal, formConfig }: Props) => {
       <Formik onSubmit={saveConfig} initialValues={formConfig}>
         {({ isSubmitting, values, setFieldValue, isValid }) => (
           <Form>
-            <Modal.Header closeButton>
+            <Modal.Header>
               <Modal.Title id="dialog_label">Update Message Processors Configuration</Modal.Title>
             </Modal.Header>
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.tsx
@@ -45,7 +45,7 @@ const ContentPackDownloadControl = ({ contentPackId, revision, show = false, onH
 
   return (
     <BootstrapModalWrapper showModal={showDownloadModal} onHide={closeModal} bsSize="large">
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{modalTitle}</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.tsx
@@ -126,7 +126,7 @@ class ContentPackEntitiesList extends React.Component<
 
     const applyModal = (
       <BootstrapModalWrapper showModal={this.state.showApplyConfigModal} onHide={closeModal} bsSize="large">
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Edit</Modal.Title>
         </Modal.Header>
         <Modal.Body>{applyParamComponent}</Modal.Body>
@@ -157,7 +157,7 @@ class ContentPackEntitiesList extends React.Component<
         showModal={entity.id === this.state.showConfigModalId}
         onHide={closeShowModal}
         bsSize="large">
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Entity Config</Modal.Title>
         </Modal.Header>
         <Modal.Body>{entityComponent}</Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.tsx
@@ -58,7 +58,7 @@ class ContentPackInstallations extends React.Component<
 
     const installModal = (
       <BootstrapModalWrapper showModal={this.state.showInstallModal} onHide={closeShowModal} bsSize="large">
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>View Installation</Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.tsx
@@ -162,7 +162,7 @@ class ContentPackParameterList extends React.Component<
 
     const modal = (
       <BootstrapModalWrapper showModal={showModal} onHide={closeModal} bsSize="large">
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>Parameter</Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackListItem.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackListItem.tsx
@@ -105,7 +105,7 @@ const ContentPackListItem = ({ pack, contentPackMetadata, onDeletePack, onInstal
       </Row>
       {showInstallModal && (
         <BootstrapModalWrapper showModal={showInstallModal} onHide={onCloseInstallModal} bsSize="large">
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>Install Content Pack</Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
@@ -104,7 +104,7 @@ const ContentPackVersionItem = ({
       </td>
       {showInstallModal && (
         <BootstrapModalWrapper showModal={showInstallModal} onHide={onCloseInstallModal} bsSize="large">
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>Install Content Pack</Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
@@ -78,6 +78,7 @@ const ContentPackVersionItem = ({
 
   return (
     <tr key={pack.id + pack.rev}>
+      {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
       <td>
         <input type="radio" value={pack.rev} onChange={onChange} checked={selectedVersion === pack.rev} />
       </td>

--- a/graylog2-web-interface/src/components/datanode/DataNodeConfiguration/CertificateRenewalPolicyConfig.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeConfiguration/CertificateRenewalPolicyConfig.tsx
@@ -230,7 +230,7 @@ const CertificateRenewalPolicyConfig = ({ className = undefined }: Props) => {
         <Formik<FormConfig> onSubmit={saveConfig} initialValues={formConfig}>
           {({ values, setFieldValue, isSubmitting, isValid, isValidating }) => (
             <Form>
-              <Modal.Header closeButton>
+              <Modal.Header>
                 <Modal.Title id="dialog_label">{modalTitle}</Modal.Title>
               </Modal.Header>
 

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeLogsDialog.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeLogsDialog.tsx
@@ -55,7 +55,7 @@ const DataNodeLogsDialog = ({ show, hostname, onHide }: Props) => {
 
   return (
     <BootstrapModalWrapper showModal={show} onHide={onHide} bsSize="large" backdrop>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{hostname} logs</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/components/datanode/client-certificate/ClientCertForm.tsx
+++ b/graylog2-web-interface/src/components/datanode/client-certificate/ClientCertForm.tsx
@@ -52,7 +52,7 @@ const ClientCertForm = ({ onCancel }: Props) => {
 
   return (
     <>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Create client certificate</Modal.Title>
       </Modal.Header>
       {!clientCerts && (

--- a/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/RemoteReindexRunning.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/remoteReindexing/RemoteReindexRunning.tsx
@@ -163,7 +163,7 @@ const RemoteReindexRunning = ({ currentStep, onTriggerStep, hideActions }: Migra
       )}
       {showLogView && (
         <BootstrapModalWrapper showModal={showLogView} onHide={handleCloseLogView} bsSize="large" backdrop>
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>Remote Reindex Migration Logs</Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/graylog2-web-interface/src/components/extractors/ExtractorSortModal.tsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorSortModal.tsx
@@ -78,7 +78,7 @@ class ExtractorSortModal extends React.Component<
 
     return (
       <BootstrapModalWrapper showModal onHide={this._cancel}>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>
             <span>
               Sort extractors for <em>{input.title}</em>

--- a/graylog2-web-interface/src/components/hotkeys/HotkeysModal.tsx
+++ b/graylog2-web-interface/src/components/hotkeys/HotkeysModal.tsx
@@ -94,7 +94,7 @@ const HotkeysModal = ({ onToggle }: Props) => {
   const enabledCollection = useEnabledCollections();
 
   return (
-    <Modal onHide={onToggle} show title="Keyboard shortcuts" bsSize="large">
+    <Modal onHide={onToggle} show bsSize="large">
       <Modal.Header>
         <Modal.Title>Keyboard shortcuts</Modal.Title>
       </Modal.Header>

--- a/graylog2-web-interface/src/components/hotkeys/HotkeysModal.tsx
+++ b/graylog2-web-interface/src/components/hotkeys/HotkeysModal.tsx
@@ -95,7 +95,7 @@ const HotkeysModal = ({ onToggle }: Props) => {
 
   return (
     <Modal onHide={onToggle} show title="Keyboard shortcuts" bsSize="large">
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Keyboard shortcuts</Modal.Title>
       </Modal.Header>
 

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.tsx
@@ -207,7 +207,7 @@ const IndexSetCustomFieldTypeRemoveModal = ({ show, fields, onClose, indexSetIds
 
   return (
     <BootstrapModalForm
-      title={<span>Remove Field Type Overrides</span>}
+      title="Remove Field Type Overrides"
       submitButtonText="Remove field type overrides"
       onSubmitForm={onSubmit}
       onCancel={onCancel}

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
@@ -270,7 +270,7 @@ describe('IndexSetFieldTypesList', () => {
       const resetButton = await within(tableRow).findByRole('button', { name: /reset/i });
       fireEvent.click(resetButton);
       await screen.findByLabelText(/Remove field type overrides/i);
-      const modal = await screen.findByTestId('modal-form');
+      const modal = await screen.findByRole('dialog');
       await within(modal).findByText('Rotate affected indices after change');
 
       expect(modal).toHaveTextContent(
@@ -297,7 +297,7 @@ describe('IndexSetFieldTypesList', () => {
       const resetButton = await within(tableRow).findByRole('button', { name: /reset/i });
       fireEvent.click(resetButton);
       await screen.findByLabelText(/Remove field type overrides/i);
-      const modal = await screen.findByTestId('modal-form');
+      const modal = await screen.findByRole('dialog');
       await within(modal).findByText('Rotate affected indices after change');
 
       expect(modal).toHaveTextContent(
@@ -448,7 +448,7 @@ describe('IndexSetFieldTypesList', () => {
       renderIndexSetFieldTypesList();
       const button = await screen.findByTitle('Set field type profile');
       fireEvent.click(button);
-      const modal = await screen.findByTestId('modal-form');
+      const modal = await screen.findByRole('dialog');
       await within(modal).findByRole('button', { name: /Set Profile/i, hidden: true });
     });
   });

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
@@ -269,9 +269,11 @@ describe('IndexSetFieldTypesList', () => {
       const tableRow = await screen.findByTestId('table-row-field-1');
       const resetButton = await within(tableRow).findByRole('button', { name: /reset/i });
       fireEvent.click(resetButton);
-      await screen.findByLabelText(/Remove field type overrides/i);
+
+      await screen.findByRole('heading', { name: /Remove field type overrides/i });
+      await screen.findByText('Rotate affected indices after change');
+
       const modal = await screen.findByRole('dialog');
-      await within(modal).findByText('Rotate affected indices after change');
 
       expect(modal).toHaveTextContent(
         'After removing the overridden field type for field-1 in index set title, the settings of your search engine will be applied for fields: field-1',
@@ -296,9 +298,10 @@ describe('IndexSetFieldTypesList', () => {
       const tableRow = await screen.findByTestId('table-row-field-2');
       const resetButton = await within(tableRow).findByRole('button', { name: /reset/i });
       fireEvent.click(resetButton);
-      await screen.findByLabelText(/Remove field type overrides/i);
+      await screen.findByRole('heading', { name: /Remove field type overrides/i });
+      await screen.findByText('Rotate affected indices after change');
+
       const modal = await screen.findByRole('dialog');
-      await within(modal).findByText('Rotate affected indices after change');
 
       expect(modal).toHaveTextContent(
         'After removing the overridden field type for field-2 in index set title, the settings from Profile-1 ( namely field-2: Boolean) will be applied',

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.tsx
@@ -117,7 +117,7 @@ const SetProfileModal = ({ show, onClose, currentProfile }: Props) => {
   return (
     <Modal onHide={onCancel} show={show} data-testid="modal-form">
       <form onSubmit={onSubmit}>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>
             <span>Set Profile</span>
           </Modal.Title>

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/SelectIndexSetTemplateModal.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/SelectIndexSetTemplateModal.tsx
@@ -128,7 +128,7 @@ const SelectIndexSetTemplateModal = ({ hideModal, show }: Props) => {
   const selectedCustomTemplate = customList.find((template) => template.id === tempSelectedTemplate?.id);
 
   return (
-    <Modal show={show} title="Index Set Templates" bsSize="large" onHide={handleClose}>
+    <Modal show={show} bsSize="large" onHide={handleClose}>
       <Modal.Header>
         <Modal.Title>Index Set Templates</Modal.Title>
       </Modal.Header>

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/SelectIndexSetTemplateModal.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/SelectIndexSetTemplateModal.tsx
@@ -129,7 +129,7 @@ const SelectIndexSetTemplateModal = ({ hideModal, show }: Props) => {
 
   return (
     <Modal show={show} title="Index Set Templates" bsSize="large" onHide={handleClose}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Index Set Templates</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/Wizard.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/Wizard.tsx
@@ -86,7 +86,7 @@ const Wizard = ({ show, input, onClose }: Props) => {
 
   return (
     <Modal show onHide={onClose} backdrop={false}>
-      <Modal.Header closeButton>Input Setup Wizard</Modal.Header>
+      <Modal.Header>Input Setup Wizard</Modal.Header>
       <Modal.Body>
         <InputSetupWizardStepsProvider>
           {EnterpriseWizard ? (

--- a/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.test.tsx
+++ b/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.test.tsx
@@ -58,7 +58,7 @@ describe('ClusterSupportBundleOverview', () => {
 
     fireEvent.click(deleteButton);
 
-    const confirmButton = screen.getByRole('button', { name: /Confirm/i, hidden: true });
+    const confirmButton = await screen.findByRole('button', { name: /Confirm/i });
 
     expect(confirmButton).toBeInTheDocument();
 

--- a/graylog2-web-interface/src/components/rules/rule-builder/ConvertToSourceCodeModal.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/ConvertToSourceCodeModal.tsx
@@ -53,7 +53,7 @@ const ConvertToSourceCodeModal = ({ show, onHide, onNavigateAway, rule }: Props)
 
   return (
     <BootstrapModalWrapper showModal={show} onHide={onHide} bsSize="large">
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{rule.title || '<no title>'}</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilderBlock.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilderBlock.tsx
@@ -253,7 +253,7 @@ const RuleBuilderBlock = ({
           />
           {Boolean(insertMode) && (
             <Modal show bsSize="lg" enforceFocus onHide={resetInsertBlock}>
-              <Modal.Header closeButton>
+              <Modal.Header>
                 <Modal.Title>
                   Insert new action {insertMode} action N°{order + 1}
                 </Modal.Title>

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilderBlock.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilderBlock.tsx
@@ -252,7 +252,7 @@ const RuleBuilderBlock = ({
             type={type}
           />
           {Boolean(insertMode) && (
-            <Modal show title="insert rule action" bsSize="lg" enforceFocus onHide={resetInsertBlock}>
+            <Modal show bsSize="lg" enforceFocus onHide={resetInsertBlock}>
               <Modal.Header closeButton>
                 <Modal.Title>
                   Insert new action {insertMode} action N°{order + 1}

--- a/graylog2-web-interface/src/components/scratchpad/Scratchpad.test.tsx
+++ b/graylog2-web-interface/src/components/scratchpad/Scratchpad.test.tsx
@@ -113,16 +113,12 @@ describe('<Scratchpad />', () => {
 
     fireEvent.click(btnClear);
 
-    await screen.findByRole('alertdialog', { hidden: true });
-
-    const confirmBtn = screen.getByRole('button', { name: /confirm/i, hidden: true });
+    const confirmBtn = await screen.findByRole('button', { name: /confirm/i });
 
     fireEvent.click(confirmBtn);
 
     await screen.findByText(/cleared\./i);
 
-    await waitFor(() => {
-      expect(textarea.value).toBe('');
-    });
+    await waitFor(() => expect(textarea.value).toBe(''));
   });
 });

--- a/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
@@ -120,7 +120,12 @@ const TeaserPageLayout = ({ children }: PropsWithChildren) => {
         </ContentArea>
       </Container>
       {showModal && (
-        <ConfirmDialog show title="Security Demo" onConfirm={() => setShowModal(false)} btnConfirmText="Close">
+        <ConfirmDialog
+          show
+          title="Security Demo"
+          onConfirm={() => setShowModal(false)}
+          onCancel={() => setShowModal(false)}
+          btnConfirmText="Close">
           <Col>
             <h2 className="text-danger">OVERVIEW</h2>
             <p>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.tsx
@@ -94,7 +94,7 @@ class SourceViewModal extends React.Component<
   render() {
     return (
       <BootstrapModalWrapper showModal={this.props.showModal} onHide={this.props.onHide}>
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>
             <span>
               Configuration <em>{this.state.name}</em>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/VerboseMessageModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/VerboseMessageModal.tsx
@@ -36,7 +36,7 @@ type VerboseMessageModalProps = {
 
 const VerboseMessageModal = ({ showModal, onHide, collectorName, collectorVerbose }: VerboseMessageModalProps) => (
   <BootstrapModalWrapper showModal={showModal} onHide={onHide} bsSize="large">
-    <Modal.Header closeButton>
+    <Modal.Header>
       <Modal.Title>
         <span>
           Error Details for <em>{collectorName}</em>

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
@@ -115,7 +115,7 @@ const StreamRuleModal = ({
   );
 
   return (
-    <Modal title={title} onHide={onClose} show>
+    <Modal onHide={onClose} show>
       <Formik<FormValues> initialValues={initialValues} onSubmit={_onSubmit} validate={validate}>
         {({ values, setFieldValue, isSubmitting, isValidating }) => (
           <Form>

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleModal.tsx
@@ -119,7 +119,7 @@ const StreamRuleModal = ({
       <Formik<FormValues> initialValues={initialValues} onSubmit={_onSubmit} validate={validate}>
         {({ values, setFieldValue, isSubmitting, isValidating }) => (
           <Form>
-            <Modal.Header closeButton>
+            <Modal.Header>
               <Modal.Title>{title}</Modal.Title>
             </Modal.Header>
             <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRuleForm.tsx
@@ -83,7 +83,7 @@ const FilterRuleForm = ({ title, filterRule, onCancel, handleSubmit, destination
 
           return (
             <>
-              <Modal.Header closeButton>
+              <Modal.Header>
                 <Modal.Title>{title}</Modal.Title>
               </Modal.Header>
               <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRuleForm.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterRuleForm.tsx
@@ -49,7 +49,7 @@ const FilterRuleForm = ({ title, filterRule, onCancel, handleSubmit, destination
   };
 
   return (
-    <BootstrapModalWrapper showModal bsSize="lg" role="alertdialog" onHide={onCancel}>
+    <BootstrapModalWrapper showModal bsSize="lg" onHide={onCancel}>
       <Formik<StreamOutputFilterRuleValues>
         initialValues={{
           ...filterRule,

--- a/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/AddOutputButton.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/AddOutputButton.tsx
@@ -110,7 +110,7 @@ const AddOutputButton = ({ stream, getTypeDefinition, assignableOutputs, availab
       </Button>
       {showAddOutput && (
         <BootstrapModalWrapper showModal role="alertdialog" onHide={() => setShowAddOutput(false)}>
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>Add output to stream</Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/AddOutputButton.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/AddOutputButton.tsx
@@ -109,7 +109,7 @@ const AddOutputButton = ({ stream, getTypeDefinition, assignableOutputs, availab
         <Icon name="add" size="sm" /> Add output
       </Button>
       {showAddOutput && (
-        <BootstrapModalWrapper showModal role="alertdialog" onHide={() => setShowAddOutput(false)}>
+        <BootstrapModalWrapper showModal onHide={() => setShowAddOutput(false)}>
           <Modal.Header>
             <Modal.Title>Add output to stream</Modal.Title>
           </Modal.Header>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/IndexSetUpdateForm.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/IndexSetUpdateForm.tsx
@@ -97,7 +97,7 @@ const IndexSetUpdateForm = ({ initialValues, indexSets, stream }: Props) => {
           <Formik<FormValues> initialValues={_initialValues} onSubmit={onSave} validate={validate}>
             {({ isSubmitting, isValidating }) => (
               <Form>
-                <Modal.Header closeButton>
+                <Modal.Header>
                   <Modal.Title>Edit Stream IndexSet</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamModal.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamModal.tsx
@@ -81,7 +81,7 @@ const StreamModal = ({
       <Formik<FormValues> initialValues={_initialValues} onSubmit={_onSubmit} validate={validate}>
         {({ isSubmitting, isValidating }) => (
           <Form>
-            <Modal.Header closeButton>
+            <Modal.Header>
               <Modal.Title>{modalTitle}</Modal.Title>
             </Modal.Header>
             <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamModal.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamModal.tsx
@@ -77,7 +77,7 @@ const StreamModal = ({
   const _onSubmit = useCallback((values: FormValues) => onSubmit(values).then(() => onClose()), [onClose, onSubmit]);
 
   return (
-    <Modal title={modalTitle} onHide={onClose} show>
+    <Modal onHide={onClose} show>
       <Formik<FormValues> initialValues={_initialValues} onSubmit={_onSubmit} validate={validate}>
         {({ isSubmitting, isValidating }) => (
           <Form>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetModal.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetModal.tsx
@@ -69,7 +69,7 @@ const AssignIndexSetModal = ({ toggleShowModal, indexSets, refetchStreams, descr
   };
 
   return (
-    <Modal title={modalTitle} onHide={toggleShowModal} show>
+    <Modal onHide={toggleShowModal} show>
       <Formik initialValues={{ index_set_id: undefined }} onSubmit={onSubmit} validate={validate}>
         {({ isSubmitting, isValidating }) => (
           <Form>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetModal.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/AssignIndexSetModal.tsx
@@ -73,7 +73,7 @@ const AssignIndexSetModal = ({ toggleShowModal, indexSets, refetchStreams, descr
       <Formik initialValues={{ index_set_id: undefined }} onSubmit={onSubmit} validate={validate}>
         {({ isSubmitting, isValidating }) => (
           <Form>
-            <Modal.Header closeButton>
+            <Modal.Header>
               <Modal.Title>{modalTitle}</Modal.Title>
             </Modal.Header>
             <Modal.Body>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/BulkActions/BulkActions.test.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { act, render, screen, within, waitFor } from 'wrappedTestingLibrary';
+import { act, render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
 
@@ -63,10 +63,7 @@ describe('StreamsOverview BulkActionsRow', () => {
   const assignIndexSet = async () => {
     userEvent.click(await screen.findByRole('menuitem', { name: /assign index set/i }));
 
-    await screen.findByRole('heading', {
-      name: /assign index set to 2 streams/i,
-      hidden: true,
-    });
+    await screen.findByRole('heading', { name: /assign index set to 2 streams/i });
 
     const indexSetSelect = await screen.findByLabelText('Index Set');
 
@@ -76,12 +73,7 @@ describe('StreamsOverview BulkActionsRow', () => {
 
     await selectEvent.select(indexSetSelect, 'Example Index Set');
 
-    const document = screen.getByRole('document', { hidden: true });
-
-    const submitButton = within(document).getByRole('button', {
-      name: /assign index set/i,
-      hidden: true,
-    });
+    const submitButton = await screen.findByRole('button', { name: /assign index set/i });
 
     await waitFor(() => expect(submitButton).toBeEnabled());
 

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -108,12 +108,12 @@ const KinesisStreams = ({
 
   return (
     <>
-      <LoadingModal show={logDataStatus.loading} backdrop="static" keyboard={false} onHide={() => {}} bsSize="small">
+      <Modal show={logDataStatus.loading} keyboard={false} onHide={() => {}} bsSize="small">
         <LoadingContent>
           <StyledSpinner />
           <LoadingMessage>This request may take a few moments.</LoadingMessage>
         </LoadingContent>
-      </LoadingModal>
+      </Modal>
 
       <FormWrap
         onSubmit={handleSubmit}
@@ -153,14 +153,6 @@ const KinesisStreams = ({
 
 const AutoSetupContent = styled.div`
   margin-bottom: 9px;
-`;
-
-const LoadingModal = styled(Modal)`
-  > .modal-dialog {
-    width: 400px;
-    margin-left: auto;
-    margin-right: auto;
-  }
 `;
 
 const LoadingContent = styled(Modal.Body)`

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -108,7 +108,7 @@ const KinesisStreams = ({
 
   return (
     <>
-      <Modal show={logDataStatus.loading} keyboard={false} onHide={() => {}} bsSize="small">
+      <Modal show={logDataStatus.loading} closeOnEscape={false} onHide={() => {}} bsSize="small">
         <LoadingContent>
           <StyledSpinner />
           <LoadingMessage>This request may take a few moments.</LoadingMessage>

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -32,6 +32,26 @@ import Spinner from 'components/common/Spinner';
 
 import FormAdvancedOptions from '../FormAdvancedOptions';
 
+const AutoSetupContent = styled.div`
+  margin-bottom: 9px;
+`;
+
+const LoadingContent = styled(Modal.Body)`
+  text-align: center;
+`;
+
+const StyledSpinner = styled(Spinner)`
+  font-size: 48px;
+  color: #702785;
+`;
+
+const LoadingMessage = styled.p`
+  font-size: 16px;
+  font-weight: bold;
+  padding-top: 15px;
+  color: #a6afbd;
+`;
+
 type KinesisStreamsProps = {
   onSubmit: (...args: any[]) => void;
   onChange: (...args: any[]) => void;
@@ -82,7 +102,7 @@ const KinesisStreams = ({ onChange, onSubmit, toggleSetup = () => {} }: KinesisS
         </Button>
       </Panel>,
     );
-  }, []);
+  }, [clearSidebar, setSidebar, toggleSetup]);
 
   useEffect(() => {
     if (logDataStatus.error) {
@@ -95,7 +115,7 @@ const KinesisStreams = ({ onChange, onSubmit, toggleSetup = () => {} }: KinesisS
         ),
       });
     }
-  }, [logDataStatus.error]);
+  }, [logDataStatus.error, setLogDataUrl]);
 
   const handleSubmit = () => {
     setLogDataUrl(ApiRoutes.INTEGRATIONS.AWS.KINESIS.HEALTH_CHECK);
@@ -145,25 +165,5 @@ const KinesisStreams = ({ onChange, onSubmit, toggleSetup = () => {} }: KinesisS
     </>
   );
 };
-
-const AutoSetupContent = styled.div`
-  margin-bottom: 9px;
-`;
-
-const LoadingContent = styled(Modal.Body)`
-  text-align: center;
-`;
-
-const StyledSpinner = styled(Spinner)`
-  font-size: 48px;
-  color: #702785;
-`;
-
-const LoadingMessage = styled.p`
-  font-size: 16px;
-  font-weight: bold;
-  padding-top: 15px;
-  color: #a6afbd;
-`;
 
 export default KinesisStreams;

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -108,7 +108,7 @@ const KinesisStreams = ({
 
   return (
     <>
-      <Modal show={logDataStatus.loading} closeOnEscape={false} onHide={() => {}} bsSize="small">
+      <Modal show={logDataStatus.loading} bsSize="small">
         <LoadingContent>
           <StyledSpinner />
           <LoadingMessage>This request may take a few moments.</LoadingMessage>

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -38,12 +38,7 @@ type KinesisStreamsProps = {
   toggleSetup?: (...args: any[]) => void;
 };
 
-const KinesisStreams = ({
-  onChange,
-  onSubmit,
-
-  toggleSetup = () => {},
-}: KinesisStreamsProps) => {
+const KinesisStreams = ({ onChange, onSubmit, toggleSetup = () => {} }: KinesisStreamsProps) => {
   const { formData } = useContext(FormDataContext);
   const [formError, setFormError] = useState(null);
   const { availableStreams, setLogData } = useContext(ApiContext);
@@ -108,7 +103,7 @@ const KinesisStreams = ({
 
   return (
     <>
-      <Modal show={logDataStatus.loading} bsSize="small">
+      <Modal show={logDataStatus.loading} bsSize="small" onHide={() => {}} closable={false}>
         <LoadingContent>
           <StyledSpinner />
           <LoadingMessage>This request may take a few moments.</LoadingMessage>

--- a/graylog2-web-interface/src/pages/DataNodeUpgradePage.tsx
+++ b/graylog2-web-interface/src/pages/DataNodeUpgradePage.tsx
@@ -323,7 +323,7 @@ const DataNodeUpgradePage = () => {
           )}
           {openUpgradeConfirmDialog && nodeInProgress && (
             <Modal show backdrop={false} onHide={() => setOpenUpgradeConfirmDialog(false)}>
-              <Modal.Header closeButton>
+              <Modal.Header>
                 <Modal.Title>Data Node Manual Upgrade</Modal.Title>
               </Modal.Header>
 

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
@@ -125,11 +125,11 @@ describe('IndexSetFieldTypesPage', () => {
     });
 
     renderIndexSetFieldTypesPage();
-    const editButton = await screen.findByText(/change field type/i);
+    const editButton = await screen.findByRole('button', { name: /change field type/i });
     fireEvent.click(editButton);
 
     const modal = await screen.findByRole('dialog');
-    await within(modal).findByText(/change field type/i);
+    await within(modal).findByRole('heading', { name: /change field type/i });
     await within(modal).findByText(/select or type the field/i);
 
     expect(within(modal).queryByText(/select targeted index sets/i)).not.toBeInTheDocument();

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.test.tsx
@@ -111,7 +111,7 @@ describe('IndexSetFieldTypesPage', () => {
     const editButton = await within(tableRow).findByText('Edit');
     fireEvent.click(editButton);
     await screen.findByText(/change field-1 field type/i);
-    const modal = await screen.findByTestId('modal-form');
+    const modal = await screen.findByRole('dialog');
     await within(modal).findByText('Boolean');
 
     expect(within(modal).queryByText(/select targeted index sets/i)).not.toBeInTheDocument();
@@ -128,7 +128,7 @@ describe('IndexSetFieldTypesPage', () => {
     const editButton = await screen.findByText(/change field type/i);
     fireEvent.click(editButton);
 
-    const modal = await screen.findByTestId('modal-form');
+    const modal = await screen.findByRole('dialog');
     await within(modal).findByText(/change field type/i);
     await within(modal).findByText(/select or type the field/i);
 

--- a/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
+++ b/graylog2-web-interface/src/views/components/CreateNewWidgetModal.tsx
@@ -109,7 +109,7 @@ const CreateNewWidgetModal = ({ onCancel, position }: Props) => {
 
   return (
     <Modal onHide={onCancel} show>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>{modalTitle}</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -87,7 +87,7 @@ describe('DashboardActionsMenu', () => {
   useViewsPlugin();
 
   const submitDashboardSaveForm = async () => {
-    const saveDashboardModal = await screen.findByTestId('modal-form');
+    const saveDashboardModal = await screen.findByRole('dialog');
 
     const saveButton = within(saveDashboardModal).getByRole('button', {
       name: /create dashboard/i,

--- a/graylog2-web-interface/src/views/components/DebugOverlay.tsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.tsx
@@ -30,7 +30,7 @@ const DebugOverlay = ({ show, onClose }: Props) => {
 
   return (
     <BootstrapModalWrapper showModal={show} onHide={onClose}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Debug information</Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -51,9 +51,9 @@ describe('QueryTitleEditModal', () => {
     await screen.findByText(modalHeadline);
   });
 
-  it('has correct initial input value', () => {
+  it('has correct initial input value', async () => {
     let modalRef;
-    const { getByDisplayValue } = render(
+    render(
       <QueryTitleEditModal
         ref={(ref) => {
           modalRef = ref;
@@ -64,7 +64,7 @@ describe('QueryTitleEditModal', () => {
 
     openModal(modalRef);
 
-    expect(getByDisplayValue('CurrentTitle')).not.toBeNull();
+    await screen.findByDisplayValue('CurrentTitle');
   });
 
   it('updates query title and closes', async () => {

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -64,13 +64,15 @@ describe('QueryTitleEditModal', () => {
 
     openModal(modalRef);
 
-    await screen.findByDisplayValue('CurrentTitle');
+    const titleInput = await screen.findByRole('textbox', { name: /Title/i });
+
+    expect(titleInput).toHaveValue('CurrentTitle');
   });
 
   it('updates query title and closes', async () => {
     let modalRef;
     const onTitleChangeFn = jest.fn();
-    const { getByDisplayValue, getByRole, queryByText } = render(
+    const { getByRole, queryByText } = render(
       <QueryTitleEditModal
         ref={(ref) => {
           modalRef = ref;
@@ -80,7 +82,10 @@ describe('QueryTitleEditModal', () => {
     );
 
     openModal(modalRef);
-    const titleInput = getByDisplayValue('CurrentTitle');
+    const titleInput = await screen.findByRole('textbox', { name: /Title/i });
+
+    expect(titleInput).toHaveValue('CurrentTitle');
+
     const saveButton = getByRole('button', { name: /update title/i, hidden: true });
 
     fireEvent.change(titleInput, { target: { value: 'NewTitle' } });

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.tsx
@@ -28,7 +28,7 @@ type Props = {
 };
 
 const SavedSearchesModal = ({ toggleModal, deleteSavedSearch, activeSavedSearchId }: Props) => (
-  <Modal show title="Saved searches" bsSize="large" onHide={toggleModal}>
+  <Modal show bsSize="large" onHide={toggleModal}>
     <Modal.Header>
       <Modal.Title>Saved Searches</Modal.Title>
     </Modal.Header>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 const SavedSearchesModal = ({ toggleModal, deleteSavedSearch, activeSavedSearchId }: Props) => (
   <Modal show title="Saved searches" bsSize="large" onHide={toggleModal}>
-    <Modal.Header closeButton>
+    <Modal.Header>
       <Modal.Title>Saved Searches</Modal.Title>
     </Modal.Header>
     <Modal.Body>

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/RowActions.tsx
@@ -87,7 +87,7 @@ const RowActions = ({ eventId, hasReplayInfo, eventDefinitionId }: Props) => {
       </ButtonToolbar>
       {showDetailsModal && (
         <Modal show={showDetailsModal} bsSize="large" onHide={toggleDetailsModal}>
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>Event details</Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.tsx
@@ -125,7 +125,7 @@ const CreateEventDefinitionModal = ({
 
   return (
     <Modal onHide={onClose} show={show}>
-      <Modal.Header closeButton>
+      <Modal.Header>
         <Modal.Title>Configure new event definition</Modal.Title>
       </Modal.Header>
       <Modal.Body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR we are replacing the [react-bootstrap modal](https://react-bootstrap-v3.netlify.app/components/modal/) with the modern [mantine modal](https://mantine.dev/core/modal/).

One difference, the main DOM element for the modal no longer contains the attribute `aria-hidden: true`. This was the case for the previous modal, because of a bug in the modal library react-bootstrap uses.

<img width="371" alt="image" src="https://github.com/user-attachments/assets/9b7617e6-14b1-4aff-9861-8af8772af9ce" />

As a result the modals are more accessible and we no longer have to use `hidden: true` in element selectors in tests, to query elements inside the modal (neither in unit nor e2e tests).

I will update the element selectors in a follow-up PR.

Related to https://github.com/Graylog2/frontend/issues/5
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/10294
/nocl
