### PR TITLE
Remove field that was added by error to group_by for event replay

### DIFF
--- a/changelog/unreleased/pr-22343.toml
+++ b/changelog/unreleased/pr-22343.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed erroneously adding fields to group_by on event replay function."
+
+issues = ["19862"]
+pulls = ["22343"]

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -82,7 +82,7 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
 };
 
-const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>; fnSeries; expr }) => {
+const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>; fnSeries: string; expr: string }) => {
   const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
   const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -83,8 +83,7 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
 };
 
 const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>; fnSeries: string; expr: string }) => {
-  const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
-  const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
+  const rowPivots = groupBy.length ? [pivotForField(groupBy, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
   const sort = [new SortConfig(SortConfig.SERIES_TYPE, fnSeries, direction)];
@@ -93,7 +92,7 @@ const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>;
 };
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries, summaryRowPivots, summaryTitle } = aggregations.reduce(
+  const { summaryFnSeries, summaryTitle } = aggregations.reduce(
     (res, { value, expr, fnSeries }) => {
       const concatTitle = `${fnSeries} ${expr} ${value}`;
       res.summaryFnSeries.push(fnSeries);
@@ -103,13 +102,12 @@ const getSummaryAggregation = ({ aggregations, groupBy }) => {
     },
     {
       summaryFnSeries: [],
-      summaryRowPivots: [],
       summaryTitle: 'Summary: ',
     },
   );
 
   const summaryWidget = getAggregationWidget({
-    rowPivots: [pivotForField(uniq([...summaryRowPivots, ...groupBy]), new FieldType('value', [], []))],
+    rowPivots: [pivotForField(groupBy, new FieldType('value', [], []))],
     fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
   });
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -16,7 +16,6 @@
  */
 import { useMemo } from 'react';
 import * as Immutable from 'immutable';
-import uniq from 'lodash/uniq';
 
 import View from 'views/logic/views/View';
 import type { AbsoluteTimeRange, RelativeTimeRangeStartOnly, TimeRange } from 'views/logic/queries/Query';

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -94,10 +94,9 @@ const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>;
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
   const { summaryFnSeries, summaryRowPivots, summaryTitle } = aggregations.reduce(
-    (res, { field, value, expr, fnSeries }) => {
+    (res, { value, expr, fnSeries }) => {
       const concatTitle = `${fnSeries} ${expr} ${value}`;
       res.summaryFnSeries.push(fnSeries);
-      if (field) res.summaryRowPivots.push(field);
       res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
 
       return res;

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -82,8 +82,8 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
 };
 
-const createViewWidget = ({ groupBy, fnSeries, expr }) => {
-  const uniqPivotFields = uniq(groupBy.filter((v) => !!v)) as Array<string>;
+const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string> }) => {
+  const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
   const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -83,7 +83,7 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
 };
 
 const createViewWidget = ({ groupBy, fnSeries, expr }) => {
-  const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
+  const uniqPivotFields = uniq(groupBy.filter((v) => !!v)) as Array<string>;
   const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -82,8 +82,8 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
 };
 
-const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
-  const uniqPivotFields = uniq([field, ...groupBy].filter((v) => !!v));
+const createViewWidget = ({ groupBy, fnSeries, expr }) => {
+  const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
   const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
@@ -139,8 +139,8 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   const needsSummaryAggregations = aggregations.length > 1;
   const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
   const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce(
-    (res, { field, value, expr, fnSeries }, index) => {
-      const widget = createViewWidget({ fnSeries, field, groupBy, expr });
+    (res, { value, expr, fnSeries }, index) => {
+      const widget = createViewWidget({ fnSeries, groupBy, expr });
       res.aggregationWidgets.push(widget);
       res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
       res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -82,7 +82,7 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
 };
 
-const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string> }) => {
+const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>; fnSeries; expr }) => {
   const uniqPivotFields = uniq(groupBy.filter((v) => !!v));
   const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -257,7 +257,7 @@ const field2Widget = AggregationWidget.builder()
   .config(
     AggregationWidgetConfig.builder()
       .columnPivots([])
-      .rowPivots([Pivot.createValues(['field2', 'field1'])])
+      .rowPivots([Pivot.createValues(['field1', 'field2'])])
       .series([Series.forFunction('count(field2)')])
       .sort([new SortConfig(SortConfig.SERIES_TYPE, 'count(field2)', Direction.Ascending)])
       .visualization('table')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When running the event-replay function, fields were added to the group_by that were not supposed to be added there and resulted in a aggregation widget that did not show the correct results.

fixes #19862 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

