### PR TITLE
Fixing the url generation to the entity in the sharing modal for reports

### DIFF
--- a/graylog2-web-interface/src/routing/hooks/useShowRouteForEntity.ts
+++ b/graylog2-web-interface/src/routing/hooks/useShowRouteForEntity.ts
@@ -69,7 +69,7 @@ const useShowRouteForEntity = (id: string, type: string) => {
     case 'search_filter':
       return Routes.getPluginRoute('MY-FILTERS_DETAILS_FILTERID')?.(id);
     case 'report':
-      return Routes.getPluginRoute('REPORTS_REPORTID_CONFIGURATION')?.(id);
+      return Routes.getPluginRoute('REPORTS_REPORTID_ARCHIVE')?.(id);
     case 'role':
       return Routes.SYSTEM.AUTHZROLES.show(id);
     case 'output':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, the newly added entity sharing button for reports showed the wrong URL that can be used to directly link to the report.

/nocl as the sharing on reports is a new, unreleased feature

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

