### PR TITLE
Default to AdaptiveCard Schema v1.5 in TeamsNotificationV2 (`6.0`)

### DIFF
--- a/changelog/unreleased/pr-22571.toml
+++ b/changelog/unreleased/pr-22571.toml
@@ -1,0 +1,4 @@
+type = "c"
+message = "Changed default AdaptiveCard schema version to 1.5 from 1.6 in Microsoft Teams Notification v2 template."
+
+pulls = ["22571"]

--- a/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/TeamsNotificationV2Form.tsx
+++ b/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/TeamsNotificationV2Form.tsx
@@ -37,14 +37,15 @@ class TeamsNotificationV2Form extends React.Component<TeamsNotificationFormV2Typ
   static defaultConfig = {
     webhook_url: '',
     /* eslint-disable no-template-curly-in-string */
-    adaptive_card: '{\n'
+    adaptive_card:
+      '{\n'
       + '  "type": "message",\n'
       + '  "attachments": [\n'
       + '    {\n'
       + '      "contentType": "application/vnd.microsoft.card.adaptive",\n'
       + '      "content": {\n'
       + '        "type": "AdaptiveCard",\n'
-      + '        "version": "1.6",\n'
+      + '        "version": "1.5",\n'
       + '        "msTeams": { "width": "full" },\n'
       + '        "body": [\n'
       + '          {\n'


### PR DESCRIPTION
Note: This is a backport of #22571 to `6.0`.

## Description
<!--- Describe your changes in detail -->
Set the default schema version of the `Microsoft Teams Notification V2` AdaptiveCard to the most recent supported version 1.5. 1.6 is not currently fully supported in Teams.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A user pointed out that schema version 1.6 AdaptiveCard was not being displayed properly in their Teams messages. Reverting the schema version to 1.5 resolved the issue. After investigation, [Microsoft Teams currently supports schema version 1.5](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#adaptive-card) fully so this change is to allow new notifications to work out of the box.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

