### PR TITLE
Collect grants of deleted entities on Content Pack uninstall

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -30,8 +30,11 @@ import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.events.processor.EventDefinitionHandler;
 import org.graylog.events.processor.EventProcessorExecutionJob;
+import org.graylog.grn.GRNTypes;
 import org.graylog.scheduler.DBJobDefinitionService;
 import org.graylog.scheduler.JobDefinitionDto;
+import org.graylog.security.GrantDTO;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.facades.EntityFacade;
 import org.graylog2.contentpacks.model.ModelId;
@@ -51,6 +54,7 @@ import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -65,6 +69,7 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     private final DBEventDefinitionService eventDefinitionService;
     private final Set<PluginMetaData> pluginMetaData;
     private final UserService userService;
+    private final EntityOwnershipService entityOwnershipService;
 
     @Inject
     public EventDefinitionFacade(ObjectMapper objectMapper,
@@ -72,13 +77,15 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
                                  Set<PluginMetaData> pluginMetaData,
                                  DBJobDefinitionService jobDefinitionService,
                                  DBEventDefinitionService eventDefinitionService,
-                                 UserService userService) {
+                                 UserService userService,
+                                 EntityOwnershipService entityOwnershipService) {
         this.objectMapper = objectMapper;
         this.pluginMetaData = pluginMetaData;
         this.eventDefinitionHandler = eventDefinitionHandler;
         this.jobDefinitionService = jobDefinitionService;
         this.eventDefinitionService = eventDefinitionService;
         this.userService = userService;
+        this.entityOwnershipService = entityOwnershipService;
     }
 
     @VisibleForTesting
