### PR TITLE
Fix issue with disabled submit button on field type modal

### DIFF
--- a/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChangeFieldType/ChangeFieldType.tsx
@@ -23,6 +23,7 @@ import type User from 'logic/users/User';
 import isReservedField from 'views/logic/IsReservedField';
 import useInitialSelection from 'views/logic/fieldactions/ChangeFieldType/hooks/useInitialSelection';
 import { isPermitted } from 'util/PermissionsMixin';
+import { Spinner } from 'components/common';
 
 const ChangeFieldType = ({ field, onClose }: ActionComponentProps) => {
   const [show, setShow] = useState(true);
@@ -32,6 +33,8 @@ const ChangeFieldType = ({ field, onClose }: ActionComponentProps) => {
   }, [onClose]);
 
   const { list, isLoading } = useInitialSelection();
+
+  if (isLoading) return <Spinner />;
 
   return show ? (
     <ChangeFieldTypeModal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the described issue. The reason for the bug was that we in https://github.com/Graylog2/graylog2-server/pull/24890/changes removed useEffect, which updates initial values. To fix the issue and get rid of useEffect, we have to render the modal content only after the initial values for the index sets have been fetched.

## Motivation and Context
fix: #24919
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl not released bug
