### PR TITLE
Remove no longer used `new_report_creation` feature flag from feature flag config.

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -82,9 +82,6 @@ investigation_report_by_ai=on
 # Configurable value units flag
 configurable_value_units=on
 
-# New Report Creation UI
-new_report_creation=on
-
 # Enable remote-reindex migration to the datanode
 remote_reindex_migration=off
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR removes the no longer used `new_report_creation` feature flag from the feature flag config.

Related to https://github.com/Graylog2/graylog-plugin-enterprise/pull/10568

/nocl