### PR TITLE
Add warning that removing prefix will break Illuminate compatibility

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -193,7 +193,8 @@ public class Beats2Codec extends AbstractCodec {
                     CK_NO_BEATS_PREFIX,
                     "Do not add Beats type as prefix",
                     false,
-                    "Do not prefix each field with the Beats type, e. g. \"source\" -> \"filebeat_source\"."
+                    "Do not prefix each field with the Beats type, e. g. \"source\" -> \"filebeat_source\". " +
+                            "Warning: Removing the beats type prefix breaks Illuminate compatibility!"
             ));
 
             return configurationRequest;


### PR DESCRIPTION
## Description
Adds a warning to beats input setup form that removing the beats prefix will break illuminate compatibility

/nocl textual change

## Motivation and Context
fixes [#10615](https://github.com/Graylog2/graylog-plugin-enterprise/issues/10615)

## How Has This Been Tested?
manually, creating beats input

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/670cb573-5720-47b2-9566-e52aeb2d3384)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

