### PR TITLE
Use default submit button variant for login button.

### DIFF
--- a/graylog2-web-interface/src/components/login/LoginForm.tsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { css } from 'styled-components';
 
 import { ModalSubmit } from 'components/common';
 import { Input } from 'components/bootstrap';
@@ -24,20 +23,6 @@ import useLogin from 'components/login/useLogin';
 type Props = {
   onErrorChange: (message?: string) => void;
 };
-
-const SigninButton = styled(ModalSubmit)(
-  ({ theme }) => css`
-    button.mantine-Button-root {
-      background-color: ${theme.colors.brand.primary};
-      border-color: ${theme.colors.brand.primary};
-
-      &:hover {
-        background-color: ${theme.colors.brand.primary};
-        border-color: ${theme.colors.brand.primary};
-      }
-    }
-  `,
-);
 
 const LoginForm = ({ onErrorChange }: Props) => {
   const { login, isLoading } = useLogin(onErrorChange);
@@ -59,7 +44,7 @@ const LoginForm = ({ onErrorChange }: Props) => {
 
       <Input id="password" type="password" label="Password" autoComplete="current-password" required />
 
-      <SigninButton
+      <ModalSubmit
         displayCancel={false}
         isSubmitting={isLoading}
         isAsyncSubmit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR changes the login button variant to the default variant used for submit buttons.

<img width="443" height="378" alt="image" src="https://github.com/user-attachments/assets/7d731f66-210b-4dde-9ff3-1cc633d2f528" />

Related to https://github.com/Graylog2/graylog2-server/pull/23826
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/12095 - which is about getting rid of the old red brand color for the login button.
/nocl