### PR TITLE
Implement views specific query validation only for query validation in search bar. `6.2`

### DIFF
--- a/changelog/unreleased/pr-23065.toml
+++ b/changelog/unreleased/pr-23065.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixing issue with query validation popover for search filter form in event definition wizard."
+
+issues = ["graylog-plugin-enterprise#11200"]
+pulls = ["23065"]

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -27,7 +27,7 @@ import SearchButton from 'views/components/searchbar/SearchButton';
 import ViewsQueryInput from 'views/components/searchbar/ViewsQueryInput';
 import DashboardActionsMenu from 'views/components/DashboardActionsMenu';
 import WidgetFocusContext from 'views/components/contexts/WidgetFocusContext';
-import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
+import ViewsQueryValidation from 'views/components/searchbar/queryvalidation/ViewsQueryValidation';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import FormWarningsProvider from 'contexts/FormWarningsProvider';
 import useParameters from 'views/hooks/useParameters';
@@ -228,7 +228,7 @@ const DashboardSearchBar = () => {
                             )}
                           </Field>
 
-                          <QueryValidation />
+                          <ViewsQueryValidation />
                           <QueryHistoryButton editorRef={editorRef} />
                         </SearchInputAndValidationContainer>
                       </SearchButtonAndQuery>

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -32,7 +32,7 @@ import StreamsFilter from 'views/components/searchbar/StreamsFilter';
 import ViewsRefreshControls from 'views/components/searchbar/ViewsRefreshControls';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import { StreamsStore } from 'views/stores/StreamsStore';
-import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
+import ViewsQueryValidation from 'views/components/searchbar/queryvalidation/ViewsQueryValidation';
 import type { FilterType, QueryId } from 'views/logic/queries/Query';
 import type Query from 'views/logic/queries/Query';
 import {
@@ -325,7 +325,7 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
                               )}
                             </Field>
 
-                            <QueryValidation />
+                            <ViewsQueryValidation />
                             <QueryHistoryButton editorRef={editorRef} />
                           </SearchInputAndValidationContainer>
                         </SearchButtonAndQuery>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -33,7 +33,7 @@ import { DEFAULT_TIMERANGE } from 'views/Constants';
 import type GlobalOverride from 'views/logic/search/GlobalOverride';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import { PropagateDisableSubmissionState } from 'views/components/aggregationwizard';
-import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
+import ViewsQueryValidation from 'views/components/searchbar/queryvalidation/ViewsQueryValidation';
 import FormWarningsContext from 'contexts/FormWarningsContext';
 import FormWarningsProvider from 'contexts/FormWarningsProvider';
 import useParameters from 'views/hooks/useParameters';
@@ -333,7 +333,7 @@ const WidgetQueryControls = ({ availableStreams }: Props) => {
                     )}
                   </Field>
 
-                  <QueryValidation />
+                  <ViewsQueryValidation />
                   <QueryHistoryButton editorRef={editorRef} />
                 </SearchInputAndValidation>
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.test.tsx
@@ -21,18 +21,16 @@ import { Form, Formik } from 'formik';
 
 import QueryValidation from 'views/components/searchbar/queryvalidation/QueryValidation';
 import FormWarningsContext from 'contexts/FormWarningsContext';
-import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+import type { QueryValidationState, ValidationExplanations } from 'views/components/searchbar/queryvalidation/types';
 import { validationError, validationErrorExplanation } from 'fixtures/queryValidationState';
-import usePluginEntities from 'hooks/usePluginEntities';
-import asMock from 'helpers/mocking/AsMock';
 
 jest.mock('hooks/usePluginEntities');
 jest.mock('logic/rest/FetchProvider', () => jest.fn(() => Promise.resolve()));
 
 type SUTProps = {
   error?: QueryValidationState;
-
   warning?: QueryValidationState;
+  validationExplanations?: ValidationExplanations;
 };
 
 describe('QueryValidation', () => {
@@ -43,7 +41,7 @@ describe('QueryValidation', () => {
     userEvent.click(validationExplanationTrigger);
   };
 
-  const SUT = ({ error, warning }: SUTProps) => (
+  const SUT = ({ error = undefined, warning = undefined, validationExplanations = undefined }: SUTProps) => (
     <Formik
       onSubmit={() => {}}
       initialValues={{}}
@@ -52,7 +50,7 @@ describe('QueryValidation', () => {
       <Form>
         <FormWarningsContext.Provider
           value={{ warnings: warning ? { queryString: warning } : {}, setFieldWarning: () => {} }}>
-          <QueryValidation />
+          <QueryValidation validationExplanations={validationExplanations} />
         </FormWarningsContext.Provider>
       </Form>
     </Formik>
@@ -93,18 +91,16 @@ describe('QueryValidation', () => {
     await screen.findByTitle('Query error documentation');
   });
 
-  it('renders pluggable validation explanation', async () => {
+  it('renders custom validation explanation', async () => {
     const ExampleComponent = ({ validationState }: { validationState: QueryValidationState }) => (
-      <>Plugable validation explanation for {validationState.explanations.map(({ errorTitle }) => errorTitle).join()}</>
+      <>Custom validation explanation for {validationState.explanations.map(({ errorTitle }) => errorTitle).join()}</>
     );
-    asMock(usePluginEntities).mockImplementation((entityKey) =>
-      entityKey === 'views.elements.validationErrorExplanation' ? [ExampleComponent] : [],
-    );
-    render(<SUT error={validationError} />);
+
+    render(<SUT error={validationError} validationExplanations={[ExampleComponent]} />);
 
     await openExplanation();
 
-    await screen.findByText('Plugable validation explanation for Parse Exception');
+    await screen.findByText('Custom validation explanation for Parse Exception');
   });
 
   it('only displays current validation explanation', async () => {

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/QueryValidation.tsx
@@ -27,8 +27,7 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import QueryValidationActions from 'views/actions/QueryValidationActions';
 import FormWarningsContext from 'contexts/FormWarningsContext';
-import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
-import usePluginEntities from 'hooks/usePluginEntities';
+import type { QueryValidationState, ValidationExplanations } from 'views/components/searchbar/queryvalidation/types';
 
 const Container = styled.div`
   margin-left: 5px;
@@ -189,8 +188,11 @@ const deduplicateExplanations = (explanations: Explanations | undefined): Explan
   return deduplicated;
 };
 
-const QueryValidation = () => {
-  const plugableValidationExplanation = usePluginEntities('views.elements.validationErrorExplanation');
+type Props = {
+  validationExplanations?: ValidationExplanations;
+};
+
+const QueryValidation = ({ validationExplanations = [] }: Props) => {
   const [shakingPopover, shake] = useShakeTemporarily();
   const [showExplanation, toggleShow] = useTriggerIfErrorsPersist(shake);
 
@@ -261,7 +263,7 @@ const QueryValidation = () => {
                 )}
               </Explanation>
             ))}
-            {plugableValidationExplanation?.map((PlugableExplanation, index) => (
+            {validationExplanations.map((PlugableExplanation, index) => (
               // eslint-disable-next-line react/no-array-index-key
               <PlugableExplanation validationState={validationState} key={index} />
             ))}

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/ViewsQueryValidation.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/ViewsQueryValidation.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import * as React from 'react';
+
+import usePluginEntities from 'hooks/usePluginEntities';
+
+import QueryValidation from './QueryValidation';
+
+const ViewsQueryValidation = () => {
+  const viewsValidationExplanation = usePluginEntities('views.elements.validationErrorExplanation');
+
+  return <QueryValidation validationExplanations={viewsValidationExplanation} />;
+};
+
+export default ViewsQueryValidation;

--- a/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/queryvalidation/types.ts
@@ -54,3 +54,5 @@ export type QueryValidationState = {
     };
   };
 };
+
+export type ValidationExplanations = Array<React.ComponentType<{ validationState: QueryValidationState }>>;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -46,7 +46,7 @@ import type { Message } from 'views/components/messagelist/Types';
 import type { ValuePath } from 'views/logic/valueactions/ValueActionHandler';
 import type WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import type MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
-import type { QueryValidationState } from 'views/components/searchbar/queryvalidation/types';
+import type { ValidationExplanations } from 'views/components/searchbar/queryvalidation/types';
 import type Query from 'views/logic/queries/Query';
 import type { CustomCommand, CustomCommandContext } from 'views/components/searchbar/queryinput/types';
 import type SearchExecutionState from 'views/logic/search/SearchExecutionState';
@@ -542,7 +542,7 @@ declare module 'graylog-web-plugin/plugin' {
     'views.components.saveViewForm'?: Array<() => SaveViewControls | null>;
     'views.elements.header'?: Array<React.ComponentType>;
     'views.elements.queryBar'?: Array<React.ComponentType>;
-    'views.elements.validationErrorExplanation'?: Array<React.ComponentType<{ validationState: QueryValidationState }>>;
+    'views.elements.validationErrorExplanation'?: ValidationExplanations;
     'views.export.formats'?: Array<ExportFormat>;
     'views.hooks.confirmDeletingDashboard'?: Array<(view: View) => Promise<boolean | null>>;
     'views.hooks.confirmDeletingDashboardPage'?: Array<


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/23065 to `6.2`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The query input and query validation icon are not only implemented for the search bar on the search page, but also for the search filter form (enterprise feature).

Before this PR, the query validation consumed pluggable validation explanation components (plugin key `views.elements.validationErrorExplanation`). These components are views specific and consume the redux store. 

As a result, opening the query validation explanation on pages which do not implement the views specific redux store, caused an error (see https://github.com/Graylog2/graylog-plugin-enterprise/issues/10911).

This PR is improving this behaviour by only implementing the views specific validation explanations, for the query input in the search bar (dashboards, searches and widgets). The related plugin entities do not provide any value in the context of search filters.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/10911