### PR TITLE
Generate processing error on JSON parse failure

### DIFF
--- a/changelog/unreleased/pr-24714.toml
+++ b/changelog/unreleased/pr-24714.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Generate a processing failure (if that is enabled) when pipeline function `parse_json` encounters invalid json."
+
+pulls = ["24714"]
+issues = ["Graylog2/graylog-plugin-enterprise#12460"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
@@ -18,15 +18,13 @@ package org.graylog.plugins.pipelineprocessor.functions.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.MissingNode;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
+import jakarta.inject.Inject;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
-
-import jakarta.inject.Inject;
 
 import java.io.IOException;
 
@@ -62,9 +60,8 @@ public class JsonParse extends AbstractFunction<JsonNode> {
             }
             return node;
         } catch (IOException e) {
-            log.warn(context.pipelineErrorMessage("Unable to parse JSON"), e);
+            throw new IllegalArgumentException(context.pipelineErrorMessage("Unable to parse JSON"), e);
         }
-        return MissingNode.getInstance();
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of just logging a warning in the server log, a failed call to pipeline function `parse_json` will now also generate a processing failure (if that is enabled).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Graylog2/graylog-plugin-enterprise#12460

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

