### PR TITLE
Remove GL mention on Enterprise page

### DIFF
--- a/graylog2-web-interface/src/components/enterprise/AdvertisementSection.tsx
+++ b/graylog2-web-interface/src/components/enterprise/AdvertisementSection.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import styled from 'styled-components';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import { Col, Row } from 'components/bootstrap';
+import useProductName from 'brand-customization/useProductName';
+import ProductLink from 'components/enterprise/ProductLink';
+import { useStore } from 'stores/connect';
+import { NodesStore } from 'stores/nodes/NodesStore';
+
+const GraylogEnterpriseHeader = styled.h2`
+  margin-bottom: 10px;
+`;
+
+const AdvertisementSection = () => {
+  const nodes = useStore(NodesStore);
+  const productName = useProductName();
+  const licensePlugin = PluginStore.exports('license');
+  const ProductLinkComponent = licensePlugin[0]?.EnterpriseProductLink || ProductLink;
+  const { clusterId } = nodes;
+
+  return (
+    <Row className="content">
+      <Col md={6}>
+        <GraylogEnterpriseHeader>{productName} Enterprise</GraylogEnterpriseHeader>
+        <p>
+          Designed to meet the needs of resource-constrained IT Operations and Software Engineering teams, {productName}{' '}
+          Enterprise provides numerous productivity enhancements that will save you thousands of hours per year in
+          collecting and analyzing log data to uncover the root cause of performance, outage, and error issues.
+        </p>
+        <ProductLinkComponent href="https://go2.graylog.org/request-graylog-operations" clusterId={clusterId}>
+          Request now
+        </ProductLinkComponent>
+      </Col>
+      <Col md={6}>
+        <GraylogEnterpriseHeader>{productName} Security</GraylogEnterpriseHeader>
+        <p>
+          Extend {productName} Open’s capabilities for detecting, investigating, and responding to cybersecurity threats
+          with security-specific dashboards and alerts, anomaly detection AI/ML engine, integrations with other security
+          tools, SOAR capabilities, and numerous compliance reporting features.
+        </p>
+        <ProductLinkComponent
+          href="https://go2.graylog.org/request-graylog-security"
+          licenseSubject="/license/security"
+          clusterId={clusterId}>
+          Request now
+        </ProductLinkComponent>
+      </Col>
+    </Row>
+  );
+};
+
+export default AdvertisementSection;

--- a/graylog2-web-interface/src/components/enterprise/PluginList.tsx
+++ b/graylog2-web-interface/src/components/enterprise/PluginList.tsx
@@ -14,18 +14,23 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { Icon } from 'components/common';
+import useProductName from 'brand-customization/useProductName';
 
 import style from './PluginList.css';
 
