### PR TITLE
Adjust z-index of PreviewModal

### DIFF
--- a/changelog/unreleased/issue-enterprise-10428.toml
+++ b/changelog/unreleased/issue-enterprise-10428.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fixed Markdown preview displaying underneath Security Events Drawer."
+
+issues=["Graylog2/graylog-plugin-enterprise#10428"]
+pulls=["22444"]

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/PreviewModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/PreviewModal.tsx
@@ -29,7 +29,7 @@ const Backdrop = styled.div`
   flex-direction: column;
   align-items: center;
   inset: 0;
-  z-index: 1051;
+  z-index: 2041;
 
   background-color: rgb(0 0 0 / 50%);
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10428

Increase the z-index of the PreviewModal to display on top of the Security Events Drawer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

