### PR TITLE
Fix: Set `isFirstContainerStart=true` when test containers are built

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/TestableSearchServerInstance.java
@@ -98,6 +98,7 @@ public abstract class TestableSearchServerInstance extends ExternalResource impl
 
     private GenericContainer<?> doBuildContainer(String image) {
         LOG.debug("Creating instance {} (cached: {})", image, cachedInstance);
+        isFirstContainerStart = true;
         final GenericContainer<?> container = buildContainer(image, network);
         container.start();
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## Description
The `TestableSearchServerInstance` currently set `isFirstContainerStart` to false when the first cached container was reused and never reset this to true for newly created cached or uncached containers.

This caused for example the `afterContainerCreated` actions in `OpenSearchInstance` not to be executed for containers other than the first, leading to errors in tests.
 
/nocl 

## Motivation and Context
fixes build failures

## How Has This Been Tested?
manually, running tests in a certain order which causes the error

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

