### PR TITLE
Fix dispatch-pr-build workflow when a PR is labeled

### DIFF
--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -33,12 +33,6 @@ jobs:
           OLD_PR_BODY: "${{ github.event.changes.body.from }}"
           NEW_PR_BODY: "${{ github.event.pull_request.body }}"
 
-      - name: Check if PR got labeled for e2e-tests
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'e2e-tests' }}"
-        id: e2e-tests-labeled
-        run: |
-          echo "triggered=true" | tee -a "$GITHUB_OUTPUT"
-
       - name: Check e2e-tests label
         id: e2e-tests
         run: |
@@ -54,7 +48,7 @@ jobs:
           PR_EVENT: "${{ toJSON(github.event.pull_request) }}"
 
       - name: Dispatch job to graylog-project-internal
-        if: ${{ (github.event.action != 'edited' && github.event.action != 'labeled') || steps.pr-string-changed.outcome == 'success' || steps.e2e-tests-labeled.outputs.triggered == 'true' }}
+        if: ${{ (github.event.action != 'edited' && (github.event.action != 'labeled' || github.event.label.name == 'e2e-tests')) || steps.pr-string-changed.outcome == 'success' }}
         run: >
           gh workflow run -R Graylog2/graylog-project-internal pr-build.yml --ref master
           -f caller_repo=${{ github.repository }}


### PR DESCRIPTION
Adding any other label than "e2e-tests" to a newly created PR resulted in the dispatch not being triggered because the extra workflow runs for the "labeled" events cancelled the running dispatch.

<img width="1458" height="480" alt="image" src="https://github.com/user-attachments/assets/40d7e2cf-ef57-46d7-8c7a-c44997194e4a" />

/nocl CI infrastructure