### PR TITLE
Change test url from https to http in InputPermissionsIT

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog2/inputs/InputPermissionsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/inputs/InputPermissionsIT.java
@@ -18,12 +18,12 @@ package org.graylog2.inputs;
 
 import net.bytebuddy.utility.RandomString;
 import org.assertj.core.api.Assertions;
+import org.graylog.testing.completebackend.FullBackendTest;
+import org.graylog.testing.completebackend.GraylogBackendConfiguration;
 import org.graylog.testing.completebackend.Lifecycle;
 import org.graylog.testing.completebackend.apis.GraylogApiResponse;
 import org.graylog.testing.completebackend.apis.GraylogApis;
 import org.graylog.testing.completebackend.apis.Users;
-import org.graylog.testing.completebackend.FullBackendTest;
-import org.graylog.testing.completebackend.GraylogBackendConfiguration;
 import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -151,7 +151,7 @@ public class InputPermissionsIT {
     void testRestrictedInputCreationAndReading() {
         String inputId = apis.forUser(inputsCreator).inputs().createGlobalInput("testInput",
                 "org.graylog2.inputs.misc.jsonpath.JsonPathInput",
-                Map.of("target_url", "https://example.org",
+                Map.of("target_url", "http://example.org",
                         "interval", 10,
                         "timeunit", "MINUTES",
                         "path", "$.data",


### PR DESCRIPTION
## Description
Changes the url in the created JsonPathInput in the InputPermissionsIT to http to avoid errors if the certificate can't be validated.

/nocl internal

## Motivation and Context
fixes CI failures

## How Has This Been Tested?
manually by calling the tested endpoint, by using the test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

