### PR TITLE
Fix: add datanode metrics call to allowlist

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
@@ -56,6 +56,8 @@ public class DataNodeRestApiProxyResource extends RestResource {
     private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
             request -> request.path().startsWith("indices-directory") && "GET".equals(request.method()),
             request -> request.path().startsWith("logs") && "GET".equals(request.method()),
+            request -> request.path().startsWith("metrics") && "GET".equals(request.method()),
+            request -> request.path().startsWith("metrics") && "POST".equals(request.method()),
             request -> request.path().startsWith("connection-check") && "POST".equals(request.method())
     );
 


### PR DESCRIPTION
## Description
Adds the data node metrics call to the default allowlist to make methods available without additional configuration.
/nocl internal

## Motivation and Context
needed for cluster config page with no additional configuration

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

