### PR TITLE
Add static fields from input again

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputImpl.java
@@ -30,8 +30,6 @@ import org.graylog2.shared.security.RestPermissions;
 import org.joda.time.DateTime;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -41,7 +39,6 @@ import java.util.Map;
 @JsonDeserialize(builder = InputImpl.Builder.class)
 @DbEntity(collection = InputServiceImpl.COLLECTION_NAME, readPermission = RestPermissions.INPUTS_READ)
 public abstract class InputImpl implements Input, MongoEntity {
-    private static final Logger LOG = LoggerFactory.getLogger(InputImpl.class);
 
     public static final String FIELD_ID = "_id";
     public static final String FIELD_TYPE = "type";
@@ -198,8 +195,8 @@ public abstract class InputImpl implements Input, MongoEntity {
         doc.put(FIELD_CONFIGURATION, getConfiguration());
 
         final List<Map<String, String>> staticFields = getEmbeddedStaticFields();
-        if (staticFields != null && !getStaticFields().isEmpty()) {
-            doc.put(EMBEDDED_STATIC_FIELDS, getEmbeddedStaticFields());
+        if (staticFields != null && !staticFields.isEmpty()) {
+            doc.put(EMBEDDED_STATIC_FIELDS, staticFields);
         }
 
         if (getContentPack() != null) {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -410,12 +410,12 @@ public class InputServiceImpl implements InputService {
         ).projection(Projections.include(InputImpl.EMBEDDED_STATIC_FIELDS)).first();
 
         return Optional.ofNullable(resultDoc)
-                .map(d -> d.getList(InputImpl.EMBEDDED_STATIC_FIELDS, Document.class))
+                .map(d -> d.getList(InputImpl.EMBEDDED_STATIC_FIELDS, Map.class, List.of()))
                 .orElse(Collections.emptyList())
                 .stream()
                 .map(field -> Map.entry(
-                        field.getString(InputImpl.FIELD_STATIC_FIELD_KEY),
-                        field.getString(InputImpl.FIELD_STATIC_FIELD_VALUE)
+                        (String)field.get(InputImpl.FIELD_STATIC_FIELD_KEY),
+                        (String)field.get(InputImpl.FIELD_STATIC_FIELD_VALUE)
                 ))
                 .toList();
     }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -410,7 +410,7 @@ public class InputServiceImpl implements InputService {
         ).projection(Projections.include(InputImpl.EMBEDDED_STATIC_FIELDS)).first();
 
         return Optional.ofNullable(resultDoc)
-                .map(d -> d.getList(InputImpl.EMBEDDED_STATIC_FIELDS, Map.class, List.of()))
+                .map(d -> d.getList(InputImpl.EMBEDDED_STATIC_FIELDS, Map.class))
                 .orElse(Collections.emptyList())
                 .stream()
                 .map(field -> Map.entry(

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -346,6 +346,14 @@ class InputServiceImplTest {
         assertThat((long) paginated.size()).isEqualTo(2);
     }
 
+    @Test
+    @MongoDBFixtures("InputServiceImplTest.json")
+    void testStaticFields() {
+        assertThat(inputService.getStaticFields("54e3deadbeefdeadbeef0002")).isEmpty();
+        List<Map.Entry<String, String>> staticFields = inputService.getStaticFields("54e3deadbeefdeadbeef0003");
+        assertThat(staticFields).isNotNull().hasSize(1).isEqualTo(List.of(Map.entry("static_field", "foo")));
+    }
+
     private InputImpl createTestInput() {
         return InputImpl.builder()
                 .setTitle("input title")

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(MongoDBExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
-public class InputServiceImplTest {
+class InputServiceImplTest {
 
     @Mock
     private ExtractorFactory extractorFactory;
@@ -88,7 +88,7 @@ public class InputServiceImplTest {
 
     @BeforeEach
     @SuppressForbidden("Executors#newSingleThreadExecutor() is okay for tests")
-    public void setUp(MongoCollections mongoCollections) throws Exception {
+    void setUp(MongoCollections mongoCollections) {
         clusterEventBus = new ClusterEventBus("inputs-test", Executors.newSingleThreadExecutor());
         encryptedValueService = new EncryptedValueService(UUID.randomUUID().toString());
         inputService = new InputServiceImpl(
@@ -102,28 +102,28 @@ public class InputServiceImplTest {
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void allReturnsAllInputs() {
+    void allReturnsAllInputs() {
         final List<Input> inputs = inputService.all();
         assertThat(inputs).hasSize(3);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void allOfThisNodeReturnsAllLocalAndGlobalInputs() {
+    void allOfThisNodeReturnsAllLocalAndGlobalInputs() {
         final List<Input> inputs = inputService.allOfThisNode("cd03ee44-b2a7-cafe-babe-0000deadbeef");
         assertThat(inputs).hasSize(3);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void allOfThisNodeReturnsGlobalInputsIfNodeIDDoesNotExist() {
+    void allOfThisNodeReturnsGlobalInputsIfNodeIDDoesNotExist() {
         final List<Input> inputs = inputService.allOfThisNode("cd03ee44-b2a7-0000-0000-000000000000");
         assertThat(inputs).hasSize(1);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void findByIdsReturnsRequestedInputs() {
+    void findByIdsReturnsRequestedInputs() {
         assertThat(inputService.findByIds(ImmutableSet.of())).isEmpty();
         assertThat(inputService.findByIds(ImmutableSet.of("54e300000000000000000000"))).isEmpty();
         assertThat(inputService.findByIds(ImmutableSet.of("54e3deadbeefdeadbeef0001"))).hasSize(1);
@@ -133,39 +133,39 @@ public class InputServiceImplTest {
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void findReturnsExistingInput() throws NotFoundException {
+    void findReturnsExistingInput() throws NotFoundException {
         final Input input = inputService.find("54e3deadbeefdeadbeef0002");
         assertThat(input.getId()).isEqualTo("54e3deadbeefdeadbeef0002");
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void findThrowsNotFoundExceptionIfInputDoesNotExist() {
+    void findThrowsNotFoundExceptionIfInputDoesNotExist() {
         assertThatThrownBy(() -> inputService.find("54e300000000000000000000"))
                 .isExactlyInstanceOf(NotFoundException.class);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void globalCountReturnsNumberOfGlobalInputs() {
+    void globalCountReturnsNumberOfGlobalInputs() {
         assertThat(inputService.globalCount()).isEqualTo(1);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void localCountReturnsNumberOfLocalInputs() {
+    void localCountReturnsNumberOfLocalInputs() {
         assertThat(inputService.localCount()).isEqualTo(2);
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void localCountForNodeReturnsNumberOfLocalInputs() {
+    void localCountForNodeReturnsNumberOfLocalInputs() {
         assertThat(inputService.localCountForNode("cd03ee44-b2a7-cafe-babe-0000deadbeef")).isEqualTo(2);
-        assertThat(inputService.localCountForNode("cd03ee44-b2a7-0000-0000-000000000000")).isEqualTo(0);
+        assertThat(inputService.localCountForNode("cd03ee44-b2a7-0000-0000-000000000000")).isZero();
     }
 
     @Test
-    public void handlesEncryptedValue() throws ValidationException, NotFoundException {
+    void handlesEncryptedValue() throws ValidationException, NotFoundException {
 
         // Setup required to detect fields that need conversion from Map to EncryptedValue when reading
         final MessageInput.Config inputConfig = mock(MessageInput.Config.class);
@@ -216,14 +216,14 @@ public class InputServiceImplTest {
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void findByTitle() {
+    void findByTitle() {
         String rawTcp = "Raw TCP";
         List<String> idsByTitle = inputService.findIdsByTitle(rawTcp);
         assertThat(idsByTitle).hasSize(1);
     }
 
     @Test
-    public void createInput() {
+    void createInput() {
         Map<String, Object> localFields = Map.of(
                 MessageInput.FIELD_TYPE, "test type",
                 MessageInput.FIELD_TITLE, "test title",
@@ -255,7 +255,7 @@ public class InputServiceImplTest {
     }
 
     @Test
-    public void inputWithOutDesiredStateDefaultsToRunning() {
+    void inputWithOutDesiredStateDefaultsToRunning() {
         Map<String, Object> localFields = Map.of(
                 MessageInput.FIELD_TYPE, "test type",
                 MessageInput.FIELD_TITLE, "test title",
@@ -268,7 +268,7 @@ public class InputServiceImplTest {
     }
 
     @Test
-    public void saveInput() throws Exception {
+    void saveInput() throws Exception {
         InputImpl newInput = createTestInput();
 
         String id = inputService.save(newInput);
@@ -283,7 +283,7 @@ public class InputServiceImplTest {
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void testExtractor() throws Exception {
+    void testExtractor() throws Exception {
         Input input = inputService.find("54e3deadbeefdeadbeef0001");
 
         String extractorId = new ObjectId().toHexString();
@@ -326,19 +326,19 @@ public class InputServiceImplTest {
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void testDeleteExtractor() throws Exception {
+    void testDeleteExtractor() throws Exception {
         Input input = inputService.find("54e3deadbeefdeadbeef0002");
         Extractor extractor = Mockito.mock(Extractor.class);
         when(extractorFactory.factory(any(), any(), anyLong(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(extractor);
         assertThat(inputService.getExtractors(input.getId())).hasSize(1);
         inputService.removeExtractor(input, "4ec88750-c522-11f0-bdff-9eee7e74cea5");
-        assertThat(inputService.getExtractors(input.getId())).hasSize(0);
+        assertThat(inputService.getExtractors(input.getId())).isEmpty();
     }
 
     @Test
     @MongoDBFixtures("InputServiceImplTest.json")
-    public void testPaginated() {
+    void testPaginated() {
         PaginatedList<Input> paginated = inputService.paginated(Filters.empty(), input -> true, SortOrder.ASCENDING, InputImpl.FIELD_TITLE, 1, 2);
 
         assertThat(paginated).isNotNull();

--- a/graylog2-server/src/test/resources/org/graylog2/inputs/InputServiceImplTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/inputs/InputServiceImplTest.json
@@ -29,7 +29,7 @@
       "type": "org.graylog2.inputs.raw.tcp.RawTCPInput",
       "title": "Raw TCP",
       "content_pack": null,
-      "node_id": "cd03ee44-b2a7-cafe-babe-0000deadbeef",
+      "node_id": "cd03ee44-b2a7-cafe-babe-0000deadbeef"
     },
     {
       "_id": {
@@ -97,6 +97,12 @@
         "tls_client_auth": "disabled",
         "override_source": null
       },
+      "static_fields": [
+        {
+          "key": "static_field",
+          "value": "foo"
+        }
+      ],
       "name": "GELF TCP",
       "created_at": {
         "$date": "2018-03-28T13:03:00.000Z"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While working on #24057, static fields of an input went missing. This PR is adding them again.
/nocl as the cause is not released yet.
Closes #24653

## Description
<!--- Describe your changes in detail -->
While loading static inputs for an input, a `ClassCastException` was thrown, but as this happened while working on a stream, it was silently ignored and simply an empty results was returned. The cast now works and also a test was added to note different behaviour in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Initially it was tested while debugging on the locally running server, once the cause was known, a unit-test was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

