### PR TITLE
Fix issue displaying table row after adding notification

### DIFF
--- a/changelog/unreleased/pr-23677.toml
+++ b/changelog/unreleased/pr-23677.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fixed issue causing Event Notificaiton to be unusable after creation without global * permission."
+
+pulls = ["23677"]

--- a/changelog/unreleased/pr-23677.toml
+++ b/changelog/unreleased/pr-23677.toml
@@ -1,4 +1,4 @@
 type = "fixed"
-message = "Fixed issue causing Event Notificaiton to be unusable after creation without global * permission."
+message = "Fixed issue causing Event Notificaiton to be unusable after creation without global notifications permissions."
 
 pulls = ["23677"]

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.tsx
@@ -23,6 +23,7 @@ import Routes from 'routing/Routes';
 import { EventNotificationsActions } from 'stores/event-notifications/EventNotificationsStore';
 import withHistory from 'routing/withHistory';
 import type CancellablePromise from 'logic/rest/CancellablePromise';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 import EventNotificationForm from './EventNotificationForm';
 
@@ -107,6 +108,7 @@ class EventNotificationFormContainer extends React.Component<
   handleSubmit = () => {
     const { action, embedded, onSubmit, history } = this.props;
     const { notification } = this.state;
+    const currentUser = CurrentUserStore.getInitialState();
 
     this.setState({ isDirty: false });
 
@@ -115,21 +117,25 @@ class EventNotificationFormContainer extends React.Component<
     if (action === 'create') {
       promise = EventNotificationsActions.create(notification);
 
-      promise.then(
-        () => {
-          if (!embedded) {
-            history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
-          }
-        },
-        (errorResponse) => {
-          const { body } = errorResponse.additional;
+      promise
+        .then(() => {
+          CurrentUserStore.update(currentUser.currentUser.username);
+        })
+        .then(
+          () => {
+            if (!embedded) {
+              history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
+            }
+          },
+          (errorResponse) => {
+            const { body } = errorResponse.additional;
 
-          if (errorResponse.status === 400 && body && body.failed) {
-            this.setState({ validation: body });
-            EventNotificationFormContainer.scrollToFirstError();
-          }
-        },
-      );
+            if (errorResponse.status === 400 && body && body.failed) {
+              this.setState({ validation: body });
+              EventNotificationFormContainer.scrollToFirstError();
+            }
+          },
+        );
     } else {
       promise = EventNotificationsActions.update(notification.id, notification);
 


### PR DESCRIPTION
Fixes issue causing event notifications to be uneditable and usable immediately after creation (until a page refresh) if the user only has the `eventnotifications:create` permissions for event notifications (no `eventnotifications:edit:*` permission).

This change refreshes user permissions (by fetching the current user and its permissions) right after adding a new notification. This allows the permission for the newly added notification to be seen by the frontend `isPermitted()` check, which allows the row contains a link to the view the notification details and Share/More actions menus all filled-out. 

Before:
<img width="1026" height="80" alt="image" src="https://github.com/user-attachments/assets/bc1f5dd8-feaf-495f-afff-747b12b7eb45" />

After:
<img width="996" height="82" alt="image" src="https://github.com/user-attachments/assets/3b04a8fe-0444-4408-b650-6b9a9fe0732b" />