### PR TITLE
Remove enterprise-specific `TEAM` GRN type

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
@@ -28,7 +28,6 @@ public class GRNTypes {
     public static final GRNType ROLE = GRNType.create("role");
     public static final GRNType SEARCH = GRNType.create("search");
     public static final GRNType STREAM = GRNType.create("stream");
-    public static final GRNType TEAM = GRNType.create("team");
     public static final GRNType USER = GRNType.create("user");
     public static final GRNType SEARCH_FILTER = GRNType.create("search_filter");
     public static final GRNType FAVORITE = GRNType.create("favorite");
@@ -47,7 +46,6 @@ public class GRNTypes {
             .add(ROLE)
             .add(SEARCH)
             .add(STREAM)
-            .add(TEAM)
             .add(USER)
             .add(SEARCH_FILTER)
             .add(FAVORITE)

--- a/graylog2-server/src/test/java/org/graylog2/users/GrantsCleanupListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/GrantsCleanupListenerTest.java
@@ -60,8 +60,6 @@ public class GrantsCleanupListenerTest {
             grnRegistry.newGRN(GRNTypes.USER, "a"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
     private final GrantDTO grantUserB = GrantDTO.of(
             grnRegistry.newGRN(GRNTypes.USER, "b"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
-    private final GrantDTO grantTeam = GrantDTO.of(
-            grnRegistry.newGRN(GRNTypes.TEAM, "t"), Capability.VIEW, grnRegistry.newGRN(GRNTypes.DASHBOARD, "d"));
 
     @BeforeEach
     void setUp() {
@@ -81,7 +79,7 @@ public class GrantsCleanupListenerTest {
     @Test
     void userRemoved() {
         when(userService.streamAll()).thenReturn(Stream.of(userA));
-        when(grantService.streamAll()).thenReturn(Stream.of(grantUserA, grantUserB, grantTeam));
+        when(grantService.streamAll()).thenReturn(Stream.of(grantUserA, grantUserB));
 
         cleanupListener.handleUserDeletedEvent(mock(UserDeletedEvent.class));
 


### PR DESCRIPTION
The `TEAM` GRN type is only used in the enterprise plugin, so we are moving it there.
