### PR TITLE
Increase z-index of select menu, to fix styling in popovers.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -135,7 +135,7 @@ const menu = (base) => ({
 
 const menuPortal = (base) => ({
   ...base,
-  zIndex: 1052,
+  zIndex: 1061,
 });
 
 const singleValueAndPlaceholder =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With https://github.com/Graylog2/graylog-plugin-enterprise/pull/10452 we started displaying the select menu in a portal. This resulted in styling issues in popovers. This PR increases the menu z-index, to fix the issues.

/nocl
