### PR TITLE
Improve deprecated function logging

### DIFF
--- a/changelog/unreleased/issue-22168.toml
+++ b/changelog/unreleased/issue-22168.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Make deprecated pipeline rule warnings less noisy and more actionable."
+
+pulls = ["22558"]
+issues = ["22168"]


### PR DESCRIPTION
Resolves #22168

<!--- Provide a general summary of your changes in the Title above -->
Reduce logging rate and add rule name.

## Description
<!--- Describe your changes in detail -->
Warnings about usage of deprecated pipeline functions are only output once a minute, instead of 5 times every 10 seconds.
We also include the rule name.

See linked issue for details