### PR TITLE
Waiting for deflector when creating index sets in tests.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Indices.java
@@ -68,6 +68,7 @@ public class Indices implements GraylogRestApi {
                 .assertThat().body("id", notNullValue())
                 .extract().body().jsonPath().getString("id");
         waitForIndexNames(id);
+        waitForDeflector(id);
         return id;
     }
 
@@ -137,6 +138,28 @@ public class Indices implements GraylogRestApi {
                 .retryIfResult(List::isEmpty)
                 .build()
                 .call(() -> listOpenIndicesWithEmptyResultOnError(indexSetId));
+    }
+
+    private boolean isDeflectorUp(String indexSetId) {
+        final var response = given()
+                .spec(api.requestSpecification())
+                .log().ifValidationFails()
+                .when()
+                .get("/system/indexer/overview/" + indexSetId);
+        if (response.statusCode() == 200) {
+            return new GraylogApiResponse(response.then()).properJSONPath().read("deflector.is_up", Boolean.class);
+        } else {
+            return false;
+        }
+    }
+
+    private void waitForDeflector(String indexSetId) throws ExecutionException, RetryException {
+        RetryerBuilder.<Boolean>newBuilder()
+                .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
+                .withStopStrategy(StopStrategies.stopAfterAttempt(30))
+                .retryIfResult(result -> result == null || result.equals(false))
+                .build()
+                .call(() -> isDeflectorUp(indexSetId));
     }
 
     public void rotateIndexSet(String indexSetId) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making sure that a newly created test environment is waiting for the deflector to come up before continuing. This prevents situations where the tests are already trying to ingest messages while the deflector alias does not exist yet.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.