### PR TITLE
Add default 30-day time range filter to Alerts Entity Table

### DIFF
--- a/changelog/unreleased/issue-24887.toml
+++ b/changelog/unreleased/issue-24887.toml
@@ -2,4 +2,4 @@ type = "a"
 message = "Add default 30-day time range filter to Security Alerts Entity Table"
 
 pulls = ["graylog2-server#24911", "graylog-plugin-enterprise#13100"]
-issues = ["24887"]
+issues = [ "graylog2-server#24887"]

--- a/changelog/unreleased/issue-24887.toml
+++ b/changelog/unreleased/issue-24887.toml
@@ -2,4 +2,4 @@ type = "a"
 message = "Add default 30-day time range filter to Security Alerts Entity Table"
 
 pulls = ["graylog2-server#24911", "graylog-plugin-enterprise#13100"]
-issues = ["Graylog2/graylog2-server/issues/24887"]
+issues = ["24887"]

--- a/changelog/unreleased/issue-24887.toml
+++ b/changelog/unreleased/issue-24887.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add default 30-day time range filter to Security Alerts Entity Table"
+
+pulls = ["graylog2-server#24911", "graylog-plugin-enterprise#13100"]
+issues = ["Graylog2/graylog2-server/issues/24887"]

--- a/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.test.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import moment from 'moment';
+
+import { createDefaultTimestampFilter } from './defaultFilters';
+import { DATE_SEPARATOR } from './timeRange';
+
+describe('createDefaultTimestampFilter', () => {
+  it('should return OrderedMap with timestamp key', () => {
+    const result = createDefaultTimestampFilter();
+
+    expect(result.has('timestamp')).toBe(true);
+  });
+
+  it('should use default 30 days when no parameter provided', () => {
+    const result = createDefaultTimestampFilter();
+    const timestampFilter = result.get('timestamp')[0];
+    const [fromDate] = timestampFilter.split(DATE_SEPARATOR);
+    const parsedDate = moment.utc(fromDate);
+    const expectedDate = moment.utc().subtract(30, 'days');
+    const diffInHours = expectedDate.diff(parsedDate, 'hours');
+
+    expect(Math.abs(diffInHours)).toBeLessThan(1);
+  });
+
+  it('should accept custom day count', () => {
+    const result = createDefaultTimestampFilter(7);
+    const timestampFilter = result.get('timestamp')[0];
+    const [fromDate] = timestampFilter.split(DATE_SEPARATOR);
+    const parsedDate = moment.utc(fromDate);
+    const expectedDate = moment.utc().subtract(7, 'days');
+    const diffInHours = expectedDate.diff(parsedDate, 'hours');
+
+    expect(Math.abs(diffInHours)).toBeLessThan(1);
+  });
+
+  it('should format timestamp in ISO 8601 UTC format', () => {
+    const result = createDefaultTimestampFilter();
+    const timestampFilter = result.get('timestamp')[0];
+
+    expect(timestampFilter).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00><$/);
+  });
+
+  it('should use DATE_SEPARATOR format', () => {
+    const result = createDefaultTimestampFilter();
+    const timestampFilter = result.get('timestamp')[0];
+
+    expect(timestampFilter).toContain(DATE_SEPARATOR);
+    expect(timestampFilter.endsWith(DATE_SEPARATOR)).toBe(true);
+  });
+
+  it('should use empty string after separator to indicate "until now"', () => {
+    const result = createDefaultTimestampFilter();
+    const timestampFilter = result.get('timestamp')[0];
+    const [, untilDate] = timestampFilter.split(DATE_SEPARATOR);
+
+    expect(untilDate).toBe('');
+  });
+
+  it('should work with various day counts', () => {
+    const testCases = [1, 7, 14, 30, 60, 90, 365];
+
+    testCases.forEach((days) => {
+      const result = createDefaultTimestampFilter(days);
+      const timestampFilter = result.get('timestamp')[0];
+      const [fromDate] = timestampFilter.split(DATE_SEPARATOR);
+      const parsedDate = moment.utc(fromDate);
+      const expectedDate = moment.utc().subtract(days, 'days');
+      const diffInHours = expectedDate.diff(parsedDate, 'hours');
+
+      expect(Math.abs(diffInHours)).toBeLessThan(1);
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import moment from 'moment';
+import { OrderedMap } from 'immutable';
+
+import type { UrlQueryFilters } from 'components/common/EntityFilters';
+
+import { DATE_SEPARATOR } from './timeRange';
+
+/**
+ * Creates a default timestamp filter for a given number of days in the past.
+ *
+ * @param days - Number of days to look back from now (default: 30)
+ * @returns OrderedMap with timestamp filter from specified days ago until now (UTC)
+ */
+export const createDefaultTimestampFilter = (days: number = 30): UrlQueryFilters => {
+  const daysAgoUTC = moment.utc().subtract(days, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+
+  return OrderedMap({ timestamp: [`${daysAgoUTC}${DATE_SEPARATOR}`] });
+};

--- a/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/helpers/defaultFilters.ts
@@ -17,7 +17,7 @@
 import moment from 'moment';
 import { OrderedMap } from 'immutable';
 
-import type { UrlQueryFilters } from 'components/common/EntityFilters';
+import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
 
 import { DATE_SEPARATOR } from './timeRange';
 

--- a/graylog2-web-interface/src/components/common/EntityFilters/hooks/useUrlQueryFilters.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/hooks/useUrlQueryFilters.test.tsx
@@ -57,7 +57,7 @@ describe('useUrlQueryFilters', () => {
     result.current[1](OrderedMap({ index_set_id: ['index_set_id_1', 'index_set_id_2'] }));
 
     await waitFor(() =>
-      expect(updateUrlQueryParams).toHaveBeenCalledWith(['index_set_id=index_set_id_1', 'index_set_id=index_set_id_2']),
+      expect(updateUrlQueryParams).toHaveBeenCalledWith(['index_set_id=index_set_id_1', 'index_set_id=index_set_id_2'], undefined),
     );
   });
 });

--- a/graylog2-web-interface/src/components/common/EntityFilters/hooks/useUrlQueryFilters.ts
+++ b/graylog2-web-interface/src/components/common/EntityFilters/hooks/useUrlQueryFilters.ts
@@ -20,7 +20,12 @@ import { OrderedMap } from 'immutable';
 import { useQueryParam, ArrayParam } from 'routing/QueryParams';
 import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
 
-const useUrlQueryFilters = (): [UrlQueryFilters, (filters: UrlQueryFilters) => void] => {
+type UpdateType = 'push' | 'pushIn' | 'replace' | 'replaceIn';
+
+const useUrlQueryFilters = (): [
+  UrlQueryFilters,
+  (filters: UrlQueryFilters, updateType?: UpdateType) => void,
+] => {
   const [pureUrlQueryFilters, setPureUrlQueryFilters] = useQueryParam('filters', ArrayParam);
 
   const filtersFromQuery = useMemo(
@@ -34,12 +39,12 @@ const useUrlQueryFilters = (): [UrlQueryFilters, (filters: UrlQueryFilters) => v
   );
 
   const setFilterValues = useCallback(
-    (newFilters: UrlQueryFilters) => {
+    (newFilters: UrlQueryFilters, updateType?: UpdateType) => {
       const newPureUrlQueryFilters = newFilters
         .entrySeq()
         .reduce((col, [attributeId, filters]) => [...col, ...filters.map((value) => `${attributeId}=${value}`)], []);
 
-      setPureUrlQueryFilters(newPureUrlQueryFilters);
+      setPureUrlQueryFilters(newPureUrlQueryFilters, updateType);
     },
     [setPureUrlQueryFilters],
   );

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -276,6 +276,7 @@ type WrapperProps<T, M> = PaginatedEntityTableProps<T, M> & {
 const TableWithLocalState = <T extends EntityBase, M = unknown>({ ...props }: WrapperProps<T, M>) => {
   const { fetchOptions, setQuery, onChangeFilters, onChangeSlicing, paginationState } = useWithLocalState(
     props.layoutConfig,
+    props.defaultFilters,
   );
   const effectiveFetchOptions = props.externalSearch
     ? { ...fetchOptions, query: props.externalSearch.query }
@@ -297,6 +298,7 @@ const TableWithLocalState = <T extends EntityBase, M = unknown>({ ...props }: Wr
 const TableWithURLParams = <T extends EntityBase, M = unknown>({ ...props }: WrapperProps<T, M>) => {
   const { fetchOptions, setQuery, onChangeFilters, paginationState, onChangeSlicing } = useWithURLParams(
     props.layoutConfig,
+    props.defaultFilters,
   );
   const effectiveFetchOptions = props.externalSearch
     ? { ...fetchOptions, query: props.externalSearch.query }
@@ -319,6 +321,8 @@ export type PaginatedEntityTableProps<T, M> = {
   additionalAttributes?: Array<Attribute>;
   bulkSelection?: EntityDataTableProps['bulkSelection'];
   columnRenderers: EntityDataTableProps['columnRenderers'];
+  // eslint-disable-next-line react/no-unused-prop-types -- Used in wrapper components via props.defaultFilters
+  defaultFilters?: UrlQueryFilters;
   entityActions: EntityDataTableProps['entityActions'];
   entityAttributesAreCamelCase: boolean;
   expandedSectionRenderers?: ExpandedSectionRenderers<T>;

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.test.tsx
@@ -109,5 +109,16 @@ describe('useFiltersAndPagination', () => {
 
       expect(result.current.fetchOptions.filters).toEqual(newFilters);
     });
+
+    it('should allow clearing all filters', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const { result } = renderHook(() => useWithURLParams(mockLayoutConfig, defaultFilters), { wrapper });
+
+      act(() => {
+        result.current.onChangeFilters(OrderedMap());
+      });
+
+      expect(result.current.fetchOptions.filters).toEqual(OrderedMap());
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { renderHook, act } from 'wrappedTestingLibrary/hooks';
+import { OrderedMap } from 'immutable';
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import DefaultQueryParamProvider from 'routing/DefaultQueryParamProvider';
+import type { LayoutConfig } from 'components/common/EntityDataTable/hooks/useTableLayout';
+
+import { useWithURLParams, useWithLocalState } from './useFiltersAndPagination';
+
+const mockLayoutConfig: LayoutConfig = {
+  pageSize: 20,
+  sort: { attributeId: 'timestamp', direction: 'desc' },
+  attributes: {},
+  order: [],
+};
+
+describe('useFiltersAndPagination', () => {
+  describe('useWithLocalState', () => {
+    it('should initialize with empty filters when no defaults provided', () => {
+      const { result } = renderHook(() => useWithLocalState(mockLayoutConfig));
+
+      expect(result.current.fetchOptions.filters).toEqual(OrderedMap());
+    });
+
+    it('should initialize with default filters when provided', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const { result } = renderHook(() => useWithLocalState(mockLayoutConfig, defaultFilters));
+
+      expect(result.current.fetchOptions.filters).toEqual(defaultFilters);
+    });
+
+    it('should allow changing filters after initialization with defaults', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const { result } = renderHook(() => useWithLocalState(mockLayoutConfig, defaultFilters));
+
+      const newFilters = OrderedMap({ priority: ['3'] });
+
+      act(() => {
+        result.current.onChangeFilters(newFilters);
+      });
+
+      expect(result.current.fetchOptions.filters).toEqual(newFilters);
+    });
+  });
+
+  describe('useWithURLParams', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MemoryRouter>
+        <DefaultQueryParamProvider>{children}</DefaultQueryParamProvider>
+      </MemoryRouter>
+    );
+
+    it('should initialize with empty filters when no defaults and no URL params', () => {
+      const { result } = renderHook(() => useWithURLParams(mockLayoutConfig), { wrapper });
+
+      expect(result.current.fetchOptions.filters).toEqual(OrderedMap());
+    });
+
+    it('should apply default filters when URL has no filter params', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const { result } = renderHook(() => useWithURLParams(mockLayoutConfig, defaultFilters), { wrapper });
+
+      expect(result.current.fetchOptions.filters).toEqual(defaultFilters);
+    });
+
+    it('should prefer URL params over default filters when URL has filters', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const urlFilters = OrderedMap({ priority: ['3'] });
+
+      const WrapperWithFilters = ({ children }: { children: React.ReactNode }) => (
+        <MemoryRouter initialEntries={['/?filters=priority%3D3']}>
+          <DefaultQueryParamProvider>{children}</DefaultQueryParamProvider>
+        </MemoryRouter>
+      );
+
+      const { result } = renderHook(() => useWithURLParams(mockLayoutConfig, defaultFilters), {
+        wrapper: WrapperWithFilters,
+      });
+
+      expect(result.current.fetchOptions.filters).toEqual(urlFilters);
+    });
+
+    it('should allow changing filters after initialization with defaults', () => {
+      const defaultFilters = OrderedMap({ timestamp: ['2025-01-01T00:00:00.000+00:00><'] });
+      const { result } = renderHook(() => useWithURLParams(mockLayoutConfig, defaultFilters), { wrapper });
+
+      const newFilters = OrderedMap({ priority: ['3'] });
+
+      act(() => {
+        result.current.onChangeFilters(newFilters);
+      });
+
+      expect(result.current.fetchOptions.filters).toEqual(newFilters);
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.ts
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.ts
@@ -24,12 +24,20 @@ import type { SearchParams } from 'stores/PaginationTypes';
 import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
 import type { LayoutConfig } from 'components/common/EntityDataTable/hooks/useTableLayout';
 
-export const useWithURLParams = (layoutConfig: LayoutConfig) => {
+export const useWithURLParams = (layoutConfig: LayoutConfig, defaultFilters?: UrlQueryFilters) => {
   const [urlQueryFilters, setUrlQueryFilters] = useUrlQueryFilters();
   const [query, setUrlQuery] = useQueryParam('query', StringParam);
   const [sliceCol, setSliceCol] = useQueryParam('sliceCol', StringParam);
   const [slice, setSlice] = useQueryParam('slice', StringParam);
   const urlPagination = usePaginationQueryParameter(undefined, layoutConfig.pageSize, false);
+
+  const effectiveFilters = useMemo(() => {
+    if (urlQueryFilters && urlQueryFilters.size > 0) {
+      return urlQueryFilters;
+    }
+
+    return defaultFilters ?? OrderedMap<string, Array<string>>();
+  }, [urlQueryFilters, defaultFilters]);
 
   const fetchOptions: SearchParams = useMemo(
     () => ({
@@ -39,9 +47,9 @@ export const useWithURLParams = (layoutConfig: LayoutConfig) => {
       page: urlPagination.page,
       pageSize: layoutConfig.pageSize,
       sort: layoutConfig.sort,
-      filters: urlQueryFilters,
+      filters: effectiveFilters,
     }),
-    [query, slice, sliceCol, urlPagination.page, layoutConfig.pageSize, layoutConfig.sort, urlQueryFilters],
+    [query, slice, sliceCol, urlPagination.page, layoutConfig.pageSize, layoutConfig.sort, effectiveFilters],
   );
 
   const onChangeFilters = useCallback(
@@ -64,11 +72,11 @@ export const useWithURLParams = (layoutConfig: LayoutConfig) => {
   };
 };
 
-export const useWithLocalState = (layoutConfig: LayoutConfig) => {
+export const useWithLocalState = (layoutConfig: LayoutConfig, defaultFilters?: UrlQueryFilters) => {
   const [transientFetchOptions, setTransientFetchOptions] = useState<any>({
     query: '',
     page: DEFAULT_PAGE,
-    filters: OrderedMap<string, Array<string>>(),
+    filters: defaultFilters ?? OrderedMap<string, Array<string>>(),
     slice: undefined,
     sliceCol: undefined,
   });

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.ts
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/useFiltersAndPagination.ts
@@ -38,7 +38,7 @@ export const useWithURLParams = (layoutConfig: LayoutConfig, defaultFilters?: Ur
       const urlHasNoFilters = !urlQueryFilters || urlQueryFilters.size === 0;
 
       if (urlHasNoFilters) {
-        setUrlQueryFilters(defaultFilters);
+        setUrlQueryFilters(defaultFilters, 'replaceIn');
       }
 
       hasInitialized.current = true;
@@ -61,7 +61,7 @@ export const useWithURLParams = (layoutConfig: LayoutConfig, defaultFilters?: Ur
   const onChangeFilters = useCallback(
     (newUrlQueryFilters: UrlQueryFilters) => {
       urlPagination.resetPage();
-      setUrlQueryFilters(newUrlQueryFilters);
+      setUrlQueryFilters(newUrlQueryFilters, 'replaceIn');
     },
     [urlPagination, setUrlQueryFilters],
   );

--- a/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
+++ b/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
@@ -32,8 +32,6 @@ import EventsRefreshControls from 'components/events/events/EventsRefreshControl
 import QueryHelper from 'components/common/QueryHelper';
 import EventsWidgets from 'components/events/EventsWidgets';
 import EventsRefreshProvider from 'components/events/EventsRefreshProvider';
-import useUserDateTime from 'hooks/useUserDateTime';
-import { adjustFormat, toUTCFromTz } from 'util/DateTime';
 import { DATE_SEPARATOR } from 'components/common/EntityFilters/helpers/timeRange';
 
 const additionalSearchFields = {
@@ -42,7 +40,6 @@ const additionalSearchFields = {
 
 const EventsEntityTable = () => {
   const { stream_id: streamId } = useQuery();
-  const { userTimezone } = useUserDateTime();
 
   const _fetchEvents = useCallback(
     (searchParams: SearchParams) => fetchEvents(searchParams, streamId as string),
@@ -53,11 +50,10 @@ const EventsEntityTable = () => {
   });
 
   const defaultFilters = useMemo(() => {
-    const thirtyDaysAgo = moment().subtract(30, 'days').format('YYYY-MM-DD HH:mm:ss');
-    const thirtyDaysAgoUTC = adjustFormat(toUTCFromTz(thirtyDaysAgo, userTimezone), 'internal');
+    const thirtyDaysAgoUTC = moment.utc().subtract(30, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
 
     return OrderedMap({ timestamp: [`${thirtyDaysAgoUTC}${DATE_SEPARATOR}`] });
-  }, [userTimezone]);
+  }, []);
 
   return (
     <EventsRefreshProvider>

--- a/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
+++ b/graylog2-web-interface/src/components/events/EventsEntityTable.tsx
@@ -15,9 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useMemo } from 'react';
-import moment from 'moment';
-import { OrderedMap } from 'immutable';
+import { useCallback } from 'react';
 
 import useTableElements from 'components/events/events/hooks/useTableComponents';
 import { eventsTableElements } from 'components/events/Constants';
@@ -32,7 +30,7 @@ import EventsRefreshControls from 'components/events/events/EventsRefreshControl
 import QueryHelper from 'components/common/QueryHelper';
 import EventsWidgets from 'components/events/EventsWidgets';
 import EventsRefreshProvider from 'components/events/EventsRefreshProvider';
-import { DATE_SEPARATOR } from 'components/common/EntityFilters/helpers/timeRange';
+import { createDefaultTimestampFilter } from 'components/common/EntityFilters/helpers/defaultFilters';
 
 const additionalSearchFields = {
   key: 'The key of the event',
@@ -49,11 +47,7 @@ const EventsEntityTable = () => {
     defaultLayout: eventsTableElements.defaultLayout,
   });
 
-  const defaultFilters = useMemo(() => {
-    const thirtyDaysAgoUTC = moment.utc().subtract(30, 'days').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-
-    return OrderedMap({ timestamp: [`${thirtyDaysAgoUTC}${DATE_SEPARATOR}`] });
-  }, []);
+  const defaultFilters = createDefaultTimestampFilter();
 
   return (
     <EventsRefreshProvider>


### PR DESCRIPTION
## Description

Adds a default 30-day time range filter to the Events Entity Table, showing events from the last 30 days on initial page load.

**Changes:**
- Added `defaultFilters` prop to `PaginatedEntityTable` component
- Updated `useWithURLParams` and `useWithLocalState` hooks to accept and apply default filters
- Implemented UTC-based 30-day default filter in `EventsEntityTable`
- Modified `useUrlQueryFilters` to accept `updateType` parameter
- All filter updates now use `history.replace` to prevent browser history pollution

## Motivation and Context

Users viewing the Events page see all events with no default filtering, which can be overwhelming and slow in environments with many historical events. This PR improves UX by showing recent events by default while keeping the filter easily modifiable or removable.

Additionally fixes unwanted browser history entries when changing filters (previously required multiple back button presses).

## How Has This Been Tested?

- Added 8 unit tests for `useFiltersAndPagination` hooks
- All tests passing: `yarn test useFiltersAndPagination.test.tsx`
- Manual testing: verified filter appears on load, syncs to URL, can be modified/removed, back button works correctly
- Lint passing: `yarn eslint [modified files] --max-warnings 0`

Fixes #24887

/prd Graylog2/graylog-plugin-enterprise/pull/13100

## Screenshots (if appropriate):
<img width="970" height="504" alt="Bildschirmfoto 2026-02-02 um 14 51 23" src="https://github.com/user-attachments/assets/20ed174c-f1d3-4169-81fc-143f01040e77" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have added tests to cover my changes.