### PR TITLE
Use OpenSearch 2.4.1 for SearchServer.OS2

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/containermatrix/SearchServer.java
@@ -26,7 +26,7 @@ import static org.graylog2.storage.SearchVersion.Distribution.OPENSEARCH;
 public enum SearchServer {
     ES7(ELASTICSEARCH, "7.10.2"),
     OS1(OPENSEARCH, "1.3.12"),
-    OS2(OPENSEARCH, "2.0.1"),
+    OS2(OPENSEARCH, "2.4.1"),
     OS2_4(OPENSEARCH, "2.4.1"),
     OS2_LATEST(OPENSEARCH, "2.17.0"),
     DATANODE_PRE_52(DATANODE, "5.1.0"),


### PR DESCRIPTION
Version 2.0.1 doesn't work with newer Linux kernels in our CI environment. Version between 2.0.1 and 2.4.0 use Java 17.0.(1|2|3|4), which have the issues. OpenSearch 2.4.1 is the first version that's using a fixed Java 17.0.5.

/nocl

