### PR TITLE
Fix timestamp parsing for Netscaler WAF logs

### DIFF
--- a/changelog/unreleased/issue-8844.toml
+++ b/changelog/unreleased/issue-8844.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Handle timestamp parsing for Netscaler WAF logs."
+
+issues = ["8844"]

--- a/changelog/unreleased/issue-8844.toml
+++ b/changelog/unreleased/issue-8844.toml
@@ -1,4 +1,4 @@
 type = "f"
 message = "Handle timestamp parsing for Netscaler WAF logs."
 
-issues = ["8844"]
+issues = ["Graylog2/graylog-plugin-enterprise#8844"]

--- a/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
@@ -105,7 +105,18 @@ public class CEFCodecTest {
         final MappedMessage cefMessage = mock(MappedMessage.class);
         when(cefMessage.mappedExtensions()).thenReturn(Collections.singletonMap("dvc", "128.66.23.42"));
         final Message message = codec.decodeSafe(rawMessage).get();
-        System.out.println(message.getTimestamp());
+
+        assertNotNull(message);
+        assertEquals(new DateTime(2024, 9, 13, 10, 28, 31, DateTimeZone.UTC), message.getTimestamp());
+    }
+
+    @Test
+    public void testIssue8844WithoutPriority() {
+        // https://github.com/Graylog2/graylog-plugin-enterprise/issues/8844
+        final RawMessage rawMessage = buildRawMessage("<134>2024-09-13T12:23:43.288000+02:00 netscaler-waf appname 1234 msgid - CEF:0|Vendor|Product|Version|EventID|Name|Severity|...\n");
+        final MappedMessage cefMessage = mock(MappedMessage.class);
+        when(cefMessage.mappedExtensions()).thenReturn(Collections.singletonMap("dvc", "128.66.23.42"));
+        final Message message = codec.decodeSafe(rawMessage).get();
 
         assertNotNull(message);
         assertEquals(new DateTime(2024, 9, 13, 10, 28, 31, DateTimeZone.UTC), message.getTimestamp());

--- a/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
@@ -17,17 +17,22 @@
 package org.graylog.plugins.cef.codec;
 
 import org.graylog.plugins.cef.parser.MappedMessage;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.TestMessageFactory;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,7 +99,24 @@ public class CEFCodecTest {
     }
 
     @Test
+    public void testIssue8844() {
+        // https://github.com/Graylog2/graylog-plugin-enterprise/issues/8844
+        final RawMessage rawMessage = buildRawMessage("<134>1 2024-09-13T12:23:43.288000+02:00 netscaler-waf appname 1234 msgid - CEF:0|Vendor|Product|Version|EventID|Name|Severity|...\n");
+        final MappedMessage cefMessage = mock(MappedMessage.class);
+        when(cefMessage.mappedExtensions()).thenReturn(Collections.singletonMap("dvc", "128.66.23.42"));
+        final Message message = codec.decodeSafe(rawMessage).get();
+        System.out.println(message.getTimestamp());
+
+        assertNotNull(message);
+        assertEquals(new DateTime(2024, 9, 13, 10, 28, 31, DateTimeZone.UTC), message.getTimestamp());
+    }
+
+    @Test
     public void getAggregator() throws Exception {
         assertNull(codec.getAggregator());
+    }
+
+    private RawMessage buildRawMessage(String message) {
+        return new RawMessage(message.getBytes(StandardCharsets.UTF_8), new InetSocketAddress("127.0.0.1", 5140));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
@@ -32,8 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -105,9 +105,7 @@ public class CEFCodecTest {
         final MappedMessage cefMessage = mock(MappedMessage.class);
         when(cefMessage.mappedExtensions()).thenReturn(Collections.singletonMap("dvc", "128.66.23.42"));
         final Message message = codec.decodeSafe(rawMessage).get();
-
-        assertNotNull(message);
-        assertEquals(new DateTime(2024, 9, 13, 10, 28, 31, DateTimeZone.UTC), message.getTimestamp());
+        verifyFields(message);
     }
 
     @Test
@@ -117,8 +115,14 @@ public class CEFCodecTest {
         final MappedMessage cefMessage = mock(MappedMessage.class);
         when(cefMessage.mappedExtensions()).thenReturn(Collections.singletonMap("dvc", "128.66.23.42"));
         final Message message = codec.decodeSafe(rawMessage).get();
+        verifyFields(message);
+    }
 
-        assertNotNull(message);
+    private static void verifyFields(Message message) {
+        assertTrue(message.getMessage().contains("Product: [EventID, Severity] Name"));
+        assertEquals(6, message.getField("level"));
+        assertEquals("Vendor", message.getField("device_vendor"));
+        assertEquals("local0", message.getField("facility"));
         assertEquals(new DateTime(2024, 9, 13, 10, 28, 31, DateTimeZone.UTC), message.getTimestamp());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
-> Updated Codec to fix the timestamp parsing for Netscaler WAF logs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
-> It handles the parsing of timestamp when log contains priority in the beginning.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
-> Added test cases which parsed the timestamp value in log properly.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

