### PR TITLE
Fix tooltip for archiving cell in streams overview.

### DIFF
--- a/graylog2-web-interface/src/components/common/StatusIcon.tsx
+++ b/graylog2-web-interface/src/components/common/StatusIcon.tsx
@@ -23,8 +23,9 @@ type Props = {
   className?: string;
 };
 
-const StatusIcon = ({ active, className = undefined }: Props) => (
+const StatusIcon = ({ active, className = undefined }: Props, ref: React.ForwardedRef<HTMLSpanElement>) => (
   <Icon
+    ref={ref}
     name={active ? 'check_circle' : 'cancel'}
     bsStyle={active ? 'success' : undefined}
     className={className}
@@ -32,4 +33,4 @@ const StatusIcon = ({ active, className = undefined }: Props) => (
   />
 );
 
-export default StatusIcon;
+export default React.forwardRef(StatusIcon);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this fix, the tooltip for the archiving cell in the streams over was not being displayed on hover.

<img width="302" height="82" alt="image" src="https://github.com/user-attachments/assets/35d874b3-6580-45a5-bb9b-532f00ba0cd6" />
 
 

This also fixes the following console warning:

 `Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?`

Check the render method of `@mantine/core/Tooltip`. Error Component Stack

/nocl - Just fixes a small visual bug. The related information is already communicated by the status icon.
