### PR TITLE
Refactor GeneratedQueryContext to use contextMap for rowBucket

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/ESGeneratedQueryContext.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.joda.time.DateTimeZone;
 
@@ -31,7 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public class ESGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder> {
+public class ESGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder, MultiBucketsAggregation.Bucket> {
 
     private final ElasticsearchBackend elasticsearchBackend;
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivot.java
@@ -47,8 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext.CONTEXT_KEY_ROW_BUCKET;
-
 public class ESPivot implements ESSearchTypeHandler<Pivot> {
     private static final Logger LOG = LoggerFactory.getLogger(ESPivot.class);
     private static final String AGG_NAME = "agg";
@@ -201,7 +199,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
                     }
                     if (!pivot.columnGroups().isEmpty()) {
-                        queryContext.contextMap().put(CONTEXT_KEY_ROW_BUCKET, rowBucket);
+                        queryContext.storeCurrentRowBucket(rowBucket);
                         try {
                             retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
                                     .forEach(columnBucketTuple -> {
@@ -213,7 +211,7 @@ public class ESPivot implements ESSearchTypeHandler<Pivot> {
                                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
                                     });
                         } finally {
-                            queryContext.contextMap().remove(CONTEXT_KEY_ROW_BUCKET);
+                            queryContext.removeCurrentRowBucket();
                         }
                     }
                     resultBuilder.addRow(rowBuilder.build());

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotBucketSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotBucketSpecHandler.java
@@ -43,7 +43,7 @@ public abstract class ESPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}
 
-    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?> queryContext, BucketOrder defaultOrder, Query query) {
+    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?, ?> queryContext, BucketOrder defaultOrder, Query query) {
         final List<AggregationBuilder> sortingAggregations = new ArrayList<>();
         final List<BucketOrder> ordering = pivot.sort()
                 .stream()
@@ -93,7 +93,7 @@ public abstract class ESPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
                 : new SortOrders(ordering, List.copyOf(sortingAggregations));
     }
 
-    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?> queryContext, Query query) {
+    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?, ?> queryContext, Query query) {
         return queryContext.fieldType(query.effectiveStreams(pivot), pivotSort.field())
                 .filter(this::isNumericFieldType)
                 .isPresent();

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/ESPivotSeriesSpecHandler.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 public abstract class ESPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_RESULT extends Aggregation>
         implements SeriesSpecHandler<SPEC_TYPE, SeriesAggregationBuilder, SearchResponse, AGGREGATION_RESULT, ESGeneratedQueryContext> {
 
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String aggName = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         return currentAggregationOrBucket.getAggregations().get(aggName);
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/series/ESCountHandler.java
@@ -80,7 +80,7 @@ public class ESCountHandler extends ESPivotSeriesSpecHandler<Count, ValueCount> 
     }
 
     @Override
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String agg = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/OSGeneratedQueryContext.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.joda.time.DateTimeZone;
 
@@ -31,7 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public class OSGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder> {
+public class OSGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder, MultiBucketsAggregation.Bucket> {
     private final OpenSearchBackend openSearchBackend;
 
     @AssistedInject

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext.CONTEXT_KEY_ROW_BUCKET;
 
 public class OSPivot implements OSSearchTypeHandler<Pivot> {
     private static final Logger LOG = LoggerFactory.getLogger(OSPivot.class);
@@ -204,7 +203,7 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
                     }
                     if (!pivot.columnGroups().isEmpty()) {
-                        queryContext.contextMap().put(CONTEXT_KEY_ROW_BUCKET, rowBucket);
+                        queryContext.storeCurrentRowBucket(rowBucket);
                         try {
                             retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
                                     .forEach(columnBucketTuple -> {
@@ -216,7 +215,7 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
                                     });
                         } finally {
-                            queryContext.contextMap().remove(CONTEXT_KEY_ROW_BUCKET);
+                            queryContext.removeCurrentRowBucket();
                         }
                     }
                     resultBuilder.addRow(rowBuilder.build());

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
@@ -43,7 +43,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}
 
-    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?> queryContext, BucketOrder defaultOrder, Query query) {
+    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?, ?> queryContext, BucketOrder defaultOrder, Query query) {
         final List<AggregationBuilder> sortingAggregations = new ArrayList<>();
         final List<BucketOrder> ordering = pivot.sort()
                 .stream()
@@ -92,7 +92,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
                 : new SortOrders(ordering, List.copyOf(sortingAggregations));
     }
 
-    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?> queryContext, Query query) {
+    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?, ?> queryContext, Query query) {
         return queryContext.fieldType(query.effectiveStreams(pivot), pivotSort.field())
                 .filter(this::isNumericFieldType)
                 .isPresent();

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_RESULT extends Aggregation>
         implements SeriesSpecHandler<SPEC_TYPE, SeriesAggregationBuilder, SearchResponse, AGGREGATION_RESULT, OSGeneratedQueryContext> {
 
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String aggName = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         return currentAggregationOrBucket.getAggregations().get(aggName);
     }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/series/OSCountHandler.java
@@ -80,7 +80,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
     }
 
     @Override
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String agg = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/OSGeneratedQueryContext.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/OSGeneratedQueryContext.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.joda.time.DateTimeZone;
 
