### PR TITLE
Implement move range buttons for time range display in search bar. (`6.3`)

### DIFF
--- a/changelog/unreleased/issue-20717.toml
+++ b/changelog/unreleased/issue-20717.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Implement buttons on search page to move search time range forward and backward."
+
+pulls = ["22953"]
+issues = ["20717"]

--- a/graylog2-web-interface/src/util/DateTime.test.ts
+++ b/graylog2-web-interface/src/util/DateTime.test.ts
@@ -28,6 +28,7 @@ import {
   relativeDifferenceDays,
   toDateObject,
   toUTCFromTz,
+  readableDifference,
 } from 'util/DateTime';
 
 const mockRootTimeZone = 'America/Chicago';
@@ -180,6 +181,16 @@ describe('DateTime utils', () => {
     it('should throw an error for an invalid date', () => {
       relativeDifference(invalidDate);
       expectErrorForInvalidDate();
+    });
+  });
+
+  describe('readableDifference', () => {
+    it('should return a readable difference for two dates', () => {
+      expect(readableDifference('2020-01-01T10:00:00.000', '2020-01-10T10:00:00.000')).toBe('9 days');
+    });
+
+    it('should return a readable difference for two dates in ms', () => {
+      expect(readableDifference('2020-01-01T10:00:00.000', '2020-01-01T10:00:00.120')).toBe('120 milliseconds');
     });
   });
 

--- a/graylog2-web-interface/src/util/DateTime.ts
+++ b/graylog2-web-interface/src/util/DateTime.ts
@@ -16,6 +16,7 @@
  */
 import type { Moment } from 'moment';
 import moment from 'moment-timezone';
+import 'moment-precise-range-plugin';
 
 export type DateTime = string | number | Moment | Date;
 
