### PR TITLE
Fix issue when click on pie chart shows in popover NaN instead of value 7.0

### DIFF
--- a/changelog/unreleased/issue-23853.toml
+++ b/changelog/unreleased/issue-23853.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix issue when click on pie chart shows in popover NaN instead of value."
+
+issues = ["23853"]
+pulls = ["24413"]

--- a/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/PieOnClickPopoverDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/PieOnClickPopoverDropdown.tsx
@@ -27,6 +27,7 @@ import type { ValueGroups, OnClickPopoverDropdownProps } from 'views/components/
 const PieOnClickPopoverDropdown = ({ clickPoint, config, setFieldData }: OnClickPopoverDropdownProps) => {
   const { rowPivotValues, columnPivotValues, metricValue } = useMemo<ValueGroups>(() => {
     if (!clickPoint || !config) return {};
+
     const traceColor = getHoverSwatchColor(clickPoint);
     const splitNames: Array<string | number> = (clickPoint.data.originalName ?? clickPoint.data.name).split(
       keySeparator,
@@ -57,17 +58,19 @@ const PieOnClickPopoverDropdown = ({ clickPoint, config, setFieldData }: OnClick
       metricValue: {
         value: clickPoint.value,
         field: metric,
-        text: `${String(clickPoint.text ?? clickPoint?.value)}`,
+        text: `${String(clickPoint?.value)}`,
         traceColor,
       },
     };
   }, [clickPoint, config]);
 
   const formatedPercentageValue = useMemo(() => {
-    const { value, unit } = getPrettifiedValue(clickPoint?.percent, { abbrev: 'd%', unitType: 'percent' });
+    if (!clickPoint.percent) return clickPoint.text;
+
+    const { value, unit } = getPrettifiedValue(clickPoint.percent, { abbrev: 'd%', unitType: 'percent' });
 
     return formatValueWithUnitLabel(value, unit?.abbrev);
-  }, [clickPoint?.percent]);
+  }, [clickPoint.percent, clickPoint.text]);
 
   return (
     <Popover.Dropdown title={formatedPercentageValue}>


### PR DESCRIPTION
This is a backport of https://github.com/Graylog2/graylog2-server/pull/24413 into 7.0

## Description
In some cases, Plotly passes a different data structure into the click event. I detailed described the issue here https://github.com/plotly/react-plotly.js/issues/358

This PR is basically a workaround for managing 2 data models. We are checking if the percent exists; if not, we use the property text as the title for the popover. We also use property value as a value for metric.

## Motivation and Context
fix: #23853 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

