### PR TITLE
Document settings for min and max shard size for time-size-optimizing rotation strategy

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -345,13 +345,13 @@ stream_aware_field_types=false
 #
 #enabled_index_rotation_strategies = count,size,time,time-size-optimizing
 
-# When time-size-optimizing rotation strategy is configured, Graylog automatically sizes shards to be 0.6x the memory
-# provision of the smallest Opensearch node assigned the "data" role, with a minimum size of 10 GB and a maximum size of 41 GB.
-# Where Graylog is not able to accurately identify the memory provision of the Opensearch nodes, such as containers with
-# dynamic memory configurations or when installing Graylog, MongoDB and Opensearch onto the same server as an all-in-one,
-# these value should be set manually within this configuration file to be 0.6x the memory available to the Opensearch process.
+# When these configuration keys are not set, Graylog automatically sizes both min and max size of shards to 0.6x the RAM 
+# provision of the smallest Opensearch node assigned the 'data' role, with a minimum value of 10 GB and a maximum value of 41 GB.
+# Where Graylog is not able to accurately identify the RAM provision of the Opensearch nodes, such as containers with 
+# dynamic memory configurations or when installing Graylog, MongoDB and Opensearch onto the same server as an all-in-one, 
+# these values should both be set manually within this configuration file to 0.6x the memory available to the Opensearch process.
 #
-#time_size_optimizing_rotation_min_shard_size = 5gb
+#time_size_optimizing_rotation_min_shard_size = 10gb
 #time_size_optimizing_rotation_max_shard_size = 10gb
 
 # The default index rotation strategy to use.


### PR DESCRIPTION
/nocl 

Provide guidance in `graylog.conf` when users might need to explicitly set min / max shard size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves Graylog2/graylog-plugin-enterprise#12656
