### PR TITLE
Prepare content pack service for permission checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/UserContext.java
+++ b/graylog2-server/src/main/java/org/graylog/security/UserContext.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security;
 
+import jakarta.inject.Inject;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.authz.permission.AllPermission;
@@ -26,8 +27,6 @@ import org.graylog.security.permissions.GRNPermission;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.users.UserService;
-
-import jakarta.inject.Inject;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -78,14 +77,39 @@ public class UserContext implements HasUser {
     /**
      * Build a temporary Shiro Subject and run the callable within that context
      *
-     * @param username The username of the subject
+     * @param username    The username of the subject
+     * @param userService The userService to resolve the userId from the username
+     * @param callable    The callable to be executed
+     * @param <T>         The return type of the callable.
+     * @return whatever the callable returns.
+     */
+    public static <T> T runAs(String username, UserService userService, Callable<T> callable) {
+        User user = userService.load(username);
+        if (user == null) {
+            throw new IllegalArgumentException("Unknown user <" + username + ">");
+        }
+        final Subject subject = new Subject.Builder()
+                .principals(new SimplePrincipalCollection(user.getId(), "runAs-context"))
+                .authenticated(true)
+                .sessionCreationEnabled(false)
+                .buildSubject();
+
+        return subject.execute(callable);
+
+    }
+
+
+    /**
+     * Build a temporary Shiro Subject and run the callable within that context
+     *
+     * @param userId The userId of the subject
      * @param callable The callable to be executed
      * @param <T>      The return type of the callable.
      * @return whatever the callable returns.
      */
-    public static <T> T runAs(String username, Callable<T> callable) {
+    public static <T> T runAs(String userId, Callable<T> callable) {
         final Subject subject = new Subject.Builder()
-                .principals(new SimplePrincipalCollection(username, "runAs-context"))
+                .principals(new SimplePrincipalCollection(userId, "runAs-context"))
                 .authenticated(true)
                 .sessionCreationEnabled(false)
                 .buildSubject();
@@ -96,12 +120,12 @@ public class UserContext implements HasUser {
     /**
      * Build a temporary Shiro Subject and run the callable within that context
      *
-     * @param username The username of the subject
+     * @param userId The userId of the subject
      * @param runnable The runnable to be executed
      */
-    public static void runAs(String username, Runnable runnable) {
+    public static void runAs(String userId, Runnable runnable) {
         final Subject subject = new Subject.Builder()
-                .principals(new SimplePrincipalCollection(username, "runAs-context"))
+                .principals(new SimplePrincipalCollection(userId, "runAs-context"))
                 .authenticated(true)
                 .sessionCreationEnabled(false)
                 .buildSubject();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -64,7 +64,6 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.contentpacks.model.entities.references.ValueType;
 import org.graylog2.contentpacks.model.parameters.Parameter;
-import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.users.UserService;
@@ -118,11 +117,7 @@ public class ContentPackService {
                                                       Map<String, ValueReference> parameters,
                                                       String comment,
                                                       String username) {
-        User user = userService.load(username);
-        if (user == null) {
-            throw new IllegalArgumentException("Unknown user <" + username + ">");
-        }
-        return UserContext.runAs(user.getId(), () -> {
+        return UserContext.runAs(username, userService, () -> {
             final UserContext userContext;
             try {
                 userContext = new UserContext.Factory(userService).create();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityWithExcerptFacade.java
@@ -29,6 +29,7 @@ import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -145,4 +146,10 @@ public interface EntityWithExcerptFacade<EntityClass, ExcerptClass> {
     default boolean usesScopedEntities() {
         return false;
     }
+
+    default Optional<List<String>> getCreatePermissions(Entity entity) {
+        return Optional.empty();
+    }
+
+    ;
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -27,6 +27,7 @@ import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import com.google.common.primitives.Ints;
+import jakarta.inject.Inject;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.ModelId;
@@ -70,11 +71,10 @@ import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.shared.inputs.InputRegistry;
 import org.graylog2.shared.inputs.MessageInputFactory;
 import org.graylog2.shared.inputs.NoSuchInputTypeException;
+import org.graylog2.shared.security.RestPermissions;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.util.Collection;
 import java.util.List;
@@ -626,6 +626,17 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
 
         public Map<String, Object> toMap() {
             return Map.of("type", type(), "configuration", configuration());
+        }
+    }
+
+    @Override
+    public Optional<List<String>> getCreatePermissions(Entity entity) {
+        if (entity instanceof EntityV1 entityV1) {
+            final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
+            String type = inputEntity.type().asString();
+            return Optional.of(List.of(RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + type));
+        } else {
+            return Optional.empty();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -36,10 +36,12 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.bson.types.ObjectId;
+import org.graylog.security.UserContext;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.contentpacks.ContentPackInstallationPersistenceService;
@@ -285,7 +287,8 @@ public class ContentPackResource extends RestResource {
             @ApiParam(name = "revision", value = "Content pack revision", required = true)
             @PathParam("revision") int revision,
             @ApiParam(name = "installation request", value = "Content pack installation request", required = true)
-            @Valid @NotNull ContentPackInstallationRequest contentPackInstallationRequest) {
+            @Valid @NotNull ContentPackInstallationRequest contentPackInstallationRequest,
+            @Context UserContext userContext) {
         checkPermission(RestPermissions.CONTENT_PACK_INSTALL, id.toString());
 
         final ContentPack contentPack = contentPackPersistenceService.findByIdAndRevision(id, revision)
@@ -296,7 +299,7 @@ public class ContentPackResource extends RestResource {
                 contentPack,
                 contentPackInstallationRequest.parameters(),
                 contentPackInstallationRequest.comment(),
-                userName);
+                userContext);
 
         return installation;
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20230601104500_AddSourcesPageV2Test.java
@@ -73,7 +73,7 @@ class V20230601104500_AddSourcesPageV2Test {
 
     static class TestContentPackService extends ContentPackService {
         public TestContentPackService() {
-            super(null, null, Map.of(), null, null);
+            super(null, null, Map.of(), null, null, null);
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
@@ -42,6 +42,7 @@ import org.graylog2.rest.resources.system.contentpacks.titles.model.EntitiesTitl
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityIdentifier;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleRequest;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleResponse;
+import org.graylog2.shared.users.UserService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -71,7 +72,7 @@ public class CatalogResourceTest {
                 mock(ContentPackInstallationPersistenceService.class);
         final Set<ConstraintChecker> constraintCheckers = Collections.emptySet();
         final Map<ModelType, EntityWithExcerptFacade<?, ?>> entityFacades = Collections.singletonMap(ModelType.of("test", "1"), mockEntityFacade);
-        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper(), mock(Configuration.class));
+        contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades, new ObjectMapper(), mock(Configuration.class), mock(UserService.class));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
@@ -17,6 +17,9 @@
 package org.graylog2.rest.resources.system.contentpacks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import org.graylog2.contentpacks.ContentPackInstallationPersistenceService;
 import org.graylog2.contentpacks.ContentPackPersistenceService;
 import org.graylog2.contentpacks.ContentPackService;
@@ -29,18 +32,17 @@ import org.graylog2.rest.models.system.contentpacks.responses.ContentPackList;
 import org.graylog2.rest.models.system.contentpacks.responses.ContentPackMetadata;
 import org.graylog2.rest.models.system.contentpacks.responses.ContentPackResponse;
 import org.graylog2.rest.models.system.contentpacks.responses.ContentPackRevisions;
+import org.graylog2.security.AuthorizationExtension;
+import org.graylog2.security.SecurityTestUtils;
+import org.graylog2.security.WithAuthorization;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.Map;
@@ -52,7 +54,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(AuthorizationExtension.class)
 public class ContentPackResourceTest {
+
     private static final String CONTENT_PACK = "" +
             "{\n" +
             "    \"v\": \"1\",\n" +
@@ -67,9 +72,6 @@ public class ContentPackResourceTest {
             "    \"entities\": [ ]\n" +
             "}";
 
-    @Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
-
     @Mock
     private ContentPackService contentPackService;
     @Mock
@@ -80,14 +82,14 @@ public class ContentPackResourceTest {
     @Mock
     private Set<ContentPackInstallation> contentPackInstallations;
 
-    private ContentPackResource contentPackResource;
+    private PermittedTestResource contentPackResource;
     private ObjectMapper objectMapper;
 
     public ContentPackResourceTest() {
         GuiceInjectorHolder.createInjector(Collections.emptyList());
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         objectMapper = new ObjectMapperProvider().get();
         objectMapper.setSubtypeResolver(new AutoValueSubtypeResolver());
@@ -95,9 +97,11 @@ public class ContentPackResourceTest {
                 contentPackService,
                 contentPackPersistenceService,
                 contentPackInstallationPersistenceService);
+        contentPackResource = SecurityTestUtils.injectSecurityManager(contentPackResource, PermittedTestResource.class);
     }
 
     @Test
+    @WithAuthorization(permissions = RestPermissions.CONTENT_PACK_CREATE)
     public void uploadContentPack() throws Exception {
         final ContentPack contentPack = objectMapper.readValue(CONTENT_PACK, ContentPack.class);
         when(contentPackPersistenceService.filterMissingResourcesAndInsert(contentPack)).thenReturn(Optional.ofNullable(contentPack));
@@ -109,6 +113,7 @@ public class ContentPackResourceTest {
     }
 
     @Test
+    @WithAuthorization(permissions = RestPermissions.CONTENT_PACK_READ)
     public void listAndLatest() throws Exception {
         final ContentPack contentPack = objectMapper.readValue(CONTENT_PACK, ContentPack.class);
         final Set<ContentPack> contentPacks = Collections.singleton(contentPack);
@@ -127,6 +132,7 @@ public class ContentPackResourceTest {
     }
 
     @Test
+    @WithAuthorization(permissions = RestPermissions.CONTENT_PACK_READ)
     public void getContentPack() throws Exception {
         final ContentPack contentPack = objectMapper.readValue(CONTENT_PACK, ContentPack.class);
         final Set<ContentPack> contentPackSet = Collections.singleton(contentPack);
@@ -149,6 +155,7 @@ public class ContentPackResourceTest {
     }
 
     @Test
+    @WithAuthorization(permissions = RestPermissions.CONTENT_PACK_DELETE)
     public void deleteContentPack() throws Exception {
         final ModelId id = ModelId.of("1");
         when(contentPackPersistenceService.deleteById(id)).thenReturn(1);
@@ -161,9 +168,9 @@ public class ContentPackResourceTest {
     }
 
     @Test
+    @WithAuthorization(permissions = RestPermissions.CONTENT_PACK_DELETE)
     public void notDeleteContentPack() throws Exception {
         final ModelId id = ModelId.of("1");
-        when(contentPackInstallations.size()).thenReturn(1);
         when(contentPackInstallationPersistenceService.findByContentPackId(id)).thenReturn(contentPackInstallations);
         boolean exceptionCalled = false;
         try {
@@ -175,7 +182,6 @@ public class ContentPackResourceTest {
         verify(contentPackInstallationPersistenceService, times(1)).findByContentPackId(id);
         verify(contentPackPersistenceService, times(0)).deleteById(id);
 
-        when(contentPackInstallations.size()).thenReturn(1);
         when(contentPackInstallationPersistenceService.findByContentPackIdAndRevision(id, 1)).thenReturn(contentPackInstallations);
         exceptionCalled = false;
         try {
@@ -193,16 +199,6 @@ public class ContentPackResourceTest {
                               ContentPackPersistenceService contentPackPersistenceService,
                               ContentPackInstallationPersistenceService contentPackInstallationPersistenceService) {
             super(contentPackService, contentPackPersistenceService, contentPackInstallationPersistenceService);
-        }
-
-        @Override
-        protected boolean isPermitted(String permission) {
-            return true;
-        }
-
-        @Override
-        protected boolean isPermitted(String permission, String id) {
-            return true;
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog2/security/AuthorizationExtension.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AuthorizationExtension.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+package org.graylog2.security;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Set;
+
+public class AuthorizationExtension implements BeforeEachCallback, AfterEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+
+        context.getTestMethod()
+                .filter(m -> m.isAnnotationPresent(WithAuthorization.class))
+                .map(m -> m.getAnnotation(WithAuthorization.class))
+                .or(() -> context.getTestClass()
+                        .filter(c -> c.isAnnotationPresent(WithAuthorization.class))
+                        .map(c -> c.getAnnotation(WithAuthorization.class)))
+                .ifPresent(annotation -> {
+                    SecurityTestUtils.setupSecurityContext(
+                            annotation.username(),
+                            annotation.rolename(),
+                            Set.of(annotation.permissions())
+                    );
+                });
+
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        SecurityTestUtils.clearSecurityContext();
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/security/SecurityTestUtils.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/SecurityTestUtils.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+package org.graylog2.security;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.SimpleAccount;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.authz.SimpleRole;
+import org.apache.shiro.authz.annotation.Logical;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.apache.shiro.authz.permission.WildcardPermission;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.realm.SimpleAccountRealm;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.ShiroSecurityContext;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SecurityTestUtils {
+
+    private static ShiroSecurityContext securityContext;
+
+    public static ShiroSecurityContext getSecurityContext() {
+        return securityContext;
+    }
+
+    public static void setSecurityContext(ShiroSecurityContext securityContext) {
+        SecurityTestUtils.securityContext = securityContext;
+    }
+
+    public static void setupSecurityContext(String username, String rolename, Set<String> permissions) {
+        String password = "test_password";
+
+        TestRealm realm = new TestRealm();
+        realm.addRole(rolename, permissions);
+        realm.addUser(username, password, rolename);
+
+        SecurityManager securityManager = new DefaultSecurityManager(realm);
+        SecurityUtils.setSecurityManager(securityManager);
+
+        Subject subject = SecurityUtils.getSubject();
+        UsernamePasswordToken token = new UsernamePasswordToken(username, password);
+        subject.login(token);
+
+        ThreadContext.bind(subject);
+
+        SecurityTestUtils.setSecurityContext(new ShiroSecurityContext(subject, token, true, null, new MultivaluedHashMap<>()));
+    }
+
+    public static void clearSecurityContext() {
+        ThreadContext.unbindSubject();
+        ThreadContext.unbindSecurityManager();
+        SecurityUtils.setSecurityManager(null);
+        SecurityTestUtils.setSecurityContext(null);
+    }
+
+
+    public static <T extends RestResource> T injectSecurityManager(T resource, Class<T> clazz) {
+        try {
+            Field securityContextField = RestResource.class.getDeclaredField("securityContext");
+            securityContextField.setAccessible(true);
+            securityContextField.set(resource, SecurityTestUtils.getSecurityContext());
+
+            return Mockito.mock(clazz, Mockito.withSettings()
+                    .spiedInstance(resource)
+                    .defaultAnswer(new PermissionInterceptor())
+            );
+
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static class PermissionInterceptor implements Answer<Object> {
+
+        @Override
+        public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+            if ((
+                    invocationOnMock.getMock().getClass().isAnnotationPresent(RequiresAuthentication.class) ||
+                            invocationOnMock.getMethod().isAnnotationPresent(RequiresAuthentication.class)
+            ) && (
+                    SecurityTestUtils.getSecurityContext() == null ||
+                            !SecurityTestUtils.getSecurityContext().getSubject().isAuthenticated()
+            )) {
+                throw new ForbiddenException("Not authenticated");
+            }
+            if (invocationOnMock.getMock().getClass().isAnnotationPresent(RequiresPermissions.class)) {
+                checkPermissions(invocationOnMock.getMock().getClass().getAnnotation(RequiresPermissions.class));
+            }
+            if (invocationOnMock.getMethod().isAnnotationPresent(RequiresPermissions.class)) {
+                checkPermissions(invocationOnMock.getMethod().getAnnotation(RequiresPermissions.class));
+            }
+            return invocationOnMock.callRealMethod();
+        }
+
+        private void checkPermissions(RequiresPermissions annotation) {
+            String[] requiredPermissions = annotation.value();
+            boolean[] permitted = SecurityTestUtils.getSecurityContext().getSubject().isPermitted(requiredPermissions);
+            if (annotation.logical().equals(Logical.AND) && ArrayUtils.contains(permitted, false)) {
+                throw new ForbiddenException("Not authorized. Necessary permissions are: " + String.join(",", requiredPermissions));
+            }
+            ;
+            if (annotation.logical().equals(Logical.OR) && !ArrayUtils.contains(permitted, true)) {
+                throw new ForbiddenException("Not authorized. Necessary permissions are: " + String.join(",", requiredPermissions));
+            }
+        }
+    }
+
+    static class TestRealm extends SimpleAccountRealm {
+
+
+        public void addRole(String roleName, Set<String> permissions) {
+            SimpleRole role = new SimpleRole(roleName, permissions.stream().map(WildcardPermission::new).collect(Collectors.toSet()));
+            super.add(role);
+        }
+
+        public void addUser(String userName, String password, String roleName) {
+            SimpleAccount user = new SimpleAccount(userName, password, getName(), Set.of(roleName), getRole(roleName).getPermissions());
+            super.add(user);
+        }
+
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/security/WithAuthorization.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/WithAuthorization.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+package org.graylog2.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface WithAuthorization {
+    String[] permissions() default {};
+
+    String username() default "test_user";
+
+    String rolename() default "test_role";
+}

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/content-pack-service-test-permissions.ini
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/content-pack-service-test-permissions.ini
@@ -1,0 +1,5 @@
+[users]
+test_user = administrator
+
+[roles]
+administrator = *

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/content-pack-service-test-permissions.ini
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/content-pack-service-test-permissions.ini
@@ -1,5 +1,0 @@
-[users]
-test_user = administrator
-
-[roles]
-administrator = *


### PR DESCRIPTION
## Description
Adds a `getCreatePermission` (optional) to the entity facades.
In the `ContentPackService` this permission is checked against the executing user.

Currently, the permission is only in place for inputs to ensure permissions for input and input type creation (see linked issue).

This can also be extended to deleting and creating content packs.

Currently, this is breaking some migrations as they use a `migration` user when installing content packs. As this user does not exist, this will throw an exception. The migrations need to be changed to use `configuration.getRootUsername() `

/nocl yet, wip

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/10479

## How Has This Been Tested?
adds some additional functionality for unit tests:

`@WithAuthorization` can be used to create a security context with an authenticated user with the given permissions in the current test

`SecurityTestUtils.injectSecurityManager()` can then additionally be used to check that all
- `@RequiresPermission`
- `@RequiresAuthentication`
- `RestResource.isPermitted()`
checks work as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

