### PR TITLE
Extend Icons props and add the default product name variable

### DIFF
--- a/graylog2-web-interface/src/brand-customization/useProductName.ts
+++ b/graylog2-web-interface/src/brand-customization/useProductName.ts
@@ -17,6 +17,8 @@
 
 import AppConfig from 'util/AppConfig';
 
-const useProductName = () => AppConfig.branding?.()?.product_name ?? 'Graylog';
+export const DEFAULT_PRODUCT_NAME = 'Graylog';
+
+const useProductName = () => AppConfig.branding?.()?.product_name ?? DEFAULT_PRODUCT_NAME;
 
 export default useProductName;

--- a/graylog2-web-interface/src/components/common/Icon/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon/Icon.tsx
@@ -29,6 +29,11 @@ const sizeMap = {
   '3x': '3.45em',
   '4x': '4.60em',
   '5x': '5.75em',
+  '6x': '6.90em',
+  '7x': '8.05em',
+  '8x': '9.20em',
+  '9x': '10.35em',
+  '10x': '11.50em',
 };
 
 const spinAnimation = keyframes`
@@ -95,19 +100,19 @@ type Props = {
 const Icon = ({
   name,
   type = 'solid',
-  size,
-  className,
+  size = undefined,
+  className = undefined,
   rotation = 0,
   spin = false,
-  flip,
-  style,
+  flip = undefined,
+  style = undefined,
   'data-testid': testId,
-  onClick,
-  onMouseEnter,
-  onMouseLeave,
-  onFocus,
-  tabIndex,
-  title,
+  onClick = undefined,
+  onMouseEnter = undefined,
+  onMouseLeave = undefined,
+  onFocus = undefined,
+  tabIndex = undefined,
+  title = undefined,
 }: Props) => (
   <StyledSpan
     className={`material-symbols-rounded ${className ?? ''}`}

--- a/graylog2-web-interface/src/components/common/Icon/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon/Icon.tsx
@@ -29,11 +29,7 @@ const sizeMap = {
   '3x': '3.45em',
   '4x': '4.60em',
   '5x': '5.75em',
-  '6x': '6.90em',
-  '7x': '8.05em',
-  '8x': '9.20em',
-  '9x': '10.35em',
-  '10x': '11.50em',
+  'huge': '10.35em',
 };
 
 const spinAnimation = keyframes`

--- a/graylog2-web-interface/src/components/common/Icon/types.ts
+++ b/graylog2-web-interface/src/components/common/Icon/types.ts
@@ -17,7 +17,7 @@
 
 import type { MaterialSymbol as IconName } from 'material-symbols';
 
-export type SizeProp = 'xs' | 'sm' | 'lg' | 'xl' | '2x' | '3x' | '4x' | '5x';
+export type SizeProp = 'xs' | 'sm' | 'lg' | 'xl' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x';
 export type RotateProp = 0 | 90 | 180 | 270;
 export type FlipProp = 'horizontal' | 'vertical' | 'both';
 export type IconType = 'regular' | 'solid';

--- a/graylog2-web-interface/src/components/common/Icon/types.ts
+++ b/graylog2-web-interface/src/components/common/Icon/types.ts
@@ -17,7 +17,7 @@
 
 import type { MaterialSymbol as IconName } from 'material-symbols';
 
-export type SizeProp = 'xs' | 'sm' | 'lg' | 'xl' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x' | '10x';
+export type SizeProp = 'xs' | 'sm' | 'lg' | 'xl' | '2x' | '3x' | '4x' | '5x' | 'huge';
 export type RotateProp = 0 | 90 | 180 | 270;
 export type FlipProp = 'horizontal' | 'vertical' | 'both';
 export type IconType = 'regular' | 'solid';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds:
- More sizes for the Icon component. Now we will have a size up to `x10`
- default product name variable, which we can import in other places 

## Motivation and Context
These changes we need to finish https://github.com/Graylog2/graylog-plugin-enterprise/issues/10582

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl