### PR TITLE
Fix -DskipTests for web tests

### DIFF
--- a/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
+++ b/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
@@ -36,6 +36,17 @@
 
     <profiles>
         <profile>
+            <id>skip-web-interface-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                </property>
+            </activation>
+            <properties>
+                <skip.web.tests>true</skip.web.tests>
+            </properties>
+        </profile>
+        <profile>
             <id>web-interface-build</id>
             <activation>
                 <property>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -1213,6 +1213,17 @@
             </build>
         </profile>
         <profile>
+            <id>skip-web-interface-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                </property>
+            </activation>
+            <properties>
+                <skip.web.tests>true</skip.web.tests>
+            </properties>
+        </profile>
+        <profile>
             <id>web-interface-build</id>
             <activation>
                 <property>


### PR DESCRIPTION
We have to set skip.web.tests to false if skipTests is present. Otherwise, the web tests run even with skipTests present.

/nocl Build infrastructure

