### PR TITLE
Input wizard: Check only permissions for referenced streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -173,12 +173,12 @@ public class InputsResource extends AbstractInputsResource {
     public InputReferences getReferences(@ApiParam(name = "inputId", required = true)
                                              @PathParam("inputId") String inputId) {
         checkPermission(RestPermissions.INPUTS_READ, inputId);
-        checkPermission(RestPermissions.STREAMS_READ);
         checkPermission(PipelineRestPermissions.PIPELINE_READ);
 
         return new InputReferences(inputId,
                 streamRuleService.loadForInput(inputId).stream()
                         .map(StreamRule::getStreamId)
+                        .peek(streamId -> checkPermission(RestPermissions.STREAMS_READ, streamId))
                         .distinct()
                         .map(streamId -> new InputReference(streamId, streamService.streamTitleFromCache(streamId)))
                         .toList(),

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceTest.java
@@ -18,7 +18,8 @@ package org.graylog2.rest.resources.system.inputs;
 
 import jakarta.annotation.Nullable;
 import jakarta.ws.rs.BadRequestException;
-import org.apache.shiro.subject.Subject;
+import jakarta.ws.rs.ForbiddenException;
+import org.assertj.core.api.Assertions;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
@@ -30,6 +31,8 @@ import org.graylog2.inputs.diagnosis.InputDiagnosticService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.rest.models.system.inputs.requests.InputCreateRequest;
+import org.graylog2.security.WithAuthorization;
+import org.graylog2.security.WithAuthorizationExtension;
 import org.graylog2.shared.inputs.MessageInputFactory;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
@@ -50,12 +53,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(WithAuthorizationExtension.class)
+@WithAuthorization(permissions = {"*"})
 class InputsResourceTest {
 
     @Mock
@@ -82,7 +86,7 @@ class InputsResourceTest {
     @Mock
     MessageInput messageInput;
 
-    InputsResource inputsResource;
+    InputsTestResource inputsResource;
 
     @BeforeEach
     public void setUp() {
@@ -128,6 +132,7 @@ class InputsResourceTest {
     }
 
     @Test
+    @WithAuthorization(permissions = {"inputs:read", "pipeline:read", "streams:read:streamId1", "streams:read:streamId2"})
     void testStreamReferences() {
         when(streamRuleService.loadForInput("inputId")).thenReturn(List.of(
                 new StreamRuleMock(Map.of("_id", "ruleId1", "stream_id", "streamId1")),
@@ -144,6 +149,18 @@ class InputsResourceTest {
 
         assertThat(refs.streamRefs()).hasSize(2);
         assertThat(refs.streamRefs()).containsAll(expected);
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"inputs:read", "pipeline:read", "streams:read:streamId1"})
+    void testStreamReferencesPermissionFailsIfNotPermitted() {
+        when(streamRuleService.loadForInput("inputId")).thenReturn(List.of(
+                new StreamRuleMock(Map.of("_id", "ruleId1", "stream_id", "streamId1")),
+                new StreamRuleMock(Map.of("_id", "ruleId2", "stream_id", "streamId2"))
+        ));
+        when(streamService.streamTitleFromCache("streamId1")).thenReturn("streamTitle1");
+
+        Assertions.assertThatThrownBy(() -> inputsResource.getReferences("inputId")).isInstanceOf(ForbiddenException.class);
     }
 
     @Test
@@ -171,7 +188,6 @@ class InputsResourceTest {
     static class InputsTestResource extends InputsResource {
 
         private final User user;
-        private final Subject subject;
 
         public InputsTestResource(InputService inputService,
                                   StreamService streamService,
@@ -188,13 +204,6 @@ class InputsResourceTest {
             lenient().when(user.getName()).thenReturn("foo");
             lenient().when(configuration.getHttpPublishUri()).thenReturn(URI.create("http://localhost"));
 
-            this.subject = mock(Subject.class);
-            lenient().when(subject.isPermitted(anyString())).thenReturn(true);
-        }
-
-        @Override
-        protected Subject getSubject() {
-            return subject;
         }
 
         @Nullable


### PR DESCRIPTION
## Description
When getting the stream references for an input, a permission check for `streams:read` was in place. 
Thus, the input wizard fails for users that have only permissions to read shared streams.

The permission check has been moved to only check the actual referenced streams instead of the catch-all permission.

/nocl

## Motivation and Context
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10757

## How Has This Been Tested?
added unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

