### PR TITLE
Fix NPE for toIndexable method when geo info when some fields null

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoLocationInformation.java
@@ -25,7 +25,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import javax.annotation.Nullable;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Map;
+import java.util.Map.Entry;
+
+import static java.util.stream.Collectors.toMap;
 
 @AutoValue
 @JsonDeserialize(builder = GeoLocationInformation.Builder.class)
@@ -114,14 +118,17 @@ public abstract class GeoLocationInformation {
 
     @JsonIgnore
     public Map<String, Object> toIndexable() {
-        return Map.of(
-                GEO_INDEXED_FIELD_PREFIX + FIELD_LATITUDE, latitude(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_LONGITUDE, longitude(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_COUNTRY_ISO_CODE, countryIsoCode(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_COUNTRY_NAME, countryName(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_CITY_NAME, cityName(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_REGION, region(),
-                GEO_INDEXED_FIELD_PREFIX + FIELD_TIME_ZONE, timeZone()
-        );
+        return java.util.stream.Stream.of(
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_LATITUDE, latitude()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_LONGITUDE, longitude()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_COUNTRY_ISO_CODE, countryIsoCode()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_COUNTRY_NAME, countryName()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_CITY_NAME, cityName()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_REGION, region()),
+                        new SimpleEntry<>(GEO_INDEXED_FIELD_PREFIX + FIELD_TIME_ZONE, timeZone())
+                )
+                .filter(e -> e.getValue() != null)
+                .collect(toMap(Entry::getKey, Entry::getValue
+                ));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
@@ -1,0 +1,38 @@
+package org.graylog.plugins.map.geoip;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GeoLocationInformationTest {
+
+    @Test
+    public void testToIndexableWithAllValues() {
+        GeoLocationInformation info = GeoLocationInformation.Builder.create()
+                .latitude(10.0)
+                .longitude(20.0)
+                .countryIsoCode("US")
+                .countryName("United States")
+                .cityName("New York")
+                .region("NY")
+                .timeZone("America/New_York")
+                .build();
+        Map<String, Object> indexable = info.toIndexable();
+        assertEquals(10.0, indexable.get("geo_latitude"));
+        assertEquals(20.0, indexable.get("geo_longitude"));
+        assertEquals("US", indexable.get("geo_country_iso_code"));
+        assertEquals("United States", indexable.get("geo_country_name"));
+        assertEquals("New York", indexable.get("geo_city_name"));
+        assertEquals("NY", indexable.get("geo_region"));
+        assertEquals("America/New_York", indexable.get("geo_time_zone"));
+        assertEquals(7, indexable.size());
+    }
+
+    @Test
+    public void testToIndexableWithNullValues() {
+        Map<String, Object> indexableNulls = GeoLocationInformation.Builder.create().build().toIndexable();
+        assertEquals(0, indexableNulls.size());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoLocationInformationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.plugins.map.geoip;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/11300

Fixes this NPE error when some Geo fields are null.

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:209)
	at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1186)
	at java.base/java.util.Map.of(Map.java:1506)
	at org.graylog.plugins.map.geoip.GeoLocationInformation.toIndexable(GeoLocationInformation.java:117)
```

Tests added to cover the null condition.

/nocl minor error handling for unreleased feature