### PR TITLE
Restore DayPicker cell sizes to prevent modal overflow

### DIFF
--- a/graylog2-web-interface/src/components/common/DatePicker.tsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.tsx
@@ -28,6 +28,10 @@ const StyledDayPicker = styled(DayPicker)(
 
     --rdp-accent-color: ${theme.colors.variant.primary};
     --rdp-disabled-opacity: 0.4;
+    --rdp-day-width: 34px;
+    --rdp-day-height: 34px;
+    --rdp-day_button-width: 34px;
+    --rdp-day_button-height: 34px;
 
     .rdp-chevron {
       fill: ${theme.colors.gray[60]};


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13085
/nocl

related to https://github.com/Graylog2/graylog2-server/pull/23857/changes#diff-fa9643ae0982aab05180b837d119095c2526751559e1e9016b39ebb7847b48b3

## Screenshots (if appropriate):
<img width="639" height="1127" alt="Screenshot 2026-01-30 at 14 40 07" src="https://github.com/user-attachments/assets/a6495de6-4c22-48e0-9d9c-c70b454f3527" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

