### PR TITLE
Add ability to preview entries in lookup tables

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -22,6 +22,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupCacheKey;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.graylog2.plugin.lookup.LookupResult;
 
 import javax.annotation.Nonnull;
@@ -131,6 +132,14 @@ public abstract class LookupTable {
         final LookupResult result = dataAdapter().assignTtl(key, ttlSec);
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
+    }
+
+    public boolean supportsPreview() {
+        return dataAdapter().supportsPreview();
+    }
+
+    public LookupPreview getPreview(int size) {
+        return dataAdapter().getPreview(size);
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -38,6 +38,7 @@ import org.graylog2.lookup.events.LookupTablesDeleted;
 import org.graylog2.lookup.events.LookupTablesUpdated;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.system.SystemEntity;
 import org.graylog2.utilities.LoggingServiceListener;
@@ -731,6 +732,22 @@ public class LookupTableService extends AbstractIdleService {
                 return LookupResult.withError();
             }
             return lookupTable.assignTtl(requireValidKey(key), ttlSec);
+        }
+
+        public boolean supportsPreview() {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return false;
+            }
+            return lookupTable.supportsPreview();
+        }
+
+        public LookupPreview getPreview(int size) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return LookupPreview.empty();
+            }
+            return lookupTable.getPreview(size);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -41,6 +41,7 @@ import org.graylog2.lookup.AllowedAuxiliaryPathChecker;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.plugin.utilities.FileInfo;
 import org.graylog2.utilities.CIDRPatriciaTrie;
@@ -60,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -291,7 +293,29 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
         return LookupResult.single(value);
     }
 
