### PR TITLE
Add java duration converter to max_event_age config property

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -301,7 +301,7 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
     @Parameter(value = "global_inputs_only")
     private boolean globalInputsOnly = false;
 
-    @Parameter(value = "max_event_age", validators = PositiveDurationValidator.class, converter = JavaDurationConverter.class)
+    @Parameter(value = "max_event_age", converter = JavaDurationConverter.class)
     private java.time.Duration maxEventAge = java.time.Duration.ofDays(1L);
 
     public boolean maintainsStreamAwareFieldTypes() {


### PR DESCRIPTION
/nocl internal fix

## Description
Added converter between duration types and removed validator, fixing incompatible classes errors. Discovered thanks to https://github.com/Graylog2/JadConfig/pull/128


## How Has This Been Tested?
Existing tests

## Screenshots (if appropriate):
<img width="1767" height="324" alt="image" src="https://github.com/user-attachments/assets/c21383f5-7659-4db4-a50f-b52d9b0fb81d" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

