### PR TITLE
Exclude `target` dir when executing tests.

### DIFF
--- a/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/jest-preset.js
@@ -42,7 +42,7 @@ module.exports = {
     '^@graylog/server-api(.*)$': '<rootDir>/target/api$1',
   },
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['.fixtures.[jt]s$'],
+  testPathIgnorePatterns: ['.fixtures.[jt]s$', '^<rootDir>/target/'],
   testTimeout: applyTimeoutMultiplier(5000),
   transform: {
     '^.+\\.[tj]sx?$': 'babel-jest',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change there was one unintended test failure locally. It only happened because the generated API stub file is named `test.ts`. The file does not include a frontend test.

```
 FAIL  target/api/TeamSync/Backends/test.ts
  ● Test suite failed to run

    Your test suite must contain at least one test.
```

/nocl

