### PR TITLE
Backport: Add support for sorting saved searches & dashboards by favorite status (6.3)

### DIFF
--- a/changelog/unreleased/issue-21659.toml
+++ b/changelog/unreleased/issue-21659.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Allow sorting saved searches & dashboards based on favorite state"
+
+pulls = ["24809"]
+issues = ["Graylog2/graylog2-server#21659"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
@@ -89,8 +89,7 @@ public class DashboardsResource extends RestResource {
             EntityAttribute.builder().id(ViewDTO.FIELD_DESCRIPTION).title("Description").searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_SUMMARY).title("Summary").searchable(true).build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_OWNER).title("Owner").build(),
-            EntityAttribute.builder().id(ViewDTO.FIELD_FAVORITE).title("Favorite").sortable(false).build()
-    );
+            EntityAttribute.builder().id(ViewDTO.FIELD_FAVORITE).title("Favorite").sortable(true).build());
     private static final EntityDefaults settings = EntityDefaults.builder()
             .sort(Sorting.create(DEFAULT_SORT_FIELD, Sorting.Direction.valueOf(DEFAULT_SORT_DIRECTION.toUpperCase(Locale.ROOT))))
             .build();
@@ -111,7 +110,7 @@ public class DashboardsResource extends RestResource {
                                                   @ApiParam(name = "sort",
                                                             value = "The field to sort the result on",
                                                             required = true,
-                                                            allowableValues = "id,title,created_at,description,summary,owner") @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sortField,
+                                                            allowableValues = "id,title,created_at,description,summary,owner,favorite") @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sortField,
                                                   @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc") @DefaultValue("asc") @QueryParam("order") SortOrder order,
                                                   @ApiParam(name = "query") @QueryParam("query") String query,
                                                   @ApiParam(name = "filters") @QueryParam("filters") List<String> filters,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
@@ -66,7 +66,7 @@ public class SavedSearchesResource extends RestResource {
             EntityAttribute.builder().id(ViewDTO.FIELD_DESCRIPTION).title("Description").build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_SUMMARY).title("Summary").build(),
             EntityAttribute.builder().id(ViewDTO.FIELD_OWNER).title("Owner").build(),
-            EntityAttribute.builder().id(ViewDTO.FIELD_FAVORITE).title("Favorite").sortable(false).build()
+            EntityAttribute.builder().id(ViewDTO.FIELD_FAVORITE).title("Favorite").sortable(true).build()
     );
 
     private static final EntityDefaults settings = EntityDefaults.builder()
@@ -89,7 +89,7 @@ public class SavedSearchesResource extends RestResource {
                                                   @ApiParam(name = "sort",
                                                             value = "The field to sort the result on",
                                                             required = true,
-                                                            allowableValues = "id,title,created_at,description,summary,owner") @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sortField,
+                                                            allowableValues = "id,title,created_at,description,summary,owner,favorite") @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sortField,
                                                   @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc") @DefaultValue("asc") @QueryParam("order") SortOrder order,
                                                   @ApiParam(name = "query") @QueryParam("query") String query,
                                                   @ApiParam(name = "filters") @QueryParam("filters") List<String> filters,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
@@ -76,7 +76,7 @@ public abstract class ViewDTO implements ContentPackable<ViewEntity.Builder>, Vi
     public static final String FIELD_OWNER = "owner";
     public static final String FIELD_FAVORITE = "favorite";
 
-    public static final ImmutableSet<String> SORT_FIELDS = ImmutableSet.of(FIELD_ID, FIELD_TITLE, FIELD_CREATED_AT, FIELD_LAST_UPDATED_AT, FIELD_OWNER, FIELD_DESCRIPTION, FIELD_SUMMARY);
+    public static final ImmutableSet<String> SORT_FIELDS = ImmutableSet.of(FIELD_ID, FIELD_TITLE, FIELD_CREATED_AT, FIELD_LAST_UPDATED_AT, FIELD_OWNER, FIELD_DESCRIPTION, FIELD_SUMMARY, FIELD_FAVORITE);
     public static final ImmutableSet<String> STRING_SORT_FIELDS = ImmutableSet.of(FIELD_TITLE, FIELD_OWNER, FIELD_DESCRIPTION, FIELD_SUMMARY);
     public static final String SECONDARY_SORT = FIELD_TITLE;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceTest.java
@@ -19,14 +19,23 @@ package org.graylog.plugins.views.search.views;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import org.graylog.grn.GRN;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNTypes;
+import org.graylog.plugins.views.favorites.FavoritesForUserDTO;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.rest.TestSearchUser;
 import org.graylog.security.entities.EntityOwnershipService;
+import org.graylog.plugins.views.search.rest.TestUser;
 import org.graylog.testing.ObjectMapperExtension;
