### PR TITLE
Fix color of comments in pipeline rule editor.  `6.1`

### DIFF
--- a/changelog/unreleased/issue-19346.toml
+++ b/changelog/unreleased/issue-19346.toml
@@ -1,5 +1,5 @@
 type = "f"
 message = "Fix color of comments in pipeline rule editor."
 
-pulls = ["23082"]
+pulls = ["23084"]
 issues = ["19346"]

--- a/changelog/unreleased/issue-19346.toml
+++ b/changelog/unreleased/issue-19346.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix color of comments in pipeline rule editor."
+
+pulls = ["23082"]
+issues = ["19346"]

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.tsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.tsx
@@ -50,6 +50,14 @@ const SourceCodeContainer = styled.div<ContainerProps>(({ $resizable, theme }) =
       .ace_active-line {
         background: ${theme.colors.variant.lightest.default};
       }
+
+      .ace_comment {
+        color: ${theme.colors.text.secondary};
+      }
+
+      .ace_selection {
+        background: Highlight;
+      }
     }
 
     .ace_gutter-active-line {


### PR DESCRIPTION
**Please note**, in post `6.3` versions the fix for this issue is part of a refactoring https://github.com/Graylog2/graylog2-server/pull/23049

## Description
<!--- Describe your changes in detail -->

With this PR we are improving the color of comments in the pipeline editor. (related to https://github.com/Graylog2/graylog2-server/issues/19346 & https://github.com/Graylog2/graylog2-server/issues/19695)


Before light and dark mode
![image](https://github.com/user-attachments/assets/7b92cb43-ae4d-495b-b230-9edff891224b)

![image](https://github.com/user-attachments/assets/54a22646-4e8b-4412-b292-4f535522bb07)

After light and dark mode:
<img width="780" alt="image" src="https://github.com/user-attachments/assets/90a16c76-9857-4dc9-9eef-bee1ad944f6c" />

![image](https://github.com/user-attachments/assets/0baced74-a99e-42a1-9ce3-ef11213a3a71)

We are also implementing the system color for the background of selected text.