### PR TITLE
Supporting overriding individual URLs for help pages. (`6.3`)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/customization/Config.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/customization/Config.java
@@ -19,6 +19,7 @@ package org.graylog2.web.customization;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
 import java.util.Optional;
 
 
@@ -28,6 +29,7 @@ public record Config(
         Optional<String> favicon,
         Optional<Logo> logo,
         @JsonProperty("help_url") Optional<String> helpUrl,
+        @JsonProperty("help_pages") Optional<Map<String, String>> helpPages,
         Optional<Login> login,
         Optional<Welcome> welcome,
         Optional<Navigation> navigation,
@@ -74,7 +76,12 @@ public record Config(
     public record FeaturesItem(Optional<Boolean> enabled) {}
 
     public static Config empty() {
-        return new Config(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        return new Config(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public static Config forProductName(String productName) {
+        return new Config(Optional.of(productName), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
@@ -56,7 +56,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -335,8 +334,7 @@ public class TeamsEventNotificationTest {
     @Test
     public void testProductNameInDefaultMessage() throws EventNotificationException {
         final var productName = "SuperDuperLog";
-        final var config = new Config(Optional.of(productName), Optional.empty(), Optional.empty(), Optional.empty(),
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        final var config = Config.forProductName(productName);
         final var customizationConfig = new CustomizationConfig(config);
 
         final var teamsEventNotification = new TeamsEventNotification(notificationCallbackService,

--- a/graylog2-web-interface/src/util/AppConfig.ts
+++ b/graylog2-web-interface/src/util/AppConfig.ts
@@ -51,6 +51,7 @@ export type Branding = {
     help?: { icon: string };
   };
   help_url?: string;
+  help_pages?: { [key: string]: string };
   footer?: { enabled: boolean };
   resources?: BrandingResources;
   features?: {

--- a/graylog2-web-interface/src/util/DocsHelper.test.ts
+++ b/graylog2-web-interface/src/util/DocsHelper.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import asMock from 'helpers/mocking/AsMock';
+import AppConfig from 'util/AppConfig';
+
+jest.mock('util/AppConfig');
+
+describe('DocsHelper', () => {
+  it('prefixes page URLs with default base URL', () => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      const DocsHelper = require('./DocsHelper').default;
+
+      expect(DocsHelper.toString(DocsHelper.PAGES.ALERTS)).toEqual(
+        'https://go2docs.graylog.org/current/interacting_with_your_log_data/alerts.html',
+      );
+      expect(DocsHelper.toString(DocsHelper.PAGES.LICENSE)).toEqual(
+        'https://go2docs.graylog.org/current/setting_up_graylog/operations_license_management.html',
+      );
+      expect(DocsHelper.toString(DocsHelper.PAGES.AUTHENTICATORS)).toEqual(
+        'https://go2docs.graylog.org/current/setting_up_graylog/user_authentication.htm',
+      );
+    });
+  });
+
+  it('applies custom url prefix', () => {
+    jest.isolateModules(() => {
+      asMock(AppConfig.branding).mockReturnValue({
+        help_url: 'https://www.example.com/docs',
+      });
+      // eslint-disable-next-line global-require
+      const DocsHelper = require('./DocsHelper').default;
+
+      expect(DocsHelper.toString(DocsHelper.PAGES.ALERTS)).toEqual(
+        'https://www.example.com/docs/interacting_with_your_log_data/alerts.html',
+      );
+      expect(DocsHelper.toString(DocsHelper.PAGES.LICENSE)).toEqual(
+        'https://www.example.com/docs/setting_up_graylog/operations_license_management.html',
+      );
+      expect(DocsHelper.toString(DocsHelper.PAGES.AUTHENTICATORS)).toEqual(
+        'https://www.example.com/docs/setting_up_graylog/user_authentication.htm',
+      );
+    });
+  });
+
+  it('applies overrides passed through branding', () => {
+    jest.isolateModules(() => {
+      asMock(AppConfig.branding).mockReturnValue({
+        help_pages: {
+          ALERTS: 'http://www.example.com/alerts',
+          LICENSE: 'foo',
+        },
+      });
+
+      // eslint-disable-next-line global-require
+      const DocsHelper = require('./DocsHelper').default;
+
+      expect(DocsHelper.toString(DocsHelper.PAGES.ALERTS)).toEqual('http://www.example.com/alerts');
+      expect(DocsHelper.toString(DocsHelper.PAGES.LICENSE)).toEqual('https://go2docs.graylog.org/current/foo');
+      expect(DocsHelper.toString(DocsHelper.PAGES.AUTHENTICATORS)).toEqual(
+        'https://go2docs.graylog.org/current/setting_up_graylog/user_authentication.htm',
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Note:** This is a backport of #23717 to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows overriding docs URLs individually per page.

/nocl Internal functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.