### PR TITLE
Fix list of opensearch initial manager nodes in datanode

### DIFF
--- a/changelog/unreleased/pr-23276.toml
+++ b/changelog/unreleased/pr-23276.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix generated list of opensearch initial manager roles in datanode"
+
+issues = []
+pulls = ["23276"]

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
@@ -17,6 +17,7 @@
 package org.graylog.datanode.opensearch.configuration.beans.impl;
 
 import com.google.common.collect.ImmutableMap;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import org.graylog.datanode.Configuration;
 import org.graylog.datanode.opensearch.configuration.OpensearchConfigurationParams;
@@ -67,8 +68,7 @@ public class OpensearchClusterConfigurationBean implements DatanodeConfiguration
         if (localConfiguration.getInitialClusterManagerNodes() != null && !localConfiguration.getInitialClusterManagerNodes().isBlank()) {
             properties.put("cluster.initial_cluster_manager_nodes", localConfiguration.getInitialClusterManagerNodes());
         } else {
-            final var nodeList = String.join(",", nodeService.allActive().values().stream().map(Node::getHostname).collect(Collectors.toSet()));
-            properties.put("cluster.initial_cluster_manager_nodes", nodeList);
+            properties.put("cluster.initial_cluster_manager_nodes", buildInitialManagerNodesList());
         }
 
         final List<String> discoverySeedHosts = localConfiguration.getOpensearchDiscoverySeedHosts();
@@ -85,6 +85,19 @@ public class OpensearchClusterConfigurationBean implements DatanodeConfiguration
                 .properties(properties.build())
                 .withConfigFile(seedHostFile())
                 .build();
