### PR TITLE
Show configured email notification templates instead of defaults when editing form (`7.0`)

### DIFF
--- a/changelog/unreleased/issue-24515.toml
+++ b/changelog/unreleased/issue-24515.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed issue where the email notification edit page displayed the default email body templates instead of user configured ones."
+
+issues = ["24515"]
+pulls = ["24657"]

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.test.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, waitFor } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import usePluggableLicenseCheck from 'hooks/usePluggableLicenseCheck';
+import usePluginEntities from 'hooks/usePluginEntities';
+
+import EmailNotificationForm from './EmailNotificationForm';
+import { DEFAULT_BODY_TEMPLATE, DEFAULT_HTML_BODY_TEMPLATE } from './emailNotificationTemplates';
+
+jest.mock('components/common', () => ({
+  IfPermitted: ({ children }) => <>{children}</>,
+  MultiSelect: () => null,
+  SourceCodeEditor: () => null,
+  TimezoneSelect: () => null,
+}));
+
+jest.mock('components/lookup-tables', () => ({
+  LookupTableFields: () => null,
+}));
+
+jest.mock('components/users/UsersSelectField', () => () => null);
+
+jest.mock('components/bootstrap', () => ({
+  Input: ({ children, bsStyle: _ignored, help, ...rest }) => (
+    <div>
+      <input {...rest} />
+      {help && <span>{help}</span>}
+      {children}
+    </div>
+  ),
+  FormGroup: ({ children, controlId: _ignored, validationState: __ignored, ...rest }) => (
+    <div {...rest} data-testid="form-group-mock">
+      {children}
+    </div>
+  ),
+  ControlLabel: ({ children, ...rest }) => (
+    <label {...rest} data-testid="control-label-mock">
+      {children}
+    </label>
+  ),
+  HelpBlock: ({ children, ...rest }) => (
+    <div {...rest} data-testid="help-block-mock">
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('util/conditional/HideOnCloud', () => ({ children }) => <>{children}</>);
+
+jest.mock('hooks/usePluggableLicenseCheck');
+jest.mock('hooks/usePluginEntities');
+
+const templateHook = () => ({
+  templateConfig: {
+    override_defaults: false,
+    text_body: 'PLUGIN_TEXT',
+    html_body: 'PLUGIN_HTML',
+  },
+});
+
+const defaultValidation = { errors: {} };
+
+const buildConfig = (overrides = {}) => ({
+  ...EmailNotificationForm.defaultConfig,
+  ...overrides,
+});
+
+describe('EmailNotificationForm', () => {
+  beforeEach(() => {
+    asMock(usePluggableLicenseCheck).mockReturnValue({
+      data: { valid: true, expired: false, violated: false },
+      isInitialLoading: false,
+      refetch: jest.fn(),
+    });
+    asMock(usePluginEntities).mockReturnValue([
+      {
+        hooks: {
+          useEmailTemplate: templateHook,
+        },
+      },
+    ] as unknown as ReturnType<typeof usePluginEntities>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not override templates when editing existing notification', async () => {
+    const onChange = jest.fn();
+    const config = buildConfig({
+      body_template: 'EXISTING_BODY',
+      html_body_template: 'EXISTING_HTML',
+    });
+
+    render(<EmailNotificationForm config={config} validation={defaultValidation} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  it('applies template defaults for new notifications with empty templates', async () => {
+    const onChange = jest.fn();
+    const config = buildConfig({
+      body_template: '',
+      html_body_template: '',
+    });
+
+    render(<EmailNotificationForm config={config} validation={defaultValidation} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body_template: DEFAULT_BODY_TEMPLATE,
+          html_body_template: DEFAULT_HTML_BODY_TEMPLATE,
+        }),
+      );
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.tsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.tsx
@@ -108,25 +108,51 @@ const EmailTemplatesRunner = ({
 
     if (override_defaults === true) {
       const nextCfg = { ...config };
+      const trimmedBody = (config.body_template ?? '').trim();
+      const trimmedHtml = (config.html_body_template ?? '').trim();
 
-      if (typeof text_body === 'string' && text_body !== config.body_template) {
+      const shouldOverrideBody =
+        typeof text_body === 'string' &&
+        (trimmedBody === '' || (config.body_template ?? '') === DEFAULT_BODY_TEMPLATE) &&
+        text_body !== config.body_template;
+      const shouldOverrideHtml =
+        typeof html_body === 'string' &&
+        (trimmedHtml === '' || (config.html_body_template ?? '') === DEFAULT_HTML_BODY_TEMPLATE) &&
+        html_body !== config.html_body_template;
+
+      if (shouldOverrideBody) {
         nextCfg.body_template = text_body;
         changed = true;
       }
-      if (typeof html_body === 'string' && html_body !== config.html_body_template) {
+      if (shouldOverrideHtml) {
         nextCfg.html_body_template = html_body;
         changed = true;
       }
 
       if (changed) next = nextCfg;
     } else {
+      const trimmedBody = (config.body_template ?? '').trim();
+      const trimmedHtml = (config.html_body_template ?? '').trim();
+      const hasCustomBody =
+        trimmedBody !== '' && (config.body_template ?? '') !== DEFAULT_BODY_TEMPLATE && trimmedBody !== DEFAULT_BODY_TEMPLATE;
+      const hasCustomHtml =
+        trimmedHtml !== '' &&
+        (config.html_body_template ?? '') !== DEFAULT_HTML_BODY_TEMPLATE &&
+        trimmedHtml !== DEFAULT_HTML_BODY_TEMPLATE;
+
+      if (hasCustomBody || hasCustomHtml) {
+        lastSigRef.current = sig;
+        
+        return;
+      }
+
       const nextCfg = { ...config };
 
-      if ((config.body_template ?? '') !== DEFAULT_BODY_TEMPLATE) {
+      if (trimmedBody === '') {
         nextCfg.body_template = DEFAULT_BODY_TEMPLATE;
         changed = true;
       }
-      if ((config.html_body_template ?? '') !== DEFAULT_HTML_BODY_TEMPLATE) {
+      if (trimmedHtml === '') {
         nextCfg.html_body_template = DEFAULT_HTML_BODY_TEMPLATE;
         changed = true;
       }


### PR DESCRIPTION
Backport to 7.0 of https://github.com/Graylog2/graylog2-server/pull/24657
---

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue where the email notification edit page always displayed the default email body templates instead of what was saved on the actual notification, even if the user had updated the template.

Looks like this was a bug in the initial implementation of the ability to configure the defaults for these, which was backported to 7.0, so we should backport this fix there too: https://github.com/Graylog2/graylog2-server/pull/24008

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/Graylog2/graylog2-server/issues/24515

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.