### PR TITLE
Always release retained ByteBuf in SyslogTCPFramingRouterHandler when Exception is thrown

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPFramingRouterHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPFramingRouterHandler.java
@@ -45,8 +45,14 @@ public class SyslogTCPFramingRouterHandler extends SimpleChannelInboundHandler<B
                     handler = new DelimiterBasedFrameDecoder(maxFrameLength, delimiter);
                 }
             }
+            try {
+                handler.channelRead(ctx, ReferenceCountUtil.retain(msg));
+            } catch (Exception e) {
+                // Because we've retained the buffer, we must release it in case of an exception to avoid memory leaks
+                ReferenceCountUtil.release(msg);
+                throw e;
+            }
 
-            handler.channelRead(ctx, ReferenceCountUtil.retain(msg));
         } else {
             ctx.fireChannelRead(msg);
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Always release retained ByteBuf in SyslogTCPFramingRouterHandler when Exception is thrown
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid running into memory leaks, we should ensure that we release the retained buffer when an Exception Occurs. 

resolves: https://github.com/Graylog2/graylog2-server/issues/23312


