### PR TITLE
Display navigation dropdown menus over pinned search sidebar.

### DIFF
--- a/changelog/unreleased/pr-23014.toml
+++ b/changelog/unreleased/pr-23014.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing issue where navigation dropdown menus were hidden behind the pinned search sidebar."
+
+issues = ["graylog-plugin-enterprise#11200"]
+pulls = ["23014"]

--- a/graylog2-web-interface/src/theme/z-indices.ts
+++ b/graylog2-web-interface/src/theme/z-indices.ts
@@ -16,6 +16,7 @@
  */
 const modalBase = 1040;
 const zIndices = {
+  searchSidebar: 6,
   modalOverlay: modalBase,
   modalBody: modalBase + 10,
   notifications: modalBase + 11,

--- a/graylog2-web-interface/src/theme/z-indices.ts
+++ b/graylog2-web-interface/src/theme/z-indices.ts
@@ -15,8 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 const modalBase = 1040;
+const sidebar = 6;
+
 const zIndices = {
-  searchSidebar: 6,
+  sidebar: sidebar,
+  sidebarContentColumn: sidebar + 1,
+  sidebarOverlay: sidebar - 1,
   modalOverlay: modalBase,
   modalBody: modalBase + 10,
   notifications: modalBase + 11,

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -42,8 +42,7 @@ export const Container = styled.div<{ $sidebarIsPinned: boolean }>(
     background: ${theme.colors.global.contentBackground};
     border-right: ${$sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
     box-shadow: ${$sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
-
-    z-index: ${zIndices.searchSidebar};
+    z-index: ${zIndices.sidebar};
 
     ${$sidebarIsPinned &&
     css`
@@ -57,7 +56,6 @@ export const Container = styled.div<{ $sidebarIsPinned: boolean }>(
         border-top-left-radius: 50%;
         background: transparent;
         box-shadow: -6px -6px 0 3px ${theme.colors.global.contentBackground};
-        z-index: 5; /* to render over Sidebar ContentColumn */
       }
     `}
   `,

--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.tsx
@@ -19,6 +19,7 @@ import styled, { css } from 'styled-components';
 
 import type { SearchPreferencesLayout } from 'views/components/contexts/SearchPagePreferencesContext';
 import { IconButton } from 'components/common';
+import zIndices from 'theme/z-indices';
 
 type Props = {
   children: React.ReactNode;
@@ -42,7 +43,7 @@ export const Container = styled.div<{ $sidebarIsPinned: boolean }>(
     border-right: ${$sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
     box-shadow: ${$sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
 
-    z-index: ${$sidebarIsPinned ? 1030 : 6};
+    z-index: ${zIndices.searchSidebar};
 
     ${$sidebarIsPinned &&
     css`

--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.tsx
@@ -37,7 +37,6 @@ const Container = styled.button<ContainerProps>(
     width: 100%;
     height: 40px;
     font-size: ${fonts.size.h3};
-    z-index: 4; /* to render over SidebarNav::before */
     cursor: ${$disabled ? 'not-allowed' : 'pointer'};
     color: ${colors.variant.darkest.default};
     background: transparent;
@@ -141,7 +140,6 @@ const Title = styled.div(
     border: 1px solid ${colors.variant.light.info};
     border-left: none;
     box-shadow: 3px 3px 3px ${colors.global.navigationBoxShadow};
-    z-index: 4;
     border-radius: 0 3px 3px 0;
     align-items: center;
     white-space: nowrap;

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.tsx
@@ -26,6 +26,7 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
+import zIndices from 'theme/z-indices';
 
 import SidebarNavigation from './SidebarNavigation';
 import ContentColumn from './ContentColumn';
@@ -56,7 +57,7 @@ const ContentOverlay = styled.div(
     position: fixed;
     inset: 0 0 0 50px;
     background: ${chroma(theme.colors.brand.tertiary).alpha(0.25).css()};
-    z-index: 5;
+    z-index: ${zIndices.sidebarOverlay};
   `,
 );
 

--- a/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.tsx
@@ -21,6 +21,7 @@ import type { SidebarAction } from 'views/components/sidebar/sidebarActions';
 import type { IconName } from 'components/common/Icon';
 import usePluginEntities from 'hooks/usePluginEntities';
 import useLocation from 'routing/useLocation';
+import zIndices from 'theme/z-indices';
 
 import NavItem from './NavItem';
 import type { SidebarSection } from './sidebarSections';
@@ -40,7 +41,7 @@ export const Container = styled.div<{ $isOpen?: boolean; $sidebarIsPinned?: bool
     width: 50px;
     height: 100%;
     position: relative;
-    z-index: 1031;
+    z-index: ${zIndices.sidebarContentColumn};
 
     &::before {
       content: '';
@@ -52,7 +53,6 @@ export const Container = styled.div<{ $isOpen?: boolean; $sidebarIsPinned?: bool
       border-top-left-radius: 50%;
       background: transparent;
       box-shadow: -6px -6px 0 3px ${theme.colors.global.navigationBackground};
-      z-index: 4; /* to render over Sidebar ContentColumn */
     }
   `,
 );


### PR DESCRIPTION
**Please note**, this PR needs a backport for `6.2` and `6.3`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this PR a pinned search sidebar could overlap navigation dropdown menus.

Before: 
![image](https://github.com/user-attachments/assets/e94a0371-6edd-4789-9593-43248141bc83)

After:
![image](https://github.com/user-attachments/assets/73f3ba9b-441f-4e40-b940-4cb153f71968)

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/11200
