### PR TITLE
Fix unrecognized `override_source` field error on follower

### DIFF
--- a/changelog/unreleased/issue-22140.toml
+++ b/changelog/unreleased/issue-22140.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Allow the source field to be overridden for the Kinesis/Cloudwatch input."
 
 issues = ["22140"]
-pulls = ["22370"]
+pulls = ["22370", "22887"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
@@ -157,7 +157,7 @@ public class KinesisService {
         final List<Record> records = retrieveRecords(request.streamName(), kinesisClient);
 
         if (records.isEmpty()) {
-            LOG.warn("The Kinesis stream [{}] is empty. Proceeding with setup at the user's own risk.", request.streamName());
+            LOG.debug("The Kinesis stream [{}] is empty.", request.streamName());
             return KinesisHealthCheckResponse.create(
                     AWSMessageType.KINESIS_RAW,
                     String.format(Locale.ROOT, "The Kinesis stream [%s] does not contain any messages.", request.streamName()),

--- a/graylog2-web-interface/src/integrations/aws/common/formDataAdapter.js
+++ b/graylog2-web-interface/src/integrations/aws/common/formDataAdapter.js
@@ -29,7 +29,6 @@ export const toAWSRequest = (formData, options) => {
     awsEndpointKinesis,
     key,
     secret,
-    overrideSource,
   } = formData;
 
   return {
@@ -47,7 +46,6 @@ export const toAWSRequest = (formData, options) => {
     dynamodb_endpoint: awsEndpointDynamoDB?.value,
     iam_endpoint: awsEndpointIAM?.value,
     kinesis_endpoint: awsEndpointKinesis?.value,
-    override_source: overrideSource?.value,
     ...options,
   };
 };

--- a/graylog2-web-interface/src/integrations/aws/common/formDataAdapter.test.js
+++ b/graylog2-web-interface/src/integrations/aws/common/formDataAdapter.test.js
@@ -83,8 +83,7 @@ describe('formDataAdapter', () => {
       cloudwatch_endpoint: 'awsEndpointCloudWatch',
       dynamodb_endpoint: 'awsEndpointDynamoDB',
       iam_endpoint: 'awsEndpointIAM',
-      kinesis_endpoint: 'awsEndpointKinesis',
-      override_source: 'overrideSource',
+      kinesis_endpoint: 'awsEndpointKinesis'
     };
 
     const request = toAWSRequest(formData, options);
@@ -117,7 +116,6 @@ describe('formDataAdapter', () => {
       awsEndpointIAM: { value: undefined },
       awsEndpointKinesis: { value: undefined },
       awsCloudWatchAwsSecret: { value: 'mysecret' },
-      overrideSource: { value: '' },
     });
 
     expect(request).toBeDefined();
@@ -132,7 +130,6 @@ describe('formDataAdapter', () => {
       awsEndpointDynamoDB: { value: undefined },
       awsEndpointIAM: { value: undefined },
       awsEndpointKinesis: { value: undefined },
-      overrideSource: { value: '' },
       secret: 'mysecret',
     });
 
@@ -155,7 +152,6 @@ describe('formDataAdapter', () => {
         awsEndpointIAM: { value: undefined },
         awsEndpointKinesis: { value: undefined },
         awsCloudWatchAwsSecret: { value: 'mysecret' },
-        overrideSource: { value: '' },
       },
       options,
     );


### PR DESCRIPTION
While testing https://github.com/Graylog2/graylog2-server/pull/22825, I noticed the following error on one of our test instances. The error was intermittent and only occurred about 50% of the time. It turns out that it was only happening on the Graylog Follower node due to https://github.com/Graylog2/graylog-plugin-enterprise/issues/11075.

This PR removes the accidental inclusion of the `override_source` field in AWS Kinesis/CloudWatch input wizard requests (except for the final input save where it's needed).

![image](https://github.com/user-attachments/assets/03cb3fa9-a5e4-4c9e-8bec-3741e9ac7d11)
