### PR TITLE
Fix alerts page if Enterprise plugin is not present.

### DIFF
--- a/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
+++ b/graylog2-web-interface/src/components/events/EventsPageNavigation.tsx
@@ -29,7 +29,7 @@ const EventsPageNavigation = () => {
 
   const {
     data: { valid: validSecurityLicense, violated: violatedSecurityLicense },
-  } = pluggableLicenseCheck[0]('/license/security');
+  } = pluggableLicenseCheck?.[0]?.('/license/security') ?? { data: { valid: false, violated: false } };
 
   const hasEventProceduresPlugin =
     pluggableEventProcedures !== undefined &&

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -642,6 +642,6 @@ declare module 'graylog-web-plugin/plugin' {
     'views.queryInput.commandContextProviders'?: Array<CustomCommandContextProvider<any>>;
     visualizationTypes?: Array<VisualizationType<any>>;
     widgetCreators?: Array<WidgetCreator>;
-    'licenseCheck'?: LicenseCheck;
+    'licenseCheck'?: Array<LicenseCheck>;
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the pluggable license check used on the Alerts page if the Enterprise plugin is missing. In this case, there is no pluggable license checker, leading to an exception being thrown.

/nocl Fixing unreleased code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.