### PR TITLE
fix: Add queryFn object key

### DIFF
--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.tsx
@@ -37,11 +37,11 @@ import formatDecorator from './decorators/FormatDecorator';
 const DecoratorsConfig = () => {
   const { data: streams, isLoading: streamsLoading } = useQuery<Array<Stream>>({
     queryKey: ['streamsMap'],
-    ...StreamsActions.listStreams,
+    queryFn: StreamsActions.listStreams,
   });
   const { data: types, isLoading: typesLoading } = useQuery<{ [key: string]: DecoratorType }>({
     queryKey: ['decorators', 'types'],
-    ...DecoratorsActions.available,
+    queryFn: DecoratorsActions.available,
   });
   const {
     data: decorators,
@@ -49,7 +49,7 @@ const DecoratorsConfig = () => {
     refetch: refetchDecorators,
   } = useQuery<Array<Decorator>>({
     queryKey: ['decorators', 'available'],
-    ...DecoratorsActions.list,
+    queryFn: DecoratorsActions.list,
   });
   const [showConfigModal, setShowConfigModal] = useState(false);
   const streamsMap = useMemo(() => Object.fromEntries(streams?.map((s) => [s.id, s] as const) ?? []), [streams]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed decorators query functions. The `queryFn` property was missing creating an unexpected state

closes: #22977 

/nocl

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

