### PR TITLE
fix: Reload current user after creating event definition

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.tsx
@@ -25,6 +25,7 @@ import { AvailableEventDefinitionTypesStore } from 'stores/event-definitions/Ava
 import { ConfigurationsActions } from 'stores/configurations/ConfigurationsStore';
 import { EventDefinitionsActions } from 'stores/event-definitions/EventDefinitionsStore';
 import { EventNotificationsActions, EventNotificationsStore } from 'stores/event-notifications/EventNotificationsStore';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 import type {
   EventDefinition,
   EventDefinitionFormControlsProps,
@@ -89,7 +90,7 @@ const EventDefinitionFormContainer = ({
   initialStep = STEP_KEYS[0],
   onCancel = undefined,
   onChangeStep = undefined,
-  onEventDefinitionChange = () => {},
+  onEventDefinitionChange = () => { },
   onSubmit = undefined,
 }: Props) => {
   const [activeStep, setActiveStep] = useState(initialStep);
@@ -147,6 +148,7 @@ const EventDefinitionFormContainer = ({
 
   const handleSubmitSuccessResponse = () => {
     setIsDirty(false);
+    CurrentUserStore.update(currentUser.username);
 
     onSubmit();
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Reload user after creating an event definition

closes: #graylog2/graylog-plugin-enterprise#10913

/nocl

## Description
<!--- Describe your changes in detail -->
The current user is stored in a global context. This PR fixed the issue with the share button that would show disabled when a user creates a new event definition by reloading the current user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

