### PR TITLE
Display error in message list widget when page exceeds search cluster result limit. `6.0`

### DIFF
--- a/changelog/unreleased/issue-18947.toml
+++ b/changelog/unreleased/issue-18947.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Display error in message list widget when page exceeds search cluster result limit."
+
+issues = ["18947", "20644"]
+pulls = ["22311"]

--- a/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
+++ b/graylog2-web-interface/src/views/components/widgets/reexecuteSearchTypes.ts
@@ -48,12 +48,15 @@ const reexecuteSearchTypes = (
 
   const executionState = new SearchExecutionState(parameterBindings, newGlobalOverride);
 
-  const handleSearchResult = (searchExecutionResult: SearchExecutionResult): SearchExecutionResult => {
-    const { result: searchResult, widgetMapping } = searchExecutionResult;
-    const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);
-    const { result } = selectSearchExecutionResult(getState());
+  const handleSearchResult = ({ result: newPartialSearchResult }: SearchExecutionResult): SearchExecutionResult => {
+    const { result: existingSearchResult, widgetMapping } = selectSearchExecutionResult(getState());
 
-    return { result: result.updateSearchTypes(updatedSearchTypes), widgetMapping };
+    const updatedSearchTypes = newPartialSearchResult.getSearchTypesFromResponse(searchTypeIds);
+    const updatedSearchResult = existingSearchResult
+      .withErrors(newPartialSearchResult.result.errors)
+      .updateSearchTypes(updatedSearchTypes);
+
+    return { result: updatedSearchResult, widgetMapping };
   };
 
   return dispatch(executeWithExecutionState(view, [], executionState, { ...searchExecutors, resultMapper: handleSearchResult }));

--- a/graylog2-web-interface/src/views/logic/SearchResult.ts
+++ b/graylog2-web-interface/src/views/logic/SearchResult.ts
@@ -85,7 +85,11 @@ class SearchResult {
     return this._results.get(queryId);
   }
 
-  updateSearchTypes(searchTypeResults) {
+  withErrors(errors: Array<SearchErrorResponse> | undefined) {
+    return new SearchResult({ ...this.result, errors });
+  }
+
+  updateSearchTypes(searchTypeResults: SearchJobResult['results']) {
     const updatedResult = this.result;
 
     searchTypeResults.forEach((searchTypeResult: { id: string; }) => {


### PR DESCRIPTION
**Please note:** This PR is a backport of https://github.com/Graylog2/graylog2-server/pull/22311 for `6.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/18947 and https://github.com/Graylog2/graylog2-server/issues/20644 an error is currently not being shown in the message list widget, when it exceeds the search cluster result window. This happens when opening.a page with a number greater than 66. Instead the last valid page of messages is being displayed.

This PR is fixing the behaviour by displaying the error again.

<img width="742" alt="image" src="https://github.com/user-attachments/assets/70df570d-fc1f-41f5-863f-f47683dd0360" />


Fixes https://github.com/Graylog2/graylog2-server/issues/18947
Fixes https://github.com/Graylog2/graylog2-server/issues/20644
