### PR TITLE
Fix issue when plotly define xaxis type wrong

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.tsx
@@ -123,7 +123,7 @@ const XYPlot = ({
     layout.xaxis = merge(layout.xaxis, {
       fixedrange: true,
       /* disable plotly sorting by setting the type of the xaxis to category */
-      type: config.sort.length > 0 ? 'category' : undefined,
+      type: layout.xaxis?.type ?? (config.sort.length > 0 ? 'category' : undefined),
     });
   }
 

--- a/graylog2-web-interface/src/views/components/visualizations/hooks/useChartLayoutSettingsWithCustomUnits.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/hooks/useChartLayoutSettingsWithCustomUnits.ts
@@ -27,7 +27,7 @@ import useWidgetUnits from 'views/components/visualizations/hooks/useWidgetUnits
 import useFeature from 'hooks/useFeature';
 import { UNIT_FEATURE_FLAG } from 'views/components/visualizations/Constants';
 import generateDomain from 'views/components/visualizations/utils/generateDomain';
-import useXAxisTicks from 'views/components/visualizations/hooks/useXAxisTicks';
+import useXAxisTicksAndType from 'views/components/visualizations/hooks/useXAxisTicksAndType';
 import getThresholdShapes from 'views/components/visualizations/utils/getThresholdShapes';
 
 const useChartLayoutSettingsWithCustomUnits = ({
@@ -40,7 +40,7 @@ const useChartLayoutSettingsWithCustomUnits = ({
   chartData: Array<ChartDefinition>;
 }) => {
   const theme = useTheme();
-  const ticksConfig = useXAxisTicks(config, chartData);
+  const ticksAndTypeConfig = useXAxisTicksAndType(config, chartData);
   const unitFeatureEnabled = useFeature(UNIT_FEATURE_FLAG);
   const widgetUnits = useWidgetUnits(config);
   const { unitTypeMapper, fieldNameToAxisNameMapper, mapperAxisNumber } = useMemo(
@@ -60,7 +60,7 @@ const useChartLayoutSettingsWithCustomUnits = ({
     if (!unitFeatureEnabled)
       return {
         xaxis: {
-          ...ticksConfig,
+          ...ticksAndTypeConfig,
         },
       };
 
@@ -80,14 +80,14 @@ const useChartLayoutSettingsWithCustomUnits = ({
       hovermode: 'x',
       xaxis: {
         domain: generateDomain(Object.keys(unitTypeMapper)?.length),
-        ...ticksConfig,
+        ...ticksAndTypeConfig,
       },
     };
 
     return _layouts;
   }, [
     unitFeatureEnabled,
-    ticksConfig,
+    ticksAndTypeConfig,
     unitTypeMapper,
     barmode,
     chartData,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a bug when Plotly defines the type for xaxis as linear when only one value in x is close to a number. 
To fix an issue, we define an explicit x-axis type when it's a category by checking if the field is numeric or if some of the values are not a numbers 

<img width="1038" height="467" alt="Screenshot 2025-10-13 at 16 09 24" src="https://github.com/user-attachments/assets/e8375bc9-890c-4c2f-923a-a6f166008f39" />


## Motivation and Context
When the chart data is contained in an x array stream with ID '000000000000000000000001', Plotly converts it to 1 and sets the type of the x-axis to linear. Because of that, it ignores all other values in x array and we see traces related only to All messages stream
<img width="1042" height="519" alt="Screenshot 2025-10-13 at 15 55 47" src="https://github.com/user-attachments/assets/4452290b-d25a-4304-aa5b-2bec561aa9ea" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl