### PR TITLE
Use header width as static width for port column in inputs overview.

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputsOveriew/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputsOveriew/ColumnRenderers.tsx
@@ -86,6 +86,7 @@ const customColumnRenderers = ({ inputTypes, inputStates }: Props): ColumnRender
       renderCell: (_port: string, input: InputSummary) => (
         <ExpandedSectionToggleWrapper id={input.id}>{input.attributes?.port || 'N/A'}</ExpandedSectionToggleWrapper>
       ),
+      staticWidth: 'matchHeader',
     },
   },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR reimplements a static width for the port column in the inputs overview.

The previous static width has been removed accidently with https://github.com/Graylog2/graylog2-server/pull/24635/changes#diff-a3d16af964549d497c3352153fbef02ea3afcc821273d2aee4c2377074be4edcL91

/nocl - fixes an unreleased change