### PR TITLE
Add retrying for retryable HTTP status codes in HTTP Noitifications

### DIFF
--- a/changelog/unreleased/issue-11313.toml
+++ b/changelog/unreleased/issue-11313.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add ability for HTTP notifications to retry requests for temporary HTTP failure codes."
+
+issues = ["11313"]
+pulls = ["23334"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -114,8 +114,12 @@ public class HTTPEventNotification extends HTTPNotification implements EventNoti
         final OkHttpClient httpClient = selectClient(config);
         try (final Response r = httpClient.newCall(request).execute()) {
             if (!r.isSuccessful()) {
+                final int status = r.code();
+                if (HTTPUtils.isRetryableStatus(status)) {
+                    throw new TemporaryEventNotificationException(buildRetryMessage(status));
+                }
                 throw new PermanentEventNotificationException(
-                        "Expected successful HTTP response [2xx] but got [" + r.code() + "]. " + config.url());
+                        "Expected successful HTTP response [2xx] but got [" + status + "]. " + config.url());
             }
         } catch (IOException e) {
             throw new PermanentEventNotificationException(e.getMessage());

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationV2.java
@@ -39,7 +39,6 @@ import org.graylog.events.notifications.EventNotificationService;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.graylog2.jackson.TypeReferences;
-import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.system.NodeId;
@@ -113,7 +112,7 @@ public class HTTPEventNotificationV2 extends HTTPNotification implements EventNo
                                    NotificationService notificationService,
                                    NodeId nodeId,
                                    final ParameterizedHttpClientProvider parameterizedHttpClientProvider) {
-        super(whitelistService, urlWhitelistNotificationService, encryptedValueService);
+        super(whitelistService, urlWhitelistNotificationService, encryptedValueService, notificationService, nodeId);
         this.notificationCallbackService = notificationCallbackService;
         this.objectMapperProvider = objectMapperProvider;
         this.configurationProvider = configurationProvider;
@@ -185,16 +184,6 @@ public class HTTPEventNotificationV2 extends HTTPNotification implements EventNo
             createSystemErrorNotification("Error: " + e.getMessage(), ctx);
             throw new PermanentEventNotificationException(e.getMessage());
         }
-    }
-
-    private void createSystemErrorNotification(String message, EventNotificationContext ctx) {
-        final Notification systemNotification = notificationService.buildNow()
-                .addNode(nodeId.getNodeId())
-                .addType(Notification.Type.GENERIC)
-                .addSeverity(Notification.Severity.URGENT)
-                .addDetail("title", "Custom HTTP Notification Failed")
-                .addDetail("description", message + " for notification [" + ctx.notificationId() + "]");
-        notificationService.publishIfFirst(systemNotification);
     }
 
     private MediaType getMediaType(HTTPEventNotificationConfigV2.ContentType contentType) {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPNotification.java
@@ -110,4 +110,9 @@ public class HTTPNotification {
                 url + "\"]";
         urlWhitelistNotificationService.publishWhitelistFailure(description);
     }
+
+    static String buildRetryMessage(int status) {
+        return "Received unsuccessful (but retryable) response [" + status + "]. " +
+                "This request will be retried again later.";
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPUtils.java
@@ -1,0 +1,20 @@
+package org.graylog.events.notifications.types;
+
+import java.util.Set;
+
+public class HTTPUtils {
+    private HTTPUtils() {
+    }
+
+    private static Set<Integer> RETRYABLE_STATUS_CODES = Set.of(
+            408,// Request Timeout
+            429 // Too Many Requests
+    );
+
+    public static boolean isRetryableStatus(int statusCode) {
+        if (RETRYABLE_STATUS_CODES.contains(statusCode)) {
+            return true;
+            // Any 5xx status code is considered retryable
+        } else return statusCode >= 500 && statusCode <= 599;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.events.notifications.types;
 
 import java.util.Set;

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.events.notifications.types;
 
 import org.junit.jupiter.api.Test;

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/types/HTTPUtilsTest.java
@@ -1,0 +1,25 @@
+package org.graylog.events.notifications.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HTTPUtilsTest {
+    @Test
+    void testIsRetryableStatus_withRetryableCodes() {
+        assertTrue(HTTPUtils.isRetryableStatus(408));
+        assertTrue(HTTPUtils.isRetryableStatus(429));
+        assertTrue(HTTPUtils.isRetryableStatus(500));
+        assertTrue(HTTPUtils.isRetryableStatus(599));
+        assertTrue(HTTPUtils.isRetryableStatus(503));
+    }
+
+    @Test
+    void testIsRetryableStatus_withNonRetryableCodes() {
+        assertFalse(HTTPUtils.isRetryableStatus(200));
+        assertFalse(HTTPUtils.isRetryableStatus(404));
+        assertFalse(HTTPUtils.isRetryableStatus(400));
+        assertFalse(HTTPUtils.isRetryableStatus(301));
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add support for retrying retryable HTTP response codes in the HTTP and Custom HTTP notifications.

These codes are now retried (let me know if I missed any):
- All 5xx codes
- 408 (timeout), 429 (too many requests) 

HTTP notification portion of https://github.com/Graylog2/graylog-plugin-enterprise/issues/11313.
Any other relevant notifications will be taken care of in separate PRs. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This test HTTP server (https://app.beeceptor.com/console/testserver98769869876789698) supports the following endpoints to respond with the corresponding codes. The notification can be tested with each to confirm that the `TemporaryEventNotificationException` is thrown to trigger retrying.

- 200 (success): https://testserver98769869876789698.free.beeceptor.com
- 400 (no retrying): https://testserver98769869876789698.free.beeceptor.com/400
- 429 (retries): https://testserver98769869876789698.free.beeceptor.com/429
- 500 (retries): https://testserver98769869876789698.free.beeceptor.com/500

