### PR TITLE
Turn permission error into validation error for empty streams in event definition.

### DIFF
--- a/changelog/unreleased/pr-22778.toml
+++ b/changelog/unreleased/pr-22778.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Turn permission error into validation error for empty streams in event definition."
+
+issues = ["Graylog2/graylog-plugin-enterprise#10869"]
+pulls = ["22778"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -24,6 +24,7 @@ import org.graylog.events.event.EventDto;
 import org.graylog.events.event.EventOriginContext;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog.security.UserContext;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -61,7 +62,7 @@ public class NotificationTestData {
                         return "test-dummy-v1";
                     }
                     @Override
-                    public ValidationResult validate() {
+                    public ValidationResult validate(UserContext userContext) {
                         return null;
                     }
                     @Override

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -18,7 +18,6 @@ package org.graylog.events.processor;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -37,6 +36,7 @@ import org.graylog.events.notifications.EventNotificationHandler;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.storage.EventStorageHandler;
 import org.graylog.events.processor.storage.PersistToStreamsStorageHandler;
+import org.graylog.security.UserContext;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.ModelId;
@@ -163,9 +163,9 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
 
     public abstract Builder toBuilder();
 
-    @JsonIgnore
     public ValidationResult validate(@Nullable EventDefinitionDto oldEventDefinitionDto,
-                                     EventDefinitionConfiguration eventDefinitionConfiguration) {
+                                     EventDefinitionConfiguration eventDefinitionConfiguration,
+                                     UserContext userContext) {
         final ValidationResult validation = new ValidationResult();
 
         if (title().isEmpty()) {
@@ -173,7 +173,7 @@ public abstract class EventDefinitionDto extends ScopedEntity implements EventDe
         }
 
         try {
-            validation.addAll(config().validate());
+            validation.addAll(config().validate(userContext));
             validation.addAll(config().validate(
                     Optional.ofNullable(oldEventDefinitionDto).map(EventDefinitionDto::config).orElse(null),
                     eventDefinitionConfiguration));

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorConfig.java
@@ -23,6 +23,7 @@ import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.scheduler.JobDefinitionConfig;
 import org.graylog.scheduler.clock.JobSchedulerClock;
+import org.graylog.security.UserContext;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -76,8 +77,7 @@ public interface EventProcessorConfig extends ContentPackable<EventProcessorConf
      *
      * @return the validation result
      */
-    @JsonIgnore
-    ValidationResult validate();
+    ValidationResult validate(UserContext userContext);
 
     /**
      * Returns the permissions that are required to create the event processor configuration. (e.g. stream permissions)
@@ -128,7 +128,7 @@ public interface EventProcessorConfig extends ContentPackable<EventProcessorConf
         }
 
         @Override
-        public ValidationResult validate() {
+        public ValidationResult validate(UserContext userContext) {
             throw new UnsupportedOperationException();
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/systemnotification/SystemNotificationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/systemnotification/SystemNotificationEventProcessorConfig.java
@@ -23,6 +23,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.graph.MutableGraph;
 import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
 import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog.security.UserContext;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -51,7 +52,7 @@ public abstract class SystemNotificationEventProcessorConfig implements EventPro
     }
 
     @Override
-    public ValidationResult validate() {
+    public ValidationResult validate(UserContext userContext) {
         // Nothing to validate
         return new ValidationResult();
     }

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -285,7 +285,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         final EventDefinitionDto dto = unwrappedCreateEntityRequest.getEntity();
         checkEventDefinitionPermissions(dto, "create");
 
-        final ValidationResult result = dto.validate(null, eventDefinitionConfiguration);
+        final ValidationResult result = dto.validate(null, eventDefinitionConfiguration, userContext);
         if (result.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(result).build();
         }
@@ -314,7 +314,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                 .orElseThrow(() -> new NotFoundException("Event definition <" + definitionId + "> doesn't exist"));
         checkProcessorConfig(oldDto, dto);
 
-        final ValidationResult result = dto.validate(oldDto, eventDefinitionConfiguration);
+        final ValidationResult result = dto.validate(oldDto, eventDefinitionConfiguration, userContext);
         if (!definitionId.equals(dto.id())) {
             result.addError("id", "Event definition IDs don't match");
         }
@@ -473,9 +473,10 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @ApiOperation(value = "Validate an event definition")
     @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
     public ValidationResult validate(@ApiParam(name = "JSON body", required = true)
-                                     @Valid @NotNull EventDefinitionDto toValidate) {
+                                         @Valid @NotNull EventDefinitionDto toValidate,
+                                     @Context UserContext userContext) {
         EventProcessorConfig oldConfig = dbService.get(toValidate.id()).map(EventDefinition::config).orElse(null);
-        ValidationResult validationResult = toValidate.config().validate();
+        ValidationResult validationResult = toValidate.config().validate(userContext);
         validationResult.addAll(toValidate.config().validate(oldConfig, eventDefinitionConfiguration));
         return validationResult;
     }

--- a/graylog2-server/src/test/java/org/graylog/events/TestEventProcessorConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/events/TestEventProcessorConfig.java
@@ -23,10 +23,11 @@ import com.google.auto.value.AutoValue;
 import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
 import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog.events.processor.EventProcessorExecutionJob;
 import org.graylog.events.processor.EventProcessorSchedulerConfig;
 import org.graylog.scheduler.clock.JobSchedulerClock;
-import org.graylog.events.processor.EventProcessorExecutionJob;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
+import org.graylog.security.UserContext;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.rest.ValidationResult;
@@ -107,7 +108,7 @@ public abstract class TestEventProcessorConfig implements EventProcessorConfig {
     }
 
     @Override
-    public ValidationResult validate() {
+    public ValidationResult validate(UserContext userContext) {
         return new ValidationResult();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
@@ -23,6 +23,7 @@ import org.graylog.events.TestEventProcessorConfig;
 import org.graylog.events.fields.EventFieldSpec;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.aggregation.AggregationEventProcessorConfig;
+import org.graylog.security.UserContext;
 import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
@@ -41,7 +42,7 @@ public class EventDefinitionDtoTest {
     @Before
     public void setUp() throws Exception {
         final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
-        when(configMock.validate()).thenReturn(new ValidationResult());
+        when(configMock.validate(mock(UserContext.class))).thenReturn(new ValidationResult());
         when(configMock.validate(any(), any())).thenReturn(new ValidationResult());
 
         testSubject = EventDefinitionDto.builder()
@@ -80,7 +81,7 @@ public class EventDefinitionDtoTest {
         final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
         final ValidationResult mockedValidationResult = new ValidationResult();
         mockedValidationResult.addError("foo", "bar");
-        when(configMock.validate()).thenReturn(mockedValidationResult);
+        when(configMock.validate(mock(UserContext.class))).thenReturn(mockedValidationResult);
         when(configMock.validate(any(), any())).thenReturn(mockedValidationResult);
 
         final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
@@ -161,6 +162,6 @@ public class EventDefinitionDtoTest {
     }
 
     private static ValidationResult validate(EventDefinitionDto eventDefinitionDto) {
-        return eventDefinitionDto.validate(null, new EventDefinitionConfiguration());
+        return eventDefinitionDto.validate(null, new EventDefinitionConfiguration(), mock(UserContext.class));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
@@ -42,7 +42,7 @@ public class EventDefinitionDtoTest {
     @Before
     public void setUp() throws Exception {
         final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
-        when(configMock.validate(mock(UserContext.class))).thenReturn(new ValidationResult());
+        when(configMock.validate(any(UserContext.class))).thenReturn(new ValidationResult());
         when(configMock.validate(any(), any())).thenReturn(new ValidationResult());
 
         testSubject = EventDefinitionDto.builder()
@@ -81,7 +81,7 @@ public class EventDefinitionDtoTest {
         final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
         final ValidationResult mockedValidationResult = new ValidationResult();
         mockedValidationResult.addError("foo", "bar");
-        when(configMock.validate(mock(UserContext.class))).thenReturn(mockedValidationResult);
+        when(configMock.validate(any(UserContext.class))).thenReturn(mockedValidationResult);
         when(configMock.validate(any(), any())).thenReturn(mockedValidationResult);
 
         final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfigTest.java
@@ -40,6 +40,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.series.Latest;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Sum;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
+import org.graylog.security.UserContext;
 import org.graylog.security.entities.EntityOwnershipService;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
@@ -84,6 +85,9 @@ public class AggregationEventProcessorConfigTest {
 
     @Mock
     private DBEventProcessorStateService stateService;
+
+    @Mock
+    private UserContext userContext;
 
     private DBEventDefinitionService dbService;
     private JobSchedulerTestClock clock;
@@ -167,7 +171,7 @@ public class AggregationEventProcessorConfigTest {
                 .searchWithinMs(-1)
                 .build();
 
-        final ValidationResult validationResult1 = invalidConfig1.validate();
+        final ValidationResult validationResult1 = invalidConfig1.validate(userContext);
         assertThat(validationResult1.failed()).isTrue();
         assertThat(validationResult1.getErrors()).containsOnlyKeys("search_within_ms");
 
@@ -175,7 +179,7 @@ public class AggregationEventProcessorConfigTest {
                 .searchWithinMs(0)
                 .build();
 
-        final ValidationResult validationResult2 = invalidConfig2.validate();
+        final ValidationResult validationResult2 = invalidConfig2.validate(userContext);
         assertThat(validationResult2.failed()).isTrue();
         assertThat(validationResult2.getErrors()).containsOnlyKeys("search_within_ms");
     }
@@ -189,7 +193,7 @@ public class AggregationEventProcessorConfigTest {
                 .conditions(trueConditionThatDoesNotMatter)
                 .build();
 
-        ValidationResult validationResult = configWithSingleSeriesWithoutField.validate();
+        ValidationResult validationResult = configWithSingleSeriesWithoutField.validate(userContext);
         assertTrue(validationResult.failed());
         assertEquals(1, validationResult.getErrors().get(FIELD_SERIES).size());
         assertThat(validationResult.getErrors()).containsOnlyKeys(FIELD_SERIES);
@@ -208,7 +212,7 @@ public class AggregationEventProcessorConfigTest {
                 .conditions(trueConditionThatDoesNotMatter)
                 .build();
 
-        validationResult = configWithMultipleSeriesWithoutField.validate();
+        validationResult = configWithMultipleSeriesWithoutField.validate(userContext);
         assertTrue(validationResult.failed());
         assertThat(validationResult.getErrors()).containsOnlyKeys(FIELD_SERIES);
         assertEquals(5, validationResult.getErrors().get(FIELD_SERIES).size());
@@ -221,7 +225,7 @@ public class AggregationEventProcessorConfigTest {
                 .executeEveryMs(-1)
                 .build();
 
-        final ValidationResult validationResult1 = invalidConfig1.validate();
+        final ValidationResult validationResult1 = invalidConfig1.validate(userContext);
         assertThat(validationResult1.failed()).isTrue();
         assertThat(validationResult1.getErrors()).containsOnlyKeys("execute_every_ms");
 
@@ -229,7 +233,7 @@ public class AggregationEventProcessorConfigTest {
                 .executeEveryMs(0)
                 .build();
 
-        final ValidationResult validationResult2 = invalidConfig2.validate();
+        final ValidationResult validationResult2 = invalidConfig2.validate(userContext);
         assertThat(validationResult2.failed()).isTrue();
         assertThat(validationResult2.getErrors()).containsOnlyKeys("execute_every_ms");
     }
@@ -289,7 +293,7 @@ public class AggregationEventProcessorConfigTest {
                 .groupBy(ImmutableList.of("foo"))
                 .build();
 
-        ValidationResult validationResult = invalidConfig.validate();
+        ValidationResult validationResult = invalidConfig.validate(userContext);
         assertThat(validationResult.failed()).isTrue();
         assertThat(validationResult.getErrors()).containsOnlyKeys("series", "conditions");
 
@@ -297,7 +301,7 @@ public class AggregationEventProcessorConfigTest {
                 .series(ImmutableList.of(this.getSeries()))
                 .build();
 
-        validationResult = invalidConfig.validate();
+        validationResult = invalidConfig.validate(userContext);
         assertThat(validationResult.failed()).isTrue();
         assertThat(validationResult.getErrors()).containsOnlyKeys("conditions");
 
@@ -305,14 +309,14 @@ public class AggregationEventProcessorConfigTest {
                 .conditions(this.getConditions())
                 .build();
 
-        validationResult = invalidConfig.validate();
+        validationResult = invalidConfig.validate(userContext);
         assertThat(validationResult.failed()).isTrue();
         assertThat(validationResult.getErrors()).containsOnlyKeys("series");
     }
 
     @Test
     public void testValidConfiguration() {
-        final ValidationResult validationResult = getConfig().validate();
+        final ValidationResult validationResult = getConfig().validate(userContext);
         assertThat(validationResult.failed()).isFalse();
         assertThat(validationResult.getErrors().size()).isEqualTo(0);
     }
@@ -324,7 +328,7 @@ public class AggregationEventProcessorConfigTest {
                 .streams(ImmutableSet.of("1", "2"))
                 .build();
 
-        final ValidationResult validationResult = config.validate();
+        final ValidationResult validationResult = config.validate(userContext);
         assertThat(validationResult.failed()).isFalse();
         assertThat(validationResult.getErrors().size()).isEqualTo(0);
     }
@@ -337,7 +341,7 @@ public class AggregationEventProcessorConfigTest {
                 .conditions(this.getConditions())
                 .build();
 
-        final ValidationResult validationResult = config.validate();
+        final ValidationResult validationResult = config.validate(userContext);
         assertThat(validationResult.failed()).isFalse();
         assertThat(validationResult.getErrors().size()).isEqualTo(0);
     }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -75,7 +75,7 @@ const EventConditionForm = ({
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
 
-  const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes');
+  const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes') ?? [];
 
   const getConditionPlugin = useCallback(
     (type: string) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -14,12 +14,12 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
-import { PluginStore } from 'graylog-web-plugin/plugin';
+import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import defaultTo from 'lodash/defaultTo';
 import get from 'lodash/get';
 
-import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
+import { defaultCompare } from 'logic/DefaultCompare';
 import { Select } from 'components/common';
 import { Clearfix, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/bootstrap';
 import { HelpPanel } from 'components/event-definitions/common/HelpPanel';
@@ -28,6 +28,8 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
+import usePluginEntities from 'hooks/usePluginEntities';
+import type { EventDefinitionType } from 'components/event-definitions/types';
 
 import styles from './EventConditionForm.css';
 
@@ -50,6 +52,17 @@ type Props = {
   canEdit: boolean;
 };
 
+const ConditionTypeDescriptions = ({ eventDefinitionTypes }: { eventDefinitionTypes: EventDefinitionType[] }) => {
+  const typeDescriptions = eventDefinitionTypes.map((type) => (
+    <React.Fragment key={type.type}>
+      <dt>{type.displayName}</dt>
+      <dd>{type.description || 'No description available.'}</dd>
+    </React.Fragment>
+  ));
+
+  return <dl>{typeDescriptions}</dl>;
+};
+
 const EventConditionForm = ({
   action = 'create',
   entityTypes = undefined,
@@ -62,35 +75,45 @@ const EventConditionForm = ({
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
 
-  const getConditionPlugin = (type: string) => {
-    if (type === undefined) {
-      return undefined;
-    }
+  const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes');
 
-    return PluginStore.exports('eventDefinitionTypes').find((eventDefinitionType) => eventDefinitionType.type === type);
-  };
-
-  const sortedEventDefinitionTypes = (): any =>
-    (PluginStore.exports('eventDefinitionTypes') as any).sort((eventDefinitionType1, eventDefinitionType2) => {
-      // Try to sort by given sort order and displayName if possible, otherwise do it by displayName
-      const eventDefinitionType1Order = eventDefinitionType1.sortOrder;
-      const eventDefinitionType2Order = eventDefinitionType2.sortOrder;
-
-      if (eventDefinitionType1Order !== undefined || eventDefinitionType2Order !== undefined) {
-        const sort =
-          defaultTo(eventDefinitionType1Order, Number.MAX_SAFE_INTEGER) -
-          defaultTo(eventDefinitionType2Order, Number.MAX_SAFE_INTEGER);
-
-        if (sort !== 0) {
-          return sort;
-        }
+  const getConditionPlugin = useCallback(
+    (type: string) => {
+      if (type === undefined) {
+        return undefined;
       }
 
-      return naturalSort(eventDefinitionType1.displayName, eventDefinitionType2.displayName);
-    });
+      return eventDefinitionTypes.find((eventDefinitionType) => eventDefinitionType.type === type);
+    },
+    [eventDefinitionTypes],
+  );
 
-  const formattedEventDefinitionTypes = () =>
-    sortedEventDefinitionTypes().map((type) => ({ label: type.displayName, value: type.type }));
+  const sortedEventDefinitionTypes = useMemo(
+    () =>
+      eventDefinitionTypes.sort((eventDefinitionType1, eventDefinitionType2) => {
+        // Try to sort by given sort order and displayName if possible, otherwise do it by displayName
+        const eventDefinitionType1Order = eventDefinitionType1.sortOrder;
+        const eventDefinitionType2Order = eventDefinitionType2.sortOrder;
+
+        if (eventDefinitionType1Order !== undefined || eventDefinitionType2Order !== undefined) {
+          const sort =
+            defaultTo(eventDefinitionType1Order, Number.MAX_SAFE_INTEGER) -
+            defaultTo(eventDefinitionType2Order, Number.MAX_SAFE_INTEGER);
+
+          if (sort !== 0) {
+            return sort;
+          }
+        }
+
+        return defaultCompare(eventDefinitionType1.displayName, eventDefinitionType2.displayName);
+      }),
+    [eventDefinitionTypes],
+  );
+
+  const formattedEventDefinitionTypes = useMemo(
+    () => sortedEventDefinitionTypes.map((type) => ({ label: type.displayName, value: type.type })),
+    [sortedEventDefinitionTypes],
+  );
 
   const handleEventDefinitionTypeChange = (nextType: string) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.EVENTDEFINITION_CONDITION.TYPE_SELECTED, {
@@ -106,23 +129,23 @@ const EventConditionForm = ({
     onChange('config', { ...defaultConfig, type: nextType });
   };
 
-  const renderConditionTypeDescriptions = () => {
-    const typeDescriptions = sortedEventDefinitionTypes().map((type) => (
-      <React.Fragment key={type.type}>
-        <dt>{type.displayName}</dt>
-        <dd>{type.description || 'No description available.'}</dd>
-      </React.Fragment>
-    ));
+  const disabledSelect = useMemo(
+    () => !formattedEventDefinitionTypes.some((edt) => eventDefinition.config.type === edt.value) && action === 'edit',
+    [action, eventDefinition.config.type, formattedEventDefinitionTypes],
+  );
+  const onlyFilters = useMemo(
+    () => eventDefinition._scope === 'ILLUMINATE' && action === 'edit',
+    [action, eventDefinition._scope],
+  );
+  const isSigma = useMemo(
+    () => eventDefinition.config.type === 'sigma-v1' && action === 'edit',
+    [action, eventDefinition.config.type],
+  );
 
-    return <dl>{typeDescriptions}</dl>;
-  };
-
-  const disabledSelect = () =>
-    !formattedEventDefinitionTypes().some((edt) => eventDefinition.config.type === edt.value) && action === 'edit';
-  const onlyFilters = () => eventDefinition._scope === 'ILLUMINATE' && action === 'edit';
-  const isSigma = () => eventDefinition.config.type === 'sigma-v1' && action === 'edit';
-
-  const eventDefinitionType = getConditionPlugin(eventDefinition.config.type);
+  const eventDefinitionType = useMemo(
+    () => getConditionPlugin(eventDefinition.config.type),
+    [eventDefinition.config.type, getConditionPlugin],
+  );
   const isSystemEventDefinition = eventDefinition.config.type === SYSTEM_EVENT_DEFINITION_TYPE;
   const canEditCondition = canEdit && !isSystemEventDefinition;
 
@@ -156,11 +179,11 @@ const EventConditionForm = ({
               <Select
                 placeholder="Select a Condition Type"
                 inputId="event-condition-type-select"
-                options={formattedEventDefinitionTypes()}
+                options={formattedEventDefinitionTypes}
                 value={eventDefinition.config.type}
                 onChange={handleEventDefinitionTypeChange}
                 clearable={false}
-                disabled={disabledSelect() || onlyFilters() || isSigma()}
+                disabled={disabledSelect || onlyFilters || isSigma}
                 required
               />
               <HelpBlock>
@@ -171,11 +194,11 @@ const EventConditionForm = ({
         )}
       </Col>
 
-      {canEditCondition && !disabledSelect() && (
+      {canEditCondition && !disabledSelect && (
         <>
           <Col md={5} lg={5} lgOffset={1}>
             <HelpPanel className={styles.conditionTypesInfo} title="Available Conditions">
-              {renderConditionTypeDescriptions()}
+              <ConditionTypeDescriptions eventDefinitionTypes={sortedEventDefinitionTypes} />
             </HelpPanel>
           </Col>
           <Clearfix />

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -75,7 +75,7 @@ const EventConditionForm = ({
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
 
-  const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes') ?? [];
+  const eventDefinitionTypes = usePluginEntities('eventDefinitionTypes');
 
   const getConditionPlugin = useCallback(
     (type: string) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.test.tsx
@@ -235,7 +235,7 @@ describe('EventDefinitionFormContainer', () => {
         ({
           'views.components.eventProcedureSummary': [],
           'licenseCheck': [(_license: string) => ({ data: { valid: false } })],
-        })[entityKey],
+        })[entityKey] ?? [],
     );
   });
 


### PR DESCRIPTION
**Note:** This is based on #22771, which needs to be merged before.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that if a user is creating an event definition, does not have the global `streams:read` permission and has an empty `streams` field in the event definition config, a validation error will be returned instead of a 403. This way, the frontend can handle it and show the user a helpful message in the event definition creation dialog instead of ending up on an error page.

Fixes Graylog2/graylog-plugin-enterprise#10869.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/10970

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.