### PR TITLE
Fix cluster management reader permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -357,7 +357,8 @@ public class RestPermissions implements PluginPermissions {
             MESSAGES_READ,
             METRICS_READ,
             SYSTEM_READ,
-            THROUGHPUT_READ
+            THROUGHPUT_READ,
+            DATANODE_READ
     ).build();
 
     protected static final Set<Permission> READER_BASE_PERMISSIONS = PERMISSIONS.stream()

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeActions.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeActions.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useState, useRef } from 'react';
 import styled from 'styled-components';
 
-import {ConfirmDialog, IfPermitted} from 'components/common';
+import { ConfirmDialog, IfPermitted } from 'components/common';
 import { Button, MenuItem } from 'components/bootstrap';
 import type { DataNode } from 'components/datanode/Types';
 import { MoreActions } from 'components/common/EntityDataTable';
@@ -152,20 +152,18 @@ const DataNodeActions = ({ dataNode, refetch = undefined, displayAs = 'dropdown'
   const isRemovingDatanode = dataNode.data_node_status === 'REMOVING';
 
   return (
-    <>
+    <IfPermitted permissions="datanode:start">
       {displayAs === 'dropdown' && (
-        <IfPermitted permissions="datanode:start">
-          <MoreActions>
-            <MenuItem onSelect={() => renewDatanodeCertificate(dataNode.node_id)}>Renew certificate</MenuItem>
-            {!isDatanodeRunning && <MenuItem onSelect={handleStartDatanode}>Start</MenuItem>}
-            {isDatanodeRunning && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.STOP)}>Stop</MenuItem>}
-            {isDatanodeRemoved && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REJOIN)}>Rejoin</MenuItem>}
-            {(!isDatanodeRemoved || isRemovingDatanode) && (
-              <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REMOVE)}>Remove</MenuItem>
-            )}
-            <MenuItem onSelect={() => setShowLogsDialog(true)}>Show logs</MenuItem>
-          </MoreActions>
-        </IfPermitted>
+        <MoreActions>
+          <MenuItem onSelect={() => renewDatanodeCertificate(dataNode.node_id)}>Renew certificate</MenuItem>
+          {!isDatanodeRunning && <MenuItem onSelect={handleStartDatanode}>Start</MenuItem>}
+          {isDatanodeRunning && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.STOP)}>Stop</MenuItem>}
+          {isDatanodeRemoved && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REJOIN)}>Rejoin</MenuItem>}
+          {(!isDatanodeRemoved || isRemovingDatanode) && (
+            <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REMOVE)}>Remove</MenuItem>
+          )}
+          <MenuItem onSelect={() => setShowLogsDialog(true)}>Show logs</MenuItem>
+        </MoreActions>
       )}
       {displayAs === 'buttons' && (
         <>
@@ -210,7 +208,7 @@ const DataNodeActions = ({ dataNode, refetch = undefined, displayAs = 'dropdown'
           onHide={() => setShowLogsDialog(false)}
         />
       )}
-    </>
+    </IfPermitted>
   );
 };
 

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeActions.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeActions.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useState, useRef } from 'react';
 import styled from 'styled-components';
 
-import { ConfirmDialog } from 'components/common';
+import {ConfirmDialog, IfPermitted} from 'components/common';
 import { Button, MenuItem } from 'components/bootstrap';
 import type { DataNode } from 'components/datanode/Types';
 import { MoreActions } from 'components/common/EntityDataTable';