+    }
+
+    @Nonnull
+    private String buildInitialManagerNodesList() {
+        return nodeService.allActive().values().stream()
+                .filter(this::isManager)
+                .map(Node::getHostname)
+                .collect(Collectors.joining(","));
+    }
+
+    private boolean isManager(DataNodeDto n) {
+        final List<String> roles = n.getOpensearchRoles();
+        return roles != null && roles.contains(OpensearchNodeRole.CLUSTER_MANAGER);
     }
 
     private TextConfigFile seedHostFile() {

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchCommonConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchCommonConfigurationBean.java
@@ -33,7 +33,12 @@ public class OpensearchCommonConfigurationBean implements DatanodeConfigurationB
     private final Configuration localConfiguration;
     private final DatanodeConfiguration datanodeConfiguration;
 
-    private static final List<String> DEFAULT_NODE_ROLES = List.of("cluster_manager", "data", "ingest", "remote_cluster_client");
+    private static final List<String> DEFAULT_NODE_ROLES = List.of(
+            OpensearchNodeRole.CLUSTER_MANAGER,
+            OpensearchNodeRole.DATA,
+            OpensearchNodeRole.INGEST,
+            OpensearchNodeRole.REMOTE_CLUSTER_CLIENT
+    );
 
     @Inject
     public OpensearchCommonConfigurationBean(Configuration localConfiguration, DatanodeConfiguration datanodeConfiguration) {

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchNodeRole.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchNodeRole.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.opensearch.configuration.beans.impl;
+
+public interface OpensearchNodeRole {
+    String CLUSTER_MANAGER = "cluster_manager";
+    String DATA = "data";
+    String INGEST = "ingest";
+    String REMOTE_CLUSTER_CLIENT = "remote_cluster_client";
+    String SEARCH = "search";
+}

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/SearchableSnapshotsConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/SearchableSnapshotsConfigurationBean.java
@@ -62,7 +62,6 @@ public class SearchableSnapshotsConfigurationBean implements DatanodeConfigurati
 
     private static final Logger LOG = LoggerFactory.getLogger(SearchableSnapshotsConfigurationBean.class);
 
-    static final String SEARCH_NODE_ROLE = "search";
     private final Configuration localConfiguration;
     private final DatanodeDirectories datanodeDirectories;
     private final S3RepositoryConfiguration s3RepositoryConfiguration;
@@ -88,7 +87,7 @@ public class SearchableSnapshotsConfigurationBean implements DatanodeConfigurati
             if (searchRoleEnabled) {
                 LOG.info("Search role enabled, validating usable space and adding search role to opensearch configuration");
                 validateUsableSpace();
-                builder.addNodeRole(SEARCH_NODE_ROLE);
+                builder.addNodeRole(OpensearchNodeRole.SEARCH);
             }
             return builder
                     .properties(properties(searchRoleEnabled))
@@ -104,12 +103,12 @@ public class SearchableSnapshotsConfigurationBean implements DatanodeConfigurati
     }
 
     private boolean searchRoleExplicitlyConfigured() {
-        return localConfiguration.getNodeRoles() != null && localConfiguration.getNodeRoles().contains(SEARCH_NODE_ROLE);
+        return localConfiguration.getNodeRoles() != null && localConfiguration.getNodeRoles().contains(OpensearchNodeRole.SEARCH);
     }
 
     private boolean searchRoleEnabled() {
         final boolean rolesNotConfigured = localConfiguration.getNodeRoles() == null || localConfiguration.getNodeRoles().isEmpty();
-        return rolesNotConfigured || localConfiguration.getNodeRoles().contains(SEARCH_NODE_ROLE);
+        return rolesNotConfigured || localConfiguration.getNodeRoles().contains(OpensearchNodeRole.SEARCH);
     }
 
     private void validateUsableSpace() throws OpensearchConfigurationException {

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.opensearch.configuration.beans.impl;
+
+import com.github.joschi.jadconfig.RepositoryException;
+import com.github.joschi.jadconfig.ValidationException;
+import org.assertj.core.api.Assertions;
+import org.graylog.datanode.DatanodeTestUtils;
+import org.graylog.datanode.opensearch.configuration.OpensearchConfigurationParams;
+import org.graylog.datanode.process.configuration.beans.DatanodeConfigurationPart;
+import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodeStatus;
+import org.graylog2.cluster.nodes.TestDataNodeNodeClusterService;
+import org.graylog2.plugin.Tools;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+class OpensearchClusterConfigurationBeanTest {
+
+    @Test
+    void testManagerNodes() throws ValidationException, RepositoryException {
+        final TestDataNodeNodeClusterService testNodeService = new TestDataNodeNodeClusterService();
+
+        testNodeService.registerServer(DataNodeDto.builder()
+                .setId(Tools.generateServerId())
+                .setTransportAddress("https://my_manager_node:9200")
+                .setHostname("my_manager_node")
+                .setDataNodeStatus(DataNodeStatus.AVAILABLE)
+                .setOpensearchRoles(List.of(OpensearchNodeRole.CLUSTER_MANAGER, OpensearchNodeRole.DATA))
+                .build());
+
+        testNodeService.registerServer(DataNodeDto.builder()
+                .setId(Tools.generateServerId())
+                .setTransportAddress("https://my_other_manager_node:9200")
+                .setHostname("my_other_manager_node")
+                .setDataNodeStatus(DataNodeStatus.AVAILABLE)
+                .setOpensearchRoles(List.of(OpensearchNodeRole.CLUSTER_MANAGER, OpensearchNodeRole.INGEST))
+                .build());
+
+        testNodeService.registerServer(DataNodeDto.builder()
+                .setId(Tools.generateServerId())
+                .setTransportAddress("https://my_search_node:9200")
+                .setHostname("my_search_node")
+                .setDataNodeStatus(DataNodeStatus.AVAILABLE)
+                .setOpensearchRoles(List.of(OpensearchNodeRole.SEARCH))
+                .build());
+
+        final OpensearchClusterConfigurationBean configurationBean = new OpensearchClusterConfigurationBean(DatanodeTestUtils.datanodeConfiguration(Collections.emptyMap()), testNodeService);
+
+        final DatanodeConfigurationPart configurationPart = configurationBean.buildConfigurationPart(new OpensearchConfigurationParams(Collections.emptyList(), Map.of()));
+
+        // initial cluster manager nodes should only contain nodes that publish cluster_manager role, ignore all other nodes
+        Assertions.assertThat(configurationPart.properties())
+                .containsEntry("cluster.initial_cluster_manager_nodes", "my_manager_node,my_other_manager_node");
+    }
+}

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
@@ -28,6 +28,7 @@ import org.graylog2.cluster.nodes.TestDataNodeNodeClusterService;
 import org.graylog2.plugin.Tools;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,11 @@ class OpensearchClusterConfigurationBeanTest {
         final DatanodeConfigurationPart configurationPart = configurationBean.buildConfigurationPart(new OpensearchConfigurationParams(Collections.emptyList(), Map.of()));
 
         // initial cluster manager nodes should only contain nodes that publish cluster_manager role, ignore all other nodes
-        Assertions.assertThat(configurationPart.properties())
-                .containsEntry("cluster.initial_cluster_manager_nodes", "my_manager_node,my_other_manager_node");
+        final String initialManagerNodes = configurationPart.properties().get("cluster.initial_cluster_manager_nodes");
+        Assertions.assertThat(initialManagerNodes).isNotEmpty();
+        final List<String> managerNodes = Arrays.asList(initialManagerNodes.split(","));
+
+        Assertions.assertThat(managerNodes)
+                .contains("my_manager_node", "my_other_manager_node");
     }
 }

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/SearchableSnapshotsConfigurationBeanTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/SearchableSnapshotsConfigurationBeanTest.java
@@ -63,7 +63,7 @@ class SearchableSnapshotsConfigurationBeanTest {
         final DatanodeConfigurationPart configurationPart = bean.buildConfigurationPart(emptyBuildParams());
 
         Assertions.assertThat(configurationPart.nodeRoles())
-                .contains(SearchableSnapshotsConfigurationBean.SEARCH_NODE_ROLE);
+                .contains(OpensearchNodeRole.SEARCH);
 
         Assertions.assertThat(configurationPart.keystoreItems())
                 .map(OpensearchKeystoreItem::key)
@@ -101,7 +101,7 @@ class SearchableSnapshotsConfigurationBeanTest {
         final DatanodeConfigurationPart configurationPart = bean.buildConfigurationPart(emptyBuildParams());
 
         Assertions.assertThat(configurationPart.nodeRoles())
-                .contains(SearchableSnapshotsConfigurationBean.SEARCH_NODE_ROLE);
+                .contains(OpensearchNodeRole.SEARCH);
 
         Assertions.assertThat(configurationPart.keystoreItems())
                 .hasSize(1)
@@ -137,7 +137,7 @@ class SearchableSnapshotsConfigurationBeanTest {
         final DatanodeConfigurationPart configurationPart = bean.buildConfigurationPart(emptyBuildParams());
 
         Assertions.assertThat(configurationPart.nodeRoles())
-                .contains(SearchableSnapshotsConfigurationBean.SEARCH_NODE_ROLE);
+                .contains(OpensearchNodeRole.SEARCH);
 
         Assertions.assertThat(configurationPart.keystoreItems())
                 .isEmpty();

--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeDto.java
@@ -152,6 +152,10 @@ public abstract class DataNodeDto extends NodeDto {
 
     public abstract Builder toBuilder();
 
+    public static Builder builder() {
+        return Builder.builder();
+    }
+
     @AutoValue.Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public abstract static class Builder extends NodeDto.Builder<Builder> {


### PR DESCRIPTION
This PR is fixing the generated `cluster.initial_cluster_manager_nodes` opensearch configuration in datanode, using only nodes that have the `cluster_manager` role.

**TODO** this would deserve at least 6.3 backport.


## Motivation and Context

Problem as reported:

If you have a node with node_roles = search configured during Data Node cluster initialisation, the config generated will still prepopulate cluster.initial_cluster_manager_nodes including that node. Since it does not have cluster_manager as a role the cluster will not form.The workaround is to not start any node that does not have cluster_manager role configured (directly or automatically). You can add them to the cluster afterwards.The fix is to not add any nodes without the cluster_manager role to cluster.initial_cluster_manager_nodes during the initial cluster initialisation.

## How Has This Been Tested?
Added unit test


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

