### PR TITLE
Generic prepare with optional dependency check

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareResponse.java
@@ -65,6 +65,8 @@ public abstract class EntityShareResponse {
         return Builder.create();
     }
 
+    public abstract Builder toBuilder();
+
     @AutoValue.Builder
     public abstract static class Builder {
         @JsonCreator
@@ -105,7 +107,7 @@ public abstract class EntityShareResponse {
     }
 
     @AutoValue
-    public static abstract class AvailableCapability {
+    public abstract static class AvailableCapability {
         @JsonProperty("id")
         public abstract String id();
 
@@ -120,7 +122,7 @@ public abstract class EntityShareResponse {
     }
 
     @AutoValue
-    public static abstract class ActiveShare {
+    public abstract static class ActiveShare {
         @JsonProperty("grant")
         public abstract String grant();
 

--- a/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
-import org.apache.shiro.subject.Subject;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
@@ -30,6 +29,7 @@ import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.security.entities.EntityDependencyPermissionChecker;
 import org.graylog.security.entities.EntityDependencyResolver;
+import org.graylog.security.entities.EntityDescriptor;
 import org.graylog.testing.GRNExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -89,13 +91,11 @@ class EntitySharesServiceTest {
 
 
         final EventBus serverEventBus = mock(EventBus.class);
-        this.entitySharesService = new EntitySharesService(dbGrantService, entityDependencyResolver, entityDependencyPermissionChecker, grnRegistry, granteeService, serverEventBus);
+        this.entitySharesService = new EntitySharesService(
+                dbGrantService, entityDependencyResolver, entityDependencyPermissionChecker, grnRegistry, granteeService, serverEventBus);
 
-        // TODO this is needed to initialize the CAPABILITIES field
         new BuiltinCapabilities();
     }
-
-    // TODO Test more EntitySharesService functionality
 
     @DisplayName("Validates we cannot remove the last owner")
     @Test
@@ -112,8 +112,7 @@ class EntitySharesServiceTest {
         lenient().when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isTrue();
             assertThat(validationResult.getErrors()).isNotEmpty();
@@ -140,8 +139,7 @@ class EntitySharesServiceTest {
         lenient().when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isFalse();
         });
@@ -159,8 +157,7 @@ class EntitySharesServiceTest {
         when(granteeService.getAvailableGrantees(user)).thenReturn(allGranteesSet);
         lenient().when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
 
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isTrue();
             assertThat(validationResult.getErrors()).isNotEmpty();
@@ -177,8 +174,7 @@ class EntitySharesServiceTest {
         final EntityShareRequest shareRequest = EntityShareRequest.create(ImmutableMap.of(horst, Capability.OWN));
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isFalse();
             assertThat(validationResult.getErrors()).isEmpty();
@@ -193,8 +189,7 @@ class EntitySharesServiceTest {
         final EntityShareRequest shareRequest = EntityShareRequest.create(ImmutableMap.of(horst, Capability.MANAGE));
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isFalse();
             assertThat(validationResult.getErrors()).isEmpty();
@@ -208,8 +203,7 @@ class EntitySharesServiceTest {
         final EntityShareRequest shareRequest = EntityShareRequest.create(null);
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
             assertThat(validationResult.failed()).isFalse();
             assertThat(validationResult.getErrors()).isEmpty();
@@ -223,8 +217,7 @@ class EntitySharesServiceTest {
         final EntityShareRequest shareRequest = EntityShareRequest.create(null);
 
         final User user = createMockUser("hans");
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.activeShares()).satisfies(activeShares -> {
             assertThat(activeShares).isEmpty();
         });
@@ -243,8 +236,7 @@ class EntitySharesServiceTest {
         when(granteeService.getAvailableGrantees(user)).thenReturn(allGranteesSet);
         when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
 
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user);
         assertThat(entityShareResponse.activeShares()).satisfies(activeShares -> {
             assertThat(activeShares).hasSize(1);
             assertThat(activeShares.iterator().next().grantee()).isEqualTo(janeGRN);
@@ -254,21 +246,43 @@ class EntitySharesServiceTest {
     @DisplayName("Show shares without entity")
     @Test
     void showShareWithoutEntity() {
-        final EntityShareRequest shareRequest = EntityShareRequest.create(null);
-
         final User user = createMockUser("hans");
         final GRN janeGRN = grnRegistry.newGRN(GRNTypes.USER, "jane");
         final ImmutableSet<Grantee> allGranteesSet = ImmutableSet.of(Grantee.createUser(janeGRN, "jane"));
-        when(granteeService.getAvailableGrantees(user)).thenReturn(allGranteesSet);
         when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
 
-        final Subject subject = mock(Subject.class);
-        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(shareRequest, user, subject);
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(user);
+
         assertThat(entityShareResponse.activeShares()).isEmpty();
         assertThat(entityShareResponse.availableGrantees()).hasSize(1);
         assertThat(entityShareResponse.availableCapabilities()).hasSize(3);
         assertThat(entityShareResponse.selectedGranteeCapabilities()).isEmpty();
     }
+
+    @DisplayName("Show shares with permissions check")
+    @Test
+    void showShareWithCheck() {
+        final String STREAM_ID = "54e3deadbeefdeadbeefaffe";
+        final String STREAM_GRN_STRING = "grn::::stream:" + STREAM_ID;
+        final GRN STREAM_GRN = grnRegistry.newGRN(GRNTypes.STREAM, STREAM_ID);
+        final User user = createMockUser("hans");
+        final GRN janeGRN = grnRegistry.newGRN(GRNTypes.USER, "jane");
+        final ImmutableSet<Grantee> allGranteesSet = ImmutableSet.of(Grantee.createUser(janeGRN, "jane"));
+        when(granteeService.getModifiableGrantees(any(), any())).thenReturn(allGranteesSet);
+        when(entityDependencyPermissionChecker.check(any(), any(), any()))
+                .thenReturn(ImmutableMultimap.of(janeGRN, EntityDescriptor.create(STREAM_GRN, "stream", Set.of())));
+
+        final EntityShareResponse entityShareResponse =
+                entitySharesService.prepareShare(List.of(STREAM_GRN_STRING), user);
+
+        assertThat(entityShareResponse.availableGrantees()).containsExactly(Grantee.createUser(janeGRN, "jane"));
+
+        assertThat(entityShareResponse.missingPermissionsOnDependencies()).hasSize(1);
+        final Collection<EntityDescriptor> entityDescriptors = entityShareResponse.missingPermissionsOnDependencies().get(janeGRN);
+        assertThat(entityDescriptors).hasSize(1);
+        assertThat(entityDescriptors.iterator().next().id()).hasToString(STREAM_GRN_STRING);
+    }
+
 
     private User createMockUser(String name) {
         final User user = mock(User.class);


### PR DESCRIPTION
/nocl
Relates to Graylog2/graylog-plugin-enterprise#10239

## Description
Extends the existing API `post /authz/shares/entities/prepare` with an optional body 

> {
> "prepare_request": [ list of entity GRNs to check ]
> }
 
We check whether all available grantees can access these entities; and return any combination that is denied.

## Motivation and Context
Surface missing dependencies early on, e.g. missing stream permission for a saved search.
