### PR TITLE
Update primary buttons to use primary styling instead of success styling

### DIFF
--- a/graylog2-web-interface/src/components/authentication/AuthenticatorActionLinks.tsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticatorActionLinks.tsx
@@ -23,7 +23,7 @@ import { ButtonToolbar, Button } from 'components/bootstrap';
 const AuthenticatorActionLinks = () => (
   <ButtonToolbar>
     <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.AUTHENTICATORS.EDIT}>
-      <Button bsStyle="success" type="button">
+      <Button bsStyle="primary" type="button">
         Edit Authenticators
       </Button>
     </LinkContainer>

--- a/graylog2-web-interface/src/components/authentication/AuthenticatorsEdit/HTTPHeaderAuthConfigSection.tsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticatorsEdit/HTTPHeaderAuthConfigSection.tsx
@@ -105,7 +105,7 @@ const HTTPHeaderAuthConfigSection = () => {
             <Row className="no-bm">
               <Col xs={12}>
                 <div className="pull-right">
-                  <Button bsStyle="success" disabled={isSubmitting || !isValid} title="Update Config" type="submit">
+                  <Button bsStyle="primary" disabled={isSubmitting || !isValid} title="Update Config" type="submit">
                     Update Config
                   </Button>
                 </div>

--- a/graylog2-web-interface/src/components/authentication/BackendActionLinks.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendActionLinks.tsx
@@ -37,7 +37,7 @@ const BackendActionLinks = ({ activeBackend, finishedLoading }: Props) => (
       </Button>
     </LinkContainer>
     <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.BACKENDS.CREATE}>
-      <Button bsStyle="success" type="button">
+      <Button bsStyle="primary" type="button">
         Create service
       </Button>
     </LinkContainer>

--- a/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendCreate/ServiceSelect.tsx
@@ -108,7 +108,7 @@ const BackendCreateSelect = () => {
               </Field>
             </FormGroup>
             &nbsp;
-            <Button bsStyle="success" disabled={isSubmitting || !isValid} type="submit">
+            <Button bsStyle="primary" disabled={isSubmitting || !isValid} type="submit">
               Get started
             </Button>
           </ElementsContainer>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/EditLinkButton.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendConfigDetails/EditLinkButton.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 const EditLinkButton = ({ authenticationBackendId, stepKey }: Props) => (
   <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authenticationBackendId, stepKey)}>
-    <Button bsStyle="success" bsSize="small">
+    <Button bsStyle="primary" bsSize="small">
       Edit
     </Button>
   </LinkContainer>

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserSyncStep.tsx
@@ -224,7 +224,7 @@ const UserSyncStep = ({
               Finish & Save Identity Service
             </Button>
             <Button
-              bsStyle="success"
+              bsStyle="primary"
               disabled={isSubmitting}
               onClick={() => {
                 sendTelemetry(TELEMETRY_EVENT_TYPE.AUTHENTICATION.DIRECTORY_NEXT_GROUP_SYNC_CLICKED, {

--- a/graylog2-web-interface/src/components/common/KeyValueTable.tsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.tsx
@@ -194,7 +194,7 @@ class KeyValueTable extends React.Component<
           </StyledDiv>
         </td>
         <td>
-          <Button bsStyle="success" bsSize="small" onClick={this._addRow} disabled={addRowDisabled}>
+          <Button bsStyle="primary" bsSize="small" onClick={this._addRow} disabled={addRowDisabled}>
             Add
           </Button>
         </td>

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/EditorModal.tsx
@@ -144,7 +144,7 @@ function EditorModal({
             </Row>
             <Row style={{ justifyContent: 'flex-end', marginTop: '1rem' }}>
               <Button onClick={() => onClose()}>Cancel</Button>
-              <Button bsStyle="success" onClick={handleOnDone}>
+              <Button bsStyle="primary" onClick={handleOnDone}>
                 Done
               </Button>
             </Row>

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/PreviewModal.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/PreviewModal.tsx
@@ -95,7 +95,7 @@ function PreviewModal({ value, show, onClose }: Props) {
             </Row>
             <Preview value={value} height={height} show />
             <Row style={{ justifyContent: 'flex-end', marginTop: '1rem' }}>
-              <Button bsStyle="success" role="button" onClick={() => onClose()}>
+              <Button bsStyle="primary" role="button" onClick={() => onClose()}>
                 Close
               </Button>
             </Row>

--- a/graylog2-web-interface/src/components/common/ModalSubmit.tsx
+++ b/graylog2-web-interface/src/components/common/ModalSubmit.tsx
@@ -109,7 +109,7 @@ const ModalSubmit = ({ ...props }: Props) => {
       )}
       <Button
         ref={confirmRef}
-        bsStyle="success"
+        bsStyle="primary"
         bsSize={bsSize}
         disabled={disabledSubmit || submittingAsync}
         form={formId}

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
@@ -86,7 +86,7 @@ const ContentPackVersionItem = ({
       <td>{pack.rev}</td>
       <td className="text-right">
         <ButtonToolbar className="pull-right">
-          <Button bsStyle="success" bsSize="small" onClick={() => handleDownload()}>
+          <Button bsStyle="primary" bsSize="small" onClick={() => handleDownload()}>
             Download
           </Button>
           <DropdownButton id={`action-${pack.rev}`} title="Actions" bsSize="small">

--- a/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
+++ b/graylog2-web-interface/src/components/content-packs/components/ContentPackVersionItem.tsx
@@ -86,6 +86,7 @@ const ContentPackVersionItem = ({
       <td>{pack.rev}</td>
       <td className="text-right">
         <ButtonToolbar className="pull-right">
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <Button bsStyle="primary" bsSize="small" onClick={() => handleDownload()}>
             Download
           </Button>

--- a/graylog2-web-interface/src/components/datanode/client-certificate/ClientCertForm.tsx
+++ b/graylog2-web-interface/src/components/datanode/client-certificate/ClientCertForm.tsx
@@ -135,7 +135,7 @@ const ClientCertForm = ({ onCancel }: Props) => {
           </Modal.Body>
           <Modal.Footer>
             <ButtonToolbar>
-              <Button bsStyle="success" onClick={() => onCancel()}>
+              <Button bsStyle="primary" onClick={() => onCancel()}>
                 Close
               </Button>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.tsx
@@ -129,11 +129,11 @@ class AddNotificationForm extends React.Component<
     const { notifications } = this.props;
     const { displayNewNotificationForm, selectedNotification } = this.state;
     const doneButton = displayNewNotificationForm ? (
-      <Button bsStyle="success" type="submit" form="new-notification-form">
+      <Button bsStyle="primary" type="submit" form="new-notification-form">
         Add notification
       </Button>
     ) : (
-      <Button bsStyle="success" onClick={this.handleSubmit}>
+      <Button bsStyle="primary" onClick={this.handleSubmit}>
         Add notification
       </Button>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.tsx
@@ -179,7 +179,7 @@ const EventDetailsForm = ({ eventDefinition, eventDefinitionEventProcedure, vali
             <>
               <ControlLabel>Event Procedure Summary</ControlLabel>
               <p>This Event Definition does not have any Event Procedures yet.</p>
-              <Button bsStyle="success" onClick={() => setShowAddEventProcedureForm(true)}>
+              <Button bsStyle="primary" onClick={() => setShowAddEventProcedureForm(true)}>
                 Add Event Procedure
               </Button>
             </>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.tsx
@@ -314,7 +314,7 @@ class FieldForm extends React.Component<
 
         <Col md={12}>
           <ButtonToolbar>
-            <Button bsStyle="success" onClick={this.handleSubmit}>
+            <Button bsStyle="primary" onClick={this.handleSubmit}>
               Add custom field
             </Button>
             <Button onClick={this.handleCancel}>Cancel</Button>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
@@ -124,7 +124,7 @@ class FieldsList extends React.Component<
 
     const fieldNames = Object.keys(fields).sort(naturalSort);
     const addCustomFieldButton = (
-      <Button bsStyle="success" onClick={this.handleAddFieldClick}>
+      <Button bsStyle="primary" onClick={this.handleAddFieldClick}>
         Add custom field
       </Button>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
@@ -108,11 +108,11 @@ class FieldsList extends React.Component<
         <td className={styles.actions}>
           <ButtonToolbar>
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-            <Button bsStyle="primary" bsSize="xsmall" onClick={this.handleRemoveClick(fieldName)}>
+            <Button bsStyle="danger" bsSize="xsmall" onClick={this.handleRemoveClick(fieldName)}>
               Remove Field
             </Button>
             {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-            <Button bsStyle="info" bsSize="xsmall" onClick={this.handleEditClick(fieldName)}>
+            <Button bsStyle="primary" bsSize="xsmall" onClick={this.handleEditClick(fieldName)}>
               Edit
             </Button>
           </ButtonToolbar>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
@@ -107,9 +107,11 @@ class FieldsList extends React.Component<
         <td>{providerFormatter(config.providers[0])}</td>
         <td className={styles.actions}>
           <ButtonToolbar>
+            {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
             <Button bsStyle="primary" bsSize="xsmall" onClick={this.handleRemoveClick(fieldName)}>
               Remove Field
             </Button>
+            {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
             <Button bsStyle="info" bsSize="xsmall" onClick={this.handleEditClick(fieldName)}>
               Edit
             </Button>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.tsx
@@ -90,7 +90,7 @@ class NotificationList extends React.Component<
         },
     );
     const addNotificationButton = (
-      <Button bsStyle="success" onClick={onAddNotificationClick}>
+      <Button bsStyle="primary" onClick={onAddNotificationClick}>
         Add notification
       </Button>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.tsx
@@ -37,7 +37,7 @@ const EmptyContent = () => (
         </p>
         <IfPermitted permissions="eventdefinitions:create">
           <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-            <Button bsStyle="success">Get Started!</Button>
+            <Button bsStyle="primary">Get Started!</Button>
           </LinkContainer>
         </IfPermitted>
       </EmptyEntity>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.tsx
@@ -29,12 +29,12 @@ const EventNotificationActionLinks = ({ notificationId }: EventNotificationActio
   <ButtonToolbar>
     <IfPermitted permissions={`eventnotifications:read:${notificationId}`}>
       <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.show(notificationId)}>
-        <Button bsStyle="success">View Details</Button>
+        <Button>View Details</Button>
       </LinkContainer>
     </IfPermitted>
     <IfPermitted permissions={`eventnotifications:edit:${notificationId}`}>
       <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notificationId)}>
-        <Button bsStyle="success">Edit Notification</Button>
+        <Button bsStyle="primary">Edit Notification</Button>
       </LinkContainer>
     </IfPermitted>
   </ButtonToolbar>

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.tsx
@@ -50,7 +50,7 @@ const renderEmptyContent = () => (
         </p>
         <IfPermitted permissions="eventnotifications:create">
           <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-            <Button bsStyle="success">Get Started!</Button>
+            <Button bsStyle="primary">Get Started!</Button>
           </LinkContainer>
         </IfPermitted>
       </EmptyEntity>

--- a/graylog2-web-interface/src/components/extractors/AddExtractorWizard.tsx
+++ b/graylog2-web-interface/src/components/extractors/AddExtractorWizard.tsx
@@ -71,7 +71,7 @@ class AddExtractorWizard extends React.Component<
           </p>
           <p>
             <Button
-              bsStyle="success"
+              bsStyle="primary"
               bsSize="small"
               onClick={this._showAddExtractorForm}
               disabled={this.state.showExtractorForm}>

--- a/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
@@ -402,7 +402,7 @@ class EditExtractor extends React.Component<EditExtractorProps, EditExtractorSta
 
                   <Row>
                     <Col mdOffset={2} md={10}>
-                      <Button type="submit" bsStyle="success">
+                      <Button type="submit" bsStyle="primary">
                         {action === 'create' ? 'Create extractor' : 'Update extractor'}
                       </Button>
                     </Col>

--- a/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.tsx
@@ -56,8 +56,6 @@ class EditExtractor extends React.Component<EditExtractorProps, EditExtractorSta
     exampleMessage: undefined,
   };
 
-  private targetField: Input;
-
   constructor(props) {
     super(props);
 
@@ -75,6 +73,8 @@ class EditExtractor extends React.Component<EditExtractorProps, EditExtractorSta
       this._updateExampleMessage(nextProps.exampleMessage);
     }
   }
+
+  private targetField: Input;
 
   _updateExampleMessage = (nextExample) => {
     this.setState({ exampleMessage: nextExample });

--- a/graylog2-web-interface/src/components/extractors/ImportExtractors.tsx
+++ b/graylog2-web-interface/src/components/extractors/ImportExtractors.tsx
@@ -68,7 +68,7 @@ class ImportExtractors extends React.Component<
                   id="extractor-export-textarea"
                   rows={30}
                 />
-                <Button type="submit" bsStyle="success">
+                <Button type="submit" bsStyle="primary">
                   Add extractors to input
                 </Button>
               </form>

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.tsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.tsx
@@ -179,7 +179,7 @@ class EditPatternModal extends React.Component<
 
     return (
       <span>
-        <Button onClick={this.openModal} bsStyle={create ? 'success' : 'default'} bsSize={create ? undefined : 'xs'}>
+        <Button onClick={this.openModal} bsStyle={create ? 'primary' : 'default'} bsSize={create ? undefined : 'xs'}>
           {triggerButtonContent}
         </Button>
         <BootstrapModalForm

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfileButton.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfileButton.tsx
@@ -23,7 +23,7 @@ import { LinkContainer } from 'components/common/router';
 
 const CreateProfileButton = () => (
   <LinkContainer to={Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.CREATE}>
-    <Button bsStyle="success">Create profile</Button>
+    <Button bsStyle="primary">Create profile</Button>
   </LinkContainer>
 );
 

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/ChangeFieldTypeButton.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypes/ChangeFieldTypeButton.tsx
@@ -31,7 +31,7 @@ const ChangeFieldTypeButton = ({ indexSetId }: Props) => {
 
   return (
     <>
-      <Button bsStyle="success" onClick={toggleModal}>
+      <Button bsStyle="primary" onClick={toggleModal}>
         Change field type
       </Button>
       {showModal && (

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateIndexSetTemplateButton.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateIndexSetTemplateButton.tsx
@@ -42,7 +42,7 @@ const CreateIndexSetTemplateButton = () => {
   };
 
   return (
-    <Button bsStyle="success" onClick={handleClick}>
+    <Button bsStyle="primary" onClick={handleClick}>
       Create template
     </Button>
   );

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.tsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.tsx
@@ -137,7 +137,7 @@ const CreateInputControl = () => {
             />
           </FormGroup>
           &nbsp;
-          <Button bsStyle="success" type="submit" disabled={!selectedInput}>
+          <Button bsStyle="primary" type="submit" disabled={!selectedInput}>
             Launch new input
           </Button>
         </StyledForm>

--- a/graylog2-web-interface/src/components/inputs/InputStateControl.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateControl.tsx
@@ -87,7 +87,7 @@ const InputStateControl = ({ input, openWizard }: Props) => {
 
   if (isInputRunning(inputStates, input.id)) {
     return (
-      <Button bsStyle="primary" onClick={stopInput} disabled={isLoading}>
+      <Button bsStyle="danger" onClick={stopInput} disabled={isLoading}>
         {isLoading ? 'Stopping...' : 'Stop input'}
       </Button>
     );

--- a/graylog2-web-interface/src/components/inputs/InputStateControl.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateControl.tsx
@@ -94,7 +94,7 @@ const InputStateControl = ({ input, openWizard }: Props) => {
   }
 
   return (
-    <Button bsStyle="success" onClick={startInput} disabled={isLoading}>
+    <Button bsStyle="primary" onClick={startInput} disabled={isLoading}>
       {isLoading ? 'Starting...' : 'Start input'}
     </Button>
   );

--- a/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.tsx
+++ b/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.tsx
@@ -77,7 +77,7 @@ const ClusterSupportBundleOverview = () => {
         <Col xs={12}>
           <Header>
             <h2>Cluster Support Bundle</h2>
-            <Button bsStyle="success" onClick={onCreate} disabled={isCreating}>
+            <Button bsStyle="primary" onClick={onCreate} disabled={isCreating}>
               Create Support Bundle
               {isCreating && <LoadingSpinner text="" delay={0} />}
             </Button>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
@@ -103,7 +103,7 @@ const DataAdapter = ({ dataAdapter }: Props) => {
               help="Key to look up a value for."
               value={lookupKey}
             />
-            <Button type="submit" bsStyle="success">
+            <Button type="submit" bsStyle="primary">
               Look up
             </Button>
           </fieldset>

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableView.tsx
@@ -126,7 +126,7 @@ const LookupTableView = ({ table, cache, dataAdapter }: Props) => {
         <h2>Description</h2>
         <Description>{table.description}</Description>
         {!loadingScopePermissions && scopePermissions?.is_mutable && (
-          <Button bsStyle="success" onClick={handleEdit(table.name)} role="button" name="edit_square">
+          <Button bsStyle="primary" onClick={handleEdit(table.name)} role="button" name="edit_square">
             Edit
           </Button>
         )}

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.tsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.tsx
@@ -156,7 +156,7 @@ const NodeOverview = ({
           <HideOnCloud>
             <span className="pull-right">
               <LinkContainer to={Routes.node_inputs(node.node_id)}>
-                <Button bsStyle="success" bsSize="small">
+                <Button bsStyle="primary" bsSize="small">
                   Manage inputs
                 </Button>
               </LinkContainer>

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
@@ -36,7 +36,7 @@ const Title = ({ count }: { count: number }) =>
 
 const Notifications = ({ count, notifications }: { count: number; notifications: Array<NotificationType> }) =>
   count === 0 ? (
-    <Alert bsStyle="primary" className="notifications-none">
+    <Alert bsStyle="success" className="notifications-none">
       No notifications
     </Alert>
   ) : (

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
@@ -36,7 +36,7 @@ const Title = ({ count }: { count: number }) =>
 
 const Notifications = ({ count, notifications }: { count: number; notifications: Array<NotificationType> }) =>
   count === 0 ? (
-    <Alert bsStyle="success" className="notifications-none">
+    <Alert bsStyle="primary" className="notifications-none">
       No notifications
     </Alert>
   ) : (

--- a/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.tsx
+++ b/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.tsx
@@ -69,7 +69,7 @@ class AssignOutputDropdown extends React.Component<Props, { selectedOutput: stri
           &nbsp;
           <Button
             id="add-existing-output"
-            bsStyle="success"
+            bsStyle="primary"
             type="button"
             disabled={selectedOutput === this.PLACEHOLDER}
             onClick={this._handleClick}>

--- a/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.tsx
+++ b/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.tsx
@@ -24,6 +24,7 @@ type Props = {
 };
 
 class AssignOutputDropdown extends React.Component<Props, { selectedOutput: string }> {
+  // eslint-disable-next-line
   PLACEHOLDER = 'placeholder';
 
   constructor(props: Props) {

--- a/graylog2-web-interface/src/components/outputs/CreateOutputDropdown.tsx
+++ b/graylog2-web-interface/src/components/outputs/CreateOutputDropdown.tsx
@@ -77,7 +77,7 @@ const CreateOutputDropdown = ({ types, getTypeDefinition, onSubmit }: CreateOutp
           {outputTypes}
         </select>
         &nbsp;
-        <Button bsStyle="success" disabled={typeName === PLACEHOLDER} onClick={_openModal}>
+        <Button bsStyle="primary" disabled={typeName === PLACEHOLDER} onClick={_openModal}>
           Launch new output
         </Button>
       </div>

--- a/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.tsx
@@ -171,7 +171,7 @@ const EntityCreateShareFormGroup = ({
                 value={shareSelection.capabilityId}
               />
               <ShareSubmitButton
-                bsStyle="success"
+                bsStyle="primary"
                 title="Add Collaborator"
                 onClick={handleAddCollaborator}
                 disabled={disableSubmit || !shareSelection.granteeId}>

--- a/graylog2-web-interface/src/components/permissions/Grantee/GranteesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/Grantee/GranteesSelector.tsx
@@ -104,7 +104,7 @@ const GranteesSelector = ({
                 availableCapabilities={availableCapabilities}
               />
               <SubmitButton
-                bsStyle="success"
+                bsStyle="primary"
                 disabled={isSubmitting || !isValid}
                 title="Add Collaborator"
                 type="submit">

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.tsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.tsx
@@ -141,7 +141,7 @@ const RolesSelector = ({
         />
         {!submitOnSelect && (
           <SubmitButton
-            bsStyle="success"
+            bsStyle="primary"
             onClick={_onSubmit}
             disabled={isSubmitting || !selectedRoleNames}
             title="Assign Role"

--- a/graylog2-web-interface/src/components/pipelines/CreatePipelineButton.tsx
+++ b/graylog2-web-interface/src/components/pipelines/CreatePipelineButton.tsx
@@ -28,7 +28,7 @@ const CreatePipelineButton = () => {
   return (
     <div className="pull-right">
       <LinkContainer to={Routes.SYSTEM.PIPELINES.PIPELINE('new')}>
-        <Button disabled={!isPermitted(currentUser.permissions, 'pipeline:create')} bsStyle="success">
+        <Button disabled={!isPermitted(currentUser.permissions, 'pipeline:create')} bsStyle="primary">
           Add new pipeline
         </Button>
       </LinkContainer>

--- a/graylog2-web-interface/src/components/pipelines/PipelineForm.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineForm.tsx
@@ -108,7 +108,7 @@ const PipelineForm = ({
         <Button
           disabled={!isPermitted(currentUser.permissions, 'pipeline:edit') || disableEdit}
           onClick={_openModal}
-          bsStyle="success">
+          bsStyle="primary">
           {create ? 'Add new pipeline' : 'Edit pipeline details'}
         </Button>
         <BootstrapModalForm

--- a/graylog2-web-interface/src/components/pipelines/PipelineForm.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineForm.tsx
@@ -83,7 +83,6 @@ const PipelineForm = ({
         id="title"
         name="title"
         label="Title"
-        autoFocus
         required
         onChange={_onChange}
         help="Pipeline name."

--- a/graylog2-web-interface/src/components/pipelines/StageForm.tsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.tsx
@@ -114,7 +114,7 @@ const StageForm = ({
       <Button
         disabled={!isPermitted(currentUser.permissions, 'pipeline:edit') || disableEdit}
         onClick={openModal}
-        bsStyle={create ? 'success' : 'info'}>
+        bsStyle={create ? 'primary' : 'info'}>
         {create ? 'Add new stage' : 'Edit'}
       </Button>
       <BootstrapModalForm

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.tsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.tsx
@@ -149,7 +149,7 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
                   />
                 )}
               </Field>
-              <SubmitButton bsStyle="success" disabled={isSubmitting || !isValid} title="Assign User" type="submit">
+              <SubmitButton bsStyle="primary" disabled={isSubmitting || !isValid} title="Assign User" type="submit">
                 Assign User
               </SubmitButton>
             </FormElements>

--- a/graylog2-web-interface/src/components/roles/navigation/RoleActionLinks.tsx
+++ b/graylog2-web-interface/src/components/roles/navigation/RoleActionLinks.tsx
@@ -28,10 +28,10 @@ type Props = {
 const RoleActionLinks = ({ roleId }: Props) => (
   <ButtonToolbar>
     <LinkContainer to={Routes.SYSTEM.AUTHZROLES.show(roleId)}>
-      <Button bsStyle="success">View Details</Button>
+      <Button>View Details</Button>
     </LinkContainer>
     <LinkContainer to={Routes.SYSTEM.AUTHZROLES.edit(roleId)}>
-      <Button bsStyle="success">Edit Role</Button>
+      <Button bsStyle="primary">Edit Role</Button>
     </LinkContainer>
   </ButtonToolbar>
 );

--- a/graylog2-web-interface/src/components/rules/Rule.tsx
+++ b/graylog2-web-interface/src/components/rules/Rule.tsx
@@ -73,7 +73,7 @@ const Rule = ({ create = false, title = '', isRuleBuilder = false }: Props) => {
         actions={
           isRuleBuilder && create ? (
             <Button
-              bsStyle="success"
+              bsStyle="primary"
               bsSize="small"
               onClick={() => {
                 sendTelemetry(TELEMETRY_EVENT_TYPE.PIPELINE_RULE_BUILDER.USE_SOURCE_CODE_EDITOR_CLICKED, {

--- a/graylog2-web-interface/src/components/rules/rule-builder/ConvertToSourceCodeModal.tsx
+++ b/graylog2-web-interface/src/components/rules/rule-builder/ConvertToSourceCodeModal.tsx
@@ -65,7 +65,7 @@ const ConvertToSourceCodeModal = ({ show, onHide, onNavigateAway, rule }: Props)
         <ModalButtonToolbar>
           <Button
             type="button"
-            bsStyle="success"
+            bsStyle="primary"
             onClick={async () => {
               sendTelemetry(TELEMETRY_EVENT_TYPE.PIPELINE_RULE_BUILDER.CREATE_NEW_RULE_FROM_CODE_CLICKED, {
                 app_pathname: getPathnameWithoutId(pathname),

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
@@ -67,7 +67,7 @@ class CollectorList extends React.Component<CollectorListProps> {
           <Col md={12}>
             <div className="pull-right">
               <LinkContainer to={Routes.SYSTEM.SIDECARS.NEW_COLLECTOR}>
-                <Button bsStyle="success" bsSize="small">
+                <Button bsStyle="primary" bsSize="small">
                   Create Log Collector
                 </Button>
               </LinkContainer>

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.tsx
@@ -72,7 +72,7 @@ class ConfigurationList extends React.Component<Props> {
           <Col md={12}>
             <div className="pull-right">
               <LinkContainer to={Routes.SYSTEM.SIDECARS.NEW_CONFIGURATION}>
-                <Button onClick={this.openModal} bsStyle="success" bsSize="small">
+                <Button onClick={this.openModal} bsStyle="primary" bsSize="small">
                   Create Configuration
                 </Button>
               </LinkContainer>

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.tsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.tsx
@@ -115,7 +115,7 @@ const StreamRulesEditor = ({ streamId, messageId = '', index = '' }: Props) => {
         <hr />
 
         <div className="buttons pull-right">
-          <Button bsStyle="success" className="show-stream-rule" onClick={_onAddStreamRule}>
+          <Button bsStyle="primary" className="show-stream-rule" onClick={_onAddStreamRule}>
             Add stream rule
           </Button>
           {showStreamRuleForm && (
@@ -158,7 +158,7 @@ const StreamRulesEditor = ({ streamId, messageId = '', index = '' }: Props) => {
 
         <p>
           <LinkContainer to={Routes.STREAMS}>
-            <Button bsStyle="success">I&apos;m done!</Button>
+            <Button bsStyle="primary">I&apos;m done!</Button>
           </LinkContainer>
         </p>
       </Col>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDataRoutingIntake.tsx
@@ -61,7 +61,7 @@ const StreamDataRoutingInstake = ({ stream }: Props) => {
         actions={
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <CreateStreamRuleButton
-              bsStyle="success"
+              bsStyle="primary"
               disabled={isDefaultStream || isNotEditable}
               streamId={stream.id}
             />

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.tsx
@@ -141,7 +141,7 @@ const PasswordSection = ({ user: { id } }: Props) => {
             <Row className="no-bm">
               <Col xs={12}>
                 <div className="pull-right">
-                  <Button bsStyle="success" disabled={isSubmitting || !isValid} title="Change Password" type="submit">
+                  <Button bsStyle="primary" disabled={isSubmitting || !isValid} title="Change Password" type="submit">
                     Change Password
                   </Button>
                 </div>

--- a/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PreferencesSection.tsx
@@ -101,7 +101,7 @@ const PreferencesSection = ({ user }: Props) => {
               <Col xs={12}>
                 <div className="pull-right">
                   <Button
-                    bsStyle="success"
+                    bsStyle="primary"
                     disabled={isSubmitting || !isValid}
                     title="Update Preferences"
                     type="submit">

--- a/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/ProfileSection.tsx
@@ -81,7 +81,7 @@ const ProfileSection = ({ user, onSubmit }: Props) => {
             <Row className="no-bm">
               <Col xs={12}>
                 <div className="pull-right">
-                  <Button bsStyle="success" disabled={isSubmitting || !isValid} title="Update Profile" type="submit">
+                  <Button bsStyle="primary" disabled={isSubmitting || !isValid} title="Update Profile" type="submit">
                     Update Profile
                   </Button>
                 </div>

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.tsx
@@ -105,7 +105,7 @@ const SettingsSection = ({
             <Row className="no-bm">
               <Col xs={12}>
                 <div className="pull-right">
-                  <Button bsStyle="success" disabled={isSubmitting || !isValid} title="Update Settings" type="submit">
+                  <Button bsStyle="primary" disabled={isSubmitting || !isValid} title="Update Settings" type="submit">
                     Update Settings
                   </Button>
                 </div>

--- a/graylog2-web-interface/src/components/users/navigation/UserActionLinks.tsx
+++ b/graylog2-web-interface/src/components/users/navigation/UserActionLinks.tsx
@@ -32,19 +32,19 @@ const UserActionLinks = ({ userId, userIsReadOnly, username }: Props) => (
   <ButtonToolbar>
     <IfPermitted permissions={`users:edit:${username}`}>
       <LinkContainer to={Routes.SYSTEM.USERS.show(userId)}>
-        <Button bsStyle="success">View Details</Button>
+        <Button>View Details</Button>
       </LinkContainer>
     </IfPermitted>
     {!userIsReadOnly && (
       <IfPermitted permissions={`users:edit:${username}`}>
         <LinkContainer to={Routes.SYSTEM.USERS.edit(userId)}>
-          <Button bsStyle="success">Edit User</Button>
+          <Button bsStyle="primary">Edit User</Button>
         </LinkContainer>
       </IfPermitted>
     )}
     <IfPermitted permissions={[`users:tokenlist:${username}`]}>
       <LinkContainer to={Routes.SYSTEM.USERS.TOKENS.edit(userId)}>
-        <Button bsStyle="success">Edit Tokens</Button>
+        <Button bsStyle="primary">Edit Tokens</Button>
       </LinkContainer>
     </IfPermitted>
   </ButtonToolbar>

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/StepHealthCheck.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/StepHealthCheck.tsx
@@ -130,7 +130,7 @@ const StepHealthCheck = ({ onChange, onSubmit }: StepHealthCheckProps) => {
             Checking again in: <Countdown timeInSeconds={120} callback={checkForLogs} paused={pauseCountdown} />
           </strong>
 
-          <Button type="button" bsStyle="success" bsSize="sm" onClick={checkForLogs} disabled={logDataProgress.loading}>
+          <Button type="button" bsStyle="primary" bsSize="sm" onClick={checkForLogs} disabled={logDataProgress.loading}>
             {logDataProgress.loading ? 'Checking...' : 'Check Now'}
           </Button>
         </CheckAgain>

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/setup-steps/SetupModal.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/kinesis/setup-steps/SetupModal.tsx
@@ -78,7 +78,7 @@ const SetupModal = ({ onSubmit, onCancel, groupName, streamName }: SetupModalPro
 
       <Modal.Footer>
         {agreed ? (
-          <Button bsStyle="success" onClick={success ? onSubmit : onCancel} type="button" disabled={!error && !success}>
+          <Button bsStyle="primary" onClick={success ? onSubmit : onCancel} type="button" disabled={!error && !success}>
             {buttonText}
           </Button>
         ) : (

--- a/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetrySettingsConfig.tsx
@@ -81,7 +81,7 @@ const TelemetrySettingsConfigComponent = () => {
               <Col xs={12}>
                 <div className="pull-right">
                   <Button
-                    bsStyle="success"
+                    bsStyle="primary"
                     disabled={isSubmitting || !isValid}
                     title="Update Preferences"
                     type="submit">

--- a/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.tsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.tsx
@@ -69,7 +69,7 @@ const AuthenticationBackendDetailsPage = ({ params: { backendId } }: Props) => {
         title={_pageTitle(authBackend.title)}
         actions={
           <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authBackend?.id)}>
-            <Button bsStyle="success" type="button">
+            <Button bsStyle="primary" type="button">
               Edit Service
             </Button>
           </LinkContainer>

--- a/graylog2-web-interface/src/pages/ContentPacksPage.tsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.tsx
@@ -99,7 +99,7 @@ const ContentPacksPage = () => {
             <ButtonToolbar>
               <ContentPackUploadControls />
               <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.CREATE}>
-                <Button bsStyle="success">Create a content pack</Button>
+                <Button bsStyle="primary">Create a content pack</Button>
               </LinkContainer>
             </ButtonToolbar>
           }>

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.tsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.tsx
@@ -41,7 +41,7 @@ const EventDefinitionsPage = () => {
           <IfPermitted permissions="eventdefinitions:create">
             <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
               <Button
-                bsStyle="success"
+                bsStyle="primary"
                 onClick={() => {
                   sendTelemetry(TELEMETRY_EVENT_TYPE.EVENTDEFINITION_CREATE_BUTTON_CLICKED, {
                     app_pathname: getPathnameWithoutId(pathname),

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.tsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.tsx
@@ -33,7 +33,7 @@ const EventNotificationsPage = () => (
       actions={
         <IfPermitted permissions="eventnotifications:create">
           <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-            <Button bsStyle="success">Create notification</Button>
+            <Button bsStyle="primary">Create notification</Button>
           </LinkContainer>
         </IfPermitted>
       }

--- a/graylog2-web-interface/src/pages/IndexSetTemplatePage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetTemplatePage.tsx
@@ -42,7 +42,7 @@ const IndexSetTemplatePage = () => {
             {!isFetching && !data.built_in && (
               <IfPermitted permissions="indexset_templates:edit">
                 <LinkContainer to={Routes.SYSTEM.INDICES.TEMPLATES.edit(templateId)}>
-                  <Button bsStyle="success">Edit</Button>
+                  <Button bsStyle="primary">Edit</Button>
                 </LinkContainer>
               </IfPermitted>
             )}

--- a/graylog2-web-interface/src/pages/IndicesPage.tsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.tsx
@@ -35,7 +35,7 @@ const IndicesPage = () => (
         <ButtonToolbar>
           <IfPermitted permissions="indexsets:create">
             <LinkContainer to={Routes.SYSTEM.INDEX_SETS.CREATE}>
-              <Button bsStyle="success">Create index set</Button>
+              <Button bsStyle="primary">Create index set</Button>
             </LinkContainer>
           </IfPermitted>
           <IfPermitted permissions="indexranges:rebuild">

--- a/graylog2-web-interface/src/pages/RulesPage.tsx
+++ b/graylog2-web-interface/src/pages/RulesPage.tsx
@@ -118,7 +118,7 @@ const RulesPage = () => {
   const RulesButtonToolbar = () => (
     <ButtonToolbar className="pull-right">
       <Button
-        bsStyle="success"
+        bsStyle="primary"
         onClick={() => {
           sendTelemetry(TELEMETRY_EVENT_TYPE.PIPELINE_RULE_BUILDER.CREATE_RULE_CLICKED, {
             app_pathname: getPathnameWithoutId(pathname),

--- a/graylog2-web-interface/src/pages/StreamsPage.tsx
+++ b/graylog2-web-interface/src/pages/StreamsPage.tsx
@@ -72,7 +72,7 @@ const StreamsPage = () => {
         }}
         actions={
           <IfPermitted permissions="streams:create">
-            <CreateStreamButton bsStyle="success" onCreate={onSave} indexSets={indexSets} />
+            <CreateStreamButton bsStyle="primary" onCreate={onSave} indexSets={indexSets} />
           </IfPermitted>
         }>
         <span>

--- a/graylog2-web-interface/src/pages/UserCreatePage.tsx
+++ b/graylog2-web-interface/src/pages/UserCreatePage.tsx
@@ -31,7 +31,7 @@ const UserCreatePage = () => (
       title="Create New User"
       actions={
         <LinkContainer to={Routes.SYSTEM.USERS.CREATE}>
-          <Button bsStyle="success">Create user</Button>
+          <Button bsStyle="primary">Create user</Button>
         </LinkContainer>
       }
       documentationLink={{

--- a/graylog2-web-interface/src/pages/UsersOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/UsersOverviewPage.tsx
@@ -32,7 +32,7 @@ const UsersOverviewPage = () => (
       actions={
         <IfPermitted permissions="users:create">
           <LinkContainer to={Routes.SYSTEM.USERS.CREATE}>
-            <Button bsStyle="success">Create user</Button>
+            <Button bsStyle="primary">Create user</Button>
           </LinkContainer>
         </IfPermitted>
       }

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
@@ -133,13 +133,13 @@ const ViewEventDefinitionPage = () => {
           actions={
             <ButtonToolbar>
               <IfPermitted permissions={`eventdefinitions:edit:${params.definitionId}`}>
-                <Button bsStyle="success" onClick={onEditEventDefinition}>
+                <Button bsStyle="primary" onClick={onEditEventDefinition}>
                   Edit Event Definition
                 </Button>
               </IfPermitted>
               {!isSystemEventDefinition(eventDefinition) && (
                 <IfPermitted permissions="eventdefinitions:create">
-                  <Button onClick={() => setShowDialog(true)} bsStyle="success">
+                  <Button onClick={() => setShowDialog(true)}>
                     Duplicate Event Definition
                   </Button>
                 </IfPermitted>

--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -173,7 +173,7 @@ const FieldUnitPopover = ({ field, predefinedUnit }: { field: string; predefined
             <Button bsSize="xs" onClick={onClear}>
               Clear
             </Button>
-            <Button bsSize="xs" bsStyle="success" onClick={toggleShow}>
+            <Button bsSize="xs" bsStyle="primary" onClick={toggleShow}>
               OK
             </Button>
           </ModalButtonToolbar>

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.tsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.tsx
@@ -48,7 +48,7 @@ const InlineForm = (submitTitle: string = 'Create'): React.ComponentType<Props> 
     return (
       <form onSubmit={onSubmit} ref={ref}>
         {children}
-        <Button type="submit" bsStyle="success" disabled={disabled}>
+        <Button type="submit" bsStyle="primary" disabled={disabled}>
           {submitTitle}
         </Button>{' '}
         <Button type="button" disabled={disabled} onClick={onCancel}>

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -107,7 +107,7 @@ const SearchButton = ({
       title={title}
       className={className}
       type="submit"
-      bsStyle="success"
+      bsStyle="primary"
       $dirty={dirty && !displaySpinner}>
       {displaySpinner ? <Spinner delay={0} text="" /> : <Icon name={glyph} size="lg" />}
     </StyledButton>

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.tsx
@@ -64,7 +64,7 @@ type Props = {
 
 const onButtonClick = (
   e: MouseEvent,
-  disabled: Boolean,
+  disabled: boolean,
   triggerTelemetry: () => void,
   onClick?: (e: MouseEvent) => void,
 ) => {

--- a/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
+++ b/graylog2-web-interface/src/views/components/views/MissingRequirements.tsx
@@ -55,7 +55,7 @@ const MissingRequirements = ({ view, missingRequirements }: Props) => {
       </Col>
 
       <Col md={1} mdOffset={8}>
-        <Button bsStyle="success" onClick={() => history.goBack()}>
+        <Button bsStyle="primary" onClick={() => history.goBack()}>
           Back
         </Button>
       </Col>

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
@@ -36,7 +36,7 @@ const DashboardsPage = () => {
           <IfPermitted permissions="dashboards:create">
             <LinkContainer to={Routes.pluginRoute('DASHBOARDS_NEW')}>
               <Button
-                bsStyle="success"
+                bsStyle="primary"
                 onClick={() => {
                   sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_CLICKED, {
                     app_pathname: 'dashboard',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As part of https://github.com/Graylog2/glc-bd-documents/issues/39, replaces all uses of bsStyle="success" with bsStyle="primary"

/nocl styling update

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

