### PR TITLE
Data Node: fix initial manager node list

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBean.java
@@ -96,7 +96,7 @@ public class OpensearchClusterConfigurationBean implements DatanodeConfiguration
                 .collect(Collectors.collectingAndThen(
                         Collectors.toSet(),
                         hostnames -> {
-                            if (localConfiguration.getNodeRoles() != null &&
+                            if (localConfiguration.getNodeRoles() == null || localConfiguration.getNodeRoles().isEmpty() ||
                                     localConfiguration.getNodeRoles().contains(OpensearchNodeRole.CLUSTER_MANAGER)) {
                                 hostnames.add(localConfiguration.getHostname());
                             }

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchClusterConfigurationBeanTest.java
@@ -97,4 +97,20 @@ class OpensearchClusterConfigurationBeanTest {
                 .containsOnly("my_manager_node", "my_other_manager_node");
     }
 
+    @Test
+    void testManagerNodesWithNoRolesSet() throws ValidationException, RepositoryException {
+        final OpensearchClusterConfigurationBean configurationBean = new OpensearchClusterConfigurationBean(DatanodeTestUtils.datanodeConfiguration(
+                Map.of("hostname", "this_node_can_be_manager")), testNodeService);
+
+        final DatanodeConfigurationPart configurationPart = configurationBean.buildConfigurationPart(new OpensearchConfigurationParams(Collections.emptyList(), Map.of()));
+
+        // initial cluster manager nodes should only contain nodes that publish cluster_manager role, ignore all other nodes
+        final String initialManagerNodes = configurationPart.properties().get("cluster.initial_cluster_manager_nodes");
+        Assertions.assertThat(initialManagerNodes).isNotEmpty();
+        final List<String> managerNodes = Arrays.asList(initialManagerNodes.split(","));
+
+        Assertions.assertThat(managerNodes)
+                .containsOnly("my_manager_node", "my_other_manager_node", "this_node_can_be_manager");
+    }
+
 }


### PR DESCRIPTION
## Description
Adds the node as a cluster manager node if no nodes have been set instead of when it has been explicitly set.
This now corresponds to the way the roles are set by default in `OpensearchCommonConfigurationBean`

/nocl fixes regression introduced in development

## Motivation and Context
fixes regression introduced in https://github.com/Graylog2/graylog2-server/pull/23284

## How Has This Been Tested?
added test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