@@ -107,6 +108,22 @@ export const relativeDifference = (dateTime: DateTime) => {
   const dateObject = toDateObject(dateTime);
 
   return validateDateTime(dateObject, dateTime).fromNow();
+};
+
+/**
+ * Returns the difference between two dates in a human-readable format.
+ */
+export const readableDifference = (from: DateTime, to: DateTime) => {
+  const fromObject = toDateObject(from);
+  const toObject = toDateObject(to);
+  const differenceMS = toObject.diff(fromObject);
+
+  // preciseDiff does not support ms
+  if (differenceMS < 1000) {
+    return `${differenceMS} milliseconds`;
+  }
+
+  return moment.preciseDiff(fromObject, toObject);
 };
 
 /**

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.tsx
@@ -63,6 +63,9 @@ import useIsLoading from 'views/hooks/useIsLoading';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
 import { executeActiveQuery } from 'views/logic/slices/viewSlice';
+import useViewsSelector from 'views/stores/useViewsSelector';
+import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
+import { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
 
 import TimeRangeFilter from './searchbar/time-range-filter';
 import type { DashboardFormValues } from './DashboardSearchBarForm';
@@ -124,6 +127,7 @@ const DashboardSearchBar = () => {
   const view = useView();
   const { userTimezone } = useUserDateTime();
   const { config } = useSearchConfiguration();
+  const results = useViewsSelector(selectCurrentQueryResults);
   const { timerange, query: { query_string: queryString = '' } = {} } = useGlobalOverride() ?? {};
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const dispatch = useViewsDispatch();
@@ -185,6 +189,11 @@ const DashboardSearchBar = () => {
                         value={values?.timerange}
                         limitDuration={limitDuration}
                         hasErrorOnMount={!!errors.timerange}
+                        moveRangeProps={{
+                          effectiveTimerange: results?.effectiveTimerange,
+                          initialTimerange: timerange ?? NO_TIMERANGE_OVERRIDE,
+                          initialTimerangeFormat: 'internal',
+                        }}
                         noOverride
                       />
                       <ViewsRefreshControls disable={!isValid} />

--- a/graylog2-web-interface/src/views/components/SearchBar.tsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.tsx
@@ -75,6 +75,8 @@ import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import { defaultCompare } from 'logic/DefaultCompare';
 import StreamCategoryFilter from 'views/components/searchbar/StreamCategoryFilter';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
+import useViewsSelector from 'views/stores/useViewsSelector';
+import { selectCurrentQueryResults } from 'views/logic/slices/viewSelectors';
 
 import SearchBarForm from './searchbar/SearchBarForm';
 
@@ -195,6 +197,7 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
   const { parameters } = useParameters();
   const currentQuery = useCurrentQuery();
   const queryFilters = useQueryFilters();
+  const results = useViewsSelector(selectCurrentQueryResults);
   const pluggableSearchBarControls = usePluginEntities('views.components.searchBar');
   const initialValues = useInitialFormValues({ queryFilters, currentQuery });
   const dispatch = useViewsDispatch();
@@ -249,6 +252,11 @@ const SearchBar = ({ onSubmit = defaultProps.onSubmit }: Props) => {
                           onChange={(nextTimeRange) => setFieldValue('timerange', nextTimeRange)}
                           value={values?.timerange}
                           hasErrorOnMount={!!errors.timerange}
+                          moveRangeProps={{
+                            effectiveTimerange: results?.effectiveTimerange,
+                            initialTimerange: currentQuery.timerange,
+                            initialTimerangeFormat: 'internalIndexer',
+                          }}
                         />
                         <StreamsAndRefresh>
                           <Field name="streams">

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.tsx
@@ -57,7 +57,6 @@ import { setGlobalOverrideQuery, setGlobalOverrideTimerange } from 'views/logic/
 import useViewsDispatch from 'views/stores/useViewsDispatch';
 import useHandlerContext from 'views/components/useHandlerContext';
 import useView from 'views/hooks/useView';
-import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
 import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
 import QueryHistoryButton from 'views/components/searchbar/QueryHistoryButton';
 import type { Editor } from 'views/components/searchbar/queryinput/ace-types';
@@ -146,9 +145,7 @@ const useBindApplySearchControlsChanges = (formRef) => {
 
         if (dirty && isValid) {
           const normalizedFormValues = {
-            timerange: isNoTimeRangeOverride(timerange)
-              ? undefined
-              : normalizeFromSearchBarForBackend(timerange, userTimezone),
+            timerange: normalizeFromSearchBarForBackend(timerange, userTimezone),
             ...rest,
           };
 

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -108,7 +108,7 @@ const SearchButton = ({
       className={className}
       type="submit"
       bsStyle="success"
-      $dirty={dirty}>
+      $dirty={dirty && !displaySpinner}>
       {displaySpinner ? <Spinner delay={0} text="" /> : <Icon name={glyph} size="lg" />}
     </StyledButton>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/MoveRange.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/MoveRange.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { Formik, Form } from 'formik';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import useCurrentUser from 'hooks/useCurrentUser';
+import { adminUser } from 'fixtures/users';
+import asMock from 'helpers/mocking/AsMock';
+
+import MoveRange from './MoveRange';
+
+jest.mock('hooks/useCurrentUser');
+
+describe('MoveRange', () => {
+  type SUTProps = Partial<
+    React.ComponentProps<typeof MoveRange> & {
+      onSubmit?: () => void;
+    }
+  >;
+
+  const SUT = ({
+    onSubmit = () => {},
+    effectiveTimerange = undefined,
+    displayMoveRangeButtons = true,
+    setCurrentTimeRange = () => {},
+    initialTimerange = undefined,
+    currentTimerange = undefined,
+    children,
+  }: SUTProps) => (
+    <Formik initialValues={{}} onSubmit={onSubmit}>
+      <Form>
+        <MoveRange
+          setCurrentTimeRange={setCurrentTimeRange}
+          effectiveTimerange={effectiveTimerange}
+          initialTimerange={initialTimerange}
+          initialTimerangeFormat="internalIndexer"
+          currentTimerange={currentTimerange}
+          displayMoveRangeButtons={displayMoveRangeButtons}>
+          {children}
+        </MoveRange>
+      </Form>
+    </Formik>
+  );
+
+  const timeRange = {
+    from: '2025-06-27T07:18:06.716Z',
+    to: '2025-06-27T07:19:41.352Z',
+    type: 'absolute' as const,
+  };
+
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
+  it('should only render children, when buttons should not be displayed', async () => {
+    render(<SUT displayMoveRangeButtons={false}>Example children</SUT>);
+
+    await screen.findByText('Example children');
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should select previous time range', async () => {
+    const onSubmit = jest.fn();
+    const setCurrentTimeRange = jest.fn();
+
+    render(
+      <SUT
+        onSubmit={onSubmit}
+        setCurrentTimeRange={setCurrentTimeRange}
+        effectiveTimerange={timeRange}
+        initialTimerange={timeRange}
+        currentTimerange={timeRange}
+      />,
+    );
+
+    const showPrevButton = await screen.findByRole('button', { name: /show previous 1 minute 35 seconds/i });
+    await userEvent.click(showPrevButton);
+
+    const newTimeRange = {
+      from: '2025-06-27 09:16:32.080',
+      to: '2025-06-27 09:18:06.716',
+      type: 'absolute',
+    };
+
+    expect(setCurrentTimeRange).toHaveBeenCalledWith(newTimeRange);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it('should select next time range', async () => {
+    const onSubmit = jest.fn();
+    const setCurrentTimeRange = jest.fn();
+
+    render(
+      <SUT
+        onSubmit={onSubmit}
+        setCurrentTimeRange={setCurrentTimeRange}
+        effectiveTimerange={timeRange}
+        initialTimerange={timeRange}
+        currentTimerange={timeRange}
+      />,
+    );
+
+    const showPrevButton = await screen.findByRole('button', { name: /show next 1 minute 35 seconds/i });
+    await userEvent.click(showPrevButton);
+
+    const newTimeRange = {
+      from: '2025-06-27 09:19:41.352',
+      to: '2025-06-27 09:21:15.988',
+      type: 'absolute',
+    };
+
+    expect(setCurrentTimeRange).toHaveBeenCalledWith(newTimeRange);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it('should calculate correct time range, when user has time range (not UTC)', async () => {
+    asMock(useCurrentUser).mockReturnValue(adminUser.toBuilder().timezone('America/Los_Angeles').build());
+
+    const onSubmit = jest.fn();
+    const setCurrentTimeRange = jest.fn();
+
+    render(
+      <SUT
+        onSubmit={onSubmit}
+        setCurrentTimeRange={setCurrentTimeRange}
+        effectiveTimerange={timeRange}
+        initialTimerange={timeRange}
+        currentTimerange={timeRange}
+      />,
+    );
+
+    const showPrevButton = await screen.findByRole('button', { name: /show next 1 minute 35 seconds/i });
+    await userEvent.click(showPrevButton);
+
+    const newTimeRange = {
+      from: '2025-06-27 09:19:41.352',
+      to: '2025-06-27 09:21:15.988',
+      type: 'absolute',
+    };
+
+    expect(setCurrentTimeRange).toHaveBeenCalledWith(newTimeRange);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/MoveRange.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/MoveRange.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import * as React from 'react';
+import isEqual from 'lodash/isEqual';
+import { useFormikContext } from 'formik';
+import styled from 'styled-components';
+import { useCallback } from 'react';
+
+import type { TimeRange, AbsoluteTimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
+import useUserDateTime from 'hooks/useUserDateTime';
+import { onInitializingTimerange } from 'views/components/TimerangeForForm';
+import { normalizeFromSearchBarForBackend } from 'views/logic/queries/NormalizeTimeRange';
+import type { IconName } from 'components/common/Icon';
+import Icon from 'components/common/Icon';
+import { Button } from 'components/bootstrap';
+import { isNoTimeRangeOverride } from 'views/typeGuards/timeRange';
+import { readableDifference } from 'util/DateTime';
+
+const DIRECTIONS = {
+  backward: 'backward',
+  forward: 'forward',
+};
+
+const DIRECTION_ICONS: Record<Direction, IconName> = {
+  [DIRECTIONS.backward]: 'keyboard_arrow_left',
+  [DIRECTIONS.forward]: 'keyboard_arrow_right',
+};
+
+type Direction = (typeof DIRECTIONS)[keyof typeof DIRECTIONS];
+
+const ArrowButton = styled(Button)`
+  padding: 0;
+  border: 0;
+`;
+
+const MoveRangeButton = ({
+  direction,
+  disabled,
+  onMoveRange,
+  title,
+}: {
+  direction: Direction;
+  disabled: boolean;
+  onMoveRange: (direction: Direction) => void;
+  title: string;
+}) => {
+  const onClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onMoveRange(direction);
+  };
+
+  return (
+    <ArrowButton onClick={onClick} disabled={disabled} title={title}>
+      <Icon name={DIRECTION_ICONS[direction]} />
+    </ArrowButton>
+  );
+};
+
+type Props = React.PropsWithChildren<{
+  setCurrentTimeRange: (newRange: TimeRange) => void;
+  // time range of the previously executed search
+  effectiveTimerange: AbsoluteTimeRange | undefined;
+  // initially selected time range
+  initialTimerange: TimeRange | NoTimeRangeOverride;
+  // current value of time range in form state
+  currentTimerange: TimeRange | NoTimeRangeOverride;
+  initialTimerangeFormat: 'internal' | 'internalIndexer';
+}>;
+
+const MoveRangeInner = ({
+  setCurrentTimeRange,
+  effectiveTimerange,
+  initialTimerange,
+  currentTimerange,
+  children = undefined,
+  initialTimerangeFormat,
+}: Props) => {
+  const { formatTime, userTimezone } = useUserDateTime();
+  const { submitForm, isValid } = useFormikContext<{ timerange: TimeRange }>();
+
+  const readableDuration = effectiveTimerange
+    ? readableDifference(effectiveTimerange.from, effectiveTimerange.to)
+    : undefined;
+
+  if (effectiveTimerange) {
+    readableDifference(effectiveTimerange.from, effectiveTimerange.to);
+  }
+
+  const onMoveRange = useCallback(
+    (direction: Direction) => {
+      // Todo: Add telemetry event
+      const currentFrom = new Date(effectiveTimerange.from);
+      const currentTo = new Date(effectiveTimerange.to);
+
+      const currentDurationMs = currentTo.getTime() - currentFrom.getTime();
+
+      const isBackwardDirection = direction === DIRECTIONS.backward;
+
+      const newFrom = (
+        isBackwardDirection ? new Date(currentFrom.getTime() - currentDurationMs) : currentTo
+      ).toISOString();
+      const newTo = (
+        isBackwardDirection ? currentFrom : new Date(currentTo.getTime() + currentDurationMs)
+      ).toISOString();
+
+      setCurrentTimeRange(onInitializingTimerange({ type: 'absolute', from: newFrom, to: newTo }, formatTime));
+      submitForm();
+    },
+    [effectiveTimerange?.from, effectiveTimerange?.to, formatTime, setCurrentTimeRange, submitForm],
+  );
+
+  const disableButton =
+    !effectiveTimerange ||
+    !isValid ||
+    isNoTimeRangeOverride(currentTimerange) ||
+    !isEqual(
+      initialTimerange,
+      normalizeFromSearchBarForBackend(currentTimerange, userTimezone, initialTimerangeFormat),
+    );
+
+  return (
+    <>
+      <MoveRangeButton
+        onMoveRange={onMoveRange}
+        disabled={disableButton}
+        direction={DIRECTIONS.backward}
+        title={disableButton ? 'Show previous' : `Show previous ${readableDuration}`}
+      />
+      {children}
+      <MoveRangeButton
+        onMoveRange={onMoveRange}
+        disabled={disableButton}
+        direction={DIRECTIONS.forward}
+        title={disableButton ? 'Show next' : `Show next ${readableDuration}`}
+      />
+    </>
+  );
+};
+
+const MoveRange = ({
+  displayMoveRangeButtons,
+  setCurrentTimeRange,
+  effectiveTimerange,
+  initialTimerange,
+  initialTimerangeFormat,
+  currentTimerange,
+  children = undefined,
+}: Props & { displayMoveRangeButtons: boolean }) => {
+  if (!displayMoveRangeButtons) {
+    return children;
+  }
+
+  return (
+    <MoveRangeInner
+      initialTimerangeFormat={initialTimerangeFormat}
+      setCurrentTimeRange={setCurrentTimeRange}
+      effectiveTimerange={effectiveTimerange}
+      initialTimerange={initialTimerange}
+      currentTimerange={currentTimerange}>
+      {children}
+    </MoveRangeInner>
+  );
+};
+
+export default MoveRange;

--- a/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/time-range-filter/TimeRangeFilter.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { useContext, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-import type { TimeRange, NoTimeRangeOverride } from 'views/logic/queries/Query';
+import type { TimeRange, NoTimeRangeOverride, AbsoluteTimeRange } from 'views/logic/queries/Query';
 import { SEARCH_BAR_GAP } from 'views/components/searchbar/SearchBarLayout';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import TimeRangeFilterSettingsContext from 'views/components/contexts/TimeRangeInputSettingsContext';
@@ -28,6 +28,7 @@ import { NO_TIMERANGE_OVERRIDE } from 'views/Constants';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import useLocation from 'routing/useLocation';
+import MoveRange from 'views/components/searchbar/time-range-filter/MoveRange';
 
 import TimeRangeFilterButtons from './TimeRangeFilterButtons';
 import TimeRangeDisplay from './TimeRangeDisplay';
@@ -40,6 +41,11 @@ const FlexContainer = styled.div`
   min-width: 430px;
   gap: ${SEARCH_BAR_GAP};
   position: relative;
+`;
+
+const RightCol = styled.div`
+  display: flex;
+  width: 100%;
 `;
 
 type Props = {
@@ -55,6 +61,11 @@ type Props = {
   value?: TimeRange | NoTimeRangeOverride;
   withinPortal?: boolean;
   submitOnPresetChange?: boolean;
+  moveRangeProps?: {
+    effectiveTimerange: AbsoluteTimeRange;
+    initialTimerange: TimeRange | NoTimeRangeOverride;
+    initialTimerangeFormat: 'internal' | 'internalIndexer';
+  };
 };
 
 const TimeRangeFilter = ({
@@ -70,6 +81,7 @@ const TimeRangeFilter = ({
   limitDuration,
   withinPortal = true,
   submitOnPresetChange = true,
+  moveRangeProps = undefined,
 }: Props) => {
   const containerRef = useRef();
   const { showDropdownButton } = useContext(TimeRangeFilterSettingsContext);
@@ -120,7 +132,17 @@ const TimeRangeFilter = ({
             submitOnPresetChange={submitOnPresetChange}
           />
         )}
-        <TimeRangeDisplay timerange={value} toggleDropdownShow={toggleShow} />
+        <RightCol>
+          <MoveRange
+            displayMoveRangeButtons={!!moveRangeProps}
+            setCurrentTimeRange={onChange}
+            initialTimerangeFormat={moveRangeProps?.initialTimerangeFormat}
+            effectiveTimerange={moveRangeProps?.effectiveTimerange}
+            initialTimerange={moveRangeProps?.initialTimerange}
+            currentTimerange={value}>
+            <TimeRangeDisplay timerange={value} toggleDropdownShow={toggleShow} />
+          </MoveRange>
+        </RightCol>
       </FlexContainer>
     </TimeRangePicker>
   );


### PR DESCRIPTION
**Please note**, this is a backport of https://github.com/Graylog2/graylog2-server/pull/22953 for `6.3`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a "move time forward" and " move time backward" button to the time range display in the search bar and dashboard search bar.

Currently the resulting time range is always based on the effective time range of the executed search. If you search for messages in the last 10 minutes first and then click the "move backward" button, the new search will query messages for the 10 minutes before your previous search. 

If you search for messages in the last 24 hours first and then click the "move backward" button, the new search will query messages for the 24 hours before your previous search.

![move range buttons](https://github.com/user-attachments/assets/80cf56c5-1547-4f63-8911-195bce33061c)

Currently we do not disable these button when the time range is "all time". You can argue about the value these actions offer for the "all time" time range. I kept these button enabled, to not artificially limit the functionality.

In a follow-up PR we can also implement these for the widget edit mode on dashboards.

Fixes: https://github.com/Graylog2/graylog2-server/issues/20717

