### PR TITLE
Revert "Restrict AWS SDK updates to version 2.29.x (#22451)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,7 @@ updates:
       # The AWS SDKs receive patch updates almost every day. Reduce dependabot
       # pull-request noise by ignoring patch updates.
       - dependency-name: "software.amazon.awssdk:bom"
-        # We don't want to pull newer versions than 2.29 until the compatibility
-        # with S3-compatible services is restored or a different solution
-        # is found.
-        # See:
-        # - https://github.com/apache/iceberg/pull/12264
-        # - https://github.com/Graylog2/graylog-plugin-enterprise/issues/10504
-        #update-types: ["version-update:semver-patch"]
-        versions:
-          - ">= 2.30"
+        update-types: ["version-update:semver-patch"]
       - dependency-name: "com.amazonaws:aws-java-sdk-bom"
         update-types: ["version-update:semver-patch"]
       # Lucene >=10 requires JDK 21


### PR DESCRIPTION
This reverts commit abc12138fcbf419534575a6d2f9366581ad8e481.

We can stop pinning AWS SDK updates. See https://github.com/Graylog2/graylog2-server/pull/23685.

/nocl
[skip ci]
