### PR TITLE
Avoid unnecessary request when opening entity tables (streams, dashboards, etc.).

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useOnRefresh.ts
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useOnRefresh.ts
@@ -21,7 +21,7 @@ import AutoRefreshContext from 'views/components/contexts/AutoRefreshContext';
 const useOnRefresh = (fn: () => void) => {
   const context = useContext(AutoRefreshContext);
   useEffect(() => {
-    if (context?.animationId !== null) {
+    if (context?.animationId !== null && context?.animationId !== undefined) {
       fn();
     }
   }, [context?.animationId, fn]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Before this PR it was possible that opening the entity table (used for e.g. streams overview) results in two initial requests.

<img width="365" height="45" alt="image" src="https://github.com/user-attachments/assets/bdf8a248-d089-47e6-9bdd-7f25bacdd45b" />

This was the case when a custom page size or sort is configured and the table is not wrapped in `AutoRefreshProvider`.

The initial request was triggered by `refetch` from `useFetchEntities`, which ignores if `enabled` in `useQuery` is `false`.
The second one was triggered by `useQuery` in `useFetchEntities`, which is being enabled after the user preferences have been loaded.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/12724
/nocl - no user facing change