### PR TITLE
Open output edit modal with first click on `Edit` button. (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-23505.toml
+++ b/changelog/unreleased/pr-23505.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = 'Fix issue with output edit button not opening edit modal after first click.'
+
+issues = ['Graylog2/graylog-plugin-enterprise#8432']
+pulls = ["23505"]

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.tsx
@@ -37,6 +37,7 @@ type Props<Configuration extends object> = {
     [key: string]: ConfigurationField;
   };
   children?: React.ReactNode;
+  initialShow?: boolean;
   titleHelpText?: string;
   includeTitleField?: boolean;
   submitAction: (data: ConfigurationFormData<Configuration>) => void;
@@ -72,6 +73,7 @@ const ConfigurationForm = forwardRef(
       configFields = defaultConfigFields,
       children = null,
       titleHelpText = '',
+      initialShow = false,
       includeTitleField = true,
       submitAction,
       title = null,
@@ -83,7 +85,7 @@ const ConfigurationForm = forwardRef(
     }: Props<Configuration>,
     ref: React.ForwardedRef<RefType<Configuration>>,
   ) => {
-    const [showConfigurationModal, setShowConfigurationModal] = useState(false);
+    const [showConfigurationModal, setShowConfigurationModal] = useState(initialShow);
     const [titleValue, setTitleValue] = useState(undefined);
     const [values, setValues] = useState<{ [key: string]: any } | undefined>(undefined);
     const [fieldStates, setFieldStates] = useState<{ [key: string]: any } | undefined>({});
@@ -132,8 +134,7 @@ const ConfigurationForm = forwardRef(
       if (!diff) {
         const isOptionalToNumber = (optional: boolean): number => (optional ? 1 : 0);
 
-        diff =
-          isOptionalToNumber(configFields[x1.name].is_optional) - isOptionalToNumber(configFields[x2.name].is_optional);
+        diff = isOptionalToNumber(configFields[x1.name].is_optional) - isOptionalToNumber(configFields[x2.name].is_optional);
       }
 
       if (!diff) {
@@ -163,10 +164,10 @@ const ConfigurationForm = forwardRef(
           const fieldState = fieldStates[fieldName as string];
 
           if (
-            fieldIsEncrypted(configField) &&
-            !fieldState?.dirty &&
-            fieldValue &&
-            (fieldValue as EncryptedFieldValue<FieldValue>).is_set !== undefined
+            fieldIsEncrypted(configField)
+            && !fieldState?.dirty
+            && fieldValue
+            && (fieldValue as EncryptedFieldValue<FieldValue>).is_set !== undefined
           ) {
             return [fieldName, { keep_value: true }];
           }
@@ -217,16 +218,14 @@ const ConfigurationForm = forwardRef(
       const value = values[key];
 
       return (
-        <ConfigurationFormField
-          key={key}
-          typeName={typeName}
-          configField={configField}
-          configKey={key}
-          configValue={value}
-          autoFocus={autoFocus}
-          dirty={fieldStates[key]?.dirty}
-          onChange={handleChange}
-        />
+        <ConfigurationFormField key={key}
+                                typeName={typeName}
+                                configField={configField}
+                                configKey={key}
+                                configValue={value}
+                                autoFocus={autoFocus}
+                                dirty={fieldStates[key]?.dirty}
+                                onChange={handleChange} />
       );
     };
 
@@ -235,13 +234,11 @@ const ConfigurationForm = forwardRef(
 
     if (includeTitleField) {
       titleElement = (
-        <TitleField
-          key={`${typeName}-title`}
-          typeName={typeName}
-          value={titleValue}
-          onChange={handleTitleChange}
-          helpText={titleHelpText}
-        />
+        <TitleField key={`${typeName}-title`}
+                    typeName={typeName}
+                    value={titleValue}
+                    onChange={handleTitleChange}
+                    helpText={titleHelpText} />
       );
 
       shouldAutoFocus = false;
@@ -262,12 +259,11 @@ const ConfigurationForm = forwardRef(
     });
 
     return (
-      <WrapperComponent
-        show={showConfigurationModal}
-        title={title}
-        onCancel={handleCancel}
-        onSubmitForm={save}
-        submitButtonText={submitButtonText}>
+      <WrapperComponent show={showConfigurationModal}
+                        title={title}
+                        onCancel={handleCancel}
+                        onSubmitForm={save}
+                        submitButtonText={submitButtonText}>
         <fieldset>
           <input type="hidden" name="type" value={typeName} />
           {children}

--- a/graylog2-web-interface/src/components/outputs/EditOutputButton.test.tsx
+++ b/graylog2-web-interface/src/components/outputs/EditOutputButton.test.tsx
@@ -44,8 +44,8 @@ describe('EditOutputButton', () => {
 
     expect(getTypeDefinition).toHaveBeenCalledWith('test-type', expect.any(Function));
 
-    await screen.findByRole('heading', { name: /Editing Output Test Output/i });
-    userEvent.click(await screen.findByRole('button', { name: /update output/i }));
+    await screen.findByRole('heading', { name: /Editing Output Test Output/i, hidden: true });
+    userEvent.click(await screen.findByRole('button', { name: /update output/i, hidden: true }));
   });
 
   it('calls onUpdate and closes modal form on submit', async () => {
@@ -55,12 +55,12 @@ describe('EditOutputButton', () => {
     const onUpdate = jest.fn();
     render(<EditOutputButton output={mockOutput} getTypeDefinition={getTypeDefinition} onUpdate={onUpdate} />);
 
-    userEvent.click(await screen.findByRole('button', { name: /edit/i }));
-    userEvent.click(await screen.findByRole('button', { name: /update output/i }));
+    userEvent.click(await screen.findByRole('button', { name: /edit/i, hidden: true }));
+    userEvent.click(await screen.findByRole('button', { name: /update output/i, hidden: true }));
 
     expect(onUpdate).toHaveBeenCalledWith(mockOutput, expect.anything());
 
-    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i, hidden: true })).not.toBeInTheDocument();
   });
 
   it('closes modal form on cancel', async () => {
@@ -72,10 +72,10 @@ describe('EditOutputButton', () => {
 
     userEvent.click(await screen.findByRole('button', { name: /edit/i }));
 
-    await screen.findByRole('heading', { name: /Editing Output Test Output/i });
-    userEvent.click(await screen.findByRole('button', { name: /cancel/i }));
+    await screen.findByRole('heading', { name: /Editing Output Test Output/i, hidden: true });
+    userEvent.click(await screen.findByRole('button', { name: /cancel/i, hidden: true }));
 
     expect(onUpdate).not.toHaveBeenCalled();
-    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i, hidden: true })).not.toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/outputs/EditOutputButton.test.tsx
+++ b/graylog2-web-interface/src/components/outputs/EditOutputButton.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import EditOutputButton from './EditOutputButton';
+
+const mockOutput = {
+  id: 'output-1',
+  type: 'test-type',
+  title: 'Test Output',
+  configuration: { foo: 'bar' },
+};
+
+const mockTypeDefinition = {
+  requested_configuration: [{ name: 'foo', type: 'string' }],
+};
+
+describe('EditOutputButton', () => {
+  it('shows configuration form modal on click', async () => {
+    const getTypeDefinition = jest.fn((_type, cb) => {
+      cb(mockTypeDefinition);
+    });
+
+    render(<EditOutputButton output={mockOutput} getTypeDefinition={getTypeDefinition} />);
+
+    userEvent.click(await screen.findByRole('button', { name: /edit/i }));
+
+    expect(getTypeDefinition).toHaveBeenCalledWith('test-type', expect.any(Function));
+
+    await screen.findByRole('heading', { name: /Editing Output Test Output/i });
+    userEvent.click(await screen.findByRole('button', { name: /update output/i }));
+  });
+
+  it('calls onUpdate and closes modal form on submit', async () => {
+    const getTypeDefinition = jest.fn((_type, cb) => {
+      cb(mockTypeDefinition);
+    });
+    const onUpdate = jest.fn();
+    render(<EditOutputButton output={mockOutput} getTypeDefinition={getTypeDefinition} onUpdate={onUpdate} />);
+
+    userEvent.click(await screen.findByRole('button', { name: /edit/i }));
+    userEvent.click(await screen.findByRole('button', { name: /update output/i }));
+
+    expect(onUpdate).toHaveBeenCalledWith(mockOutput, expect.anything());
+
+    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i })).not.toBeInTheDocument();
+  });
+
+  it('closes modal form on cancel', async () => {
+    const getTypeDefinition = jest.fn((_type, cb) => {
+      cb(mockTypeDefinition);
+    });
+    const onUpdate = jest.fn();
+    render(<EditOutputButton output={mockOutput} getTypeDefinition={getTypeDefinition} onUpdate={onUpdate} />);
+
+    userEvent.click(await screen.findByRole('button', { name: /edit/i }));
+
+    await screen.findByRole('heading', { name: /Editing Output Test Output/i });
+    userEvent.click(await screen.findByRole('button', { name: /cancel/i }));
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.queryByRole('heading', { name: /Editing Output Test Output/i })).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/outputs/EditOutputButton.tsx
+++ b/graylog2-web-interface/src/components/outputs/EditOutputButton.tsx
@@ -14,11 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 
 import { Button } from 'components/bootstrap';
 import { ConfigurationForm } from 'components/configurationforms';
-import type { RefType } from 'components/configurationforms/ConfigurationForm';
 
 type EditOutputButtonProps = {
   output: any;
@@ -27,78 +27,47 @@ type EditOutputButtonProps = {
   onUpdate?: (...args: any[]) => void;
 };
 
-class EditOutputButton extends React.Component<
-  EditOutputButtonProps,
-  {
-    [key: string]: any;
-  }
-> {
-  static defaultProps = {
-    disabled: false,
-    onUpdate: () => {},
-  };
-
-  private configurationForm: React.RefObject<RefType<{}>>;
-
-  constructor(props) {
-    super(props);
-
-    this.configurationForm = React.createRef();
-
-    this.state = {
-      typeDefinition: undefined,
-    };
-  }
-
-  handleClick = () => {
-    const { getTypeDefinition, output } = this.props;
-
-    getTypeDefinition(output.type, (definition) => {
-      this.setState({ typeDefinition: definition.requested_configuration });
-
-      if (this.configurationForm.current) {
-        this.configurationForm.current.open();
-      }
+const EditOutputButton = ({
+  output,
+  disabled = false,
+  getTypeDefinition,
+  onUpdate = () => {},
+}: EditOutputButtonProps) => {
+  const [typeDefinition, setTypeDefinition] = useState<any>(null);
+  const onModalClose = () => setTypeDefinition(null);
+  const handleClick = () => {
+    getTypeDefinition(output.type, (definition: any) => {
+      setTypeDefinition(definition.requested_configuration);
     });
   };
 
-  _handleSubmit = (data) => {
-    const { onUpdate, output } = this.props;
-
+  const handleSubmit = (data: any) => {
     onUpdate(output, data);
+    onModalClose();
   };
 
-  render() {
-    const { typeDefinition } = this.state;
-    const { disabled, output } = this.props;
-    let configurationForm;
-
-    if (typeDefinition) {
-      configurationForm = (
+  return (
+    <span>
+      <Button disabled={disabled} onClick={handleClick}>
+        Edit
+      </Button>
+      {typeDefinition && (
         <ConfigurationForm
-          ref={this.configurationForm}
+          initialShow
+          cancelAction={() => onModalClose()}
           key={`configuration-form-output-${output.id}`}
           configFields={typeDefinition}
           title={`Editing Output ${output.title}`}
           typeName={output.type}
           titleHelpText="Select a name of your new output that describes it."
-          submitAction={this._handleSubmit}
+          submitAction={handleSubmit}
           submitButtonText="Update output"
           values={output.configuration}
           titleValue={output.title}
         />
-      );
-    }
-
-    return (
-      <span>
-        <Button disabled={disabled} onClick={this.handleClick}>
-          Edit
-        </Button>
-        {configurationForm}
-      </span>
-    );
-  }
-}
+      )}
+    </span>
+  );
+};
 
 export default EditOutputButton;


### PR DESCRIPTION
Note: This is a backport of #23505 to `6.2`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in https://github.com/Graylog2/graylog-plugin-enterprise/issues/8432, the `Edit` output button in the outputs list requires two clicks to open the edit modal.


Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/8432

