### PR TITLE
Pass proper prop into docComponent to handle editing

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.tsx
@@ -263,7 +263,7 @@ const DataAdapterForm = ({
                   </fieldset>
                 </Col>
                 <Col lg={6} style={{ marginTop: 10 }}>
-                  {DocComponent ? <DocComponent /> : null}
+                  {DocComponent ? <DocComponent dataAdapterId={dataAdapter?.id} /> : null}
                 </Col>
               </Row>
               <Row style={{ marginBottom: 20 }}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When editing a mongodb data adapter, we are not passing in the dataAdapterId prop into the DocComponent that is expecting it, which prevents the form to configure keys and values to render.

/nocl
/jpd 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

