### PR TITLE
Don't let node command tests write into source directory

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/commands/MinimalNodeCommandTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/commands/MinimalNodeCommandTest.java
@@ -22,13 +22,13 @@ import jakarta.annotation.Nonnull;
 import org.graylog2.GraylogNodeConfiguration;
 import org.graylog2.featureflag.FeatureFlags;
 import org.graylog2.plugin.ServerStatus;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 
@@ -40,25 +40,19 @@ import static org.mockito.Mockito.verify;
 public class MinimalNodeCommandTest {
 
     @Test
-    public void startMinimalNode() {
-        MinimalNode node = spy(new MinimalNode());
+    public void startMinimalNode(@TempDir Path tmpDir) throws Exception {
+        final var configFile = tmpDir.resolve("minimal-node.conf");
+        Files.write(configFile, List.of("password_secret = 1234567890123456"));
+        MinimalNode node = spy(new MinimalNode(configFile));
         node.run();
         verify(node, times(1)).startCommand();
     }
 
     static class MinimalNode extends AbstractNodeCommand {
 
-        public MinimalNode() {
+        public MinimalNode(Path configFile) {
             super(new MinimalNodeConfiguration());
-            URL resource = this.getClass().getResource("minimal-node.conf");
-            if (resource == null) {
-                Assertions.fail("Cannot read configuration file");
-            }
-            try {
-                setConfigFile(resource.toURI().getPath());
-            } catch (URISyntaxException e) {
-                Assertions.fail("Cannot read configuration file");
-            }
+            setConfigFile(configFile.toString());
         }
 
         @Override

--- a/graylog2-server/src/test/resources/org/graylog2/commands/common-node.conf
+++ b/graylog2-server/src/test/resources/org/graylog2/commands/common-node.conf
@@ -1,2 +1,0 @@
-node_id_file=./node_id_file
-password_secret=1234567890123456

--- a/graylog2-server/src/test/resources/org/graylog2/commands/minimal-node.conf
+++ b/graylog2-server/src/test/resources/org/graylog2/commands/minimal-node.conf
@@ -1,1 +1,0 @@
-password_secret=1234567890123456


### PR DESCRIPTION
The common node test wrote a node ID file into the source directory. (`graylog2-server/node_id_file`)

Replace static config files with dynamically generated files that are written to a tmp directory.

/nocl Internal test refactoring

