### PR TITLE
Backport 6.3: stop/start button behind inputs:changestate permission

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputListItem.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.tsx
@@ -190,7 +190,7 @@ const InputListItem = ({ input, currentNode }: Props) => {
         </LinkContainer>
       </IfPermitted>
     </HideOnCloud>,
-    <IfPermitted permissions={[`inputs:edit:${input.id}`, `input_types:create:${input.type}`]}>
+    <IfPermitted permissions={`inputs:changestate:${input.id}`}>
       <InputStateControl key={`input-state-control-${input.id}`} input={input} openWizard={openWizard} />
     </IfPermitted>,
     <DropdownButton


### PR DESCRIPTION
Backport 6.3: stop/start button behind inputs:changestate permission

fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/12659#issuecomment-3773413644

/nocl
