### PR TITLE
Fix legacy public notifications missing `variant` field breaking login screen. (`6.3`)

### DIFF
--- a/changelog/unreleased/pr-24645.toml
+++ b/changelog/unreleased/pr-24645.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix legacy public notifications missing `variant` field created in previous versions breaking login screen."
+
+pulls = ["24645"]

--- a/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.test.tsx
@@ -19,8 +19,9 @@ import { fireEvent, render, screen, within } from 'wrappedTestingLibrary';
 import type { PluginExports } from 'graylog-web-plugin/plugin';
 
 import type { Notifications } from 'theme/types';
-import { asMock } from 'helpers/mocking';
-import usePluginEntities from 'hooks/usePluginEntities';
+import { usePluginExports } from 'views/test/testPlugins';
+import asMock from 'helpers/mocking/AsMock';
+import AppConfig from 'util/AppConfig';
 
 import PublicNotifications from './PublicNotifications';
 
@@ -73,73 +74,78 @@ const mockedConfigNotifications: Notifications = {
   },
 };
 
-jest.mock('hooks/usePluginEntities');
-
 jest.mock('util/AppConfig', () => ({
   publicNotifications: jest.fn(() => mockedConfigNotifications),
 }));
 
 const onDismissPublicNotification = jest.fn();
 
-const mockedUsePublicNotifications = () => ({
-  hooks: {
-    usePublicNotifications: () => ({
-      notifications: mockedNotifications,
-      dismissedNotifications: new Set(),
-      onDismissPublicNotification,
-    }),
-  },
-});
-
-const beforeMock = () => {
-  const mockedFn = mockedUsePublicNotifications();
-
-  return asMock(usePluginEntities).mockImplementation((entityKey) => {
-    if (entityKey === 'customization.publicNotifications') {
-      return [mockedFn] as PluginExports['customization.publicNotifications'];
-    }
-
-    return [];
-  });
+const testPlugin: PluginExports = {
+  'customization.publicNotifications': [
+    {
+      hooks: {
+        usePublicNotifications: () => ({
+          notifications: mockedNotifications,
+          dismissedNotifications: new Set(),
+          onDismissPublicNotification,
+        }),
+      },
+    },
+  ],
 };
 
 describe('PublicNotifications', () => {
-  beforeEach(beforeMock);
+  describe('with loaded plugin', () => {
+    usePluginExports(testPlugin);
 
-  it('should render all active notifications', () => {
-    render(<PublicNotifications />);
+    it('should render all active notifications', () => {
+      render(<PublicNotifications />);
 
-    const alerts = screen.getAllByRole('alert');
+      const alerts = screen.getAllByRole('alert');
 
-    expect(alerts).toHaveLength(1);
-  });
-
-  it('should dismiss notification', () => {
-    render(<PublicNotifications />);
-    const dismissedId = Object.keys(mockedNotifications)[1];
-
-    const alert = screen.getByRole('alert', { name: /Danger Alert/i });
-
-    const dismissBtn = within(alert).getByRole('button', {
-      name: /close alert/i,
+      expect(alerts).toHaveLength(1);
     });
 
-    fireEvent.click(dismissBtn);
+    it('should dismiss notification', () => {
+      render(<PublicNotifications />);
+      const dismissedId = Object.keys(mockedNotifications)[1];
 
-    expect(onDismissPublicNotification).toHaveBeenCalledWith(dismissedId);
-  });
+      const alert = screen.getByRole('alert', { name: /Danger Alert/i });
 
-  it('should render from AppConfig', () => {
-    render(<PublicNotifications login />);
+      const dismissBtn = within(alert).getByRole('button', {
+        name: /close alert/i,
+      });
 
-    const alerts = screen.getAllByRole('alert');
+      fireEvent.click(dismissBtn);
 
-    expect(alerts).toHaveLength(1);
+      expect(onDismissPublicNotification).toHaveBeenCalledWith(dismissedId);
+    });
+
+    it('should render from AppConfig', async () => {
+      render(<PublicNotifications login />);
+
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts).toHaveLength(1);
+
+      await screen.findByText('zxcvzxcvzxcvzxcvzxcvzxcv');
+    });
+
+    it('should render legacy notifications from AppConfig', async () => {
+      const { variant: _variant, ...notificationWithoutVariant } =
+        mockedConfigNotifications['607468afaaa2380afe0757f1'];
+      asMock(AppConfig.publicNotifications).mockReturnValue({
+        '607468afaaa2380afe0757f1': { ...notificationWithoutVariant, variant: null },
+      });
+      render(<PublicNotifications login />);
+
+      const alerts = await screen.findAllByRole('alert');
+      expect(alerts).toHaveLength(1);
+
+      await screen.findByText('zxcvzxcvzxcvzxcvzxcvzxcv');
+    });
   });
 
   it('should render from AppConfig when no plugins are configured', () => {
-    asMock(usePluginEntities).mockImplementation(() => []);
-
     render(<PublicNotifications login />);
 
     const alerts = screen.getAllByRole('alert');

--- a/graylog2-web-interface/src/components/common/PublicNotifications.tsx
+++ b/graylog2-web-interface/src/components/common/PublicNotifications.tsx
@@ -89,7 +89,10 @@ const PublicNotification = ({ notificationId, notification, onDismissPublicNotif
 
   return (
     <AlertContainer key={title}>
-      <StyledAlert bsStyle={variant} onDismiss={isDismissible ? _dismiss : undefined} title={!hiddenTitle && title}>
+      <StyledAlert
+        bsStyle={variant ?? 'default'}
+        onDismiss={isDismissible ? _dismiss : undefined}
+        title={!hiddenTitle && title}>
         <FlexWrap>
           <ShortContent>{shortMessage}</ShortContent>
           {longMessage && (


### PR DESCRIPTION
**Note:** This is a backport of #24645 to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR ensures that notifications created with previous versions, which are not containing the variant field, can still be rendered on the login page without breaking the whole page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.