### PR TITLE
Support date formatting in jmte templates (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-22296.toml
+++ b/changelog/unreleased/issue-22296.toml
@@ -1,0 +1,5 @@
+type="a"
+message="Add support for date formatting in JMTE templates for custom notification bodies."
+
+pulls = ["22632"]
+issues = ["22296"]

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -32,6 +32,7 @@ import org.graylog2.alerts.AlertSender;
 import org.graylog2.alerts.EmailRecipients;
 import org.graylog2.alerts.FormattedEmailAlertSender;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
+import org.graylog2.bindings.providers.DefaultJmteEngineProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
 import org.graylog2.bindings.providers.HtmlSafeJmteEngineProvider;
@@ -194,7 +195,7 @@ public class ServerBindings extends Graylog2Module {
         bind(ClusterStatsModule.class).asEagerSingleton();
         bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class).asEagerSingleton();
         bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
-        bind(Engine.class).toInstance(Engine.createEngine());
+        bind(Engine.class).toProvider(DefaultJmteEngineProvider.class).asEagerSingleton();
         bind(Engine.class).annotatedWith(Names.named("HtmlSafe")).toProvider(HtmlSafeJmteEngineProvider.class).asEagerSingleton();
         bind(Engine.class).annotatedWith(Names.named("JsonSafe")).toProvider(JsonSafeEngineProvider.class).asEagerSingleton();
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultJmteEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultJmteEngineProvider.java
@@ -17,37 +17,23 @@
 package org.graylog2.bindings.providers;
 
 import com.floreysoft.jmte.Engine;
-import com.floreysoft.jmte.Renderer;
-import com.google.common.html.HtmlEscapers;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.graylog2.jmte.NamedDateRenderer;
 
-import java.util.Locale;
-import java.util.Map;
-
-
 @Singleton
-public class HtmlSafeJmteEngineProvider implements Provider<Engine> {
+public class DefaultJmteEngineProvider implements Provider<Engine> {
     private final Engine engine;
 
     @Inject
-    public HtmlSafeJmteEngineProvider() {
+    public DefaultJmteEngineProvider() {
         engine = Engine.createEngine();
         engine.registerNamedRenderer(new NamedDateRenderer());
-        engine.registerRenderer(String.class, new HtmlSafeRenderer());
     }
 
     @Override
     public Engine get() {
         return engine;
-    }
-
-    private static class HtmlSafeRenderer implements Renderer<String> {
-        @Override
-        public String render(String value, Locale locale, Map<String, Object> model) {
-            return HtmlEscapers.htmlEscaper().escape(value);
-        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JsonSafeEngineProvider.java
@@ -22,6 +22,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.graylog2.jmte.NamedDateRenderer;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -35,6 +36,7 @@ public class JsonSafeEngineProvider implements Provider<Engine> {
     @Inject
     public JsonSafeEngineProvider() {
         engine = Engine.createEngine();
+        engine.registerNamedRenderer(new NamedDateRenderer());
         engine.registerRenderer(String.class, new JsonSafeRenderer());
         engine.registerRenderer(Map.class, new JsonSafeMapRenderer());
         engine.registerRenderer(Iterable.class, new JsonSafeIterableRenderer());

--- a/graylog2-server/src/main/java/org/graylog2/jmte/NamedDateRenderer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jmte/NamedDateRenderer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.jmte;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Locale;
+import java.util.Map;
+
+public class NamedDateRenderer implements NamedRenderer {
+    private static final Logger LOG = LoggerFactory.getLogger(NamedDateRenderer.class);
+    private static final String DEFAULT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private static final String RENDERER_DESCRIPTION = "Use Java date format patterns like yyyy-MM-dd or HH:mm:ss";
+
+    private DateTime convert(Object o) throws ParseException {
+        if (o == null) {
+            return null;
+        }
+
+        if (o instanceof DateTime) {
+            return (DateTime) o;
+        } else if (o instanceof Number) {
+            long longValue = ((Number) o).longValue();
+            return new DateTime(longValue, DateTimeZone.UTC);
+        } else if (o instanceof String) {
+            return DateTime.parse((String) o);
+        }
+        return null;
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return new DateRendererFormatInfo(RENDERER_DESCRIPTION, DEFAULT_PATTERN);
+    }
+
+    @Override
+    public String getName() {
+        return "date";
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class[] { DateTime.class, String.class, Integer.class, Long.class };
+    }
+
+    @Override
+    public String render(Object o, String pattern, Locale locale, Map<String, Object> model) {
+        String formatPattern = pattern != null ? pattern : DEFAULT_PATTERN;
+        try {
+            final DateTime value = convert(o);
+            if (value != null) {
+                final DateTimeFormatter formatter = locale != null
+                        ? DateTimeFormat.forPattern(formatPattern).withLocale(locale)
+                        : DateTimeFormat.forPattern(formatPattern);
+
+                return formatter.print(value);
+            } else {
+                LOG.warn("Failed to convert [{}] to a date object for formatting.", o);
+            }
+        } catch (ParseException pe) {
+            LOG.warn("Failed to convert [{}] to a date object for formatting.", o, pe);
+        } catch (Exception e) {
+            LOG.warn("Failed to format [{}] as a date string with format [{}]", o, formatPattern, e);
+        }
+        return o.toString();
+
+    }
+}
+
+record DateRendererFormatInfo(String description, String defaultFormat) implements RenderFormatInfo {}

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPEventNotificationV2Test.java
@@ -16,10 +16,10 @@
  */
 package org.graylog.events.notifications.types;
 
-import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableList;
 import org.graylog.events.configuration.EventsConfigurationProvider;
 import org.graylog.events.notifications.EventNotificationService;
+import org.graylog2.bindings.providers.DefaultJmteEngineProvider;
 import org.graylog2.bindings.providers.JsonSafeEngineProvider;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
@@ -69,7 +69,7 @@ public class HTTPEventNotificationV2Test {
     void setUp() {
         notification = new HTTPEventNotificationV2(notificationCallbackService, objectMapperProvider,
                 whitelistService, urlWhitelistNotificationService, encryptedValueService, configurationProvider,
-                new Engine(), new JsonSafeEngineProvider().get(), notificationService, nodeId,
+                new DefaultJmteEngineProvider().get(), new JsonSafeEngineProvider().get(), notificationService, nodeId,
                 parameterizedHttpClientProvider);
     }
 
@@ -115,6 +115,27 @@ public class HTTPEventNotificationV2Test {
         assertThat(body).contains("\\\"list_value1\\\"");
     }
 
+    @Test
+    public void testDateFormatting() {
+        Map<String, Object> model = Map.of(
+                "event_definition_title", "<<Test Event Title>>",
+                "backlog", createBacklog(),
+                "event", createEvent()
+        );
+
+        String bodyTemplate = "formatted date: ${event.event_time;date(yyyy-MM-dd HH:mm:ss)}";
+        String body = notification.transformBody(bodyTemplate, HTTPEventNotificationConfigV2.ContentType.PLAIN_TEXT, model);
+        assertThat(body).isEqualTo("formatted date: 2025-04-02 15:37:46");
+
+        bodyTemplate = "{\"formatted date\": \"${event.event_time;date(HH:mm:ss)}\"}";
+        body = notification.transformBody(bodyTemplate, HTTPEventNotificationConfigV2.ContentType.JSON, model);
+        assertThat(body).isEqualTo("{\"formatted date\": \"15:37:46\"}");
+
+        bodyTemplate = "formatted_date=${event.event_time;date(dd-MM-yyyy)}";
+        body = notification.transformBody(bodyTemplate, HTTPEventNotificationConfigV2.ContentType.FORM_DATA, model);
+        assertThat(body).isEqualTo("formatted_date=02-04-2025");
+    }
+
     private ImmutableList<MessageSummary> createBacklog() {
         Message message = new TestMessageFactory().createMessage("Message with \"Double Quotes\"", "Unit Test", DateTime.now(DateTimeZone.UTC));
         MessageSummary summary = new MessageSummary("index1", message);
@@ -130,6 +151,7 @@ public class HTTPEventNotificationV2Test {
         event.put("message", "Event Message & Whatnot");
         event.put("fields", fields);
         event.put("list_field", List.of("\"list_value1\"", "\"list_value2\""));
+        event.put("event_time", DateTime.parse("2025-04-02T15:37:46.717Z"));
         return event;
     }
 


### PR DESCRIPTION
Note: This is a backport of #22632 to `6.1`.

## Description
<!--- Describe your changes in detail -->
Add `NamedDateRenderer` to JMTE Engine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows use of custom date formatting inside of custom notification templates.

closes #22296 
closes Graylog2/support#210
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local dev env, unit test
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

