### PR TITLE
Aligning plugin loading order in development mode.

### DIFF
--- a/graylog2-web-interface/templates/index.html.template
+++ b/graylog2-web-interface/templates/index.html.template
@@ -7,10 +7,10 @@
     <% for (var vendorChunk in vendorModule().files.js) { %>
     <script defer src="/<%= vendorModule().files.js[vendorChunk] %>"></script>
     <% } %>
-    <%= htmlWebpackPlugin.tags.headTags %>
     <% for (var idx in pluginNames()) { %>
     <script defer src="/<%= pluginNames()[idx] %>.js"></script>
     <% } %>
+    <%= htmlWebpackPlugin.tags.headTags %>
   </head>
   <body>
     <%= htmlWebpackPlugin.tags.bodyTags %>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that the plugin loading order is aligned between development and production mode.

/nocl Only relevant for dev.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.