### PR TITLE
Fix: Alerts aggregations - show only compatible fields in black, gray otherwise

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.tsx
@@ -36,11 +36,12 @@ import GroupExpression from './AggregationConditionExpressions/GroupExpression';
 
 import styles from './AggregationConditionExpression.css';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
 type AggregationConditionExpressionProps = {
   eventDefinition: EventDefinition;
   validation?: any;
-  formattedFields: any[];
+  formattedFields: FieldTypeMapping[];
   aggregationFunctions: any[];
   onChange: (...args: any[]) => void;
   expression: any;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.test.tsx
@@ -18,6 +18,9 @@ import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
+
 import NumberRefExpression from './NumberRefExpression';
 
 describe('NumberRefExpression', () => {
@@ -28,9 +31,9 @@ describe('NumberRefExpression', () => {
   });
 
   const aggregationFunctions = ['avg', 'card'];
-  const formattedFields = [
-    { label: 'source - string', value: 'source' },
-    { label: 'took_ms - long', value: 'took_ms' },
+  const formattedFields: FieldTypeMapping[] = [
+    new FieldTypeMapping('source', FieldTypes.STRING()),
+    new FieldTypeMapping('took_ms', FieldTypes.LONG()),
   ];
 
   it('should have no selected function and field with an undefined ref', async () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.tsx
@@ -21,6 +21,7 @@ import get from 'lodash/get';
 import { Alert, Row } from 'components/bootstrap';
 import { emptyComparisonExpressionConfig } from 'logic/alerts/AggregationExpressionConfig';
 import validateExpression from 'logic/alerts/AggregationExpressionValidation';
+import type FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 
 import AggregationConditionExpression from './AggregationConditionExpression';
 import AggregationConditionsFormSummary from './AggregationConditionsFormSummary';
@@ -52,7 +53,7 @@ const StyledAlert = styled(Alert)`
 type AggregationConditionsFormProps = {
   eventDefinition: any;
   validation: any;
-  formattedFields: any[];
+  formattedFields: FieldTypeMapping[];
   aggregationFunctions: any[];
   onChange: (...args: any[]) => void;
 };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.tsx
@@ -20,7 +20,6 @@ import { useCallback, useMemo } from 'react';
 import { MultiSelect } from 'components/common';
 import { Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/bootstrap';
 // TODO: This should be moved to a general place outside of `views`
-import { defaultCompare } from 'logic/DefaultCompare';
 import useFieldTypes from 'views/logic/fieldtypes/useFieldTypes';
 import { ALL_MESSAGES_TIMERANGE } from 'views/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -43,16 +42,7 @@ type Props = {
 const AggregationForm = ({ aggregationFunctions, eventDefinition, validation, onChange }: Props) => {
   const { data: allFieldTypes } = useFieldTypes(eventDefinition?.config?.streams ?? [], ALL_MESSAGES_TIMERANGE);
   // Memoize function to only format fields when they change. Use joined fieldNames as cache key.
-  const formattedFields = useMemo(
-    () =>
-      (allFieldTypes ?? [])
-        .sort((ftA, ftB) => defaultCompare(ftA.name, ftB.name))
-        .map((fieldType) => ({
-          label: `${fieldType.name} – ${fieldType.value.type.type}`,
-          value: fieldType.name,
-        })),
-    [allFieldTypes],
-  );
+  const formattedFields = useMemo(() => allFieldTypes ?? [], [allFieldTypes]);
 
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, the fields to select for an aggregation in the alerts definition where always shown as a list of "black" fields. The same functionality in the search's aggregation wizard is graying out incompatible fields for the selected function. 
This PR adds the same to the alerts' aggregation wizard.

You can still select an incompatible field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

