### PR TITLE
Fix "Teams Overview" tab visibility for `Team Inspector` role (`6.2`)

### DIFF
--- a/changelog/unreleased/issue-enterprise-11568.toml
+++ b/changelog/unreleased/issue-enterprise-11568.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix Teams Overview tab visibility for Team Inspector role"
+
+issues = ["Graylog2/graylog-plugin-enterprise#11568"]
+pulls = ["23599"]

--- a/graylog2-web-interface/src/components/users/navigation/UsersPageNavigation.tsx
+++ b/graylog2-web-interface/src/components/users/navigation/UsersPageNavigation.tsx
@@ -23,7 +23,7 @@ import { Row } from 'components/bootstrap';
 const UsersPageNavigation = () => {
   const NAV_ITEMS = [
     { title: 'Users Overview', path: Routes.SYSTEM.USERS.OVERVIEW, permissions: 'users:list' },
-    { title: 'Teams Overview', path: Routes.getPluginRoute('SYSTEM_TEAMS'), permissions: 'teams:list' },
+    { title: 'Teams Overview', path: Routes.getPluginRoute('SYSTEM_TEAMS'), permissions: 'team:read' },
     { title: 'Token Management', path: Routes.SYSTEM.USERS_TOKEN_MANAGEMENT.overview, permissions: 'users:tokenlist' },
   ];
 


### PR DESCRIPTION
Note: This is a backport of #23599 to `6.2`.

<!--- Provide a general summary of your changes in the Title above -->

Related to Graylog2/graylog-plugin-enterprise#11568

## Description
The **Teams Overview** tab on the `/system/users` page is currently hidden from users with the **Team Inspector** role. This happens because the frontend checks for a permission that is not included in the role. This was fixed by using the proper permission (`team:read`).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually in my dev environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

