### PR TITLE
Improve updates of message table pagination. (`6.1`)

### DIFF
--- a/changelog/unreleased/issue-22321.toml
+++ b/changelog/unreleased/issue-22321.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing issue with message table pagination on search page, where the active page was not set correctly when opening pages very fast."
+
+pulls = ["23013"]
+issues = ["22321"]

--- a/changelog/unreleased/issue-23002.toml
+++ b/changelog/unreleased/issue-23002.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixing issue with message table pagination on search page, where active page was not reset correctly when executing new search."
+
+pulls = ["23013"]
+issues = ["23002"]

--- a/graylog2-web-interface/src/components/common/PaginatedList.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.tsx
@@ -26,14 +26,15 @@ import PageSizeSelect from './PageSizeSelect';
 export const INITIAL_PAGE = 1;
 
 type Props = {
-  children: React.ReactNode,
-  className?: string,
-  hideFirstAndLastPageLinks?: boolean
-  hidePreviousAndNextPageLinks?: boolean
-  onChange?: (currentPage: number, pageSize: number) => void,
-  pageSizes?: Array<number>,
-  showPageSizeSelect?: boolean,
-  totalItems: number,
+  children: React.ReactNode;
+  className?: string;
+  hideFirstAndLastPageLinks?: boolean;
+  hidePreviousAndNextPageLinks?: boolean;
+  onChange?: (currentPage: number, pageSize: number) => void;
+  pageSizes?: Array<number>;
+  showPageSizeSelect?: boolean;
+  totalItems: number;
+  enforcePageBounds?: boolean;
 };
 
 const ListBase = ({
@@ -48,6 +49,7 @@ const ListBase = ({
   setPagination,
   showPageSizeSelect,
   totalItems,
+  enforcePageBounds,
 }: Required<Props> & {
   currentPageSize: number,
   currentPage: number;
@@ -68,8 +70,10 @@ const ListBase = ({
   }, [setPagination, currentPageSize, onChange]);
 
   useEffect(() => {
-    if (numberPages > 0 && currentPage > numberPages) _onChangePage(numberPages);
-  }, [currentPage, numberPages, _onChangePage]);
+    if (enforcePageBounds && numberPages > 0 && currentPage > numberPages) {
+      _onChangePage(numberPages);
+    }
+  }, [enforcePageBounds, currentPage, numberPages, _onChangePage]);
 
   return (
     <>
@@ -85,7 +89,8 @@ const ListBase = ({
 
       <IfInteractive>
         <div className={`text-center pagination-wrapper ${className ?? ''}`}>
-          <Pagination totalPages={numberPages}
+          <Pagination warnIfPageOutOfBounds={false}
+                      totalPages={numberPages}
                       currentPage={currentPage}
                       hidePreviousAndNextPageLinks={hidePreviousAndNextPageLinks}
                       hideFirstAndLastPageLinks={hideFirstAndLastPageLinks}
@@ -154,35 +159,32 @@ const PaginatedList = ({
   showPageSizeSelect,
   totalItems,
   useQueryParameter,
+  enforcePageBounds = true,
 }: Props & {
   activePage?: number,
   pageSize?: number,
   useQueryParameter?: boolean,
 }) => {
+  const baseProps = {
+    enforcePageBounds: enforcePageBounds,
+    className: className,
+    hideFirstAndLastPageLinks: hideFirstAndLastPageLinks,
+    hidePreviousAndNextPageLinks: hidePreviousAndNextPageLinks,
+    onChange: onChange,
+    pageSizes: pageSizes,
+    pageSize: pageSize,
+    showPageSizeSelect: showPageSizeSelect,
+    totalItems: totalItems,
+  };
+
   if (useQueryParameter) {
     return (
-      <ListBasedOnQueryParams className={className}
-                              hideFirstAndLastPageLinks={hideFirstAndLastPageLinks}
-                              hidePreviousAndNextPageLinks={hidePreviousAndNextPageLinks}
-                              onChange={onChange}
-                              pageSizes={pageSizes}
-                              pageSize={pageSize}
-                              showPageSizeSelect={showPageSizeSelect}
-                              totalItems={totalItems}>
-        {children}
-      </ListBasedOnQueryParams>
+      <ListBasedOnQueryParams {...baseProps}>{children}</ListBasedOnQueryParams>
     );
   }
 
   return (
-    <ListWithOwnState className={className}
-                      hideFirstAndLastPageLinks={hideFirstAndLastPageLinks}
-                      hidePreviousAndNextPageLinks={hidePreviousAndNextPageLinks}
-                      onChange={onChange}
-                      pageSizes={pageSizes}
-                      pageSize={pageSize}
-                      showPageSizeSelect={showPageSizeSelect}
-                      totalItems={totalItems}
+    <ListWithOwnState {...baseProps}
                       activePage={activePage}>
       {children}
     </ListWithOwnState>

--- a/graylog2-web-interface/src/components/common/Pagination.tsx
+++ b/graylog2-web-interface/src/components/common/Pagination.tsx
@@ -24,15 +24,16 @@ import styled, { css } from 'styled-components';
 import Icon from './Icon';
 
 type Props = {
-  currentPage: number,
-  totalPages: number,
-  boundaryPagesRange?: number,
-  siblingPagesRange?: number,
-  hideEllipsis?: boolean,
-  hidePreviousAndNextPageLinks?: boolean,
-  hideFirstAndLastPageLinks?: boolean,
-  disabled?: boolean,
-  onChange: (nextPage: number) => void,
+  currentPage: number;
+  totalPages: number;
+  boundaryPagesRange?: number;
+  siblingPagesRange?: number;
+  hideEllipsis?: boolean;
+  hidePreviousAndNextPageLinks?: boolean;
+  hideFirstAndLastPageLinks?: boolean;
+  disabled?: boolean;
+  onChange?: (nextPage: number) => void;
+  warnIfPageOutOfBounds?: boolean;
 };
 
 const StyledBootstrapPagination = styled(BootstrapPagination)(({ theme }) => css`
@@ -185,14 +186,17 @@ const Pagination = ({
   hideFirstAndLastPageLinks,
   disabled,
   onChange,
+  warnIfPageOutOfBounds = true,
 }: Props) => {
   if (totalPages <= 1) {
     return null;
   }
 
   if (currentPage > totalPages) {
-    // eslint-disable-next-line no-console
-    console.warn('Graylog Pagination: `currentPage` prop should not be larger than `totalPages` prop.');
+    if (warnIfPageOutOfBounds) {
+      // eslint-disable-next-line no-console
+      console.warn('Graylog Pagination: `currentPage` prop should not be larger than `totalPages` prop.');
+    }
 
     return null;
   }

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.tsx
@@ -19,6 +19,7 @@ import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import userEvent from '@testing-library/user-event';
 
+import useSearchResult from 'views/hooks/useSearchResult';
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
 import { TIMESTAMP_FIELD, Messages } from 'views/Constants';
@@ -33,7 +34,6 @@ import { finishedLoading } from 'views/logic/slices/searchExecutionSlice';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import SearchResult from 'views/logic/SearchResult';
 import reexecuteSearchTypes from 'views/components/widgets/reexecuteSearchTypes';
-import type { SearchErrorResponse } from 'views/logic/SearchError';
 import TestStoreProvider from 'views/test/TestStoreProvider';
 import useViewsPlugin from 'views/test/testViewsPlugin';
 import useAutoRefresh from 'views/hooks/useAutoRefresh';
@@ -55,6 +55,7 @@ jest.mock('stores/inputs/InputsStore', () => ({
 }));
 
 jest.mock('views/hooks/useAutoRefresh');
+jest.mock('views/hooks/useSearchResult');
 
 const searchTypeResults = {
   'search-type-id': {
@@ -70,7 +71,13 @@ const dummySearchJobResults = {
   id: 'foo',
   owner: 'me',
   search_id: 'bar',
-  results: {},
+  results: {
+    deadbeef: {
+      query: { search_types: [{ id: 'search-type-id', limit: 10000 }] },
+      execution_stats: {},
+      errors: [],
+    },
+  },
 };
 jest.mock('views/hooks/useActiveQueryId');
 jest.mock('views/components/widgets/useCurrentSearchTypesResults');
@@ -234,25 +241,29 @@ describe('MessageList', () => {
     await waitFor(() => expect(stopAutoRefresh).toHaveBeenCalledTimes(1));
   });
 
-  it('displays error description, when using pagination throws an error', async () => {
-    const dispatch = jest.fn().mockResolvedValue(finishedLoading({
+  it('displays search result limit errors', async () => {
+    asMock(useSearchResult).mockReturnValue({
       result: new SearchResult({
         ...dummySearchJobResults,
-        errors: [{
-          description: 'Error description',
-        } as SearchErrorResponse],
+        errors: [
+          {
+            query_id: 'deadbeef',
+            search_type_id: 'search-type-id',
+            description: 'Error description',
+            backtrace: undefined,
+            type: 'result_window_limit',
+            result_window_limit: 10000,
+          },
+        ],
       }),
       widgetMapping: Immutable.Map(),
-    }));
-    asMock(useAppDispatch).mockReturnValue(dispatch);
+    });
 
-    const secondPageSize = 10;
+    render(<SimpleMessageList />);
 
-    render(<SimpleMessageList data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }} />);
-
-    clickNextPageButton();
-
-    await screen.findByText('Error description');
+    await screen.findByText(
+      'Elasticsearch limits the search result to 10000 messages. With a page size of 10000 messages, you can use the first 1 pages. Error description',
+    );
   });
 
   it('calls render completion callback after first render', async () => {

--- a/graylog2-web-interface/src/views/logic/SearchResult.ts
+++ b/graylog2-web-interface/src/views/logic/SearchResult.ts
@@ -45,7 +45,7 @@ export type SearchJobResult = {
   owner: string,
   results: { [id: string]: any },
   search_id: SearchId,
-  errors: Array<SearchErrorResponse>,
+  errors: Array<SearchErrorResponse | ResultWindowLimitErrorResponse>,
 };
 
 class SearchResult {


### PR DESCRIPTION
Note: This is a backport of https://github.com/Graylog2/graylog2-server/pull/23013 to `6.1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There are currently two issues with the message table pagination. https://github.com/Graylog2/graylog2-server/issues/23002 & https://github.com/Graylog2/graylog2-server/issues/22321

Both are related to the circumstance that the pagination is updated after the request for a page finished. The logic for the message table pagination is quite complex because
- the active page is maintained inside the `PaginatedList` and the `MessageList` component.
- the results are provided via the `MessageList` props and not via the response of `reexecuteSearchTypes`. Currently we can't identify the page a set of messages relate to.
- although all messages are provided via the props, their origin is not always the same. The initial result for page one come from the general search endpoint, which returns all results for all widgets. When you open another page we call a different endpoint to fetch only the result for the new page. This means we can't just add a `useEffect` which fetches the results when the active page changes.
- the props (incl. `totalMessages`) change before `setPagination` in `useResetPaginationOnSearchExecution` has been executed. Therefore there is a small window where the active page could be larger than the new largest page.

This PR does not simplify the state management related to the pagination, but it fixes the two issues by:
- not calling `setPagination` twice when the currently active page is larger than the new largest page (after executing a new search with less results).
- syncing the pagination in `MessageList` before we call `reexecuteSearchTypes`.

Fixes https://github.com/Graylog2/graylog2-server/issues/23002 
Fixes https://github.com/Graylog2/graylog2-server/issues/22321