### PR TITLE
Use query param setup_wizard to ensure back-compat

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -29,6 +29,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -36,6 +37,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -209,7 +211,8 @@ public class InputsResource extends AbstractInputsResource {
     })
     @RequiresPermissions(RestPermissions.INPUTS_CREATE)
     @AuditEvent(type = AuditEventTypes.MESSAGE_INPUT_CREATE)
-    public Response create(@ApiParam(name = "JSON body", required = true)
+    public Response create(@ApiParam @QueryParam("setup_wizard") @DefaultValue("false") boolean isSetupWizard,
+                           @ApiParam(name = "JSON body", required = true)
                            @Valid @NotNull InputCreateRequest lr) throws ValidationException {
         try {
             throwBadRequestIfNotGlobal(lr);

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/MessageInputFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/MessageInputFactory.java
@@ -49,6 +49,10 @@ public class MessageInputFactory {
     }
 
     public MessageInput create(InputCreateRequest lr, String user, String nodeId) throws NoSuchInputTypeException {
+        return create(lr, user, nodeId, false);
+    }
+
+    public MessageInput create(InputCreateRequest lr, String user, String nodeId, boolean isSetupWizard) throws NoSuchInputTypeException {
         final MessageInput input = create(lr.type(), new Configuration(lr.configuration()));
         input.setTitle(lr.title());
         input.setGlobal(lr.global());
@@ -58,7 +62,7 @@ public class MessageInputFactory {
             input.setNodeId(nodeId);
         }
 
-        if (featureFlags.isOn("SETUP_MODE") && input.supportsSetupMode()) {
+        if (featureFlags.isOn("SETUP_MODE") && input.supportsSetupMode() && isSetupWizard) {
             input.setDesiredState(IOState.Type.SETUP);
         }
 


### PR DESCRIPTION
/nocl 

<!--- Provide a general summary of your changes in the Title above -->
Adds an optional query param to the create input API. 

## Description
<!--- Describe your changes in detail -->
To prevent breaking automated creation of inputs - which doesn't know about setup wizard - we add a new optional query param `setup_wizard`. By default it is `false` and inputs will be started immediately, bypassing ISW.
If set to `true`, the input is created in setup mode.
