### PR TITLE
Fixing issue with column visibility in entity tables.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -240,7 +240,36 @@ describe('<EntityDataTable />', () => {
     expect(rowCheckboxes[0]).not.toBeChecked();
   });
 
-  it('should display default columns, which are not hidden via user column preferences and update visibility correctly', async () => {
+  it('user preferences should include all currently visible columns on preferences update', async () => {
+    const onLayoutPreferencesChange = jest.fn();
+
+    render(
+      <EntityDataTable
+        {...defaultProps}
+        layoutPreferences={{}}
+        defaultDisplayedColumns={['description', 'status', 'title']}
+        defaultColumnOrder={['description', 'status', 'title']}
+        onLayoutPreferencesChange={onLayoutPreferencesChange}
+      />,
+    );
+
+    await screen.findByRole('columnheader', { name: /title/i });
+    await screen.findByRole('columnheader', { name: /status/i });
+    await screen.findByRole('columnheader', { name: /description/i });
+
+    userEvent.click(await screen.findByRole('button', { name: /configure visible columns/i }));
+    userEvent.click(await screen.findByRole('menuitem', { name: /hide title/i }));
+
+    expect(onLayoutPreferencesChange).toHaveBeenCalledWith({
+      attributes: {
+        description: { status: ATTRIBUTE_STATUS.show },
+        status: { status: ATTRIBUTE_STATUS.show },
+        title: { status: 'hide' },
+      },
+    });
+  });
+
+  it('if there are user preferences, only selected columns should be displayed', async () => {
     const onLayoutPreferencesChange = jest.fn();
 
     render(
@@ -259,15 +288,13 @@ describe('<EntityDataTable />', () => {
     );
 
     userEvent.click(await screen.findByRole('button', { name: /configure visible columns/i }));
-    userEvent.click(await screen.findByRole('menuitem', { name: /hide title/i }));
+    await screen.findByRole('menuitem', { name: /show title/i });
 
-    expect(onLayoutPreferencesChange).toHaveBeenCalledWith({
-      attributes: {
-        description: { status: ATTRIBUTE_STATUS.show },
-        status: { status: ATTRIBUTE_STATUS.show },
-        title: { status: 'hide' },
-      },
-    });
+    expect(
+      screen.queryByRole('columnheader', {
+        name: /title/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it('should reset layout preferences via reset all columns action', async () => {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
@@ -43,17 +43,18 @@ const columnVisibilityChanges = (prevVisibleColumns: VisibilityState, currVisibl
 };
 
 const updateColumnPreferences = (
-  addedColumns: Set<string>,
+  visibleAttributeColumns: Set<string>,
   removedColumns: Set<string>,
   columnPreferences: ColumnPreferences | undefined = {},
 ) => {
   const updatedPreferences = { ...columnPreferences };
 
-  // only update the preferences for columns which have been shown/hidden by the user
-  addedColumns.forEach((col) => {
+  // All currently visible columns will be marked as 'show'
+  visibleAttributeColumns.forEach((col) => {
     updatedPreferences[col] = { status: ATTRIBUTE_STATUS.show };
   });
 
+  // Only explicitly hidden columns will be marked as 'hide'
   removedColumns.forEach((col) => {
     updatedPreferences[col] = { status: ATTRIBUTE_STATUS.hide };
   });
@@ -128,13 +129,16 @@ const useTable = <Entity extends EntityBase>({
   const onColumnVisibilityChange = useCallback(
     (updater: Updater<VisibilityState>) => {
       const newColumnVisibility = updater instanceof Function ? updater(columnVisibility) : updater;
+      const visibleAttributeColumns = new Set(
+        Object.keys(newColumnVisibility).filter((colId) => newColumnVisibility[colId] && !UTILITY_COLUMNS.has(colId)),
+      );
       const { addedColumns, removedColumns } = columnVisibilityChanges(columnVisibility, newColumnVisibility);
 
       const newLayoutPreferences: {
         attributes?: ColumnPreferences;
         order?: Array<string>;
       } = {
-        attributes: updateColumnPreferences(addedColumns, removedColumns, layoutPreferences.attributes),
+        attributes: updateColumnPreferences(visibleAttributeColumns, removedColumns, layoutPreferences.attributes),
       };
 
       // if user has a custom order, we need to update it to reflect the visibility changes

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useVisibleColumnOrder.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useVisibleColumnOrder.ts
@@ -24,20 +24,17 @@ const getVisibleAttributeColumns = (
   defaultDisplayedColumns: Array<string>,
   userColumnPreferences: ColumnPreferences | undefined = {},
 ) => {
-  const visible = new Set(
+  const userSelection = new Set(
     Object.entries(userColumnPreferences)
       .filter(([, { status }]) => status === ATTRIBUTE_STATUS.show)
       .map(([attr]) => attr),
   );
 
-  // Add default columns, which are not explicitly hidden
-  defaultDisplayedColumns.forEach((attr) => {
-    if (!(userColumnPreferences[attr]?.status === 'hide')) {
-      visible.add(attr);
-    }
-  });
+  if (userSelection.size > 0) {
+    return userSelection;
+  }
 
-  return visible;
+  return new Set(defaultDisplayedColumns);
 };
 const useVisibleColumnOrder = (
   columnPreferences: ColumnPreferences | undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In Graylog `7.0` when a user made changes to the column visibility in an entity table (streams, dashboard overview, etc.), we saved all currently visible columns in the user preferences.

<img width="268" height="119" alt="image" src="https://github.com/user-attachments/assets/be052f2a-1d84-43cc-9038-0012fac9fb58" />

One side effect is that newly introduced columns were hidden by default, if there already are user preferences. They could only be added via a migration. With recent changes we tried to improve this behavior, but these changes could resulted in a state where many previously hidden columns were now displayed.

This PR restores the previous behavior to fix the described bug. 

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/12694
/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/12734
/nocl - fixes an unreleased bug

