### PR TITLE
Use proper ssl context in os3 client provider

### DIFF
--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/testing/OpenSearchInstance.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/testing/OpenSearchInstance.java
@@ -145,7 +145,8 @@ public class OpenSearchInstance extends TestableSearchServerInstance {
                 ImmutableList.of(URI.create(protocol + this.getHttpHostAddress())),
                 IndexerJwtAuthToken.disabled(),
                 createCredentialsProvider(),
-                getElasticsearchClientConfiguration()
+                getElasticsearchClientConfiguration(),
+                getTrustManagerAndSocketFactoryProvider()
         ).get();
     }
 


### PR DESCRIPTION
/nocl internal refactoring during os2->os3 client transition

Use TrustManagerAndSocketFactoryProvider in opensearch client provider to provide properly initialized ssl context with our system-wide truststore manager. 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

