### PR TITLE
Show line numbers in data table by default.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/DataTableVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/DataTableVisualizationConfigDTO.java
@@ -31,9 +31,13 @@ public abstract class DataTableVisualizationConfigDTO implements VisualizationCo
     public static final String NAME = "table";
 
     private static final String FIELD_PINNED_COLUMNS = "pinned_columns";
+    private static final String FIELD_SHOW_ROW_NUMBERS = "show_row_numbers";
 
     @JsonProperty(FIELD_PINNED_COLUMNS)
     public abstract List<String> pinnedColumns();
+
+    @JsonProperty(FIELD_SHOW_ROW_NUMBERS)
+    public abstract boolean showRowNumbers();
 
     public static DataTableVisualizationConfigDTO.Builder builder() {
         return Builder.create();
@@ -45,13 +49,17 @@ public abstract class DataTableVisualizationConfigDTO implements VisualizationCo
     public static abstract class Builder {
 
         @JsonCreator
-        public static DataTableVisualizationConfigDTO.Builder create() {
+        public static Builder create() {
             return new AutoValue_DataTableVisualizationConfigDTO.Builder()
-                    .pinnedColumns(List.of());
+                    .pinnedColumns(List.of())
+                    .showRowNumbers(true);
         }
 
         @JsonProperty(FIELD_PINNED_COLUMNS)
-        public abstract DataTableVisualizationConfigDTO.Builder pinnedColumns(List<String> pinnedColumns);
+        public abstract Builder pinnedColumns(List<String> pinnedColumns);
+
+        @JsonProperty(FIELD_SHOW_ROW_NUMBERS)
+        public abstract Builder showRowNumbers(boolean showRowNumbers);
 
         public abstract DataTableVisualizationConfigDTO build();
     }

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.tsx
@@ -216,7 +216,8 @@ const DataTable = ({
     [formContext?.dirty, editing, widget?.config, widget?.id, dispatch],
   );
 
-  const { columnPivots, rowPivots, series, rollupForBackendQuery: rollup } = config;
+  const { columnPivots, rowPivots, series, rollupForBackendQuery: rollup, visualizationConfig } = config;
+  const showRowNumbers = (visualizationConfig as DataTableVisualizationConfig)?.showRowNumbers ?? true;
   const widgetUnits = useWidgetUnits(config);
 
   const rows = retrieveChartData(data) ?? [];
@@ -271,6 +272,7 @@ const DataTable = ({
 
     return (
       <DataTableEntry
+        index={idx + 1}
         key={key}
         fields={effectiveFields}
         item={reducedItem}
@@ -279,6 +281,7 @@ const DataTable = ({
         columnPivotValues={actualColumnPivotFields}
         types={fields}
         series={series}
+        showRowNumbers={showRowNumbers}
         units={widgetUnits}
       />
     );
@@ -308,6 +311,7 @@ const DataTable = ({
               setLoadingState={setLoadingState}
               pinnedColumns={pinnedColumns}
               togglePin={togglePin}
+              showRowNumbers={showRowNumbers}
             />
           </THead>
           <TBody $stickyLeftMarginsByColumnIndex={stickyLeftMarginsByColumnIndex}>{formattedRows}</TBody>

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.tsx
@@ -62,6 +62,7 @@ const SUT = (props: Partial<React.ComponentProps<typeof DataTableEntry>>) => (
   <table>
     <tbody>
       <DataTableEntry
+        index={1}
         columnPivots={columnPivots}
         columnPivotValues={columnPivotValues}
         fields={fields}
@@ -70,6 +71,7 @@ const SUT = (props: Partial<React.ComponentProps<typeof DataTableEntry>>) => (
         types={List([])}
         valuePath={valuePath}
         units={UnitsConfig.empty()}
+        showRowNumbers
         {...props}
       />
     </tbody>

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -19,6 +19,7 @@ import { useMemo } from 'react';
 import type * as Immutable from 'immutable';
 import flatten from 'lodash/flatten';
 import get from 'lodash/get';
+import styled, { css } from 'styled-components';
 
 import Value from 'views/components/Value';
 import type FieldType from 'views/logic/fieldtypes/FieldType';
@@ -42,11 +43,13 @@ type Field = {
   source: string;
 };
 type Props = {
+  index: number;
   columnPivots: Array<string>;
   columnPivotValues: Array<Array<string>>;
   fields: Immutable.Set<Field>;
   item: { [key: string]: any };
   series: Array<Series>;
+  showRowNumbers: boolean;
   types: FieldTypeMappingsList;
   valuePath: ValuePath;
   units: UnitsConfig;
@@ -97,7 +100,26 @@ const columnNameToField = (column: string, series: Series[] = []) => {
   return currentSeries ? currentSeries.function : column;
 };
 
-const DataTableEntry = ({ columnPivots, fields, series, columnPivotValues, valuePath, item, types, units }: Props) => {
+const LineNumber = styled.td(
+  ({ theme }) => css`
+    width: 20px;
+    text-align: right;
+    color: ${theme.colors.text.secondary} !important;
+  `,
+);
+
+const DataTableEntry = ({
+  index,
+  columnPivots,
+  fields,
+  series,
+  columnPivotValues,
+  valuePath,
+  item,
+  showRowNumbers,
+  types,
+  units,
+}: Props) => {
   const classes = 'message-group';
   const activeQuery = useActiveQueryId();
 
@@ -127,6 +149,7 @@ const DataTableEntry = ({ columnPivots, fields, series, columnPivotValues, value
 
   return (
     <tr className={`fields-row ${classes}`}>
+      {showRowNumbers && <LineNumber>{index}</LineNumber>}
       {columns.map(({ field, value, path, source }, idx) => {
         const key = `${activeQuery}-${field}=${value}-${idx}`;
         const nameForField = columnNameToField(field, series);

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -102,9 +102,12 @@ const columnNameToField = (column: string, series: Series[] = []) => {
 
 const LineNumber = styled.td(
   ({ theme }) => css`
-    width: 20px;
-    text-align: right;
-    color: ${theme.colors.text.secondary} !important;
+    &&& {
+      width: 20px;
+      min-width: 20px;
+      text-align: right;
+      color: ${theme.colors.text.secondary};
+    }
   `,
 );
 

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.tsx
@@ -105,6 +105,8 @@ const LineNumber = styled.td(
     &&& {
       width: 20px;
       min-width: 20px;
+      max-width: 200px;
+      white-space: nowrap;
       text-align: right;
       color: ${theme.colors.text.secondary};
     }

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -166,10 +166,9 @@ const Spacer = ({ span }: { span: number }) => <th aria-label="spacer" colSpan={
 
 const RowNumberHeader = styled(TableHeaderCell)(
   ({ theme }) => css`
-    width: 20px;
-    color: ${theme.colors.text.secondary} !important;
-
     && {
+      width: 20px;
+      color: ${theme.colors.text.secondary};
       min-width: 20px;
     }
   `,

--- a/graylog2-web-interface/src/views/components/datatable/Headers.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.tsx
@@ -168,8 +168,10 @@ const RowNumberHeader = styled(TableHeaderCell)(
   ({ theme }) => css`
     && {
       width: 20px;
-      color: ${theme.colors.text.secondary};
       min-width: 20px;
+      max-width: 200px;
+      white-space: nowrap;
+      color: ${theme.colors.text.secondary};
     }
   `,
 );

--- a/graylog2-web-interface/src/views/components/datatable/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/datatable/bindings.tsx
@@ -23,6 +23,7 @@ import DataTable from './DataTable';
 
 type DataTableVisualizationConfigFormValues = {
   pinnedColumns: Array<string>;
+  showRowNumbers: boolean;
 };
 const dataTable: VisualizationType<typeof DataTable.type> = {
   type: DataTable.type,
@@ -31,10 +32,11 @@ const dataTable: VisualizationType<typeof DataTable.type> = {
   config: {
     createConfig: () => ({ pinnedColumns: [] }),
     fromConfig: (config: DataTableVisualizationConfig | undefined) => ({
-      pinnedColumns: config?.pinnedColumns.toJS() ?? [],
+      pinnedColumns: config?.pinnedColumns.toArray() ?? [],
+      showRowNumbers: config?.showRowNumbers ?? true,
     }),
     toConfig: (formValues: DataTableVisualizationConfigFormValues) =>
-      DataTableVisualizationConfig.create(formValues.pinnedColumns),
+      DataTableVisualizationConfig.create(formValues.pinnedColumns, formValues.showRowNumbers),
     fields: [
       {
         name: 'pinnedColumns',
@@ -45,6 +47,11 @@ const dataTable: VisualizationType<typeof DataTable.type> = {
             .filter((grouping) => grouping?.direction === 'row' && grouping?.fields)
             .flatMap((grouping) => grouping.fields) ?? [],
         required: false,
+      },
+      {
+        name: 'showRowNumbers',
+        title: 'Show Row Numbers',
+        type: 'boolean',
       },
     ],
   },

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig.ts
@@ -22,18 +22,20 @@ export type PinnedColumns = Array<string>;
 
 export type DataTableVisualizationConfigType = {
   pinnedColumns: PinnedColumns;
+  showRowNumbers: boolean;
 };
 
 export type DataTableVisualizationConfigTypeJSON = {
   pinned_columns: PinnedColumns;
+  show_row_numbers?: boolean | null;
 };
 
 export default class DataTableVisualizationConfig extends VisualizationConfig {
   _value: DataTableVisualizationConfigType;
 
-  constructor(pinnedColumns: PinnedColumns) {
+  constructor(pinnedColumns: PinnedColumns, showRowNumbers: boolean) {
     super();
-    this._value = { pinnedColumns: pinnedColumns || [] };
+    this._value = { pinnedColumns: pinnedColumns ?? [], showRowNumbers };
   }
 
   static empty() {
@@ -44,6 +46,10 @@ export default class DataTableVisualizationConfig extends VisualizationConfig {
     return Immutable.Set(this._value.pinnedColumns);
   }
 
+  get showRowNumbers() {
+    return this._value.showRowNumbers ?? true;
+  }
+
   toBuilder() {
     const { pinnedColumns } = this._value;
 
@@ -51,8 +57,8 @@ export default class DataTableVisualizationConfig extends VisualizationConfig {
     return new Builder(Immutable.Map({ pinnedColumns }));
   }
 
-  static create(pinnedColumns: PinnedColumns) {
-    return new DataTableVisualizationConfig(pinnedColumns);
+  static create(pinnedColumns: PinnedColumns, showRowNumbers: boolean = true) {
+    return new DataTableVisualizationConfig(pinnedColumns, showRowNumbers);
   }
 
   toJSON() {
@@ -84,8 +90,8 @@ class Builder {
   }
 
   build() {
-    const { pinnedColumns } = this.value.toObject();
+    const { pinnedColumns, showRowNumbers } = this.value.toObject();
 
-    return new DataTableVisualizationConfig(pinnedColumns);
+    return new DataTableVisualizationConfig(pinnedColumns, showRowNumbers);
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding line numbers to the data table visualization for aggregation widgets. It is enabled by default, but can be toggled in the widget configuration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.