### PR TITLE
Add ignoreInitialUrlQueries flag to ReplaySearch and SearchPage

### DIFF
--- a/graylog2-web-interface/src/components/events/ReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearch.tsx
@@ -41,6 +41,7 @@ type ReplaySearchProps = {
   replayEventDefinition: boolean;
   searchPageLayout: Partial<LayoutState>;
   forceSidebarPinned: boolean;
+  ignoreInitialUrlQueries?: boolean;
 };
 
 const defaultSearchPageLayout = {};
@@ -54,6 +55,7 @@ const ReplaySearch = ({
   replayEventDefinition,
   searchPageLayout,
   forceSidebarPinned,
+  ignoreInitialUrlQueries = false,
 }: ReplaySearchProps) => {
   const _view = useCreateViewForEvent({ eventData, eventDefinition, aggregations });
   const view = useCreateSearch(_view);
@@ -79,7 +81,12 @@ const ReplaySearch = ({
   return (
     <ReplaySearchContext.Provider value={replaySearchContext}>
       <SearchPageLayoutProvider value={_searchPageLayout}>
-        <SearchPage view={view} isNew forceSideBarPinned={forceSidebarPinned} />
+        <SearchPage
+          view={view}
+          isNew
+          forceSideBarPinned={forceSidebarPinned}
+          ignoreInitialUrlQueries={ignoreInitialUrlQueries}
+        />
       </SearchPageLayoutProvider>
     </ReplaySearchContext.Provider>
   );
@@ -91,6 +98,7 @@ type Props = {
   replayEventDefinition?: boolean;
   searchPageLayout?: Partial<LayoutState>;
   forceSidebarPinned?: boolean;
+  ignoreInitialUrlQueries?: boolean;
 };
 
 const canReplayEvent = (eventDefinition: EventDefinition) => {
@@ -109,6 +117,7 @@ const LoadingBarrier = ({
   replayEventDefinition = false,
   searchPageLayout = defaultSearchPageLayout,
   forceSidebarPinned = false,
+  ignoreInitialUrlQueries = false,
 }: Props) => {
   const { eventDefinition, aggregations, eventData, isLoading } = useAlertAndEventDefinitionData(alertId, definitionId);
 
@@ -128,6 +137,7 @@ const LoadingBarrier = ({
       searchPageLayout={searchPageLayout}
       replayEventDefinition={replayEventDefinition}
       forceSidebarPinned={forceSidebarPinned}
+      ignoreInitialUrlQueries={ignoreInitialUrlQueries}
     />
   ) : (
     <Center>Cannot replay this event: {canReplay} Please select a different one.</Center>

--- a/graylog2-web-interface/src/views/pages/SearchPage.tsx
+++ b/graylog2-web-interface/src/views/pages/SearchPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
@@ -44,6 +44,7 @@ type Props = React.PropsWithChildren<{
   searchResult?: SearchExecutionResult;
   forceSideBarPinned?: boolean;
   skipNoStreamsCheck?: boolean;
+  ignoreInitialUrlQueries?: boolean;
 }>;
 
 const SearchPageTitle = ({ children }: { children: React.ReactNode }) => {
@@ -62,8 +63,10 @@ const SearchPage = ({
   searchResult = undefined,
   forceSideBarPinned = false,
   skipNoStreamsCheck = false,
+  ignoreInitialUrlQueries = false,
 }: Props) => {
-  const query = useQuery();
+  const urlQuery = useQuery();
+  const query = useMemo(() => (ignoreInitialUrlQueries ? {} : urlQuery), [ignoreInitialUrlQueries, urlQuery]);
   const initialQuery = query?.page as string;
   const history = useHistory();
   const loadNewView = useCallback(() => _loadNewView(history), [_loadNewView, history]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a new flag `ignoreInitialUrlQueries` to ReplaySearch and SearchPage components. That will help ignore URL parameters while creating a new initial view for the page. That might be useful on pages where we open SearchPage in the modal and already have some parameters related to the search page component but have the same names

## Motivation and Context
More details about why we need this change are here https://github.com/Graylog2/graylog-plugin-enterprise/pull/11473

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
