### PR TITLE
IT Tests: we also need to catch AssertionError and not only Exception in waitFor

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogRestApi.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogRestApi.java
@@ -43,7 +43,7 @@ public interface GraylogRestApi {
                 if (result != null && result.isPresent()) {
                     return result.get();
                 }
-            } catch (Exception e) {
+            } catch (Exception | AssertionError e) {
                 // ignore and retry
             }
             msPassed += SLEEP_MS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe your changes in detail -->
The test below throws an `AssertionError` during the `waitFor` which is not an Exception, so we catch these also.



```
[INFO] Running org.graylog2.inputs.InputCreationIT
HTTP/1.1 404 Not Found
X-Content-Type-Options: nosniff
X-Graylog-Node-ID: 44206fb7-682e-44fb-8be9-479a23ee9181
X-Frame-Options: DENY
X-Runtime-Microseconds: 1161
Content-Type: application/json
Content-Length: 100

{
    "type": "ApiError",
    "message": "No input state for input id <68d3e074f6967d70af674328> on this node."
}
Error:  Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.225 s <<< FAILURE! -- in org.graylog2.inputs.InputCreationIT
Error:  org.graylog2.inputs.InputCreationIT.testHttpRandomInputCreation -- Time elapsed: 0.071 s <<< FAILURE!
java.lang.AssertionError: 
1 expectation failed.
Expected status code <200> but was <404>.
```

/nocl internal refactoring



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

