### PR TITLE
Correctly generate stream category select options

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.tsx
@@ -112,7 +112,7 @@ type StreamCategorySelectorProps = {
 const StreamCategorySelector = ({ onChange, streams, value }: StreamCategorySelectorProps) => {
   const streamCategoryOptions = useMemo(
     () =>
-      [...new Set<string>(streams.flatMap((stream) => stream?.categories))]
+      [...new Set<string>(streams.flatMap((stream) => stream?.categories ?? []))]
         .sort(defaultCompare)
         .map((category) => ({ label: category, value: category })),
     [streams],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Avoid `undefined` options when calling `flatMap` on a `stream.categories` value of `null`. 

/nocl
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
addresses Graylog2/graylog-plugin-enterprise#11022 possibly along with changes in #22853? Not 100% sure if we need that change as well.

eliminates the phantom category option in the select seen here:
![image](https://github.com/user-attachments/assets/1568b180-b14d-4915-8e8a-ee44e63d9afa)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
could not repro in latest code, but I think this is likely the cause of the bug in 6.3-rc1
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

