### PR TITLE
Add missing notification grns to sharing dependency check during event definition creation

### DIFF
--- a/changelog/unreleased/pr-23283.toml
+++ b/changelog/unreleased/pr-23283.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix dependency check during sharing of event definitions."
+
+issues = ["graylog-plugin-enterprise#11055"]
+pulls = ["23283"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
@@ -32,6 +32,9 @@ type Props = {
 const ShareForm = ({ onChange, eventDefinition }: Props) => {
   const handleEntityShareSet = (entityShare?: EntitySharePayload) => onChange('share_request', entityShare);
   const streamDependenciesGRN = eventDefinition?.config?.streams?.map((streamId) => createGRN('stream', streamId));
+  const notificationDependenciesGRN = eventDefinition?.notifications?.map((notification) =>
+    createGRN('notification', notification.notification_id),
+  );
 
   return (
     <Row>
@@ -44,7 +47,7 @@ const ShareForm = ({ onChange, eventDefinition }: Props) => {
           onSetEntityShare={handleEntityShareSet}
           entityType="event_definition"
           entityTitle=""
-          dependenciesGRN={streamDependenciesGRN}
+          dependenciesGRN={[...streamDependenciesGRN, ...notificationDependenciesGRN]}
         />
       </Col>
     </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

During event definition creation, if one directly shares the event definition, the dependency check did not take the notifications into account as dependencies. This PR adds the missing grns to the check.


fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/11055

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

