### PR TITLE
Skip template selection on index set creation based on permission

### DIFF
--- a/graylog2-web-interface/src/components/indices/CreateIndexSet.tsx
+++ b/graylog2-web-interface/src/components/indices/CreateIndexSet.tsx
@@ -30,6 +30,8 @@ import { adjustFormat } from 'util/DateTime';
 import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
 
 type Props = {
   showSelectTemplateModal: boolean;
@@ -41,6 +43,8 @@ const CreateIndexSet = ({ showSelectTemplateModal, setShowSelectTemplateModal }:
   const history = useHistory();
   const sendTelemetry = useSendTelemetry();
   const { retentionStrategies, rotationStrategies, retentionStrategiesContext } = useStore(IndicesConfigurationStore);
+
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     IndicesConfigurationActions.loadRotationStrategies();
@@ -79,7 +83,7 @@ const CreateIndexSet = ({ showSelectTemplateModal, setShowSelectTemplateModal }:
         cancelLink={Routes.SYSTEM.INDICES.LIST}
         onUpdate={_saveConfiguration}
       />
-      {!isCloud && showSelectTemplateModal && (
+      {!isCloud && isPermitted(currentUser.permissions, 'indexset_templates:read') && showSelectTemplateModal && (
         <SelectIndexSetTemplateModal
           show={showSelectTemplateModal}
           hideModal={() => setShowSelectTemplateModal(false)}

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -18,12 +18,10 @@ import React, { useState } from 'react';
 
 import AppConfig from 'util/AppConfig';
 import { Button, Row, Col } from 'components/bootstrap';
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, PageHeader, IfPermitted } from 'components/common';
 import { CreateIndexSet, IndicesPageNavigation } from 'components/indices';
 import DocsHelper from 'util/DocsHelper';
 import SelectIndexSetTemplateProvider from 'components/indices/IndexSetTemplates/contexts/SelectedIndexSetTemplateProvider';
-import useCurrentUser from 'hooks/useCurrentUser';
-import { isPermitted } from 'util/PermissionsMixin';
 
 const SelectTemplateButton = ({ onClick }: { onClick: () => void }) => {
   const isCloud = AppConfig.isCloud();
@@ -33,10 +31,7 @@ const SelectTemplateButton = ({ onClick }: { onClick: () => void }) => {
 };
 
 const IndexSetCreationPage = () => {
-  const currentUser = useCurrentUser();
-  const [showSelectTemplateModal, setShowSelectTemplateModal] = useState<boolean>(
-    !isPermitted(currentUser.permissions, ['indexset_templates:read']),
-  );
+  const [showSelectTemplateModal, setShowSelectTemplateModal] = useState<boolean>(true);
 
   return (
     <SelectIndexSetTemplateProvider>
@@ -49,7 +44,11 @@ const IndexSetCreationPage = () => {
               title: 'Index model documentation',
               path: DocsHelper.PAGES.INDEX_MODEL,
             }}
-            actions={<SelectTemplateButton onClick={() => setShowSelectTemplateModal(true)} />}>
+            actions={
+              <IfPermitted permissions="indexset_templlates:read">
+                <SelectTemplateButton onClick={() => setShowSelectTemplateModal(true)} />
+              </IfPermitted>
+            }>
             <span>
               Create a new index set that will let you configure the retention, sharding, and replication of messages
               coming from one or more streams.

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -45,7 +45,7 @@ const IndexSetCreationPage = () => {
               path: DocsHelper.PAGES.INDEX_MODEL,
             }}
             actions={
-              <IfPermitted permissions="indexset_templlates:read">
+              <IfPermitted permissions="indexset_templates:read">
                 <SelectTemplateButton onClick={() => setShowSelectTemplateModal(true)} />
               </IfPermitted>
             }>

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.tsx
@@ -22,6 +22,8 @@ import { DocumentTitle, PageHeader } from 'components/common';
 import { CreateIndexSet, IndicesPageNavigation } from 'components/indices';
 import DocsHelper from 'util/DocsHelper';
 import SelectIndexSetTemplateProvider from 'components/indices/IndexSetTemplates/contexts/SelectedIndexSetTemplateProvider';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
 
 const SelectTemplateButton = ({ onClick }: { onClick: () => void }) => {
   const isCloud = AppConfig.isCloud();
@@ -31,7 +33,10 @@ const SelectTemplateButton = ({ onClick }: { onClick: () => void }) => {
 };
 
 const IndexSetCreationPage = () => {
-  const [showSelectTemplateModal, setShowSelectTemplateModal] = useState<boolean>(true);
+  const currentUser = useCurrentUser();
+  const [showSelectTemplateModal, setShowSelectTemplateModal] = useState<boolean>(
+    !isPermitted(currentUser.permissions, ['indexset_templates:read']),
+  );
 
   return (
     <SelectIndexSetTemplateProvider>


### PR DESCRIPTION
## Description

Skip the template selection stage of creating a new index set when the 'indexset_templates:read' permission is not present.

/nocl
closes: #23394 