### PR TITLE
Add permission checks to UI for access of Index Set Template items

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndicesPageNavigation.tsx
+++ b/graylog2-web-interface/src/components/indices/IndicesPageNavigation.tsx
@@ -22,7 +22,12 @@ import Routes from 'routing/Routes';
 import { Row } from 'components/bootstrap';
 
 const PREM_ONLY_NAV_ITEMS = [
-  { description: 'Index Set Templates', path: Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW, exactPathMatch: false },
+  {
+    description: 'Index Set Templates',
+    path: Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW,
+    exactPathMatch: false,
+    permissions: 'indexset_templates:read',
+  },
 ];
 
 const NAV_ITEMS = [

--- a/graylog2-web-interface/src/pages/IndexSetTemplatesPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetTemplatesPage.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, PageHeader, IfPermitted } from 'components/common';
 import { Alert, Row, Col } from 'components/bootstrap';
 import IndexSetTemplatesList from 'components/indices/IndexSetTemplates/IndexSetTemplatesList';
 import CreateIndexSetTemplateButton from 'components/indices/IndexSetTemplates/CreateIndexSetTemplateButton';
@@ -25,7 +25,13 @@ import { IndicesPageNavigation } from 'components/indices';
 const IndexSetTemplatesPage = () => (
   <DocumentTitle title="Index Set Templates">
     <IndicesPageNavigation />
-    <PageHeader title="Index Set Templates" actions={<CreateIndexSetTemplateButton />}>
+    <PageHeader
+      title="Index Set Templates"
+      actions={
+        <IfPermitted permissions="indexset_templates:create">
+          <CreateIndexSetTemplateButton />
+        </IfPermitted>
+      }>
       <span>
         View and manage your Index Set Templates. These allow Index Set configurations to be saved and re-used upon
         creating a new Index Sets.


### PR DESCRIPTION
## Description
Will add the following permission checks:
- Check for 'indexset_templates:read' permission to see the 'Index Set Templates' nav item under '/system/indices'
- Check for 'indexset_templates:create' permission to see the 'Create template' button on the 'Index Set Templates' page

/nocl
closes: Graylog2/graylog-plugin-enterprise/issues/11565