### PR TITLE
Create `FormDataContext` and `FormDataProvider`, which can be used for all related inputs

### DIFF
--- a/graylog2-web-interface/src/integrations/aws/StepAuthorize.tsx
+++ b/graylog2-web-interface/src/integrations/aws/StepAuthorize.tsx
@@ -17,7 +17,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { ApiContext } from 'integrations/aws/context/Api';
 import { SidebarContext } from 'integrations/aws/context/Sidebar';
 import ValidatedInput from 'integrations/aws/common/ValidatedInput';

--- a/graylog2-web-interface/src/integrations/aws/authentication/AWSAuthenticationTypes.tsx
+++ b/graylog2-web-interface/src/integrations/aws/authentication/AWSAuthenticationTypes.tsx
@@ -18,7 +18,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Input } from 'components/bootstrap';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { AWS_AUTH_TYPES } from 'integrations/aws/common/constants';
 import AppConfig from 'util/AppConfig';
 

--- a/graylog2-web-interface/src/integrations/aws/authentication/AWSAuthenticationTypes.tsx
+++ b/graylog2-web-interface/src/integrations/aws/authentication/AWSAuthenticationTypes.tsx
@@ -55,6 +55,7 @@ const AWSAuthenticationTypes = ({ onChange }: AWSAuthenticationTypesProps) => {
 
   useEffect(() => {
     onChange({ target: { name: 'awsAuthenticationType', value: defaultAuthTypeValue } });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const isType = (type) => currentType === type;

--- a/graylog2-web-interface/src/integrations/aws/authentication/AWSCustomEndpoints.tsx
+++ b/graylog2-web-interface/src/integrations/aws/authentication/AWSCustomEndpoints.tsx
@@ -18,7 +18,7 @@ import React, { useContext } from 'react';
 import styled from 'styled-components';
 
 import { ExternalLink } from 'components/common';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { AdvancedOptionsContext } from 'integrations/aws/context/AdvancedOptions';
 import AdditionalFields from 'integrations/aws/common/AdditionalFields';
 import ValidatedInput from 'integrations/aws/common/ValidatedInput';

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.test.jsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.test.jsx
@@ -54,7 +54,7 @@ const TestCommonProviders = ({ children }) => (
       <FormDataProvider initialFormData={exampleFormDataWithKeySecretAuth}>
         <SidebarContext.Provider
           value={{
-            sidebar: <></>,
+            sidebar: <div />,
             clearSidebar: jest.fn(),
           }}>
           {children}

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.test.jsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.test.jsx
@@ -19,13 +19,14 @@ import { screen, render, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
 import { exampleFormDataWithKeySecretAuth } from 'fixtures/aws/FormData.fixtures';
-import { FormDataProvider } from 'integrations/aws/context/FormData';
 import { ApiContext } from 'integrations/aws/context/Api';
 import { StepsContext } from 'integrations/aws/context/Steps';
 import { SidebarContext } from 'integrations/aws/context/Sidebar';
 import Routes from 'routing/Routes';
 
 import CloudWatch from './CloudWatch';
+
+import FormDataProvider from '../../contexts/FormDataProvider';
 
 const mockNavigate = jest.fn();
 

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.tsx
@@ -22,7 +22,7 @@ import { getValueFromInput } from 'util/FormsUtils';
 import Routes from 'routing/Routes';
 import StepAuthorize from 'integrations/aws/StepAuthorize';
 import { StepsContext } from 'integrations/aws/context/Steps';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { ApiContext } from 'integrations/aws/context/Api';
 import { SidebarContext } from 'integrations/aws/context/Sidebar';
 

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/EmbeddedCloudWatchApp.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/EmbeddedCloudWatchApp.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { SidebarProvider } from 'integrations/aws/context/Sidebar';
-import { FormDataProvider } from 'integrations/aws/context/FormData';
+import FormDataProvider from 'integrations/contexts/FormDataProvider';
 import { StepsProvider } from 'integrations/aws/context/Steps';
 import { ApiProvider } from 'integrations/aws/context/Api';
 import { AdvancedOptionsProvider } from 'integrations/aws/context/AdvancedOptions';

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/FormAdvancedOptions.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/FormAdvancedOptions.tsx
@@ -18,7 +18,7 @@ import React, { useContext } from 'react';
 
 import ThrottlingCheckbox from 'integrations/components/ThrottlingCheckbox';
 import { Input } from 'components/bootstrap';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { AdvancedOptionsContext } from 'integrations/aws/context/AdvancedOptions';
 import AdditionalFields from 'integrations/aws/common/AdditionalFields';
 

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/StepHealthCheck.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/StepHealthCheck.tsx
@@ -25,7 +25,7 @@ import { ApiRoutes } from 'integrations/aws/common/Routes';
 import Countdown from 'integrations/aws/common/Countdown';
 import { KINESIS_LOG_TYPES } from 'integrations/aws/common/constants';
 import { ApiContext } from 'integrations/aws/context/Api';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import Icon from 'components/common/Icon';
 
 const Notice = styled.span`

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/StepReview.test.jsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/StepReview.test.jsx
@@ -21,10 +21,11 @@ import userEvent from '@testing-library/user-event';
 import { exampleFormDataWithKeySecretAuth } from 'fixtures/aws/FormData.fixtures';
 import { asMock, StoreMock as MockStore } from 'helpers/mocking';
 import fetch from 'logic/rest/FetchProvider';
-import { FormDataProvider } from 'integrations/aws/context/FormData';
 import { ApiContext } from 'integrations/aws/context/Api';
 
 import StepReview from './StepReview';
+
+import FormDataProvider from '../../contexts/FormDataProvider';
 
 jest.mock('stores/sessions/SessionStore', () => ({ SessionStore: MockStore(['isLoggedIn', jest.fn()]) }));
 jest.mock('stores/system/SystemStore', () => ({ SystemStore: MockStore() }));

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/StepReview.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/StepReview.tsx
@@ -21,7 +21,7 @@ import { Link } from 'components/common/router';
 import Routes from 'routing/Routes';
 import { Input } from 'components/bootstrap';
 import { Icon, StatusIcon } from 'components/common';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { ApiContext } from 'integrations/aws/context/Api';
 import useFetch from 'integrations/aws/common/hooks/useFetch';
 import FormWrap from 'integrations/aws/common/FormWrap';

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/ExistingStreams.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import { Button, Modal, Panel } from 'components/bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { ApiContext } from 'integrations/aws/context/Api';
 import { SidebarContext } from 'integrations/aws/context/Sidebar';
 import useFetch from 'integrations/aws/common/hooks/useFetch';

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/SetupNewStream.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/SetupNewStream.tsx
@@ -24,7 +24,7 @@ import { ApiRoutes } from 'integrations/aws/common/Routes';
 import { renderOptions } from 'integrations/aws/common/Options';
 import useFetch from 'integrations/aws/common/hooks/useFetch';
 import formValidation from 'integrations/aws/utils/formValidation';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 import { ApiContext } from 'integrations/aws/context/Api';
 
 import SetupModal from './setup-steps/SetupModal';

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/setup-steps/KinesisSetupSteps.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/setup-steps/KinesisSetupSteps.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import { ApiRoutes } from 'integrations/aws/common/Routes';
 import useFetch from 'integrations/aws/common/hooks/useFetch';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 
 import KinesisSetupStep from './KinesisSetupStep';
 

--- a/graylog2-web-interface/src/integrations/aws/common/SkipHealthCheck.tsx
+++ b/graylog2-web-interface/src/integrations/aws/common/SkipHealthCheck.tsx
@@ -22,7 +22,7 @@ import AdditionalFields from 'integrations/aws/common/AdditionalFields';
 import { renderOptions } from 'integrations/aws/common/Options';
 import ValidatedInput from 'integrations/aws/common/ValidatedInput';
 import { KINESIS_LOG_TYPES } from 'integrations/aws/common/constants';
-import { FormDataContext } from 'integrations/aws/context/FormData';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 
 const StyledFormWrap = styled(FormWrap)`
   padding-top: 25px;

--- a/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
+++ b/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
@@ -19,7 +19,7 @@ import { useContext, useEffect, useState } from 'react';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
-import { FormDataContext } from '../../context/FormData';
+import { FormDataContext } from '../../../contexts/FormDataProvider';
 import { toAWSRequest } from '../formDataAdapter';
 
 /* useFetch Custom Hook

--- a/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
+++ b/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
@@ -110,6 +110,7 @@ const useFetch = (url, setHook = () => {}, method = 'GET', options = {}) => {
     return () => {
       isFetchable = false;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qualifiedURL]);
 
   return [{ loading, error, data }, setFetchUrl];

--- a/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
+++ b/graylog2-web-interface/src/integrations/aws/common/hooks/useFetch.js
@@ -18,8 +18,8 @@ import { useContext, useEffect, useState } from 'react';
 
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
+import FormDataContext from 'integrations/contexts/FormDataContext';
 
-import { FormDataContext } from '../../../contexts/FormDataProvider';
 import { toAWSRequest } from '../formDataAdapter';
 
 /* useFetch Custom Hook

--- a/graylog2-web-interface/src/integrations/contexts/FormDataContext.tsx
+++ b/graylog2-web-interface/src/integrations/contexts/FormDataContext.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import { singleton } from 'logic/singleton';
+import type { FieldData, FormDataType } from 'integrations/types';
+
+type ContextValue = {
+  formData: FormDataType;
+  setFormData: (id: string, fieldData: FieldData) => void;
+  clearField: (id: string) => void;
+};
+
+const FormDataContext = React.createContext<ContextValue | undefined>(undefined);
+export default singleton('contexts.integrations.FormDataContext', () => FormDataContext);

--- a/graylog2-web-interface/src/integrations/contexts/FormDataProvider.tsx
+++ b/graylog2-web-interface/src/integrations/contexts/FormDataProvider.tsx
@@ -14,17 +14,17 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { createContext, useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 
-// TODO: Fix typing
-export const FormDataContext = createContext<any>(undefined);
+import type { FormDataType } from 'integrations/types';
 
-type FormDataProviderProps = {
-  children: any;
-  initialFormData?: any;
-};
+import FormDataContext from './FormDataContext';
 
-export const FormDataProvider = ({ initialFormData = {}, children }: FormDataProviderProps) => {
+type Props = React.PropsWithChildren<{
+  initialFormData?: FormDataType;
+}>;
+
+const FormDataProvider = ({ initialFormData = {}, children = undefined }: Props) => {
   const [formData, updateState] = useState(initialFormData);
 
   const setFormData = useCallback(

--- a/graylog2-web-interface/src/integrations/types.ts
+++ b/graylog2-web-interface/src/integrations/types.ts
@@ -1,0 +1,13 @@
+export type FieldData = {
+  defaultValue?: any;
+  value?: any;
+  error?: string;
+  dirty?: boolean;
+  fileName?: string;
+  fileContent?: string;
+};
+
+// This type is called FormDataType, because FormData is a reserved type
+export type FormDataType = {
+  [key: string]: FieldData;
+};

--- a/graylog2-web-interface/src/integrations/types.ts
+++ b/graylog2-web-interface/src/integrations/types.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
 export type FieldData = {
   defaultValue?: any;
   value?: any;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR creates a `FormDataContext` and `FormDataProvider` component and types, which can be used for all related inputs. The goal is to remove redundant code.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/11524
/nocl - no visible changes