### PR TITLE
Download and use static jdk for OpenSearch with data node on Mac

### DIFF
--- a/data-node/pom.xml
+++ b/data-node/pom.xml
@@ -45,6 +45,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <opensearch.version>2.15.0</opensearch.version>
+        <opensearch.mac.jdk.version>21.0.7</opensearch.mac.jdk.version>
+        <opensearch.mac.jdk.build>6</opensearch.mac.jdk.build>
 
         <!--
            We don't need to sign anything in this module. This fixes a release build error related to setting
@@ -955,5 +957,76 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>run-on-mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graylog.repackaged</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>${download-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>fix-mac-jdk-for-os-x64</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>
+                                        https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${opensearch.mac.jdk.version}%2B${opensearch.mac.jdk.build}/OpenJDK21U-jdk_x64_mac_hotspot_${opensearch.mac.jdk.version}_${opensearch.mac.jdk.build}.tar.gz
+                                    </url>
+                                    <sha512>
+                                        981de4ed6629975b84f2604dd2c601e66633691b1da835e0b8741c4712d5b24b51e757686624dc1b2492e61a9e9a27c8ac73bfc9e571d6e8c1c5db8ec6a4189c
+                                    </sha512>
+                                    <outputDirectory>
+                                        ${project.build.directory}/opensearch/opensearch-${opensearch.version}-linux-x64/jdk-mac
+                                    </outputDirectory>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^(jdk-.*/Contents/Home)/(.*)</pattern>
+                                            <replacement>$2</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <unpack>true</unpack>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>fix-mac-jdk-for-os-aarch</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>
+                                        https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${opensearch.mac.jdk.version}%2B${opensearch.mac.jdk.build}/OpenJDK21U-jdk_aarch64_mac_hotspot_${opensearch.mac.jdk.version}_${opensearch.mac.jdk.build}.tar.gz
+                                    </url>
+                                    <sha512>
+                                        5bd61c1634daa5b6e0c473de6c0883ac2d29c0daa7101dd852113a5197b6cd60f790c0f7f53a64b2dbbb45f030ee4481c9d38745615a1a39b8efbef41e4b8115
+                                    </sha512>
+                                    <outputDirectory>
+                                        ${project.build.directory}/opensearch/opensearch-${opensearch.version}-linux-aarch64/jdk-mac
+                                    </outputDirectory>
+                                    <fileMappers>
+                                        <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                            <pattern>^(jdk-.*/Contents/Home)/(.*)</pattern>
+                                            <replacement>$2</replacement>
+                                        </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                                    </fileMappers>
+                                    <unpack>true</unpack>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
+
 </project>


### PR DESCRIPTION
## Description
Since we cannot use the bundled jdk for OpenSearch with Data Node on Macs (for development), we are currently using the system default jdk to startup OpenSearch and call `opensearch-cli` during packaging for safely installing/removing plugins.

This can lead to unpredictable behavior depending on the installed version. Moreover, with an installed Java 24, this causes failure on startup/packing.

To resolve this, this pr will download a specific jvm during `mvn package` (only when run on a Mac) and install it alongside OpenSearch's bundled jvm. The current workaround for using a different jvm on Mac is adjusted to now use this.

## Motivation and Context
solves #22992 

## How Has This Been Tested?
Run `mvn package` on Mac:
- assure that jvm is installed alongside current jdk
- assure that plugin installation and removal during build is working

Run data node on Mac:
- assure the downloaded jdk is used on startup

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

