### PR TITLE
Check for scope modification in mutability check

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/utils/ScopedEntityMongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/ScopedEntityMongoUtils.java
@@ -16,8 +16,8 @@
  */
 package org.graylog2.database.utils;
 
-import org.graylog2.database.MongoCollection;
 import org.bson.types.ObjectId;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.entities.EntityScopeService;
 import org.graylog2.database.entities.ScopedEntity;
 
@@ -124,6 +124,9 @@ public class ScopedEntityMongoUtils<T extends ScopedEntity> {
         // Else, the entity does not exist in the database, This could be a new entity--check it
         Optional<T> current = scopedEntity.id() == null ? Optional.empty()
                 : Optional.ofNullable(collection.find(idEq(scopedEntity.id())).first());
+        if (current.isPresent() && (!current.get().scope().equals(scopedEntity.scope()))) {
+            throw new IllegalArgumentException("Entity scope cannot be modified.");
+        }
         return current
                 .map(t -> entityScopeService.isMutable(t, scopedEntity))
                 .orElseGet(() -> entityScopeService.isMutable(scopedEntity));

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/ScopedEntityMongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/ScopedEntityMongoUtilsTest.java
@@ -16,11 +16,11 @@
  */
 package org.graylog2.database.utils;
 
-import org.graylog2.database.MongoCollection;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.database.entities.EntityScope;
@@ -116,6 +116,15 @@ public class ScopedEntityMongoUtilsTest {
         assertThatThrownBy(() -> scopedEntityMongoUtils.create(invalidScoped))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
         assertThat(collection.countDocuments()).isEqualTo(0L);
+    }
+
+    @Test
+    void testScopeModificationDisallowed() {
+        final ScopedDTO nonDeletableScope = ScopedDTO.builder().name("test").scope(NonDeletableScope.NAME).build();
+        final String id = scopedEntityMongoUtils.create(nonDeletableScope);
+        final ScopedDTO updated = ScopedDTO.builder().id(id).name("updated").scope(DefaultEntityScope.NAME).build();
+        assertThatThrownBy(() -> scopedEntityMongoUtils.update(updated))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     static class ImmutableScope extends EntityScope {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Entity scopes should not be able to be modified. While many/most/all services might currently handle this in their own way either with specific UpdateRequest objects that do not include scope or some other method, we should still ensure its enforcement at as low of a level as possible.

/nocl no user facing changes
/prd Graylog2/graylog-plugin-enterprise#11647
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enforce entity scope immutability 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

