### PR TITLE
Improve focus styling for buttons in navigation.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/NavDropdown.tsx
@@ -39,7 +39,7 @@ const DropdownTrigger = styled.button<{ $active: boolean }>(
     gap: ${theme.spacings.xs};
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       ${hoverIndicatorStyles(theme)}
       color: ${theme.colors.variant.darker.default};
       background-color: transparent;

--- a/graylog2-web-interface/src/components/common/PageNavigation.tsx
+++ b/graylog2-web-interface/src/components/common/PageNavigation.tsx
@@ -52,7 +52,7 @@ const StyledButton = styled(Button)(
     ${activeIndicatorStyles(theme)}
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       ${activeIndicatorStyles(theme)}
     }
 `,

--- a/graylog2-web-interface/src/components/navigation/Navigation.styles.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.styles.tsx
@@ -41,7 +41,7 @@ const StyledNavbar = styled(Navbar)(
           font-size: ${theme.fonts.size.navigation};
 
           &:hover,
-          &:focus {
+          &:focus-visible {
             ${hoverIndicatorStyles(theme)}
           }
         }
@@ -50,7 +50,7 @@ const StyledNavbar = styled(Navbar)(
           > * {
             ${activeIndicatorStyles(theme)}
             &:hover,
-          &:focus {
+            &:focus-visible {
               ${activeIndicatorStyles(theme)}
             }
           }

--- a/graylog2-web-interface/src/components/navigation/ScratchpadToggle.tsx
+++ b/graylog2-web-interface/src/components/navigation/ScratchpadToggle.tsx
@@ -33,7 +33,7 @@ const Toggle = styled(Button)(
     color: ${theme.colors.global.textDefault};
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       ${hoverIndicatorStyles(theme)}
       background: transparent;
       color: ${theme.colors.variant.darker.default};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change it was possible that nav dropdown buttons in the navigation had the following styling after clicking them twice. The styling can be irritating, since the button is not actively focused.

![image](https://github.com/user-attachments/assets/3475016c-0e45-48b3-9397-b1f7b1e52d63)



With this PR we are implementing the `:focus-visible` selector, which makes sure we only display the focus styling when an element also has the browser focus styling:

![image](https://github.com/user-attachments/assets/a3bb349c-5f93-4f39-b27d-a144b178f1ce)


/nocl