### PR TITLE
Update event stream cache when stream is created

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/ast/expressions/FunctionExpression.java
@@ -28,10 +28,8 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory;
 
-import java.time.Duration;
-
 public class FunctionExpression extends BaseExpression {
-    private static final RateLimitedLog RATE_LIMITED_LOG = RateLimitedLogFactory.createRateLimitedLog(FunctionExpression.class, 1, Duration.ofSeconds(60));
+    private static final RateLimitedLog RATE_LIMITED_LOG = RateLimitedLogFactory.createQuietDefaultRateLimitedLog(FunctionExpression.class);
 
     private final FunctionArgs args;
     private final Function<?> function;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/ratelimitedlog/RateLimitedLogFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/ratelimitedlog/RateLimitedLogFactory.java
@@ -52,7 +52,7 @@ public class RateLimitedLogFactory {
 
     /**
      * @return Rate limited log that only prints once per 60 seconds. Use for frequently occurring code paths
-     * that you don't want to generate a lot of noise in the logs.
+     * that you don't want to generate a lot of log noise.
      */
     public static RateLimitedLog createQuietDefaultRateLimitedLog(final Class<?> clazz) {
         return createRateLimitedLog(LoggerFactory.getLogger(clazz), MAX_QUIET_RATE, MAX_QUIET_DURATION);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/ratelimitedlog/RateLimitedLogFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/ratelimitedlog/RateLimitedLogFactory.java
@@ -27,6 +27,9 @@ public class RateLimitedLogFactory {
     private static final int DEFAULT_MAX_RATE = 5;
     private static final Duration DEFAULT_DURATION = Duration.ofSeconds(10);
 
+    protected static final int MAX_QUIET_RATE = 1;
+    protected static final Duration MAX_QUIET_DURATION = Duration.ofSeconds(60);
+
     public static RateLimitedLog createRateLimitedLog(final Logger logger,
                                                       final int maxRate,
                                                       final Duration duration) {
@@ -47,4 +50,11 @@ public class RateLimitedLogFactory {
         return createRateLimitedLog(LoggerFactory.getLogger(clazz), DEFAULT_MAX_RATE, DEFAULT_DURATION);
     }
 
+    /**
+     * @return Rate limited log that only prints once per 60 seconds. Use for frequently occurring code paths
+     * that you don't want to generate a lot of noise in the logs.
+     */
+    public static RateLimitedLog createQuietDefaultRateLimitedLog(final Class<?> clazz) {
+        return createRateLimitedLog(LoggerFactory.getLogger(clazz), MAX_QUIET_RATE, MAX_QUIET_DURATION);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -475,8 +475,8 @@ public class StreamServiceImpl implements StreamService {
     @Override
     public String save(Stream stream) throws ValidationException {
         final StreamImpl streamImpl = (StreamImpl) stream;
-        scopedMongoUtils.upsert(streamImpl.toDTO());
-
+        final StreamDTO upserted = scopedMongoUtils.upsert(streamImpl.toDTO());
+        clusterEventBus.post(StreamsChangedEvent.create(upserted.id()));
         return streamImpl.id();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update/notify the `StreamCacheService` when new stream is created. Previously components using `StreamCacheService` would not successfully load new streams until the server was reloaded. 

This appears to be a regression in https://github.com/Graylog2/graylog2-server/pull/22313 (where the cluster event bus post was inadvertently lost), which was only introduced as part of Graylog 7.0, so there is no need for a backport or a change log.

Also adds rate limited logging when stream not found in cache to more loudly alert user to cause of issue. 

/nocl bug did not exist in previous stable releases, so no need for a change log.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/12035

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/12028.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a unit test.

Manual testing: See https://github.com/Graylog2/graylog-plugin-enterprise/issues/12028 for full steps to reproduce and test for the issue. Note that a fresh setup is not needed. The important part is to verify that the stream does not exist before testing.

Additional manual testing: 
1) Create a new stream.
2) Do not reboot the Graylog server.
2) Attempt to route messages to it by title with `route_to_stream(name: "Illuminate:<stream-name>", remove_from_default: true)`.
3) Verify that the messages route to the stream successfully. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)