### PR TITLE
Update json-smart to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.5.2</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Release notes: https://github.com/netplex/json-smart-v2/releases/tag/v2.6.0

/nocl Dependency update
