### PR TITLE
AggTypes do not seem to do anything with types... Preparation for ref…

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/AggTypes.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/AggTypes.java
@@ -19,8 +19,6 @@ package org.graylog.storage.elasticsearch7.views.searchtypes.pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.HasAggregations;
-import org.jooq.lambda.tuple.Tuple;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,18 +28,19 @@ import java.util.Map;
  * It's just ugly and in the way.
  */
 public class AggTypes {
-    final Map<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new HashMap<>();
+    final Map<PivotSpec, String> aggMap = new HashMap<>();
 
-    public void record(PivotSpec pivotSpec, String name, Class<? extends Aggregation> aggClass) {
-        aggTypeMap.put(pivotSpec, Tuple.tuple(name, aggClass));
+    public void record(PivotSpec pivotSpec, String name) {
+        aggMap.put(pivotSpec, name);
     }
 
-    public Aggregation getSubAggregation(PivotSpec pivotSpec, HasAggregations currentAggregationOrBucket) {
-        final Tuple2<String, Class<? extends Aggregation>> tuple2 = getTypes(pivotSpec);
-        return currentAggregationOrBucket.getAggregations().get(tuple2.v1);
+    public Aggregation getSubAggregation(PivotSpec pivotSpec,
+                                         HasAggregations currentAggregationOrBucket) {
+        final String aggName = getTypes(pivotSpec);
+        return currentAggregationOrBucket.getAggregations().get(aggName);
     }
 
-    public Tuple2<String, Class<? extends Aggregation>> getTypes(PivotSpec pivotSpec) {
-        return aggTypeMap.get(pivotSpec);
+    public String getTypes(PivotSpec pivotSpec) {
+        return aggMap.get(pivotSpec);
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotBucketSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotBucketSpecHandler.java
@@ -46,7 +46,7 @@ public abstract class ESPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
     }
 
     protected void record(ESGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
@@ -38,7 +38,7 @@ public abstract class ESPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGG
     }
 
     protected void record(ESGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
@@ -33,7 +33,6 @@ import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
 import org.graylog.storage.elasticsearch7.views.searchtypes.ESSearchTypeHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.ESPivotSeriesSpecHandler;
 import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.SeriesAggregationBuilder;
-import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +82,8 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
 
     @Override
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, ESGeneratedQueryContext queryContext) {
-        final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
-        if (objects == null) {
+        final String agg = aggTypes(queryContext, pivot).getTypes(spec);
+        if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {
                 return createValueCount(((MultiBucketsAggregation.Bucket) aggregations).getDocCount());
             } else if (aggregations instanceof Missing) {
@@ -93,7 +92,7 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
         } else {
             // try to saved sub aggregation type. this might fail if we refer to the total result of the entire result instead of a specific
             // value_count aggregation. we'll handle that special case in doHandleResult above
-            return aggregations.getAggregations().get(objects.v1);
+            return aggregations.getAggregations().get(agg);
         }
 
         return null;

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/AggTypes.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/AggTypes.java
@@ -19,8 +19,6 @@ package org.graylog.storage.opensearch2.views.searchtypes.pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
-import org.jooq.lambda.tuple.Tuple;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,18 +28,19 @@ import java.util.Map;
  * It's just ugly and in the way.
  */
 public class AggTypes {
-    final Map<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new HashMap<>();
+    final Map<PivotSpec, String> aggMap = new HashMap<>();
 
-    public void record(PivotSpec pivotSpec, String name, Class<? extends Aggregation> aggClass) {
-        aggTypeMap.put(pivotSpec, Tuple.tuple(name, aggClass));
+    public void record(PivotSpec pivotSpec, String name) {
+        aggMap.put(pivotSpec, name);
     }
 
-    public Aggregation getSubAggregation(PivotSpec pivotSpec, HasAggregations currentAggregationOrBucket) {
-        final Tuple2<String, Class<? extends Aggregation>> tuple2 = getTypes(pivotSpec);
-        return currentAggregationOrBucket.getAggregations().get(tuple2.v1);
+    public Aggregation getSubAggregation(PivotSpec pivotSpec,
+                                         HasAggregations currentAggregationOrBucket) {
+        final String aggName = getTypes(pivotSpec);
+        return currentAggregationOrBucket.getAggregations().get(aggName);
     }
 
-    public Tuple2<String, Class<? extends Aggregation>> getTypes(PivotSpec pivotSpec) {
-        return aggTypeMap.get(pivotSpec);
+    public String getTypes(PivotSpec pivotSpec) {
+        return aggMap.get(pivotSpec);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
@@ -46,7 +46,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
     }
 
     protected void record(OSGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -38,7 +38,7 @@ public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGG
     }
 
     protected void record(OSGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
@@ -33,7 +33,6 @@ import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
-import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +82,8 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
 
     @Override
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
-        final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
-        if (objects == null) {
+        final String agg = aggTypes(queryContext, pivot).getTypes(spec);
+        if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {
                 return createValueCount(((MultiBucketsAggregation.Bucket) aggregations).getDocCount());
             } else if (aggregations instanceof Missing) {
@@ -93,7 +92,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
         } else {
             // try to saved sub aggregation type. this might fail if we refer to the total result of the entire result instead of a specific
             // value_count aggregation. we'll handle that special case in doHandleResult above
-            return aggregations.getAggregations().get(objects.v1);
+            return aggregations.getAggregations().get(agg);
         }
 
         return null;

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/AggTypes.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/AggTypes.java
@@ -19,8 +19,6 @@ package org.graylog.storage.opensearch3.views.searchtypes.pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
-import org.jooq.lambda.tuple.Tuple;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,18 +28,19 @@ import java.util.Map;
  * It's just ugly and in the way.
  */
 public class AggTypes {
-    final Map<PivotSpec, Tuple2<String, Class<? extends Aggregation>>> aggTypeMap = new HashMap<>();
+    final Map<PivotSpec, String> aggMap = new HashMap<>();
 
-    public void record(PivotSpec pivotSpec, String name, Class<? extends Aggregation> aggClass) {
-        aggTypeMap.put(pivotSpec, Tuple.tuple(name, aggClass));
+    public void record(PivotSpec pivotSpec, String name) {
+        aggMap.put(pivotSpec, name);
     }
 
-    public Aggregation getSubAggregation(PivotSpec pivotSpec, HasAggregations currentAggregationOrBucket) {
-        final Tuple2<String, Class<? extends Aggregation>> tuple2 = getTypes(pivotSpec);
-        return currentAggregationOrBucket.getAggregations().get(tuple2.v1);
+    public Aggregation getSubAggregation(PivotSpec pivotSpec,
+                                         HasAggregations currentAggregationOrBucket) {
+        final String aggName = getTypes(pivotSpec);
+        return currentAggregationOrBucket.getAggregations().get(aggName);
     }
 
-    public Tuple2<String, Class<? extends Aggregation>> getTypes(PivotSpec pivotSpec) {
-        return aggTypeMap.get(pivotSpec);
+    public String getTypes(PivotSpec pivotSpec) {
+        return aggMap.get(pivotSpec);
     }
 }

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
@@ -46,7 +46,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
     }
 
     protected void record(OSGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -38,7 +38,7 @@ public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGG
     }
 
     protected void record(OSGeneratedQueryContext queryContext, Pivot pivot, PivotSpec spec, String name, Class<? extends Aggregation> aggregationClass) {
-        aggTypes(queryContext, pivot).record(spec, name, aggregationClass);
+        aggTypes(queryContext, pivot).record(spec, name);
     }
 
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/series/OSCountHandler.java
@@ -33,7 +33,6 @@ import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch3.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.SeriesAggregationBuilder;
-import org.jooq.lambda.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +82,8 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
 
     @Override
     public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, OSGeneratedQueryContext queryContext) {
-        final Tuple2<String, Class<? extends Aggregation>> objects = aggTypes(queryContext, pivot).getTypes(spec);
-        if (objects == null) {
+        final String agg = aggTypes(queryContext, pivot).getTypes(spec);
+        if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {
                 return createValueCount(((MultiBucketsAggregation.Bucket) aggregations).getDocCount());
             } else if (aggregations instanceof Missing) {
@@ -93,7 +92,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
         } else {
             // try to saved sub aggregation type. this might fail if we refer to the total result of the entire result instead of a specific
             // value_count aggregation. we'll handle that special case in doHandleResult above
-            return aggregations.getAggregations().get(objects.v1);
+            return aggregations.getAggregations().get(agg);
         }
 
         return null;


### PR DESCRIPTION
## Description
AggTypes do not seem to do anything with types... Preparation for refactoring.
/nocl

## Motivation and Context
AggTypes store name and class as a tuple, but when data is accessed, it is always... the first element of the tuple (`v1`), so the class seems to not be needed at all !!!

If accepted, further refactoring will follow. It may be needed to properly accomplish a big refactoring started here : https://github.com/Graylog2/graylog2-server/pull/24406


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

