### PR TITLE
Improve menu label text color and size. `6.0`

### DIFF
--- a/changelog/unreleased/issue-22465.toml
+++ b/changelog/unreleased/issue-22465.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve text color and size of labels in dropdown menus."
+
+pulls = ["22480"]
+issues = ["22465"]

--- a/graylog2-web-interface/src/components/bootstrap/Menu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Menu.tsx
@@ -82,7 +82,8 @@ const StyledMenuDivider = styled(MantineMenu.Divider)(({ theme }) => css`
 `);
 
 const StyledMenuLabel = styled(MantineMenu.Label)(({ theme }) => css`
-  font-size: ${theme.fonts.size.navigation};
+  font-size: ${theme.fonts.size.small};
+  color: ${theme.colors.global.textSecondary};
 `);
 
 Menu.Target = MantineMenu.Target;


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/21542 for `6.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Small fix to improve the text color and size of menu labels to differentiate them from the other menu items.

Before:
<img width="137" alt="image" src="https://github.com/user-attachments/assets/28a073e6-2862-4e80-acff-537656e39348" />

<img width="148" alt="image" src="https://github.com/user-attachments/assets/ed1c75b6-1d0b-429f-9fc9-71bdd26a0ef4" />



After:
<img width="134" alt="image" src="https://github.com/user-attachments/assets/534bb454-42f9-469f-986f-9ee3fdb08877" />

<img width="134" alt="image" src="https://github.com/user-attachments/assets/c1168515-b118-4b48-9778-2f8e0e205788" />


/nocl
Fixes https://github.com/Graylog2/graylog2-server/issues/22465
