### PR TITLE
Testable environment for integration tests

### DIFF
--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/cluster/ClusterStateApiIT.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/cluster/ClusterStateApiIT.java
@@ -18,73 +18,45 @@ package org.graylog.storage.opensearch3.cluster;
 
 import org.assertj.core.api.Assertions;
 import org.graylog.storage.opensearch3.testing.OpenSearchInstance;
+import org.graylog.testing.elasticsearch.testenv.TestableIndex;
 import org.junit.Rule;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.IntStream;
 
 class ClusterStateApiIT {
 
-    private static final String MY_INDEX_NAME = "my_index_0";
-    private static final String MY_OTHER_INDEX_NAME = "my_other_index_0";
-    private static final String MY_EMPTY_INDEX_NAME = "my_empty_index_0";
     @Rule
     public final OpenSearchInstance opensearch = OpenSearchInstance.create();
     private ClusterStateApi clusterStateApi;
 
-    @BeforeEach
-    void setUp() {
-        generateIndex(MY_INDEX_NAME, 10, i -> new MyDocument("doc" + i, i, new Date()));
-        generateIndex(MY_OTHER_INDEX_NAME, 10, i -> new MyDatapoint(i, new Date()));
-
-        // this one is empty and has no document and no mappings
-        opensearch.getOfficialOpensearchClient().sync(c -> c.indices().create(r -> r.index(MY_EMPTY_INDEX_NAME)), "Failed to create index " + MY_EMPTY_INDEX_NAME);
-
-        opensearch.client().refreshNode();
-        clusterStateApi = new ClusterStateApi(opensearch.getOfficialOpensearchClient());
-    }
-
-    @AfterEach
-    void tearDown() {
-        opensearch.client().deleteIndices(MY_INDEX_NAME, MY_OTHER_INDEX_NAME, MY_EMPTY_INDEX_NAME);
-    }
-
     @Test
     void testFields() {
-        final Map<String, Set<String>> fields = clusterStateApi.fields(Set.of(MY_INDEX_NAME, MY_OTHER_INDEX_NAME));
-        Assertions.assertThat(fields).containsEntry(MY_INDEX_NAME, Set.of("name", "count", "created"));
-        Assertions.assertThat(fields).containsEntry(MY_OTHER_INDEX_NAME, Set.of("value", "created"));
+        opensearch.withTestableEnvironment(testEnvironment -> {
 
-        Assertions.assertThat(clusterStateApi.fields(Set.of(MY_EMPTY_INDEX_NAME))).isEmpty();
+            final TestableIndex firstIndex = testEnvironment.createIndex().indexDocuments(10, i1 -> Map.of(
+                    "name", "doc" + i1,
+                    "count", i1,
+                    "created",new Date()));
+
+            final TestableIndex secondIndex = testEnvironment.createIndex().indexDocuments(10, i -> Map.of(
+                    "value", i,
+                    "created",new Date()));
+
+            // this one is empty, has no messages ingested
+            final TestableIndex thirdIndex = testEnvironment.createIndex();
+
+            testEnvironment.refreshNode();
+
+            clusterStateApi = new ClusterStateApi(opensearch.getOfficialOpensearchClient());
+
+            final Map<String, Set<String>> fields = clusterStateApi.fields(Set.of(firstIndex.getIndexName(), secondIndex.getIndexName(), thirdIndex.getIndexName()));
+            Assertions.assertThat(fields).containsEntry(firstIndex.getIndexName(), Set.of("name", "count", "created"));
+            Assertions.assertThat(fields).containsEntry(secondIndex.getIndexName(), Set.of("value", "created"));
+
+            Assertions.assertThat(clusterStateApi.fields(Set.of(thirdIndex.getIndexName()))).isEmpty();
+        });
     }
-
-    private <T> void generateIndex(String indexName, int documentsCount, Function<Integer, T> documentCreator) {
-        opensearch.getOfficialOpensearchClient().sync(c -> c.indices().create(r -> r.index(indexName)), "Failed to create index");
-        BulkRequest.Builder br = new BulkRequest.Builder();
-
-        final List<BulkOperation> bulkIndexRequests = IntStream.range(0, documentsCount)
-                .mapToObj(documentCreator::apply)
-                .map(doc -> indexObjectOperation(doc, indexName))
-                .toList();
-
-        opensearch.getOfficialOpensearchClient().sync(c -> c.bulk(br.operations(bulkIndexRequests).build()), "Failed to index documents");
-    }
-
-    private BulkOperation indexObjectOperation(Object doc, String indexName) {
-        return BulkOperation.of(bulk -> bulk.index(r -> r.index(indexName).document(doc)));
-    }
-
-
-    private record MyDocument(String name, int count, Date created) {}
-
-    private record MyDatapoint(int value, Date created) {}
 }

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/stats/ClusterStatsApiIT.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/stats/ClusterStatsApiIT.java
@@ -22,13 +22,11 @@ import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
 import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.opensearch.core.BulkRequest;
 
 import java.util.Map;
