### PR TITLE
Creating an id for a global search filter that get's inlined

### DIFF
--- a/changelog/unreleased/pr-22531.toml
+++ b/changelog/unreleased/pr-22531.toml
@@ -1,0 +1,5 @@
+type = "f" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "When inlining a global search filter, add a newly created ID"
+
+issues = ["graylog-plugin-enterprise#9719"]
+pulls = ["22531"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
@@ -111,7 +111,7 @@ public abstract class ReferencedQueryStringSearchFilter implements ReferencedSea
     @Override
     public InlineQueryStringSearchFilter toInlineRepresentation() {
         return InlineQueryStringSearchFilter.builder()
-                // create a new ID for the inlined filter, so it's not the same as the global one
+                // create a new ID for the inlined filter on purpose, so it's not the same as the global one. if you later inline the same global filter a 2nd time, it would crash/overwrite your first 
                 .id(new org.bson.types.ObjectId().toHexString())
                 .queryString(this.queryString())
                 .description(this.description())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchfilters/model/ReferencedQueryStringSearchFilter.java
@@ -111,6 +111,8 @@ public abstract class ReferencedQueryStringSearchFilter implements ReferencedSea
     @Override
     public InlineQueryStringSearchFilter toInlineRepresentation() {
         return InlineQueryStringSearchFilter.builder()
+                // create a new ID for the inlined filter, so it's not the same as the global one
+                .id(new org.bson.types.ObjectId().toHexString())
                 .queryString(this.queryString())
                 .description(this.description())
                 .negation(this.negation())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prior to this PR, a global Search Filter on a Search that got inlined has no ID, which leads to problems removing/changing it in the FE. This PR fixes it by adding a newly created ID and not by taking the existing ID from the global filter because that could create problems with references.

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/9719

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

