### PR TITLE
Fix Sharing notification message string

### DIFF
--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
@@ -88,7 +88,7 @@ const EntityShareModal = ({
       app_pathname: entityType,
     });
 
-    EntityShareDomain.update(entityType, entityTitle, entityGRN, payload).then(() => {
+    EntityShareDomain.update(entityTitle, entityType, entityGRN, payload).then(() => {
       setDisableSubmit(true);
       onClose();
     });

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.tsx
@@ -88,7 +88,7 @@ const EntityShareModal = ({
       app_pathname: entityType,
     });
 
-    EntityShareDomain.update(entityTitle, entityType, entityGRN, payload).then(() => {
+    EntityShareDomain.update(entityType, entityTitle, entityGRN, payload).then(() => {
       setDisableSubmit(true);
       onClose();
     });

--- a/graylog2-web-interface/src/domainActions/permissions/EntityShareDomain.ts
+++ b/graylog2-web-interface/src/domainActions/permissions/EntityShareDomain.ts
@@ -20,17 +20,17 @@ import notifyingAction from '../notifyingAction';
 
 const prepare = notifyingAction({
   action: EntityShareActions.prepare,
-  error: (error, entityName, entityType) => ({
+  error: (error, entityType, entityName) => ({
     message: `Preparing shares for ${entityType} "${entityName}" failed with status: ${error}`,
   }),
 });
 
 const update = notifyingAction({
   action: EntityShareActions.update,
-  error: (error, entityName, entityType) => ({
+  error: (error, entityType, entityName) => ({
     message: `Updating shares for ${entityType} "${entityName}" failed with status: ${error}`,
   }),
-  success: (entityName, entityType) => ({
+  success: (entityType, entityName) => ({
     message: `Shares for ${entityType} "${entityName}" updated successfully`,
   }),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this change, the message shown when finishing sharing an object was wrong:
In place of the title, the entity type was printed and in place of the type was the entity name.
See https://github.com/Graylog2/graylog-plugin-enterprise/pull/10627#pullrequestreview-2836872800 for an example.

/nocl because it's a small change/fix that does not really impact anything 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

