### PR TITLE
Poll for index ranges in test.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/periodical/IndexRangesCleanUpIT.java
@@ -20,6 +20,7 @@ import com.github.rholder.retry.RetryException;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
+import org.assertj.core.api.ListAssert;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.containermatrix.annotations.ContainerMatrixTest;
@@ -28,6 +29,7 @@ import org.graylog.testing.containermatrix.annotations.ContainerMatrixTestsConfi
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,28 +52,32 @@ public class IndexRangesCleanUpIT {
         api.indices().rotateIndexSet(indexSetId);
         api.indices().rotateIndexSet(indexSetId);
 
-        assertThat(getIndexRangesList()).isNotEmpty().contains(INDEX_ONE, INDEX_TWO);
+        assertIndexRanges(ranges -> ranges.isNotEmpty().contains(INDEX_ONE, INDEX_TWO));
 
         //Deleting index should automatically remove the range
         api.indices().deleteIndex(INDEX_ONE);
 
-        assertThat(getIndexRangesList()).isNotEmpty().doesNotContain(INDEX_ONE);
+        assertIndexRanges(ranges -> ranges.isNotEmpty().doesNotContain(INDEX_ONE));
 
         //Deleting index set without deleting underlying indices
         api.indices().deleteIndexSet(indexSetId, false);
-        assertThat(getIndexRangesList()).isNotEmpty().contains(INDEX_TWO);
+        assertIndexRanges(ranges -> ranges.isNotEmpty().contains(INDEX_TWO));
 
         //Trigger clean up periodical over api
         api.indices().rebuildIndexRanges();
-        assertThat(getIndexRangesList()).isNotEmpty().doesNotContain(INDEX_TWO);
+        assertIndexRanges(ranges -> ranges.isNotEmpty().doesNotContain(INDEX_TWO));
     }
 
-    private List<String> getIndexRangesList() throws ExecutionException, RetryException {
-        return RetryerBuilder.<List<String>>newBuilder()
+    private void assertIndexRanges(Consumer<ListAssert<String>> assertion) throws ExecutionException, RetryException {
+        RetryerBuilder.<Void>newBuilder()
                 .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
-                .withStopStrategy(StopStrategies.stopAfterAttempt(3))
-                .retryIfResult(List::isEmpty)
+                .withStopStrategy(StopStrategies.stopAfterDelay(30, TimeUnit.SECONDS))
+                .retryIfRuntimeException()
                 .build()
-                .call(() -> api.indices().listIndexRanges().properJSONPath().read("ranges.*.index_name"));
+                .call(() -> {
+                    final List<String> ranges = api.indices().listIndexRanges().properJSONPath().read("ranges.*.index_name");
+                    assertion.accept(assertThat(ranges));
+                    return null;
+                });
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adjusting the logic in `IndexRangesCleanUpIT` to poll for the predicate/assertion to hold true before continuing, instead of polling for the first valid response from the index ranges endpoint. This could fix an issue, where the index ranges cleanup job is still running, while the test already polls for the range to have vanished.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.