### PR TITLE
Permit access to the API browser with the “api_browser:read” permission.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -62,6 +62,8 @@ can only talk to Kafka brokers with version 2.1 or newer.
     }
 }
 ```
+- Access to the API browser now requires the `api_browser:read` permission. This permission can be granted by assigning 
+  the new “API Browser Reader” role to a user.
 
 ## REST API Endpoint Changes
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -31,11 +31,13 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.Configuration;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.RestTools;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.rest.resources.csp.CSP;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.activation.MimetypesFileTypeMap;
 import java.io.IOException;
@@ -49,6 +51,7 @@ import static java.util.Objects.requireNonNull;
 @Path("/api-browser")
 @CSP(group = CSP.SWAGGER)
 @RequiresAuthentication
+@RequiresPermissions(RestPermissions.API_BROWSER_READ)
 public class DocumentationBrowserResource extends RestResource {
     private final MimetypesFileTypeMap mimeTypes;
     private final HttpConfiguration httpConfiguration;

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -32,6 +32,7 @@ public class RestPermissions implements PluginPermissions {
      * These should all be in the form of "domain:action", because {@link Permissions#allPermissionsMap()} below depends on it.
      * Should this ever change, you need to adapt the code below, too.
      */
+    public static final String API_BROWSER_READ = "api_browser:read";
     public static final String AUTH_HTTP_HEADER_CONFIG_EDIT = "authhttpheaderconfig:edit";
     public static final String AUTH_HTTP_HEADER_CONFIG_READ = "authhttpheaderconfig:read";
     public static final String AUTH_SERVICE_BACKEND_CREATE = "authservicebackend:create";
@@ -193,6 +194,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String USERS_TOKENREMOVE = "users:tokenremove";
 
     protected static final ImmutableSet<Permission> PERMISSIONS = ImmutableSet.<Permission>builder()
+            .add(create(API_BROWSER_READ, ""))
             .add(create(AUTH_HTTP_HEADER_CONFIG_EDIT, ""))
             .add(create(AUTH_HTTP_HEADER_CONFIG_READ, ""))
             .add(create(AUTH_SERVICE_BACKEND_CREATE, ""))
@@ -383,6 +385,9 @@ public class RestPermissions implements PluginPermissions {
             )),
             BuiltinRole.create("Cluster Configuration Reader", "Allows viewing the Cluster Configuration page", ImmutableSet.of(
                     RestPermissions.CLUSTER_CONFIGURATION_READ
+            )),
+            BuiltinRole.create("API Browser Reader", "Allows viewing the API browser page", ImmutableSet.of(
+                    RestPermissions.API_BROWSER_READ
             ))
     ).build();
 

--- a/graylog2-web-interface/src/components/cluster-configuration/ClusterActions.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/ClusterActions.tsx
@@ -103,9 +103,11 @@ const ClusterActions = ({ node }: Props) => {
             <MenuItem>Get recent system log messages</MenuItem>
           </LinkContainer>
         </IfPermitted>
-        <MenuItem href={apiBrowserURI} target="_blank">
-          <ExternalLink>API Browser</ExternalLink>
-        </MenuItem>
+        <IfPermitted permissions="api_browser:read">
+          <MenuItem href={apiBrowserURI} target="_blank">
+            <ExternalLink>API Browser</ExternalLink>
+          </MenuItem>
+        </IfPermitted>
       </DropdownButton>
       {showMessageProcessingModal && (
         <ConfirmDialog

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 
 import { NavDropdown } from 'components/bootstrap';
-import { Icon } from 'components/common';
+import { Icon, IfPermitted } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 import useHotkeysContext from 'hooks/useHotkeysContext';
@@ -39,7 +39,9 @@ const HelpMenu = () => {
 
       <Menu.Item onClick={() => setShowHotkeysModal(true)}>Keyboard Shortcuts</Menu.Item>
 
-      <HelpMenuLinkItem href={Routes.global_api_browser()}>Cluster Global API browser</HelpMenuLinkItem>
+      <IfPermitted permissions="api_browser:read">
+        <HelpMenuLinkItem href={Routes.global_api_browser()}>Cluster Global API browser</HelpMenuLinkItem>
+      </IfPermitted>
     </NavDropdown>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
In some cases, it is not desirable for users to have access to the API browser. With the new permission `api_browser:read `and the new role "API Browser Reader", you can now grant these rights to individual users.

fixes Graylog2/graylog-plugin-enterprise#10625

/nocl