### PR TITLE
Fail lock acquisition if service already holds one.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/lock/RefreshingLockService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/lock/RefreshingLockService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.graylog2.shared.utilities.StringUtils.f;
 
@@ -61,11 +62,10 @@ public class RefreshingLockService implements AutoCloseable {
      * @throws AlreadyLockedException when the resource couldn't be locked
      */
     public void acquireAndKeepLock(String resource, int maxConcurrency) throws AlreadyLockedException {
-        Optional<Lock> optionalLock = lockService.lock(resource, maxConcurrency);
-        if (optionalLock.isEmpty()) {
-            throw new AlreadyLockedException(f("Could not acquire lock for resource <%s> with max concurrency <%d>", resource, maxConcurrency));
-        }
-        scheduleLock(optionalLock.get());
+        assertNoLockYet();
+        final var newLock = lockService.lock(resource, maxConcurrency)
+                .orElseThrow(() -> new AlreadyLockedException(f("Could not acquire lock for resource <%s> with max concurrency <%d>", resource, maxConcurrency)));
+        scheduleLock(newLock);
     }
 
     /**
@@ -76,18 +76,18 @@ public class RefreshingLockService implements AutoCloseable {
      * @throws AlreadyLockedException when the resource couldn't be locked
      */
     public void acquireAndKeepLock(String resource, String lockContext) throws AlreadyLockedException {
+        assertNoLockYet();
         checkArgument(!isNullOrEmpty(lockContext), "lockContext cannot be blank");
-        Optional<Lock> optionalLock = lockService.lock(resource, lockContext);
-        if (optionalLock.isEmpty()) {
-            throw new AlreadyLockedException(f("Could not acquire lock for resource <%s> and lock context <%s>", resource, lockContext));
-        }
-        scheduleLock(optionalLock.get());
+        final var newLock = lockService.lock(resource, lockContext)
+                .orElseThrow(() -> new AlreadyLockedException(f("Could not acquire lock for resource <%s> and lock context <%s>", resource, lockContext)));
+        scheduleLock(newLock);
+    }
+
+    private void assertNoLockYet() {
+        checkState(lock == null, "Unable to acquire new lock, already holding lock that would get lost: " + lock);
     }
 
     private void scheduleLock(Lock newLock) {
-        if (lock != null) {
-            throw new IllegalStateException("Unable to acquire new lock, already holding lock that would get lost: " + lock);
-        }
         lock = newLock;
         Duration duration = lockTTL.minusSeconds(30);
         if (duration.isNegative() || duration.isZero()) {

--- a/graylog2-server/src/test/java/org/graylog2/cluster/lock/RefreshingLockServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/lock/RefreshingLockServiceTest.java
@@ -45,7 +45,7 @@ public class RefreshingLockServiceTest {
     private ScheduledExecutorService scheduler;
 
     private RefreshingLockService refreshingLockService;
-    
+
     private final Lock firstLock = Lock.builder()
             .resource("first-resource")
             .lockedBy("node-123")
@@ -83,8 +83,6 @@ public class RefreshingLockServiceTest {
         // Mock the lock service to return locks
         when(lockService.lock(eq("first-resource"), anyString()))
                 .thenReturn(Optional.of(firstLock));
-        when(lockService.lock(eq("second-resource"), anyString()))
-                .thenReturn(Optional.of(secondLock));
 
         // Acquire first lock successfully
         refreshingLockService.acquireAndKeepLock("first-resource", "context-1");
@@ -100,8 +98,6 @@ public class RefreshingLockServiceTest {
         // Mock the lock service to return locks
         when(lockService.lock(eq("first-resource"), eq(1)))
                 .thenReturn(Optional.of(firstLock));
-        when(lockService.lock(eq("second-resource"), eq(1)))
-                .thenReturn(Optional.of(secondLock));
 
         // Acquire first lock successfully
         refreshingLockService.acquireAndKeepLock("first-resource", 1);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The commit adds a safety check to prevent the `RefreshingLockService` from acquiring a new lock when it already holds an existing one. Before scheduling a new lock, the code now checks if the current lock is not null, and if so, throws an `IllegalStateException` indicating that acquiring a new lock would cause the existing lock to be lost.

This is a defensive programming improvement that prevents potential bugs where a service might accidentally overwrite an active lock, which could lead to lock management issues in the cluster.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.