### PR TITLE
Dispatch PR build when base branch changes

### DIFF
--- a/.github/workflows/dispatch-pr-build.yml
+++ b/.github/workflows/dispatch-pr-build.yml
@@ -24,6 +24,12 @@ jobs:
         id: pr-string-changed
         continue-on-error: true
         run: |
+          if [ -n "$BASE_CHANGE" ]; then
+            echo "PR base branch change detected: $BASE_CHANGE"
+            echo "Re-triggering PR build..."
+            exit 0
+          fi
+
           old_pr_string=$(grep -P '^/(jenkins-pr-deps|jpd|prd)' <<< "$OLD_PR_BODY" | \
             grep -ioP '(Graylog2/\S+?#|https?://github.com/Graylog2/\S+?/pull/)[0-9]+' || true)
           new_pr_string=$(grep -P '^/(jenkins-pr-deps|jpd|prd)' <<< "$NEW_PR_BODY" | \
@@ -37,6 +43,7 @@ jobs:
         env:
           OLD_PR_BODY: "${{ github.event.changes.body.from }}"
           NEW_PR_BODY: "${{ github.event.pull_request.body }}"
+          BASE_CHANGE: "${{ github.event.changes.base || '' }}"
 
       - name: Check e2e-tests label
         id: e2e-tests


### PR DESCRIPTION
We previously didn't check for base branch changes on edit events.

/nocl Build infrastructure