### PR TITLE
Create users metrics supplier (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-24090.toml
+++ b/changelog/unreleased/pr-24090.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Create metrics supplier for users."
+
+pulls = ["24090"]
+issues = ["Graylog2/graylog-plugin-enterprise#12207"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/users/UserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/users/UserService.java
@@ -25,6 +25,7 @@ import org.graylog2.plugin.database.users.User;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -71,6 +72,11 @@ public interface UserService extends PersistedService {
     Optional<User> getRootUser();
 
     long count();
+
+    /**
+     * @return The counts of users by privilege category (admin vs non-admin).
+     */
+    Map<String, Long> countByPrivilege();
 
     List<User> loadAllForAuthServiceBackend(String authServiceBackendId);
 

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
@@ -19,6 +19,7 @@ package org.graylog2.telemetry;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.PluginModule;
 import org.graylog2.telemetry.scheduler.TelemetrySubmissionPeriodical;
+import org.graylog2.telemetry.suppliers.UsersMetricsSupplier;
 import org.graylog2.telemetry.suppliers.InputsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.OutputsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.MongoDBMetricsSupplier;
@@ -34,6 +35,7 @@ public class TelemetryModule extends PluginModule {
         addPeriodical(TelemetrySubmissionPeriodical.class);
         Multibinder.newSetBinder(binder(), TelemetryDataProvider.class);
 
+        addTelemetryMetricProvider("Users Metrics", UsersMetricsSupplier.class);
         addTelemetryMetricProvider("Inputs Metrics", InputsMetricsSupplier.class);
         addTelemetryMetricProvider("Outputs Metrics", OutputsMetricsSupplier.class);
         addTelemetryMetricProvider("MongoDB Metrics", MongoDBMetricsSupplier.class);

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/UsersMetricsSupplier.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/UsersMetricsSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.telemetry.suppliers;
+
+import jakarta.inject.Inject;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.graylog2.telemetry.scheduler.TelemetryMetricSupplier;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class UsersMetricsSupplier implements TelemetryMetricSupplier {
+    private final UserService userService;
+
+    @Inject
+    public UsersMetricsSupplier(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public Optional<TelemetryEvent> get() {
+        Map<String, Object> metrics = new HashMap<>(userService.countByPrivilege());
+
+        return Optional.of(TelemetryEvent.of(metrics));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -343,6 +343,21 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
     }
 
     @Override
+    public Map<String, Long> countByPrivilege() {
+        ObjectId adminRoleId = new ObjectId(roleService.getAdminRoleObjectId());
+
+        final long adminCount = collection(UserImpl.class)
+                .count(new BasicDBObject(UserImpl.ROLES, adminRoleId)) + (configuration.isRootUserDisabled() ? 0 : 1);
+
+        final long totalUsers = collection(UserImpl.class).count();
+
+        return Map.of(
+                "admin_users", adminCount,
+                "non_admin_users", totalUsers - adminCount
+        );
+    }
+
+    @Override
     public List<User> loadAllForAuthServiceBackend(String authServiceBackendId) {
         final DBObject query = BasicDBObjectBuilder.start(UserImpl.AUTH_SERVICE_ID, authServiceBackendId).get();
         return buildUserList(query);

--- a/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -159,6 +160,11 @@ public class TestUserService extends PersistedServiceImpl implements UserService
 
     @Override
     public long count() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public Map<String, Long> countByPrivilege() {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/UsersMetricsSupplierTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/UsersMetricsSupplierTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.telemetry.suppliers;
+
+import org.graylog2.shared.users.UserService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UsersMetricsSupplierTest {
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UsersMetricsSupplier usersMetricsSupplier;
+
+    @Test
+    public void shouldReturnUsersMetrics() {
+        Map<String, Long> counts = Map.of(
+                "admin_users", 2L,
+                "non_admin_users", 4L
+        );
+
+        when(userService.countByPrivilege()).thenReturn(counts);
+
+        Optional<TelemetryEvent> event = usersMetricsSupplier.get();
+
+        assertTrue(event.isPresent());
+        assertEquals(counts, event.get().metrics());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -99,7 +99,7 @@ public class UserServiceImplTest {
         this.userService = new UserServiceImpl(mongoConnection, configuration, roleService, accessTokenService,
                 userFactory, permissionsResolver, serverEventBus, GRNRegistry.createWithBuiltinTypes(), permissionAndRoleResolver);
 
-        lenient().when(roleService.getAdminRoleObjectId()).thenReturn("deadbeef");
+        lenient().when(roleService.getAdminRoleObjectId()).thenReturn("deadbeefdeadbeefdeadbeef");
     }
 
     @Test
@@ -216,7 +216,7 @@ public class UserServiceImplTest {
     @Test
     @MongoDBFixtures("UserServiceImplTest.json")
     public void testLoadAll() {
-        assertThat(userService.loadAll()).hasSize(5);
+        assertThat(userService.loadAll()).hasSize(6);
     }
 
     @Test
@@ -266,7 +266,7 @@ public class UserServiceImplTest {
     @Test
     @MongoDBFixtures("UserServiceImplTest.json")
     public void testCount() {
-        assertThat(userService.count()).isEqualTo(5L);
+        assertThat(userService.count()).isEqualTo(6L);
     }
 
     public static class UserImplFactory implements UserImpl.Factory {
@@ -361,5 +361,15 @@ public class UserServiceImplTest {
         assertThat(userService.getPermissionsForUser(user).stream().map(p -> p instanceof CaseSensitiveWildcardPermission ? p.toString() : p).collect(Collectors.toSet()))
                 .containsExactlyInAnyOrder("users:passwordchange:user", "users:edit:user", "foo:bar", "hello:world", "users:tokenlist:user",
                         "users:tokenremove:user", "perm:from:grant", ownerShipPermission, "perm:from:role");
+    }
+
+    @Test
+    @MongoDBFixtures("UserServiceImplTest.json")
+    public void testCountByPrivilege() {
+        final Map<String, Long> counts = userService.countByPrivilege();
+
+        assertThat(counts)
+                .containsEntry("admin_users", 2L)
+                .containsEntry("non_admin_users", 4L);
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/users/UserServiceImplTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/users/UserServiceImplTest.json
@@ -62,6 +62,23 @@
       "timezone": "UTC",
       "permissions": [],
       "external": true
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0006"
+      },
+      "roles": [
+        {
+          "$oid": "deadbeefdeadbeefdeadbeef"
+        }
+      ],
+      "username": "admin-user",
+      "email": "admin-user@example.com",
+      "full_name": "Admin user",
+      "password": "NO LOGIN",
+      "session_timeout_ms": -1,
+      "timezone": "UTC",
+      "permissions": []
     }
   ]
 }


### PR DESCRIPTION
Note: This is a backport of #24090 to `6.2`.

Closes Graylog2/graylog-plugin-enterprise/issues/12207

## Description
Introduce `UsersMetricsSupplier` to collect counts for admin and non-admin users. The metrics are sent to PostHog as a single event named `Users Metrics`.

**Example event properties:**
```json
{
  "cluster_id": "<UUID>",
  "admin_users": 2,
  "non_admin_users": 1,
  ...
}
```

## How Has This Been Tested?
Tested on a local instance + unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

