### PR TITLE
Refactor usage of brand color from theme, use danger color instead where suitable.

### DIFF
--- a/graylog2-web-interface/src/components/common/InputList/useInputListStyles.tsx
+++ b/graylog2-web-interface/src/components/common/InputList/useInputListStyles.tsx
@@ -58,7 +58,7 @@ const useInputListStyles = (size: 'small' | 'normal') => {
       ...(size === 'small' ? { minHeight: 29, height: 29 } : { minHeight: 34 }),
       borderRadius: INPUT_BORDER_RADIUS,
       alignItems: 'center',
-      borderColor: isValid ? provided.borderColor : inputListTheme.colors.brand.primary,
+      borderColor: isValid ? provided.borderColor : inputListTheme.colors.variant.danger,
     }),
     placeHolder: (provided: any) => ({
       ...provided,
@@ -79,7 +79,7 @@ const useInputListStyles = (size: 'small' | 'normal') => {
     }),
     multiValueLabel: (provided: any) => ({
       ...provided,
-      color: isValid ? provided.color : inputListTheme.colors.brand.primary,
+      color: isValid ? provided.color : inputListTheme.colors.variant.danger,
       padding: '2px 5px',
       fontSize: inputListTheme.fonts.size.small,
     }),

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -107,7 +107,7 @@ const Claim = styled.h1(
 );
 const Highlight = styled.span(
   ({ theme }) => css`
-    color: ${theme.colors.brand.primary};
+    color: ${theme.colors.variant.danger};
   `,
 );
 

--- a/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
+++ b/graylog2-web-interface/src/components/navigation/ThemeModeToggle.tsx
@@ -32,7 +32,7 @@ const ThemeModeToggleWrap = styled.div`
 const ModeIcon = styled(Icon)<{ $currentMode: boolean }>(
   ({ theme, $currentMode }) => css`
     opacity: ${$currentMode ? '1' : '0.5'};
-    color: ${$currentMode ? theme.colors.brand.primary : theme.colors.variant.darkest.default};
+    color: ${$currentMode ? theme.colors.variant.danger : theme.colors.variant.darkest.default};
   `,
 );
 

--- a/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/TeaserPageLayout.tsx
@@ -71,7 +71,7 @@ const Row = styled.div<{ $justify?: string; $fullWidth?: boolean }>`
 `;
 
 const StyledIcon = styled(Icon)`
-  color: ${({ theme }) => theme.colors.brand.primary};
+  color: ${({ theme }) => theme.colors.variant.danger};
 `;
 
 const LEFT_COLUMN_ITEM_LIST = [

--- a/graylog2-web-interface/src/preflight/navigation/ThemeModeToggle.tsx
+++ b/graylog2-web-interface/src/preflight/navigation/ThemeModeToggle.tsx
@@ -34,10 +34,11 @@ type ModeIconProps = {
   name: React.ComponentProps<typeof Icon>['name'];
   spin: boolean;
 };
+
 const ModeIcon: React.ComponentType<ModeIconProps> = styled(Icon)<{ $currentMode: boolean }>(
   ({ theme, $currentMode }) => css`
     opacity: ${$currentMode ? '1' : '0.5'};
-    color: ${$currentMode ? theme.colors.brand.primary : theme.colors.variant.darkest.default};
+    color: ${$currentMode ? theme.colors.variant.danger : theme.colors.variant.darkest.default};
   `,
 );
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.tsx
@@ -114,12 +114,12 @@ const StyledAceEditor = styled(AceEditor)<Props>(
       }
 
       .ace_invalid {
-        color: ${$scTheme.utils.readableColor($scTheme.colors.brand.primary)};
-        background-color: ${$scTheme.colors.brand.primary};
+        color: ${$scTheme.utils.readableColor($scTheme.colors.variant.danger)};
+        background-color: ${$scTheme.colors.variant.danger};
       }
 
       .ace_invalid.ace_deprecated {
-        color: ${$scTheme.utils.readableColor($scTheme.colors.brand.primary)};
+        color: ${$scTheme.utils.readableColor($scTheme.colors.variant.danger)};
         background-color: ${$scTheme.colors.variant.dark.primary};
       }
 
@@ -151,7 +151,7 @@ const StyledAceEditor = styled(AceEditor)<Props>(
       .ace_meta.ace_tag,
       .ace_string.ace_regexp,
       .ace_variable {
-        color: ${$scTheme.colors.brand.primary};
+        color: ${$scTheme.colors.variant.danger};
       }
 
       .ace_comment {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There are a few cases where we used the theme color `colors.brand.primary` instead of `colors.variant.danger`, to display a red color.

