### PR TITLE
Improving Telemetry for Widget Creation

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/create/AddWidgetButton.tsx
@@ -97,15 +97,23 @@ const CreateMenuItem = ({
   const { setWidgetEditing } = useContext(WidgetFocusContext);
 
   const createHandlerFor = () => {
-    if (isCreatorFunc(creator)) {
-      return () => {
-        sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_CREATE[upperCase(creator.title).replace(/ /g, '_')], {
+    const telemetry = () =>
+      sendTelemetry(
+        TELEMETRY_EVENT_TYPE.SEARCH_WIDGET_CREATE[upperCase(creator.title).replace(/ /g, '_')] ??
+          `Search Widget ${creator.title} Created`,
+        {
           app_pathname: getPathnameWithoutId(location.pathname),
           app_section: 'search-sidebar',
           event_details: {
             widgetType: creator.type,
+            widgetTitle: creator.title,
           },
-        });
+        },
+      );
+
+    if (isCreatorFunc(creator)) {
+      return () => {
+        telemetry();
 
         onClick();
 
@@ -119,6 +127,8 @@ const CreateMenuItem = ({
       const CreatorComponent = creator.component;
 
       return () => {
+        telemetry();
+
         const id = generateId();
 
         const onClose = () => {


### PR DESCRIPTION
**Note:** This needs to be backported to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is improving telemetry for widget creation by:

  - Falling back to dynamic string when there is no widget specific event type
  - Including widget type in event details

This prevents missing out on widget creation event which have no specific telemetry event defined for them.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.