@@ -154,16 +154,18 @@ const DataNodeActions = ({ dataNode, refetch = undefined, displayAs = 'dropdown'
   return (
     <>
       {displayAs === 'dropdown' && (
-        <MoreActions>
-          <MenuItem onSelect={() => renewDatanodeCertificate(dataNode.node_id)}>Renew certificate</MenuItem>
-          {!isDatanodeRunning && <MenuItem onSelect={handleStartDatanode}>Start</MenuItem>}
-          {isDatanodeRunning && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.STOP)}>Stop</MenuItem>}
-          {isDatanodeRemoved && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REJOIN)}>Rejoin</MenuItem>}
-          {(!isDatanodeRemoved || isRemovingDatanode) && (
-            <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REMOVE)}>Remove</MenuItem>
-          )}
-          <MenuItem onSelect={() => setShowLogsDialog(true)}>Show logs</MenuItem>
-        </MoreActions>
+        <IfPermitted permissions="datanode:start">
+          <MoreActions>
+            <MenuItem onSelect={() => renewDatanodeCertificate(dataNode.node_id)}>Renew certificate</MenuItem>
+            {!isDatanodeRunning && <MenuItem onSelect={handleStartDatanode}>Start</MenuItem>}
+            {isDatanodeRunning && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.STOP)}>Stop</MenuItem>}
+            {isDatanodeRemoved && <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REJOIN)}>Rejoin</MenuItem>}
+            {(!isDatanodeRemoved || isRemovingDatanode) && (
+              <MenuItem onSelect={() => handleAction(DIALOG_TYPES.REMOVE)}>Remove</MenuItem>
+            )}
+            <MenuItem onSelect={() => setShowLogsDialog(true)}>Show logs</MenuItem>
+          </MoreActions>
+        </IfPermitted>
       )}
       {displayAs === 'buttons' && (
         <>

--- a/graylog2-web-interface/src/components/datanode/hooks/useMigrationState.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useMigrationState.ts
@@ -25,10 +25,7 @@ import { onError } from 'util/conditional/onError';
 
 export const MIGRATION_STATE_QUERY_KEY = ['migration-state'];
 
-const useMigrationState = ({
-  refetchInterval = false,
-  enabled = true,
-}?: {
+const useMigrationState = (args?: {
   refetchInterval?: number | false;
   enabled?: boolean;
 }): {
@@ -39,9 +36,9 @@ const useMigrationState = ({
     MIGRATION_STATE_QUERY_KEY,
     () => onError(Migration.status(), (error: Error) => UserNotification.error(error.message)),
     {
-      enabled,
+      enabled: args?.enabled ?? true,
       retry: 2,
-      refetchInterval,
+      refetchInterval: args?.refetchInterval ?? false,
     },
   );
 

--- a/graylog2-web-interface/src/components/datanode/hooks/useMigrationState.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useMigrationState.ts
@@ -25,9 +25,13 @@ import { onError } from 'util/conditional/onError';
 
 export const MIGRATION_STATE_QUERY_KEY = ['migration-state'];
 
-const useMigrationState = (
-  refetchInterval: number | false = false,
-): {
+const useMigrationState = ({
+  refetchInterval = false,
+  enabled = true,
+}?: {
+  refetchInterval?: number | false;
+  enabled?: boolean;
+}): {
   currentStep: MigrationState;
   isLoading: boolean;
 } => {
@@ -35,6 +39,7 @@ const useMigrationState = (
     MIGRATION_STATE_QUERY_KEY,
     () => onError(Migration.status(), (error: Error) => UserNotification.error(error.message)),
     {
+      enabled,
       retry: 2,
       refetchInterval,
     },

--- a/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
@@ -30,21 +30,21 @@ const useShowDatanodeMigration = (): {
   showDatanodeMigration: boolean;
 } => {
   const { permissions } = useCurrentUser();
-  const canReadDataNode = React.useMemo(
+  const canStartDataNode = React.useMemo(
     () => permissions.includes('datanode:start') || permissions.includes('*'),
     [permissions],
   );
 
   const { data: isDatanodeConfiguredAndUsed } = useQuery(['show_datanode_migration'], fetchShowDatanodeMigration, {
-    enabled: canReadDataNode,
+    enabled: canStartDataNode,
   });
 
-  const { currentStep } = useMigrationState({ enabled: canReadDataNode });
+  const { currentStep } = useMigrationState({ enabled: canStartDataNode });
   const noMigrationInProgress = !currentStep || currentStep?.state === 'NEW' || currentStep?.state === 'FINISHED';
 
   return {
-    isDatanodeConfiguredAndUsed: canReadDataNode && !!isDatanodeConfiguredAndUsed,
-    showDatanodeMigration: canReadDataNode && (!isDatanodeConfiguredAndUsed || !noMigrationInProgress),
+    isDatanodeConfiguredAndUsed: canStartDataNode && !!isDatanodeConfiguredAndUsed,
+    showDatanodeMigration: canStartDataNode && (!isDatanodeConfiguredAndUsed || !noMigrationInProgress),
   };
 };
 

--- a/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
@@ -14,10 +14,12 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import useMigrationState from './useMigrationState';
 
@@ -27,16 +29,22 @@ const useShowDatanodeMigration = (): {
   isDatanodeConfiguredAndUsed: boolean;
   showDatanodeMigration: boolean;
 } => {
-  const { data: isDatanodeConfiguredAndUsed } = useQuery(['show_datanode_migration'], fetchShowDatanodeMigration);
+  const { permissions } = useCurrentUser();
+  const canReadDataNode = React.useMemo(
+    () => permissions.includes('datanode:start') || permissions.includes('*'),
+    [permissions],
+  );
 
-  const { currentStep } = useMigrationState();
+  const { data: isDatanodeConfiguredAndUsed } = useQuery(['show_datanode_migration'], fetchShowDatanodeMigration, {
+    enabled: canReadDataNode,
+  });
+
+  const { currentStep } = useMigrationState({ enabled: canReadDataNode });
+  const noMigrationInProgress = !currentStep || currentStep?.state === 'NEW' || currentStep?.state === 'FINISHED';
 
   return {
-    isDatanodeConfiguredAndUsed: !!isDatanodeConfiguredAndUsed,
-    showDatanodeMigration: !(
-      isDatanodeConfiguredAndUsed &&
-      (!currentStep || currentStep?.state === 'NEW' || currentStep?.state === 'FINISHED')
-    ),
+    isDatanodeConfiguredAndUsed: canReadDataNode && !!isDatanodeConfiguredAndUsed,
+    showDatanodeMigration: canReadDataNode && (!isDatanodeConfiguredAndUsed || !noMigrationInProgress),
   };
 };
 

--- a/graylog2-web-interface/src/components/datanode/migrations/common/CertificatesProvisioning.tsx
+++ b/graylog2-web-interface/src/components/datanode/migrations/common/CertificatesProvisioning.tsx
@@ -25,7 +25,7 @@ import MigrationDatanodeList from 'components/datanode/migrations/MigrationDatan
 import { Alert } from 'components/bootstrap';
 
 const CertificatesProvisioning = ({ currentStep, onTriggerStep, hideActions }: MigrationStepComponentProps) => {
-  const { currentStep: step, isLoading } = useMigrationState(3000);
+  const { currentStep: step, isLoading } = useMigrationState({ refetchInterval: 3000 });
 
   if (isLoading) {
     return <Spinner text="Loading migration state." />;

--- a/graylog2-web-interface/src/components/navigation/bindings.ts
+++ b/graylog2-web-interface/src/components/navigation/bindings.ts
@@ -55,7 +55,7 @@ const navigationBindings: PluginExports = {
               description: 'Configurations',
               permissions: ['clusterconfigentry:read'],
             },
-            { path: Routes.SYSTEM.CLUSTER.NODES, description: 'Cluster Configuration' },
+            { path: Routes.SYSTEM.CLUSTER.NODES, description: 'Cluster Configuration', permissions: ['datanode:read'] },
             { path: Routes.SYSTEM.INPUTS, description: 'Inputs', permissions: ['inputs:read'] },
             { path: Routes.SYSTEM.OUTPUTS, description: 'Outputs', permissions: ['outputs:read'] },
             { path: Routes.SYSTEM.INDICES.LIST, description: 'Indices', permissions: ['indices:read'] },


### PR DESCRIPTION
## Description
Adds the `datanode:read` permission to the reader role and hides unavailable tabs and action items

/nocl regression introduced before release

## Motivation and Context
fixes [#10340 ](https://github.com/Graylog2/graylog-plugin-enterprise/issues/10340)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

