### PR TITLE
Look up final input before returning summary

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/api/CloudTrailDriver.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/api/CloudTrailDriver.java
@@ -124,7 +124,7 @@ public class CloudTrailDriver {
             final String newInputId = inputService.save(input);
             LOG.info("New CloudTrail input created. id [{}] request [{}]", newInputId, request);
 
-            return input;
+            return inputService.find(newInputId);
         } catch (NoSuchInputTypeException e) {
             LOG.error("There is no such input type registered. {}", ExceptionUtils.getRootCauseMessage(e));
             throw new NotFoundException("There is no such input type registered.", e);

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -154,7 +154,7 @@ public class AWSService {
             final Input input = this.inputService.create(messageInput.asMap());
             final String newInputId = inputService.save(input);
             LOG.debug("New AWS input created. id [{}] request [{}]", newInputId, request);
-            return input;
+            return inputService.find(newInputId);
         } catch (NoSuchInputTypeException e) {
             LOG.error("There is no such input type registered.", e);
             throw new NotFoundException("There is no such input type registered.", e);

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -275,15 +275,6 @@ public class InputServiceImpl implements InputService {
                 .setConfiguration((Map<String, Object>) fields.get(MessageInput.FIELD_CONFIGURATION))
                 .setCreatedAt(createdAt);
 
-        final Object idField = fields.get(InputImpl.FIELD_ID);
-        if (idField instanceof ObjectId objectId) {
-            builder.setId(objectId.toHexString());
-        } else if (idField instanceof String idStr && !idStr.isBlank()) {
-            builder.setId(idStr);
-        } else {
-            builder.setId(new ObjectId().toHexString());
-        }
-
         final String desiredStateStr = (String) fields.get(MessageInput.FIELD_DESIRED_STATE);
         if (desiredStateStr != null && !desiredStateStr.isBlank()) {
             builder.setPersistedDesiredState(IOState.Type.valueOf(desiredStateStr));

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -165,34 +165,6 @@ public class InputServiceImplTest {
     }
 
     @Test
-    public void createMapAssignsIdWhenMissing() {
-        final Map<String, Object> fields = new HashMap<>();
-        fields.put(MessageInput.FIELD_TITLE, "TestInput");
-        fields.put(MessageInput.FIELD_TYPE, "org.graylog.plugins.Test");
-        fields.put(MessageInput.FIELD_CONFIGURATION, Map.of());
-        fields.put(MessageInput.FIELD_CREATOR_USER_ID, "admin");
-
-        final Input input = inputService.create(fields);
-
-        assertThat(input.getId()).isNotBlank();
-    }
-
-    @Test
-    public void createMapRespectsProvidedId() {
-        final String desiredId = new ObjectId().toHexString();
-        final Map<String, Object> fields = new HashMap<>();
-        fields.put(InputImpl.FIELD_ID, desiredId);
-        fields.put(MessageInput.FIELD_TITLE, "GenericInput");
-        fields.put(MessageInput.FIELD_TYPE, "org.graylog.plugins.GenericInput");
-        fields.put(MessageInput.FIELD_CONFIGURATION, Map.of());
-        fields.put(MessageInput.FIELD_CREATOR_USER_ID, "user");
-
-        final Input input = inputService.create(fields);
-
-        assertThat(input.getId()).isEqualTo(desiredId);
-    }
-
-    @Test
     public void handlesEncryptedValue() throws ValidationException, NotFoundException {
 
         // Setup required to detect fields that need conversion from Map to EncryptedValue when reading


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix `InputSummary: Null inputId` error when creating Cloud Trail and Kinesis/CloudWatch inputs with setup wizard. 

See https://github.com/Graylog2/graylog-plugin-enterprise/pull/12676 for additional details and context. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added, and manual input creation. See https://github.com/Graylog2/graylog-plugin-enterprise/issues/12675 for additional details and instructions to reproduce the error.
