### PR TITLE
Rotate UPGRADING.md for 7.0, Add note about ObjectMapper unknown properties change

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,11 +1,9 @@
-Upgrading to Graylog 6.3.x
+Upgrading to Graylog 7.0.x
 ==========================
 
 ## Breaking Changes
 
-- By introducing a report creator role in Enterprise, we change from the functionality in the 
-previous version that allowed every user to create reports to a more restrictive approach that a 
-user needs the report creator role from now on to create reports.
+- tbd
 
 ## Configuration File Changes
 
@@ -15,18 +13,11 @@ user needs the report creator role from now on to create reports.
 
 ## Default Configuration Changes
 
-- A permission `input_types:create` for creating input types has been introduced.
-
-  By granting only permissions for specific input types (e.g.
-  `input_types:create:org.graylog2.inputs.misc.jsonpath.JsonPathInput`),
-  users can be only allowed to manage inputs of specific types. Granting the permission without specifying input
-  types (as shown above) will allow management of all input types.
-  Existing roles and users are updated to automatically include the permissions for all input types if they contain a
-  manage permission for inputs.
+- tbd
 
 ## Java API Changes
 
-- Database consumers are now using our custom MongoDB collection interface `org.graylog2.database.MongoCollection` instead of `com.mongodb.client.MongoCollection`.
+- tbd
 
 ## REST API Endpoint Changes
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,12 @@ Upgrading to Graylog 7.0.x
 
 - tbd
 
+## General REST API Changes
+
+- In Graylog 7.0, an issue was fixed that previously allowed additional unknown JSON properties to be accepted 
+  (and ignored) in API requests on the Graylog leader node. Now that the issue has been fixed, API requests on the 
+  leader node will once again only accept JSON payloads that contain explicitly mapped/supported properties.  
+
 ## REST API Endpoint Changes
 
 The following REST API changes have been made.


### PR DESCRIPTION
Rotates UPGRADING.md for 7.0. Also adds a note about API change which restores enforcement of unknown JSON fields from https://github.com/Graylog2/graylog-plugin-enterprise/pull/11085.

/nocl Change log is present in https://github.com/Graylog2/graylog-plugin-enterprise/pull/11085.