### PR TITLE
Disable ESLint rule `jsx-a11y/no-autofocus`.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -153,6 +153,7 @@ export default [
       ],
       'sort-imports': 'off', // disabled in favor of 'import/order'
       'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
+      'jsx-a11y/no-autofocus': 'off',
       'max-classes-per-file': 'off',
       'max-len': 'off',
       'new-cap': 'off',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR disables the ESLint rule `jsx-a11y/no-autofocus` because there are some use cases, such as automatically focusing a search input in a modal, where autofocus is desired.

I tested this change by comparing the output of `yarn lint`.

/nocl
