### PR TITLE
Fix AWS CloudTrail input to support IAM temporary security credentials

### DIFF
--- a/changelog/unreleased/issue-22086.toml
+++ b/changelog/unreleased/issue-22086.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix AWS CloudTrail input to support IAM temporary security credentials."
+
+issues = ["22086"]

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
@@ -111,7 +111,14 @@ public class CloudTrailRecord implements Serializable {
 
     public String getConstructedMessage() {
         return eventSource + ":" + eventName + " in " + awsRegion + " by " + sourceIPAddress + " / " +
-                Optional.ofNullable(userIdentity).map(i -> i.userName).orElse("<unknown user_name>");
+                Optional.ofNullable(userIdentity)
+                        .map(ui -> ui.userName != null ? ui.userName :
+                                Optional.ofNullable(ui.sessionContext)
+                                        .map(sc -> sc.sessionIssuer)
+                                        .map(issuer -> issuer.userName)
+                                        .orElse(null)
+                        )
+                        .orElse("<unknown user_name>");
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
@@ -52,6 +52,14 @@ public class CloudTrailUserIdentity {
             m.put("user_session_mfa_authenticated", Boolean.valueOf(sessionContext.attributes.mfaAuthenticated));
         }
 
+        if (sessionContext != null && sessionContext.sessionIssuer != null) {
+            m.put("user_type", sessionContext.sessionIssuer.type);
+            m.put("user_name", sessionContext.sessionIssuer.userName);
+            m.put("user_principal_id", sessionContext.sessionIssuer.principalId);
+            m.put("user_principal_arn", sessionContext.sessionIssuer.arn);
+            m.put("user_account_id", sessionContext.sessionIssuer.accountId);
+        }
+
         return m;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrialSessionContextIssuer.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrialSessionContextIssuer.java
@@ -18,10 +18,16 @@ package org.graylog.aws.inputs.cloudtrail.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class CloudTrailSessionContext {
-    @JsonProperty("attributes")
-    public CloudTrailSessionContextAttributes attributes;
-    @JsonProperty("sessionIssuer")
-    public CloudTrialSessionContextIssuer sessionIssuer;
+public class CloudTrialSessionContextIssuer {
+    @JsonProperty("type")
+    public String type;
+    @JsonProperty("principalId")
+    public String principalId;
+    @JsonProperty("arn")
+    public String arn;
+    @JsonProperty("accountId")
+    public String accountId;
+    @JsonProperty("userName")
+    public String userName;
 
 }

--- a/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/static_credentials.json
+++ b/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/static_credentials.json
@@ -1,0 +1,29 @@
+{
+  "eventVersion": "1.08",
+  "userIdentity": {
+    "type": "IAMUser",
+    "principalId": "AIDAJ45Q7YFFAREXAMPLE",
+    "arn": "arn:aws:iam::123456789012:user/Alice",
+    "accountId": "123456789012",
+    "accessKeyId": "",
+    "userName": "Alice"
+  },
+  "eventTime": "2021-09-01T12:00:00Z",
+  "eventSource": "signin.amazonaws.com",
+  "eventName": "ConsoleLogin",
+  "awsRegion": "us-west-2",
+  "sourceIPAddress": "192.168.1.1",
+  "userAgent": "Mozilla/5.0",
+  "requestParameters": null,
+  "responseElements": {
+    "ConsoleLogin": "Success"
+  },
+  "additionalEventData": {
+    "LoginTo": "https://console.aws.amazon.com/console/home",
+    "MobileVersion": "Yes",
+    "MFAUsed": "No"
+  },
+  "eventID": "abc12345-6789-4321-aaaa-bbbbccccdddd",
+  "eventType": "AwsConsoleSignIn",
+  "recipientAccountId": "123456789012"
+}

--- a/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/temporary_credentials.json
+++ b/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/temporary_credentials.json
@@ -1,0 +1,41 @@
+{
+  "eventVersion": "1.08",
+  "userIdentity": {
+    "type": "AssumedRole",
+    "principalId": "AROAIDPPEZS35WEXAMPLE:AssumedRoleSessionName",
+    "arn": "arn:aws:sts::123456789012:assumed-role/someTestUser/MySessionName",
+    "accountId": "123456789012",
+    "accessKeyId": "",
+    "sessionContext": {
+      "sessionIssuer": {
+        "type": "Role",
+        "principalId": "AROAIDPPEZS35WEXAMPLE",
+        "arn": "arn:aws:iam::123456789012:role/someTestUser",
+        "accountId": "123456789012",
+        "userName": "someTestUser"
+      },
+      "attributes": {
+        "mfaAuthenticated": "false",
+        "creationDate": "2013-11-02T01:06:28Z"
+      }
+    }
+  },
+  "eventTime": "2021-09-01T13:00:00Z",
+  "eventSource": "signin.amazonaws.com",
+  "eventName": "ConsoleLogin",
+  "awsRegion": "us-east-2",
+  "sourceIPAddress": "10.0.0.1",
+  "userAgent": "Mozilla/5.0",
+  "requestParameters": null,
+  "responseElements": {
+    "ConsoleLogin": "Success"
+  },
+  "additionalEventData": {
+    "LoginTo": "https://console.aws.amazon.com/billing",
+    "MobileVersion": "No",
+    "MFAUsed": "Yes"
+  },
+  "eventID": "xyz98765-4321-aaaa-bbbb-ccccddddeeee",
+  "eventType": "AwsConsoleSignIn",
+  "recipientAccountId": "123456789012"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
->  UserIdentity element is different when using Simple IAM credentials and Temporary Security credentials.Previously,
 code supports only Simple IAM credentials. When using temporary Security credentials some message fields are missing.Now the latest code changes will support both Simple IAM credentials as well as Temporary Security credentials and message fields are extracted properly. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
->  Fix AWS Cloud Trail Input to support temporary security credentials.Previously, this input only support Simple IAM credentials.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
-> Added test cases to check the parsing of the temporary security credentials as well as Simple IAM credentials. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

