### PR TITLE
Use system color to highlight selected text in search query input. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-21900.toml
+++ b/changelog/unreleased/issue-21900.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve background color of selected text in search query input."
+
+pulls = ["22964"]
+issues = ["21900"]

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
@@ -57,7 +57,8 @@ const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled 
     }
 
     .ace_marker-layer .ace_selection {
-      background: ${$scTheme.colors.variant.lightest.default};
+      background: Highlight;
+      border-radius: 0;
     }
 
     .ace_marker-layer .ace_step {
@@ -79,6 +80,7 @@ const StyledAceEditor = styled(AceEditor)<Props>(({ $scTheme, $height, disabled 
 
     .ace_marker-layer .ace_selected-word {
       border: 1px solid ${$scTheme.colors.gray[80]};
+      background: transparent;
     }
 
     .ace_invisible {


### PR DESCRIPTION
Note: This is a backport of #22964 to `6.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR improves the background color of selected text in search query input by using the system default.

Before:
![image](https://github.com/user-attachments/assets/adacc186-670f-4f8b-a16e-ca2ad010c0c6)

After:
![image](https://github.com/user-attachments/assets/23e257bf-4ebb-49ef-84bc-2ae9ba3b7cca)


Fixes #21900 