### PR TITLE
Revert change to only show iwgdet actions on hover for now.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetFrame.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFrame.tsx
@@ -103,13 +103,11 @@ const WidgetWrap = styled.div(
     }
 
     .${widgetActionsMenuClass}, .${widgetDragHandleClass} {
-      opacity: 0;
       pointer-events: none;
       transition: opacity 0.2s;
     }
 
     &:hover .${widgetActionsMenuClass}, &:hover .${widgetDragHandleClass} {
-      opacity: 1;
       pointer-events: auto;
     }
   `,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is temporary reverting the change we made in https://github.com/Graylog2/graylog2-server/pull/22880. Currently there is a bug when the actions dropdown is being displayed in a portal:



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

