### PR TITLE
Allow events search per default only on the default events stream

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
@@ -65,9 +65,8 @@ public class EventsSearchService {
             return eventStreams;
         }
 
-        return eventStreams.stream()
-                .filter(streamId -> subject.isPermitted(String.join(":", RestPermissions.STREAMS_READ, streamId)))
-                .collect(Collectors.toSet());
+        return subject.isPermitted(String.join(":", RestPermissions.STREAMS_READ, DEFAULT_SYSTEM_EVENTS_STREAM_ID)) ?
+                eventStreams : Set.of(DEFAULT_EVENTS_STREAM_ID);
     }
 
     public EventsSearchResult search(EventsSearchParameters parameters, Subject subject) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchService.java
@@ -65,8 +65,9 @@ public class EventsSearchService {
             return eventStreams;
         }
 
-        return subject.isPermitted(String.join(":", RestPermissions.STREAMS_READ, DEFAULT_SYSTEM_EVENTS_STREAM_ID)) ?
-                eventStreams : Set.of(DEFAULT_EVENTS_STREAM_ID);
+        return eventStreams.stream()
+                .filter(streamId -> subject.isPermitted(String.join(":", RestPermissions.STREAMS_READ, streamId)) || streamId.equals(DEFAULT_EVENTS_STREAM_ID))
+                .collect(Collectors.toSet());
     }
 
     public EventsSearchResult search(EventsSearchParameters parameters, Subject subject) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes the necessity to share the Default Event stream (introduced by https://github.com/Graylog2/graylog2-server/pull/22488) which leads to full visibility of the whole stream to the user. This is no longer necessary with this PR.

For the System Event stream, this is still needed (sharing) and the assumption is, that if you want to see these in the Alerts & Events page, the user should also be able to search this stream with our regular functionality.
(Which is different from the Default Event stream handling then)


/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

