### PR TITLE
adapt log level for failure submission queue

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
+++ b/graylog2-server/src/main/java/org/graylog/failure/FailureSubmissionQueue.java
@@ -77,7 +77,7 @@ class FailureSubmissionQueue {
         queue.put(batch);
 
         if (queueSize() == configuration.getFailureHandlingQueueCapacity()) {
-            logger.debug("The queue is full! Current capacity: {}", configuration.getFailureHandlingQueueCapacity());
+            logger.warn("The queue is full! Current capacity: {}", configuration.getFailureHandlingQueueCapacity());
         }
 
         submittedFailureBatches.mark();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In this [issue](https://github.com/Graylog2/forwarder/issues/170) we had the problem that the failure queue was full and blocked. We are increasing the log level so that this can be detected earlier in the future.
/nocl

