### PR TITLE
Removing overspecific version in unknown widget warning.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
@@ -79,7 +79,7 @@ const UnknownWidget: React.ComponentType<WidgetComponentProps & EditWidgetCompon
 
         <Row>
           What can you do about it? You can load the plugin again, contact the original plugin author for a plugin that
-          works with {productName} 3.2+, or remove the widget if you do not need it anymore.
+          works with the current version of {productName}, or remove the widget if you do not need it anymore.
         </Row>
         <Row>
           Either way, you can copy the widget&rsquo;s config to the clipboard:{' '}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is removing an overly specific product version from the warning, that is shown when a widget has an unknown type (e.g. because it was created with a plugin that does not exist anymore).

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.