### PR TITLE
Fix scroll on click behaviour for scroll hint on search page (`6.3`).

### DIFF
--- a/changelog/unreleased/issue-19329.toml
+++ b/changelog/unreleased/issue-19329.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix scroll on click behaviour for scroll hint on search page."
+
+issues = ["19329"]
+pulls = ["23026"]

--- a/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
+++ b/graylog2-web-interface/src/components/layout/PageContentLayout.tsx
@@ -23,6 +23,8 @@ import { Grid } from 'components/bootstrap';
 import Footer from 'components/layout/Footer';
 import useFooterCustomization from 'brand-customization/useFooterCustomization';
 
+export const SCROLL_CONTAINER_ID = 'page-content';
+
 type Props = React.PropsWithChildren<{
   className?: string;
   FooterComponent?: React.ComponentType;
@@ -61,7 +63,7 @@ const PageContentLayout = ({
   const { enabled } = useFooterCustomization();
 
   return (
-    <Container className={className}>
+    <Container className={className} id={SCROLL_CONTAINER_ID}>
       <NotificationsComponent>
         <StyledGrid fluid className="page-content-grid">
           {children || <Outlet />}

--- a/graylog2-web-interface/src/util/UIUtils.js
+++ b/graylog2-web-interface/src/util/UIUtils.js
@@ -16,6 +16,8 @@
  */
 import $ from 'jquery';
 
+import { SCROLL_CONTAINER_ID } from 'components/layout/PageContentLayout';
+
 const UIUtils = {
   NAVBAR_HEIGHT: 55,
   scrollToHint(element) {
@@ -30,7 +32,7 @@ const UIUtils = {
           event.preventDefault();
           const top = window.pageYOffset - this.NAVBAR_HEIGHT + element.getBoundingClientRect().top;
 
-          $('html, body').animate({ scrollTop: top }, 'fast');
+          $(`#${SCROLL_CONTAINER_ID}`).animate({ scrollTop: top }, 'fast');
           $scrollHint.off('click');
         });
     }


### PR DESCRIPTION
**Please note**, for post `6.3` versions, the related bug has been fixed by refactoring the scroll hint implementation. See https://github.com/Graylog2/graylog2-server/pull/22928.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing the problem with the scroll hint on the search page, described in https://github.com/Graylog2/graylog2-server/issues/19329, by using the correct selector for the scroll container.
