### PR TITLE
Always store auth context in session

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/PersistSessionDataListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/PersistSessionDataListener.java
@@ -30,6 +30,10 @@ import org.graylog2.security.sessions.SessionAuthContext;
  * A listener that is invoked by shiro after an authentication attempt
  * (e.g. within {@link org.apache.shiro.subject.Subject#login(AuthenticationToken)}). The listener checks if the
  * authentication info contains a {@link SessionAuthContext} and if so, persists it to the current session.
+ * <p>
+ * If a session auth context is provided, but no session exists at this point, we will create a session. We can treat
+ * the presence of a {@link SessionAuthContext} as a sufficient indicator that the creation of a session is expected or
+ * required during this authentication flow.
  */
 public class PersistSessionDataListener implements AuthenticationListener {
     @Override


### PR DESCRIPTION
If a session auth context is provided during authentication, we will now always store it to a session. If no session exists at this point, we will create a session because we can treat the presence of a SessionAuthContext as a sufficient indicator that the creation of a session is expected/required.

Previously, we were only storing the auth context in the session if the session existed. Most likely because of a refactoring of the SessionCreator in 5cdac60877dc11fcdc81f4765cedbbc5b3f72971, the listener that persists the data is now called before the session is created.

/nocl