### PR TITLE
Introduce grace period for missing leader notification in static mode

### DIFF
--- a/changelog/unreleased/issue-20672.toml
+++ b/changelog/unreleased/issue-20672.toml
@@ -1,0 +1,5 @@
+type="c"
+message="Adds a configurable grace period `static_leader_timeout` for missing leader notification in static mode."
+
+pulls = [""]
+issues = ["20672"]

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -153,6 +153,9 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
     @Parameter(value = "stale_leader_timeout", validators = PositiveIntegerValidator.class)
     private Integer staleLeaderTimeout;
 
+    @Parameter(value = "static_leader_timeout")
+    private java.time.Duration staticLeaderTimeout = java.time.Duration.of(60, java.time.temporal.ChronoUnit.SECONDS);
+
     @Parameter(value = "ldap_connection_timeout", validators = PositiveIntegerValidator.class)
     private int ldapConnectionTimeout = 2000;
 
@@ -447,6 +450,10 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
 
     public int getStaleLeaderTimeout() {
         return staleLeaderTimeout != null ? staleLeaderTimeout : staleMasterTimeout;
+    }
+
+    public java.time.Duration getStaticLeaderTimeout() {
+        return staticLeaderTimeout;
     }
 
     public int getLdapConnectionTimeout() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We poll for leader status every 5 seconds. If we are in static (manually configured) mode and no leader is detected, a notification is generated.
We now introduce a grace period `static_leader_timeout` (default 60s) to ignore brief periods of unavailability.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #20672 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

