### PR TITLE
UnknownFieldsValidator without a warning for asterisk in field name

### DIFF
--- a/changelog/unreleased/issue-22373.toml
+++ b/changelog/unreleased/issue-22373.toml
@@ -1,0 +1,7 @@
+type = "fixed"
+message = "Fix search validation. No warning when asterisk used in field names."
+
+issues = ["22373"]
+pulls = ["22824"]
+
+

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidator.java
@@ -69,6 +69,7 @@ public class UnknownFieldsValidator implements QueryValidator {
                 .filter(term -> !SEARCHABLE_ES_FIELDS.contains(term.getRealFieldName()))
                 .filter(term -> !RESERVED_SETTABLE_FIELDS.contains(term.getRealFieldName()))
                 .filter(term -> !availableFields.contains(term.getRealFieldName()))
+                .filter(term -> !term.getRealFieldName().contains("*"))
                 .distinct()
                 .collect(Collectors.groupingBy(ParsedTerm::getRealFieldName));
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/validation/validators/UnknownFieldsValidatorTest.java
@@ -48,6 +48,19 @@ class UnknownFieldsValidatorTest {
     }
 
     @Test
+    void testDoesNotIdentifyFieldsWithAsteriskWildcardAsUnknown() {
+        final List<ParsedTerm> unknownFields = toTest.identifyUnknownFields(
+                Set.of("http_response_code"),
+                List.of(
+                        ParsedTerm.create("_exists_", "http_response_\\*"),
+                        ParsedTerm.create("http_res\\*", "400"),
+                        ParsedTerm.create("_exists_", "\\*_code")
+                )
+        );
+        assertTrue(unknownFields.isEmpty());
+    }
+
+    @Test
     void testDoesNotIdentifySpecialIdFieldAsUnknown() {
         final List<ParsedTerm> unknownFields = toTest.identifyUnknownFields(
                 Set.of("some_normal_field"),


### PR DESCRIPTION
## Description
UnknownFieldsValidator without a warning for asterisk in field name.
Fixes #22373


## Motivation and Context
See #22373

## How Has This Been Tested?
Manually and with a new unit test.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/324ee77d-29c1-4e85-951a-cb76cbd95562)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

