### PR TITLE
Fix Validation of Event Definition Custom Fields

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.tsx
@@ -40,7 +40,7 @@ import withLocation from 'routing/withLocation';
 
 import commonStyles from '../common/commonStyles.css';
 
-const requiredFields = ['fieldName', 'config.providers[0].type'];
+const requiredFields = ['fieldName'];
 
 const getProviderPlugin = (type) => {
   if (type === undefined) {
@@ -104,10 +104,14 @@ class FieldForm extends React.Component<
     }
 
     requiredFields.forEach((requiredField) => {
-      if (!this.state.requiredField) {
+      if (!this.state[requiredField]) {
         errors[requiredField] = 'Field cannot be empty.';
       }
     });
+
+    if (!config.providers[0]?.type) {
+      errors['config.providers[0].type'] = 'Field cannot be empty.';
+    }
 
     if (isKey && (!isNumber(keyPosition) || Number(keyPosition) < 1)) {
       errors.key_position = 'Field must be a positive number.';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Use proper bracket access for `fieldName` required field
- Add hardcoded validation of `config.providers[0]?.type` to avoid need for `lodash/get`

/nocl bug introduced in [unreleased refactoring](https://github.com/Graylog2/graylog2-server/pull/22853/files#diff-d1d900280c43cffd63ae0e113056ed2aed323d308c00668e88818b75b45b348c) 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes blocker bug #23530 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

