### PR TITLE
Add methods to filter entity source for entities that do not currently use EntityTable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/entities/source/DBEntitySourceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/source/DBEntitySourceService.java
@@ -28,6 +28,7 @@ import org.graylog2.rest.resources.entities.FilterOption;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.or;
@@ -73,5 +74,14 @@ public class DBEntitySourceService {
                 in(EntitySource.FIELD_PARENT_ID, entityObjectIds)
         );
         collection.deleteMany(filter);
+    }
+
+    public boolean existsForTypeAndSource(String entityType, String source) {
+        final Bson filter = and(
+                eq(EntitySource.FIELD_ENTITY_TYPE, entityType),
+                eq(EntitySource.FIELD_SOURCE, source)
+        );
+
+        return collection.countDocuments(filter) > 0L;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySourceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySourceService.java
@@ -44,4 +44,8 @@ public class EntitySourceService {
     public void bulkDeleteByEntityId(Set<String> entityIds) {
         dbEntitySourceService.bulkDeleteByEntityId(entityIds);
     }
+
+    public boolean existsForTypeAndSource(String entityType, String source) {
+        return dbEntitySourceService.existsForTypeAndSource(entityType, source);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Utility methods for filtering by EntitySource for components that do not yet use the common EntityTable component on the frontend.
/nocl included in enterprise CL
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
filtering content by source
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local dev 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

