### PR TITLE
Configure ESLint rule to avoid imports from `react-router-dom`.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -173,6 +173,11 @@ export default [
               message: 'Please use Link from `components/common/router` instead.',
             },
             {
+              name: 'react-router-dom',
+              importNames: ['useLocation'],
+              message: 'Please use `routing/useLocation` instead.',
+            },
+            {
               name: 'create-react-class',
               message: 'Please use an ES6 or functional component instead.',
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a ESLint rule to avoid importing `Link` or `useLocation` from `react-router-dom`.
We have our own abstraction for the `Link` component and the `useLocation` hook, but it is very easy to accidentally add an import from `react-router-dom`.

/nocl
