### PR TITLE
Datanode: fix possible race condition when building iniital manager nodes

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
@@ -89,10 +89,20 @@ public class OpensearchClusterConfigurationBean implements DatanodeConfiguration
 
     @Nonnull
     private String buildInitialManagerNodesList() {
+        // this node itself might not be registered with the node service yet, therefore we always add it to the list.
         return nodeService.allActive().values().stream()
                 .filter(this::isManager)
                 .map(Node::getHostname)
-                .collect(Collectors.joining(","));
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toSet(),
+                        hostnames -> {
+                            if (localConfiguration.getNodeRoles() != null &&
+                                    localConfiguration.getNodeRoles().contains(OpensearchNodeRole.CLUSTER_MANAGER)) {
+                                hostnames.add(localConfiguration.getHostname());
+                            }
+                            return String.join(",", hostnames);
+                        }
+                ));
     }
 
     private boolean isManager(DataNodeDto n) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `cluster.initial_cluster_manager_nodes` is populated with nodes registered with the nodeService. 
It is possible that the node that is currently starting up has not sent a heartbeat yet and therefore might not be registered. For single node installations, this results in an empty string as `cluster.initial_cluster_manager_nodes`, causing Opensearch not being able to form a cluster.

/nocl fixes regression introduced during development

## How Has This Been Tested?
added unit tests / manual startup

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

