### PR TITLE
Small refactoring related to styled-components in AWS integrations components.

### DIFF
--- a/graylog2-web-interface/src/integrations/aws/common/AdditionalFields.tsx
+++ b/graylog2-web-interface/src/integrations/aws/common/AdditionalFields.tsx
@@ -24,9 +24,9 @@ const Container = styled.div`
   margin: 0 0 35px;
 `;
 
-const AdditionalFieldsContent = styled.div<{ visible: boolean }>(
-  ({ visible }) => css`
-    display: ${visible ? 'block' : 'none'};
+const AdditionalFieldsContent = styled.div<{ $visible: boolean }>(
+  ({ $visible }) => css`
+    display: ${$visible ? 'block' : 'none'};
     padding: 0 100px 0 25px;
   `,
 );
@@ -69,7 +69,7 @@ const AdditionalFields = ({
         {title} <Icon name={fieldsVisible ? 'keyboard_arrow_down' : 'chevron_right'} />
       </ToggleAdditionalFields>
 
-      <AdditionalFieldsContent visible={fieldsVisible}>{children}</AdditionalFieldsContent>
+      <AdditionalFieldsContent $visible={fieldsVisible}>{children}</AdditionalFieldsContent>
     </Container>
   );
 };

--- a/graylog2-web-interface/src/integrations/aws/common/FormWrap.tsx
+++ b/graylog2-web-interface/src/integrations/aws/common/FormWrap.tsx
@@ -73,9 +73,9 @@ const ErrorToggleInfo = styled.button(
   `,
 );
 
-const MoreIcon = styled(Icon)<{ expanded: boolean }>(
-  ({ expanded }) => css`
-    transform: rotate(${expanded ? '90deg' : '0deg'});
+const MoreIcon = styled(Icon)<{ $expanded: boolean }>(
+  ({ $expanded }) => css`
+    transform: rotate(${$expanded ? '90deg' : '0deg'});
     transition: 150ms transform ease-in-out;
   `,
 );
@@ -89,7 +89,7 @@ export const ErrorMessage = ({ fullMessage, niceMessage = null }: ErrorMessagePr
       <ErrorOutput>{niceMessage || fullMessage}</ErrorOutput>
       {niceMessage && (
         <ErrorToggleInfo onClick={() => toggleExpanded(!expanded)}>
-          More Info <MoreIcon name="chevron_right" expanded={expanded} />
+          More Info <MoreIcon name="chevron_right" $expanded={expanded} />
         </ErrorToggleInfo>
       )}
     </>

--- a/graylog2-web-interface/src/integrations/aws/common/FormWrap.tsx
+++ b/graylog2-web-interface/src/integrations/aws/common/FormWrap.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import styled, { createGlobalStyle, css, useTheme } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 
 import { Button, Panel } from 'components/bootstrap';
 import Icon from 'components/common/Icon';
@@ -61,15 +61,17 @@ const ErrorOutput = styled.span`
   display: block;
 `;
 
-const ErrorToggleInfo = styled.button<{ isDarkMode: boolean }>`
-  border: 0;
-  background: none;
-  color: ${({ isDarkMode }) => (isDarkMode ? 'white' : 'black')};
-  font-size: 11px;
-  text-transform: uppercase;
-  margin: 12px 0 0;
-  padding: 0;
-`;
+const ErrorToggleInfo = styled.button(
+  ({ theme }) => css`
+    border: 0;
+    background: none;
+    color: ${theme.colors.text.primary};
+    font-size: 11px;
+    text-transform: uppercase;
+    margin: 12px 0 0;
+    padding: 0;
+  `,
+);
 
 const MoreIcon = styled(Icon)<{ expanded: boolean }>(
   ({ expanded }) => css`
@@ -80,15 +82,13 @@ const MoreIcon = styled(Icon)<{ expanded: boolean }>(
 
 export const ErrorMessage = ({ fullMessage, niceMessage = null }: ErrorMessageProps) => {
   const [expanded, toggleExpanded] = useState(false);
-  const theme = useTheme();
-  const isDarkMode = theme.mode === 'dark';
 
   const Header = (
     <>
       <ErrorOutputStyle />
       <ErrorOutput>{niceMessage || fullMessage}</ErrorOutput>
       {niceMessage && (
-        <ErrorToggleInfo isDarkMode={isDarkMode} onClick={() => toggleExpanded(!expanded)}>
+        <ErrorToggleInfo onClick={() => toggleExpanded(!expanded)}>
           More Info <MoreIcon name="chevron_right" expanded={expanded} />
         </ErrorToggleInfo>
       )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is a small follow-up for https://github.com/Graylog2/graylog2-server/pull/22370 and implements some best practices:

1. In styled components we do not check if the dark mode is active, to display a different color. We point to a specific color in the theme, like `theme.colors.text.primary` and the theme will provide different colors depending on the selected theme mode (dark / light).
2. We avoid hard coded colors and only point to the theme, to be able to customize the colors easily.
3. When defining a prop, like `isDarkMode`, for a styled component we prefix it with a `$`, otherwise this will create an attribute for the DOM node. https://styled-components.com/docs/api#transient-props.

/nocl