### PR TITLE
Use link instead of just text notification name on event definition page

### DIFF
--- a/changelog/unreleased/issue-22758.toml
+++ b/changelog/unreleased/issue-22758.toml
@@ -1,0 +1,5 @@
+type="f"
+message="On event definition overview page show link to the notification instead of plain text."
+
+pulls = ["22834"]
+issues = ["22758"]

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/CommonNotificationSummary.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/CommonNotificationSummary.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 
 import { Table, Button } from 'components/bootstrap';
 import { Icon } from 'components/common';
+import { Link } from 'components/common/router';
+import Routes from 'routing/Routes';
 
 import styles from './CommonNotificationSummary.css';
 
@@ -41,7 +43,11 @@ const CommonNotificationSummary = ({
 
   return (
     <>
-      <h4>{notification.title || definitionNotification.notification_id}</h4>
+      <h4>
+        <Link target="_blank" to={Routes.ALERTS.NOTIFICATIONS.show(definitionNotification.notification_id)}>
+          {notification.title || definitionNotification.notification_id}
+        </Link>
+      </h4>
       <dl>
         <dd>{type}</dd>
         <dd>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
From now we use link instead of just a name 
<img width="258" alt="Screenshot 2025-06-10 at 14 58 19" src="https://github.com/user-attachments/assets/75eddaa2-e8bd-4a0b-b24f-972523fb7977" />


## Motivation and Context
fix: #22758

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

