### PR TITLE
Remove field that was added by error to group_by for event replay (`6.1`)

### DIFF
--- a/changelog/unreleased/pr-22343.toml
+++ b/changelog/unreleased/pr-22343.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed erroneously adding fields to group_by on event replay function."
+
+issues = ["19862"]
+pulls = ["22343"]

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -16,7 +16,6 @@
  */
 import { useMemo } from 'react';
 import * as Immutable from 'immutable';
-import uniq from 'lodash/uniq';
 
 import View from 'views/logic/views/View';
 import type { AbsoluteTimeRange, ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
@@ -76,9 +75,8 @@ const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   return new WidgetPosition(col, row, AGGREGATION_WIDGET_HEIGHT, 6);
 };
 
-const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
-  const uniqPivotFields = uniq([field, ...groupBy].filter((v) => !!v));
-  const rowPivots = uniqPivotFields.length ? [pivotForField(uniqPivotFields, new FieldType('value', [], []))] : [];
+const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>; fnSeries: string; expr: string }) => {
+  const rowPivots = groupBy.length ? [pivotForField(groupBy, new FieldType('value', [], []))] : [];
   const fnSeriesForFunc = Series.forFunction(fnSeries);
   const direction = ['>', '>=', '=='].includes(expr) ? Direction.Descending : Direction.Ascending;
   const sort = [new SortConfig(SortConfig.SERIES_TYPE, fnSeries, direction)];
@@ -87,21 +85,21 @@ const createViewWidget = ({ field, groupBy, fnSeries, expr }) => {
 };
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries, summaryRowPivots, summaryTitle } = aggregations.reduce((res, { field, value, expr, fnSeries }) => {
+  const { summaryFnSeries,  summaryTitle } = aggregations.reduce((res, {  value, expr, fnSeries }) => {
     const concatTitle = `${fnSeries} ${expr} ${value}`;
     res.summaryFnSeries.push(fnSeries);
-    if (field) res.summaryRowPivots.push(field);
+
     res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
 
     return res;
   }, {
     summaryFnSeries: [],
-    summaryRowPivots: [],
+
     summaryTitle: 'Summary: ',
   });
 
   const summaryWidget = getAggregationWidget({
-    rowPivots: [pivotForField(uniq([...summaryRowPivots, ...groupBy]), new FieldType('value', [], []))],
+    rowPivots: [pivotForField(groupBy, new FieldType('value', [], []))],
     fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
   });
 
@@ -128,8 +126,8 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   const messageTable = allMessagesTable(undefined, allDecorators);
   const needsSummaryAggregations = aggregations.length > 1;
   const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
-  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { field, value, expr, fnSeries }, index) => {
-    const widget = createViewWidget({ fnSeries, field, groupBy, expr });
+  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { value, expr, fnSeries }, index) => {
+    const widget = createViewWidget({ fnSeries, groupBy, expr });
     res.aggregationWidgets.push(widget);
     res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
     res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -18,11 +18,7 @@ import { useMemo } from 'react';
 import * as Immutable from 'immutable';
 
 import View from 'views/logic/views/View';
-import type {
-  AbsoluteTimeRange,
-  ElasticsearchQueryString,
-  RelativeTimeRangeStartOnly,
-} from 'views/logic/queries/Query';
+import type { AbsoluteTimeRange, ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
 import type { Event } from 'components/events/events/types';
 import type { EventDefinition, SearchFilter } from 'components/event-definitions/event-definitions-types';
 import QueryGenerator from 'views/logic/queries/QueryGenerator';
@@ -52,28 +48,23 @@ import FormattingSettings from 'views/logic/views/formatting/FormattingSettings'
 
 const AGGREGATION_WIDGET_HEIGHT = 3;
 
-export const getAggregationWidget = ({
-  rowPivots,
-  fnSeries,
-  sort = [],
-}: {
-  rowPivots: Array<Pivot>;
-  fnSeries: Array<Series>;
-  sort?: Array<SortConfig>;
-}) =>
-  AggregationWidget.builder()
-    .id(generateId())
-    .config(
-      AggregationWidgetConfig.builder()
-        .columnPivots([])
-        .rowPivots(rowPivots)
-        .series(fnSeries)
-        .sort(sort)
-        .visualization('table')
-        .rollup(true)
-        .build(),
-    )
-    .build();
+export const getAggregationWidget = ({ rowPivots, fnSeries, sort = [] }: {
+  rowPivots: Array<Pivot>,
+  fnSeries: Array<Series>,
+  sort?: Array<SortConfig>
+}) => AggregationWidget.builder()
+  .id(generateId())
+  .config(
+    AggregationWidgetConfig.builder()
+      .columnPivots([])
+      .rowPivots(rowPivots)
+      .series(fnSeries)
+      .sort(sort)
+      .visualization('table')
+      .rollup(true)
+      .build(),
+  )
+  .build();
 
 const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   const isEven = (index + 1) % 2 === 0;
@@ -94,32 +85,29 @@ const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>;
 };
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries, summaryTitle } = aggregations.reduce(
-    (res, { value, expr, fnSeries }) => {
-      const concatTitle = `${fnSeries} ${expr} ${value}`;
-      res.summaryFnSeries.push(fnSeries);
+  const { summaryFnSeries,  summaryTitle } = aggregations.reduce((res, {  value, expr, fnSeries }) => {
+    const concatTitle = `${fnSeries} ${expr} ${value}`;
+    res.summaryFnSeries.push(fnSeries);
 
-      res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
+    res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
 
-      return res;
-    },
-    {
-      summaryFnSeries: [],
+    return res;
+  }, {
+    summaryFnSeries: [],
 
-      summaryTitle: 'Summary: ',
-    },
-  );
+    summaryTitle: 'Summary: ',
+  });
 
   const summaryWidget = getAggregationWidget({
     rowPivots: [pivotForField(groupBy, new FieldType('value', [], []))],
     fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
   });
 
-  return {
+  return ({
     summaryTitle,
     summaryWidget,
     summaryPosition: new WidgetPosition(1, 1, AGGREGATION_WIDGET_HEIGHT, Infinity),
-  };
+  });
 };
 
 export const WidgetsGenerator = async ({ streams, streamCategories, aggregations, groupBy }) => {
@@ -129,29 +117,29 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   const streamDecorators = decorators?.length ? decorators.filter(byStreamId) : [];
   const streamCategoryDecorators = decorators?.length ? decorators.filter(byStreamCategory) : [];
   // eslint-disable-next-line no-nested-ternary
-  const allDecorators =
-    streamDecorators.length && streamCategoryDecorators.length
-      ? [...streamDecorators, ...streamCategoryDecorators]
-      : streamDecorators.length
-        ? streamDecorators
-        : streamCategoryDecorators;
+  const allDecorators = streamDecorators.length && streamCategoryDecorators.length
+    ? [...streamDecorators, ...streamCategoryDecorators]
+    : streamDecorators.length
+      ? streamDecorators
+      : streamCategoryDecorators;
   const histogram = resultHistogram();
   const messageTable = allMessagesTable(undefined, allDecorators);
   const needsSummaryAggregations = aggregations.length > 1;
   const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
-  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce(
-    (res, { value, expr, fnSeries }, index) => {
-      const widget = createViewWidget({ fnSeries, groupBy, expr });
-      res.aggregationWidgets.push(widget);
-      res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
-      res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
+  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { value, expr, fnSeries }, index) => {
+    const widget = createViewWidget({ fnSeries, groupBy, expr });
+    res.aggregationWidgets.push(widget);
+    res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
+    res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
 
-      return res;
-    },
-    { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} },
-  );
+    return res;
+  }, { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} });
 
