### PR TITLE
Remove no longer needed `hidden: true` option from element queries in tests.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.tsx
@@ -52,7 +52,7 @@ describe('BootstrapModalForm', () => {
 
     render(renderModalForm(true, onSubmit, onCancel));
 
-    (await screen.findByRole('button', { name: 'Submit', hidden: true })).click();
+    (await screen.findByRole('button', { name: 'Submit' })).click();
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalled();
@@ -67,7 +67,7 @@ describe('BootstrapModalForm', () => {
 
     render(renderModalForm(true, onSubmit, onCancel));
 
-    (await screen.findByRole('button', { name: 'Cancel', hidden: true })).click();
+    (await screen.findByRole('button', { name: 'Cancel' })).click();
 
     await waitFor(() => {
       expect(onCancel).toHaveBeenCalled();

--- a/graylog2-web-interface/src/components/common/HelpPopoverButton.tsx
+++ b/graylog2-web-interface/src/components/common/HelpPopoverButton.tsx
@@ -25,7 +25,7 @@ import Popover from 'components/common/Popover';
 import type { BsSize } from 'components/bootstrap/types';
 
 type Props = PropsWithChildren<{
-  helpText: string|React.ReactNode;
+  helpText: string | React.ReactNode;
   bsStyle?: ColorVariant;
   bsSize?: BsSize;
 }>;
@@ -44,7 +44,7 @@ const StyledIcon = styled(Icon)<{ $bsStyle: ColorVariant }>(
   `,
 );
 
-const HelpPopoverButton = ({ helpText, bsStyle = "info", bsSize = "medium" }: Props) => {
+const HelpPopoverButton = ({ helpText, bsStyle = 'info', bsSize = 'medium' }: Props) => {
   const [showHelp, setShowHelp] = useState(false);
   const toggleHelp = () => setShowHelp((cur) => !cur);
 

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.test.tsx
@@ -68,7 +68,7 @@ describe('<URLWhiteListFormModal>', () => {
     expect(await screen.findByText('Whitelist URLs')).toBeInTheDocument();
     expect(screen.getByDisplayValue('http://graylog.com')).toBeInTheDocument();
     expect(screen.getByText(/exact match/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /update configuration/i, hidden: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /update configuration/i })).toBeInTheDocument();
     expect(screen.getByText(/cancel/i)).toBeInTheDocument();
   });
 

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.test.tsx
@@ -58,13 +58,11 @@ describe('ConfigurationForm', () => {
 
     await screen.findByRole('heading', {
       name: /edit entity/i,
-      hidden: true,
     });
 
     userEvent.click(
       await screen.findByRole('button', {
         name: /update entity/i,
-        hidden: true,
       }),
     );
 
@@ -74,7 +72,6 @@ describe('ConfigurationForm', () => {
       expect(
         screen.queryByRole('heading', {
           name: /edit entity/i,
-          hidden: true,
         }),
       ).not.toBeInTheDocument(),
     );

--- a/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.test.tsx
@@ -101,7 +101,6 @@ describe('MessageProcessorsConfig', () => {
 
     await screen.findByRole('heading', {
       name: /update message processors configuration/i,
-      hidden: true,
     });
   });
 });

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.test.tsx
@@ -63,14 +63,12 @@ describe('SidecarConfig', () => {
     fireEvent.click(
       await screen.findByRole('checkbox', {
         name: /override sidecar configuration/i,
-        hidden: true,
       }),
     );
 
     fireEvent.click(
       await screen.findByRole('button', {
         name: /update configuration/i,
-        hidden: true,
       }),
     );
 

--- a/graylog2-web-interface/src/components/configurations/message-processors/ProcessingConfigModalForm.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/message-processors/ProcessingConfigModalForm.test.tsx
@@ -101,12 +101,10 @@ describe('MessageProcessorsConfig', () => {
 
     await screen.findByRole('heading', {
       name: /update message processors configuration/i,
-      hidden: true,
     });
 
     const gracePeriod = screen.getByRole('textbox', {
       name: /grace period/i,
-      hidden: true,
     });
 
     fireEvent.change(gracePeriod, {
@@ -116,7 +114,6 @@ describe('MessageProcessorsConfig', () => {
     fireEvent.click(
       await screen.findByRole('button', {
         name: /update configuration/i,
-        hidden: true,
       }),
     );
 
@@ -137,12 +134,10 @@ describe('MessageProcessorsConfig', () => {
 
     await screen.findByRole('heading', {
       name: /update message processors configuration/i,
-      hidden: true,
     });
 
     const enableTimestampNormalization = screen.getByRole('checkbox', {
       name: /future timestamp normalization/i,
-      hidden: true,
     });
 
     fireEvent.click(enableTimestampNormalization);
@@ -151,7 +146,6 @@ describe('MessageProcessorsConfig', () => {
     fireEvent.click(
       await screen.findByRole('button', {
         name: /update configuration/i,
-        hidden: true,
       }),
     );
 

--- a/graylog2-web-interface/src/components/hotkeys/HotkeysModalContainer.test.tsx
+++ b/graylog2-web-interface/src/components/hotkeys/HotkeysModalContainer.test.tsx
@@ -36,7 +36,6 @@ describe('HotkeysModalContainer', () => {
 
     await screen.findByRole('heading', {
       name: /keyboard shortcuts/i,
-      hidden: true,
     });
   });
 });

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.test.tsx
@@ -78,11 +78,9 @@ describe('CreateProfile', () => {
 
     const name = await screen.findByRole('textbox', {
       name: /name/i,
-      hidden: true,
     });
     const description = await screen.findByRole('textbox', {
       name: /description/i,
-      hidden: true,
     });
     const addMappingButton = await screen.findByRole('button', { name: /add mapping/i });
 

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.test.tsx
@@ -80,7 +80,6 @@ describe('EditProfile', () => {
 
     const name = await screen.findByRole('textbox', {
       name: /name/i,
-      hidden: true,
     });
 
     const fieldFirst = await screen.findByLabelText(/select customFieldMappings.0.field/i);

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetCustomFieldTypeRemoveModal.test.tsx
@@ -83,7 +83,6 @@ describe('IndexSetFieldTypesList', () => {
 
       const submit = await screen.findByRole('button', {
         name: /remove field type overrides/i,
-        hidden: true,
       });
       fireEvent.click(submit);
 
@@ -100,7 +99,6 @@ describe('IndexSetFieldTypesList', () => {
       const checkbox = await screen.findByText(/rotate affected indices after change/i);
       const submit = await screen.findByRole('button', {
         name: /remove field type overrides/i,
-        hidden: true,
       });
       fireEvent.click(checkbox);
       fireEvent.click(submit);

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/IndexSetFieldTypesList.test.tsx
@@ -452,7 +452,7 @@ describe('IndexSetFieldTypesList', () => {
       const button = await screen.findByTitle('Set field type profile');
       fireEvent.click(button);
       const modal = await screen.findByRole('dialog');
-      await within(modal).findByRole('button', { name: /Set Profile/i, hidden: true });
+      await within(modal).findByRole('button', { name: /Set Profile/i });
     });
   });
 });

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.test.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/SetProfileModal.test.tsx
@@ -77,7 +77,7 @@ describe('IndexSetFieldTypesList', () => {
     renderModal();
     const select = await screen.findByLabelText(/Select profile/i);
     await selectItem(select, 'Profile-2');
-    const submit = await screen.findByRole('button', { name: /Set Profile/i, hidden: true });
+    const submit = await screen.findByRole('button', { name: /Set Profile/i });
     fireEvent.click(submit);
 
     expect(setIndexSetFieldTypeProfileMock).toHaveBeenCalledWith({
@@ -91,10 +91,9 @@ describe('IndexSetFieldTypesList', () => {
     renderModal();
     const select = await screen.findByLabelText(/Select profile/i);
     await selectItem(select, 'Profile-2');
-    const submit = await screen.findByRole('button', { name: /Set Profile/i, hidden: true });
+    const submit = await screen.findByRole('button', { name: /Set Profile/i });
     const checkBox = await screen.findByRole('checkbox', {
       name: /rotate affected indices after change/i,
-      hidden: true,
     });
     fireEvent.click(checkBox);
     fireEvent.click(submit);
@@ -108,10 +107,9 @@ describe('IndexSetFieldTypesList', () => {
 
   it('run removeProfileFromIndex on submit without rotation', async () => {
     renderModal();
-    const removeButton = await screen.findByRole('button', { name: /Remove profile/i, hidden: true });
+    const removeButton = await screen.findByRole('button', { name: /Remove profile/i });
     const checkBox = await screen.findByRole('checkbox', {
       name: /rotate affected indices after change/i,
-      hidden: true,
     });
     fireEvent.click(checkBox);
     fireEvent.click(removeButton);
@@ -124,7 +122,7 @@ describe('IndexSetFieldTypesList', () => {
 
   it('run removeProfileFromIndex on submit with rotation', async () => {
     renderModal();
-    const removeButton = await screen.findByRole('button', { name: /Remove profile/i, hidden: true });
+    const removeButton = await screen.findByRole('button', { name: /Remove profile/i });
     fireEvent.click(removeButton);
 
     expect(removeProfileFromIndexMock).toHaveBeenCalledWith({
@@ -135,7 +133,7 @@ describe('IndexSetFieldTypesList', () => {
 
   it('render modal without removal button when profile is not set', async () => {
     renderModal(null);
-    const removeButton = screen.queryByRole('button', { name: /Remove profile/i, hidden: true });
+    const removeButton = screen.queryByRole('button', { name: /Remove profile/i });
 
     expect(removeButton).not.toBeInTheDocument();
   });

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.SetupRouting.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.SetupRouting.test.tsx
@@ -156,29 +156,24 @@ const useIndexSetsListResult = {
 const getStreamCreateFormFields = async () => {
   const titleInput = await screen.findByRole('textbox', {
     name: /Title/i,
-    hidden: true,
   });
 
   const descriptionInput = await screen.findByRole('textbox', {
     name: /Description/i,
-    hidden: true,
   });
 
   const indexSetSelect = await screen.findByLabelText('Select Index Set');
 
   const removeMatchesCheckbox = await screen.findByRole('checkbox', {
     name: /Remove matches from/i,
-    hidden: true,
   });
 
   const newPipelineCheckbox = await screen.findByRole('checkbox', {
     name: /Create a new pipeline for this stream/i,
-    hidden: true,
   });
 
   const submitButton = await screen.findByRole('button', {
     name: 'Next',
-    hidden: true,
   });
 
   return {
@@ -231,7 +226,6 @@ describe('InputSetupWizard Setup Routing', () => {
         renderWizard();
         const selectStreamButton = await screen.findByRole('button', {
           name: /Select Stream/i,
-          hidden: true,
         });
 
         fireEvent.click(selectStreamButton);
@@ -250,7 +244,6 @@ describe('InputSetupWizard Setup Routing', () => {
         renderWizard();
         const selectStreamButton = await screen.findByRole('button', {
           name: /Select Stream/i,
-          hidden: true,
         });
 
         fireEvent.click(selectStreamButton);
@@ -278,7 +271,6 @@ describe('InputSetupWizard Setup Routing', () => {
 
         const selectStreamButton = await screen.findByRole('button', {
           name: /Select Stream/i,
-          hidden: true,
         });
 
         fireEvent.click(selectStreamButton);
@@ -306,7 +298,6 @@ describe('InputSetupWizard Setup Routing', () => {
 
         const selectStreamButton = await screen.findByRole('button', {
           name: /Select Stream/i,
-          hidden: true,
         });
 
         fireEvent.click(selectStreamButton);
@@ -336,7 +327,6 @@ describe('InputSetupWizard Setup Routing', () => {
 
         const selectStreamButton = await screen.findByRole('button', {
           name: /Select Stream/i,
-          hidden: true,
         });
 
         fireEvent.click(selectStreamButton);
@@ -376,12 +366,11 @@ describe('InputSetupWizard Setup Routing', () => {
 
       const createStreamButton = await screen.findByRole('button', {
         name: /Create Stream/i,
-        hidden: true,
       });
 
       fireEvent.click(createStreamButton);
 
-      await screen.findByRole('heading', { name: /Create new stream/i, hidden: true });
+      await screen.findByRole('heading', { name: /Create new stream/i });
 
       const { titleInput, descriptionInput, indexSetSelect, removeMatchesCheckbox, newPipelineCheckbox, submitButton } =
         await getStreamCreateFormFields();
@@ -404,12 +393,11 @@ describe('InputSetupWizard Setup Routing', () => {
 
       const createStreamButton = await screen.findByRole('button', {
         name: /Create Stream/i,
-        hidden: true,
       });
 
       fireEvent.click(createStreamButton);
 
-      await screen.findByRole('heading', { name: /Create new stream/i, hidden: true });
+      await screen.findByRole('heading', { name: /Create new stream/i });
 
       const { titleInput, descriptionInput, indexSetSelect } = await getStreamCreateFormFields();
 
@@ -426,12 +414,11 @@ describe('InputSetupWizard Setup Routing', () => {
 
       const createStreamButton = await screen.findByRole('button', {
         name: /Create Stream/i,
-        hidden: true,
       });
 
       fireEvent.click(createStreamButton);
 
-      await screen.findByRole('heading', { name: /Create new stream/i, hidden: true });
+      await screen.findByRole('heading', { name: /Create new stream/i });
 
       const { titleInput, descriptionInput, indexSetSelect } = await getStreamCreateFormFields();
 

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.StartInput.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/InputSetupWizard.StartInput.test.tsx
@@ -177,13 +177,13 @@ const newPipelineConfig = {
 };
 
 const goToStartInputStep = async () => {
-  const nextButton = await screen.findByRole('button', { name: /Next/i, hidden: true });
+  const nextButton = await screen.findByRole('button', { name: /Next/i });
 
   fireEvent.click(nextButton);
 };
 
 const startInput = async () => {
-  const startInputButton = await screen.findByRole('button', { name: /Start Input/i, hidden: true });
+  const startInputButton = await screen.findByRole('button', { name: /Start Input/i });
 
   fireEvent.click(startInputButton);
 };
@@ -191,36 +191,30 @@ const startInput = async () => {
 const createStream = async (newPipeline = false, removeFromDefault = true) => {
   const createStreamButton = await screen.findByRole('button', {
     name: /Create Stream/i,
-    hidden: true,
   });
 
   fireEvent.click(createStreamButton);
 
-  await screen.findByRole('heading', { name: /Create new stream/i, hidden: true });
+  await screen.findByRole('heading', { name: /Create new stream/i });
 
   const titleInput = await screen.findByRole('textbox', {
     name: /Title/i,
-    hidden: true,
   });
 
   const descriptionInput = await screen.findByRole('textbox', {
     name: /Description/i,
-    hidden: true,
   });
 
   const newPipelineCheckbox = await screen.findByRole('checkbox', {
     name: /Create a new pipeline for this stream/i,
-    hidden: true,
   });
 
   const removeFromDefaultCheckbox = await screen.findByRole('checkbox', {
     name: /remove matches from ‘default stream’/i,
-    hidden: true,
   });
 
   const submitButton = await screen.findByRole('button', {
     name: 'Next',
-    hidden: true,
   });
 
   fireEvent.change(titleInput, { target: { value: 'Wingardium' } });
@@ -262,7 +256,7 @@ describe('InputSetupWizard Start Input', () => {
 
       await waitFor(() => expect(InputStatesStore.start).toHaveBeenCalledWith(input));
 
-      expect(await screen.findByRole('heading', { name: /Setting up Input.../i, hidden: true })).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: /Setting up Input.../i })).toBeInTheDocument();
       expect(await screen.findByText(/Input started successfully!/i)).toBeInTheDocument();
     });
 
@@ -271,7 +265,6 @@ describe('InputSetupWizard Start Input', () => {
 
       const selectStreamButton = await screen.findByRole('button', {
         name: /Select Stream/i,
-        hidden: true,
       });
 
       fireEvent.click(selectStreamButton);
@@ -295,7 +288,7 @@ describe('InputSetupWizard Start Input', () => {
         }),
       );
 
-      expect(await screen.findByRole('heading', { name: /Setting up Input.../i, hidden: true })).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: /Setting up Input.../i })).toBeInTheDocument();
       expect(await screen.findByText(/Routing set up!/i)).toBeInTheDocument();
       expect(await screen.findByText(/Input started successfully!/i)).toBeInTheDocument();
     });
@@ -305,7 +298,6 @@ describe('InputSetupWizard Start Input', () => {
 
       const selectStreamButton = await screen.findByRole('button', {
         name: /Select Stream/i,
-        hidden: true,
       });
 
       fireEvent.click(selectStreamButton);
@@ -318,7 +310,6 @@ describe('InputSetupWizard Start Input', () => {
 
       const removeFromDefaultCheckbox = await screen.findByRole('checkbox', {
         name: /remove matches from ‘default stream’/i,
-        hidden: true,
       });
 
       fireEvent.click(removeFromDefaultCheckbox);
@@ -335,7 +326,7 @@ describe('InputSetupWizard Start Input', () => {
         }),
       );
 
-      expect(await screen.findByRole('heading', { name: /Setting up Input.../i, hidden: true })).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: /Setting up Input.../i })).toBeInTheDocument();
       expect(await screen.findByText(/Routing set up!/i)).toBeInTheDocument();
       expect(await screen.findByText(/Input started successfully!/i)).toBeInTheDocument();
     });
@@ -352,7 +343,7 @@ describe('InputSetupWizard Start Input', () => {
       goToStartInputStep();
       startInput();
 
-      expect(await screen.findByRole('heading', { name: /Setting up Input.../i, hidden: true })).toBeInTheDocument();
+      expect(await screen.findByRole('heading', { name: /Setting up Input.../i })).toBeInTheDocument();
       expect(await screen.findByText(/Stream "Wingardium" created!/i)).toBeInTheDocument();
       expect(await screen.findByText(/Routing set up!/i)).toBeInTheDocument();
       expect(await screen.findByText(/Input started successfully!/i)).toBeInTheDocument();

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.tsx
@@ -77,7 +77,7 @@ describe('EntityShareModal', () => {
     />
   );
 
-  const getModalSubmitButton = () => screen.queryByRole('button', { name: /update sharing/i, hidden: true });
+  const getModalSubmitButton = () => screen.queryByRole('button', { name: /update sharing/i });
 
   it('fetches entity share state initially', async () => {
     render(<SimpleEntityShareModal />);
@@ -90,7 +90,7 @@ describe('EntityShareModal', () => {
   it('updates entity share state on submit', async () => {
     render(<SimpleEntityShareModal />);
 
-    fireEvent.click(await screen.findByRole('button', { name: /update sharing/i, hidden: true }));
+    fireEvent.click(await screen.findByRole('button', { name: /update sharing/i }));
 
     await waitFor(() => expect(EntityShareActions.update).toHaveBeenCalledTimes(1));
 
@@ -105,7 +105,6 @@ describe('EntityShareModal', () => {
 
     const cancelButton = await screen.findByRole('button', {
       name: /cancel/i,
-      hidden: true,
     });
 
     fireEvent.click(cancelButton);
@@ -187,7 +186,6 @@ describe('EntityShareModal', () => {
         // Submit form
         const submitButton = await screen.findByRole('button', {
           name: /add collaborator/i,
-          hidden: true,
         });
 
         fireEvent.click(submitButton);
@@ -225,7 +223,7 @@ describe('EntityShareModal', () => {
 
       await selectEvent.select(granteesSelect, john.title);
 
-      fireEvent.click(await screen.findByRole('button', { name: /update sharing/i, hidden: true }));
+      fireEvent.click(await screen.findByRole('button', { name: /update sharing/i }));
 
       await waitFor(() => {
         expect(window.confirm).toHaveBeenCalledWith(

--- a/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.test.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/RuleBuilder.test.tsx
@@ -125,7 +125,7 @@ describe('RuleBuilder', () => {
     });
   });
 
-  it('should be able to convert Rule Builder to Source Code', () => {
+  it('should be able to convert Rule Builder to Source Code', async () => {
     const title = 'title';
     const description = 'description';
     const rule_builder = { actions: [], conditions: [], operator: 'AND' };
@@ -134,7 +134,7 @@ describe('RuleBuilder', () => {
       rule: { title, description, rule_builder },
     } as any);
 
-    const { getByRole } = render(
+    render(
       <PipelineRulesContext.Provider
         value={{
           simulateRule: () => {},
@@ -145,11 +145,11 @@ describe('RuleBuilder', () => {
       </PipelineRulesContext.Provider>,
     );
 
-    const convertButton = getByRole('button', { name: 'Convert Rule Builder to Source Code', hidden: true });
+    const convertButton = await screen.findByRole('button', { name: 'Convert Rule Builder to Source Code' });
     userEvent.click(convertButton);
 
-    const createRuleFromCodeButton = getByRole('button', { name: 'Create new Rule from Code', hidden: true });
-    const copyCloseButton = getByRole('button', { name: 'Copy & Close', hidden: true });
+    const createRuleFromCodeButton = await screen.findByRole('button', { name: 'Create new Rule from Code' });
+    const copyCloseButton = await screen.findByRole('button', { name: 'Copy & Close' });
 
     expect(createRuleFromCodeButton).toBeInTheDocument();
     expect(copyCloseButton).toBeInTheDocument();

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleModal.test.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleModal.test.tsx
@@ -69,7 +69,6 @@ describe('StreamRuleModal', () => {
 
     await screen.findByRole('textbox', {
       name: /field/i,
-      hidden: true,
     });
   });
 
@@ -78,12 +77,10 @@ describe('StreamRuleModal', () => {
 
     const fieldInput = await screen.findByRole('textbox', {
       name: /field/i,
-      hidden: true,
     });
 
     const valueInput = await screen.findByRole('textbox', {
       name: /value/i,
-      hidden: true,
     });
 
     expect(fieldInput).toHaveValue('field_1');
@@ -97,7 +94,6 @@ describe('StreamRuleModal', () => {
 
     const submitBtn = await screen.findByRole('button', {
       name: /update rule/i,
-      hidden: true,
     });
 
     const ruleTypeSelect = await screen.findByLabelText('Type');

--- a/graylog2-web-interface/src/components/streams/StreamModal.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamModal.test.tsx
@@ -51,12 +51,10 @@ describe('StreamModal', () => {
 
     await screen.findByRole('textbox', {
       name: /title/i,
-      hidden: true,
     });
 
     await screen.findByRole('textbox', {
       name: /description/i,
-      hidden: true,
     });
   });
 
@@ -66,12 +64,10 @@ describe('StreamModal', () => {
 
     const title = await screen.findByRole('textbox', {
       name: /title/i,
-      hidden: true,
     });
 
     const description = await screen.findByRole('textbox', {
       name: /description/i,
-      hidden: true,
     });
 
     const indexSetSelect = await screen.findByLabelText('Index Set');
@@ -94,7 +90,6 @@ describe('StreamModal', () => {
 
     const submitButton = await screen.findByRole('button', {
       name: /submit/i,
-      hidden: true,
     });
 
     await waitFor(() => {

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedRulesActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedRulesActions.test.tsx
@@ -33,7 +33,6 @@ describe('ExpandedRulesActions', () => {
 
     await screen.findByRole('heading', {
       name: /new stream rule/i,
-      hidden: true,
     });
   });
 });

--- a/graylog2-web-interface/src/components/users/CreateTokenForm.tsx
+++ b/graylog2-web-interface/src/components/users/CreateTokenForm.tsx
@@ -95,7 +95,9 @@ const CreateTokenForm = ({
         bsStyle="primary">
         {creatingToken ? <Spinner text="Creating..." /> : 'Create Token'}
       </Button>
-       <HelpBlock>TTL Syntax Examples: for 60 seconds: PT60S, for 60 minutes PT60M, for 24 hours: PT24H, for 30 days: PT30D</HelpBlock>
+      <HelpBlock>
+        TTL Syntax Examples: for 60 seconds: PT60S, for 60 minutes PT60M, for 24 hours: PT24H, for 30 days: PT30D
+      </HelpBlock>
     </StyledForm>
   );
 };

--- a/graylog2-web-interface/src/pages/DataNodeUpgradePage.tsx
+++ b/graylog2-web-interface/src/pages/DataNodeUpgradePage.tsx
@@ -186,25 +186,29 @@ const DataNodeUpgradePage = () => {
             <h3>
               <Label bsStyle={getClusterHealthStyle(data?.cluster_state?.status)} bsSize="xs">
                 {data?.cluster_state?.cluster_name}: {data?.cluster_state?.status}
-              </Label>&nbsp;
-              <HelpPopoverButton helpText={
-                <>
-                  <p>How does my cluster change state during the rolling upgrade?</p>
-                  <p>
-                    RED - if you are using indices with no replication and upgrade the node hosting the shards of these indices,
-                    the cluster will go to a red state and no data will be ingested into or searchable from these indices.
-                  </p>
-                  <p>
-                    YELLOW - after starting the upgrade of a node, shard allocation will be set to no replication to allow
-                    OpenSearch to use only the available shards.
-                  </p>
-                  <p>
-                    After a node has been upgraded and you click on <em>Confirm Upgrade</em>, shard replication will be re-enabled
-                    and all shards that were unavailable due to the node being upgraded will be re-allocated and the cluster will
-                    return to a GREEN state.
-                  </p>
-                </>
-              } />
+              </Label>
+              &nbsp;
+              <HelpPopoverButton
+                helpText={
+                  <>
+                    <p>How does my cluster change state during the rolling upgrade?</p>
+                    <p>
+                      RED - if you are using indices with no replication and upgrade the node hosting the shards of
+                      these indices, the cluster will go to a red state and no data will be ingested into or searchable
+                      from these indices.
+                    </p>
+                    <p>
+                      YELLOW - after starting the upgrade of a node, shard allocation will be set to no replication to
+                      allow OpenSearch to use only the available shards.
+                    </p>
+                    <p>
+                      After a node has been upgraded and you click on <em>Confirm Upgrade</em>, shard replication will
+                      be re-enabled and all shards that were unavailable due to the node being upgraded will be
+                      re-allocated and the cluster will return to a GREEN state.
+                    </p>
+                  </>
+                }
+              />
             </h3>
             <StyledHorizontalDl>
               <dt>Shard Replication:</dt>

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -68,7 +68,7 @@ const DEFAULT_PROPS = {
   dashboardId: 'dashboard-id',
 };
 
-const AdaptableQueryTabs = (props: React.ComponentProps<typeof OriginalAdaptableQueryTabs>) => (
+const AdaptableQueryTabs = ({ ...props }: React.ComponentProps<typeof OriginalAdaptableQueryTabs>) => (
   <TestStoreProvider>
     <OriginalAdaptableQueryTabs {...props} />
   </TestStoreProvider>

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.test.tsx
@@ -292,7 +292,6 @@ describe('AdaptableQueryTabs', () => {
 
     await screen.findByRole('button', {
       name: /copy page/i,
-      hidden: true,
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabsConfiguration.test.tsx
@@ -82,7 +82,6 @@ describe('AdaptableQueryTabsConfiguration', () => {
     renderConfiguration();
     const deleteButton = await screen.findByRole('button', {
       name: /remove page query title 2/i,
-      hidden: true,
     });
 
     // eslint-disable-next-line testing-library/no-unnecessary-act

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.test.tsx
@@ -91,7 +91,6 @@ describe('DashboardActionsMenu', () => {
 
     const saveButton = within(saveDashboardModal).getByRole('button', {
       name: /create dashboard/i,
-      hidden: true,
     });
 
     userEvent.click(saveButton);
@@ -160,13 +159,12 @@ describe('DashboardActionsMenu', () => {
     await findByText(/Editing dashboard/);
   });
 
-  it('should open dashboard share modal', () => {
-    const { getByRole, getByText } = render(<SUT />);
-    const openShareButton = getByText(/Share/i);
-
+  it('should open dashboard share modal', async () => {
+    render(<SUT />);
+    const openShareButton = await screen.findByRole('button', { name: /Share/i });
     userEvent.click(openShareButton);
 
-    expect(getByRole('button', { name: /update sharing/i, hidden: true })).not.toBeNull();
+    await screen.findByRole('button', { name: /update sharing/i });
   });
 
   it('should use FULL_MENU layout option by default and render all buttons', async () => {

--- a/graylog2-web-interface/src/views/components/QueryBar.test.tsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.test.tsx
@@ -118,7 +118,7 @@ describe('QueryBar', () => {
 
     fireEvent.click(dropdown);
 
-    const closeButton = await screen.findByRole('menuitem', { name: /delete/i, hidden: true });
+    const closeButton = await screen.findByRole('menuitem', { name: /delete/i });
 
     fireEvent.click(closeButton);
 

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardPropertiesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardPropertiesModal.test.tsx
@@ -39,11 +39,11 @@ describe('DashboardPropertiesModal', () => {
     );
 
     await screen.findByText('Saving new dashboard');
-    const titleInput = await screen.findByRole('textbox', { name: /title/i, hidden: true });
+    const titleInput = await screen.findByRole('textbox', { name: /title/i });
 
     await userEvent.type(titleInput, 'My title');
 
-    userEvent.click(await screen.findByRole('button', { name: /create dashboard/i, hidden: true }));
+    userEvent.click(await screen.findByRole('button', { name: /create dashboard/i }));
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(

--- a/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/export/ExportModal.test.tsx
@@ -78,10 +78,9 @@ jest.mock('./startDownload');
 describe('ExportModal', () => {
   // Prepare expected payload
 
-  const triggerFormSubmit = () => {
-    const submitButton = screen.getByRole('button', {
+  const triggerFormSubmit = async () => {
+    const submitButton = await screen.findByRole('button', {
       name: /start download/i,
-      hidden: true,
     });
 
     fireEvent.click(submitButton);
@@ -143,7 +142,7 @@ describe('ExportModal', () => {
     };
     render(<SimpleExportModal />);
 
-    triggerFormSubmit();
+    await triggerFormSubmit();
 
     await waitFor(() =>
       expect(exportSearchMessages).toHaveBeenCalledWith(
@@ -161,7 +160,7 @@ describe('ExportModal', () => {
 
     expect(getAllByText('Start Download')).toHaveLength(2);
 
-    triggerFormSubmit();
+    await triggerFormSubmit();
 
     await findByText('Downloading...');
   });
@@ -170,7 +169,7 @@ describe('ExportModal', () => {
     const closeModalStub = jest.fn();
     render(<SimpleExportModal closeModal={closeModalStub} />);
 
-    triggerFormSubmit();
+    await triggerFormSubmit();
 
     await waitFor(() => expect(closeModalStub).toHaveBeenCalledTimes(1));
   });
@@ -187,7 +186,7 @@ describe('ExportModal', () => {
     const view = viewWithoutWidget(View.Type.Search).toBuilder().state(viewStateMap).build();
     render(<SimpleExportModal view={view} />);
 
-    triggerFormSubmit();
+    await triggerFormSubmit();
 
     await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
@@ -226,7 +225,7 @@ describe('ExportModal', () => {
     const view = viewWithoutWidget(View.Type.Search).toBuilder().state(viewStateMap).build();
     render(<SimpleExportModal view={view} />);
 
-    triggerFormSubmit();
+    await triggerFormSubmit();
 
     await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
@@ -261,7 +260,7 @@ describe('ExportModal', () => {
     it('should export all messages with default fields when no widget exists', async () => {
       render(<SearchExportModal />);
 
-      triggerFormSubmit();
+      await triggerFormSubmit();
 
       await waitFor(() => expect(exportSearchMessages).toHaveBeenCalledTimes(1));
 
@@ -290,7 +289,7 @@ describe('ExportModal', () => {
     it('should export messages related to preselected widget', async () => {
       render(<SearchExportModal view={viewWithOneWidget(View.Type.Search)} />);
 
-      triggerFormSubmit();
+      await triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(
@@ -333,7 +332,7 @@ describe('ExportModal', () => {
     it('should export widget messages on direct export', async () => {
       render(<SearchExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
 
-      triggerFormSubmit();
+      await triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(
@@ -424,7 +423,7 @@ describe('ExportModal', () => {
         <DashboardExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />,
       );
 
-      triggerFormSubmit();
+      await triggerFormSubmit();
       await waitFor(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
 
       expect(exportSearchTypeMessages).toHaveBeenCalledWith(

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.tsx
@@ -72,7 +72,7 @@ describe('QueryTitleEditModal', () => {
   it('updates query title and closes', async () => {
     let modalRef;
     const onTitleChangeFn = jest.fn();
-    const { getByRole, queryByText } = render(
+    render(
       <QueryTitleEditModal
         ref={(ref) => {
           modalRef = ref;
@@ -86,7 +86,7 @@ describe('QueryTitleEditModal', () => {
 
     expect(titleInput).toHaveValue('CurrentTitle');
 
-    const saveButton = getByRole('button', { name: /update title/i, hidden: true });
+    const saveButton = await screen.findByRole('button', { name: /update title/i });
 
     fireEvent.change(titleInput, { target: { value: 'NewTitle' } });
     fireEvent.click(saveButton);
@@ -96,7 +96,7 @@ describe('QueryTitleEditModal', () => {
 
     // Modal should not be visible anymore
     await waitFor(() => {
-      expect(queryByText(modalHeadline)).toBeNull();
+      expect(screen.queryByText(modalHeadline)).toBeNull();
     });
   });
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -218,14 +218,12 @@ describe('SavedSearchesModal', () => {
 
       const pageSizeDropdown = await screen.findByRole('button', {
         name: /configure page size/i,
-        hidden: true,
       });
 
       userEvent.click(pageSizeDropdown);
 
       const pageSizeOption = await screen.findByRole('menuitem', {
         name: /100/i,
-        hidden: true,
       });
 
       userEvent.click(pageSizeOption);

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.test.tsx
@@ -54,7 +54,6 @@ describe('TimeRangeFilter', () => {
 
     const button = await screen.findByRole('button', {
       name: /open time range selector/i,
-      hidden: true,
     });
 
     fireEvent.click(button);

--- a/graylog2-web-interface/src/views/components/views/ViewHeader.test.tsx
+++ b/graylog2-web-interface/src/views/components/views/ViewHeader.test.tsx
@@ -68,10 +68,10 @@ describe('ViewHeader', () => {
     fireEvent.click(editButton);
     await screen.findByText('Editing saved dashboard', { exact: false });
 
-    const titleInput = await screen.findByRole('textbox', { name: /title/i, hidden: true });
+    const titleInput = await screen.findByRole('textbox', { name: /title/i });
     await userEvent.type(titleInput, ' updated');
 
-    const saveButton = await screen.findByRole('button', { name: /save dashboard/i, hidden: true });
+    const saveButton = await screen.findByRole('button', { name: /save dashboard/i });
     await userEvent.click(saveButton);
 
     expect(onSaveView).toHaveBeenCalledWith(expect.objectContaining({ title: 'Some view updated' }));

--- a/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.test.tsx
@@ -67,8 +67,8 @@ describe('CopyToDashboardForm', () => {
     />
   );
 
-  const submitModal = () => {
-    const submitButton = screen.getByRole('button', { name: /submit/i, hidden: true });
+  const submitModal = async () => {
+    const submitButton = await screen.findByRole('button', { name: /submit/i });
     fireEvent.click(submitButton);
   };
 
@@ -123,7 +123,7 @@ describe('CopyToDashboardForm', () => {
 
     render(<SUT />);
 
-    const submitButton = await screen.findByRole('button', { name: /submit/i, hidden: true });
+    const submitButton = await screen.findByRole('button', { name: /submit/i });
 
     await waitFor(() => {
       expect(submitButton).toBeDisabled();
@@ -138,9 +138,9 @@ describe('CopyToDashboardForm', () => {
     const firstView = getByText('view 1');
 
     fireEvent.click(firstView);
-    submitModal();
+    await submitModal();
 
-    await screen.findByRole('button', { name: /submit/i, hidden: true });
+    await screen.findByRole('button', { name: /submit/i });
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith('view-1');
@@ -153,9 +153,9 @@ describe('CopyToDashboardForm', () => {
     const checkBox = await findByLabelText(/create a new dashboard/i);
 
     fireEvent.click(checkBox);
-    submitModal();
+    await submitModal();
 
-    await screen.findByRole('button', { name: /submit/i, hidden: true });
+    await screen.findByRole('button', { name: /submit/i });
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith();

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.test.tsx
@@ -256,7 +256,7 @@ describe('<WidgetActionsMenu />', () => {
       const view1ListItem = screen.getByText('view 1');
 
       fireEvent.click(view1ListItem);
-      const selectBtn = screen.getByRole('button', { name: /copy widget/i, hidden: true });
+      const selectBtn = await screen.findByRole('button', { name: /copy widget/i });
 
       fireEvent.click(selectBtn);
     };

--- a/graylog2-web-interface/src/views/logic/valueactions/SelectExtractorType.test.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/SelectExtractorType.test.tsx
@@ -50,7 +50,7 @@ describe('SelectExtractorType', () => {
       </AdditionalContext.Provider>,
     );
 
-    await screen.findByRole('heading', { name: /select extractor type/i, hidden: true });
+    await screen.findByRole('heading', { name: /select extractor type/i });
   });
 
   it('should select a extractor and open a new window', async () => {
@@ -64,7 +64,7 @@ describe('SelectExtractorType', () => {
     await selectEvent.openMenu(extractorType);
     await selectEvent.select(extractorType, 'Grok pattern');
 
-    await userEvent.click(await screen.findByRole('button', { name: /submit/i, hidden: true }));
+    await userEvent.click(await screen.findByRole('button', { name: /submit/i }));
 
     expect(window.open).toHaveBeenCalled();
     expect(focus).toHaveBeenCalled();

--- a/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.test.tsx
+++ b/graylog2-web-interface/src/views/logic/valueactions/createEventDefinition/CreateEventDefinitionModal.test.tsx
@@ -260,7 +260,6 @@ describe('CreateEventDefinitionModal', () => {
 
     const linkButton = await screen.findByRole<HTMLAnchorElement>('link', {
       name: /continue configuration/i,
-      hidden: true,
     });
 
     expect(linkButton.href).toContain('/alerts/definitions/new?step=condition&session-id=cedfv-session-id');


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up for https://github.com/Graylog2/graylog2-server/pull/22261.

In many tests we no longer need to use the `hidden: true` option in element queries for elements inside modals. The modal is no longer wrapped in a div with the attribute `aria-hidden="true"`.

/nocl