### PR TITLE
Timestamp field gets special handling in aggregations in Scripting API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/AggregationSpecToPivotMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/AggregationSpecToPivotMapper.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.rest.scriptingapi.mapping;
 
+import jakarta.inject.Inject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.AggregationRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
@@ -25,9 +26,6 @@ import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSort;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 
-import jakarta.inject.Inject;
-
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -51,7 +49,7 @@ public class AggregationSpecToPivotMapper implements Function<AggregationRequest
     public Pivot apply(final AggregationRequestSpec aggregationSpec) {
         final List<BucketSpec> groups = aggregationSpec.groupings()
                 .stream()
-                .map(rowGroupCreator)
+                .map(gr -> rowGroupCreator.apply(gr, aggregationSpec.timerange()))
                 .collect(Collectors.toList());
 
         final List<ImmutablePair<Metric, SeriesSpec>> series = aggregationSpec.metrics()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/GroupingToBucketSpecMapper.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/GroupingToBucketSpecMapper.java
@@ -18,18 +18,51 @@ package org.graylog.plugins.views.search.rest.scriptingapi.mapping;
 
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Grouping;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.DateRange;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.DateRangeBucket;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
 
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
 
-public class GroupingToBucketSpecMapper implements Function<Grouping, BucketSpec> {
+public class GroupingToBucketSpecMapper implements BiFunction<Grouping, TimeRange, BucketSpec> {
 
     @Override
-    public BucketSpec apply(final Grouping grouping) {
-        return Values.builder()
-                .field(grouping.requestedField().name())
-                .type(Values.NAME)
-                .limit(grouping.limit())
-                .build();
+    public BucketSpec apply(final Grouping grouping,
+                            final TimeRange timerange) {
+        if (timerange != null && Message.FIELD_TIMESTAMP.equals(grouping.requestedField().name())) {
+            return DateRangeBucket.builder()
+                    .field(Message.FIELD_TIMESTAMP)
+                    .type(DateRangeBucket.NAME)
+                    .ranges(buildEqualDateRangeBuckets(timerange, grouping.limit()))
+                    .build();
+        } else {
+            return Values.builder()
+                    .field(grouping.requestedField().name())
+                    .type(Values.NAME)
+                    .limit(grouping.limit())
+                    .build();
+        }
+    }
+
+    private List<DateRange> buildEqualDateRangeBuckets(final TimeRange timeRange,
+                                                       final int numBuckets) {
+        final List<DateRange> ranges = new ArrayList<>(numBuckets);
+        DateTime from = timeRange.getFrom();
+        DateTime to = timeRange.getTo();
+        final long bucketRangeInSeconds = new Duration(from, to).getStandardSeconds() / numBuckets;
+
+        for (int i = 0; i < numBuckets; i++) {
+            ranges.add(DateRange.builder()
+                    .from(from.plusSeconds((int) (i * bucketRangeInSeconds)))
+                    .to(to.plusSeconds((int) ((i + 1) * bucketRangeInSeconds)))
+                    .build());
+        }
+        return ranges;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/GroupingToBucketSpecMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/scriptingapi/mapping/GroupingToBucketSpecMapperTest.java
@@ -39,13 +39,13 @@ class GroupingToBucketSpecMapperTest {
 
     @Test
     void throwsNullPointerExceptionOnNullGrouping() {
-        assertThrows(NullPointerException.class, () -> toTest.apply(null));
+        assertThrows(NullPointerException.class, () -> toTest.apply(null, null));
     }
 
     @Test
     void buildsBucketSpecCorrectly() {
         Grouping grouping = new Grouping("source", 3);
-        final BucketSpec bucketSpec = toTest.apply(grouping);
+        final BucketSpec bucketSpec = toTest.apply(grouping, null);
 
         assertThat(bucketSpec)
                 .isNotNull()
@@ -58,7 +58,7 @@ class GroupingToBucketSpecMapperTest {
     @Test
     void usesDefaultLimitIfWrongLimitProvided() {
         Grouping grouping = new Grouping("source", -42);
-        final BucketSpec bucketSpec = toTest.apply(grouping);
+        final BucketSpec bucketSpec = toTest.apply(grouping, null);
 
         assertThat(bucketSpec)
                 .isNotNull()


### PR DESCRIPTION
## Description
Timestamp field gets special handling in aggregations in Scripting API.
/nocl

## Motivation and Context
When timestamp field is used in aggregations, we want to aggregate in ranges.
Limit field from grouping changes its function - it defines number of equal ranges the `timerange` will be split into for bucketing.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
<img width="687" height="694" alt="image" src="https://github.com/user-attachments/assets/ccb495d5-2720-40dd-b68e-45a5b41b08c6" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