-const ENTERPRISE_PLUGINS = {
-  'graylog-plugin-enterprise': 'Graylog Plugin Enterprise',
-};
-
 const PluginList = () => {
+  const productName = useProductName();
+  const ENTERPRISE_PLUGINS = useMemo(
+    () => ({
+      'graylog-plugin-enterprise': `${productName} Plugin Enterprise`,
+    }),
+    [productName],
+  );
+
   const _formatPlugin = (pluginName: string) => {
     const plugin = PluginStore.get().filter((p) => p.metadata.name === pluginName)[0];
 
@@ -42,7 +47,7 @@ const PluginList = () => {
 
   return (
     <>
-      <p>This is the status of Graylog Enterprise modules in this cluster:</p>
+      <p>This is the status of {productName} Enterprise modules in this cluster:</p>
       <ul className={style.enterprisePlugins}>{enterprisePluginList}</ul>
     </>
   );

--- a/graylog2-web-interface/src/pages/EnterprisePage.tsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.tsx
@@ -15,41 +15,34 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import styled from 'styled-components';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { useStore } from 'stores/connect';
 import { NodesStore } from 'stores/nodes/NodesStore';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import { Col, Row } from 'components/bootstrap';
 import { GraylogClusterOverview } from 'components/cluster';
 import PluginList from 'components/enterprise/PluginList';
 import EnterpriseProductLink from 'components/enterprise/EnterpriseProductLink';
-import ProductLink from 'components/enterprise/ProductLink';
 import HideOnCloud from 'util/conditional/HideOnCloud';
-
-const GraylogEnterpriseHeader = styled.h2`
-  margin-bottom: 10px;
-`;
+import useProductName from 'brand-customization/useProductName';
+import AdvertisementSection from 'components/enterprise/AdvertisementSection';
+import usePluggableUpsellWrapper from 'hooks/usePluggableUpsellWrapper';
 
 const EnterprisePage = () => {
   const nodes = useStore(NodesStore);
-  const licensePlugin = PluginStore.exports('license');
-  const ProductLinkComponent = licensePlugin[0]?.EnterpriseProductLink || ProductLink;
+  const productName = useProductName();
+  const UpsellWrapper = usePluggableUpsellWrapper();
 
   if (!nodes) {
     return <Spinner />;
   }
 
-  const { clusterId } = nodes;
-
   return (
-    <DocumentTitle title="Try Graylog Enterprise">
+    <DocumentTitle title={`Try ${productName} Enterprise`}>
       <div>
-        <PageHeader title="Try Graylog Enterprise">
+        <PageHeader title={`Try ${productName} Enterprise`}>
           <span>
-            Graylog Enterprise adds commercial functionality to the Open Source Graylog core. You can learn more about
-            Graylog Enterprise on the <EnterpriseProductLink>product page</EnterpriseProductLink>.
+            {productName} Enterprise adds commercial functionality to the Open Source {productName} core. You can learn
+            more about {productName} Enterprise on the <EnterpriseProductLink>product page</EnterpriseProductLink>.
           </span>
         </PageHeader>
 
@@ -57,33 +50,9 @@ const EnterprisePage = () => {
           <PluginList />
         </GraylogClusterOverview>
         <HideOnCloud>
-          <Row className="content">
-            <Col md={6}>
-              <GraylogEnterpriseHeader>Graylog Enterprise</GraylogEnterpriseHeader>
-              <p>
-                Designed to meet the needs of resource-constrained IT Operations and Software Engineering teams, Graylog
-                Enterprise provides numerous productivity enhancements that will save you thousands of hours per year in
-                collecting and analyzing log data to uncover the root cause of performance, outage, and error issues.
-              </p>
-              <ProductLinkComponent href="https://go2.graylog.org/request-graylog-operations" clusterId={clusterId}>
-                Request now
-              </ProductLinkComponent>
-            </Col>
-            <Col md={6}>
-              <GraylogEnterpriseHeader>Graylog Security</GraylogEnterpriseHeader>
-              <p>
-                Extend Graylog Open’s capabilities for detecting, investigating, and responding to cybersecurity threats
-                with security-specific dashboards and alerts, anomaly detection AI/ML engine, integrations with other
-                security tools, SOAR capabilities, and numerous compliance reporting features.
-              </p>
-              <ProductLinkComponent
-                href="https://go2.graylog.org/request-graylog-security"
-                licenseSubject="/license/security"
-                clusterId={clusterId}>
-                Request now
-              </ProductLinkComponent>
-            </Col>
-          </Row>
+          <UpsellWrapper>
+            <AdvertisementSection />
+          </UpsellWrapper>
         </HideOnCloud>
       </div>
     </DocumentTitle>

--- a/graylog2-web-interface/src/pages/EnterprisePage.tsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.tsx
@@ -41,8 +41,11 @@ const EnterprisePage = () => {
       <div>
         <PageHeader title={`Try ${productName} Enterprise`}>
           <span>
-            {productName} Enterprise adds commercial functionality to the Open Source {productName} core. You can learn
-            more about {productName} Enterprise on the <EnterpriseProductLink>product page</EnterpriseProductLink>.
+            {productName} Enterprise adds commercial functionality to the Open Source {productName} core.{' '}
+            <UpsellWrapper>
+              You can learn more about {productName} Enterprise on the{' '}
+              <EnterpriseProductLink>product page</EnterpriseProductLink>.
+            </UpsellWrapper>
           </span>
         </PageHeader>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes mention of GL on the Enterprise Overview page and also hides the advertisement for the enterprise users 
## Motivation and Context
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/10591
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
