### PR TITLE
Implement `StatusIcon` component and add color variants for `Icon` component. (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-23225.toml
+++ b/changelog/unreleased/pr-23225.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Improve color of status icon in streams and users overview, in dark mode."
+
+pulls = ["23225"]
+issues = ["20746"]

--- a/graylog2-web-interface/src/components/common/Icon/Icon.tsx
+++ b/graylog2-web-interface/src/components/common/Icon/Icon.tsx
@@ -40,14 +40,17 @@ const spinAnimation = keyframes`
   }
 `;
 
+type ColorVariants = 'success' | 'warning';
+
 const StyledSpan = styled.span<{
+  $bsStyle: ColorVariants | undefined;
   $size: string;
   $spin: boolean;
   $rotation: RotateProp;
   $flip: FlipProp;
   $fill: boolean;
 }>(
-  ({ $size, $spin, $rotation, $flip, $fill }) => css`
+  ({ $bsStyle, $size, $spin, $rotation, $flip, $fill, theme }) => css`
     font-variation-settings:
       'opsz' 48,
       'wght' 700 ${$fill ? ", 'FILL' 1" : ''};
@@ -60,10 +63,12 @@ const StyledSpan = styled.span<{
         `
       : 'none'};
     vertical-align: middle;
+    color: ${$bsStyle ? theme.colors.button[$bsStyle].background : 'inherit'};
   `,
 );
 
 type Props = {
+  bsStyle?: ColorVariants; // if this prop is not defined, the inherited font color will be used.
   className?: string;
   'data-testid'?: string;
   /** Name of Material Symbol icon */
@@ -93,6 +98,7 @@ type Props = {
  * Have a look at the `BrandIcon` component for brand icons.
  */
 const Icon = ({
+  bsStyle,
   name,
   type = 'solid',
   size,
@@ -119,6 +125,7 @@ const Icon = ({
     onMouseEnter={onMouseEnter}
     onMouseLeave={onMouseLeave}
     tabIndex={tabIndex}
+    $bsStyle={bsStyle}
     $rotation={rotation}
     $flip={flip}
     $size={size}

--- a/graylog2-web-interface/src/components/common/StatusIcon.tsx
+++ b/graylog2-web-interface/src/components/common/StatusIcon.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import Icon from 'components/common/Icon';
+
+type Props = {
+  active: boolean;
+  className?: string;
+};
+
+const StatusIcon = ({ active, className = undefined }: Props) => (
+  <Icon
+    name={active ? 'check_circle' : 'cancel'}
+    bsStyle={active ? 'success' : undefined}
+    className={className}
+    title={active ? 'Yes' : 'No'}
+  />
+);
+
+export default StatusIcon;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -113,6 +113,7 @@ export { default as ShareButton } from './ShareButton';
 export { default as SortableList } from './SortableList';
 export { default as Spinner } from './Spinner';
 export { default as Spoiler } from './Spoiler';
+export { default as StatusIcon } from './StatusIcon';
 export { default as Switch } from './Switch';
 export { default as TextOverflowEllipsis } from './TextOverflowEllipsis';
 export { default as Timeline } from './Timeline';

--- a/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/IndexSetArchivingCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/IndexSetArchivingCell.tsx
@@ -15,20 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { Icon, Tooltip } from 'components/common';
+import { Tooltip, StatusIcon } from 'components/common';
 
 type Props = {
   isArchivingEnabled: boolean;
   streamId: string;
 };
-const Wrapper = styled.div<{ $enabled: boolean }>(
-  ({ theme, $enabled }) => css`
-    color: ${$enabled ? theme.colors.variant.success : theme.colors.variant.darker.default};
-  `,
-);
+
 const StyledDiv = styled.div`
   display: flex;
 `;
@@ -39,9 +35,7 @@ const IndexSetArchivingCell = ({ isArchivingEnabled, streamId }: Props) => {
   return (
     <StyledDiv>
       <Tooltip withArrow position="right" label={`Archiving is ${isArchivingEnabled ? 'enabled' : 'disabled'}`}>
-        <Wrapper $enabled={isArchivingEnabled}>
-          <Icon name={isArchivingEnabled ? 'check_circle' : 'cancel'} />
-        </Wrapper>
+        <StatusIcon active={isArchivingEnabled} />
       </Tooltip>
       {StreamIndexSetDataLakeWarning && (
         <StreamIndexSetDataLakeWarning streamId={streamId} isArchivingEnabled={isArchivingEnabled} />

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.tsx
@@ -16,10 +16,9 @@
  */
 
 import * as React from 'react';
-import styled, { css } from 'styled-components';
 
 import type { Stream } from 'stores/streams/StreamsStore';
-import { Icon, Tooltip } from 'components/common';
+import { StatusIcon, Tooltip } from 'components/common';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import { ARCHIVE_RETENTION_STRATEGY } from 'stores/indices/IndicesStore';
 
@@ -27,13 +26,6 @@ type Props = {
   stream: Stream;
   indexSets: Array<IndexSet>;
 };
-
-const Wrapper = styled.div<{ $enabled: boolean }>(
-  ({ theme, $enabled }) => css`
-    color: ${$enabled ? theme.colors.variant.success : theme.colors.variant.default};
-    width: fit-content;
-  `,
-);
 
 const ArchivingsCell = ({ stream, indexSets }: Props) => {
   if (stream.is_default || !stream.is_editable) {
@@ -48,9 +40,7 @@ const ArchivingsCell = ({ stream, indexSets }: Props) => {
 
   return (
     <Tooltip withArrow position="right" label={`Archiving is ${archivingEnabled ? 'enabled' : 'disabled'}`}>
-      <Wrapper $enabled={archivingEnabled}>
-        <Icon name={archivingEnabled ? 'check_circle' : 'cancel'} />
-      </Wrapper>
+      <StatusIcon active={archivingEnabled} />
     </Tooltip>
   );
 };

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/LoggedInCell.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/LoggedInCell.tsx
@@ -19,9 +19,7 @@ import styled from 'styled-components';
 import type { $PropertyType } from 'utility-types';
 
 import type UserOverview from 'logic/users/UserOverview';
-import { OverlayTrigger, RelativeTime } from 'components/common';
-
-import LoggedInIcon from '../../LoggedInIcon';
+import { OverlayTrigger, RelativeTime, StatusIcon } from 'components/common';
 
 type Props = {
   lastActivity: $PropertyType<UserOverview, 'lastActivity'>;
@@ -52,7 +50,7 @@ const LoggedInCell = ({ lastActivity, sessionActive, clientAddress }: Props) => 
         )
       }
       rootClose>
-      <LoggedInIcon active={sessionActive} />
+      <StatusIcon active={sessionActive} />
     </OverlayTrigger>
   </Td>
 );

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/StatusCell.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/StatusCell.tsx
@@ -15,23 +15,17 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import type { $PropertyType } from 'utility-types';
 
 import type UserOverview from 'logic/users/UserOverview';
-import { Icon } from 'components/common';
+import { StatusIcon } from 'components/common';
 import Tooltip from 'components/common/Tooltip';
 
 type Props = {
   authServiceEnabled: $PropertyType<UserOverview, 'authServiceEnabled'>;
   accountStatus: $PropertyType<UserOverview, 'accountStatus'>;
 };
-
-const Wrapper = styled.div<{ $enabled: boolean }>(
-  ({ theme, $enabled }) => css`
-    color: ${$enabled ? theme.colors.variant.success : theme.colors.variant.default};
-  `,
-);
 
 const Td = styled.td`
   width: 35px;
@@ -49,9 +43,9 @@ const StatusCell = ({ accountStatus, authServiceEnabled }: Props) => (
           {!authServiceEnabled ? ' (authentication service is disabled)' : ''}
         </>
       }>
-      <Wrapper $enabled={authServiceEnabled && accountStatus === 'enabled'}>
-        <Icon name={accountStatus === 'enabled' ? 'check_circle' : 'cancel'} />
-      </Wrapper>
+      <div>
+        <StatusIcon active={accountStatus === 'enabled'} />
+      </div>
     </Tooltip>
   </Td>
 );


### PR DESCRIPTION
Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/23225 to `6.2`. It only contains the changes to fix the color issues in the streams and users overview.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change we had different implementations for the status Icon.

In many cases we were just rendering the following Icon:

`<Icon name={active ? 'check_circle' : 'cancel'} />`.

In other cases we were defining a custom active / inactive icon color or we were using different icons. 
Some of these custom styles result in bad contrast in the dark mode:

<img width="214" height="100" alt="image" src="https://github.com/user-attachments/assets/744524ee-7c53-4a24-b82a-12334b2a2997" />

<img width="68" height="77" alt="image" src="https://github.com/user-attachments/assets/eea14f27-9fb8-44b0-b504-a46b1e9bca84" />

With this PR we unify the styling of cases where we want to indicate a boolean status, via an Icon.

Part of this change is adding color variants (currently `warning` and `success`) to the `Icon` component. The variants can be configured via the `bsStyle` prop, similar to `Buttons` and `Badges`.

If no `bsStyle` is defined the Icon will inherit the font color of the parent element. This behaviour did not change with this PR.

New dark mode color (light mode color did not change noticeably).
<img width="546" height="87" alt="image" src="https://github.com/user-attachments/assets/93d3556f-baec-4d9a-99b9-fc4133455a78" />


Together with https://github.com/Graylog2/graylog2-server/pull/23211, this PR fixes https://github.com/Graylog2/graylog2-server/issues/20746.


/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/11511