### PR TITLE
Remove purge toast on lookup preview

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
@@ -125,9 +125,6 @@ export function usePurgeAllLookupTableKey() {
 export function useTestLookupTableKey() {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: testLookupTableKey,
-    onSuccess: () => {
-      UserNotification.success('Lookup table purged successfully');
-    },
     onError: (error: Error) => UserNotification.error(error.message),
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removes incorrect purge toast when performing lookup preview
/nocl minor change to unreleased feature

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Performing a Lookup Table preview lookup from the Lookup Tables page gives an erroneous `Lookup table purged successfully` toast.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

