### PR TITLE
Close Threat Intelligence Lookup Configuration modal on cancel.

### DIFF
--- a/changelog/unreleased/pr-22643.toml
+++ b/changelog/unreleased/pr-22643.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Close threat intelligence lookup configuration modal, located on system overview page, on cancel."
+
+pulls = ["22643"]

--- a/graylog2-web-interface/src/threatintel/components/ThreatIntelPluginConfig.tsx
+++ b/graylog2-web-interface/src/threatintel/components/ThreatIntelPluginConfig.tsx
@@ -63,6 +63,7 @@ const ThreatIntelPluginConfig = ({ config: initialConfig = defaultConfig, update
   const _resetConfig = () => {
     // Reset to initial state when the modal is closed without saving.
     setConfig(initialConfig);
+    _closeModal();
   };
 
   const _saveConfig = () => {


### PR DESCRIPTION
**Please note**, this PR needs to be backported.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change the modal did not close when clicking the cancel or close button.

<img width="636" alt="image" src="https://github.com/user-attachments/assets/ccb02e21-3d41-46d6-ad54-e6345705deb6" />
