### PR TITLE
Filter collection entities in shares list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
@@ -29,7 +29,7 @@ public interface CollectionRequestHandler {
         // Intentionally left empty - ignore this in the community edition.
     }
 
-    default Predicate<GRN> collectionEntitiesFilter() {
+    default Predicate<GRN> collectionFilter() {
         // Ignore this in the community edition
         return grn -> false;
     }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
@@ -30,7 +30,7 @@ public interface CollectionRequestHandler {
     }
 
     default Predicate<GRN> collectionEntitiesFilter() {
-        // Intentionally left empty - ignore this in the community edition.
-        return entityDescriptor -> true;
+        // Ignore this in the community edition
+        return grn -> false;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
@@ -19,12 +19,18 @@ package org.graylog.security.shares;
 import org.graylog.grn.GRN;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 public interface CollectionRequestHandler {
     /**
-     * Pluggable handler to add given entity to the specified collections.
+     * Pluggable handler for actions related to collections.
      */
     default void addToCollection(GRN entity, Set<GRN> collections) {
         // Intentionally left empty - ignore this in the community edition.
+    }
+
+    default Predicate<GRN> collectionEntitiesFilter() {
+        // Intentionally left empty - ignore this in the community edition.
+        return entityDescriptor -> true;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/CollectionRequestHandler.java
@@ -25,12 +25,7 @@ public interface CollectionRequestHandler {
     /**
      * Pluggable handler for actions related to collections.
      */
-    default void addToCollection(GRN entity, Set<GRN> collections) {
-        // Intentionally left empty - ignore this in the community edition.
-    }
+    void addToCollection(GRN entity, Set<GRN> collections);
 
-    default Predicate<GRN> collectionFilter() {
-        // Ignore this in the community edition
-        return grn -> false;
-    }
+    Predicate<GRN> collectionFilter();
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/GranteeSharesService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/GranteeSharesService.java
@@ -66,7 +66,7 @@ public class GranteeSharesService {
 
     private Predicate<GRN> excludeCollectionTypesFilter() {
         return entityDescriptor -> collectionRequestHandlers.stream()
-                .noneMatch(handler -> handler.collectionEntitiesFilter().test(entityDescriptor));
+                .noneMatch(handler -> handler.collectionFilter().test(entityDescriptor));
     }
 
     public SharesResponse getPaginatedSharesFor(GRN grantee,

--- a/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security.shares;
 
+import com.google.common.collect.ImmutableSet;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNDescriptor;
 import org.graylog.grn.GRNDescriptorService;
@@ -62,7 +63,7 @@ class GranteeSharesServiceTest {
         this.grnDescriptorService = grnDescriptorService;
         final DBGrantService dbGrantService = new DBGrantService(new MongoCollections(mongoJackObjectMapperProvider, mongodb.mongoConnection()));
         when(granteeService.getGranteeAliases(any(GRN.class))).thenAnswer(a -> Collections.singleton(a.getArgument(0)));
-        this.granteeSharesService = new GranteeSharesService(dbGrantService, grnDescriptorService, granteeService);
+        this.granteeSharesService = new GranteeSharesService(dbGrantService, grnDescriptorService, granteeService, ImmutableSet.of());
     }
 
     @DisplayName("Paginated shares for a user")


### PR DESCRIPTION
/nocl
/jpd Graylog2/graylog-plugin-enterprise#11386

## Description
<!--- Describe your changes in detail -->
Grants of type COLLECTION and COLLECTION_ENTITIES should not be displayed when showing the list of entities that are shared with a user or team - we handle those elsewhere in the UI.
