### PR TITLE
Check field restrictions on config instead of creation/update request

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/restrictions/IndexSetRestrictionsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/restrictions/IndexSetRestrictionsService.java
@@ -71,18 +71,19 @@ public class IndexSetRestrictionsService {
                 .map(IndexSetTemplate::indexSetConfig)
                 .orElse(indexSetDefaultTemplateService.getOrCreateDefaultConfig());
 
+        final IndexSetConfig newConfig = creationRequest.toIndexSetConfig(true, indexSetTemplateConfig.fieldRestrictions());
         if(!skipRestrictionCheck) {
-            checkRestrictions(indexSetTemplateConfig.fieldRestrictions(), doc(creationRequest), doc(indexSetTemplateConfig));
+            checkRestrictions(indexSetTemplateConfig.fieldRestrictions(), doc(newConfig), doc(indexSetTemplateConfig));
         }
-
-        return creationRequest.toIndexSetConfig(true, indexSetTemplateConfig.fieldRestrictions());
+        return newConfig;
     }
 
     public IndexSetConfig updateIndexSetConfig(IndexSetUpdateRequest updateRequest,
                                                IndexSetConfig oldConfig,
                                                boolean skipRestrictionCheck) {
+        final IndexSetConfig newConfig = updateRequest.toIndexSetConfig(oldConfig);
         if (!skipRestrictionCheck) {
-            DocumentContext doc1 = doc(updateRequest);
+            DocumentContext doc1 = doc(newConfig);
             DocumentContext doc2 = doc(oldConfig);
             if (!Objects.equals(doc1.read(FIELD_RESTRICTIONS_PATH), doc2.read(FIELD_RESTRICTIONS_PATH))) {
                 throw new ForbiddenException("Missing permission %s to change field %s!".formatted(
@@ -90,7 +91,7 @@ public class IndexSetRestrictionsService {
             }
             checkRestrictions(oldConfig.fieldRestrictions(), doc1, doc2);
         }
-        return updateRequest.toIndexSetConfig(oldConfig);
+        return newConfig;
     }
 
     private void checkRestrictions(Map<String, Set<IndexSetFieldRestriction>> indexSetFieldRestrictions,


### PR DESCRIPTION
/nocl
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When checking index set field restrictions, we are comparing an existing index set configuration with a creation or update request.
We need to first convert the request to an updated config and perform the validation on that. Otherwise we miss changes that are performed in that conversion process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Graylog2/graylog-plugin-enterprise#12041

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

