### PR TITLE
Dependabot: Ignore Opensearch java client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       - dependency-name: "org.apache.lucene:lucene-*"
         versions:
           - ">= 10"
+      # we want to manually update the opensearch-java client as long as it requires intensive testing
+      - dependency-name: "org.opensearch.client:opensearch-java"
     open-pull-requests-limit: 25
     labels:
       - dependencies


### PR DESCRIPTION
## Description
The OpenSearch Java client uses autogeneration to generate its dtos from the specification. 
However, there are almost no tests in place to assure that there are no regressions caused by the generation.
Whilst we try to cover most of our use cases in ITs, a more comprehensive test needs to be done, also regarding compatibility with our recommended OpenSearch versions.

/nocl internal

## Motivation and Context
more stable OpenSearch Java client usage.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

