### PR TITLE
Fix sidecar config modal for "edit" case

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModalContainer.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModalContainer.tsx
@@ -44,6 +44,7 @@ type Props = {
   ) => void;
   show: boolean;
   onCancel: () => void;
+  onSubmitConfigurationModal: () => void;
 };
 
 const CollectorConfigurationModalContainer = ({
@@ -53,6 +54,7 @@ const CollectorConfigurationModalContainer = ({
   onConfigurationSelectionChange,
   show,
   onCancel,
+  onSubmitConfigurationModal,
 }: Props) => {
   const [nextAssignedConfigurations, setNextAssignedConfigurations] = useState<string[]>([]);
   const [nextPartiallyAssignedConfigurations, setNextPartiallyAssignedConfigurations] = useState<string[]>([]);
@@ -105,7 +107,7 @@ const CollectorConfigurationModalContainer = ({
     setNextAssignedConfigurations(fullyAssignedConfigs);
     setNextPartiallyAssignedConfigurations(partiallyAssignedConfigs);
     // Close config modal before showing confirmation to avoid stacking
-    onCancel();
+    onSubmitConfigurationModal();
     setShowConfirmModal(true);
   };
 

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.tsx
@@ -437,6 +437,7 @@ const CollectorsAdministration = ({
         selectedSidecarCollectorPairs={selectedSidecarCollectorPairs}
         onConfigurationSelectionChange={handleConfigurationChange}
         show={showConfigurationModal}
+        onSubmitConfigurationModal={() => setShowConfigurationModal(false)}
         onCancel={() => {
           setSelected([]);
           setShowConfigurationModal(false);

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationActions.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationActions.tsx
@@ -82,6 +82,7 @@ const CollectorsAdministrationActions = ({
         configurations={configurations}
         selectedSidecarCollectorPairs={selectedSidecarCollectorPairs}
         onConfigurationSelectionChange={onConfigurationSelectionChange}
+        onSubmitConfigurationModal={() => setShowConfigurationModal(false)}
         show={showConfigurationModal}
         onCancel={onCancelConfigurationModal}
       />


### PR DESCRIPTION
This is a follow-up PR for #24792, where only one of the two possibilities to open the config modal was fixed.

/nocl