### PR TITLE
Using `msearch` for fetching field value suggestions. (`6.3`)

### DIFF
--- a/changelog/unreleased/pr-24242.toml
+++ b/changelog/unreleased/pr-24242.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixing field value suggestions for large numbers of indices."
+
+pulls = ["24242"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/QuerySuggestionsES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/QuerySuggestionsES7.java
@@ -17,6 +17,7 @@
 package org.graylog.storage.elasticsearch7;
 
 import com.google.common.collect.ImmutableMap;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.QuerySuggestionsService;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionEntry;
@@ -25,6 +26,7 @@ import org.graylog.plugins.views.search.engine.suggestions.SuggestionRequest;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
@@ -40,8 +42,6 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.suggest.term.T
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 import org.graylog.storage.errors.ResponseError;
 import org.graylog2.plugin.Message;
-
-import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -75,7 +75,9 @@ public class QuerySuggestionsES7 implements QuerySuggestionsService {
                 .suggest(new SuggestBuilder().addSuggestion("corrections", suggestionBuilder));
 
         try {
-            final SearchResponse result = client.singleSearch(new SearchRequest(affectedIndices.toArray(new String[]{})).source(search), "Failed to execute aggregation");
+            final SearchResponse result = client.search(new SearchRequest(affectedIndices.toArray(new String[]{}))
+                    .source(search)
+                    .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN), "Failed to execute aggregation");
             final ParsedTerms fieldValues = result.getAggregations().get("fieldvalues");
             final List<SuggestionEntry> entries = fieldValues.getBuckets().stream().map(b -> new SuggestionEntry(b.getKeyAsString(), b.getDocCount())).collect(Collectors.toList());
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Scroll.java
@@ -47,7 +47,7 @@ public class Scroll implements MultiChunkResultRetriever {
     public ChunkedResult retrieveChunkedResult(ChunkCommand chunkCommand) {
         final SearchSourceBuilder searchQuery = searchRequestFactory.create(chunkCommand);
         final SearchRequest request = scrollBuilder(searchQuery, chunkCommand.indices());
-        final SearchResponse result = client.singleSearch(request, "Unable to perform scroll search");
+        final SearchResponse result = client.execute((c, requestOptions) -> c.search(request, requestOptions), "Unable to perform scroll search");
         return scrollResultFactory.create(result, searchQuery.toString(), DEFAULT_SCROLLTIME, chunkCommand.fields(), chunkCommand.limit().orElse(-1));
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/export/ExportClient.java
@@ -60,14 +60,6 @@ public class ExportClient {
         return new ExportException("Unable to complete export: ", new ElasticsearchException(e));
     }
 
-    public SearchResponse singleSearch(SearchRequest request, String errorMessage) {
-        try {
-            return this.client.singleSearch(request, errorMessage);
-        } catch (Exception e) {
-            throw wrapException(e);
-        }
-    }
-
     public <R> R execute(ThrowingBiFunction<RestHighLevelClient, RequestOptions, R, IOException> fn, String errorMessage) {
         try {
             return this.client.execute(fn, errorMessage);

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/QuerySuggestionsOS2.java
@@ -17,15 +17,16 @@
 package org.graylog.storage.opensearch2;
 
 import com.google.common.collect.ImmutableMap;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.engine.QuerySuggestionsService;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionEntry;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionError;
-import org.graylog.plugins.views.search.engine.suggestions.SuggestionFieldType;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionRequest;
 import org.graylog.plugins.views.search.engine.suggestions.SuggestionResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchRequest;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.action.support.IndicesOptions;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
@@ -41,8 +42,6 @@ import org.graylog.shaded.opensearch2.org.opensearch.search.suggest.term.TermSug
 import org.graylog.shaded.opensearch2.org.opensearch.search.suggest.term.TermSuggestionBuilder;
 import org.graylog.storage.errors.ResponseError;
 import org.graylog2.plugin.Message;
-
-import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -76,7 +75,9 @@ public class QuerySuggestionsOS2 implements QuerySuggestionsService {
                 .suggest(new SuggestBuilder().addSuggestion("corrections", suggestionBuilder));
 
         try {
-            final SearchResponse result = client.singleSearch(new SearchRequest(affectedIndices.toArray(new String[]{})).source(search), "Failed to execute aggregation");
+            final SearchResponse result = client.search(new SearchRequest(affectedIndices.toArray(new String[]{}))
+                    .source(search)
+                    .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN), "Failed to execute aggregation");
             final ParsedTerms fieldValues = result.getAggregations().get("fieldvalues");
             final List<SuggestionEntry> entries = fieldValues.getBuckets().stream().map(b -> new SuggestionEntry(b.getKeyAsString(), b.getDocCount())).collect(Collectors.toList());
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/Scroll.java
@@ -47,7 +47,7 @@ public class Scroll implements MultiChunkResultRetriever {
     public ChunkedResult retrieveChunkedResult(ChunkCommand chunkCommand) {
         final SearchSourceBuilder searchQuery = searchRequestFactory.create(chunkCommand);
         final SearchRequest request = scrollBuilder(searchQuery, chunkCommand.indices());
-        final SearchResponse result = client.singleSearch(request, "Unable to perform scroll search");
+        final SearchResponse result = client.execute((c, requestOptions) -> c.search(request, requestOptions), "Unable to perform scroll search");
         return scrollResultFactory.create(result, searchQuery.toString(), DEFAULT_SCROLLTIME, chunkCommand.fields(), chunkCommand.limit().orElse(-1));
     }
 

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/export/ExportClient.java
@@ -60,14 +60,6 @@ public class ExportClient {
         return new ExportException("Unable to complete export: ", new ElasticsearchException(e));
     }
 
-    public SearchResponse singleSearch(SearchRequest request, String errorMessage) {
-        try {
-            return this.client.singleSearch(request, errorMessage);
-        } catch (Exception e) {
-            throw wrapException(e);
-        }
-    }
-
     public <R> R execute(ThrowingBiFunction<RestHighLevelClient, RequestOptions, R, IOException> fn, String errorMessage) {
         try {
             return this.client.execute(fn, errorMessage);


### PR DESCRIPTION
**Note:** This is a backport of #24242 to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is changing the indexer-specific query suggestions code to avoid using `singleSearch` and uses `(m)search` instead. This way, we do not run into errors being thrown when too many indices are used, exceeding the query length limit for `GET`.

In addition, this PR is removing `singleSearch` altogether and replaces existing usages with alternatives.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.