### PR TITLE
Using correct class when casting alerts histogram result on ES7

### DIFF
--- a/changelog/unreleased/issue-22618.toml
+++ b/changelog/unreleased/issue-22618.toml
@@ -1,0 +1,5 @@
+type="f"
+message="Fixing Alerts & Events histogram on Elasticsearch 7."
+
+pulls = ["22622"]
+issues = ["22618"]

--- a/full-backend-tests/src/test/java/org/graylog/events/rest/EventsResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/events/rest/EventsResourceIT.java
@@ -1,0 +1,32 @@
+package org.graylog.events.rest;
+
+import org.graylog.testing.completebackend.Lifecycle;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.containermatrix.SearchServer;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
+import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfiguration;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+@ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, searchVersions = {SearchServer.DATANODE_DEV, SearchServer.OS2_LATEST, SearchServer.ES7})
+public class EventsResourceIT {
+    private final GraylogApis api;
+
+    public EventsResourceIT(GraylogApis graylogApis) {
+        this.api = graylogApis;
+    }
+
+    @ContainerMatrixTest
+    void testDefaultRequest() {
+        given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .post("/events/histogram", Map.of())
+                .then()
+                .statusCode(HTTP_OK);
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/events/rest/EventsResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/events/rest/EventsResourceIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.events.rest;
 
 import org.graylog.testing.completebackend.Lifecycle;

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -38,7 +38,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.b
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ExtendedBounds;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ParsedAutoDateHistogram;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.FieldSortBuilder;
@@ -188,7 +188,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
 
         final SearchResponse searchResult = client.search(searchRequest, "Unable to perform search query");
 
-        final ParsedAutoDateHistogram histogramResult = searchResult.getAggregations().get(histogramAggregationName);
+        final ParsedDateHistogram histogramResult = searchResult.getAggregations().get(histogramAggregationName);
         final var histogramBuckets = histogramResult.getBuckets();
 
         final var alerts = new ArrayList<MoreSearch.Histogram.Bucket>(histogramBuckets.size());


### PR DESCRIPTION
**Note:** This needs to be backported to `6.2.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue as reported in #22618, where the Events histogram did not work on ES7, due to the result being casted to the wrong result class. This PR is now adding a test to reproduce this and fixes the class used for casting.

Fixes #22618.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.