### PR TITLE
Update AWS java SDK to version 2.33.11

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/S3MinioContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/S3MinioContainer.java
@@ -31,7 +31,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 public class S3MinioContainer extends GenericContainer<S3MinioContainer> {
-    private static final String IMAGE_NAME = "minio/minio:latest";
+    public static final String MINIO_LATEST = "minio/minio:latest";
     private static final int PORT = 9000;
     private final String accessKey;
     private final String secretKey;
@@ -43,12 +43,20 @@ public class S3MinioContainer extends GenericContainer<S3MinioContainer> {
         this(Network.newNetwork(), true);
     }
 
+    public S3MinioContainer(String imageName) {
+        this(imageName, Network.newNetwork(), true);
+    }
+
     public S3MinioContainer(Network network) {
         this(network, false);
     }
 
     public S3MinioContainer(Network network, final boolean closeNetwork) {
-        super(IMAGE_NAME);
+        this(MINIO_LATEST, network, closeNetwork);
+    }
+
+    public S3MinioContainer(String imageName, Network network, final boolean closeNetwork) {
+        super(imageName);
         this.closeNetwork = closeNetwork;
         this.network = Optional.of(network);
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <auto-value.version>1.11.0</auto-value.version>
         <auto-value-javabean.version>2.5.2</auto-value-javabean.version>
         <aws-java-sdk-1.version>1.12.675</aws-java-sdk-1.version>
-        <aws-java-sdk-2.version>2.29.52</aws-java-sdk-2.version>
+        <aws-java-sdk-2.version>2.33.11</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.6.1</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.3.2</aws-msk-iam-auth.version>
         <!-- When bumping bouncycastle.version, check if the explicit management for bcutil-jdk18on can/must be removed. -->


### PR DESCRIPTION
Updates `software.amazon.awssdk:bom` to version `2.33.11`. 

Updating beyond version `2.29.x` wasn't possible before because it required code changes in the Graylog Enterprise plugin to ensure backward compatibility with third-party S3-compatible storage solutions. With those changes now implemented, we can update the SDK.

Fixes #23433

/nocl
