### PR TITLE
Reset clock in MessageTimestampTest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/shared/buffers/processors/MessageTimestampTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/buffers/processors/MessageTimestampTest.java
@@ -35,6 +35,7 @@ import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -60,6 +61,11 @@ class MessageTimestampTest {
         DateTimeUtils.setCurrentMillisProvider(clock);
 
         processBufferProcessor = createProcessor(Duration.ofDays(GRACE_PERIOD_DAYS));
+    }
+
+    @AfterEach
+    void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test


### PR DESCRIPTION
If we use "DateTimeUtils.setCurrentMillis*", we *have* to reset it after the test to avoid wrong timestamps in other tests running in the same JVM.

/nocl Fixing test code

