### PR TITLE
Filter event definition IDs to those the requesting user has permissions to view

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -268,11 +268,11 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @ApiOperation("Get multiple event definitions by id")
     @NoAuditEvent("Bulk retrieval, no data is changed.")
     public List<EventDefinitionDto> getById(@ApiParam(name = "JSON body") @Valid GetByIdRequest request) {
-        for (String id : request.eventDefinitionIds()) {
-            checkPermission(RestPermissions.EVENT_DEFINITIONS_READ, id);
-        }
+        final Set<String> permittedIds = request.eventDefinitionIds().stream()
+                .filter(id -> isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, id))
+                .collect(Collectors.toSet());
 
-        return dbService.getByIds(request.eventDefinitionIds());
+        return dbService.getByIds(permittedIds);
     }
 
     @POST


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Filter list of requested event definition IDs to those the user is permitted to see so that certain pages do not blow up when requesting this info.

/nocl 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
open piece of resolution to blocker bug https://github.com/Graylog2/graylog-plugin-enterprise/issues/11096
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

