### PR TITLE
Fix handling of `Optional<T>` in swagger/OpenAPI specs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/CustomSchemaFactoryWrapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/CustomSchemaFactoryWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.documentation.generator;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.factories.ObjectVisitor;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.factories.SchemaFactoryWrapper;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.factories.VisitorContext;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.types.ObjectSchema;
+
+public class CustomSchemaFactoryWrapper extends SchemaFactoryWrapper {
+    @Override
+    public JsonObjectFormatVisitor expectObjectFormat(JavaType convertedType) {
+        ObjectSchema s = new ObjectSchemaWithOptionalSupport();
+        schema = s;
+
+        // if we don't already have a recursive visitor context, create one
+        if (visitorContext == null) {
+            visitorContext = new VisitorContext();
+        }
+
+        // give each object schema a reference id and keep track of the ones we've seen
+        String schemaUri = visitorContext.addSeenSchemaUri(convertedType);
+        if (schemaUri != null) {
+            s.setId(schemaUri);
+        }
+
+        final var result = visitorFactory.objectFormatVisitor(provider, s);
+        ((ObjectVisitor) result).setVisitorContext(visitorContext);
+        return result;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
@@ -18,6 +18,7 @@ package org.graylog2.shared.rest.documentation.generator;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.jsonSchema.jakarta.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.jakarta.JsonSchemaGenerator;
 import com.fasterxml.jackson.module.jsonSchema.jakarta.factories.SchemaFactoryWrapper;
@@ -123,7 +124,7 @@ public class Generator {
         this.resourceClasses = resourceClasses;
         this.pluginMapping = pluginMapping;
         this.pluginPathPrefix = pluginPathPrefix;
-        this.mapper = mapper;
+        this.mapper = mapper.copy().registerModule(new Jdk8Module());
         this.isCloud = isCloud;
         this.prefixPlugins = prefixPlugins;
     }
@@ -631,7 +632,7 @@ public class Generator {
     }
 
     private Map<String, Object> schemaForType(Type valueType) {
-        final SchemaFactoryWrapper schemaFactoryWrapper = new SchemaFactoryWrapper() {};
+        final SchemaFactoryWrapper schemaFactoryWrapper = new CustomSchemaFactoryWrapper();
         final JsonSchemaGenerator schemaGenerator = new JsonSchemaGenerator(mapper, schemaFactoryWrapper);
         try {
             final JsonSchema schema = schemaGenerator.generateSchema(mapper.getTypeFactory().constructType(valueType));

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/ObjectSchemaWithOptionalSupport.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/ObjectSchemaWithOptionalSupport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.documentation.generator;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.jakarta.types.ObjectSchema;
+
+import java.util.Optional;
+
+public class ObjectSchemaWithOptionalSupport extends ObjectSchema {
+    @Override
+    public void putOptionalProperty(BeanProperty property, JsonSchema jsonSchema) {
+        if (property.getType().isTypeOrSubTypeOf(Optional.class)) {
+            jsonSchema.setRequired(false);
+        }
+        super.putOptionalProperty(property, jsonSchema);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/documentation/generator/GeneratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/documentation/generator/GeneratorTest.java
@@ -101,6 +101,8 @@ public class GeneratorTest {
         assertThat(jsonResult.read("$.apis[0].operations[0].nickname", String.class)).isEqualTo("sample");
 
         assertThat(jsonResult.read("$.models.GeneratorTest__SampleEntity.properties.type.type", String.class)).isEqualTo("string");
+        assertThat(jsonResult.read("$.models.GeneratorTest__SampleResponse.properties.foo.type", String.class)).isEqualTo("string");
+        assertThat(jsonResult.read("$.models.GeneratorTest__SampleResponse.properties.foo.required", String.class)).isEqualTo("false");
         assertThat(jsonResult.read("$.models.GeneratorTest__SampleResponse.properties.entity[\"$ref\"]", String.class)).isEqualTo("GeneratorTest__SampleEntity");
         assertThat(jsonResult.read("$.models.GeneratorTest__SampleResponse.properties.another_entity[\"$ref\"]", String.class)).isEqualTo("GeneratorTest__SampleEntity");
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing up handling of `Optional<T>` in swagger/OpenAPI specs by:

  - Adding JDK8 module to object mapper explicitly
  - Mark reference types returned from serializing `Optional` to JSON Schema as optional

/nocl No user-facing changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.