### PR TITLE
Adding async submit props to `ConfirmDialog`.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.tsx
@@ -23,15 +23,18 @@ import Modal from './Modal';
 import BootstrapModalWrapper from './BootstrapModalWrapper';
 
 type Props = {
-  showModal: boolean;
-  title: string | React.ReactNode;
-  confirmButtonText?: string;
   cancelButtonDisabled?: boolean;
-  confirmButtonDisabled?: boolean;
-  onConfirm: (e: React.BaseSyntheticEvent) => void;
-  onCancel: () => void;
-  size?: ModalSize;
   children: React.ReactNode;
+  confirmButtonDisabled?: boolean;
+  confirmButtonText?: string;
+  isAsyncSubmit?: boolean;
+  isSubmitting?: boolean;
+  onCancel: () => void;
+  onConfirm: (e: React.BaseSyntheticEvent) => void;
+  showModal: boolean;
+  size?: ModalSize;
+  submitLoadingText?: string;
+  title: string | React.ReactNode;
 };
 
 /**
@@ -39,14 +42,17 @@ type Props = {
  * cancel or confirm.
  */
 const BootstrapModalConfirm = ({
-  showModal,
-  title,
-  children,
   cancelButtonDisabled = false,
+  children,
   confirmButtonDisabled = false,
   confirmButtonText = 'Confirm',
+  isAsyncSubmit = undefined,
+  isSubmitting = undefined,
   onCancel,
   onConfirm,
+  showModal,
+  submitLoadingText = undefined,
+  title,
   ...restProps
 }: Props) => (
   <BootstrapModalWrapper showModal={showModal} onHide={onCancel} {...restProps}>
@@ -60,8 +66,11 @@ const BootstrapModalConfirm = ({
       <ModalSubmit
         disabledCancel={cancelButtonDisabled}
         disabledSubmit={confirmButtonDisabled}
+        isAsyncSubmit={isAsyncSubmit}
+        submitLoadingText={submitLoadingText}
         onCancel={onCancel}
         onSubmit={onConfirm}
+        isSubmitting={isSubmitting}
         submitButtonText={confirmButtonText}
         submitButtonType="button"
       />

--- a/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
+++ b/graylog2-web-interface/src/components/common/ConfirmDialog.tsx
@@ -25,14 +25,17 @@ const StyledModal = styled(Modal)`
 `;
 
 type Props = {
-  show?: boolean;
-  onConfirm: () => void;
-  onCancel?: () => void;
-  title: string | React.ReactNode;
-  children: React.ReactNode;
   btnConfirmDisabled?: boolean;
   btnConfirmText?: React.ReactNode;
+  children: React.ReactNode;
   hideCancelButton?: boolean;
+  isAsyncSubmit?: boolean;
+  isSubmitting?: boolean;
+  onCancel?: () => void;
+  onConfirm: () => void;
+  show?: boolean;
+  submitLoadingText?: string;
+  title: string | React.ReactNode;
 };
 
 /**
@@ -40,14 +43,17 @@ type Props = {
  * cancel or confirm.
  */
 const ConfirmDialog = ({
-  show = false,
-  title,
-  children,
-  onCancel = () => {},
-  onConfirm,
   btnConfirmDisabled = false,
   btnConfirmText = 'Confirm',
+  children,
   hideCancelButton = false,
+  isAsyncSubmit = undefined,
+  isSubmitting = undefined,
+  onCancel = () => {},
+  onConfirm,
+  show = false,
+  submitLoadingText = undefined,
+  title,
 }: Props) => {
   const onHide = hideCancelButton ? onConfirm : onCancel;
 
@@ -62,12 +68,15 @@ const ConfirmDialog = ({
   ) : (
     <ModalSubmit
       autoFocus
+      disabledSubmit={btnConfirmDisabled}
+      displayCancel
+      isAsyncSubmit={isAsyncSubmit}
+      isSubmitting={isSubmitting}
       onCancel={onCancel}
       onSubmit={onConfirm}
-      submitButtonType="button"
-      disabledSubmit={btnConfirmDisabled}
       submitButtonText={btnConfirmText}
-      displayCancel
+      submitButtonType="button"
+      submitLoadingText={submitLoadingText}
     />
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds props to the `ConfirmDialog` to be allow displaying a loading indicator for the confirm button, while the confirm request is pending.

/nocl

