### PR TITLE
Fixing issues where no table columns are displayed, when attribute in user preferences is an empty object.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUserLayoutPreferences.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useUserLayoutPreferences.ts
@@ -23,8 +23,15 @@ import { defaultOnError } from 'util/conditional/onError';
 
 const INITIAL_DATA = {};
 
-const attributesFromJSON = (attributes: TableLayoutPreferencesJSON['attributes']) =>
-  Object.keys(attributes).filter((key) => attributes[key].status === 'show');
+const attributesFromJSON = (attributes: TableLayoutPreferencesJSON['attributes']) => {
+  const attributeIds = Object.keys(attributes ?? {});
+
+  if (attributeIds.length <= 0) {
+    return undefined;
+  }
+
+  return attributeIds.filter((key) => attributes[key].status === 'show');
+};
 
 const preferencesFromJSON = ({
   attributes,
@@ -32,7 +39,7 @@ const preferencesFromJSON = ({
   per_page,
   custom_preferences,
 }: TableLayoutPreferencesJSON): TableLayoutPreferences => ({
-  displayedAttributes: attributes ? attributesFromJSON(attributes) : undefined,
+  displayedAttributes: attributesFromJSON(attributes),
   sort: sort ? { attributeId: sort.field, direction: sort.order } : undefined,
   perPage: per_page,
   customPreferences: custom_preferences,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a follow-up for https://github.com/Graylog2/graylog2-server/pull/24122 and fixes an error which occurs when a user has no user preferences and changes only the page size for an entity data table. In this case the table attributes preferences are an empty object, which we did not handle properly in the frontend.

This PR can be tested by removing the user preferences for a table in the `entity_list_preferences` collection and only setting page size in the UI for this specific table.

/nocl - fixes an unreleased change
/prd https://github.com/Graylog2/e2e-tests/pull/1378