### PR TITLE
Add Elasticsearch deprecation note

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -146,3 +146,14 @@ The following REST API changes have been made.
 | All `/api/plugins/org.graylog.plugins.datalake/data_lake/...`               | Renamed from `/api/plugins/org.graylog.plugins.datawarehouse/data_warehouse/...`. The corresponding permissions are also renamed to `data_lake...` |
 | All `/api/plugins/org.graylog.plugins.securityapp.asset/assets/history/...` | Removed all endpoints. Contents of underlying `asset_history` MongoDB collection migrated to `Asset History` Index set and Stream               |
 | `GET /<endpoint>`                                                           | description                                                                                                                                        |
+
+## Deprecation of Elasticsearch
+
+Graylog introduced support for OpenSearch as its new search backend in 2022. To simplify the installation and management
+of OpenSearch, the Graylog Data Node component was later developed. Today, Data Node or a self-managed OpenSearch
+deployment are the preferred search backend options for running Graylog.
+
+Starting with Graylog 7.0, the use of Elasticsearch as a search backend is deprecated.
+
+Graylog users are encouraged to migrate to Data Node or self-managed OpenSearch, as Elasticsearch support will be 
+removed entirely in Graylog 8.0.


### PR DESCRIPTION
## Description

Add Elasticsearch deprecation note to UPGRADE notes.

## Motivation and Context

Our last supported Elasticsearch version (7.10) has been EOL for years. New Graylog feature development (and testing) clearly favors OpenSearch. So ideally we would want to remove any support for Elasticsearch as soon as possible, so that we can focus the engineering time on OpenSearch (and [Data Node](https://go2docs.graylog.org/current/downloading_and_installing_graylog/install_graylog_data_node.htm)). But at the same time, we know that many Graylog users are still using Elasticsearch.

So we want to use Graylog 7.x as a soft Elasticsearch deprecation phase, so that users can get prepared for the removal of Elasticsearch support in GL 8.0 (which is more than a year away). So no breaking changes or failing preflight checks yet, just a deprecation note.

/nocl