### PR TITLE
Improve colors of badges in streams overview. (`6.2`)

### DIFF
--- a/changelog/unreleased/issue-20746.toml
+++ b/changelog/unreleased/issue-20746.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve color of count badges in streams overview."
+
+pulls = ["23211"]
+issues = ["20746"]

--- a/graylog2-web-interface/src/components/bootstrap/Badge.md
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.md
@@ -1,5 +1,5 @@
 ```js
-const styles = ['Primary', 'Danger', 'Warning', 'Success', 'Info', 'Default'];
+const styles = ['Primary', 'Danger', 'Warning', 'Success', 'Info', 'Gray'];
 
 styles.map((style, i) => {
   return (

--- a/graylog2-web-interface/src/components/bootstrap/Badge.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.tsx
@@ -19,10 +19,13 @@ import type { ColorVariant } from '@graylog/sawmill';
 import { Badge as MantineBadge } from '@mantine/core';
 import styled, { css } from 'styled-components';
 
+const mapStyle = (style: ColorVariant) => (style === 'default' ? 'gray' : style);
+
 const StyledBadge = styled(MantineBadge)<{ color: ColorVariant }>(
   ({ theme, color }) => css`
-    color: ${theme.colors.contrast[color]};
     text-transform: none;
+    background: ${theme.colors.button[color].background};
+    color: ${theme.colors.button[color].color};
 
     .mantine-Badge-label {
       font-size: ${theme.fonts.size.small};
@@ -39,9 +42,12 @@ type Props = React.PropsWithChildren<{
 }>;
 
 const Badge = React.forwardRef<HTMLDivElement, Props>(
-  ({ bsStyle = 'default', className, children, 'data-testid': dataTestid, onClick, title }, ref) => (
+  ({ bsStyle = 'default', className, children, 'data-testid': dataTestid, onClick, title }, ref) => {
+    const color = mapStyle(bsStyle);
+
+  return (
     <StyledBadge
-      color={bsStyle}
+      color={color}
       className={className}
       title={title}
       data-testid={dataTestid}
@@ -50,7 +56,7 @@ const Badge = React.forwardRef<HTMLDivElement, Props>(
       onClick={onClick}>
       {children}
     </StyledBadge>
-  ),
-);
+  )
+});
 
 export default Badge;

--- a/graylog2-web-interface/src/components/streams/StreamCountBadge.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamCountBadge.tsx
@@ -15,14 +15,31 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import styled, { css } from 'styled-components';
+import * as React from 'react';
+import { forwardRef } from 'react';
 
-import { CountBadge } from 'components/common';
+import { Badge } from 'components/bootstrap';
 
-const StreamCountBadge = styled(CountBadge)<{ $disabled: boolean }>(
-  ({ $disabled, theme }) => css`
-    cursor: pointer;
-    background-color: ${$disabled ? theme.colors.variant.default : theme.colors.variant.light.info};
+const StyledBadge = styled(Badge)<{ onClick: () => void }>(
+  ({ onClick }) => css`
+    cursor: ${onClick ? 'pointer' : 'default'};
   `,
 );
 
-export default StreamCountBadge;
+type Props = {
+  disabled?: boolean;
+  children: React.ReactNode;
+  onClick?: () => void;
+  title: string;
+};
+
+const StreamCountBadge = (
+  { disabled = false, children, onClick = undefined, title }: Props,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) => (
+  <StyledBadge bsStyle={disabled ? 'gray' : 'info'} onClick={onClick} title={title} ref={ref}>
+    {children}
+  </StyledBadge>
+);
+
+export default forwardRef(StreamCountBadge);

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
@@ -35,7 +35,7 @@ const OutputsCell = ({ stream }: Props) => {
   const outputCount = stream.outputs?.length || 0;
 
   return (
-    <StreamCountBadge $disabled={outputCount === 0} ref={buttonRef} title="Stream Outputs">
+    <StreamCountBadge disabled={outputCount === 0} ref={buttonRef} title="Stream Outputs">
       {outputCount}
     </StreamCountBadge>
   );

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
@@ -37,7 +37,7 @@ const PipelinesCell = ({ stream }: Props) => {
   const pipelinesCount = data?.length || 0;
 
   return (
-    <StreamCountBadge $disabled={pipelinesCount === 0} ref={buttonRef} title="Connected pipelines">
+    <StreamCountBadge disabled={pipelinesCount === 0} ref={buttonRef} title="Connected pipelines">
       {pipelinesCount}
     </StreamCountBadge>
   );

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/StreamRulesCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/StreamRulesCell.tsx
@@ -40,7 +40,7 @@ const StreamRulesCell = ({ stream }: Props) => {
 
   return (
     <StreamCountBadge
-      $disabled={stream.rules.length === 0}
+      disabled={stream.rules.length === 0}
       onClick={toggleRulesSection}
       ref={buttonRef}
       title={`${streamRulesSectionIsOpen ? 'Hide' : 'Show'} stream rules`}>


### PR DESCRIPTION
Note: This is a backport of #23211 to `6.2`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog2-server/issues/20746 some badges in the streams overview are missing contrast in the dark mode.

<img width="598" height="454" alt="image" src="https://github.com/user-attachments/assets/7c2fda9d-c59c-41d1-ab95-b46c0d8a61b8" />

This is how they look in the light mode:
<img width="568" height="444" alt="image" src="https://github.com/user-attachments/assets/ee583879-959c-4e63-af2d-82e5d4c59e29" />

This PR improves the styling by using the `gray` / `info` `Badge` variants instead of custom colors.

Dark mode
<img width="578" height="306" alt="image" src="https://github.com/user-attachments/assets/8ad2d814-0240-4956-80e8-92bdf45b774c" />

Light mode
<img width="588" height="302" alt="image" src="https://github.com/user-attachments/assets/681da9f9-5e41-4182-abac-11e4e4398949" />

Please note, we will improve the icon color issue, mentioned in https://github.com/Graylog2/graylog2-server/issues/20746, in a follow-up PR.

<img width="214" height="81" alt="image" src="https://github.com/user-attachments/assets/707685fe-5b17-4357-8aaa-b8d874694b19" />
