### PR TITLE
Stream Action Update Bug Fix

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/StreamActions.tsx
@@ -243,7 +243,7 @@ const StreamActions = ({ stream, indexSets }: { stream: Stream; indexSets: Array
           </MenuItem>
         </IfPermitted>
 
-        <IfPermitted permissions={`streams:edit:${stream.id}`}>
+        <IfPermitted permissions={`streams:delete:${stream.id}`}>
           <DeleteMenuItem onSelect={toggleDeleteModal} disabled={isDefaultStream}>
             Delete this stream {isDefaultStream && <DefaultStreamHelp />}
           </DeleteMenuItem>

--- a/graylog2-web-interface/src/pages/StreamsPage.tsx
+++ b/graylog2-web-interface/src/pages/StreamsPage.tsx
@@ -32,6 +32,7 @@ import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import type { EntityShare } from 'actions/permissions/EntityShareActions';
 import useStreamMutations from 'hooks/useStreamMutations';
 import { KEY_PREFIX } from 'components/streams/hooks/useStreams';
+import { CurrentUserStore } from 'stores/users/CurrentUserStore';
 
 const StreamsPage = () => {
   const { indexSets } = useStore(IndexSetsStore);
@@ -39,7 +40,7 @@ const StreamsPage = () => {
   const { createStream } = useStreamMutations();
   const queryClient = useQueryClient();
 
-  const onSave = (stream: Stream & EntityShare) => {
+  const onSave = async (stream: Stream & EntityShare) => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.STREAMS.NEW_STREAM_CREATED, {
       app_pathname: 'streams',
     });
@@ -47,6 +48,7 @@ const StreamsPage = () => {
     return createStream(stream).then(() => {
       UserNotification.success('Stream has been successfully created.', 'Success');
       queryClient.invalidateQueries({ queryKey: KEY_PREFIX });
+      CurrentUserStore.reload();
     });
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This is a fix for the bug found by @AntonEbel where the actions on a newly created stream, for a user with only the stream:create permission, are missing or disabled until the page is reloaded.

/nocl
closes: #23305 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
