### PR TITLE
Fix For Lookup Tables/Caches/Data Adapters Editing Bug

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
@@ -72,10 +72,16 @@ export function useCreateLookupTable() {
 }
 
 export function useUpdateLookupTable() {
+  const queryClient = useQueryClient();
+
   const { mutateAsync, isPending: isLoading } = useMutation({
     mutationFn: updateLookupTable,
     onSuccess: () => {
       UserNotification.success('Lookup Table updated successfully');
+      queryClient.invalidateQueries({
+        queryKey: ['lookup-tables'],
+        refetchType: 'active',
+      });
     },
     onError: (error: Error) => UserNotification.error(error.message),
   });
@@ -208,10 +214,16 @@ export function useCreateCache() {
 }
 
 export function useUpdateCache() {
+  const queryClient = useQueryClient();
+
   const { mutateAsync, isPending: isLoading } = useMutation({
     mutationFn: updateCache,
     onSuccess: () => {
       UserNotification.success('Cache updated successfully');
+      queryClient.invalidateQueries({
+        queryKey: ['caches'],
+        refetchType: 'active',
+      });
     },
     onError: (error: Error) => UserNotification.error(error.message),
   });
@@ -276,10 +288,16 @@ export function useCreateAdapter() {
 }
 
 export function useUpdateAdapter() {
+  const queryClient = useQueryClient();
+
   const { mutateAsync, isPending: isLoading } = useMutation({
     mutationFn: updateDataAdapter,
     onSuccess: () => {
       UserNotification.success('Data Adapter updated successfully');
+      queryClient.invalidateQueries({
+        queryKey: ['adapters'],
+        refetchType: 'active',
+      });
     },
     onError: (error: Error) => UserNotification.error(error.message),
   });


### PR DESCRIPTION
## Description
This fix adds an `InvalidateQueries()` call to the hooks for updating lookup tables, chaches, and data adapters. This ensures that the respective lists of those entities update properly after a user makes changes to one of those existing entities.

/nocl

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes Graylog2/graylog-plugin-enterprise/issues/11959

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local environment using most recent master branch code at time of testing. I was able to successfully create, edit, and delete lookup tables, caches, and data adapters and see these changes immediately propagate through the UI without a page refresh.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)