### PR TITLE
Backport 7.0: Fix audit logging for AuthzRolesResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -36,10 +36,15 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.security.UserContext;
+import org.graylog2.audit.AuditActor;
+import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
@@ -73,7 +78,7 @@ import static org.graylog2.shared.security.RestPermissions.USERS_ROLESEDIT;
 @Path("/authz/roles")
 @Produces(MediaType.APPLICATION_JSON)
 public class AuthzRolesResource extends RestResource {
-    private static final Logger LOG = LoggerFactory.getLogger(RestResource.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthzRolesResource.class);
 
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put(AuthzRoleDTO.FIELD_ID, SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
@@ -92,9 +97,15 @@ public class AuthzRolesResource extends RestResource {
     private final UserService userService;
     private final SearchQueryParser searchQueryParser;
     private final SearchQueryParser userSearchQueryParser;
+    private final AuditEventSender auditEventSender;
 
     @Inject
-    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService, PaginatedUserService paginatedUserService, UserService userService) {
+    public AuthzRolesResource(
+            PaginatedAuthzRolesService authzRolesService,
+            PaginatedUserService paginatedUserService,
+            UserService userService,
+            AuditEventSender auditEventSender) {
+        this.auditEventSender = auditEventSender;
         this.authzRolesService = authzRolesService;
         this.paginatedUserService = paginatedUserService;
         this.userService = userService;
@@ -223,29 +234,31 @@ public class AuthzRolesResource extends RestResource {
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation("Add user to role")
-    @AuditEvent(type = AuditEventTypes.ROLE_MEMBERSHIP_UPDATE)
     @Path("{roleId}/assignees")
+    @NoAuditEvent("Has custom audit events")
     public void addUser(
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
-            @ApiParam(name = "usernames") Set<String> usernames) throws ValidationException {
-        updateUserRole(roleId, usernames, Set::add);
+            @ApiParam(name = "usernames") Set<String> usernames,
+            @Context UserContext userContext) {
+        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_UPDATE, roleId, usernames, Set::add);
     }
 
     @DELETE
     @ApiOperation("Remove user from role")
     @Path("{roleId}/assignee/{username}")
-    @AuditEvent(type = AuditEventTypes.ROLE_MEMBERSHIP_DELETE)
+    @NoAuditEvent("Has custom audit events")
     public void removeUser(
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
-            @ApiParam(name = "username") @PathParam("username") @NotBlank String username) throws ValidationException {
-        updateUserRole(roleId, ImmutableSet.of(username), Set::remove);
+            @ApiParam(name = "username") @PathParam("username") @NotBlank String username,
+            @Context UserContext userContext) {
+        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_DELETE, roleId, ImmutableSet.of(username), Set::remove);
     }
 
     interface UpdateRoles {
         boolean update(Set<String> roles, String roleId);
     }
 
-    private void updateUserRole(String roleId, Set<String> usernames, UpdateRoles rolesUpdater) {
+    private void updateUserRole(UserContext userContext, String auditEventType, String roleId, Set<String> usernames, UpdateRoles rolesUpdater) {
         usernames.forEach(username -> {
             checkPermission(USERS_ROLESEDIT, username);
 
@@ -253,12 +266,14 @@ public class AuthzRolesResource extends RestResource {
             if (user == null) {
                 throw new NotFoundException("Cannot find user with name: " + username);
             }
-            authzRolesService.get(roleId)
-                    .ifPresentOrElse(role -> {
-                        checkPermission(RestPermissions.ROLES_ASSIGN, role.name());
-                    }, () -> {
-                        throw new NotFoundException("Cannot find role with id: " + roleId);
-                    });
+            String roleName;
+            final Optional<AuthzRoleDTO> authzRoleDTO = authzRolesService.get(roleId);
+            if (authzRoleDTO.isEmpty()) {
+                throw new NotFoundException("Cannot find role with id: " + roleId);
+            } else {
+                roleName = authzRoleDTO.get().name();
+                checkPermission(RestPermissions.ROLES_ASSIGN, roleName);
+            }
             Set<String> roles = user.getRoleIds();
             rolesUpdater.update(roles, roleId);
             user.setRoleIds(roles);
@@ -267,6 +282,11 @@ public class AuthzRolesResource extends RestResource {
             } catch (ValidationException e) {
                 LOG.warn("Could not update user: {}", username);
             }
+
+            auditEventSender.success(AuditActor.user(userContext.getUser().getName()),
+                    auditEventType,
+                    ImmutableMap.of("roleName", roleName, "userName", username));
+
         });
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -132,6 +132,8 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String NODE_SHUTDOWN_INITIATE = PREFIX + "node_shutdown:initiate";
     public static final String NODE_STARTUP_COMPLETE = PREFIX + "node_startup:complete";
     public static final String NODE_STARTUP_INITIATE = PREFIX + "node_startup:initiate";
+    public static final String ROLE_AUTHZ_DELETE = PREFIX + "role_authz_membership:delete";
+    public static final String ROLE_AUTHZ_UPDATE = PREFIX + "role_authz_membership:update";
     public static final String ROLE_CREATE = PREFIX + "role:create";
     public static final String ROLE_DELETE = PREFIX + "role:delete";
     public static final String ROLE_MEMBERSHIP_DELETE = PREFIX + "role_membership:delete";
@@ -176,6 +178,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String USER_PERMISSIONS_DELETE = PREFIX + "user_permissions:delete";
     public static final String USER_PREFERENCES_UPDATE = PREFIX + "user_preferences:update";
     public static final String USER_UPDATE = PREFIX + "user:update";
+    public static final String USER_ROLES_UPDATE = PREFIX + "user_roles:update";
     public static final String TELEMETRY_USER_SETTINGS_UPDATE = PREFIX + "telemetry_user_settings:update";
     public static final String CONTENT_STREAM_USER_SETTINGS_UPDATE = PREFIX + "content_stream_user_settings:update";
 
@@ -298,6 +301,8 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(NODE_SHUTDOWN_INITIATE)
             .add(NODE_STARTUP_COMPLETE)
             .add(NODE_STARTUP_INITIATE)
+            .add(ROLE_AUTHZ_DELETE)
+            .add(ROLE_AUTHZ_UPDATE)
             .add(ROLE_CREATE)
             .add(ROLE_DELETE)
             .add(ROLE_MEMBERSHIP_DELETE)
@@ -341,6 +346,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(USER_PERMISSIONS_DELETE)
             .add(USER_PREFERENCES_UPDATE)
             .add(USER_UPDATE)
+            .add(USER_ROLES_UPDATE)
             .add(TELEMETRY_USER_SETTINGS_UPDATE)
             .add(CONTENT_STREAM_USER_SETTINGS_UPDATE)
             .add(CERTIFICATE_RENEWAL_MANUALLY_INITIATED)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -61,6 +61,8 @@ import org.graylog.security.authservice.AuthServiceBackendDTO;
 import org.graylog.security.authservice.GlobalAuthServiceConfig;
 import org.graylog.security.permissions.CaseSensitiveWildcardPermission;
 import org.graylog.security.permissions.GRNPermission;
+import org.graylog2.audit.AuditActor;
+import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.PaginatedList;
@@ -156,6 +158,7 @@ public class UsersResource extends RestResource {
     private final DefaultSecurityManager securityManager;
     private final GlobalAuthServiceConfig globalAuthServiceConfig;
     private final ClusterConfigService clusterConfigService;
+    private final AuditEventSender auditEventSender;
 
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put(UserOverviewDTO.FIELD_ID, SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
@@ -173,7 +176,8 @@ public class UsersResource extends RestResource {
                          UserSessionTerminationService sessionTerminationService,
                          DefaultSecurityManager securityManager,
                          GlobalAuthServiceConfig globalAuthServiceConfig,
-                         ClusterConfigService clusterConfigService) {
+                         ClusterConfigService clusterConfigService,
+                         AuditEventSender auditEventSender) {
         this.userManagementService = userManagementService;
         this.accessTokenService = accessTokenService;
         this.roleService = roleService;
@@ -184,6 +188,7 @@ public class UsersResource extends RestResource {
         this.searchQueryParser = new SearchQueryParser(UserOverviewDTO.FIELD_FULL_NAME, SEARCH_FIELD_MAPPING);
         this.globalAuthServiceConfig = globalAuthServiceConfig;
         this.clusterConfigService = clusterConfigService;
+        this.auditEventSender = auditEventSender;
     }
 
     /**
@@ -375,7 +380,8 @@ public class UsersResource extends RestResource {
     })
     @AuditEvent(type = AuditEventTypes.USER_CREATE)
     public Response create(@ApiParam(name = "JSON body", value = "Must contain username, full_name, email, password and a list of permissions.", required = true)
-                           @Valid @NotNull CreateUserRequest cr) throws ValidationException {
+                               @Valid @NotNull CreateUserRequest cr,
+                           @Context UserContext userContext) throws ValidationException {
         if (isUserNameInUse(cr.username())) {
             final String msg = "Cannot create user " + cr.username() + ". Username is already taken.";
             LOG.error(msg);
@@ -393,7 +399,7 @@ public class UsersResource extends RestResource {
         user.setFirstLastFullNames(cr.firstName(), cr.lastName());
         user.setEmail(cr.email());
         user.setPermissions(cr.permissions());
-        setUserRoles(cr.roles(), user);
+        setUserRoles(cr.roles(), user, userContext);
         user.setServiceAccount(cr.isServiceAccount());
 
         if (cr.timezone() != null) {
@@ -464,7 +470,7 @@ public class UsersResource extends RestResource {
         }
     }
 
-    private void setUserRoles(@Nullable List<String> roles, User user) {
+    private void setUserRoles(@Nullable List<String> roles, User user, UserContext userContext) {
         if (roles == null) {
             return;
         }
@@ -503,6 +509,11 @@ public class UsersResource extends RestResource {
                     .collect(Collectors.toSet());
 
             user.setRoleIds(roleIds);
+            auditEventSender.success(AuditActor.user(userContext.getUser().getName()),
+                    AuditEventTypes.USER_ROLES_UPDATE,
+                    ImmutableMap.of("roles", String.join(",", normalizedRoles),
+                            "userName", user.getName(),
+                            "userId", user.getId()));
 
         } catch (org.graylog2.database.NotFoundException e) {
             throw new InternalServerErrorException(e);
@@ -520,7 +531,8 @@ public class UsersResource extends RestResource {
     public void changeUser(@ApiParam(name = "userId", value = "The ID of the user to modify.", required = true)
                            @PathParam("userId") String userId,
                            @ApiParam(name = "JSON body", value = "Updated user information.", required = true)
-                           @Valid @NotNull ChangeUserRequest cr) throws ValidationException {
+                           @Valid @NotNull ChangeUserRequest cr,
+                           @Context UserContext userContext) throws ValidationException {
 
         final User user = loadUserById(userId);
         final String username = user.getName();
@@ -545,7 +557,7 @@ public class UsersResource extends RestResource {
 
         if (isPermitted(USERS_ROLESEDIT, user.getName())) {
             checkAdminRoleForServiceAccount(cr, user);
-            setUserRoles(cr.roles(), user);
+            setUserRoles(cr.roles(), user, userContext);
         }
 
         final String timezone = cr.timezone();

--- a/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
@@ -18,6 +18,8 @@ package org.graylog.security.authzroles;
 
 import jakarta.ws.rs.ForbiddenException;
 import org.bson.types.ObjectId;
+import org.graylog.security.UserContext;
+import org.graylog2.audit.AuditEventSender;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.search.SearchQueryParser;
@@ -29,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -38,6 +39,7 @@ import java.util.Set;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +56,8 @@ class AuthzRolesResourceTest {
     private SearchQueryParser searchQueryParser;
     @Mock
     private SearchQueryParser userSearchQueryParser;
+    @Mock
+    AuditEventSender auditEventSender;
 
     @InjectMocks
     private AuthzRolesResource classUnderTest;
@@ -62,7 +66,7 @@ class AuthzRolesResourceTest {
     @WithAuthorization(permissions = "roles:read:reader")
     void testGetSingleRole() {
         ObjectId readerRoleId = new ObjectId();
-        AuthzRoleDTO readerRole = Mockito.mock(AuthzRoleDTO.class);
+        AuthzRoleDTO readerRole = mock(AuthzRoleDTO.class);
         String idHexString = readerRoleId.toHexString();
 
         when(authzolesService.get(eq(idHexString))).thenReturn(Optional.of(readerRole));
@@ -78,7 +82,7 @@ class AuthzRolesResourceTest {
     @WithAuthorization(permissions = "roles:read:random")
     void testGEtSignleRoleThrowsAccessError() {
         ObjectId readerRoleId = new ObjectId();
-        AuthzRoleDTO readerRole = Mockito.mock(AuthzRoleDTO.class);
+        AuthzRoleDTO readerRole = mock(AuthzRoleDTO.class);
         String idHexString = readerRoleId.toHexString();
 
         when(authzolesService.get(eq(idHexString))).thenReturn(Optional.of(readerRole));
@@ -90,15 +94,18 @@ class AuthzRolesResourceTest {
     @WithAuthorization(permissions = { "users:rolesedit:johnny", "roles:assign:reader" })
     void testAddingUserToRole() throws ValidationException {
         ObjectId readerRoleId = new ObjectId();
-        AuthzRoleDTO readerRole = Mockito.mock(AuthzRoleDTO.class);
+        AuthzRoleDTO readerRole = mock(AuthzRoleDTO.class);
         String idHexString = readerRoleId.toHexString();
+        UserContext userContext = mock(UserContext.class);
 
         when(authzolesService.get(eq(idHexString))).thenReturn(Optional.of(readerRole));
         when(readerRole.name()).thenReturn("reader");
-        User user = Mockito.mock(User.class);
+        User user = mock(User.class);
         when(userService.load(eq("johnny"))).thenReturn(user);
+        when(userContext.getUser()).thenReturn(user);
+        when(user.getName()).thenReturn("johnny");
 
-        classUnderTest.addUser(idHexString, Set.of("johnny"));
+        classUnderTest.addUser(idHexString, Set.of("johnny"), userContext);
 
         verify(user).setRoleIds(eq(Set.of(idHexString)));
     }
@@ -107,24 +114,24 @@ class AuthzRolesResourceTest {
     @WithAuthorization(permissions = { "roles:assign:reader" })
     void testAddingUserToRoleFailsWithoutRolesEdit() {
         ObjectId readerRoleId = new ObjectId();
-        AuthzRoleDTO readerRole = Mockito.mock(AuthzRoleDTO.class);
+        AuthzRoleDTO readerRole = mock(AuthzRoleDTO.class);
         String idHexString = readerRoleId.toHexString();
 
-        assertThrows(ForbiddenException.class, () -> classUnderTest.addUser(idHexString, Set.of("johnny")));
+        assertThrows(ForbiddenException.class, () -> classUnderTest.addUser(idHexString, Set.of("johnny"), mock(UserContext.class)));
     }
 
     @Test
     @WithAuthorization(permissions = { "users:rolesedit:johnny", "roles:assign:wrong" })
     void testAddingUserToRoleFailsWithWrongAssignRole() {
         ObjectId readerRoleId = new ObjectId();
-        AuthzRoleDTO readerRole = Mockito.mock(AuthzRoleDTO.class);
+        AuthzRoleDTO readerRole = mock(AuthzRoleDTO.class);
         String idHexString = readerRoleId.toHexString();
 
         when(authzolesService.get(eq(idHexString))).thenReturn(Optional.of(readerRole));
         when(readerRole.name()).thenReturn("reader");
-        User user = Mockito.mock(User.class);
+        User user = mock(User.class);
         when(userService.load(eq("johnny"))).thenReturn(user);
 
-        assertThrows(ForbiddenException.class, () -> classUnderTest.addUser(idHexString, Set.of("johnny")));
+        assertThrows(ForbiddenException.class, () -> classUnderTest.addUser(idHexString, Set.of("johnny"), mock(UserContext.class)));
     }
 }


### PR DESCRIPTION
Backport of Graylog2/graylog2-server#24510
See original issue for details.

/jpd Graylog2/graylog-plugin-enterprise#12780
/nocl see enterprise issue

Automatic backport not possible due to changes in DB session handling in 7.1.