### PR TITLE
Show widget controls/icons only when hovering over widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFrame.tsx
@@ -99,6 +99,19 @@ const WidgetWrap = styled.div(
         padding: 0 5px;
       }
     }
+
+    .widget-actions-menu,
+    .widget-drag-handle {
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+    }
+
+    &:hover .widget-actions-menu,
+    &:hover .widget-drag-handle {
+      opacity: 1;
+      pointer-events: auto;
+    }
   `,
 );
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the widget icons & drag handle to show only when hovering over the widget. This leads to a cleaner, less distracting look of the widget grid, while not impacting editing/exporting capabilities.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.