### PR TITLE
Retain IndexSetConfig _scope on update

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -77,5 +77,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20250506090000_AddInputTypesPermissions.class);
         addMigration(V20250721090000_AddClusterConfigurationPermission.class);
         addMigration(V20250804104500_TightenTokenSecurity.class);
+        addMigration(V20250820180000_ReapplyIndexSetScopeMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20250820180000_ReapplyIndexSetScopeMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20250820180000_ReapplyIndexSetScopeMigration.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.migrations;
+
+import com.mongodb.client.model.Filters;
+import jakarta.inject.Inject;
+import org.graylog2.database.MongoCollection;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.entities.NonDeletableSystemScope;
+import org.graylog2.database.entities.ScopedEntity;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.MongoIndexSetService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import static org.graylog2.database.utils.MongoUtils.idEq;
+import static org.graylog2.indexer.indexset.IndexSetConfig.FIELD_REGULAR;
+
+/**
+ * Make system index sets (regular==false) non-deletable by assigning NonDeletableSystemScope - again. This migration
+ * was originally applied in {@link V20250304102900_ScopeMigration} but could have potentially been modified when scope
+ * modification was not blocked. That issue was resolved in
+ * <a href="https://github.com/Graylog2/graylog2-server/pull/23413">this PR.</a> The bug did not affect the system
+ * event definitions so they have been omitted from this migration.
+ */
+public class V20250820180000_ReapplyIndexSetScopeMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20250820180000_ReapplyIndexSetScopeMigration.class);
+
+    private final ClusterConfigService configService;
+    private final MongoCollection<IndexSetConfig> indexSetCollection;
+
+    @Inject
+    public V20250820180000_ReapplyIndexSetScopeMigration(ClusterConfigService configService, MongoCollections mongoCollections) {
+        this.configService = configService;
+        this.indexSetCollection = mongoCollections.collection(MongoIndexSetService.COLLECTION_NAME, IndexSetConfig.class);
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2025-08-20T18:00:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (migrationAlreadyApplied()) {
+            return;
+        }
+        updateSystemIndexScope();
+        markMigrationApplied();
+    }
+
+    private void updateSystemIndexScope() {
+        indexSetCollection.find(
+                        Filters.and(
+                                Filters.eq(FIELD_REGULAR, false),
+                                Filters.not(Filters.eq(ScopedEntity.FIELD_SCOPE, NonDeletableSystemScope.NAME))))
+                .forEach(indexSetConfig -> {
+                    final IndexSetConfig newIndexSetConfig = indexSetConfig.toBuilder().scope(NonDeletableSystemScope.NAME).build();
+                    indexSetCollection.replaceOne(idEq(Objects.requireNonNull(indexSetConfig.id())), newIndexSetConfig);
+                    LOG.info("Successfully updated scope for index set: {}", newIndexSetConfig.title());
+                });
+    }
+
+    private boolean migrationAlreadyApplied() {
+        return Objects.nonNull(configService.get(MigrationCompleted.class));
+    }
+
+    private void markMigrationApplied() {
+        configService.write(new MigrationCompleted());
+    }
+
+    // Just a marker class to indicate that the migration has been applied
+    public record MigrationCompleted() {}
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -78,6 +78,7 @@ public record IndexSetUpdateRequest(@JsonProperty(FIELD_TITLE) @NotBlank String 
     public IndexSetConfig toIndexSetConfig(final String id, final IndexSetConfig oldConfig) {
         return IndexSetConfig.builder()
                 .id(id)
+                .scope(oldConfig.scope())
                 .title(title())
                 .description(description())
                 .isWritable(isWritable())


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Retain `IndexSetConfig` scope when updating index sets. Prior to #23413 we did not check for modification of entity scopes when saving entities. Any modifications made to system index sets have subsequently modified their scope back to `DEFAULT`. This means they can now be deleted. These changes enforce scope retention on IndexSets and adds a migration to reapply the non-deletable scope to any system index sets that may have been modified.

/nocl shouldn't affect users
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cloud team reported: 
> Starting from cloud build dev:7.0.0-486 (and possibly earlier in 7.x), our automation fails to update index sets for a new tenant with the following error when it reaches the “Events” IndexSet: '{"type":"ApiError","message":"Entity scope cannot be modified."}'
I also see the same error when attempting to update the index set directly via the UI
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

