### PR TITLE
Change precondition for connecting pipelines to streams

### DIFF
--- a/changelog/unreleased/pr-23795.toml
+++ b/changelog/unreleased/pr-23795.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Change precondition for connecting streams to pipelines to `streams:read`."
+
+pulls = ["23795"]
+issues = ["graylog-plugin-enterprise#11960"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineConnectionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineConnectionsResource.java
@@ -84,8 +84,8 @@ public class PipelineConnectionsResource extends RestResource implements PluginR
     public PipelineConnections connectPipelines(@ApiParam(name = "Json body", required = true) @NotNull PipelineConnections connection) throws NotFoundException {
         final String streamId = connection.streamId();
 
-        // verify the stream exists and is editable
-        checkPermission(RestPermissions.STREAMS_EDIT, streamId);
+        // verify the stream exists and is readable
+        checkPermission(RestPermissions.STREAMS_READ, streamId);
         final Stream stream = streamService.load(streamId);
         checkNotEditable(stream, "Cannot connect pipeline to non editable stream");
 
@@ -115,10 +115,10 @@ public class PipelineConnectionsResource extends RestResource implements PluginR
                 .filter(p -> p.pipelineIds().contains(pipelineId))
                 .collect(Collectors.toSet());
 
-        // verify the streams exist and the user has permission to edit them
+        // verify the streams exist and the user has permission to read them
         final Set<Stream> connectedStreams = streamService.loadByIds(connection.streamIds());
         connectedStreams.forEach(stream -> {
-            checkPermission(RestPermissions.STREAMS_EDIT, stream.getId());
+            checkPermission(RestPermissions.STREAMS_READ, stream.getId());
             checkNotEditable(stream, "Cannot connect pipeline to non editable stream");
         });
 


### PR DESCRIPTION
## Description
In the dropdown to connect streams to pipelines, the user sees all streams that he has `read` permissions for.
When connecting them, we check for the `edit` permission for that stream, leading to inconsistent behavior.

## Motivation and Context
Having `read` permission should be sufficient. This implies that users could potentially edit or route messages from streams. 

However, if you have access to edit pipelines, you are already performing an administrative task (and can already direct messages into any stream you choose using a pipeline rule). the pipeline subsystem is separate from the stream subsystem (pipelines relate to processing, while the stream subsystem relates to labelling and storage) and if you have permission to use it, it would follow that you should be able to administrate the processing of any stream your user can see.

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/11960

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

