### PR TITLE
Update lucene to 10.2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,6 @@ updates:
           - ">= 2.30"
       - dependency-name: "com.amazonaws:aws-java-sdk-bom"
         update-types: ["version-update:semver-patch"]
-      # Lucene >=10 requires JDK 21
-      - dependency-name: "org.apache.lucene:lucene-*"
-        versions:
-          - ">= 10"
     open-pull-requests-limit: 25
     labels:
       - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <kafka.version>4.1.0</kafka.version>
         <kafka09.version>0.9.0.1-7</kafka09.version>
         <log4j.version>2.25.1</log4j.version>
-        <lucene.version>9.12.2</lucene.version>
+        <lucene.version>10.2.2</lucene.version>
         <metrics.version>4.2.36</metrics.version>
         <mongodb-driver.version>5.5.1</mongodb-driver.version>
         <mongojack.version>5.0.3</mongojack.version>


### PR DESCRIPTION
Remove the dependabot version restriction because we are using Java 21 now.

/nocl Dependency update
