### PR TITLE
Allow resolving dependencies for multiple entities at once

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -30,10 +30,9 @@ import com.google.common.graph.Traverser;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.ForbiddenException;
-import org.apache.shiro.authz.annotation.Logical;
+import org.graylog.security.GrantDTO;
 import org.graylog.security.UserContext;
 import org.graylog.security.UserContextMissingException;
-import org.graylog.security.GrantDTO;
 import org.graylog2.Configuration;
 import org.graylog2.contentpacks.constraints.ConstraintChecker;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
@@ -397,6 +396,10 @@ public class ContentPackService {
     }
 
     public Set<EntityDescriptor> resolveEntities(Collection<EntityDescriptor> unresolvedEntities) {
+        return resolveEntityDependencyGraph(unresolvedEntities).nodes();
+    }
+
+    public Graph<EntityDescriptor> resolveEntityDependencyGraph(Collection<EntityDescriptor> unresolvedEntities) {
         final MutableGraph<EntityDescriptor> dependencyGraph = GraphBuilder.directed()
                 .allowsSelfLoops(false)
                 .nodeOrder(ElementOrder.insertion())
@@ -408,7 +411,7 @@ public class ContentPackService {
 
         LOG.debug("Final dependency graph: {}", finalDependencyGraph);
 
-        return finalDependencyGraph.nodes();
+        return finalDependencyGraph;
     }
 
     private MutableGraph<EntityDescriptor> resolveDependencyGraph(Graph<EntityDescriptor> dependencyGraph, Set<EntityDescriptor> resolvedEntities) {


### PR DESCRIPTION
Allow resolving **sharing** dependencies for multiple entities at once.

Before, it was only possible to resolve the dependencies of a single entity. So, for container entities, like collections (which is an enterprise feature), the content pack resolver and additional post-processing had to be executed in a loop for every entity in the container.

This PR deliberately avoids changing too many things at once. The dependency resolver for sharing will now operate on the dependency graph of the content pack resolver, which is exposed for that purpose. This way, the sharing resolver's additional filtering requirements will still work. Other parts, which could use refactoring, like resolving the titles of entities, are not touched.

There's still plenty of room for improvement, but with these minimal changes alone, resolving ~70 `Search` entities with the same stream dependency each is a lot less resource hungry than before:

before:
<img width="721" height="158" alt="image" src="https://github.com/user-attachments/assets/3afb7130-23b4-4373-87b4-6b885b4f6fac" />
 
after:
<img width="712" height="151" alt="image" src="https://github.com/user-attachments/assets/e64b922c-b436-4766-8a38-c664814f8459" />

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/11395
/nocl
