### PR TITLE
Restrict AWS SDK updates to version 2.29.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         # - https://github.com/Graylog2/graylog-plugin-enterprise/issues/10504
         #update-types: ["version-update:semver-patch"]
         versions:
-          - "> 2.29"
+          - ">= 2.30"
       - dependency-name: "com.amazonaws:aws-java-sdk-bom"
         update-types: ["version-update:semver-patch"]
       # Lucene >=10 requires JDK 21

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,15 @@ updates:
       # The AWS SDKs receive patch updates almost every day. Reduce dependabot
       # pull-request noise by ignoring patch updates.
       - dependency-name: "software.amazon.awssdk:bom"
-        update-types: ["version-update:semver-patch"]
+        # We don't want to pull newer versions than 2.29 until the compatibility
+        # with S3-compatible services is restored or a different solution
+        # is found.
+        # See:
+        # - https://github.com/apache/iceberg/pull/12264
+        # - https://github.com/Graylog2/graylog-plugin-enterprise/issues/10504
+        #update-types: ["version-update:semver-patch"]
+        versions:
+          - "> 2.29"
       - dependency-name: "com.amazonaws:aws-java-sdk-bom"
         update-types: ["version-update:semver-patch"]
       # Lucene >=10 requires JDK 21


### PR DESCRIPTION
Newer versions break compatibility with S3-compatible services.

See:
- https://github.com/apache/iceberg/pull/12264
- https://github.com/Graylog2/graylog-plugin-enterprise/issues/10504

/nocl