### PR TITLE
Fix data node native lib dir location

### DIFF
--- a/changelog/unreleased/issue-22544.toml
+++ b/changelog/unreleased/issue-22544.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix location of native_lib directory in data node distribution packages."
+
+pulls = [""]
+issues = ["22544"]

--- a/changelog/unreleased/issue-22544.toml
+++ b/changelog/unreleased/issue-22544.toml
@@ -1,5 +1,5 @@
 type = "f"
 message = "Fix location of native_lib directory in data node distribution packages."
 
-pulls = [""]
+pulls = ["22791"]
 issues = ["22544"]

--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -129,7 +129,7 @@ public class Configuration implements CommonNodeConfiguration, NativeLibPathConf
 
     @Documentation(visible = false)
     @Parameter(value = "native_lib_dir", required = true)
-    private Path nativeLibDir = Path.of("native_libs");
+    private String nativeLibDir = "native_libs";
 
     @Documentation("How many log entries of the opensearch process should Datanode hold in memory and make accessible via API calls.")
     @Parameter(value = "process_logs_buffer_size")
@@ -512,7 +512,7 @@ public class Configuration implements CommonNodeConfiguration, NativeLibPathConf
     }
 
     public Path getNativeLibDir() {
-        return nativeLibDir;
+        return getOpensearchConfigLocation().resolve(Path.of(nativeLibDir));
     }
 
     public static class NodeIdFileValidator implements Validator<String> {


### PR DESCRIPTION
## Description
The `native_lib_dir` location in data node was previously set to `native_lib` which caused an error in the distribution packages as this will try to write it to `/native_lib`.

This PR creates the directory inside of the configured `opensearch_config_location` to make sure we have a writable directory.

## Motivation and Context
fixes #22544 

## How Has This Been Tested?
locally, observe `native_lib` dir inside opensearch config directory.
 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

