### PR TITLE
Remove Security start page change log

### DIFF
--- a/changelog/unreleased/issue-enterprise-11539.toml
+++ b/changelog/unreleased/issue-enterprise-11539.toml
@@ -1,5 +1,0 @@
-type = "added"
-message = "Add option to select Security Overview page on startup with valid security license."
-
-issues = ["Graylog2/graylog-plugin-enterprise#11539"]
-pulls = ["23582"]


### PR DESCRIPTION
This change does not apply to Graylog Open.

See https://github.com/Graylog2/graylog-plugin-enterprise/pull/11955.

/nocl