### PR TITLE
Replace daemon thread in InMemoryRolePermissionResolver with RoleChangedEvent

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/RoleChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleChangedEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import org.graylog2.shared.users.Role;
+
+/**
+ * Fired every time a role is persisted or deleted.
+ *
+ * @param roleName name from {@link Role#getName()}
+ */
+public record RoleChangedEvent(String roleName) {
+}

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -33,6 +33,7 @@ import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
@@ -82,7 +83,7 @@ class RolesToGrantsMigrationTest {
         this.grnRegistry = grnRegistry;
 
         roleService = new RoleServiceImpl(
-                new MongoCollections(mongoJackObjectMapperProvider, mongodb.mongoConnection()), permissions, validator);
+                new MongoCollections(mongoJackObjectMapperProvider, mongodb.mongoConnection()), permissions, validator, new ClusterEventBus());
 
         this.dbGrantService = new DBGrantService(new MongoCollections(mongoJackObjectMapperProvider, mongodb.mongoConnection()));
         this.userService = userService;

--- a/graylog2-server/src/test/java/org/graylog2/security/InMemoryRolePermissionResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/InMemoryRolePermissionResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.security;
+
+import com.google.common.eventbus.EventBus;
+import jakarta.annotation.Nonnull;
+import jakarta.validation.Validator;
+import org.apache.shiro.authz.permission.AllPermission;
+import org.apache.shiro.authz.permission.RolePermissionResolver;
+import org.assertj.core.api.Assertions;
+import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.shared.security.Permissions;
+import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.Role;
+import org.graylog2.users.RoleImpl;
+import org.graylog2.users.RoleService;
+import org.graylog2.users.RoleServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Set;
+
+@ExtendWith(MongoDBExtension.class)
+class InMemoryRolePermissionResolverTest {
+    @Test
+    void testRoleChangedEventHandling(MongoCollections mongoCollections) throws NotFoundException, ValidationException {
+        final EventBus eventBus = new EventBus();
+        final ClusterEventBus clusterEventBus = new ClusterEventBus() {
+            @Override
+            public void post(@Nonnull Object event) {
+                eventBus.post(event);
+            }
+        };
+        final RoleService service = new RoleServiceImpl(mongoCollections, new Permissions(Collections.emptySet()), Mockito.mock(Validator.class), clusterEventBus);
+        final RolePermissionResolver resolver = new InMemoryRolePermissionResolver(service, eventBus);
+
+        // test that the built-in roles are present right after resolver init
+        Assertions.assertThat(resolver.resolvePermissionsInRole(service.getAdminRoleObjectId()))
+                .anySatisfy(permission -> permission.implies(new AllPermission()));
+
+        // now let the service create a role. This information should be immediately propagated to the resolver
+        final Role createdRole = service.save(createRole("inputs_manager", "manages inputs", Set.of(RestPermissions.INPUTS_READ, RestPermissions.INPUTS_CREATE)));
+
+        // without explicitly updating the resolver (relying on the event bus), let's check that the role and its permissions
+        // are available.
+        Assertions.assertThat(resolver.resolvePermissionsInRole(createdRole.getId()))
+                .hasSize(2)
+                .anySatisfy(permission -> permission.implies(new CaseSensitiveWildcardPermission(RestPermissions.INPUTS_READ)))
+                .anySatisfy(permission -> permission.implies(new CaseSensitiveWildcardPermission(RestPermissions.INPUTS_CREATE)));
+
+        // now let's delete a role and check that the resolver got rid of it as well
+        service.delete("inputs_manager");
+        Assertions.assertThat(resolver.resolvePermissionsInRole(createdRole.getId()))
+                .isEmpty();
+    }
+
+
+    @Nonnull
+    private static RoleImpl createRole(String name, String description, Set<String> permissions) {
+        final RoleImpl role = new RoleImpl();
+        role.setName(name);
+        role.setDescription(description);
+        role.setPermissions(permissions);
+        role.setReadOnly(false);
+        return role;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/RoleServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/RoleServiceImplTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import jakarta.annotation.Nonnull;
+import jakarta.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.shared.security.Permissions;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+@ExtendWith(MongoDBExtension.class)
+class RoleServiceImplTest {
+
+    @Test
+    void testChangeEvents(MongoCollections mongoCollections) throws ValidationException {
+        final EventsCollector eventsCollector = new EventsCollector();
+        final EventBus eventBus = new EventBus();
+
+        final ClusterEventBus clusterEventBus = new ClusterEventBus() {
+            @Override
+            public void post(@Nonnull Object event) {
+                eventBus.post(event);
+            }
+        };
+
+        eventBus.register(eventsCollector);
+        final RoleService service = new RoleServiceImpl(mongoCollections, new Permissions(Collections.emptySet()), Mockito.mock(Validator.class), clusterEventBus);
+        service.save(createRole("inputs_manager", "manages inputs", Set.of(RestPermissions.INPUTS_READ, RestPermissions.INPUTS_CREATE), false));
+        service.save(createRole("inputs_reader", "reads inputs", Set.of(RestPermissions.INPUTS_READ), false));
+
+        Assertions.assertThat(eventsCollector.getEvents())
+                .hasSize(4) // two built-in roles, Admin and Reader + whatever we add here
+                .map(RoleChangedEvent::roleName)
+                .contains("Admin", "Reader", "inputs_manager", "inputs_reader");
+    }
+
+    @Nonnull
+    private static RoleImpl createRole(String name, String description, Set<String> permissions, boolean readOnly) {
+        final RoleImpl role = new RoleImpl();
+        role.setName(name);
+        role.setDescription(description);
+        role.setPermissions(permissions);
+        role.setReadOnly(readOnly);
+        return role;
+    }
+
+    private class EventsCollector {
+        private final List<RoleChangedEvent> events = new LinkedList<>();
+
+        @Subscribe
+        public void subscribe(RoleChangedEvent event) {
+            this.events.add(event);
+        }
+
+        public List<RoleChangedEvent> getEvents() {
+            return events;
+        }
+    }
+}


### PR DESCRIPTION
It doesn't make sense to trigger a roles query in mongodb every second to get an information that stays almost ever constant. This PR replaces the update thread with cluster events when a role changes.  

/nocl internal refactoring only

## Description
Instead of the original polling thread we are now using cluster events to notify InMemoryRolePermissionResolver when a role changes - is saved or deleted.

## Motivation and Context
The original implementation kept polling roles every second. But roles are something that hardly ever changes and querying these every sec is a huge waste of resources.

Additionally, the polling thread added a 1s delay that caused problems in integration tests and forced every usage to artificially wait for another second after modifying a role.  

## How Has This Been Tested?
Added new unit tests, existing set of integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

