### PR TITLE
PagerDuty Notification Improvements (`7.0`)

### DIFF
--- a/changelog/unreleased/issue-24328.toml
+++ b/changelog/unreleased/issue-24328.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Added multiple PagerDuty Notification improvements: custom incident title, fully customizable incident key, and use Replay Search URL for link instead of generic stream search."
+
+issues = ["24328"]
+pulls = ["24504"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotification.java
@@ -17,6 +17,7 @@
 package org.graylog.integrations.pagerduty;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationException;
@@ -28,8 +29,6 @@ import org.graylog.integrations.pagerduty.dto.PagerDutyResponse;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.system.NodeId;
-
-import jakarta.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
@@ -71,7 +70,7 @@ public class PagerDutyNotification implements EventNotification {
         try {
             PagerDutyResponse response = pagerDutyClient.enqueue(payloadString);
             List<String> errors = response.getErrors();
-            if (errors != null && errors.size() > 0) {
+            if (errors != null && !errors.isEmpty()) {
                 throw new IllegalStateException(
                         "There was an error triggering the PagerDuty event, details: " + errors);
             }

--- a/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotificationConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import jakarta.annotation.Nullable;
 import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
@@ -33,6 +34,7 @@ import org.graylog2.plugin.rest.ValidationResult;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 
 /**
  * Configuration class for Pager Duty notifications.
@@ -51,6 +53,8 @@ public abstract class PagerDutyNotificationConfig implements EventNotificationCo
     static final String FIELD_KEY_PREFIX = "key_prefix";
     static final String FIELD_CLIENT_NAME = "client_name";
     static final String FIELD_CLIENT_URL = "client_url";
+    static final String FIELD_PAGER_DUTY_TITLE = "pager_duty_title";
+    static final String FIELD_INCIDENT_KEY = "incident_key";
 
     @JsonProperty(FIELD_ROUTING_KEY)
     public abstract String routingKey();
@@ -66,6 +70,12 @@ public abstract class PagerDutyNotificationConfig implements EventNotificationCo
 
     @JsonProperty(FIELD_CLIENT_URL)
     public abstract String clientUrl();
+
+    @JsonProperty(FIELD_PAGER_DUTY_TITLE)
+    public abstract Optional<String> pagerDutyTitle();
+
+    @JsonProperty(FIELD_INCIDENT_KEY)
+    public abstract Optional<String> incidentKey();
 
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
@@ -87,8 +97,8 @@ public abstract class PagerDutyNotificationConfig implements EventNotificationCo
         else if (routingKey().length() != 32) {
             validation.addError(FIELD_ROUTING_KEY, "Routing Key must be 32 characters long.");
         }
-        if (customIncident() && keyPrefix().isEmpty()) {
-            validation.addError(FIELD_KEY_PREFIX, "Incident Key Prefix cannot be empty when Custom Incident Key is selected.");
+        if (customIncident() && keyPrefix().isEmpty() && incidentKey().isEmpty()) {
+            validation.addError(FIELD_KEY_PREFIX, "Incident Key or Incident Key Prefix must be provided when Custom Incident Key is selected.");
         }
         if (clientName().isEmpty()) {
             validation.addError(FIELD_CLIENT_NAME, "Client Name cannot be empty.");
@@ -122,19 +132,25 @@ public abstract class PagerDutyNotificationConfig implements EventNotificationCo
         }
 
         @JsonProperty(FIELD_ROUTING_KEY)
-        public abstract PagerDutyNotificationConfig.Builder routingKey(String routingKey);
+        public abstract Builder routingKey(String routingKey);
 
         @JsonProperty(FIELD_CUSTOM_INCIDENT)
-        public abstract PagerDutyNotificationConfig.Builder customIncident(boolean customIncident);
+        public abstract Builder customIncident(boolean customIncident);
 
         @JsonProperty(FIELD_KEY_PREFIX)
-        public abstract PagerDutyNotificationConfig.Builder keyPrefix(String keyPrefix);
+        public abstract Builder keyPrefix(String keyPrefix);
 
         @JsonProperty(FIELD_CLIENT_NAME)
-        public abstract PagerDutyNotificationConfig.Builder clientName(String clientName);
+        public abstract Builder clientName(String clientName);
 
         @JsonProperty(FIELD_CLIENT_URL)
-        public abstract PagerDutyNotificationConfig.Builder clientUrl(String clientUrl);
+        public abstract Builder clientUrl(String clientUrl);
+
+        @JsonProperty(FIELD_PAGER_DUTY_TITLE)
+        public abstract Builder pagerDutyTitle(@Nullable String pagerDutyTitle);
+
+        @JsonProperty(FIELD_INCIDENT_KEY)
+        public abstract Builder incidentKey(@Nullable String incidentKey);
 
         public abstract PagerDutyNotificationConfig build();
     }
@@ -149,6 +165,8 @@ public abstract class PagerDutyNotificationConfig implements EventNotificationCo
                 .keyPrefix(ValueReference.of(keyPrefix()))
                 .clientName(ValueReference.of(clientName()))
                 .clientUrl(ValueReference.of(clientUrl()))
+                .pagerDutyTitle(ValueReference.ofNullable(pagerDutyTitle().orElse(null)))
+                .incidentKey(ValueReference.ofNullable(incidentKey().orElse(null)))
                 .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/PagerDutyNotificationConfigEntity.java
@@ -21,12 +21,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import jakarta.annotation.Nullable;
 import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Configuration entity for PagerDuty notification events.
@@ -54,6 +56,12 @@ public abstract class PagerDutyNotificationConfigEntity implements EventNotifica
 
     @JsonProperty(PagerDutyNotificationConfig.FIELD_CLIENT_URL)
     public abstract ValueReference clientUrl();
+
+    @JsonProperty(PagerDutyNotificationConfig.FIELD_PAGER_DUTY_TITLE)
+    public abstract Optional<ValueReference> pagerDutyTitle();
+
+    @JsonProperty(PagerDutyNotificationConfig.FIELD_INCIDENT_KEY)
+    public abstract Optional<ValueReference> incidentKey();
 
     public static Builder builder() {
         return Builder.create();
@@ -84,6 +92,12 @@ public abstract class PagerDutyNotificationConfigEntity implements EventNotifica
         @JsonProperty(PagerDutyNotificationConfig.FIELD_CLIENT_URL)
         public abstract Builder clientUrl(ValueReference clientUrl);
 
+        @JsonProperty(PagerDutyNotificationConfig.FIELD_PAGER_DUTY_TITLE)
+        public abstract Builder pagerDutyTitle(@Nullable ValueReference pagerDutyTitle);
+
+        @JsonProperty(PagerDutyNotificationConfig.FIELD_INCIDENT_KEY)
+        public abstract Builder incidentKey(@Nullable ValueReference incidentKey);
+
         public abstract PagerDutyNotificationConfigEntity build();
     }
 
@@ -97,6 +111,8 @@ public abstract class PagerDutyNotificationConfigEntity implements EventNotifica
                 .keyPrefix(keyPrefix().asString(parameters))
                 .clientName(clientName().asString(parameters))
                 .clientUrl(clientUrl().asString(parameters))
+                .pagerDutyTitle(pagerDutyTitle().map(vr -> vr.asString(parameters)).orElse(null))
+                .incidentKey(incidentKey().map(vr -> vr.asString(parameters)).orElse(null))
                 .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/client/MessageFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/client/MessageFactory.java
@@ -16,21 +16,21 @@
  */
 package org.graylog.integrations.pagerduty.client;
 
+import com.floreysoft.jmte.Engine;
 import com.google.common.collect.ImmutableList;
 import jakarta.inject.Inject;
-import org.apache.commons.lang3.StringUtils;
+import jakarta.inject.Named;
+import org.apache.commons.lang3.Strings;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.notifications.EventNotificationService;
-import org.graylog.events.processor.EventDefinitionDto;
-import org.graylog.events.processor.aggregation.AggregationEventProcessorConfig;
+import org.graylog.events.notifications.TemplateModelProvider;
 import org.graylog.integrations.pagerduty.PagerDutyNotificationConfig;
 import org.graylog.integrations.pagerduty.dto.Link;
 import org.graylog.integrations.pagerduty.dto.PagerDutyMessage;
 import org.graylog2.plugin.MessageSummary;
-import org.graylog2.plugin.streams.Stream;
-import org.graylog2.streams.StreamService;
 import org.graylog2.web.customization.CustomizationConfig;
+import org.joda.time.DateTimeZone;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Factory class for PagerDuty messages, heavily based on the works of the cited authors.
@@ -52,54 +51,70 @@ import java.util.stream.Collectors;
  * @author Edgar Molina
  */
 public class MessageFactory {
-    private static final List<String> PAGER_DUTY_PRIORITIES = Arrays.asList("info", "warning", "critical");
+    private static final List<String> PAGER_DUTY_PRIORITIES = Arrays.asList("info", "warning", "critical", "critical");
 
-    private final StreamService streamService;
     private final EventNotificationService eventNotificationService;
     private final CustomizationConfig customizationConfig;
+    private final Engine templateEngine;
+    private final TemplateModelProvider templateModelProvider;
 
     @Inject
-    MessageFactory(StreamService streamService, EventNotificationService eventNotificationService,
-                   CustomizationConfig customizationConfig) {
-        this.streamService = streamService;
+    MessageFactory(EventNotificationService eventNotificationService,
+                   CustomizationConfig customizationConfig,
+                   @Named("JsonSafe") Engine jsonTemplateEngine,
+                   TemplateModelProvider templateModelProvider) {
         this.eventNotificationService = eventNotificationService;
         this.customizationConfig = customizationConfig;
+        this.templateEngine = jsonTemplateEngine;
+        this.templateModelProvider = templateModelProvider;
     }
 
     public PagerDutyMessage createTriggerMessage(EventNotificationContext ctx) {
         final ImmutableList<MessageSummary> backlog = eventNotificationService.getBacklogForEvent(ctx);
         final EventNotificationModelData modelData = EventNotificationModelData.of(ctx, backlog);
         final PagerDutyNotificationConfig config = (PagerDutyNotificationConfig) ctx.notificationConfig();
+        final Map<String, Object> messageModel = getCustomMessageModel(ctx, backlog);
 
-        String eventTitle = modelData.eventDefinitionTitle();
+        final String eventTitle = config.pagerDutyTitle()
+                .map(customTitle -> templateEngine.transform(customTitle, messageModel))
+                .orElse(modelData.eventDefinitionTitle());
         String eventPriority = PAGER_DUTY_PRIORITIES.get(0);
         int priority = ctx.eventDefinition().get().priority() - 1;
-        if (priority >= 0 && priority <= 2) {
+        if (priority >= 0 && priority <= 3) {
             eventPriority = PAGER_DUTY_PRIORITIES.get(priority);
         }
 
-        List<Link> streamLinks =
-                streamService
-                        .loadByIds(modelData.event().sourceStreams())
-                        .stream()
-                        .map(stream -> buildStreamWithUrl(stream, ctx, config))
-                        .collect(Collectors.toList());
+        final List<Link> replayLink;
+        try {
+            final String replayUrl = Strings.CS.appendIfMissing(
+                    config.clientUrl(), "/") + "alerts/" + modelData.event().id() + "/replay-search";
+            replayLink = List.of(new Link(new URI(replayUrl).toURL(), "Replay Event"));
+        } catch (URISyntaxException | MalformedURLException e) {
+            throw new IllegalStateException("Error when building the event replay URL.", e);
+        }
 
         String dedupKey = "";
         if (config.customIncident()) {
-            dedupKey = String.format(Locale.ROOT,
-                    "%s/%s/%s", config.keyPrefix(), modelData.event().sourceStreams(), eventTitle);
+            final String formattedPrefix = templateEngine.transform(config.keyPrefix(), messageModel);
+            final String prefixedIncidentKey = String.format(Locale.ROOT,
+                    "%s/%s/%s", formattedPrefix, modelData.event().sourceStreams(), eventTitle);
+            // Use the custom incident key if provided, otherwise fall back to the prefixed key.
+            dedupKey = config.incidentKey()
+                    .map(incidentKeyTemplate -> templateEngine.transform(incidentKeyTemplate, messageModel))
+                    .orElse(prefixedIncidentKey);
         }
 
-
-        Map<String, String> payload = new HashMap<String, String>();
-        payload.put("summary", modelData.event().message());
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("summary", config.pagerDutyTitle()
+                .map(customTitle -> templateEngine.transform(customTitle, messageModel))
+                .orElse(modelData.event().message()));
         payload.put("source", customizationConfig.productName() + ":" + modelData.event().sourceStreams());
         payload.put("severity", eventPriority);
         payload.put("timestamp", modelData.event().eventTimestamp().toString());
         payload.put("component", "GraylogAlerts");
         payload.put("group", modelData.event().sourceStreams().toString());
         payload.put("class", "alerts");
+        payload.put("custom_details", ctx.event().fields());
 
         return new PagerDutyMessage(
                 config.routingKey(),
@@ -107,27 +122,11 @@ public class MessageFactory {
                 dedupKey,
                 config.clientName(),
                 config.clientUrl(),
-                streamLinks,
+                replayLink,
                 payload);
     }
 
-    private Link buildStreamWithUrl(Stream stream, EventNotificationContext ctx, PagerDutyNotificationConfig config) {
-        final String graylogUrl = config.clientUrl();
-        String streamUrl =
-                StringUtils.appendIfMissing(graylogUrl, "/") + "streams/" + stream.getId() + "/search";
-
-        if (ctx.eventDefinition().isPresent()) {
-            EventDefinitionDto eventDefinitionDto = ctx.eventDefinition().get();
-            if (eventDefinitionDto.config() instanceof AggregationEventProcessorConfig) {
-                String query =
-                        ((AggregationEventProcessorConfig) eventDefinitionDto.config()).query();
-                streamUrl += "?q=" + query;
-            }
-        }
-        try {
-            return new Link(new URI(streamUrl).toURL(), stream.getTitle());
-        } catch (URISyntaxException | MalformedURLException e) {
-            throw new IllegalStateException("Error when building the stream link URL.", e);
-        }
+    private Map<String, Object> getCustomMessageModel(EventNotificationContext ctx, List<MessageSummary> backlog) {
+        return templateModelProvider.of(ctx, backlog, DateTimeZone.UTC, Map.of("type", PagerDutyNotificationConfig.TYPE_NAME));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/dto/PagerDutyMessage.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/pagerduty/dto/PagerDutyMessage.java
@@ -18,6 +18,7 @@ package org.graylog.integrations.pagerduty.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,7 @@ public class PagerDutyMessage {
     @JsonProperty("links")
     private final List<Link> links;
     @JsonProperty("payload")
-    private final Map<String, String> payload;
+    private final Map<String, Object> payload;
 
     public PagerDutyMessage(
             String routingKey,
@@ -49,7 +50,7 @@ public class PagerDutyMessage {
             String client,
             String clientUrl,
             List<Link> links,
-            Map<String, String> payload) {
+            Map<String, Object> payload) {
         this.routingKey = routingKey;
         this.eventAction = eventAction;
         this.dedupKey = dedupKey;
@@ -83,7 +84,7 @@ public class PagerDutyMessage {
         return links;
     }
 
-    public Map<String, String> getPayload() {
+    public Map<String, Object> getPayload() {
         return payload;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/integrations/pagerduty/client/MessageFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/pagerduty/client/MessageFactoryTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.pagerduty.client;
+
+import com.floreysoft.jmte.Engine;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.notifications.EventNotificationContext;
+import org.graylog.events.notifications.EventNotificationService;
+import org.graylog.events.notifications.NotificationDto;
+import org.graylog.events.notifications.NotificationTestData;
+import org.graylog.events.notifications.TemplateModelProvider;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.integrations.pagerduty.PagerDutyNotificationConfig;
+import org.graylog.integrations.pagerduty.dto.PagerDutyMessage;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.web.customization.CustomizationConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessageFactoryTest {
+
+    private static final String ROUTING_KEY = "12345678901234567890123456789012";
+    private static final String CLIENT_NAME = "client";
+    private static final String CLIENT_URL = "http://localhost/";
+
+    @Mock
+    private EventNotificationService eventNotificationService;
+
+    private TemplateModelProvider templateModelProvider;
+    private MessageFactory messageFactory;
+
+    @BeforeEach
+    void setUp() {
+        templateModelProvider = new TemplateModelProvider(CustomizationConfig.empty(), new ObjectMapperProvider(), new HttpConfiguration());
+        messageFactory = new MessageFactory(
+                eventNotificationService,
+                CustomizationConfig.empty(),
+                Engine.createEngine(),
+                templateModelProvider);
+
+        when(eventNotificationService.getBacklogForEvent(any(EventNotificationContext.class))).thenReturn(ImmutableList.<MessageSummary>of());
+    }
+
+    @Test
+    void usesCustomIncidentKeyWhenProvided() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder()
+                .customIncident(true)
+                .keyPrefix("prefix")
+                .incidentKey("test/${event.id}")
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(buildContext(config));
+
+        assertThat(message.getDedupKey()).isEqualTo("test/TEST_NOTIFICATION_ID");
+    }
+
+    @Test
+    void createsEmptyDedupKeyWhenCustomIncidentDisabled() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder().build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(buildContext(config));
+
+        assertThat(message.getDedupKey()).isEmpty();
+        assertThat(message.getPayload().get("summary")).isEqualTo("Notification test message triggered from user <user>");
+    }
+
+    @Test
+    void buildsPrefixedIncidentKeyWhenTemplateMissing() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder()
+                .customIncident(true)
+                .keyPrefix("prefix")
+                .build();
+
+        final EventNotificationContext baseContext = buildContext(config);
+        final EventDto event = baseContext.event().toBuilder()
+                .sourceStreams(ImmutableSet.of("stream-one"))
+                .build();
+        final EventNotificationContext context = baseContext.toBuilder()
+                .event(event)
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(context);
+
+        assertThat(message.getDedupKey()).isEqualTo("prefix/[stream-one]/Event Definition Test Title");
+    }
+
+    @Test
+    void derivesSeverityFromEventDefinitionPriority() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder().build();
+        final EventNotificationContext context = buildContext(config);
+        final EventDefinitionDto eventDefinition = context.eventDefinition().orElseThrow().toBuilder()
+                .priority(4)
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(context.toBuilder()
+                .eventDefinition(eventDefinition)
+                .build());
+
+        assertThat(message.getPayload().get("severity")).isEqualTo("critical");
+    }
+
+    @Test
+    void defaultsToInfoSeverityWhenPriorityOutOfBounds() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder().build();
+        final EventNotificationContext context = buildContext(config);
+        final EventDefinitionDto eventDefinition = context.eventDefinition().orElseThrow().toBuilder()
+                .priority(6)
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(context.toBuilder()
+                .eventDefinition(eventDefinition)
+                .build());
+
+        assertThat(message.getPayload().get("severity")).isEqualTo("info");
+    }
+
+    @Test
+    void usesCustomPagerDutyTitleAsSummary() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder()
+                .pagerDutyTitle("Custom ${event_definition_title}")
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(buildContext(config));
+
+        assertThat(message.getPayload().get("summary")).isEqualTo("Custom Event Definition Test Title");
+    }
+
+    @Test
+    void createsReplayLinkUsingClientUrlAndEventId() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder()
+                .clientUrl("http://pagerduty.example.com")
+                .build();
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(buildContext(config));
+
+        assertThat(message.getLinks()).hasSize(1);
+        assertThat(message.getLinks().get(0).getText()).isEqualTo("Replay Event");
+        assertThat(message.getLinks().get(0).getHref().toString())
+                .isEqualTo("http://pagerduty.example.com/alerts/TEST_NOTIFICATION_ID/replay-search");
+    }
+
+    @Test
+    void populatesCustomDetailsWithEventFields() {
+        final PagerDutyNotificationConfig config = baseConfigBuilder().build();
+        final EventNotificationContext context = buildContext(config);
+
+        final PagerDutyMessage message = messageFactory.createTriggerMessage(context);
+
+        assertThat(message.getPayload().get("custom_details")).isEqualTo(context.event().fields());
+    }
+
+    private PagerDutyNotificationConfig.Builder baseConfigBuilder() {
+        return PagerDutyNotificationConfig.builder()
+                .routingKey(ROUTING_KEY)
+                .customIncident(false)
+                .keyPrefix("")
+                .clientName(CLIENT_NAME)
+                .clientUrl(CLIENT_URL)
+                .pagerDutyTitle(null)
+                .incidentKey(null);
+    }
+
+    private EventNotificationContext buildContext(PagerDutyNotificationConfig config) {
+        final NotificationDto notificationDto = NotificationDto.builder()
+                .id("notification-id")
+                .title("title")
+                .description("desc")
+                .config(config)
+                .build();
+
+        return NotificationTestData.getDummyContext(notificationDto, "user")
+                .toBuilder()
+                .notificationConfig(config)
+                .build();
+    }
+}

--- a/graylog2-web-interface/src/integrations/bindings.jsx
+++ b/graylog2-web-interface/src/integrations/bindings.jsx
@@ -19,6 +19,7 @@ import Routes from 'integrations/aws/common/Routes';
 import AWSInputConfiguration from './aws/AWSInputConfiguration';
 import AWSCloudWatchApp from './aws/cloudwatch/CloudWatchApp';
 import EmbeddedCloudWatchApp from './aws/cloudwatch/EmbeddedCloudWatchApp';
+import { defaultConfig as PagerDutyDefaultConfig } from './pager-duty/PagerDutyConfig';
 import PagerDutyNotificationDetails from './pager-duty/PagerDutyNotificationDetails';
 import PagerDutyNotificationForm from './pager-duty/PagerDutyNotificationForm';
 import PagerDutyNotificationSummary from './pager-duty/PagerDutyNotificationSummary';
@@ -51,7 +52,7 @@ const bindings = {
       formComponent: PagerDutyNotificationForm,
       summaryComponent: PagerDutyNotificationSummary,
       detailsComponent: PagerDutyNotificationDetails,
-      defaultConfig: PagerDutyNotificationForm.defaultConfig,
+      defaultConfig: PagerDutyDefaultConfig,
     },
     {
       type: 'slack-notification-v1',

--- a/graylog2-web-interface/src/integrations/pager-duty/PagerDutyConfig.ts
+++ b/graylog2-web-interface/src/integrations/pager-duty/PagerDutyConfig.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+export type PagerDutyConfig = {
+  routing_key: string;
+  pager_duty_title?: string;
+  custom_incident?: boolean;
+  key_prefix?: string;
+  incident_key?: string;
+  client_name: string;
+  client_url: string;
+};
+
+export const defaultConfig = {
+  client_name: '',
+  client_url: '',
+  custom_incident: false,
+  key_prefix: '',
+  routing_key: '',
+  pager_duty_title: null,
+  incident_key: null,
+};

--- a/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationDetails.tsx
+++ b/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationDetails.tsx
@@ -18,23 +18,25 @@ import * as React from 'react';
 
 import { ReadOnlyFormGroup } from 'components/common';
 
+import type { PagerDutyConfig } from './PagerDutyConfig';
+
 type PagerDutyNotificationDetailsProps = {
   notification: {
-    config: {
-      routing_key?: string;
-      custom_incident?: boolean;
-      key_prefix?: string;
-      client_name?: string;
-      client_url?: string;
-    };
+    config: PagerDutyConfig;
   };
 };
 
 const PagerDutyNotificationDetails = ({ notification }: PagerDutyNotificationDetailsProps) => (
   <>
     <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
+    <ReadOnlyFormGroup label="Incident Title" value={notification.config?.pager_duty_title} />
     <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident} />
-    <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+    {notification?.config?.custom_incident && notification.config?.key_prefix && (
+      <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+    )}
+    {notification?.config?.custom_incident && notification.config?.incident_key && (
+      <ReadOnlyFormGroup label="Incident Key" value={notification.config?.incident_key} />
+    )}
     <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
     <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
   </>

--- a/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationForm.tsx
+++ b/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationForm.tsx
@@ -15,21 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { Input } from 'components/bootstrap';
 import { getValueFromInput } from 'util/FormsUtils';
 import useProductName from 'brand-customization/useProductName';
 
+import type { PagerDutyConfig } from './PagerDutyConfig';
+
 type PagerDutyNotificationFormProps = {
-  config: {
-    client_name?: string;
-    client_url?: string;
-    custom_incident?: boolean;
-    key_prefix?: string;
-    routing_key?: string;
-  };
+  config: PagerDutyConfig;
   validation: {
     failed: boolean;
     errors?: {
@@ -38,6 +33,8 @@ type PagerDutyNotificationFormProps = {
       custom_incident?: string[];
       key_prefix?: string[];
       routing_key?: string[];
+      pager_duty_title?: string[];
+      incident_key?: string[];
     };
     error_context?: any;
   };
@@ -48,7 +45,11 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
   const productName = useProductName();
   const propagateChange = (key: string, value: unknown) => {
     const nextConfig = cloneDeep(config);
-    nextConfig[key] = value;
+    if ((key === 'pager_duty_title' || key === 'incident_key') && value === '') {
+      nextConfig[key] = null;
+    } else {
+      nextConfig[key] = value;
+    }
     onChange(nextConfig);
   };
 
@@ -65,10 +66,23 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
         label="Routing Key"
         type="text"
         bsStyle={validation.errors.routing_key ? 'error' : null}
-        help={get(validation, 'errors.routing_key[0]', 'The Pager Duty integration Routing Key.')}
+        help={validation.errors?.routing_key?.[0] ?? 'The Pager Duty integration Routing Key.'}
         value={config.routing_key}
         onChange={handleChange}
         required
+      />
+      <Input
+        id="pagerduty-notification-v2-pager_duty_title"
+        name="pager_duty_title"
+        label="Incident Title"
+        type="text"
+        bsStyle={validation.errors.pager_duty_title ? 'error' : null}
+        help={
+          validation.errors?.pager_duty_title?.[0] ??
+          `Custom title for the incident in Pager Duty. Will be the event title as shown in ${productName} if not set.`
+        }
+        value={config.pager_duty_title}
+        onChange={handleChange}
       />
       <Input
         id="pagerduty-notification-v2-custom_incident"
@@ -76,11 +90,7 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
         label="Use Custom Incident Key"
         type="checkbox"
         bsStyle={validation.errors.custom_incident ? 'error' : null}
-        help={get(
-          validation,
-          'errors.custom_incident[0]',
-          'Generate a custom incident key based on the Stream and the Alert Condition.',
-        )}
+        help={validation.errors?.custom_incident?.[0] ?? 'Generate a custom incident key.'}
         checked={config.custom_incident}
         onChange={handleChange}
       />
@@ -90,10 +100,25 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
         label="Incident Key Prefix"
         type="text"
         bsStyle={validation.errors.key_prefix ? 'error' : null}
-        help={get(validation, 'errors.key_prefix[0]', 'Incident key prefix that identifies the incident.')}
+        help={
+          validation.errors?.key_prefix?.[0] ??
+          'Incident key prefix that will be followed by Stream(s) and the Event Definition title. Use Incident Key to customize entire key.'
+        }
         value={config.key_prefix}
         onChange={handleChange}
-        required
+      />
+      <Input
+        id="pagerduty-notification-v2-incident_key"
+        name="incident_key"
+        label="Incident Key"
+        type="text"
+        bsStyle={validation.errors.incident_key ? 'error' : null}
+        help={
+          validation.errors?.incident_key?.[0] ??
+          'Full key to identify the incident. Will be used instead of prefix, if provided.'
+        }
+        value={config.incident_key}
+        onChange={handleChange}
       />
       <Input
         id="pagerduty-notification-v2-client_name"
@@ -101,11 +126,10 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
         label="Client Name"
         type="text"
         bsStyle={validation.errors.client_name ? 'error' : null}
-        help={get(
-          validation,
-          'errors.client_name[0]',
-          `The name of the ${productName} system that is triggering the PagerDuty event.`,
-        )}
+        help={
+          validation.errors?.client_name?.[0] ??
+          `The name of the ${productName} system that is triggering the PagerDuty event.`
+        }
         value={config.client_name}
         onChange={handleChange}
         required
@@ -116,11 +140,10 @@ const PagerDutyNotificationForm = ({ config, validation, onChange }: PagerDutyNo
         label="Client URL"
         type="text"
         bsStyle={validation.errors.client_url ? 'error' : null}
-        help={get(
-          validation,
-          'errors.client_url[0]',
-          `The URL of the ${productName} system that is triggering the PagerDuty event.`,
-        )}
+        help={
+          validation.errors?.client_url?.[0] ??
+          `The URL of the ${productName} system that is triggering the PagerDuty event.`
+        }
         value={config.client_url}
         onChange={handleChange}
         required

--- a/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationSummary.tsx
+++ b/graylog2-web-interface/src/integrations/pager-duty/PagerDutyNotificationSummary.tsx
@@ -18,16 +18,12 @@ import React from 'react';
 
 import CommonNotificationSummary from 'components/event-notifications/event-notification-types/CommonNotificationSummary';
 
+import type { PagerDutyConfig } from './PagerDutyConfig';
+
 type PagerDutyNotificationSummaryProps = {
   type: string;
   notification: {
-    config: {
-      routing_key?: string;
-      custom_incident?: boolean;
-      key_prefix?: string;
-      client_name?: string;
-      client_url?: string;
-    };
+    config: PagerDutyConfig;
   };
   definitionNotification: any;
 };
@@ -42,17 +38,33 @@ function PagerDutyNotificationSummary({ notification, ...restProps }: PagerDutyN
         </td>
       </tr>
       <tr>
+        <td>Incident Title</td>
+        <td>
+          <code>{notification?.config?.pager_duty_title ?? 'Default'}</code>
+        </td>
+      </tr>
+      <tr>
         <td>Use Custom Incident Key</td>
         <td>
           <code>{notification?.config?.custom_incident ? 'Yes' : 'No'}</code>
         </td>
       </tr>
-      <tr>
-        <td>Incident Key Prefix</td>
-        <td>
-          <code>{notification?.config?.key_prefix}</code>
-        </td>
-      </tr>
+      {notification?.config?.custom_incident && notification?.config?.key_prefix && (
+        <tr>
+          <td>Incident Key Prefix</td>
+          <td>
+            <code>{notification?.config?.key_prefix}</code>
+          </td>
+        </tr>
+      )}
+      {notification?.config?.custom_incident && notification?.config?.incident_key && (
+        <tr>
+          <td>Incident Key</td>
+          <td>
+            <code>{notification?.config?.incident_key}</code>
+          </td>
+        </tr>
+      )}
       <tr>
         <td>Client Name</td>
         <td>


### PR DESCRIPTION
Note: This is a backport of  #24504 to `7.0`.

(cherry picked from commit b216af772604335d3b4b980e0f69a572ca5ebb02)

## Description
<!--- Describe your changes in detail -->
- Adds ability to customize incident title within PagerDuty
- Adds ability to fully customize the incident key
- Adds templated variable substitution support in new title and incident key as well as existing incident key prefix
- Use Replay Search API endpoint instead of generic stream search for link back into Graylog

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
UX improvements to more efficiently pivot from PagerDuty back into Graylog
 
closes #24328 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

