### PR TITLE
Make maximum event age configurable. (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-24441.toml
+++ b/changelog/unreleased/pr-24441.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Make maximum event age of cluster events configurable. "
+
+pulls = ["24441"]

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -301,6 +301,9 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
     @Parameter(value = "global_inputs_only")
     private boolean globalInputsOnly = false;
 
+    @Parameter(value = "max_event_age", converter = JavaDurationConverter.class)
+    private java.time.Duration maxEventAge = java.time.Duration.ofDays(1L);
+
     public boolean maintainsStreamAwareFieldTypes() {
         return streamAwareFieldTypes;
     }


### PR DESCRIPTION
**Note:** This is a backport of #24441 & #24455 to `7.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is making the maximum event age used when cleaning up cluster events configurable. It is used to purge events from the `cluster_events` collection in MongoDB which have expired and are assumed to have been processed already. This helps reducing runtime for polling queries. An ideal sizing would be the maximum time that a cluster has no active leader node.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.