### PR TITLE
Update to Netty 4.1.127

### DIFF
--- a/changelog/unreleased/pr-23576.toml
+++ b/changelog/unreleased/pr-23576.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Netty to 4.1.127 to fix [GHSA-fghv-69vj-qj49](https://github.com/netty/netty/security/advisories/GHSA-fghv-69vj-qj49) and [GHSA-3p8m-j85q-pgmj](https://github.com/netty/netty/security/advisories/GHSA-3p8m-j85q-pgmj)."
+
+pulls = ["23642"]

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
         <mongodb-driver.version>5.2.0</mongodb-driver.version>
         <mongojack.version>4.11.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.118.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.127.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.73.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.12.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.32.0</opentelemetry.version>


### PR DESCRIPTION
Release notes: https://netty.io/news/2025/09/08/4-1-127-Final.html

(cherry picked from commit 049ba4cded2b0841da63772c095495c9b73ec62a)