### PR TITLE
Fix panel colors for dark mode `6.3`

### DIFF
--- a/changelog/unreleased/pr-23150.toml
+++ b/changelog/unreleased/pr-23150.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve dark mode colors for panel component."
+
+pulls = ["23150"]
+issues = ["Graylog2/graylog-plugin-enterprise#10175"]

--- a/graylog2-web-interface/src/components/bootstrap/Panel.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Panel.tsx
@@ -40,24 +40,18 @@ const PanelFooter = styled(BootstrapPanel.Footer)(
 );
 
 const panelVariantStyles = css<{ bsStyle?: string }>(({ bsStyle = 'default', theme }) => {
-  const backgroundColor = theme.colors.variant.lighter[bsStyle];
-  const borderColor = theme.colors.variant.dark[bsStyle];
+  const backgroundColor = theme.colors.variant.lightest[bsStyle];
+  const borderColor = theme.colors.variant.lighter[bsStyle];
 
   return css`
     border-color: ${borderColor};
 
     > ${PanelHeading} {
-      color: ${theme.utils.readableColor(backgroundColor)};
       background-color: ${backgroundColor};
       border-color: ${borderColor};
 
       + .panel-collapse > .panel-body {
         border-top-color: ${borderColor};
-      }
-
-      .badge {
-        color: ${backgroundColor};
-        background-color: ${theme.colors.variant[bsStyle]};
       }
     }
 
@@ -71,13 +65,12 @@ const panelVariantStyles = css<{ bsStyle?: string }>(({ bsStyle = 'default', the
 
 const StyledPanel = styled(BootstrapPanel)(
   ({ theme }) => css`
-    background-color: ${theme.utils.colorLevel(theme.colors.global.background, -4)};
+    background-color: ${theme.colors.global.contentBackground};
 
-    > ${PanelHeading} {
-      .panel-title,
-      .panel-title h3 {
-        font-size: ${theme.fonts.size.large};
-      }
+    .panel-heading,
+    .panel-heading h3 {
+      color: ${theme.colors.text.primary};
+      font-size: ${theme.fonts.size.large};
     }
 
     .panel-group {


### PR DESCRIPTION
**Please note**, in post `6.3` versions we improved the styles by unifying the `Alert` and `Panel` colors. https://github.com/Graylog2/graylog2-server/pull/23147

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before light mode:
<img width="199" height="449" alt="image" src="https://github.com/user-attachments/assets/f1ec98e5-9754-4f52-ab32-de2a04306f01" />

Before dark mode:
<img width="272" height="463" alt="image" src="https://github.com/user-attachments/assets/7aa6e4ff-a1af-4588-a90d-fe31282c48ca" />

After light mode:
<img width="204" height="467" alt="image" src="https://github.com/user-attachments/assets/25b5b887-6269-40d8-8388-d6645515a0b5" />

After dark mode:
<img width="225" height="468" alt="image" src="https://github.com/user-attachments/assets/a7ea0dae-5654-4d68-a0c0-bece5534ccaf" />

