### PR TITLE
Fix issue causing quotes to be escaped in markdown content

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -159,8 +159,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
         </dependency>
 
         <dependency>

--- a/graylog2-server/src/main/java/org/graylog2/security/html/HTMLSanitizerConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/html/HTMLSanitizerConverter.java
@@ -17,8 +17,9 @@
 package org.graylog2.security.html;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
-import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.PolicyFactory;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.safety.Safelist;
 
 /**
  * Jackson converter that removes all HTML elements from a specified string.
@@ -28,10 +29,11 @@ import org.owasp.html.PolicyFactory;
  * @see <a href="https://github.com/OWASP/java-html-sanitizer">OWASP Java HTML Sanitizer</a>
  */
 public class HTMLSanitizerConverter extends StdConverter<String, String> {
-    private static final PolicyFactory POLICY = new HtmlPolicyBuilder().toFactory();
-
+    private static final Document.OutputSettings OUTPUT_SETTINGS =
+            new Document.OutputSettings()
+                    .prettyPrint(false); // Prevent removal of carriage returns.
     @Override
     public String convert(String input) {
-        return POLICY.sanitize(input);
+        return Jsoup.clean(input, "", Safelist.none(), OUTPUT_SETTINGS);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/security/html/HTMLSanitizerConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/html/HTMLSanitizerConverterTest.java
@@ -38,7 +38,7 @@ class HTMLSanitizerConverterTest {
         final String result = new HTMLSanitizerConverter().convert(markdownHtmlString);
         final Set<String> forbiddenElements = Set.of("script", "form", "label", "input", "br", "button", "iframe", "footer", "<", ">");
         forbiddenElements.forEach(s -> assertFalse(result.contains(s)));
-        final Set<String> markdownStrings = Set.of("Short Markdown Example", "Introduction", "List", "Item 2");
-        markdownStrings.forEach(s -> assertTrue(result.contains(s)));
+        final Set<String> requiredElements = Set.of("Short Markdown Example", "## Introduction", "### List", "- Item 2", "Quotes and certain chars are ok too \"'@:");
+        requiredElements.forEach(s -> assertTrue(result.contains(s)));
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/security/html/html-and-markdown.md
+++ b/graylog2-server/src/test/resources/org/graylog2/security/html/html-and-markdown.md
@@ -1,7 +1,7 @@
 # Short Markdown Example
 
 ## Introduction
-Markdown should be allowed.
+Markdown should be allowed. Quotes and certain chars are ok too "'@:
 
 ### List
 - Item 1

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <jool.version>0.9.15</jool.version>
         <json-org.version>20250517</json-org.version>
         <json-path.version>2.9.0</json-path.version>
+        <jsoup.version>1.20.1</jsoup.version>
         <kafka.version>3.9.0</kafka.version>
         <kafka09.version>0.9.0.1-7</kafka09.version>
         <log4j.version>2.25.0</log4j.version>
@@ -164,7 +165,6 @@
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.32.0</opentelemetry.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
-        <owasp-sanitizer.version>20240325.1</owasp-sanitizer.version>
         <pkts.version>3.0.18</pkts.version>
         <prometheus-client.version>0.16.0</prometheus-client.version>
         <protobuf.version>3.25.8</protobuf.version>
@@ -429,9 +429,9 @@
                 <version>${okhttp.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-                <artifactId>owasp-java-html-sanitizer</artifactId>
-                <version>${owasp-sanitizer.version}</version>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
             </dependency>
 
             <!-- Explicitly manage avro to fix CVE-2023-39410. We are using this only as a transitive dependency in


### PR DESCRIPTION
Fix issue causing quote and other special characters to be escaped in Markdown content.

The issue stemmed from how the OWASP HTML Sanitizer works. It is very strict about sanitizing only HTML documents. Any text outside of the document (e.g. markdown) is subject to escaping, and there is no configuration to change this behavior. 

This PR changes to use JSoup instead, which allows for removing all HTML elements, and also to retain all surrounding text.

The `` unit test has also been updated to verify that quotes are no longer escaped.