### PR TITLE
CloudTrail input: Avoid overriding userIdentity fields for temporary credentials

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailRecord.java
@@ -112,12 +112,7 @@ public class CloudTrailRecord implements Serializable {
     public String getConstructedMessage() {
         return eventSource + ":" + eventName + " in " + awsRegion + " by " + sourceIPAddress + " / " +
                 Optional.ofNullable(userIdentity)
-                        .map(ui -> ui.userName != null ? ui.userName :
-                                Optional.ofNullable(ui.sessionContext)
-                                        .map(sc -> sc.sessionIssuer)
-                                        .map(issuer -> issuer.userName)
-                                        .orElse(null)
-                        )
+                        .flatMap(CloudTrailUserIdentity::resolveUserName)
                         .orElse("<unknown user_name>");
     }
 

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/json/CloudTrailUserIdentity.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class CloudTrailUserIdentity {
     private static final String USER_TYPE = "user_type";
@@ -27,6 +28,7 @@ public class CloudTrailUserIdentity {
     private static final String USER_PRINCIPAL_ID = "user_principal_id";
     private static final String USER_PRINCIPAL_ARN = "user_principal_arn";
     private static final String USER_ACCOUNT_ID = "user_account_id";
+    private static final String SESSION_ISSUER_PREFIX = "session_issuer_";
     @JsonProperty("type")
     public String type;
     @JsonProperty("principalId")
@@ -52,20 +54,36 @@ public class CloudTrailUserIdentity {
         m.put(USER_ACCOUNT_ID, accountId);
         m.put("user_access_key_id", accessKeyId);
 
-        if (sessionContext != null && sessionContext.attributes != null) {
-            m.put("user_session_creation_date", sessionContext.attributes.creationDate);
-            m.put("user_session_mfa_authenticated", Boolean.valueOf(sessionContext.attributes.mfaAuthenticated));
-        }
-
-        if (sessionContext != null && sessionContext.sessionIssuer != null) {
-            m.put(USER_TYPE, sessionContext.sessionIssuer.type);
-            m.put(USER_NAME, sessionContext.sessionIssuer.userName);
-            m.put(USER_PRINCIPAL_ID, sessionContext.sessionIssuer.principalId);
-            m.put(USER_PRINCIPAL_ARN, sessionContext.sessionIssuer.arn);
-            m.put(USER_ACCOUNT_ID, sessionContext.sessionIssuer.accountId);
+        if (sessionContext != null) {
+            if (sessionContext.attributes != null) {
+                m.put("user_session_creation_date", sessionContext.attributes.creationDate);
+                m.put("user_session_mfa_authenticated", Boolean.valueOf(sessionContext.attributes.mfaAuthenticated));
+            }
+            if (sessionContext.sessionIssuer != null) {
+                // Explicitly set the username field. It will only be present in either the parent userIdentity element,
+                // or the sessionIssuer element, but not both.
+                // See documentation https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html#STS-API-source-identity
+                m.put(USER_NAME, sessionContext.sessionIssuer.userName);
+                // Add session issuer fields with a prefix, since those are unique to the temporary credential role.
+                m.put(SESSION_ISSUER_PREFIX + USER_TYPE, sessionContext.sessionIssuer.type);
+                m.put(SESSION_ISSUER_PREFIX + USER_PRINCIPAL_ID, sessionContext.sessionIssuer.principalId);
+                m.put(SESSION_ISSUER_PREFIX + USER_PRINCIPAL_ARN, sessionContext.sessionIssuer.arn);
+                m.put(SESSION_ISSUER_PREFIX + USER_ACCOUNT_ID, sessionContext.sessionIssuer.accountId);
+            }
         }
 
         return m;
     }
 
+    /**
+     * @return top-level userName if available, otherwise the userName from the session context if present.
+     */
+    public Optional<String> resolveUserName() {
+        return Optional.ofNullable(userName)
+                .filter(name -> !name.isEmpty())
+                .or(() -> Optional.ofNullable(sessionContext)
+                        .map(ctx -> ctx.sessionIssuer)
+                        .map(issuer -> issuer.userName)
+                        .filter(name -> !name.isEmpty()));
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/aws/inputs/cloudtrail/CloudTrailCodecTest.java
@@ -123,7 +123,17 @@ public class CloudTrailCodecTest {
 
         Message message = codec.decodeSafe(getRawMessageFromFile(STATIC_CREDENTIALS_FILE)).get();
         String userName = message.getField("user_name").toString();
+        assertTrue(message.getMessage().contains("Alice"));
         assertEquals("Alice", userName);
+        assertEquals("IAMUser", message.getField("user_type"));
+        assertEquals("AIDAJ45Q7YFFAREXAMPLE", message.getField("user_principal_id"));
+        assertEquals("arn:aws:iam::123456789012:user/Alice", message.getField("user_principal_arn"));
+        assertEquals("123456789012", message.getField("user_account_id"));
+
+        assertNull(message.getField("session_issuer_user_type"));
+        assertNull(message.getField("session_issuer_user_principal_id"));
+        assertNull(message.getField("session_issuer_user_principal_arn"));
+        assertNull(message.getField("session_issuer_user_account_id"));
     }
 
     @Test
@@ -133,10 +143,17 @@ public class CloudTrailCodecTest {
 
         Message message = codec.decodeSafe(getRawMessageFromFile(TEMPORARY_CREDENTIALS_FILE)).get();
         String userName = message.getField("user_name").toString();
-
+        assertTrue(message.getMessage().contains("someTestUser"));
         assertEquals("someTestUser", userName);
-        assertEquals("AROAIDPPEZS35WEXAMPLE", message.getField("user_principal_id"));
-        assertEquals("arn:aws:iam::123456789012:role/someTestUser", message.getField("user_principal_arn"));
+        assertEquals("AssumedRole", message.getField("user_type"));
+        assertEquals("AROAIDPPEZS35WEXAMPLE:AssumedRoleSessionName", message.getField("user_principal_id"));
+        assertEquals("arn:aws:sts::123456789012:assumed-role/someTestUser/MySessionName", message.getField("user_principal_arn"));
+        assertEquals("123456789015", message.getField("user_account_id"));
+
+        assertEquals("Role", message.getField("session_issuer_user_type"));
+        assertEquals("AROAIDPPEZS35WEXAMPLE", message.getField("session_issuer_user_principal_id"));
+        assertEquals("arn:aws:iam::123456789012:role/someTestUser", message.getField("session_issuer_user_principal_arn"));
+        assertEquals("123456789012", message.getField("session_issuer_user_account_id"));
     }
 
     private RawMessage getRawMessageFromFile(String fileName) throws IOException, URISyntaxException {

--- a/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/temporary_credentials.json
+++ b/graylog2-server/src/test/resources/org/graylog/aws/inputs/cloudtrail/temporary_credentials.json
@@ -4,7 +4,7 @@
     "type": "AssumedRole",
     "principalId": "AROAIDPPEZS35WEXAMPLE:AssumedRoleSessionName",
     "arn": "arn:aws:sts::123456789012:assumed-role/someTestUser/MySessionName",
-    "accountId": "123456789012",
+    "accountId": "123456789015",
     "accessKeyId": "",
     "sessionContext": {
       "sessionIssuer": {


### PR DESCRIPTION
Fixes issue noted [here](https://github.com/Graylog2/graylog2-server/issues/22086#issuecomment-3046723536), where when temporary credentials were obtained, top-level user identity fields () were overwritten. Additional fields are now added with a `session_issuer` prefix. 

- `session_issuer_user_type`
- `session_issuer_user_principal_id`
- `session_issuer_user_principal_arn`
- `session_issuer_user_account_id`

Also, since a `user_name` field cannot be present in both the `userIdentity` and `sessionIssuer` elements (see official documentation), a single `user_name` field is retained for it, which includes the value from `sessionIssuer` when present. 

Closes #22086