### PR TITLE
Unify `Badge` colors with `Button` colors.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Badge.md
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.md
@@ -1,5 +1,5 @@
 ```js
-const styles = ['Primary', 'Danger', 'Warning', 'Success', 'Info', 'Default'];
+const styles = ['Primary', 'Danger', 'Warning', 'Success', 'Info', 'Default', 'Gray'];
 
 styles.map((style, i) => {
   return (

--- a/graylog2-web-interface/src/components/bootstrap/Badge.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.tsx
@@ -21,8 +21,9 @@ import styled, { css } from 'styled-components';
 
 const StyledBadge = styled(MantineBadge)<{ color: ColorVariant }>(
   ({ theme, color }) => css`
-    color: ${theme.colors.contrast[color]};
     text-transform: none;
+    background: ${theme.colors.button[color].background};
+    color: ${theme.colors.button[color].color};
 
     .mantine-Badge-label {
       font-size: ${theme.fonts.size.small};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR unifies the badge colors with the button colors. It only results in a visible change for the `gray` badge variant.

<img width="501" height="50" alt="image" src="https://github.com/user-attachments/assets/9dc7bc36-0fbc-4d75-a51e-4823be04c3bd" />

Please note we will improve the text color of the `default` variant in a follow-up PR.

/nocl