### PR TITLE
Use named exports when importing `FormsUtils`.

### DIFF
--- a/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 
 import { Col, ControlLabel, FormControl, FormGroup, Row, Button, Input } from 'components/bootstrap';
 import ExtractorUtils from 'util/ExtractorUtils';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 import { ExtractorsActions } from 'stores/extractors/ExtractorsStore';
 
@@ -85,7 +85,7 @@ class EditExtractor extends React.Component<EditExtractorProps, EditExtractorSta
     const nextState: EditExtractorState = {};
     const { updatedExtractor } = this.state;
 
-    updatedExtractor[key] = FormUtils.getValueFromInput(event.target);
+    updatedExtractor[key] = getValueFromInput(event.target);
     nextState.updatedExtractor = updatedExtractor;
 
     // Reset result of testing condition after a change in the input

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/CSVConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/CSVConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Row, Col, Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type CSVConverterConfigurationProps = {
   type: string;
@@ -45,7 +45,7 @@ class CSVConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
@@ -55,7 +55,7 @@ class CSVConverterConfiguration extends React.Component<
   _onChange = (key) => (event) => {
     const newConfig = this.props.configuration;
 
-    newConfig[key] = FormUtils.getValueFromInput(event.target);
+    newConfig[key] = getValueFromInput(event.target);
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.tsx
@@ -20,7 +20,7 @@ import { LocaleSelect, TimezoneSelect } from 'components/common';
 import { Row, Col, Input } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type DateConverterConfigurationProps = {
   type: string;
@@ -48,7 +48,7 @@ class DateConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
@@ -59,7 +59,7 @@ class DateConverterConfiguration extends React.Component<
     const newConfig = this.props.configuration;
 
     // data can be an event or a value, we need to check its type :sick:
-    newConfig[key] = typeof data === 'object' ? FormUtils.getValueFromInput(data.target) : data;
+    newConfig[key] = typeof data === 'object' ? getValueFromInput(data.target) : data;
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/FlexdateConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/FlexdateConverterConfiguration.tsx
@@ -16,11 +16,11 @@
  */
 import React from 'react';
 
+import { getValueFromInput } from 'util/FormsUtils';
 import { TimezoneSelect } from 'components/common';
 import { Row, Col, Input } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
-import FormUtils from 'util/FormsUtils';
 
 type FlexdateConverterConfigurationProps = {
   type: string;
@@ -46,7 +46,7 @@ class FlexdateConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
@@ -57,7 +57,7 @@ class FlexdateConverterConfiguration extends React.Component<
     const newConfig = this.props.configuration;
 
     // data can be an event or a value, we need to check its type :sick:
-    newConfig[key] = typeof data === 'object' ? FormUtils.getValueFromInput(data.target) : data;
+    newConfig[key] = typeof data === 'object' ? getValueFromInput(data.target) : data;
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/HashConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/HashConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type HashConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class HashConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/IpAnonymizerConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/IpAnonymizerConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type IpAnonymizerConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class IpAnonymizerConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.tsx
@@ -20,7 +20,7 @@ import { Link } from 'components/common/router';
 import { Select, Spinner } from 'components/common';
 import { Row, Col, Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import { LookupTablesActions } from 'stores/lookup-tables/LookupTablesStore';
 
 type LookupTableConverterConfigurationProps = {
@@ -58,7 +58,7 @@ class LookupTableConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
@@ -72,7 +72,7 @@ class LookupTableConverterConfiguration extends React.Component<
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 
-  _onChange = (key) => (event) => this._updateConfigValue(key, FormUtils.getValueFromInput(event.target));
+  _onChange = (key) => (event) => this._updateConfigValue(key, getValueFromInput(event.target));
 
   _onSelect = (key) => (value) => this._updateConfigValue(key, value);
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.tsx
@@ -72,8 +72,6 @@ class LookupTableConverterConfiguration extends React.Component<
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 
-  _onChange = (key) => (event) => this._updateConfigValue(key, getValueFromInput(event.target));
-
   _onSelect = (key) => (value) => this._updateConfigValue(key, value);
 
   render() {

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LowercaseConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LowercaseConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type LowercaseConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class LowercaseConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/NumericConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/NumericConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type NumericConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class NumericConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SplitAndCountConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SplitAndCountConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Row, Col, Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type SplitAndCountConverterConfigurationProps = {
   type: string;
@@ -45,7 +45,7 @@ class SplitAndCountConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
@@ -55,7 +55,7 @@ class SplitAndCountConverterConfiguration extends React.Component<
   _onChange = (key) => (event) => {
     const newConfig = this.props.configuration;
 
-    newConfig[key] = FormUtils.getValueFromInput(event.target);
+    newConfig[key] = getValueFromInput(event.target);
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
   };
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriFacilityConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriFacilityConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type SyslogPriFacilityConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class SyslogPriFacilityConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriLevelConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriLevelConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type SyslogPriLevelConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class SyslogPriLevelConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/TokenizerConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/TokenizerConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type TokenizerConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class TokenizerConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/UppercaseConverterConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/UppercaseConverterConfiguration.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { Input } from 'components/bootstrap';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 
 type UppercaseConverterConfigurationProps = {
   type: string;
@@ -40,7 +40,7 @@ class UppercaseConverterConfiguration extends React.Component<
   _toggleConverter = (event) => {
     let converter;
 
-    if (FormUtils.getValueFromInput(event.target) === true) {
+    if (getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.tsx
@@ -20,7 +20,7 @@ import { Icon } from 'components/common';
 import { Row, Col, ControlLabel, Button, Input } from 'components/bootstrap';
 import GrokPatternInput from 'components/grok-patterns/GrokPatternInput';
 import UserNotification from 'util/UserNotification';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 import { GrokPatternsStore } from 'stores/grok-patterns/GrokPatternsStore';
 import type CancellablePromise from 'logic/rest/CancellablePromise';
@@ -80,7 +80,7 @@ class GrokExtractorConfiguration extends React.Component<
       onExtractorPreviewLoad(undefined);
       const newConfig = configuration;
 
-      newConfig[key] = FormUtils.getValueFromInput(event.target);
+      newConfig[key] = getValueFromInput(event.target);
       onChange(newConfig);
     };
   };

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { Icon } from 'components/common';
 import { Col, Row, Button, Input } from 'components/bootstrap';
 import ExtractorUtils from 'util/ExtractorUtils';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 type Configuration = {
@@ -83,7 +83,7 @@ class JSONExtractorConfiguration extends React.Component<Props, State> {
       this.props.onExtractorPreviewLoad(undefined);
       const newConfig = this.state.configuration;
 
-      newConfig[key] = FormUtils.getValueFromInput(event.target);
+      newConfig[key] = getValueFromInput(event.target);
       this.props.onChange(newConfig);
     };
   }

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
@@ -21,7 +21,7 @@ import { Select, Spinner, Icon } from 'components/common';
 import { Row, Col, Button, Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 import UserNotification from 'util/UserNotification';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 import { LookupTablesActions } from 'stores/lookup-tables/LookupTablesStore';
 
@@ -62,7 +62,7 @@ class LookupTableExtractorConfiguration extends React.Component<
     this.props.onChange(newConfig);
   };
 
-  _onChange = (key) => (event) => this._updateConfigValue(key, FormUtils.getValueFromInput(event.target));
+  _onChange = (key) => (event) => this._updateConfigValue(key, getValueFromInput(event.target));
 
   _onSelect = (key) => (value) => this._updateConfigValue(key, value);
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
@@ -62,8 +62,6 @@ class LookupTableExtractorConfiguration extends React.Component<
     this.props.onChange(newConfig);
   };
 
-  _onChange = (key) => (event) => this._updateConfigValue(key, getValueFromInput(event.target));
-
   _onSelect = (key) => (value) => this._updateConfigValue(key, value);
 
   _onTryClick = () => {

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.tsx
@@ -21,7 +21,6 @@ import { Select, Spinner, Icon } from 'components/common';
 import { Row, Col, Button, Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 import UserNotification from 'util/UserNotification';
-import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 import { LookupTablesActions } from 'stores/lookup-tables/LookupTablesStore';
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexExtractorConfiguration.tsx
@@ -21,7 +21,7 @@ import { Row, Col, Button, Input } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import UserNotification from 'util/UserNotification';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 type RegexExtractorConfigurationProps = {
@@ -49,7 +49,7 @@ class RegexExtractorConfiguration extends React.Component<
     this.props.onExtractorPreviewLoad(undefined);
     const newConfig = this.props.configuration;
 
-    newConfig[key] = FormUtils.getValueFromInput(event.target);
+    newConfig[key] = getValueFromInput(event.target);
     this.props.onChange(newConfig);
   };
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexReplaceExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexReplaceExtractorConfiguration.tsx
@@ -21,7 +21,7 @@ import { Col, Row, Button, Input } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import UserNotification from 'util/UserNotification';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 type RegexReplaceExtractorConfigurationProps = {
@@ -49,7 +49,7 @@ class RegexReplaceExtractorConfiguration extends React.Component<
     this.props.onExtractorPreviewLoad(undefined);
     const newConfig = this.props.configuration;
 
-    newConfig[key] = FormUtils.getValueFromInput(event.target);
+    newConfig[key] = getValueFromInput(event.target);
     this.props.onChange(newConfig);
   };
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/SplitAndIndexExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/SplitAndIndexExtractorConfiguration.tsx
@@ -21,7 +21,7 @@ import { Icon } from 'components/common';
 import { Col, Row, Button, Input } from 'components/bootstrap';
 import UserNotification from 'util/UserNotification';
 import ExtractorUtils from 'util/ExtractorUtils';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 const DEFAULT_CONFIGURATION = { index: 1 };
@@ -54,7 +54,7 @@ const SplitAndIndexExtractorConfiguration = ({
     onExtractorPreviewLoad(undefined);
     const newConfig = configuration;
 
-    newConfig[key] = FormUtils.getValueFromInput(event.target);
+    newConfig[key] = getValueFromInput(event.target);
     onChange(newConfig);
   };
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/SubstringExtractorConfiguration.tsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/SubstringExtractorConfiguration.tsx
@@ -21,7 +21,7 @@ import { Button, Col, Row, Input } from 'components/bootstrap';
 import { Icon } from 'components/common';
 import UserNotification from 'util/UserNotification';
 import ExtractorUtils from 'util/ExtractorUtils';
-import FormUtils from 'util/FormsUtils';
+import { getValueFromInput } from 'util/FormsUtils';
 import ToolsStore from 'stores/tools/ToolsStore';
 
 type Config = {
@@ -58,7 +58,7 @@ const SubstringExtractorConfiguration = ({
     onExtractorPreviewLoad(undefined);
     const newConfig = {
       ...configuration,
-      [key]: FormUtils.getValueFromInput(event.target),
+      [key]: getValueFromInput(event.target),
     };
     setConfig(newConfig);
     onChange(newConfig);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing ESLint hints related to the `import/no-named-as-default-member` rule.
Please note, there are some ESLint hints in the changed files, most of them will be addressed in follow-up PRs.

/nocl