### PR TITLE
Add scope to event definition details page

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.tsx
@@ -146,6 +146,7 @@ const EventDefinitionSummary = ({
         config,
         currentUser,
         definitionId,
+        entityScope: eventDefinition._scope,
       })
     ) : (
       <p>

--- a/graylog2-web-interface/src/components/event-definitions/types.ts
+++ b/graylog2-web-interface/src/components/event-definitions/types.ts
@@ -54,6 +54,7 @@ export interface EventDefinitionType {
     currentUser: User;
     config: EventDefinition['config'];
     definitionId?: string;
+    entityScope?: string;
   }>;
   useCondition: () => boolean;
 }


### PR DESCRIPTION
Provide scope to event definition summary page. This allows child components to access it.

/nocl not a visible change