-  const widgets = [...aggregationWidgets, histogram, messageTable];
+  const widgets = [
+    ...aggregationWidgets,
+    histogram,
+    messageTable,
+  ];
 
   const titles = {
     widget: {
@@ -163,18 +151,8 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
 
   const positions = {
     ...aggregationPositions,
-    [histogram.id]: new WidgetPosition(
-      1,
-      AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA,
-      2,
-      Infinity,
-    ),
-    [messageTable.id]: new WidgetPosition(
-      1,
-      AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA,
-      6,
-      Infinity,
-    ),
+    [histogram.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA, 2, Infinity),
+    [messageTable.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA, 6, Infinity),
   };
 
   if (needsSummaryAggregations) {
@@ -187,22 +165,10 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   return { titles, widgets, positions };
 };
 
-export const ViewStateGenerator = async ({
-  streams,
-  streamCategories,
-  aggregations,
-  groupBy,
-}: {
-  groupBy: Array<string>;
-  streams: string | string[] | undefined;
-  streamCategories: string | string[] | undefined;
-  aggregations: Array<any>;
-}) => {
+export const ViewStateGenerator = async ({ streams, streamCategories, aggregations, groupBy }: {groupBy: Array<string>, streams: string | string[] | undefined, streamCategories: string | string[] | undefined, aggregations: Array<any>}) => {
   const { titles, widgets, positions } = await WidgetsGenerator({ streams, streamCategories, aggregations, groupBy });
 
-  const highlightRules = aggregations?.map(({ fnSeries, value, expr }) =>
-    HighlightingRule.create(fnSeries, value, exprToConditionMapper[expr] || 'equal', randomColor()),
-  );
+  const highlightRules = aggregations?.map(({ fnSeries, value, expr }) => HighlightingRule.create(fnSeries, value, exprToConditionMapper[expr] || 'equal', randomColor()));
 
   return ViewState.create()
     .toBuilder()
@@ -223,20 +189,17 @@ export const ViewGenerator = async ({
   queryParameters,
   searchFilters,
 }: {
-  streams: string | string[] | undefined | null;
-  streamCategories: string | string[] | undefined | null;
-  timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly;
-  queryString: ElasticsearchQueryString;
-  aggregations: Array<EventDefinitionAggregation>;
-  groupBy: Array<string>;
-  queryParameters: Array<ParameterJson>;
-  searchFilters?: Array<SearchFilter>;
+  streams: string | string[] | undefined | null,
+  streamCategories: string | string[] | undefined | null,
+  timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly,
+  queryString: ElasticsearchQueryString,
+  aggregations: Array<EventDefinitionAggregation>
+  groupBy: Array<string>,
+  queryParameters: Array<ParameterJson>,
+  searchFilters?: Array<SearchFilter>,
 }) => {
-  const query = QueryGenerator(streams, streamCategories, undefined, timeRange, queryString, searchFilters || []);
-  const search = Search.create()
-    .toBuilder()
-    .queries([query])
-    .parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
+  const query = QueryGenerator(streams, streamCategories, undefined, timeRange, queryString, (searchFilters || []));
+  const search = Search.create().toBuilder().queries([query]).parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
     .build();
   const viewState = await ViewStateGenerator({ streams, streamCategories, aggregations, groupBy });
 
@@ -251,19 +214,10 @@ export const ViewGenerator = async ({
   return UpdateSearchForWidgets(view);
 };
 
-export const UseCreateViewForEvent = ({
-  eventData,
-  eventDefinition,
-  aggregations,
-}: {
-  eventData: Event;
-  eventDefinition: EventDefinition;
-  aggregations: Array<EventDefinitionAggregation>;
-}) => {
-  const queryStringFromGrouping = concatQueryStrings(
-    Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`),
-    { withBrackets: false },
-  );
+export const UseCreateViewForEvent = (
+  { eventData, eventDefinition, aggregations }: { eventData: Event, eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
+) => {
+  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`), { withBrackets: false });
   const eventQueryString = eventData?.replay_info?.query || '';
   const { streams, stream_categories: streamCategories } = eventData.replay_info;
   const timeRange: AbsoluteTimeRange = {
@@ -283,17 +237,7 @@ export const UseCreateViewForEvent = ({
   const searchFilters = eventDefinition.config?.filters;
 
   return useMemo(
-    () =>
-      ViewGenerator({
-        streams,
-        streamCategories,
-        timeRange,
-        queryString,
-        aggregations,
-        groupBy,
-        queryParameters,
-        searchFilters,
-      }),
+    () => ViewGenerator({ streams, streamCategories, timeRange, queryString, aggregations, groupBy, queryParameters, searchFilters }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -85,7 +85,7 @@ const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>;
 };
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries,  summaryTitle } = aggregations.reduce((res, {  value, expr, fnSeries }) => {
+  const { summaryFnSeries, summaryTitle } = aggregations.reduce((res, { value, expr, fnSeries }) => {
     const concatTitle = `${fnSeries} ${expr} ${value}`;
     res.summaryFnSeries.push(fnSeries);
 

--- a/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
+++ b/graylog2-web-interface/src/views/logic/views/UseCreateViewForEvent.ts
@@ -18,7 +18,11 @@ import { useMemo } from 'react';
 import * as Immutable from 'immutable';
 
 import View from 'views/logic/views/View';
-import type { AbsoluteTimeRange, ElasticsearchQueryString, RelativeTimeRangeStartOnly } from 'views/logic/queries/Query';
+import type {
+  AbsoluteTimeRange,
+  ElasticsearchQueryString,
+  RelativeTimeRangeStartOnly,
+} from 'views/logic/queries/Query';
 import type { Event } from 'components/events/events/types';
 import type { EventDefinition, SearchFilter } from 'components/event-definitions/event-definitions-types';
 import QueryGenerator from 'views/logic/queries/QueryGenerator';
@@ -48,23 +52,28 @@ import FormattingSettings from 'views/logic/views/formatting/FormattingSettings'
 
 const AGGREGATION_WIDGET_HEIGHT = 3;
 
-export const getAggregationWidget = ({ rowPivots, fnSeries, sort = [] }: {
-  rowPivots: Array<Pivot>,
-  fnSeries: Array<Series>,
-  sort?: Array<SortConfig>
-}) => AggregationWidget.builder()
-  .id(generateId())
-  .config(
-    AggregationWidgetConfig.builder()
-      .columnPivots([])
-      .rowPivots(rowPivots)
-      .series(fnSeries)
-      .sort(sort)
-      .visualization('table')
-      .rollup(true)
-      .build(),
-  )
-  .build();
+export const getAggregationWidget = ({
+  rowPivots,
+  fnSeries,
+  sort = [],
+}: {
+  rowPivots: Array<Pivot>;
+  fnSeries: Array<Series>;
+  sort?: Array<SortConfig>;
+}) =>
+  AggregationWidget.builder()
+    .id(generateId())
+    .config(
+      AggregationWidgetConfig.builder()
+        .columnPivots([])
+        .rowPivots(rowPivots)
+        .series(fnSeries)
+        .sort(sort)
+        .visualization('table')
+        .rollup(true)
+        .build(),
+    )
+    .build();
 
 const createViewPosition = ({ index, SUMMARY_ROW_DELTA }) => {
   const isEven = (index + 1) % 2 === 0;
@@ -85,29 +94,32 @@ const createViewWidget = ({ groupBy, fnSeries, expr }: { groupBy: Array<string>;
 };
 
 const getSummaryAggregation = ({ aggregations, groupBy }) => {
-  const { summaryFnSeries,  summaryTitle } = aggregations.reduce((res, {  value, expr, fnSeries }) => {
-    const concatTitle = `${fnSeries} ${expr} ${value}`;
-    res.summaryFnSeries.push(fnSeries);
+  const { summaryFnSeries, summaryTitle } = aggregations.reduce(
+    (res, { value, expr, fnSeries }) => {
+      const concatTitle = `${fnSeries} ${expr} ${value}`;
+      res.summaryFnSeries.push(fnSeries);
 
-    res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
+      res.summaryTitle = `${res.summaryTitle} ${concatTitle}`;
 
-    return res;
-  }, {
-    summaryFnSeries: [],
+      return res;
+    },
+    {
+      summaryFnSeries: [],
 
-    summaryTitle: 'Summary: ',
-  });
+      summaryTitle: 'Summary: ',
+    },
+  );
 
   const summaryWidget = getAggregationWidget({
     rowPivots: [pivotForField(groupBy, new FieldType('value', [], []))],
     fnSeries: summaryFnSeries.map((s) => Series.forFunction(s)),
   });
 
-  return ({
+  return {
     summaryTitle,
     summaryWidget,
     summaryPosition: new WidgetPosition(1, 1, AGGREGATION_WIDGET_HEIGHT, Infinity),
-  });
+  };
 };
 
 export const WidgetsGenerator = async ({ streams, streamCategories, aggregations, groupBy }) => {
@@ -117,29 +129,29 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   const streamDecorators = decorators?.length ? decorators.filter(byStreamId) : [];
   const streamCategoryDecorators = decorators?.length ? decorators.filter(byStreamCategory) : [];
   // eslint-disable-next-line no-nested-ternary
-  const allDecorators = streamDecorators.length && streamCategoryDecorators.length
-    ? [...streamDecorators, ...streamCategoryDecorators]
-    : streamDecorators.length
-      ? streamDecorators
-      : streamCategoryDecorators;
+  const allDecorators =
+    streamDecorators.length && streamCategoryDecorators.length
+      ? [...streamDecorators, ...streamCategoryDecorators]
+      : streamDecorators.length
+        ? streamDecorators
+        : streamCategoryDecorators;
   const histogram = resultHistogram();
   const messageTable = allMessagesTable(undefined, allDecorators);
   const needsSummaryAggregations = aggregations.length > 1;
   const SUMMARY_ROW_DELTA = needsSummaryAggregations ? AGGREGATION_WIDGET_HEIGHT : 0;
-  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce((res, { value, expr, fnSeries }, index) => {
-    const widget = createViewWidget({ fnSeries, groupBy, expr });
-    res.aggregationWidgets.push(widget);
-    res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
-    res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
+  const { aggregationWidgets, aggregationTitles, aggregationPositions } = aggregations.reduce(
+    (res, { value, expr, fnSeries }, index) => {
+      const widget = createViewWidget({ fnSeries, groupBy, expr });
+      res.aggregationWidgets.push(widget);
+      res.aggregationTitles[widget.id] = `${fnSeries} ${expr} ${value}`;
+      res.aggregationPositions[widget.id] = createViewPosition({ index, SUMMARY_ROW_DELTA });
 
-    return res;
-  }, { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} });
+      return res;
+    },
+    { aggregationTitles: {}, aggregationWidgets: [], aggregationPositions: {} },
+  );
 
-  const widgets = [
-    ...aggregationWidgets,
-    histogram,
-    messageTable,
-  ];
+  const widgets = [...aggregationWidgets, histogram, messageTable];
 
   const titles = {
     widget: {
@@ -151,8 +163,18 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
 
   const positions = {
     ...aggregationPositions,
-    [histogram.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA, 2, Infinity),
-    [messageTable.id]: new WidgetPosition(1, AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA, 6, Infinity),
+    [histogram.id]: new WidgetPosition(
+      1,
+      AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 1 + SUMMARY_ROW_DELTA,
+      2,
+      Infinity,
+    ),
+    [messageTable.id]: new WidgetPosition(
+      1,
+      AGGREGATION_WIDGET_HEIGHT * aggregationWidgets.length + 3 + SUMMARY_ROW_DELTA,
+      6,
+      Infinity,
+    ),
   };
 
   if (needsSummaryAggregations) {
@@ -165,10 +187,22 @@ export const WidgetsGenerator = async ({ streams, streamCategories, aggregations
   return { titles, widgets, positions };
 };
 
-export const ViewStateGenerator = async ({ streams, streamCategories, aggregations, groupBy }: {groupBy: Array<string>, streams: string | string[] | undefined, streamCategories: string | string[] | undefined, aggregations: Array<any>}) => {
+export const ViewStateGenerator = async ({
+  streams,
+  streamCategories,
+  aggregations,
+  groupBy,
+}: {
+  groupBy: Array<string>;
+  streams: string | string[] | undefined;
+  streamCategories: string | string[] | undefined;
+  aggregations: Array<any>;
+}) => {
   const { titles, widgets, positions } = await WidgetsGenerator({ streams, streamCategories, aggregations, groupBy });
 
-  const highlightRules = aggregations?.map(({ fnSeries, value, expr }) => HighlightingRule.create(fnSeries, value, exprToConditionMapper[expr] || 'equal', randomColor()));
+  const highlightRules = aggregations?.map(({ fnSeries, value, expr }) =>
+    HighlightingRule.create(fnSeries, value, exprToConditionMapper[expr] || 'equal', randomColor()),
+  );
 
   return ViewState.create()
     .toBuilder()
@@ -189,17 +223,20 @@ export const ViewGenerator = async ({
   queryParameters,
   searchFilters,
 }: {
-  streams: string | string[] | undefined | null,
-  streamCategories: string | string[] | undefined | null,
-  timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly,
-  queryString: ElasticsearchQueryString,
-  aggregations: Array<EventDefinitionAggregation>
-  groupBy: Array<string>,
-  queryParameters: Array<ParameterJson>,
-  searchFilters?: Array<SearchFilter>,
+  streams: string | string[] | undefined | null;
+  streamCategories: string | string[] | undefined | null;
+  timeRange: AbsoluteTimeRange | RelativeTimeRangeStartOnly;
+  queryString: ElasticsearchQueryString;
+  aggregations: Array<EventDefinitionAggregation>;
+  groupBy: Array<string>;
+  queryParameters: Array<ParameterJson>;
+  searchFilters?: Array<SearchFilter>;
 }) => {
-  const query = QueryGenerator(streams, streamCategories, undefined, timeRange, queryString, (searchFilters || []));
-  const search = Search.create().toBuilder().queries([query]).parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
+  const query = QueryGenerator(streams, streamCategories, undefined, timeRange, queryString, searchFilters || []);
+  const search = Search.create()
+    .toBuilder()
+    .queries([query])
+    .parameters(queryParameters.map((param) => Parameter.fromJSON(param)))
     .build();
   const viewState = await ViewStateGenerator({ streams, streamCategories, aggregations, groupBy });
 
@@ -214,10 +251,19 @@ export const ViewGenerator = async ({
   return UpdateSearchForWidgets(view);
 };
 
-export const UseCreateViewForEvent = (
-  { eventData, eventDefinition, aggregations }: { eventData: Event, eventDefinition: EventDefinition, aggregations: Array<EventDefinitionAggregation> },
-) => {
-  const queryStringFromGrouping = concatQueryStrings(Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`), { withBrackets: false });
+export const UseCreateViewForEvent = ({
+  eventData,
+  eventDefinition,
+  aggregations,
+}: {
+  eventData: Event;
+  eventDefinition: EventDefinition;
+  aggregations: Array<EventDefinitionAggregation>;
+}) => {
+  const queryStringFromGrouping = concatQueryStrings(
+    Object.entries(eventData.group_by_fields).map(([field, value]) => `${field}:${escape(value)}`),
+    { withBrackets: false },
+  );
   const eventQueryString = eventData?.replay_info?.query || '';
   const { streams, stream_categories: streamCategories } = eventData.replay_info;
   const timeRange: AbsoluteTimeRange = {
@@ -237,7 +283,17 @@ export const UseCreateViewForEvent = (
   const searchFilters = eventDefinition.config?.filters;
 
   return useMemo(
-    () => ViewGenerator({ streams, streamCategories, timeRange, queryString, aggregations, groupBy, queryParameters, searchFilters }),
+    () =>
+      ViewGenerator({
+        streams,
+        streamCategories,
+        timeRange,
+        queryString,
+        aggregations,
+        groupBy,
+        queryParameters,
+        searchFilters,
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
+++ b/graylog2-web-interface/test/helpers/mocking/EventAndEventDefinitions_mock.ts
@@ -271,7 +271,7 @@ const field2Widget = AggregationWidget.builder()
   .config(
     AggregationWidgetConfig.builder()
       .columnPivots([])
-      .rowPivots([Pivot.createValues(['field2', 'field1'])])
+      .rowPivots([Pivot.createValues(['field1', 'field2'])])
       .series([Series.forFunction('count(field2)')])
       .sort([new SortConfig(SortConfig.SERIES_TYPE, 'count(field2)', Direction.Ascending)])
       .visualization('table')


### PR DESCRIPTION
Note: This is a backport of #22343 to `6.1`.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When running the event-replay function, fields were added to the group_by that were not supposed to be added there and resulted in a aggregation widget that did not show the correct results.

fixes #19862 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

