### PR TITLE
OSSerializationUtils do not depend on client and gain some first tests

### DIFF
--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/indextemplates/OSSerializationUtils.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/indextemplates/OSSerializationUtils.java
@@ -18,12 +18,10 @@ package org.graylog.storage.opensearch3.indextemplates;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.json.stream.JsonParser;
 import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.PlainJsonSerializable;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 
@@ -37,22 +35,20 @@ import java.util.Map;
 @Singleton
 public class OSSerializationUtils {
 
-    private final ObjectMapper objectMapper;
-    private final JsonpMapper jsonpMapper;
+    private final JacksonJsonpMapper jsonpMapper;
 
     @Inject
-    public OSSerializationUtils(final ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-        this.jsonpMapper = new JacksonJsonpMapper(objectMapper);
+    public OSSerializationUtils() {
+        this.jsonpMapper = new JacksonJsonpMapper();
     }
 
     public Map<String, Object> toMap(final PlainJsonSerializable openSearchSerializableObject) throws JsonProcessingException {
-        return objectMapper.readValue(openSearchSerializableObject.toJsonString(), new TypeReference<>() {});
+        return this.jsonpMapper.objectMapper().readValue(openSearchSerializableObject.toJsonString(), new TypeReference<>() {});
     }
 
     public <T> T fromMap(final Map<String, Object> mapRepresentation,
                          final JsonpDeserializer<T> deserializer) throws JsonProcessingException {
-        final String json = objectMapper.writeValueAsString(mapRepresentation);
+        final String json = this.jsonpMapper.objectMapper().writeValueAsString(mapRepresentation);
         final JsonParser parser = jsonpMapper.jsonProvider().createParser(new StringReader(json));
         return deserializer.deserialize(parser, jsonpMapper);
     }

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/IndicesAdapterOSTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/IndicesAdapterOSTest.java
@@ -84,7 +84,7 @@ class IndicesAdapterOSTest {
                 indexTemplateAdapter,
                 indexStatisticsBuilder,
                 objectMapper,
-                new OSSerializationUtils(objectMapper)
+                new OSSerializationUtils()
         );
     }
 

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/indextemplates/OSSerializationUtilsTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/indextemplates/OSSerializationUtilsTest.java
@@ -16,8 +16,6 @@
  */
 package org.graylog.storage.opensearch3.indextemplates;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.mapping.DynamicTemplate;
@@ -98,12 +96,11 @@ class OSSerializationUtilsTest {
             Map.of("enabled", true));
 
 
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
     private OSSerializationUtils toTest;
 
     @BeforeEach
     void setUp() {
-        toTest = new OSSerializationUtils(objectMapper);
+        toTest = new OSSerializationUtils();
     }
 
     @Test

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/testing/AdaptersOS.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/testing/AdaptersOS.java
@@ -78,7 +78,7 @@ public class AdaptersOS implements Adapters {
 
     @Override
     public IndicesAdapter indicesAdapter() {
-        final OSSerializationUtils osSerializationUtils = new OSSerializationUtils(objectMapper);
+        final OSSerializationUtils osSerializationUtils = new OSSerializationUtils();
         return new IndicesAdapterOS(officialOpensearchClient,
                 new org.graylog.storage.opensearch3.stats.StatsApi(officialOpensearchClient),
                 new org.graylog.storage.opensearch3.stats.ClusterStatsApi(officialOpensearchClient),


### PR DESCRIPTION
## Description
OSSerializationUtils do not depend on client and gain some first tests.
/nocl

## Motivation and Context
Avoid dependency to client and transport, use own JsonP Mapper instead.
Add some unit tests.

## How Has This Been Tested?
With new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