-import java.util.stream.IntStream;
 
 class ClusterStatsApiIT {
-    public static final String INDEX_NAME = "my_index_0";
+
     @Rule
     public final OpenSearchInstance opensearch = OpenSearchInstance.create();
     private ClusterStatsApi api;
@@ -40,26 +38,21 @@ class ClusterStatsApiIT {
 
     @Test
     void testStats() {
-        // capture numbers for existing cluster, whatever that means
-        final IndexSetStats before = api.clusterStats();
+        opensearch.withTestableEnvironment((environment) -> {
+            // capture numbers for existing cluster, whatever that means
+            final IndexSetStats before = api.clusterStats();
 
-        // create new index with 10 docs
-        generateIndex(INDEX_NAME, 10);
+            environment.createIndex().indexDocuments(10, i -> Map.of("foo", i));
 
-        // capture numbers again, they should be already refreshed by the previous generateIndex call
-        final IndexSetStats after = api.clusterStats();
+            // capture numbers again, they should be already refreshed by the previous generateIndex call
+            final IndexSetStats after = api.clusterStats();
 
-        // verify that *after* values are the *before* plus 1 index with 10 docs
-        Assertions.assertThat(after.indices()).isGreaterThanOrEqualTo(before.indices() + 1);
-        Assertions.assertThat(after.documents()).isGreaterThanOrEqualTo(before.documents() + 10);
-        Assertions.assertThat(after.size()).isGreaterThan(before.size());
+            // verify that *after* values are the *before* plus 1 index with 10 docs
+            Assertions.assertThat(after.indices()).isGreaterThanOrEqualTo(before.indices() + 1);
+            Assertions.assertThat(after.documents()).isGreaterThanOrEqualTo(before.documents() + 10);
+            Assertions.assertThat(after.size()).isGreaterThan(before.size());
+        });
     }
 
-    private void generateIndex(String indexName, int documentsCount) {
-        opensearch.getOfficialOpensearchClient().sync(c -> c.indices().create(r -> r.index(indexName)), "Failed to create index");
-        BulkRequest.Builder br = new BulkRequest.Builder();
-        IntStream.range(0, documentsCount).forEach(i -> br.operations(op -> op.index(idx -> idx.index(indexName).document(Map.of("foo", i)))));
-        opensearch.getOfficialOpensearchClient().sync(c -> c.bulk(br.build()), "Failed to index documents");
-        opensearch.getOfficialOpensearchClient().sync(c -> c.indices().refresh(), "Failed to refresh indices");
-    }
+
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
@@ -17,6 +17,7 @@
 package org.graylog.testing.elasticsearch;
 
 import com.google.common.io.Resources;
+import org.graylog.testing.elasticsearch.testenv.IntegrationTestEnvironment;
 import org.graylog2.shared.utilities.StringUtils;
 import org.graylog2.storage.SearchVersion;
 import org.junit.rules.ExternalResource;
@@ -26,11 +27,13 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -182,5 +185,17 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
     public TestableSearchServerInstance init() {
         createContainer();
         return this;
+    }
+
+    /**
+     * Create new integration test environment. Resources created inside this environment
+     * will be automatically deleted when the {@code action} finishes.
+     */
+    public void withTestableEnvironment(Consumer<IntegrationTestEnvironment> action)  {
+        try(final IntegrationTestEnvironment environment = new IntegrationTestEnvironment(this)) {
+            action.accept(environment);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/testenv/IntegrationTestEnvironment.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/testenv/IntegrationTestEnvironment.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.elasticsearch.testenv;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.graylog.testing.elasticsearch.TestableSearchServerInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class IntegrationTestEnvironment implements Closeable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IntegrationTestEnvironment.class);
+
+    private final Set<Closeable> cleanupObjects = new HashSet<>();
+    private final TestableSearchServerInstance searchServerInstance;
+
+    public IntegrationTestEnvironment(TestableSearchServerInstance searchServerInstance) {
+        this.searchServerInstance = searchServerInstance;
+    }
+
+    public TestableIndex createIndex() {
+        final var randomId = RandomStringUtils.secure().next(10, false, true);
+        final String indexName = "test_index_" + randomId;
+        searchServerInstance.client().createIndex(indexName);
+        final TestableIndex index = new TestableIndex(indexName, searchServerInstance.client());
+        cleanupObjects.add(index);
+        return index;
+    }
+
+    public void refreshNode() {
+        searchServerInstance.client().refreshNode();
+    }
+
+    @Override
+    public void close() throws IOException {
+        LOG.debug("Closing test environment, {} object will be automatically cleaned", cleanupObjects.size());
+        for(Closeable closeable : cleanupObjects) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to run cleanup for " + closeable, e);
+            }
+        }
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/testenv/TestableIndex.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/testenv/TestableIndex.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.elasticsearch.testenv;
+
+import org.graylog.testing.elasticsearch.BulkIndexRequest;
+import org.graylog.testing.elasticsearch.Client;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+public class TestableIndex implements Closeable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestableIndex.class);
+
+    private final String indexName;
+    private final Client client;
+
+    public TestableIndex(String indexName, Client client) {
+        this.indexName = indexName;
+        this.client = client;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public TestableIndex indexDocuments(int documentsCount, Function<Integer, Map<String, Object>> creator) {
+        return indexDocuments(
+                IntStream.range(0, documentsCount)
+                        .mapToObj(creator::apply)
+                        .toList()
+        );
+    }
+
+    public TestableIndex indexDocuments(List<Map<String, Object>> docs) {
+        final BulkIndexRequest req = new BulkIndexRequest();
+        docs.forEach(d -> req.addRequest(indexName, d));
+        client.bulkIndex(req);
+        return this;
+    }
+
+    /**
+     * Delete index when closing this object
+     */
+    @Override
+    public void close() throws IOException {
+        LOG.debug("Deleting index {}", indexName);
+        client.deleteIndices(indexName);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("TestableIndex{");
+        sb.append("indexName='").append(indexName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
/nocl internal test infra

## Description
This PR introduces, similarly to full integration tests, a testable environment, which controls what indices are created. These indices will be automatically deleted at the end of the testable action/test itself.

## Motivation and Context
Simplify resources cleanup in integration tests setup where we reuse running instances of search servers.

## How Has This Been Tested?
Used in two integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

