### PR TITLE
Update lz4-java library to 1.10.2 (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-24687.toml
+++ b/changelog/unreleased/pr-24687.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update lz4-java library to 1.10.2 to fix CVE-2025-12183."
+
+pulls = ["24687", "graylog-plugin-enterprise#12940"]

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -183,6 +183,12 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.lz4</groupId>
+                        <artifactId>lz4-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
         <kafka09.version>0.9.0.1-7</kafka09.version>
         <log4j.version>2.24.3</log4j.version>
         <lucene.version>9.12.1</lucene.version>
+        <lz4.version>1.10.2</lz4.version>
         <metrics.version>4.2.30</metrics.version>
         <mongodb-driver.version>5.4.0</mongodb-driver.version>
         <mongojack.version>5.0.2</mongojack.version>
@@ -325,6 +326,11 @@
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
                 <version>${zstd.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>${lz4.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
@@ -767,6 +773,10 @@
                                         <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
                                         <exclude>org.bouncycastle:bcpkix-jdk15on</exclude>
                                         <exclude>org.bouncycastle:bcutil-jdk15on</exclude>
+                                        <!-- Ban org.lz4:lz4-java because of CVE-2025-12183 (see: https://www.sonatype.com/security-advisories/cve-2025-12183)
+                                             The original repository is unmaintained, so we have to use the community fork at at.yawk.lz4:lz4-java
+                                             and exclude the original dependency everywhere. -->
+                                        <exclude>org.lz4:lz4-java</exclude>
                                     </excludes>
                                 </bannedDependencies>
                                 <banDuplicatePomDependencyVersions/>


### PR DESCRIPTION
This fixes CVE-2025-12183.

Since the org.lz4:lz4-java library is no longer maintained, we switched to the maintained at.yawk.lz4:lz4-java community fork. (as recommended in the security advisory)

See: https://www.sonatype.com/security-advisories/cve-2025-12183

We banned org.lz4:lz4-java via the enforcer plugin and excluded the dependency in affected dependency declarations.

(cherry picked from commit e8b3fff7873e9876b3e232e853baf316bdd1904a)

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/12944
