### PR TITLE
Fix compatibility issue with MongoDB 8.2 (6.3)

### DIFF
--- a/changelog/unreleased/issue-24581.toml
+++ b/changelog/unreleased/issue-24581.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix compatibility issue with MongoDB >=8.2."
+
+issues = ["24581"]
+pulls = ["24733"]

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/BuildInfo.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/BuildInfo.java
@@ -38,6 +38,7 @@ public abstract class BuildInfo {
     public abstract String gitVersion();
 
     @JsonProperty
+    @Nullable
     public abstract String sysInfo();
 
     @JsonProperty


### PR DESCRIPTION
MongoDB doesn't provide the "sysInfo" field build information anymore since version 8.2. The "sys_info" field in BuildInfo is now nullable.

* Start test for MongoProbe
* Remove defensive version check in MongoDBVersion

Fixes #24581

(cherry picked from commit f400cdb9e6f12a3a9f72a5bb0427141b4a141b1e)