### PR TITLE
Display correct visualization for bar charts with logarithmic axis type (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-23031.toml
+++ b/changelog/unreleased/issue-23031.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Display correct visualization for bar charts with logarithmic axis type"
+
+issues = ["23031"]
+pulls = ["23032"]

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -93,8 +93,9 @@ const XYPlot = ({
     defaultLayout.legend = { y: yLegendPosition(height) };
   }
 
-  const layout: Partial<PlotLayout> = { ...defaultLayout, ...plotLayout };
+  const layout: Partial<PlotLayout> = merge({}, defaultLayout, plotLayout);
   const dispatch = useAppDispatch();
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const _onZoom = useCallback(config.isTimeline
     ? (from: string, to: string) => (onZoom ? onZoom(from, to, userTimezone) : dispatch(OnZoom(from, to, userTimezone)))

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -163,4 +163,23 @@ describe('XYPlot', () => {
       legend: { y: -0.14 },
     }));
   });
+
+  it('maps axis type correctly', async () => {
+    const plotLayout = {
+      yaxis: {
+        side: 'left' as const,
+      },
+    };
+
+    render(<SimpleXYPlot plotLayout={plotLayout} axisType="logarithmic" />);
+
+    expect(GenericPlot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'layout': expect.objectContaining({
+          yaxis: expect.objectContaining({ type: 'log', side: 'left' }), // ensure plotLayout is merged correctly
+        }),
+      }),
+      {},
+    );
+  });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.tsx
@@ -171,15 +171,11 @@ describe('XYPlot', () => {
       },
     };
 
-    render(<SimpleXYPlot plotLayout={plotLayout} axisType="logarithmic" />);
+    const wrapper = mount(<SimpleXYPlot plotLayout={plotLayout} axisType="logarithmic" />);
+    const genericPlot = wrapper.find('GenericPlot');
 
-    expect(GenericPlot).toHaveBeenCalledWith(
-      expect.objectContaining({
-        'layout': expect.objectContaining({
-          yaxis: expect.objectContaining({ type: 'log', side: 'left' }), // ensure plotLayout is merged correctly
-        }),
-      }),
-      {},
-    );
+    expect(genericPlot).toHaveProp('layout', expect.objectContaining({
+      yaxis: expect.objectContaining({ type: 'log', side: 'left' }), // ensure plotLayout is merged correctly
+    }));
   });
 });


### PR DESCRIPTION
Note: This is a backport of #23032 to `6.1`.

## Description
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #23031, selecting the axis type `logarithmic` has currently no effect. This PR is fixing this issue.

Fixes #23031 