### PR TITLE
Add description to input descriptor and configuration form

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -482,6 +482,10 @@ public abstract class MessageInput implements Stoppable {
         public boolean isForwarderCompatible() {
             return true;
         }
+
+        public String getDescription() {
+            return null;
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/inputs/responses/InputTypeInfo.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/inputs/responses/InputTypeInfo.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import jakarta.annotation.Nullable;
 
 import java.util.Map;
 
@@ -35,6 +36,10 @@ public abstract class InputTypeInfo {
     @JsonProperty("name")
     public abstract String name();
 
+    @JsonProperty("description")
+    @Nullable
+    public abstract String description();
+
     @JsonProperty("is_exclusive")
     public abstract boolean isExclusive();
 
@@ -47,9 +52,10 @@ public abstract class InputTypeInfo {
     @JsonCreator
     public static InputTypeInfo create(@JsonProperty("type") String type,
                                        @JsonProperty("name") String name,
+                                       @Nullable @JsonProperty("description") String description,
                                        @JsonProperty("is_exclusive") boolean isExclusive,
                                        @JsonProperty("requested_configuration") Map<String, Map<String, Object>> requestedConfiguration,
                                        @JsonProperty("link_to_docs") String linkToDocs) {
-        return new AutoValue_InputTypeInfo(type, name, isExclusive, requestedConfiguration, linkToDocs);
+        return new AutoValue_InputTypeInfo(type, name, description, isExclusive, requestedConfiguration, linkToDocs);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
@@ -50,6 +50,10 @@ public class InputDescription {
         return descriptor.isForwarderCompatible();
     }
 
+    public String getDescription() {
+        return descriptor.getDescription();
+    }
+
     public Map<String, Map<String, Object>> getRequestedConfiguration() {
         return config.combinedRequestedConfiguration().asList();
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/inputs/InputTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/inputs/InputTypesResource.java
@@ -94,8 +94,8 @@ public class InputTypesResource extends RestResource {
                 .filter(e -> isPermitted(RestPermissions.INPUT_TYPES_CREATE, e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
             final InputDescription description = entry.getValue();
-            return InputTypeInfo.create(entry.getKey(), description.getName(), description.isExclusive(),
-                    description.getRequestedConfiguration(), description.getLinkToDocs());
+                    return InputTypeInfo.create(entry.getKey(), description.getName(), description.getDescription(),
+                            description.isExclusive(), description.getRequestedConfiguration(), description.getLinkToDocs());
         }));
     }
 
@@ -116,7 +116,8 @@ public class InputTypesResource extends RestResource {
             throwInputTypeNotFound(inputType);
         }
 
-        return InputTypeInfo.create(inputType, description.getName(), description.isExclusive(), description.getRequestedConfiguration(), description.getLinkToDocs());
+        return InputTypeInfo.create(inputType, description.getName(), description.getDescription(),
+                description.isExclusive(), description.getRequestedConfiguration(), description.getLinkToDocs());
     }
 
     private static void throwInputTypeNotFound(String inputType) {

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.tsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.tsx
@@ -21,8 +21,8 @@ import styled from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { InputsActions } from 'stores/inputs/InputsStore';
-import { InputTypesActions } from 'stores/inputs/InputTypesStore';
 import type { InputDescription } from 'stores/inputs/InputTypesStore';
+import { InputTypesActions } from 'stores/inputs/InputTypesStore';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -150,6 +150,7 @@ const CreateInputControl = () => {
                 key="configuration-form-input"
                 setShowModal={setShowConfigurationForm}
                 configFields={selectedInputDefinition.requested_configuration}
+                description={selectedInputDefinition.description}
                 title={
                   <span>
                     Launch new <em>{inputTypes[selectedInput] ?? ''}</em> input

--- a/graylog2-web-interface/src/components/inputs/InputForm.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.tsx
@@ -18,11 +18,11 @@ import * as React from 'react';
 import { useEffect, useState, useRef } from 'react';
 
 import { NodeOrGlobalSelect } from 'components/inputs';
+import type { ConfigurationField } from 'components/configurationforms';
 import { ConfigurationForm } from 'components/configurationforms';
 import HideOnCloud from 'util/conditional/HideOnCloud';
 import AppConfig from 'util/AppConfig';
 import type { Input } from 'components/messageloaders/Types';
-import type { ConfigurationField } from 'components/configurationforms';
 
 type FormValues = Input['attributes'];
 
@@ -40,6 +40,7 @@ type Props = {
   values?: FormValues;
   setShowModal: (show: boolean) => void;
   submitButtonText: string;
+  description?: string;
 };
 
 const InputForm = ({
@@ -49,6 +50,7 @@ const InputForm = ({
   titleValue = undefined,
   title,
   typeName,
+  description = undefined,
   includeTitleField = undefined,
   handleSubmit,
   values = undefined,
@@ -130,6 +132,7 @@ const InputForm = ({
       submitAction={onSubmit}
       typeName={typeName}
       cancelAction={onCancel}>
+      <span>{description}</span>
       <HideOnCloud>
         <NodeOrGlobalSelect onChange={handleChange} global={global} node={node} />
       </HideOnCloud>

--- a/graylog2-web-interface/src/stores/inputs/InputTypesStore.ts
+++ b/graylog2-web-interface/src/stores/inputs/InputTypesStore.ts
@@ -40,6 +40,7 @@ export type InputTypes = {
 export type InputDescription = {
   type: string;
   name: string;
+  description: string;
   is_exclusive: boolean;
   requested_configuration: {
     [key: string]: ConfigurationField;


### PR DESCRIPTION
## Description
Adds an optional description field to input descriptors that will be displayed on the top of the input configuration modal.

## Motivation and Context
required for showing inline help/info for input types

## How Has This Been Tested?
manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

