### PR TITLE
Display field value suggestions for values which include a dot, after mistyping. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-21814.toml
+++ b/changelog/unreleased/issue-21814.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Display field value suggestions in search query input, for values which include a dot, after mistyping."
+
+issues = ["21814"]
+pulls = ["23061"]

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldValueCompletion.ts
@@ -233,7 +233,7 @@ class FieldValueCompletion implements Completer {
     });
   };
 
-  public identifierRegexps = [/[a-zA-Z_0-9$\\/\-\u00A2-\u2000\u2070-\uFFFF]/];
+  public identifierRegexps = [/[a-zA-Z_0-9$\\/.\-\u00A2-\u2000\u2070-\uFFFF]/];
 }
 
 export default FieldValueCompletion;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/custom-lucene-mode.js
@@ -71,7 +71,7 @@ ace.define('ace/mode/lucene_highlight_rules', ['require', 'exports', 'module', '
           next: 'maybeRegex',
         }, {
           token: 'term',
-          regex: /[\w\\/]+/,
+          regex: /[\w\\/.]+/,
         }, {
           token: 'text',
           regex: /\s+/,


### PR DESCRIPTION
Note: This is a backport of #23061 to `6.1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As described in https://github.com/Graylog2/graylog2-server/issues/21814, the autocompletion no longer displays field value suggestions after mistyping, for field values which contain a dot.

Before this change:
![autocomplete](https://github.com/user-attachments/assets/62147412-87a3-48ad-b3af-f97ceb8dc816)

After this change:
![autocomplete-after](https://github.com/user-attachments/assets/0d52e1fd-29b7-4b0d-a985-e3b80eb8ac84)


Fixes: https://github.com/Graylog2/graylog2-server/issues/21814
