### PR TITLE
Fix errors on Event Definition create wizard sharing page when config does not have streams

### DIFF
--- a/changelog/unreleased/pr-23351.toml
+++ b/changelog/unreleased/pr-23351.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fixed errors on Event Definition create wizard 'Share' page for definition types that don't use streams."
+
+pulls = ["23351"]

--- a/changelog/unreleased/pr-23351.toml
+++ b/changelog/unreleased/pr-23351.toml
@@ -1,4 +1,0 @@
-type = "fixed"
-message = "Fixed errors on Event Definition create wizard 'Share' page for definition types that don't use streams."
-
-pulls = ["23351"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 const ShareForm = ({ onChange, eventDefinition }: Props) => {
   const handleEntityShareSet = (entityShare?: EntitySharePayload) => onChange('share_request', entityShare);
-  const streamDependenciesGRN = eventDefinition?.config?.streams?.map((streamId) => createGRN('stream', streamId));
+  const streamDependenciesGRN = eventDefinition?.config?.streams?.map((streamId) => createGRN('stream', streamId)) || [];
   const notificationDependenciesGRN = eventDefinition?.notifications?.map((notification) =>
     createGRN('notification', notification.notification_id),
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Event Definition create wizard sharing page was throwing errors for Event Definition config types that do not use streams (e.g. Asset Events).

This PR adds handling for that case.

https://github.com/user-attachments/assets/f4cdf454-4233-4798-8084-38e6f29e615e

/nocl - only affects unreleased feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above video.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in development environment by creating an Asset Events definition and progressing through the create wizard.

Reproduction Steps:
1. Create a new event definition
2. On Condition page select "Asset Events"
3. Click "Next" the "Share page is reached"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