@@ -217,5 +224,10 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     @Override
     public boolean usesScopedEntities() {
         return true;
+    }
+
+    @Override
+    public List<GrantDTO> resolveGrants(EventDefinitionDto nativeEntity) {
+        return entityOwnershipService.getGrantsForTarget(GRNTypes.EVENT_DEFINITION, nativeEntity.id());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -243,7 +243,6 @@ public class DBGrantService {
         return mongoUtils.save(grantDTO);
     }
 
-    // TODO: Use this in PreservedEntityService
     public void bulkCreate(List<GrantDTO> grants) {
         List<InsertOneModel<GrantDTO>> bulkWrites = grants.stream()
                 .map(InsertOneModel::new)

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -24,6 +24,7 @@ import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.InsertOneModel;
 import jakarta.inject.Inject;
 import org.bson.conversions.Bson;
 import org.graylog.grn.GRN;
@@ -240,6 +241,14 @@ public class DBGrantService {
 
     public GrantDTO save(GrantDTO grantDTO) {
         return mongoUtils.save(grantDTO);
+    }
+
+    // TODO: Use this in PreservedEntityService
+    public void bulkCreate(List<GrantDTO> grants) {
+        List<InsertOneModel<GrantDTO>> bulkWrites = grants.stream()
+                .map(InsertOneModel::new)
+                .toList();
+        collection.bulkWrite(bulkWrites);
     }
 
     public Optional<GrantDTO> get(String id) {

--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityOwnershipService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityOwnershipService.java
@@ -29,6 +29,8 @@ import org.graylog2.plugin.database.users.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 @Singleton
 public class EntityOwnershipService {
     private static final Logger LOG = LoggerFactory.getLogger(EntityOwnershipService.class);
@@ -78,6 +80,11 @@ public class EntityOwnershipService {
     //TODO: this method could replace all methods from unregister... family, so that we don't have to add two methods and tests for each new GRN Type in the future
     public void unregisterEntity(final String id, final GRNType grnType) {
         removeGrantsForTarget(grnRegistry.newGRN(grnType, id));
+    }
+
+    public List<GrantDTO> getGrantsForTarget(final GRNType type, final String id) {
+        final GRN grn = grnRegistry.newGRN(type, id);
+        return dbGrantService.getForTarget(grn);
     }
 
     private void registerNewEntity(GRN entity, User user) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -17,22 +17,27 @@
 package org.graylog2.contentpacks.facades;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewSummaryService;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.shared.users.UserService;
-
-import jakarta.inject.Inject;
 
 public class DashboardFacade extends ViewFacade implements DashboardEntityCreator {
     public static final ModelType TYPE_V2 = ModelTypes.DASHBOARD_V2;
 
     @Inject
-    public DashboardFacade(ObjectMapper objectMapper, SearchDbService searchDbService, ViewService viewService, ViewSummaryService viewSummaryService, UserService userService) {
-        super(objectMapper, searchDbService, viewService, viewSummaryService, userService);
+    public DashboardFacade(ObjectMapper objectMapper,
+                           SearchDbService searchDbService,
+                           ViewService viewService,
+                           ViewSummaryService viewSummaryService,
+                           UserService userService,
+                           EntityOwnershipService entityOwnershipService) {
+        super(objectMapper, searchDbService, viewService, viewSummaryService, userService, entityOwnershipService);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
@@ -20,6 +20,7 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
+import org.graylog.security.GrantDTO;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
@@ -29,6 +30,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -144,5 +146,15 @@ public interface EntityWithExcerptFacade<EntityClass, ExcerptClass> {
      */
     default boolean usesScopedEntities() {
         return false;
+    }
+
+    /**
+     * Return a list of existing grants targeting the given entity.
+     *
+     * @param nativeEntity target entity
+     * @return list of grants where the entity is the target
+     */
+    default List<GrantDTO> resolveGrants(EntityClass nativeEntity) {
+        return List.of();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SearchFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SearchFacade.java
@@ -17,22 +17,27 @@
 package org.graylog2.contentpacks.facades;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewSummaryService;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.shared.users.UserService;
-
-import jakarta.inject.Inject;
 
 public class SearchFacade extends ViewFacade {
     public static final ModelType TYPE_V1 = ModelTypes.SEARCH_V1;
 
     @Inject
-    public SearchFacade(ObjectMapper objectMapper, SearchDbService searchDbService, ViewService viewService, ViewSummaryService viewSummaryService, UserService userService) {
-        super(objectMapper, searchDbService, viewService, viewSummaryService, userService);
+    public SearchFacade(ObjectMapper objectMapper,
+                        SearchDbService searchDbService,
+                        ViewService viewService,
+                        ViewSummaryService viewSummaryService,
+                        UserService userService,
+                        EntityOwnershipService entityOwnershipService) {
+        super(objectMapper, searchDbService, viewService, viewSummaryService, userService, entityOwnershipService);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/DashboardV1Facade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/DashboardV1Facade.java
@@ -20,11 +20,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.Graph;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewSummaryDTO;
 import org.graylog.plugins.views.search.views.ViewSummaryService;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.contentpacks.facades.ViewFacade;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
@@ -37,8 +39,6 @@ import org.graylog2.contentpacks.model.entities.ViewEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
-
-import jakarta.inject.Inject;
 
 import java.util.Map;
 import java.util.Optional;
@@ -55,8 +55,9 @@ public class DashboardV1Facade extends ViewFacade {
                              EntityConverter entityConverter,
                              ViewService viewService,
                              ViewSummaryService viewSummaryService,
-                             UserService userService) {
-        super(objectMapper, searchDbService, viewService, viewSummaryService, userService);
+                             UserService userService,
+                             EntityOwnershipService entityOwnershipService) {
+        super(objectMapper, searchDbService, viewService, viewSummaryService, userService, entityOwnershipService);
         this.objectMapper = objectMapper;
         this.entityConverter = entityConverter;
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.security.GrantDTO;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 @AutoValue
 @JsonDeserialize(builder = ContentPackUninstallation.Builder.class)
@@ -33,6 +35,7 @@ public abstract class ContentPackUninstallation {
     private static final String FIELD_ENTITY_OBJECTS = "entity_objects";
     private static final String FIELD_FAILED_ENTITIES = "failed_entities";
     private static final String FIELD_SKIPPED_ENTITIES = "skipped_entities";
+    private static final String FIELD_ENTITY_GRANTS = "entity_grants";
 
     @JsonProperty(FIELD_ENTITIES)
     public abstract ImmutableSet<NativeEntityDescriptor> entities();
@@ -47,6 +50,9 @@ public abstract class ContentPackUninstallation {
     @JsonProperty(FIELD_SKIPPED_ENTITIES)
     public abstract ImmutableSet<NativeEntityDescriptor> skippedEntities();
 
+    @JsonProperty(FIELD_ENTITY_GRANTS)
+    public abstract ImmutableMap<ModelId, List<GrantDTO>> entityGrants();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -57,7 +63,7 @@ public abstract class ContentPackUninstallation {
     public static abstract class Builder {
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_ContentPackUninstallation.Builder();
+            return new AutoValue_ContentPackUninstallation.Builder().entityGrants(ImmutableMap.of());
         }
 
         @JsonProperty(FIELD_ENTITIES)
@@ -71,6 +77,9 @@ public abstract class ContentPackUninstallation {
 
         @JsonProperty(FIELD_SKIPPED_ENTITIES)
         public abstract Builder skippedEntities(ImmutableSet<NativeEntityDescriptor> skippedEntities);
+
+        @JsonProperty(FIELD_ENTITY_GRANTS)
+        public abstract Builder entityGrants(ImmutableMap<ModelId, List<GrantDTO>> entityGrants);
 
         public abstract ContentPackUninstallation build();
     }

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
@@ -157,7 +157,7 @@ public class EventDefinitionFacadeTest {
         eventDefinitionHandler = new EventDefinitionHandler(
                 eventDefinitionService, jobDefinitionService, jobTriggerService, jobSchedulerClock);
         Set<PluginMetaData> pluginMetaData = new HashSet<>();
-        facade = new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService);
+        facade = new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService, entityOwnershipService);
     }
 
     @Test
@@ -332,7 +332,7 @@ public class EventDefinitionFacadeTest {
     @Test
     public void listExcerptsExcludesNonContentPackExportableEventDefinitions() {
         EventDefinitionFacade testFacade = new EventDefinitionFacade(
-                objectMapper, eventDefinitionHandler, new HashSet<>(), jobDefinitionService, mockEventDefinitionService, userService);
+                objectMapper, eventDefinitionHandler, new HashSet<>(), jobDefinitionService, mockEventDefinitionService, userService, entityOwnershipService);
         EventDefinitionDto dto = validEventDefinitionDto(mockEventProcessorConfig);
 
         when(mockEventProcessorConfig.isContentPackExportable()).thenReturn(false);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -50,6 +50,7 @@ import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.ViewSummaryService;
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
 import org.graylog.scheduler.DBJobDefinitionService;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog2.Configuration;
 import org.graylog2.contentpacks.constraints.ConstraintChecker;
 import org.graylog2.contentpacks.constraints.GraylogVersionConstraintChecker;
@@ -190,6 +191,8 @@ public class ContentPackServiceTest {
     ServerStatus serverStatus;
     @Mock
     Configuration configuration;
+    @Mock
+    EntityOwnershipService entityOwnershipService;
 
     private ContentPackService contentPackService;
     private Set<PluginMetaData> pluginMetaData;
@@ -214,8 +217,8 @@ public class ContentPackServiceTest {
                 ModelTypes.GROK_PATTERN_V1, new GrokPatternFacade(objectMapper, patternService),
                 ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, legacyAlertConditionMigration, indexSetService, userService),
                 ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2),
-                ModelTypes.SEARCH_V1, new SearchFacade(objectMapper, searchDbService, viewService, viewSummaryService, userService),
-                ModelTypes.EVENT_DEFINITION_V1, new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService),
+                ModelTypes.SEARCH_V1, new SearchFacade(objectMapper, searchDbService, viewService, viewSummaryService, userService, entityOwnershipService),
+                ModelTypes.EVENT_DEFINITION_V1, new EventDefinitionFacade(objectMapper, eventDefinitionHandler, pluginMetaData, jobDefinitionService, eventDefinitionService, userService, entityOwnershipService),
                 ModelTypes.INPUT_V1, new InputFacade(objectMapper, inputService, inputRegistry, lookupTableService, grokPatternService, messageInputFactory,
                         extractorFactory, converterFactory, serverStatus, pluginMetaData, new HashMap<>())
                 );

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -388,6 +388,7 @@ public class ContentPackServiceTest {
                 .failedEntities(ImmutableSet.of())
                 .entities(nativeEntityDescriptors)
                 .entityObjects(entityObjectMap)
+                .entityGrants(ImmutableMap.of(ModelId.of("12345"), new ArrayList<>()))
                 .build();
 
         ContentPackUninstallation resultSuccess = contentPackService.uninstallContentPack(contentPack, contentPackInstallation);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardV1FacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardV1FacadeTest.java
@@ -39,6 +39,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.TimeHistogramC
 import org.graylog.plugins.views.search.views.widgets.aggregation.ValueConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.PivotSortConfig;
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
+import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -113,12 +114,13 @@ public class DashboardV1FacadeTest {
         ViewFacadeTest.TestViewService viewService = new ViewFacadeTest.TestViewService(null, mongoCollections);
         ViewFacadeTest.TestViewSummaryService viewSummaryService = new ViewFacadeTest.TestViewSummaryService(mongoCollections);
         UserService userService = mock(UserService.class);
+        EntityOwnershipService entityOwnershipService = mock(EntityOwnershipService.class);
         final UserImpl fakeUser = new UserImpl(mock(PasswordAlgorithmFactory.class), new Permissions(ImmutableSet.of()),
                 mock(ClusterConfigService.class), ImmutableMap.of("username", "testuser"));
         when(userService.load("testuser")).thenReturn(fakeUser);
         final DashboardWidgetConverter dashboardWidgetConverter = new DashboardWidgetConverter();
         final EntityConverter entityConverter = new EntityConverter(dashboardWidgetConverter);
-        DashboardV1Facade facade = new DashboardV1Facade(objectMapper, searchDbService, entityConverter, viewService, viewSummaryService, userService);
+        DashboardV1Facade facade = new DashboardV1Facade(objectMapper, searchDbService, entityConverter, viewService, viewSummaryService, userService, entityOwnershipService);
         final URL resourceUrl = Resources.getResource(DashboardV1Facade.class, "content-pack-dashboard-v1.json");
         final ContentPack contentPack = objectMapper.readValue(resourceUrl, ContentPack.class);
         assertThat(contentPack).isInstanceOf(ContentPackV1.class);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
@@ -129,7 +129,7 @@ public class ViewFacadeTest {
     private final String newStreamId = "5def958063303ae5f68ebeaf";
     private final String streamId = "5cdab2293d27467fbe9e8a72"; /* stored in database */
     private UserService userService;
-
+    private EntityOwnershipService entityOwnershipService;
 
     @Before
     public void setUp() {
@@ -153,8 +153,9 @@ public class ViewFacadeTest {
         viewService = new TestViewService(null, mongoCollections);
         viewSummaryService = new TestViewSummaryService(mongoCollections);
         userService = mock(UserService.class);
+        entityOwnershipService = mock(EntityOwnershipService.class);
 
-        facade = new SearchFacade(objectMapper, searchDbService, viewService, viewSummaryService, userService);
+        facade = new SearchFacade(objectMapper, searchDbService, viewService, viewSummaryService, userService, entityOwnershipService);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Keeps track of grants that existed for deleted content pack entities during uninstalls

/prd Graylog2/graylog-plugin-enterprise#10658
/nocl will include PR in enterprise changelog
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
preserve entity sharing across Illuminate upgrades
see Graylog2/graylog-plugin-enterprise#10161
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local dev environment doing multiple Illuminate upgrades
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

