### PR TITLE
Improve some full-backed tests to be less flaky

### DIFF
--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -199,6 +199,10 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/plugins/views/ScriptingApiResourceIT.java
@@ -99,7 +99,7 @@ public class ScriptingApiResourceIT {
                         {"short_message":"search-sync-test-3", "host":"lorem-ipsum.com", "facility":"another-test", "_level":3, "_http_method":"POST", "_target_stream": "stream2"}
                         """);
 
-        api.search().waitForMessagesCount(3);
+        api.search().waitForMessages("search-sync-test", "search-sync-test-2", "search-sync-test-3");
         api.fieldTypes().waitForFieldTypeDefinitions("source", "facility", "level");
     }
 

--- a/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeOpensearchProxyIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeOpensearchProxyIT.java
@@ -32,6 +32,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static java.time.Duration.ofSeconds;
+import static org.awaitility.Awaitility.waitAtMost;
+
 @ContainerMatrixTestsConfiguration(serverLifecycle = Lifecycle.CLASS, searchVersions = SearchServer.DATANODE_DEV, additionalConfigurationParameters = {@ContainerMatrixTestsConfiguration.ConfigurationParameter(key = "GRAYLOG_DATANODE_PROXY_API_ALLOWLIST", value = "true")})
 public class DatanodeOpensearchProxyIT {
 
@@ -44,15 +47,19 @@ public class DatanodeOpensearchProxyIT {
 
     @ContainerMatrixTest
     void testProxyPlaintextGet() throws ExecutionException, RetryException {
-        final ValidatableResponse response = apis.get("/datanodes/any/opensearch/_cat/indices", 200);
-        final String responseBody = response.extract().body().asString();
-        Assertions.assertThat(responseBody).contains("graylog_0").contains("gl-system-events_0");
+        waitAtMost(ofSeconds(30)).untilAsserted(() -> {
+            final ValidatableResponse response = apis.get("/datanodes/any/opensearch/_cat/indices", 200);
+            final String responseBody = response.extract().body().asString();
+            Assertions.assertThat(responseBody).contains("graylog_0").contains("gl-system-events_0");
+        });
     }
 
     @ContainerMatrixTest
     void testProxyJsonGet() {
-        final ValidatableResponse response = apis.get("/datanodes/any/opensearch/_mapping", 200);
-        response.assertThat().body("graylog_0.mappings.properties.gl2_accounted_message_size.type", Matchers.equalTo("long"));
+        waitAtMost(ofSeconds(30)).untilAsserted(() -> {
+            final ValidatableResponse response = apis.get("/datanodes/any/opensearch/_mapping", 200);
+            response.assertThat().body("graylog_0.mappings.properties.gl2_accounted_message_size.type", Matchers.equalTo("long"));
+        });
     }
 
     @ContainerMatrixTest

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
@@ -101,6 +101,7 @@ public class Indices implements GraylogRestApi {
         return createIndexSet(indexSetSummary);
     }
 
+    // fails with a 404 if the index set does not exist
     public GraylogApiResponse listOpenIndices(String indexSetId) {
         final ValidatableResponse response = given()
                 .spec(api.requestSpecification())
@@ -115,13 +116,28 @@ public class Indices implements GraylogRestApi {
         return new GraylogApiResponse(response);
     }
 
+    // can be used as in "waitForIndexNames", does not fail if the index set does not exist/is not yet available
+    public List<String> listOpenIndicesWithEmptyResultOnError(String indexSetId) {
+        final var response = given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .get("/system/indexer/indices/" + indexSetId + "/open");
+
+        if(response.statusCode() == 200) {
+            return new GraylogApiResponse(response.then()).properJSONPath().read("indices.*.index_name");
+        } else {
+            return List.of();
+        }
+    }
+
     public List<String> waitForIndexNames(String indexSetId) throws ExecutionException, RetryException {
         return RetryerBuilder.<List<String>>newBuilder()
                 .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                 .withStopStrategy(StopStrategies.stopAfterAttempt(30))
                 .retryIfResult(List::isEmpty)
                 .build()
-                .call(() -> listOpenIndices(indexSetId).properJSONPath().read("indices.*.index_name"));
+                .call(() -> listOpenIndicesWithEmptyResultOnError(indexSetId));
     }
 
     public void rotateIndexSet(String indexSetId) {


### PR DESCRIPTION
- Wrap test methods in awaitility in DatanodeOpensearchProxyIT
- In ScriptingApiResourceIT, wait for the actual messages to be present instead of relying on the message count which could be wrong depending on the order of other tests
- In AggregationSortingIT, waiting for the successful creation of the needed indices/index set was not safe enough regarding all the possible error conditions during waiting

The tests we see fail:

```
[INFO] Running org.graylog.searchbackend.datanode.DatanodeOpensearchProxyIT
Error:  Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.449 s <<< FAILURE! -- in org.graylog.searchbackend.datanode.DatanodeOpensearchProxyIT
Error:  org.graylog.searchbackend.datanode.DatanodeOpensearchProxyIT.testProxyPlaintextGet -- Time elapsed: 0.078 s <<< FAILURE!
java.lang.AssertionError: 

Expecting actual:
  "green open .ds-gl-datanode-metrics-000001 VfMTpvTWRDa7yF76pWxWRw 1 0 0 0 208b 208b
green open graylog_0                      inRseBbZSj2A1-_7i-k_pw 1 0 0 0 208b 208b
"
to contain:
  "gl-system-events_0" 
	at org.graylog.searchbackend.datanode.DatanodeOpensearchProxyIT.testProxyPlaintextGet(DatanodeOpensearchProxyIT.java:49)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.lang.Iterable.forEach(Unknown Source)
	at java.base/java.util.Collections$SynchronizedCollection.forEach(Collections.java:2351)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1116)
```

```
Error:  Failures: 
Error:  org.graylog.plugins.views.ScriptingApiResourceIT.testAggregationByStream
[INFO]   Run 1: PASS
Error:    Run 2: ScriptingApiResourceIT.testAggregationByStream:128->validateRow:951 1 expectation failed.
JSON path datarows doesn't match.
Expected: a collection containing <[68b81d12fc086739a1c1c85b, 2]>
  Actual: <[[000000000000000000000001, 3], [68b81d12fc086739a1c1c84f, 1], [68b81d12fc086739a1c1c85b, 1]]>

[INFO] 
Error:  org.graylog.plugins.views.ScriptingApiResourceIT.testAggregationByStreamTitle
[INFO]   Run 1: PASS
Error:    Run 2: ScriptingApiResourceIT.testAggregationByStreamTitle:206->validateRow:951 1 expectation failed.
JSON path datarows doesn't match.
Expected: a collection containing <[Stream #2, 2]>
  Actual: <[[Default Stream, 3], [Stream #1, 1], [Stream #2, 1]]>

[INFO] 
Error:  org.graylog.plugins.views.ScriptingApiResourceIT.testStreamFiltering
[INFO]   Run 1: PASS
Error:    Run 2: ScriptingApiResourceIT.testStreamFiltering:607->validateRow:951 1 expectation failed.
JSON path datarows doesn't match.
Expected: a collection containing <[another-test, 2]>
  Actual: <[[another-test, 1]]>

[INFO] 
Error:  org.graylog.plugins.views.ScriptingApiResourceIT.testUserWithLimitedPermissionRequest
[INFO]   Run 1: PASS
Error:    Run 2: ScriptingApiResourceIT.testUserWithLimitedPermissionRequest:238->validateRow:951 1 expectation failed.
JSON path datarows doesn't match.
Expected: a collection containing <[another-test, 2]>
  Actual: <[[another-test, 1]]>
```

```
[INFO] Running org.graylog.plugins.views.aggregations.AggregationSortingIT
2025-09-03 12:41:39,716 INFO : org.graylog.testing.completebackend.apis.inputs.GelfInputApi - GELF input listening on port 33048
HTTP/1.1 404 Not Found
X-Graylog-Node-ID: b2045ea9-284c-41a3-a665-4ab6944bf879
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Runtime-Microseconds: 2433
Content-Type: application/json
Content-Length: 79

{
    "type": "ApiError",
    "message": "Index set <68b837972834ea5f85f39c40> not found."
}
Request method:	GET
Request URI:	http://localhost:33049/api/system/indexer/indices/68b837972834ea5f85f39c40/open
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	<none>
Headers:		Accept=application/json, application/javascript, text/javascript, text/json
				X-Requested-By=peterchen
				Content-Type=application/json
Cookies:		<none>
Multiparts:		<none>
Body:			<none>

HTTP/1.1 404 Not Found
X-Graylog-Node-ID: b2045ea9-284c-41a3-a665-4ab6944bf879
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Runtime-Microseconds: 2433
Content-Type: application/json
Content-Length: 79

{
    "type": "ApiError",
    "message": "Index set <68b837972834ea5f85f39c40> not found."
}
Error:  Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 20.05 s <<< FAILURE! -- in org.graylog.plugins.views.aggregations.AggregationSortingIT
Error:  org.graylog.plugins.views.aggregations.AggregationSortingIT.sortingOnNumericPivotFieldSortsNumerically -- Time elapsed: 0.049 s <<< ERROR!
java.util.concurrent.ExecutionException: 
java.lang.AssertionError: 1 expectation failed.
Expected status code <200> but was <404>.
```

/nocl Test improvements