### PR TITLE
Fix `assertFunctionNames` regex, related to ESLint Jest expect rule.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -59,7 +59,7 @@ module.exports = {
       rules: {
         'jest/expect-expect': [
           'error',
-          { assertFunctionNames: ['expect*', '(screen.)?find(All)?By*', 'selectEvent.assertOptionExists(*'] },
+          { assertFunctionNames: ['expect*', '(screen.)?find(All)?By*', 'selectEvent.assertOptionExists*'] },
         ],
         'react/jsx-no-constructed-context-values': 'off',
         'testing-library/await-async-events': 'off',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In https://github.com/Graylog2/graylog2-server/pull/22790 a custom regex has been added for the `assertFunctionNames` option of the ESLint Jest expect rule.

It currently throws an error when running ESLint:
`SyntaxError: Invalid regular expression: /^selectEvent\.assertOptionExists([a-z\d]*(\.|$)/iu: Unterminated group`

This PR fixes the error.

/nocl