-    public LookupResult getResultForCIDRRange(Object ip) {
+    @Override
+    public boolean supportsPreview() {
+        return true;
+    }
+
+    @Override
+    public LookupPreview getPreview(int size) {
+        if (config.isCidrLookup()) {
+            return cidrLookupRef.get().getPreview(size);
+        } else {
+            final Map<Object, Object> result = new HashMap<>();
+            final Map<String, String> lookup = lookupRef.get();
+            for (Map.Entry<String, String> entries : lookup.entrySet()) {
+                if (result.size() == size) {
+                    break;
+                }
+                result.put(entries.getKey(), entries.getValue());
+            }
+            return new LookupPreview(lookup.size(), result);
+        }
+    }
+
+    private LookupResult getResultForCIDRRange(Object ip) {
         LookupResult result = getEmptyResult();
         try {
             final String resultValue = cidrLookupRef.get().longestPrefixRangeLookup(String.valueOf(ip));

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
@@ -26,6 +26,10 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
 import com.google.inject.assistedinject.Assisted;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import okhttp3.HttpUrl;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.lookup.adapters.dsvhttp.DSVParser;
@@ -33,6 +37,7 @@ import org.graylog2.lookup.adapters.dsvhttp.HTTPFileRetriever;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.system.urlwhitelist.UrlNotWhitelistedException;
 import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
@@ -41,13 +46,8 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.inject.Inject;
-
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
-
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -162,6 +162,24 @@ public class DSVHTTPDataAdapter extends LookupDataAdapter {
         }
 
         return LookupResult.single(value);
+    }
+
+    @Override
+    public boolean supportsPreview() {
+        return true;
+    }
+
+    @Override
+    public LookupPreview getPreview(int size) {
+        final Map<Object, Object> result = new HashMap<>();
+        final Map<String, String> lookup = lookupRef.get();
+        for (Map.Entry<String, String> entries : lookup.entrySet()) {
+            if (result.size() == size) {
+                break;
+            }
+            result.put(entries.getKey(), entries.getValue());
+        }
+        return new LookupPreview(lookup.size(), result);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -237,6 +237,14 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
         return resultWithError;
     }
 
+    public boolean supportsPreview() {
+        return false;
+    }
+
+    public LookupPreview getPreview(int size) {
+        return LookupPreview.empty();
+    }
+
     public LookupDataAdapterConfiguration getConfig() {
         return config;
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupPreview.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupPreview.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin.lookup;
+
+import java.util.Map;
+
+public record LookupPreview(long total, Map<Object, Object> results) {
+    public static LookupPreview empty() {
+        return new LookupPreview(0, Map.of());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -69,6 +69,7 @@ import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.rest.models.SortOrder;
@@ -227,7 +228,7 @@ public class LookupTableResource extends RestResource {
     public void performPurge(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName,
                              @ApiParam(name = "key") @QueryParam("key") String key) {
         final Optional<LookupTableDto> lookupTableDto = dbTableService.get(idOrName);
-        if (!lookupTableDto.isPresent()) {
+        if (lookupTableDto.isEmpty()) {
             throw new NotFoundException("Lookup table <" + idOrName + "> not found");
         }
 
@@ -304,7 +305,7 @@ public class LookupTableResource extends RestResource {
                                @ApiParam(name = "resolve") @QueryParam("resolve") @DefaultValue("false") boolean resolveObjects) {
 
         Optional<LookupTableDto> lookupTableDto = dbTableService.get(idOrName);
-        if (!lookupTableDto.isPresent()) {
+        if (lookupTableDto.isEmpty()) {
             throw new NotFoundException();
         }
         LookupTableDto tableDto = lookupTableDto.get();
@@ -369,7 +370,7 @@ public class LookupTableResource extends RestResource {
     public LookupTableApi removeTable(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName) {
         // TODO validate that table isn't in use, how?
         Optional<LookupTableDto> lookupTableDto = dbTableService.get(idOrName);
-        if (!lookupTableDto.isPresent()) {
+        if (lookupTableDto.isEmpty()) {
             throw new NotFoundException();
         }
         checkPermission(RestPermissions.LOOKUP_TABLES_DELETE, lookupTableDto.get().id());
@@ -412,6 +413,25 @@ public class LookupTableResource extends RestResource {
         }
 
         return validation;
+    }
+
+    @GET
+    @Path("tables/preview/{idOrName}")
+    @ApiOperation(value = "Retrieve the named lookup table")
+    public LookupPreview getPreview(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName,
+                                    @ApiParam(name = "size") @QueryParam("size") @DefaultValue("5") int size) {
+        Optional<LookupTableDto> lookupTableDto = dbTableService.get(idOrName);
+        if (lookupTableDto.isEmpty()) {
+            throw new NotFoundException();
+        }
+        LookupTableDto tableDto = lookupTableDto.get();
+
+        checkPermission(RestPermissions.LOOKUP_TABLES_READ, tableDto.id());
+        final var service = lookupTableService.newBuilder().lookupTable(tableDto.name()).build();
+        if (!service.supportsPreview()) {
+            throw new UnsupportedOperationException("Backing data adapter does not support preview.");
+        }
+        return service.getPreview(size);
     }
 
     @JsonAutoDetect

--- a/graylog2-server/src/main/java/org/graylog2/utilities/CIDRPatriciaTrie.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/CIDRPatriciaTrie.java
@@ -18,9 +18,11 @@ package org.graylog2.utilities;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.graylog2.plugin.lookup.LookupPreview;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -190,6 +192,20 @@ public class CIDRPatriciaTrie {
         }
     }
 
+    // Gets a preview of the nodes in the trie. Since initial CIDR ranges have been converted to binary strings, the
+    // keys in the result map need to be converted back to their original format.
+    public LookupPreview getPreview(int size) {
+        final Map<Object, Object> result = new HashMap<>();
+        for (Map.Entry<String, Node> entry : trie.entrySet()) {
+            if (result.size() == size) {
+                break;
+            }
+            final String cidrRange = fromBinaryString(entry.getKey(), entry.getValue().rangeIsIPv6());
+            result.put(cidrRange, entry.getValue().rangeName);
+        }
+        return new LookupPreview(trie.size(), result);
+    }
+
     // Convert an IP address to a binary string (supports both IPv4 and IPv6)
     static String toBinaryString(String ip, int prefixLength) {
         final boolean isIPv6 = ip.contains(":");
@@ -232,6 +248,85 @@ public class CIDRPatriciaTrie {
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid IP address format: " + ip);
         }
+    }
+
+    static String fromBinaryString(String binary, boolean isIPv6) {
+        if (isIPv6) {
+            return fromBinaryIPv6(binary);
+        } else {
+            return fromBinaryIPv4(binary);
+        }
+    }
+
+    private static String fromBinaryIPv4(String binary) {
+        final int prefixLength = binary.length();
+        // Pad to 32 bits
+        binary = String.format("%-32s", binary).replace(' ', '0');
+        StringBuilder ip = new StringBuilder();
+        for (int i = 0; i < 32; i += 8) {
+            String octet = binary.substring(i, i + 8);
+            ip.append(Integer.parseInt(octet, 2));
+            if (i < 24) ip.append('.');
+        }
+        if (prefixLength == 32) {
+            return ip.toString();
+        }
+        return ip + "/" + prefixLength;
+    }
+
+    private static String fromBinaryIPv6(String binary) {
+        final int prefixLength = binary.length();
+        // Pad to 128 bits
+        binary = String.format("%-128s", binary).replace(' ', '0');
+        StringBuilder ip = new StringBuilder();
+        for (int i = 0; i < 128; i += 16) {
+            String hextet = binary.substring(i, i + 16);
+            ip.append(Integer.toHexString(Integer.parseInt(hextet, 2)));
+            if (i < 112) ip.append(':');
+        }
+
+        // Compress using "::" for longest run of zeros
+        String compressed = compressIPv6(ip.toString());
+        if (prefixLength == 128) {
+            return compressed;
+        }
+        return compressed + "/" + prefixLength;
+    }
+
+    // Utility to compress IPv6 address (e.g., turn "2001:0:0:0:0:0:0:1" into "2001::1")
+    private static String compressIPv6(String fullAddress) {
+        String[] parts = fullAddress.split(":");
+        int bestStart = -1, bestLen = 0;
+        int currStart = -1, currLen = 0;
+
+        for (int i = 0; i <= parts.length; i++) {
+            if (i < parts.length && parts[i].equals("0")) {
+                if (currStart == -1) currStart = i;
+                currLen++;
+            } else {
+                if (currLen > bestLen) {
+                    bestStart = currStart;
+                    bestLen = currLen;
+                }
+                currStart = -1;
+                currLen = 0;
+            }
+        }
+
+        if (bestLen > 1) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < bestStart; i++) {
+                sb.append(parts[i]).append(":");
+            }
+            sb.append("::");
+            for (int i = bestStart + bestLen; i < parts.length; i++) {
+                sb.append(parts[i]);
+                if (i < parts.length - 1) sb.append(":");
+            }
+            return sb.toString().replaceAll("(^:)|(:$)", "");
+        }
+
+        return fullAddress;
     }
 
     // Used only for testing purposes.

--- a/graylog2-server/src/test/java/org/graylog2/utilities/CIDRPatriciaTrieTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/CIDRPatriciaTrieTest.java
@@ -138,7 +138,18 @@ public class CIDRPatriciaTrieTest {
         assertThat(cidrBinary).isEqualTo("00100000000000010000110110110111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         cidrBinary = CIDRPatriciaTrie.toBinaryString("192.168.102.0", 24);
         assertThat(cidrBinary).isEqualTo("110000001010100001100110");
+    }
 
+    @Test
+    public void testFromBinaryIP() {
+        String cidr = CIDRPatriciaTrie.fromBinaryString("0010000000000010000000000000000000000000000000000001001000110100", true);
+        assertThat(cidr).isEqualTo("2002:0:0:1234::/64");
+        cidr = CIDRPatriciaTrie.fromBinaryString("11000000101010000110011100010000", false);
+        assertThat(cidr).isEqualTo("192.168.103.16");
+        cidr = CIDRPatriciaTrie.fromBinaryString("00100000000000010000110110110111000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", true);
+        assertThat(cidr).isEqualTo("2001:db7::");
+        cidr = CIDRPatriciaTrie.fromBinaryString("110000001010100001100110", false);
+        assertThat(cidr).isEqualTo("192.168.102.0/24");
     }
 
     private static CIDRPatriciaTrie buildTrie() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds ability to preview lookup table entries for tables backed by `CSVFileDataAdapter` and `DSVHTTPDataAdapter`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes Graylog2/graylog-plugin-enterprise#11114 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

