### PR TITLE
Don't go into journal recovery when shutting down

### DIFF
--- a/changelog/unreleased/pr-22715.toml
+++ b/changelog/unreleased/pr-22715.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix issue with message journal recovery on server shutdown."
+
+pulls = ["22715"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
@@ -621,7 +621,7 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
 
         List<JournalReadEntry> messages = read(startOffset, requestedMaximumCount);
 
-        if (messages.isEmpty()) {
+        if (messages.isEmpty() && !shuttingDown) {
             // If we got an empty result BUT we know that there are more messages in the log, we bump the readOffset
             // by 1 and try to read again. We continue until we either get an non-empty result or we reached the
             // end of the log.

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.joschi.jadconfig.util.Size;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -855,7 +856,7 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
     @Override
     protected void shutDown() throws Exception {
         LOG.debug("Shutting down journal!");
-        shuttingDown = true;
+        triggerShutDown();
 
         offsetFlusherFuture.cancel(false);
         logRetentionFuture.cancel(false);
@@ -869,6 +870,11 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
 
         // Teardown log metrics to prevent errors when restarting instances.
         teardownLogMetrics();
+    }
+
+    @VisibleForTesting
+    void triggerShutDown() {
+        shuttingDown = true;
     }
 
     /**


### PR DESCRIPTION
In 7a0b955f228e7b0f39ba2274e5c6af75532be691 we implemented a journal recovery mechanism that tries to read from truncated journals. We trigger the recovery when the #read() method returns an empty list.

The method can also return an empty list when the journal is in shutdown mode. In that case, we don't want to go into recovery mode.