### PR TITLE
Backport Only override index_hot_lifetime_min when data tiering is restricted

### DIFF
--- a/changelog/unreleased/pr-24114.toml
+++ b/changelog/unreleased/pr-24114.toml
@@ -1,0 +1,5 @@
+type = "fixed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Fix that Index Set Warm Tier couldn't be activated for some existing indices."
+
+issues = ["graylog-plugin-enterprise#12430"]
+pulls = ["24114"]

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm/IndexSetConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm/IndexSetConfigurationForm.tsx
@@ -14,7 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import moment from 'moment';
 import { Formik, Form, Field } from 'formik';
 import styled, { css } from 'styled-components';
@@ -143,6 +143,9 @@ const IndexSetConfigurationForm = ({
     setHiddenFields(tmpHidden);
   }, [indexSet]);
 
+  const isDataTieringImmutable = useMemo(() => immutableFields.includes('data_tiering'), [immutableFields]);
+  const isDataTieringLocked = isDataTieringImmutable && !ignoreFieldRestrictions;
+
   const prepareRetentionConfigBeforeSubmit = useCallback(
     (values: IndexSetFormValues): IndexSet => {
       const indexSetValues = values;
@@ -171,7 +174,7 @@ const IndexSetConfigurationForm = ({
 
       const configWithDataTiering = {
         ...indexSetValues,
-        data_tiering: prepareDataTieringConfig(values.data_tiering, PluginStore),
+        data_tiering: prepareDataTieringConfig(values.data_tiering, PluginStore, isDataTieringLocked),
       };
 
       if (loadingIndexSetTemplateDefaults || !indexSetTemplateDefaults)
@@ -193,6 +196,7 @@ const IndexSetConfigurationForm = ({
       selectedRetentionSegment,
       enableDataTieringCloud,
       isCloud,
+      isDataTieringLocked,
     ],
   );
 
@@ -232,7 +236,10 @@ const IndexSetConfigurationForm = ({
 
   const prepareInitialValues = () => {
     if (indexSet.data_tiering) {
-      return { ...indexSet, data_tiering: prepareDataTieringInitialValues(indexSet.data_tiering, PluginStore) };
+      return {
+        ...indexSet,
+        data_tiering: prepareDataTieringInitialValues(indexSet.data_tiering, PluginStore, isDataTieringLocked),
+      };
     }
 
     return indexSet as unknown as IndexSetFormValues;

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/IndexSetTemplateCard.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/IndexSetTemplateCard.tsx
@@ -59,7 +59,7 @@ const Description = styled.p`
 `;
 
 const IndexSetTemplateCard = ({ template, handleCardClick, isSelected }: Props) => {
-  const dataTieringConfig = prepareDataTieringInitialValues(template.index_set_config.data_tiering, PluginStore);
+  const dataTieringConfig = prepareDataTieringInitialValues(template.index_set_config.data_tiering, PluginStore, false);
 
   return (
     <StyledCard $selected={isSelected} $disabled={!template.enabled}>

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/TemplateDetails.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/TemplateDetails.tsx
@@ -99,7 +99,7 @@ const formatRefreshInterval = (intervalInMs: number) => {
 const TemplateDetails = ({ template, showDescription = false }: Props) => {
   const dataTieringPlugins = usePluginEntities('dataTiering');
   const dataTieringPlugin = dataTieringPlugins.find((plugin) => plugin.type === DATA_TIERING_TYPE.HOT_WARM);
-  const dataTieringConfig = prepareDataTieringInitialValues(template.index_set_config.data_tiering, PluginStore);
+  const dataTieringConfig = prepareDataTieringInitialValues(template.index_set_config.data_tiering, PluginStore, false);
 
   return (
     <Row>

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/TemplateForm.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/TemplateForm.tsx
@@ -254,7 +254,7 @@ const TemplateForm = ({
         data_tiering:
           selectedRetentionSegment === 'legacy'
             ? undefined
-            : prepareDataTieringConfig(index_set_config.data_tiering, PluginStore),
+            : prepareDataTieringConfig(index_set_config.data_tiering, PluginStore, false),
       },
     };
 
@@ -273,7 +273,7 @@ const TemplateForm = ({
       ...indexSetConfig
     } = values.index_set_config;
 
-    const data_tiering = prepareDataTieringInitialValues(values.index_set_config.data_tiering, PluginStore);
+    const data_tiering = prepareDataTieringInitialValues(values.index_set_config.data_tiering, PluginStore, false);
 
     return {
       ...values,

--- a/graylog2-web-interface/src/components/indices/data-tiering/DataTieringConfiguration.tsx
+++ b/graylog2-web-interface/src/components/indices/data-tiering/DataTieringConfiguration.tsx
@@ -40,14 +40,23 @@ const DATA_TIERING_HOT_WARM_DEFAULTS = {
 
 export const durationToRoundedDays = (duration: string) => Math.round(moment.duration(duration).asDays());
 
-const dataTieringFormValuesWithDefaults = (values: DataTieringFormValues, pluginStore): DataTieringFormValues => {
+const dataTieringFormValuesWithDefaults = (
+  values: DataTieringFormValues,
+  pluginStore,
+  isDataTieringImmutable: boolean,
+): DataTieringFormValues => {
   const dataTieringPlugin = pluginStore
     .exports('dataTiering')
     .find((plugin) => plugin.type === DATA_TIERING_TYPE.HOT_WARM);
   const dataTieringType = dataTieringPlugin?.type ?? DATA_TIERING_TYPE.HOT_ONLY;
 
   if (dataTieringType === DATA_TIERING_TYPE.HOT_WARM) {
-    const hotWarmDefaults = { ...DATA_TIERING_HOT_ONLY_DEFAULTS, ...DATA_TIERING_HOT_WARM_DEFAULTS, ...values };
+    const hotWarmDefaults = {
+      ...DATA_TIERING_HOT_ONLY_DEFAULTS,
+      ...DATA_TIERING_HOT_WARM_DEFAULTS,
+      ...values,
+      ...(values.type === DATA_TIERING_TYPE.HOT_ONLY && isDataTieringImmutable ? { index_hot_lifetime_min: null } : {}),
+    };
 
     return hotWarmDefaults;
   }
@@ -57,7 +66,11 @@ const dataTieringFormValuesWithDefaults = (values: DataTieringFormValues, plugin
   return hotOnlyDefaults;
 };
 
-export const prepareDataTieringInitialValues = (config: DataTieringConfig, pluginStore): DataTieringFormValues => {
+export const prepareDataTieringInitialValues = (
+  config: DataTieringConfig,
+  pluginStore,
+  isDataTieringImmutable: boolean,
+): DataTieringFormValues => {
   let formValues = { ...config };
 
   dayFields.forEach((field) => {
@@ -67,16 +80,24 @@ export const prepareDataTieringInitialValues = (config: DataTieringConfig, plugi
     }
   });
 
-  return dataTieringFormValuesWithDefaults(formValues as unknown as DataTieringFormValues, pluginStore);
+  return dataTieringFormValuesWithDefaults(
+    formValues as unknown as DataTieringFormValues,
+    pluginStore,
+    isDataTieringImmutable,
+  );
 };
 
-export const prepareDataTieringConfig = (formValues: DataTieringFormValues, pluginStore): DataTieringConfig => {
+export const prepareDataTieringConfig = (
+  formValues: DataTieringFormValues,
+  pluginStore,
+  isDataTieringImmutable: boolean,
+): DataTieringConfig => {
   const dataTieringPlugin = pluginStore
     .exports('dataTiering')
     .find((plugin) => plugin.type === DATA_TIERING_TYPE.HOT_WARM);
   const dataTieringType = dataTieringPlugin?.type ?? DATA_TIERING_TYPE.HOT_ONLY;
 
-  let config = dataTieringFormValuesWithDefaults(formValues, pluginStore);
+  let config = dataTieringFormValuesWithDefaults(formValues, pluginStore, isDataTieringImmutable);
 
   if (dataTieringType === DATA_TIERING_TYPE.HOT_ONLY) {
     hotWarmOnlyFormFields.forEach((field) => {


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/24114
Issue: https://github.com/Graylog2/graylog-plugin-enterprise/issues/12430

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

