### PR TITLE
Allow configuring help link when server is unavailable. (`6.3`)

### DIFF
--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.tsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.tsx
@@ -26,6 +26,7 @@ import { qualifyUrl } from 'util/URLUtils';
 import LoginChrome from 'components/login/LoginChrome';
 import useProductName from 'brand-customization/useProductName';
 import type { ServerError } from 'stores/sessions/ServerAvailabilityStore';
+import DocsHelper from 'util/DocsHelper';
 
 const StyledIcon = styled(Icon)`
   margin-left: 6px;
@@ -126,7 +127,7 @@ const ServerUnavailablePage = ({ server = undefined }: Props) => {
               <p>You will be automatically redirected to the previous page once we can connect to the server.</p>
               <p>
                 Do you need a hand?{' '}
-                <a href="https://www.graylog.org/community-support" rel="noopener noreferrer" target="_blank">
+                <a href={DocsHelper.PAGES.SERVER_UNAVAILABLE} rel="noopener noreferrer" target="_blank">
                   We can help you
                 </a>
                 .

--- a/graylog2-web-interface/src/util/DocsHelper.ts
+++ b/graylog2-web-interface/src/util/DocsHelper.ts
@@ -71,6 +71,7 @@ const defaultPages = {
     WELCOME: '', // Welcome page to the documentation
     DATA_TIERING: 'setting_up_graylog/data_tiering.htm',
     DATA_TIERING_WARM_TIER_SETUP: 'setting_up_graylog/data_tiering.htm#PrepareYourEnvironmentforaWarmTier',
+    SERVER_UNAVAILABLE: 'https://www.graylog.org/community-support',
 } as const;
 
 type Pages = Record<keyof typeof defaultPages, string>;


### PR DESCRIPTION
**Note:** This is a backport of #23869 to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR makes use of the `DocsHelper` in the `ServerUnavailablePage` so the link the page is pointing too can be configured.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.