### PR TITLE
Improve wording for conversion function defaultToNull parameter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/AbstractConversion.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/conversion/AbstractConversion.java
@@ -29,7 +29,7 @@ public abstract class AbstractConversion<T> extends AbstractFunction<T> {
     public final ParameterDescriptor<Boolean, Boolean> defaultToNullParam;
 
     public AbstractConversion() {
-        defaultToNullParam = bool("defaultToNull").optional().description("Returns null when 'value' is null and overrides the \"default\" parameter.").defaultValue(Optional.of(false)).build();
+        defaultToNullParam = bool("defaultToNull").optional().description("Returns null when the 'value' parameter is null, and overrides any default value.").defaultValue(Optional.of(false)).build();
     }
 
     protected Boolean defaultToNull(FunctionArgs args, EvaluationContext context) {


### PR DESCRIPTION
Minor improvement for `defaultToNull` parameter description for conversion pipeline functions (introduced in https://github.com/Graylog2/graylog2-server/pull/22733). This is a common parameter to many functions, and some have an actual default configuration parameter, and some do not. Most have a value to that they default to (even if they don't have an actual configurable `default` param) such as `to_map` and `csv_to_map`. This adjustment generalizes the description to help it work for all functions.

Originated from docs improvements for https://github.com/Graylog2/graylog2-server/pull/22733.

/nocl minor wording change