### PR TITLE
Pulled some journal-methods into the interface

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
@@ -38,7 +38,7 @@ public class JournalShow extends AbstractJournalCommand {
     protected void runCommand() {
         long sizeInBytes = journal.size();
         int numSegments = journal.numberOfSegments();
-        long committedReadOffset = journal.getCommittedReadOffset();
+        long committedReadOffset = journal.getCommittedOffset();
         final StringBuilder sb = new StringBuilder();
 
         final long startOffset = journal.getLogStartOffset();

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/Journal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/Journal.java
@@ -28,7 +28,51 @@ public interface Journal {
 
     List<JournalReadEntry> read(long maximumCount);
 
+    /**
+     * Read from the journal, starting at the given offset. If the underlying journal implementation returns an empty
+     * list of entries, it will be returned even if we know there are more entries in the journal.
+     *
+     * @param readOffset            Offset to start reading at
+     * @param requestedMaximumCount Maximum number of entries to return.
+     * @return A list of entries
+     */
+    List<JournalReadEntry> read(long readOffset, long requestedMaximumCount);
+
     void markJournalOffsetCommitted(long offset);
+
+    /**
+     * Returns the highest journal offset that has been written to persistent storage by Graylog.
+     * <p>
+     * Every message at an offset prior to this one can be considered as processed and does not need to be held in
+     * the journal any longer. By default, Graylog will try to aggressively flush the journal to consume a smaller
+     * amount of disk space.
+     * </p>
+     *
+     * @return the offset of the last message which has been successfully processed.
+     */
+    long getCommittedOffset();
+
+    /**
+     * Returns the next offset the client should read.
+     * <p>
+     * This offset is *not* the committed offset (see {@link #getCommittedOffset()} for that), it just keeps track
+     * of the message this client has already processed without telling the journal that all the read messages have
+     * been processed successfully.
+     * </p><p>
+     * Caution: Do not use the {@code nextReadOffset} with more than one consumer!
+     * </p>
+     *
+     * @return The offset of the next message to consume.
+     */
+    long getNextReadOffset();
+
+    /**
+     * Resets the next read offset the client should start reading from to {@code getCommittedOffset() + 1}.
+     *
+     * This method should be used in case of an error while consuming the messages. The next time the consumer asks
+     * for messages, the next ones after the last successful commit will be returned.
+     */
+    void resetNextReadOffset();
 
     void flush();
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java
@@ -656,6 +656,7 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
      * @param requestedMaximumCount Maximum number of entries to return.
      * @return A list of entries
      */
+    @Override
     public List<JournalReadEntry> read(long readOffset, long requestedMaximumCount) {
         // Always read at least one!
         final long maximumCount = Math.max(1, requestedMaximumCount);
@@ -790,12 +791,21 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
         }
     }
 
+    @Override
     public long getCommittedOffset() {
         return committedOffset.get();
     }
 
+    @Override
     public long getNextReadOffset() {
         return nextReadOffset;
+    }
+
+    @Override
+    public void resetNextReadOffset() {
+        final long newValue = committedOffset.get() + 1;
+        LOG.info("Resetting next read offset to the last committed offset ({} -> {})", this.nextReadOffset, newValue);
+        this.nextReadOffset = newValue;
     }
 
     /**
@@ -919,20 +929,6 @@ public class LocalKafkaJournal extends AbstractIdleService implements Journal {
      */
     public int numberOfSegments() {
         return kafkaLog.numberOfSegments();
-    }
-
-    /**
-     * Returns the highest journal offset that has been writting to persistent storage by Graylog.
-     * <p>
-     * Every message at an offset prior to this one can be considered as processed and does not need to be held in
-     * the journal any longer. By default Graylog will try to aggressively flush the journal to consume a smaller
-     * amount of disk space.
-     * </p>
-     *
-     * @return the offset of the last message which has been successfully processed.
-     */
-    public long getCommittedReadOffset() {
-        return committedOffset.get();
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/NoopJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/NoopJournal.java
@@ -48,7 +48,27 @@ public class NoopJournal extends AbstractIdleService implements Journal {
     }
 
     @Override
+    public List<JournalReadEntry> read(long readOffset, long requestedMaximumCount) {
+        return List.of();
+    }
+
+    @Override
     public void markJournalOffsetCommitted(long offset) {
+        // nothing to do
+    }
+
+    @Override
+    public long getCommittedOffset() {
+        return Long.MIN_VALUE;
+    }
+
+    @Override
+    public long getNextReadOffset() {
+        return Long.MIN_VALUE;
+    }
+
+    @Override
+    public void resetNextReadOffset() {
         // nothing to do
     }
 


### PR DESCRIPTION
Pulled some already existing methods of the [LocalKafkaJournal](https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/shared/journal/LocalKafkaJournal.java) into its interface, to be able to use them elsewhere properly.
Also, this removes a duplicate way of accessing the latest commit offset.

/nocl refactoring

---

* Pulled some already existing methods up into the Journal-interface, removed duplicate method to getCommittedOffset

* Expose setter for nextReadOffset to allow consuming uncommitted messages again

* Don't allow to setNexReadOffset to an arbitrary value, only resetting to "lastCommitOffset + 1" is possible now.

---------


(cherry picked from commit e6d0b6a48e788c9c17dc906c1b09932638e6c64f)

