### PR TITLE
Relaxing `img-src` directive from CSP.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSP.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface CSP {
-    static final String DEFAULT = "default";
-    static final String SWAGGER = "swagger";
+    String DEFAULT = "default";
+    String SWAGGER = "swagger";
 
     String group() default DEFAULT;
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPDynamicFeature.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPDynamicFeature.java
@@ -16,11 +16,7 @@
  */
 package org.graylog2.shared.rest.resources.csp;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.inject.Inject;
-
 import jakarta.ws.rs.container.DynamicFeature;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Context;
@@ -29,17 +25,12 @@ import jakarta.ws.rs.core.FeatureContext;
 import java.lang.reflect.Method;
 
 public class CSPDynamicFeature implements DynamicFeature {
-    private static final Logger LOG = LoggerFactory.getLogger(CSPDynamicFeature.class);
     public static final String CSP_NONCE_PROPERTY = "cspNonce";
     private final CSPService cspService;
 
     @Inject
     public CSPDynamicFeature(@Context CSPService cspService) {
         this.cspService = cspService;
-    }
-
-    public String cspDefault() {
-        return cspService.cspString(CSP.DEFAULT);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPResponseFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPResponseFilter.java
@@ -26,7 +26,7 @@ import static org.graylog2.shared.rest.resources.csp.CSPDynamicFeature.CSP_NONCE
 public class CSPResponseFilter implements ContainerResponseFilter {
     public final static String CSP_HEADER = "Content-Security-Policy";
     private final static String noncePattern = "\\{nonce}";
-    private String group;
+    private final String group;
     private final CSPService cspService;
 
     public CSPResponseFilter(String group, CSPService cspService) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/csp/CSPServiceImpl.java
@@ -16,14 +16,13 @@
  */
 package org.graylog2.shared.rest.resources.csp;
 
+import jakarta.inject.Inject;
 import org.graylog.security.authservice.DBAuthServiceBackendService;
 import org.graylog2.configuration.ContentStreamConfiguration;
 import org.graylog2.configuration.TelemetryConfiguration;
 import org.graylog2.rest.PaginationParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.net.URI;
 import java.util.stream.Collectors;
@@ -62,11 +61,9 @@ public class CSPServiceImpl implements CSPService {
     }
 
     private String getContentStreamHost(URI contentStreamRssApiHost) {
-        String slash = "/";
-        if (contentStreamRssApiHost.getPath().endsWith(slash)) {
-            return contentStreamRssApiHost.toString();
-        } else {
-            return contentStreamRssApiHost.toString() + slash;
-        }
+        final var slash = "/";
+        return contentStreamRssApiHost.getPath().endsWith(slash)
+                ? contentStreamRssApiHost.toString()
+                : contentStreamRssApiHost + slash;
     }
 }

--- a/graylog2-server/src/main/resources/org/graylog2/security/csp.config
+++ b/graylog2-server/src/main/resources/org/graylog2/security/csp.config
@@ -27,7 +27,7 @@
 default.default-src='self'
 default.style-src='self' 'unsafe-inline'
 default.script-src='strict-dynamic' 'nonce-{nonce}' 'unsafe-eval'
-default.img-src=data: 'self' https://*.tile.openstreetmap.org https://graylog.org
+default.img-src=data: 'self' https://* http://*
 
 swagger.style-src='self' 'unsafe-inline'
 swagger.script-src='self' 'unsafe-eval' 'unsafe-inline'

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -28,6 +28,9 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
     node.setAttribute('target', '_blank');
     node.setAttribute('rel', 'noopener noreferrer');
   }
+  if (node instanceof HTMLImageElement && node.getAttribute('src')) {
+    node.setAttribute('referrerpolicy', 'noreferrer');
+  }
 });
 
 const Markdown = ({ text }: Props) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In order to embed images from external sources (e.g. status badges) in the markdown widget, this PR is relaxing the `img-src` directive from the server's content security policy. This allows loading of images from all sources. To send as little information to external hosts as possible, the `Markdown` component adds a `referrerpolicy="noreferrer"` attribute to all `img` tags. Still, this could be used to track users visiting a search/dashboard, as requests will be sent from the user's browser to external hosts.

/nocl Fixing an unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.