### PR TITLE
Raise default heap for test search servers to 1.5g

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/SearchServerBuilder.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/SearchServerBuilder.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class SearchServerBuilder<T extends SearchServerInstance> {
-    public static final String DEFAULT_HEAP_SIZE = "1g";
+    public static final String DEFAULT_HEAP_SIZE = "1536m";
     private final SearchVersion version;
     private String hostname = "indexer";
     private Network network;


### PR DESCRIPTION
## Description
Raises the heap for test search servers to 1.5g 

/nocl internal

## Motivation and Context
```
Caused by: org.graylog.shaded.opensearch2.org.opensearch.client.ResponseException: method [GET], host [http://localhost:32860], URI [/_cat/indices?format=json&h=index], status line [HTTP/1.1 429 Too Many Requests]
{"error":{"root_cause":[{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1023494288/976mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1023494288/976mb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=1491/1.4kb, in_flight_requests=0/0b]","bytes_wanted":1023494288,"bytes_limit":1020054732,"durability":"PERMANENT"}],"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1023494288/976mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1023494288/976mb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=1491/1.4kb, 
```
This error started occuring seemingly randomly with the changes for full backend tests which included a reduction of the default heap size of test search servers from 2g to 1g together with caching them for reusal.
I can’t find a memory leak when running the tests repeatedly in the same vm, but the tests using the ChunkedBulkIndexer regularly (sometimes in the first run, sometimes later) trip the (parent) circuit breaker by a couple of mb.

## How Has This Been Tested?
run storage-module-os2 tests repeatedly until failure, observing
- failure regularly occuring with 1g
- no failure occuring after a large number of repetions on 1.5g

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

