### PR TITLE
Revert AWS SDK to 2.29.52

### DIFF
--- a/changelog/unreleased/pr-22450.toml
+++ b/changelog/unreleased/pr-22450.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Revert AWS SDK to version 2.29.52 to fix compatibility with S3-compatible services."
+
+issues = ["graylog-plugin-enterprise#10504"]
+pulls = ["22450"]

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <auto-value.version>1.11.0</auto-value.version>
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
         <aws-java-sdk-1.version>1.12.675</aws-java-sdk-1.version>
-        <aws-java-sdk-2.version>2.31.2</aws-java-sdk-2.version>
+        <aws-java-sdk-2.version>2.29.52</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.6.1</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.3.2</aws-msk-iam-auth.version>
         <!-- When bumping bouncycastle.version, check if the explicit management for bcutil-jdk18on can/must be removed. -->


### PR DESCRIPTION
Newer SDKs break compatibility with third-party S3-compatible services.

See: https://github.com/apache/iceberg/pull/12264

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10504