### PR TITLE
Backport 6.3: Add request id header when using UserContext.runAs (#23938)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/UserContext.java
+++ b/graylog2-server/src/main/java/org/graylog/security/UserContext.java
@@ -17,15 +17,21 @@
 package org.graylog.security;
 
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.authz.permission.AllPermission;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
 import org.graylog.grn.GRN;
 import org.graylog.security.permissions.GRNPermission;
+import org.graylog.util.uuid.ConcurrentUUID;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.rest.RequestIdFilter;
+import org.graylog2.shared.security.ShiroRequestHeadersBinder;
 import org.graylog2.shared.users.UserService;
 
 import java.util.Optional;
@@ -51,7 +57,7 @@ public class UserContext implements HasUser {
          * Create a UserContext from the currently accessible Shiro Subject available to the calling code depending on runtime environment.
          * This should only be called from within an existing Shiro context.
          * If a UserContext is needed from an environment where there is no existing context,
-         * the code can be run using: {@link UserContext#runAs(String username, Callable)}
+         * the code can be run using: {@link UserContext#runAs(String username, UserService userService, Callable)}
          *
          * @return a user context reflecting the currently executing user.
          * @throws UserContextMissingException
@@ -94,43 +100,24 @@ public class UserContext implements HasUser {
                 .sessionCreationEnabled(false)
                 .buildSubject();
 
-        return subject.execute(callable);
+        return subject.execute(wrapWithRequestHeader(callable));
 
     }
 
-
-    /**
-     * Build a temporary Shiro Subject and run the callable within that context
-     *
-     * @param userId The userId of the subject
-     * @param callable The callable to be executed
-     * @param <T>      The return type of the callable.
-     * @return whatever the callable returns.
-     */
-    public static <T> T runAs(String userId, Callable<T> callable) {
-        final Subject subject = new Subject.Builder()
-                .principals(new SimplePrincipalCollection(userId, "runAs-context"))
-                .authenticated(true)
-                .sessionCreationEnabled(false)
-                .buildSubject();
-
-        return subject.execute(callable);
-    }
-
-    /**
-     * Build a temporary Shiro Subject and run the callable within that context
-     *
-     * @param userId The userId of the subject
-     * @param runnable The runnable to be executed
-     */
-    public static void runAs(String userId, Runnable runnable) {
-        final Subject subject = new Subject.Builder()
-                .principals(new SimplePrincipalCollection(userId, "runAs-context"))
-                .authenticated(true)
-                .sessionCreationEnabled(false)
-                .buildSubject();
-
-        subject.execute(runnable);
+    private static <T> Callable<T> wrapWithRequestHeader(Callable<T> callable) {
+        // temporarily add "X-Request-Id" header to suppress warning in org.graylog2.security.realm.MongoDbAuthorizationRealm
+        return () -> {
+            final MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+            headers.putSingle(RequestIdFilter.X_REQUEST_ID, ConcurrentUUID.generateRandomUuid().toString());
+            ThreadContext.put(ShiroRequestHeadersBinder.REQUEST_HEADERS, headers);
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                ThreadContext.remove(ShiroRequestHeadersBinder.REQUEST_HEADERS);
+            }
+        };
     }
 
     public UserContext(String userId, Subject subject, UserService userService) {

--- a/graylog2-server/src/test/java/org/graylog/security/UserContextTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/UserContextTest.java
@@ -16,24 +16,24 @@
  */
 package org.graylog.security;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
-import org.apache.shiro.mgt.DefaultSessionStorageEvaluator;
-import org.apache.shiro.mgt.DefaultSubjectDAO;
-import org.apache.shiro.subject.Subject;
-import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.util.ThreadContext;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.security.PasswordAlgorithmFactory;
-import org.graylog2.shared.security.Permissions;
+import org.graylog2.security.SecurityTestUtils;
+import org.graylog2.shared.rest.RequestIdFilter;
+import org.graylog2.shared.security.ShiroRequestHeadersBinder;
 import org.graylog2.shared.users.UserService;
-import org.graylog2.users.UserImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,33 +54,46 @@ class UserContextTest {
 
     @Test
     void runAs() {
-        // Simulate what we do in the DefaultSecurityManagerProvider
-        DefaultSecurityManager sm = new DefaultSecurityManager();
-        SecurityUtils.setSecurityManager(sm);
-        final DefaultSubjectDAO subjectDAO = new DefaultSubjectDAO();
-        final DefaultSessionStorageEvaluator sessionStorageEvaluator = new DefaultSessionStorageEvaluator() {
-            @Override
-            public boolean isSessionStorageEnabled(Subject subject) {
-                // save to session if we already have a session. do not create on just for saving the subject
-                return subject.getSession(false) != null;
-            }
-        };
-        sessionStorageEvaluator.setSessionStorageEnabled(false);
-        subjectDAO.setSessionStorageEvaluator(sessionStorageEvaluator);
-        sm.setSubjectDAO(subjectDAO);
 
-        final User user = new UserImpl(mock(PasswordAlgorithmFactory.class), mock(Permissions.class), mock(ClusterConfigService.class), ImmutableMap.of());
-        when(userService.load(anyString())).thenReturn(user);
-        when(userService.loadById(anyString())).thenReturn(user);
+        final String userName = "user";
+        final String roleName = "role";
+        final Set<String> permissions = ImmutableSet.of("permission1", "permission2");
+        String password = "test_password";
 
-        final String USERID = "123456";
-        UserContext.<Void>runAs(USERID, () -> {
+        SecurityTestUtils.TestRealm realm = new SecurityTestUtils.TestRealm();
+        realm.addRole(roleName, permissions);
+        realm.addUser(userName, password, roleName);
+
+        SecurityManager securityManager = new DefaultSecurityManager(realm);
+        SecurityUtils.setSecurityManager(securityManager);
+
+        final User user = mock(User.class);
+        when(user.getId()).thenReturn(userName);
+        when(userService.load(userName)).thenReturn(user);
+        when(userService.loadById(userName)).thenReturn(user);
+
+        UserContext.<Void>runAs(userName, userService, () -> {
 
             final UserContext userContext = new UserContext.Factory(userService).create();
-            assertThat(userContext.getUserId()).isEqualTo(USERID);
+            // test user context basics
+            assertThat(userContext.getUserId()).isEqualTo(userName);
             assertThat(userContext.getUser()).isEqualTo(user);
+
+            // test permission check
+            assertThat(userContext.isPermitted("permission1")).isTrue();
+            assertThat(userContext.isPermitted("permission2")).isTrue();
+            assertThat(userContext.isPermitted("permission3")).isFalse();
+
+            // test request header fix
+            Object requestHeaders = ThreadContext.get(ShiroRequestHeadersBinder.REQUEST_HEADERS);
+            assertThat(requestHeaders).isNotNull();
+            assertThat(requestHeaders).isInstanceOf(MultivaluedMap.class);
+            assertThat((MultivaluedMap<String, String>) requestHeaders).containsKey(RequestIdFilter.X_REQUEST_ID);
 
             return null;
         });
+
+        assertThat(ThreadContext.get(ShiroRequestHeadersBinder.REQUEST_HEADERS)).isNull();
+
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/security/SecurityTestUtils.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/SecurityTestUtils.java
@@ -188,7 +188,7 @@ public class SecurityTestUtils {
     /**
      * Simple Shiro Realm to hold user/role information
      */
-    static class TestRealm extends SimpleAccountRealm {
+    public static class TestRealm extends SimpleAccountRealm {
 
         public void addRole(String roleName, Set<String> permissions) {
             SimpleRole role = new SimpleRole(roleName, permissions.stream().map(WildcardPermission::new).collect(Collectors.toSet()));


### PR DESCRIPTION
## Description
Backport for #23938 

/nocl

## Motivation and Context
backport to suppress log warnings during migrations that use runAs

## How Has This Been Tested?
manually, added test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

