### PR TITLE
Remove .github/runs-on.yml config file

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,3 +1,0 @@
-# See https://github.com/Graylog2/graylog-project-internal/blob/main/.github/runs-on.yml
-# for the shared configuration file.
-_extends: "graylog-project-internal"


### PR DESCRIPTION
RunsOn automatically checks for a custom config file in the ".github-private" repository, so we don't need a runs-on.yml in every repo we want to use RunsOn runners.

/nocl Build infrastructure