### PR TITLE
Create event notifications metrics supplier (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-24048.toml
+++ b/changelog/unreleased/pr-24048.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Create metrics supplier for event notifications."
+
+pulls = ["24048"]
+issues = ["Graylog2/graylog-plugin-enterprise#12225"]

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/DBNotificationService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/DBNotificationService.java
@@ -27,6 +27,7 @@ import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.search.SearchQuery;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -88,5 +89,9 @@ public class DBNotificationService {
 
     public Stream<NotificationDto> streamAll() {
         return stream(collection.find());
+    }
+
+    public Map<String, Long> countByType() {
+        return mongoUtils.countByField("config.type");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -21,6 +21,8 @@ import com.mongodb.ErrorCategory;
 import com.mongodb.MongoException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoIterable;
+import com.mongodb.client.model.Accumulators;
+import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.ReplaceOptions;
@@ -32,12 +34,16 @@ import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonValue;
 import org.bson.codecs.EncoderContext;
+import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.graylog2.database.BuildableMongoEntity;
 import org.graylog2.database.MongoEntity;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -262,5 +268,25 @@ public class MongoUtils<T extends MongoEntity> {
             collection.replaceOne(idEq(id), orig, new ReplaceOptions().upsert(true));
             return orig;
         }
+    }
+
+    /**
+     * Counts the number of documents for each distinct value of the given field.
+     *
+     * @param field the field to group by.
+     * @return Map of field values to their respective counts.
+     */
+    public Map<String, Long> countByField(String field) {
+        final Map<String, Long> counts = new HashMap<>();
+        collection.aggregate(
+                List.of(Aggregates.group("$" + field, Accumulators.sum("count", 1))),
+                Document.class
+        ).forEach(doc -> {
+            String id = doc.getString("_id");
+            if (id != null) {
+                counts.put(id, doc.getInteger("count").longValue());
+            }
+        });
+        return counts;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
@@ -25,6 +25,7 @@ import org.graylog2.telemetry.suppliers.OutputsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.MongoDBMetricsSupplier;
 import org.graylog2.telemetry.suppliers.ShardsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.LookupTablesSupplier;
+import org.graylog2.telemetry.suppliers.EventNotificationsMetricsSupplier;
 
 public class TelemetryModule extends PluginModule {
     @Override
@@ -41,5 +42,6 @@ public class TelemetryModule extends PluginModule {
         addTelemetryMetricProvider("MongoDB Metrics", MongoDBMetricsSupplier.class);
         addTelemetryMetricProvider("Shards Metrics", ShardsMetricsSupplier.class);
         addTelemetryMetricProvider("Lookup Tables Metrics", LookupTablesSupplier.class);
+        addTelemetryMetricProvider("Event Notifications Metrics", EventNotificationsMetricsSupplier.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/EventNotificationsMetricsSupplier.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/EventNotificationsMetricsSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.telemetry.suppliers;
+
+import jakarta.inject.Inject;
+import org.graylog.events.notifications.DBNotificationService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.graylog2.telemetry.scheduler.TelemetryMetricSupplier;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class EventNotificationsMetricsSupplier implements TelemetryMetricSupplier {
+    private final DBNotificationService dbNotificationService;
+
+    @Inject
+    public EventNotificationsMetricsSupplier(DBNotificationService dbNotificationService) {
+        this.dbNotificationService = dbNotificationService;
+    }
+
+    @Override
+    public Optional<TelemetryEvent> get() {
+        Map<String, Object> metrics = new HashMap<>(dbNotificationService.countByType());
+
+        return Optional.of(TelemetryEvent.of(metrics));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -318,4 +318,22 @@ class MongoUtilsTest {
                 .isEqualTo(orig)
                 .isEqualTo(util.getById(orig.id()).orElse(null));
     }
+
+    @Test
+    void testCountByField() {
+        collection.insertMany(List.of(
+                new DTO(null, "name-1"),
+                new DTO(null, "name-2"),
+                new DTO(null, "name-2"),
+                new DTO(null, null)
+        ));
+
+        Map<String, Long> counts = utils.countByField("name");
+
+        assertThat(counts)
+                .containsEntry("name-1", 1L)
+                .containsEntry("name-2", 2L)
+                .hasSize(2)
+                .doesNotContainKey(null);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/EventNotificationsMetricsSupplierTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/EventNotificationsMetricsSupplierTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.telemetry.suppliers;
+
+import org.graylog.events.notifications.DBNotificationService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EventNotificationsMetricsSupplierTest {
+    @Mock
+    private DBNotificationService dbNotificationService;
+
+    @InjectMocks
+    private EventNotificationsMetricsSupplier eventNotificationsMetricsSupplier;
+
+    @Test
+    public void shouldReturnNotificationMetrics() {
+        Map<String, Long> counts = Map.of(
+                "http-notification-v1", 1L,
+                "email-notification-v1", 3L,
+                "slack-notification-v1", 2L
+        );
+
+        when(dbNotificationService.countByType()).thenReturn(counts);
+
+        Optional<TelemetryEvent> event = eventNotificationsMetricsSupplier.get();
+
+        assertTrue(event.isPresent());
+        assertEquals(counts, event.get().metrics());
+    }
+}


### PR DESCRIPTION
Note: This is a backport of #24048 to `6.2`.

Closes Graylog2/graylog-plugin-enterprise/issues/12225

## Description
Introduce `EventNotificationsMetricsSupplier` to collect event notification types and their respective counts. The metrics are sent to PostHog as a single event named `Event Notifications Metrics`.

**Example event properties:**
```json
{
  "cluster_id": "<UUID>",
  "http-notification-v1": 2,
  "slack-notification-v1": 1,
  ...
}
```

## How Has This Been Tested?
Tested on a local instance + unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