+import org.graylog.testing.GRNExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.events.ClusterEventBus;
@@ -43,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,15 +61,20 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(ObjectMapperExtension.class)
+@ExtendWith(MongoJackExtension.class)
+@ExtendWith(GRNExtension.class)
 public class ViewServiceTest {
     private ViewService dbService;
+    private MongoCollection<FavoritesForUserDTO> favoritesCollection;
+    private GRNRegistry grnRegistry;
 
     private SearchUser searchUser;
     private MongoDBTestService mongodb;
 
     @BeforeEach
-    public void setUp(MongoDBTestService mongodb, ObjectMapper objectMapper) throws Exception {
+    public void setUp(MongoDBTestService mongodb, ObjectMapper objectMapper, GRNRegistry grnRegistry) throws Exception {
         this.mongodb = mongodb;
+        this.grnRegistry = grnRegistry;
         final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
         final MongoCollections mongoCollections = new MongoCollections(objectMapperProvider, mongodb.mongoConnection());
         ClusterConfigServiceImpl clusterConfigService = new ClusterConfigServiceImpl(
@@ -76,7 +91,16 @@ public class ViewServiceTest {
                 mock(EntityOwnershipService.class),
                 mock(ViewSummaryService.class),
                 mongoCollections);
-        this.searchUser = TestSearchUser.builder().build();
+
+        // Set up favorites collection using MongoCollections to ensure proper serialization
+        this.favoritesCollection = mongoCollections.collection("favorites", FavoritesForUserDTO.class);
+
+        // Create a test user with a specific ID for favorites testing
+        final org.graylog2.plugin.database.users.User testUser = TestUser.builder()
+                .withId("637748db06e1d74da0a54330")
+                .withUsername("test")
+                .build();
+        this.searchUser = TestSearchUser.builder().withUser(testUser).build();
     }
 
     @AfterEach
@@ -315,5 +339,63 @@ public class ViewServiceTest {
 
         assertThatThrownBy(() -> dbService.saveDefault(ViewDTO.builder().title("err").searchId("abc123").state(Collections.emptyMap()).build()))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void searchPaginatedSortedByFavorite() {
+        // Create several views
+        final ViewDTO view1 = dbService.save(ViewDTO.builder().title("View Alpha").searchId("abc123").state(Collections.emptyMap()).build());
+        final ViewDTO view2 = dbService.save(ViewDTO.builder().title("View Beta").searchId("abc123").state(Collections.emptyMap()).build());
+        final ViewDTO view3 = dbService.save(ViewDTO.builder().title("View Gamma").searchId("abc123").state(Collections.emptyMap()).build());
+        final ViewDTO view4 = dbService.save(ViewDTO.builder().title("View Delta").searchId("abc123").state(Collections.emptyMap()).build());
+
+        // Mark view2 and view4 as favorites using MongoCollection with FavoritesForUserDTO
+        // This uses the same data structure as FavoritesService to avoid storage format drift
+        final GRN grn2 = grnRegistry.newGRN(GRNTypes.SEARCH, view2.id());
+        final GRN grn4 = grnRegistry.newGRN(GRNTypes.SEARCH, view4.id());
+        final FavoritesForUserDTO favorites = new FavoritesForUserDTO(searchUser.getUser().getId(), List.of(grn2, grn4));
+        favoritesCollection.insertOne(favorites);
+
+        final SearchQueryParser queryParser = new SearchQueryParser(ViewDTO.FIELD_TITLE, ImmutableMap.of());
+
+        // Test sorting by favorite DESCENDING (favorites first)
+        PaginatedList<ViewDTO> result = dbService.searchPaginated(
+                searchUser,
+                queryParser.parse(""),
+                view -> true,
+                SortOrder.DESCENDING,
+                ViewDTO.FIELD_FAVORITE,
+                1,
+                10
+        );
+
+        assertThat(result)
+                .hasSize(4)
+                .extracting(ViewDTO::favorite)
+                .containsExactly(true, true, false, false);
+
+        // Verify the specific views (favorites should be view2 and view4)
+        assertThat(result.stream().filter(ViewDTO::favorite).map(ViewDTO::id))
+                .containsExactlyInAnyOrder(view2.id(), view4.id());
+
+        // Test sorting by favorite ASCENDING (non-favorites first)
+        result = dbService.searchPaginated(
+                searchUser,
+                queryParser.parse(""),
+                view -> true,
+                SortOrder.ASCENDING,
+                ViewDTO.FIELD_FAVORITE,
+                1,
+                10
+        );
+
+        assertThat(result)
+                .hasSize(4)
+                .extracting(ViewDTO::favorite)
+                .containsExactly(false, false, true, true);
+
+        // Verify non-favorites are first (view1 and view3)
+        assertThat(result.stream().filter(v -> !v.favorite()).map(ViewDTO::id))
+                .containsExactlyInAnyOrder(view1.id(), view3.id());
     }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchesModal/SavedSearchesModal.test.tsx
@@ -58,6 +58,11 @@ const createPaginatedSearches = (count = 1) => {
         title: 'Description',
         sortable: true,
       },
+      {
+        id: 'favorite',
+        title: 'Favorite',
+        sortable: true,
+      },
     ],
     list: views,
   };


### PR DESCRIPTION
## Description

This PR enables users to sort their saved searches & dashboards by whether they are marked as favorites. Users can now click on the "Favorite" column header in the saved searches/dashboards list to toggle between:
  - Descending order (favorites first)
  - Ascending order (non-favorites first)

The implementation leverages the existing MongoDB aggregation pipeline that computes the favorite field at query time via a lookup join with the favorites collection, avoiding data duplication.

Note: This is a backport of https://github.com/Graylog2/graylog2-server/pull/24809 to 7.0.
  
## Motivation and Context
Users requested the ability to sort saved searches/dashboards by favorite status to quickly access their most important searches. Previously, the favorite field was displayed in the table but could not be used for sorting, requiring users to manually scan through the list to find their favorite searches.

  ## How Has This Been Tested?
 **Backend testing:**
  - Added comprehensive integration test `ViewServiceTest.searchPaginatedSortedByFavorite()`
    - Tests sorting by favorite in both DESC (favorites first) and ASC (non-favorites first) order
    - Validates that the MongoDB aggregation pipeline correctly computes and sorts by the favorite field
    - Manually inserts test favorites into the favorites collection to simulate real usage

## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Refactoring (non-breaking change)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have requested a documentation update.
  - [ ] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.