### PR TITLE
Fix: avoid possible race condition on collection creation in `RecentActivityService` 

### DIFF
--- a/changelog/unreleased/pr-23111.toml
+++ b/changelog/unreleased/pr-23111.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix possible race condition in RecentActivityService init"
+
+pulls = ["23111"]
+issues = ["23092"]

--- a/changelog/unreleased/pr-23111.toml
+++ b/changelog/unreleased/pr-23111.toml
@@ -1,5 +1,5 @@
 type = "f"
-message = "Fix possible race condition in RecentActivityService init"
+message = "Fix possible race condition when creating database collection for recent activity."
 
 pulls = ["23111"]
 issues = ["23092"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.startpage.recentActivities;
 
 import com.google.common.eventbus.EventBus;
 import com.mongodb.BasicDBObject;
+import jakarta.inject.Singleton;
 import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.Filters;
@@ -37,6 +38,7 @@ import org.graylog2.rest.models.SortOrder;
 
 import java.util.HashSet;
 
+@Singleton
 public class RecentActivityService {
     public static final String COLLECTION_NAME = "recent_activity";
     private final EventBus eventBus;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, there was the slight possibility for a race condition between the check for the existence of the collection and the creation because multiple instances of the service could be created. Now, as a singleton, the check/creation code should only run once per server. 

This problem should only occur with Mongo5&6 - re-creating collections with the same parameter set is idempotent in mongo7 (and probably upwards, have not tested later versions)

fixes #23092 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

