### PR TITLE
Add ignoreExtraCsvValues option for the csv_to_map pipeline function

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/CsvMapConversion.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/CsvMapConversion.java
@@ -40,7 +40,6 @@ import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescr
 public class CsvMapConversion extends AbstractFunction<Map> {
     private final Logger log = LoggerFactory.getLogger(CsvMapConversion.class);
 
-
     public static final String NAME = "csv_to_map";
     private static final String VALUE = "value";
 
@@ -52,7 +51,7 @@ public class CsvMapConversion extends AbstractFunction<Map> {
     private final ParameterDescriptor<Boolean, Boolean> strictQuotesParam;
     private final ParameterDescriptor<Boolean, Boolean> trimParam;
     private final ParameterDescriptor<Boolean, Boolean> ignoreExtraFieldNamesParam;
-
+    private final ParameterDescriptor<Boolean, Boolean> ignoreExtraCsvValuesParam;
 
     public CsvMapConversion() {
         this.valueParam = string(VALUE).ruleBuilderVariable().description("Map-like value to convert").build();
@@ -63,6 +62,7 @@ public class CsvMapConversion extends AbstractFunction<Map> {
         this.strictQuotesParam = bool("strictQuotes").optional().description("Ignore content outside of quotes").defaultValue(Optional.of(false)).build();
         this.trimParam = bool("trimLeadingWhitespace").optional().description("Trim leading whitespace").defaultValue(Optional.of(false)).build();
         this.ignoreExtraFieldNamesParam = bool("ignoreExtraFieldNames").optional().description("Ignore extra fieldName values, which do not have a corresponding value.").defaultValue(Optional.of(false)).build();
+        this.ignoreExtraCsvValuesParam = bool("ignoreExtraCsvValues").optional().description("Ignore extra values, which do not have a corresponding field name.").defaultValue(Optional.of(false)).build();
     }
 
     private Character getFirstChar(String s) {
@@ -81,6 +81,7 @@ public class CsvMapConversion extends AbstractFunction<Map> {
         final boolean strictQuotes = strictQuotesParam.optional(args, context).orElse(false);
         final boolean trimLeadingWhiteSpace = trimParam.optional(args, context).orElse(true);
         final boolean ignoreExtraFieldNames = ignoreExtraFieldNamesParam.optional(args, context).orElse(false);
+        final boolean ignoreExtraCsvValues = ignoreExtraCsvValuesParam.optional(args, context).orElse(false);
 
         final CSVParser parser = new CSVParser(separator,
                 quoteChar,
@@ -97,21 +98,32 @@ public class CsvMapConversion extends AbstractFunction<Map> {
 
             final Map<String, String> map = Maps.newHashMap();
             try {
-                final String[] strings = parser.parseLine(value);
+                final String[] values = parser.parseLine(value);
 
-                if (ignoreExtraFieldNames) {
-                    if (strings.length > fieldNames.length) {
+                if (ignoreExtraFieldNames && !ignoreExtraCsvValues) {
+                    if (values.length > fieldNames.length) {
                         log.error("More columns of CSV data ({}) were specified than field names ({}). Discarding input.",
-                                strings.length, fieldNames.length);
+                                values.length, fieldNames.length);
                         return Collections.emptyMap();
                     }
-                } else if (strings.length != fieldNames.length) {
+                } else if (!ignoreExtraFieldNames && ignoreExtraCsvValues) {
+                    if (values.length < fieldNames.length) {
+                        log.error("More field names ({}) were specified than columns of CSV data ({}). Discarding input.",
+                                values.length, fieldNames.length);
+                        return Collections.emptyMap();
+                    }
+                } else if (values.length != fieldNames.length) {
                     log.error("Different number of columns in CSV data ({}) and configured field names ({}). Discarding input.",
-                            strings.length, fieldNames.length);
+                            values.length, fieldNames.length);
                     return Collections.emptyMap();
                 }
-                for (int i = 0; i < strings.length; i++) {
-                    map.put(fieldNames[i], strings[i]);
+
+                for (int i = 0; i < values.length; i++) {
+                    // When ignoring extra CSV values, skip iterations where a matching column header is not present.
+                    if (ignoreExtraCsvValues && i >= fieldNames.length) {
+                        continue;
+                    }
+                    map.put(fieldNames[i], values[i]);
                 }
             } catch (IOException e) {
                 log.error("Invalid CSV input, discarding input", e);
@@ -123,8 +135,6 @@ public class CsvMapConversion extends AbstractFunction<Map> {
             log.error("Error parsing csv: {}", e.getMessage());
             return Collections.emptyMap();
         }
-
-
     }
 
     @Override
@@ -139,7 +149,8 @@ public class CsvMapConversion extends AbstractFunction<Map> {
                         escapeCharParam,
                         strictQuotesParam,
                         trimParam,
-                        ignoreExtraFieldNamesParam
+                        ignoreExtraFieldNamesParam,
+                        ignoreExtraCsvValuesParam
                 ))
                 .description("Converts a single line of a CSV string into a map usable by set_fields()")
                 .ruleBuilderEnabled()

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1614,6 +1614,11 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("ignore_extra_field_names_k2")).isEqualTo("v2");
         assertThat(message.getField("ignore_extra_field_names_k3")).isEqualTo("v3");
         assertThat(message.getField("ignore_extra_field_names_k4")).isNull();
+
+        // When extra values are ignored, extra specified values should be permitted (and ignored).
+        assertThat(message.getField("ignore_extra_values_k1")).isEqualTo("v1");
+        assertThat(message.getField("ignore_extra_values_k2")).isEqualTo("v2");
+        assertThat(message.getField("ignore_extra_values_k3")).isEqualTo("v3");
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/csvMap.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/csvMap.txt
@@ -73,4 +73,12 @@ then
         );
     set_fields(fields: map, prefix: "ignore_extra_field_names_");
 
+        let csv = "v1,v2,v3,v4";
+            let map =  csv_to_map(
+                value: csv,
+                fieldNames: "k1,k2,k3",
+                ignoreExtraCsvValues: true
+            );
+    set_fields(fields: map, prefix: "ignore_extra_values_");
+
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add new `ignoreExtraCsvValues` option for the `csv_to_map` pipeline function. 

Closes https://github.com/Graylog2/graylog2-server/issues/22522.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes, incoming Palo Alto CSV data has extra columns of data (see https://github.com/Graylog2/graylog2-server/issues/22522). This allows those extra columns to be gracefully ignored.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, manual testing.