### PR TITLE
Fix header styling of copy widget to dashboard modal.

### DIFF
--- a/changelog/unreleased/pr-23181.toml
+++ b/changelog/unreleased/pr-23181.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix header styling of copy widget to dashboard modal."
+
+pulls = ["23181"]

--- a/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/CopyToDashboardForm.tsx
@@ -109,7 +109,10 @@ const CopyToDashboardForm = ({
   const showCreateNewDashboardCheckbox = typeof onCreateNewDashboard === 'function';
 
   return (
-    <Modal show onHide={() => {}}>
+    <Modal show onHide={onCancel}>
+      <Modal.Header>
+        <Modal.Title>Copy widget to dashboard</Modal.Title>
+      </Modal.Header>
       <Modal.Body>
         {isLoadingDashboards && <Spinner />}
         {!isLoadingDashboards && (


### PR DESCRIPTION
**Please note**, this PR should be backported to `6.1`, `6.2` and `6.3`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes the header styling of the "copy widget to dashboard" modal, by adding a headline.

Before:
<img width="637" height="157" alt="image" src="https://github.com/user-attachments/assets/c994cd37-15e8-45e8-bb6a-67cd5285cb77" />


After:
<img width="634" height="220" alt="image" src="https://github.com/user-attachments/assets/c04fcfd3-8746-4394-86d2-b745dd7ebf70" />


