### PR TITLE
Show widget description inline in full screen mode.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/TimerangeInfo.tsx
@@ -37,17 +37,13 @@ type Props = {
   returnsAllRecords?: boolean;
 };
 
-const Wrapper = styled.div(
-  ({ theme }) => css`
-    font-size: ${theme.fonts.size.tiny};
-    color: ${theme.colors.gray[30]};
-    width: max-content;
-    display: flex;
-    gap: 5px;
-    align-items: center;
-    margin-right: 10px;
-  `,
-);
+const Wrapper = styled.div`
+  width: max-content;
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  margin-right: 10px;
+`;
 
 const StyledIcon = styled(Icon)(
   ({ theme }) => css`

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useContext } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Spinner, Icon, OverlayTrigger } from 'components/common';
@@ -22,6 +23,7 @@ import EditableTitle, { Title } from 'views/components/common/EditableTitle';
 import { Input } from 'components/bootstrap';
 import IconButton from 'components/common/IconButton';
 import { widgetDragHandleClass } from 'views/components/widgets/Constants';
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
 
 const LoadingSpinner = styled(Spinner)`
   margin-left: 10px;
@@ -192,20 +194,26 @@ const WidgetHeader = ({
   titleIcon = undefined,
   onRename = undefined,
   onUpdateDescription = undefined,
-}: Props) => (
-  <Container>
-    <Col>
-      {hideDragHandle || (
-        <DragHandleContainer className={widgetDragHandleClass} title={`Drag handle for ${title}`}>
-          <WidgetDragHandle name="drag_indicator" />
-        </DragHandleContainer>
-      )}
-      <WidgetTitle editing={editing} title={title} titleIcon={titleIcon} onChange={onRename} />
-      <WidgetDescription editing={editing} description={description} onChange={onUpdateDescription} />
-      {loading && <LoadingSpinner text="" delay={0} />}
-    </Col>
-    {children}
-  </Container>
-);
+}: Props) => {
+  const interactive = useContext(InteractiveContext);
+
+  return (
+    <Container>
+      <Col>
+        {hideDragHandle || (
+          <DragHandleContainer className={widgetDragHandleClass} title={`Drag handle for ${title}`}>
+            <WidgetDragHandle name="drag_indicator" />
+          </DragHandleContainer>
+        )}
+        <WidgetTitle editing={editing} title={title} titleIcon={titleIcon} onChange={onRename} />
+        {interactive && (
+          <WidgetDescription editing={editing} description={description} onChange={onUpdateDescription} />
+        )}
+        {loading && <LoadingSpinner text="" delay={0} />}
+      </Col>
+      {children}
+    </Container>
+  );
+};
 
 export default WidgetHeader;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is showing the widget description at the bottom-left of a widget when in non-interactive/full screen mode. This makes the widget description widget visible in contexts where the popover cannot be clicked/hovered.

/nocl Extending unreleased feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1486" height="990" alt="image" src="https://github.com/user-attachments/assets/9e270681-e22f-4068-ae32-ab2ea60856f1" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.