### PR TITLE
Workaround for broken clock skew tolerance in opensearch

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/Configuration.java
+++ b/data-node/src/main/java/org/graylog/datanode/Configuration.java
@@ -225,6 +225,16 @@ public class Configuration implements CommonNodeConfiguration, NativeLibPathConf
     @Parameter(value = "indexer_jwt_auth_token_expiration_duration")
     Duration indexerJwtAuthTokenExpirationDuration = Duration.seconds(180);
 
+    @DocumentationSection(heading = "OpenSearch JWT token usage",description = """
+            communication between Graylog and OpenSearch is secured by JWT. These are the defaults used for the token usage
+            adjust them, if you have special needs.
+            """)
+    @Documentation(value = """
+            Sets a window of time, in seconds, to compensate for any disparity between the graylog server and OpenSearch node clock times,
+             thereby preventing authentication failures due to the misalignment.""")
+    @Parameter(value = "indexer_jwt_auth_token_clock_skew_tolerance")
+    Duration indexerJwtAuthTokeClockSkewTolerance = Duration.seconds(30);
+
     @Documentation("""
             The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
             to use an absolute file path here if you are starting Graylog DataNode from init scripts or similar.
@@ -748,5 +758,9 @@ public class Configuration implements CommonNodeConfiguration, NativeLibPathConf
 
     public Duration getIndexerJwtAuthTokenExpirationDuration() {
         return indexerJwtAuthTokenExpirationDuration;
+    }
+
+    public Duration getIndexerJwtAuthTokenClockSkewTolerance() {
+        return indexerJwtAuthTokeClockSkewTolerance;
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/jwt/DatanodeJwtAuthTokenProvider.java
+++ b/data-node/src/main/java/org/graylog/datanode/jwt/DatanodeJwtAuthTokenProvider.java
@@ -30,6 +30,6 @@ public class DatanodeJwtAuthTokenProvider extends IndexerJwtAuthTokenProvider {
      */
     @Inject
     public DatanodeJwtAuthTokenProvider(JwtSecret jwtSecret, Configuration configuration) {
-        super(jwtSecret, configuration.getIndexerJwtAuthTokenExpirationDuration(), configuration.getIndexerJwtAuthTokenCachingDuration(), true, Clock.systemDefaultZone());
+        super(jwtSecret, configuration.getIndexerJwtAuthTokenExpirationDuration(), configuration.getIndexerJwtAuthTokenCachingDuration(), configuration.getIndexerJwtAuthTokenClockSkewTolerance(), true, Clock.systemDefaultZone());
     }
 }

--- a/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchSecurityConfigurationBean.java
+++ b/data-node/src/main/java/org/graylog/datanode/opensearch/configuration/beans/impl/OpensearchSecurityConfigurationBean.java
@@ -141,7 +141,7 @@ public class OpensearchSecurityConfigurationBean implements DatanodeConfiguratio
                 .javaOpts(javaOptions(truststorePassword))
                 .trustStore(truststoreCreator.getTruststore())
                 .withConfigFile(truststoreFile(truststoreCreator, truststorePassword))
-                .withConfigFile(new OpensearchSecurityConfigurationFile(jwtSecret))
+                .withConfigFile(new OpensearchSecurityConfigurationFile(jwtSecret, localConfiguration.getIndexerJwtAuthTokenClockSkewTolerance()))
                 .build();
     }
 

--- a/data-node/src/test/java/org/graylog/datanode/initializers/JwtTokenAuthFilterTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/initializers/JwtTokenAuthFilterTest.java
@@ -95,7 +95,7 @@ class JwtTokenAuthFilterTest {
 
     @Nonnull
     private static String generateToken(String signingKey) {
-        final IndexerJwtAuthTokenProvider tokenProvider = new IndexerJwtAuthTokenProvider(new JwtSecret(signingKey), Duration.seconds(180), Duration.seconds(90), true, Clock.systemDefaultZone());
+        final IndexerJwtAuthTokenProvider tokenProvider = new IndexerJwtAuthTokenProvider(new JwtSecret(signingKey), Duration.seconds(180), Duration.seconds(90), Duration.seconds(30), true, Clock.systemDefaultZone());
         return tokenProvider.get().rawTokenValue().get();
     }
 }

--- a/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
+++ b/data-node/src/test/java/org/graylog/datanode/testinfra/DatanodeContainerizedBackend.java
@@ -42,11 +42,11 @@ public class DatanodeContainerizedBackend {
     public static final String IMAGE_WORKING_DIR = "/usr/share/graylog/datanode";
     static public final String SIGNING_SECRET = ContainerizedGraylogBackend.PASSWORD_SECRET;
 
-    public static final IndexerJwtAuthToken JWT_AUTH_TOKEN = createJwtAuthToken(SIGNING_SECRET, Duration.seconds(120), Duration.seconds(60));
+    public static final IndexerJwtAuthToken JWT_AUTH_TOKEN = createJwtAuthToken(SIGNING_SECRET, Duration.seconds(120), Duration.seconds(60), Duration.seconds(30));
 
     @Nonnull
-    private static IndexerJwtAuthToken createJwtAuthToken(String signingSecret, Duration tokenExpirationDuration, Duration cachingDuration) {
-        return new IndexerJwtAuthTokenProvider(new JwtSecret(signingSecret), tokenExpirationDuration, cachingDuration, true, Clock.systemDefaultZone())
+    private static IndexerJwtAuthToken createJwtAuthToken(String signingSecret, Duration tokenExpirationDuration, Duration cachingDuration, Duration clockSkewTolerance) {
+        return new IndexerJwtAuthTokenProvider(new JwtSecret(signingSecret), tokenExpirationDuration, cachingDuration, clockSkewTolerance, true, Clock.systemDefaultZone())
                 .get();
     }
 

--- a/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeProvisioningIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeProvisioningIT.java
@@ -144,7 +144,7 @@ public class DatanodeProvisioningIT {
 
     @Nonnull
     private static IndexerJwtAuthToken createJwtAuthToken() {
-        final IndexerJwtAuthTokenProvider provider = new IndexerJwtAuthTokenProvider(new JwtSecret(ContainerizedGraylogBackend.PASSWORD_SECRET), Duration.seconds(120), Duration.seconds(60), true, Clock.systemDefaultZone());
+        final IndexerJwtAuthTokenProvider provider = new IndexerJwtAuthTokenProvider(new JwtSecret(ContainerizedGraylogBackend.PASSWORD_SECRET), Duration.seconds(120), Duration.seconds(60), Duration.seconds(30), true, Clock.systemDefaultZone());
         return provider.get();
     }
 

--- a/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeSelfsignedStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeSelfsignedStartupIT.java
@@ -84,7 +84,7 @@ public class DatanodeSelfsignedStartupIT {
 
     @Nonnull
     private static IndexerJwtAuthToken createJwtAuthToken() {
-        final IndexerJwtAuthTokenProvider provider = new IndexerJwtAuthTokenProvider(new JwtSecret(ContainerizedGraylogBackend.PASSWORD_SECRET), Duration.seconds(120), Duration.seconds(60), true, Clock.systemDefaultZone());
+        final IndexerJwtAuthTokenProvider provider = new IndexerJwtAuthTokenProvider(new JwtSecret(ContainerizedGraylogBackend.PASSWORD_SECRET), Duration.seconds(120), Duration.seconds(60), Duration.seconds(30), true, Clock.systemDefaultZone());
         return provider.get();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -115,6 +115,15 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "indexer_jwt_auth_token_expiration_duration")
     private Duration indexerJwtAuthTokenExpirationDuration = Duration.seconds(180);
 
+    /**
+     * This should be datanode/opensearch setting. But there is a bug in current opensearch
+     * versions and the clock skew will be supported only in 3.2 and newer (see https://github.com/opensearch-project/security/pull/5506)
+     * Till then, we can work around that by generating tokens with extended validity in both directions
+     */
+    @Deprecated(forRemoval = true)
+    @Parameter(value = "indexer_jwt_clock_skew_tolerance")
+    private Duration indexerJwtAuthTokenClockSkewTolerance = Duration.seconds(30);
+
     @Parameter(value = "indexer_max_concurrent_searches")
     private Integer indexerMaxConcurrentSearches = null;
 
@@ -219,6 +228,10 @@ public class ElasticsearchClientConfiguration {
 
     public Duration indexerJwtAuthTokenExpirationDuration() {
         return indexerJwtAuthTokenExpirationDuration;
+    }
+
+    public Duration getIndexerJwtAuthTokenClockSkewTolerance() {
+        return indexerJwtAuthTokenClockSkewTolerance;
     }
 
     public Integer indexerMaxConcurrentSearches() {

--- a/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
@@ -44,7 +44,8 @@ class IndexerIndexerJwtAuthTokenProviderTest {
                 jwtSecret,
                 Duration.seconds(90),
                 Duration.seconds(60),
-                true,
+                Duration.seconds(30)
+                , true,
                 Clock.fixed(now, ZoneOffset.UTC)
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
@@ -67,6 +67,7 @@ class IndexerIndexerJwtAuthTokenProviderTest {
                     // Additionally, there may be small difference, as JWT is using only seconds but now is more precise.
                     // Let's give or take 5s, this won't change the validity of the test.
                     final long delta = Duration.seconds(5).toMilliseconds();
+                    Assertions.assertThat(claims.getNotBefore()).isCloseTo(now.minus(30, ChronoUnit.SECONDS), delta); // add clock skew workaround
                     Assertions.assertThat(claims.getIssuedAt()).isCloseTo(now, delta);
                     Assertions.assertThat(claims.getExpiration()).isCloseTo(now
                                     .plus(90, ChronoUnit.SECONDS) // add expected expiration

--- a/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/jwt/IndexerIndexerJwtAuthTokenProviderTest.java
@@ -68,7 +68,10 @@ class IndexerIndexerJwtAuthTokenProviderTest {
                     // Let's give or take 5s, this won't change the validity of the test.
                     final long delta = Duration.seconds(5).toMilliseconds();
                     Assertions.assertThat(claims.getIssuedAt()).isCloseTo(now, delta);
-                    Assertions.assertThat(claims.getExpiration()).isCloseTo(now.plus(90, ChronoUnit.SECONDS), delta);
+                    Assertions.assertThat(claims.getExpiration()).isCloseTo(now
+                                    .plus(90, ChronoUnit.SECONDS) // add expected expiration
+                                    .plus(30, ChronoUnit.SECONDS),  // add clock skew workaround
+                            delta);
                 });
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/storage/versionprobe/VersionProbeImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/storage/versionprobe/VersionProbeImplTest.java
@@ -247,6 +247,7 @@ class VersionProbeImplTest {
                 secret,
                 Duration.seconds(60),
                 Duration.seconds(30),
+                Duration.seconds(30),
                 useJwtAuthentication,
                 Clock.systemDefaultZone()
         ).get();


### PR DESCRIPTION
/nocl yet

## Description
Opensearch currently doesn't support clock skew tolerance setting for plain JWT auth, which we use between graylog server, datanode and opensearch. If the clock in the server is ahead of clock in datanode, it may happen that we'll generate tokens that are considered invalid in datanode/opensearch. 

This fix in opensearch is correcting the problem https://github.com/opensearch-project/security/pull/5506, but it will be available only in 3.2 and newer.

To work around this problem now, we can generate tokens with extended validity on both ends - *not before* and *expiration*, adding those default 30s. 

<img width="4000" height="2250" alt="image" src="https://github.com/user-attachments/assets/019df8c5-cb6c-456f-9aab-9aa6b7c567b8" />

This should provide enough tolerance for systems slightly out of time sync. 


## How Has This Been Tested?
Manually + existing and extended unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

