### PR TITLE
Fix the stream reference excerpt to use the id as the id (not the title!)

### DIFF
--- a/changelog/unreleased/pr-24149.toml
+++ b/changelog/unreleased/pr-24149.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Use the correct ID on Stream Reference Excerpts for Content Pack Generation."
+
+issues = ["24106"]
+pulls = ["24149"]

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
@@ -160,7 +160,7 @@ public class StreamReferenceFacade extends StreamFacade {
     @Override
     public EntityExcerpt createExcerpt(Stream stream) {
         return EntityExcerpt.builder()
-                .id(ModelId.of(stream.getTitle()))
+                .id(ModelId.of(stream.getId()))
                 .type(ModelTypes.STREAM_REF_V1)
                 .title(stream.getTitle())
                 .build();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, the content pack generation would look for the stream to export via the title. This is not the expected behaviour. We want the reference to use the title on import, but not on export.

fixes https://github.com/Graylog2/graylog2-server/issues/24106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

