### PR TITLE
Warn when unnecessary `lodash` functions are used.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -30,10 +30,7 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       parser: '@typescript-eslint/parser',
-      plugins: [
-        '@typescript-eslint/eslint-plugin',
-        '@tanstack/query',
-      ],
+      plugins: ['@typescript-eslint/eslint-plugin', '@tanstack/query'],
       rules: {
         'no-undef': 'off',
         'no-use-before-define': 'off',
@@ -51,14 +48,8 @@ module.exports = {
       files: ['*.js', '*.jsx'],
     },
     {
-      files: [
-        '*.test.js', '*.test.jsx', '*.test.ts', '*.test.tsx',
-        '*.it.js', '*.it.jsx', '*.it.ts', '*.it.tsx',
-      ],
-      plugins: [
-        'jest',
-        'testing-library',
-      ],
+      files: ['*.test.js', '*.test.jsx', '*.test.ts', '*.test.tsx', '*.it.js', '*.it.jsx', '*.it.ts', '*.it.tsx'],
+      plugins: ['jest', 'testing-library'],
       extends: [
         'plugin:jest/recommended',
         'plugin:testing-library/react',
@@ -85,28 +76,28 @@ module.exports = {
     'plugin:graylog/recommended',
     'prettier',
   ],
-  plugins: [
-    'import',
-    'react-hooks',
-    'jest-formatting',
-    'graylog',
-  ],
+  plugins: ['import', 'react-hooks', 'jest-formatting', 'graylog'],
   rules: {
     'arrow-body-style': ['error', 'as-needed'],
     camelcase: 'off',
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
-    'import/order': ['error', {
-      groups: ['builtin', 'external', 'internal', ['sibling', 'index'], 'parent'],
-      pathGroups: [{
-        pattern: '@graylog/*-api',
-        group: 'external',
-        position: 'after',
-      }],
-      'newlines-between': 'always',
-      pathGroupsExcludedImportTypes: ['builtin'],
-    }],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', ['sibling', 'index'], 'parent'],
+        pathGroups: [
+          {
+            pattern: '@graylog/*-api',
+            group: 'external',
+            position: 'after',
+          },
+        ],
+        'newlines-between': 'always',
+        pathGroupsExcludedImportTypes: ['builtin'],
+      },
+    ],
     'sort-imports': 'off', // disabled in favor of 'import/order'
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'max-classes-per-file': 'off',
@@ -115,21 +106,41 @@ module.exports = {
     'no-else-return': 'warn',
     'no-unused-vars': ['error', noUnusedVarsOptions],
     'no-nested-ternary': 'warn',
-    'no-restricted-imports': ['error', {
-      paths: [{
-        name: 'react-bootstrap',
-        message: 'Please use `components/bootstrap` instead.',
-      }, {
-        name: 'create-react-class',
-        message: 'Please use an ES6 or functional component instead.',
-      }, {
-        name: 'jest-each',
-        message: 'Please use `it.each` instead.',
-      }, {
-        name: 'lodash',
-        message: 'Please use `lodash/<function>` instead for reduced bundle sizes.',
-      }],
-    }],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'react-bootstrap',
+            message: 'Please use `components/bootstrap` instead.',
+          },
+          {
+            name: 'create-react-class',
+            message: 'Please use an ES6 or functional component instead.',
+          },
+          {
+            name: 'jest-each',
+            message: 'Please use `it.each` instead.',
+          },
+          {
+            name: 'lodash',
+            message: 'Please use `lodash/<function>` instead for reduced bundle sizes.',
+          },
+          {
+            name: 'lodash/get',
+            message: 'Please use optional chaining (`foo?.bar?.baz`) instead.',
+          },
+          {
+            name: 'lodash/defaultTo',
+            message: 'Please use nullish coalescing (`foo ?? 42`) instead.',
+          },
+          {
+            name: 'lodash/max',
+            message: 'Please use `Math.max` instead.',
+          },
+        ],
+      },
+    ],
     'no-underscore-dangle': 'off',
     'object-shorthand': ['error', 'methods'],
     'react/destructuring-assignment': 'off',
@@ -182,11 +193,8 @@ module.exports = {
         config: './webpack.config.js',
       },
     },
-    'import/internal-regex': '^(actions|components|contexts|domainActions|fixtures|helpers|hooks|logic|routing|stores|util|theme|views)/',
-    polyfills: [
-      'fetch',
-      'IntersectionObserver',
-      'Promise',
-    ],
+    'import/internal-regex':
+      '^(actions|components|contexts|domainActions|fixtures|helpers|hooks|logic|routing|stores|util|theme|views)/',
+    polyfills: ['fetch', 'IntersectionObserver', 'Promise'],
   },
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding linter hints to warn developers when `lodash` functions are used unnecessarily, which can be replaced with builtins.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.