@@ -31,7 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 
-public class OSGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder> {
+public class OSGeneratedQueryContext extends IndexerGeneratedQueryContext<SearchSourceBuilder, MultiBucketsAggregation.Bucket> {
     private final OpenSearchBackend openSearchBackend;
 
     @AssistedInject

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivot.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext.CONTEXT_KEY_ROW_BUCKET;
 
 public class OSPivot implements OSSearchTypeHandler<Pivot> {
     private static final Logger LOG = LoggerFactory.getLogger(OSPivot.class);
@@ -201,7 +200,7 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
                     }
                     if (!pivot.columnGroups().isEmpty()) {
-                        queryContext.contextMap().put(CONTEXT_KEY_ROW_BUCKET, rowBucket);
+                        queryContext.storeCurrentRowBucket(rowBucket);
                         try {
                             retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
                                     .forEach(columnBucketTuple -> {
@@ -213,7 +212,7 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                                         processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
                                     });
                         } finally {
-                            queryContext.contextMap().remove(CONTEXT_KEY_ROW_BUCKET);
+                            queryContext.removeCurrentRowBucket();
                         }
                     }
                     resultBuilder.addRow(rowBuilder.build());

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotBucketSpecHandler.java
@@ -43,7 +43,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
 
     public record SortOrders(List<BucketOrder> orders, List<AggregationBuilder> sortingAggregations) {}
 
-    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?> queryContext, BucketOrder defaultOrder, Query query) {
+    protected SortOrders orderListForPivot(Pivot pivot, IndexerGeneratedQueryContext<?, ?> queryContext, BucketOrder defaultOrder, Query query) {
         final List<AggregationBuilder> sortingAggregations = new ArrayList<>();
         final List<BucketOrder> ordering = pivot.sort()
                 .stream()
@@ -92,7 +92,7 @@ public abstract class OSPivotBucketSpecHandler<SPEC_TYPE extends BucketSpec>
                 : new SortOrders(ordering, List.copyOf(sortingAggregations));
     }
 
-    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?> queryContext, Query query) {
+    private boolean isSortOnNumericPivotField(Pivot pivot, PivotSort pivotSort, IndexerGeneratedQueryContext<?, ?> queryContext, Query query) {
         return queryContext.fieldType(query.effectiveStreams(pivot), pivotSort.field())
                 .filter(this::isNumericFieldType)
                 .isPresent();

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivotSeriesSpecHandler.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 public abstract class OSPivotSeriesSpecHandler<SPEC_TYPE extends SeriesSpec, AGGREGATION_RESULT extends Aggregation>
         implements SeriesSpecHandler<SPEC_TYPE, SeriesAggregationBuilder, SearchResponse, AGGREGATION_RESULT, OSGeneratedQueryContext> {
 
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String aggName = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         return currentAggregationOrBucket.getAggregations().get(aggName);
     }

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/series/OSCountHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/series/OSCountHandler.java
@@ -80,7 +80,7 @@ public class OSCountHandler extends OSPivotSeriesSpecHandler<Count, ValueCount> 
     }
 
     @Override
-    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?> queryContext) {
+    public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations aggregations, IndexerGeneratedQueryContext<?, ?> queryContext) {
         final String agg = queryContext.getAggNameForPivotSpecFromContext(pivot, spec);
         if (agg == null) {
             if (aggregations instanceof MultiBucketsAggregation.Bucket) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/IndexerGeneratedQueryContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/engine/IndexerGeneratedQueryContext.java
@@ -29,9 +29,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public abstract class IndexerGeneratedQueryContext<S> implements GeneratedQueryContext {
+public abstract class IndexerGeneratedQueryContext<S, H> implements GeneratedQueryContext {
 
-    public static final String CONTEXT_KEY_ROW_BUCKET = "currentRowBucket";
+    private static final String CONTEXT_KEY_ROW_BUCKET = "currentRowBucket";
 
     protected final Map<Object, Object> contextMap;
     protected final Set<SearchError> errors;
@@ -56,6 +56,18 @@ public abstract class IndexerGeneratedQueryContext<S> implements GeneratedQueryC
 
     public Optional<String> fieldType(final Set<String> streamIds, final String field) {
         return fieldTypes.getType(streamIds, field);
+    }
+
+    public Optional<H> getCurrentRowBucket() {
+        return Optional.ofNullable((H) contextMap.get(CONTEXT_KEY_ROW_BUCKET));
+    }
+
+    public void storeCurrentRowBucket(final H bucket) {
+        contextMap.put(CONTEXT_KEY_ROW_BUCKET, bucket);
+    }
+
+    public void removeCurrentRowBucket() {
+        contextMap.remove(CONTEXT_KEY_ROW_BUCKET);
     }
 
     public Map<String, S> searchTypeQueries() {


### PR DESCRIPTION
## Description
Remove duplicate code across ES7/OS2/OS3 implementations by storing rowBucket in contextMap instead of requiring immutable context copies.

- Remove rowBucket field, withRowBucket(), and private constructors
- Add CONTEXT_KEY_ROW_BUCKET constant to base class
- Update Pivot classes to use contextMap with try-finally cleanup
- Update PercentageHandlers to read from contextMap
- Reduces ~50-70 lines of duplicated code

/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

