### PR TITLE
Optimize getStreams() perf to improve pipeline processing (6.3)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -18,6 +18,7 @@ package org.graylog2.plugin;
 
 import com.codahale.metrics.Meter;
 import com.eaio.uuid.UUID;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
@@ -768,6 +769,17 @@ public class Message implements Messages, Indexable, Acknowledgeable {
      */
     public Set<Stream> getStreams() {
         return ImmutableSet.copyOf(this.streams);
+    }
+
+    /**
+     * Returns a lightweight, unmodifiable view of the streams this message is currently routed to.
+     * Unlike {@link #getStreams()}, this does not create a copy — changes to the message's streams
+     * will be reflected in the returned set. Only use this when the set is consumed immediately
+     * (e.g. iteration, streaming) and not held across operations that may mutate the message.
+     */
+    @JsonIgnore
+    public Set<Stream> getStreamsUnmodifiable() {
+        return Collections.unmodifiableSet(this.streams);
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -48,6 +48,7 @@ import org.graylog.plugins.pipelineprocessor.functions.messages.SetField;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
+import org.graylog2.Configuration;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageCollection;
@@ -58,7 +59,8 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.messageq.MessageQueueAcknowledger;
-import org.junit.Test;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -72,39 +74,43 @@ import java.util.stream.Collectors;
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PipelineInterpreterTest {
-    private static final RuleDao RULE_TRUE = RuleDao.create("true", "true", "true",
-            "rule \"true\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "end", null, null, null, null);
-    private static final RuleDao RULE_FALSE = RuleDao.create("false", "false", "false",
-            "rule \"false\"\n" +
-                    "when false\n" +
-                    "then\n" +
-                    "end", null, null, null, null);
-    private static final RuleDao RULE_ADD_FOOBAR = RuleDao.create("add_foobar", "add_foobar", "add_foobar",
-            "rule \"add_foobar\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "  set_field(\"foobar\", \"covfefe\");\n" +
-                    "end", null, null, null, null);
-    private static final java.util.function.Function<String, RuleDao> RULE_SET_FIELD = (name) -> RuleDao.create("false", "false", "false",
-            "rule \"" + name + "\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "  set_field(\"" + name + "\", \"value\");" +
-                    "end", null, null, null, null);
-    private static final RuleDao RULE_DROP_MESSAGE = RuleDao.create("false", "false", "false",
-            "rule \"drop_message\"\n" +
-                    "when true\n" +
-                    "then\n" +
-                    "  drop_message();" +
-                    "end", null, null, null, null);
+    private static final RuleDao RULE_TRUE = RuleDao.create("true", null, "true", "true",
+            """
+                    rule "true"
+                    when true
+                    then
+                    end""", null, null, null, null);
+    private static final RuleDao RULE_FALSE = RuleDao.create("false", null, "false", "false",
+            """
+                    rule "false"
+                    when false
+                    then
+                    end""", null, null, null, null);
+    private static final RuleDao RULE_ADD_FOOBAR = RuleDao.create("add_foobar", null, "add_foobar", "add_foobar",
+            """
+                    rule "add_foobar"
+                    when true
+                    then
+                      set_field("foobar", "covfefe");
+                    end""", null, null, null, null);
+    private static final java.util.function.Function<String, RuleDao> RULE_SET_FIELD =
+            (name) -> RuleDao.create("false", null, "false", "false", "rule \"" + name + "\"\n" +
+                                                                      "when true\n" +
+                                                                      "then\n" +
+                                                                      "  set_field(\"" + name + "\", \"value\");" +
+                                                                      "end", null, null, null, null);
+    private static final RuleDao RULE_DROP_MESSAGE = RuleDao.create("false", null, "false", "false",
+            """
+                    rule "drop_message"
+                    when true
+                    then
+                      drop_message();\
+                    end""", null, null, null, null);
     private final MessageQueueAcknowledger messageQueueAcknowledger = mock(MessageQueueAcknowledger.class);
 
     private final RuleService ruleService = Mockito.mock(RuleService.class);
@@ -115,25 +121,24 @@ public class PipelineInterpreterTest {
     public void testCreateMessage() {
         final RuleService ruleService = mock(MongoDbRuleService.class);
         when(ruleService.loadAll()).thenReturn(Collections.singleton(
-                RuleDao.create("abc",
-                        "title",
-                        "description",
-                        "rule \"creates message\"\n" +
-                                "when to_string($message.message) == \"original message\"\n" +
-                                "then\n" +
-                                "  create_message(\"derived message\");\n" +
-                                "end",
-                        Tools.nowUTC(),
-                        null, null, null)
+                RuleDao.create("abc", null, "title", "description",
+                        """
+                                rule "creates message"
+                                when to_string($message.message) == "original message"
+                                then
+                                  create_message("derived message");
+                                end""", Tools.nowUTC(), null, null, null)
         ));
 
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"creates message\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "creates message";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -159,12 +164,14 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"true\";\n" +
-                                "stage 1 match either\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "true";
+                                stage 1 match either
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -189,13 +196,15 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"true\";\n" +
-                                "    rule \"false\";\n" +
-                                "stage 1 match either\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "true";
+                                    rule "false";
+                                stage 1 match either
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -220,13 +229,15 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match either\n" +
-                                "    rule \"true\";\n" +
-                                "    rule \"false\";\n" +
-                                "stage 1 match either\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match either
+                                    rule "true";
+                                    rule "false";
+                                stage 1 match either
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -251,12 +262,14 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match either\n" +
-                                "    rule \"false\";\n" +
-                                "stage 1 match either\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match either
+                                    rule "false";
+                                stage 1 match either
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -281,13 +294,15 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match pass\n" +
-                                "    rule \"true\";\n" +
-                                "    rule \"false\";\n" +
-                                "stage 1 match pass\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match pass
+                                    rule "true";
+                                    rule "false";
+                                stage 1 match pass
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -312,12 +327,14 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match pass\n" +
-                                "    rule \"false\";\n" +
-                                "stage 1 match pass\n" +
-                                "    rule \"add_foobar\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match pass
+                                    rule "false";
+                                stage 1 match pass
+                                    rule "add_foobar";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -348,22 +365,26 @@ public class PipelineInterpreterTest {
         final PipelineService pipelineService = mock(MongoDbPipelineService.class);
         when(pipelineService.loadAll()).thenReturn(ImmutableList.of(
                 PipelineDao.create("p1", null, "title1", "description",
-                        "pipeline \"pipeline1\"\n" +
-                                "stage 0 match pass\n" +
-                                "    rule \"1-a\";\n" +
-                                "    rule \"drop_message\";\n" +
-                                "stage 1 match pass\n" +
-                                "    rule \"1-b\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline1"
+                                stage 0 match pass
+                                    rule "1-a";
+                                    rule "drop_message";
+                                stage 1 match pass
+                                    rule "1-b";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null),
                 PipelineDao.create("p2", null, "title2", "description",
-                        "pipeline \"pipeline2\"\n" +
-                                "stage 0 match pass\n" +
-                                "    rule \"2-a\";\n" +
-                                "stage 1 match pass\n" +
-                                "    rule \"2-b\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline2"
+                                stage 0 match pass
+                                    rule "2-a";
+                                stage 1 match pass
+                                    rule "2-b";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -418,7 +439,8 @@ public class PipelineInterpreterTest {
                 metricRegistry,
                 Executors.newScheduledThreadPool(1),
                 mock(EventBus.class),
-                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) -> new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, metricRegistry, 1, true)
+                (currentPipelines, streamPipelineConnections, ruleMetricsConfig) ->
+                        new PipelineInterpreter.State(currentPipelines, streamPipelineConnections, ruleMetricsConfig, metricRegistry, 1, true)
         );
         return new PipelineInterpreter(
                 messageQueueAcknowledger,
@@ -446,12 +468,14 @@ public class PipelineInterpreterTest {
 
         final PipelineService pipelineService = new InMemoryPipelineService(new ClusterEventBus());
         pipelineService.save(PipelineDao.create("cde", null, "title", "description",
-                "pipeline \"pipeline\"\n" +
-                        "stage 0 match all\n" +
-                        "    rule \"match_all\";\n" +
-                        "stage 1 match all\n" +
-                        "    rule \"match_all\";\n" +
-                        "end\n",
+                """
+                        pipeline "pipeline"
+                        stage 0 match all
+                            rule "match_all";
+                        stage 1 match all
+                            rule "match_all";
+                        end
+                        """,
                 Tools.nowUTC(),
                 null)
         );
@@ -528,21 +552,23 @@ public class PipelineInterpreterTest {
     @Test
     public void process_ruleConditionEvaluationErrorConvertedIntoMessageProcessingError() throws Exception {
         // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_condition", "broken_condition",
-                "broken_condition",
-                "rule \"broken_condition\"\n" +
-                        "when\n" +
-                        "    to_double($message.num * $message.num) > 0.0\n" +
-                        "then\n" +
-                        "    set_field(\"num_sqr\", $message.num * $message.num);\n" +
-                        "end", null, null, null, null)));
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_condition", null, "broken_condition", "broken_condition",
+                """
+                        rule "broken_condition"
+                        when
+                            to_double($message.num * $message.num) > 0.0
+                        then
+                            set_field("num_sqr", $message.num * $message.num);
+                        end""", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"broken_condition\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "broken_condition";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -559,35 +585,36 @@ public class PipelineInterpreterTest {
         // then
         assertThat(processed)
                 .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
+                .hasOnlyOneElementSatisfying(m ->
                     assertThat(m.processingErrors())
                             .hasSize(1)
                             .hasOnlyOneElementSatisfying(pe -> {
                                 assertThat(pe.getCause()).isEqualTo(ProcessingFailureCause.RuleConditionEvaluationError);
                                 assertThat(pe.getMessage()).isEqualTo("Error evaluating condition for rule <broken_condition/broken_condition> (pipeline <pipeline/p1>)");
                                 assertThat(pe.getDetails()).isEqualTo("In call to function 'to_double' at 3:4 an exception was thrown: class java.lang.String cannot be cast to class java.lang.Double (java.lang.String and java.lang.Double are in module java.base of loader 'bootstrap')");
-                            });
-                });
+                            }));
     }
 
     @Test
     public void process_ruleStatementEvaluationErrorConvertedIntoMessageProcessingError() throws Exception {
         // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_statement", "broken_statement",
-                "broken_statement",
-                "rule \"broken_statement\"\n" +
-                        "when\n" +
-                        "    has_field(\"num\")\n" +
-                        "then\n" +
-                        "    set_field(\"num_sqr\", $message.num * $message.num);\n" +
-                        "end", null, null, null, null)));
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("broken_statement", null, "broken_statement", "broken_statement",
+                """
+                        rule "broken_statement"
+                        when
+                            has_field("num")
+                        then
+                            set_field("num_sqr", $message.num * $message.num);
+                        end""", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"broken_statement\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "broken_statement";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));
@@ -605,35 +632,36 @@ public class PipelineInterpreterTest {
         // then
         assertThat(processed)
                 .hasSize(1)
-                .hasOnlyOneElementSatisfying(m -> {
+                .hasOnlyOneElementSatisfying(m ->
                     assertThat(m.processingErrors())
                             .hasSize(1)
                             .hasOnlyOneElementSatisfying(pe -> {
                                 assertThat(pe.getCause()).isEqualTo(ProcessingFailureCause.RuleStatementEvaluationError);
                                 assertThat(pe.getMessage()).isEqualTo("Error evaluating action for rule <broken_statement/broken_statement> (pipeline <pipeline/p1>)");
                                 assertThat(pe.getDetails()).isEqualTo("In call to function 'set_field' at 5:4 an exception was thrown: class java.lang.Long cannot be cast to class java.lang.Double (java.lang.Long and java.lang.Double are in module java.base of loader 'bootstrap')");
-                            });
-                });
+                            }));
     }
 
     @Test
     public void process_noEvaluationErrorsResultIntoNoMessageProcessingErrors() {
         // given
-        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("valid_rule", "valid_rule",
-                "valid_rule",
-                "rule \"valid_rule\"\n" +
-                        "when\n" +
-                        "    has_field(\"num\")\n" +
-                        "then\n" +
-                        "    set_field(\"num_sqr\", to_double($message.num) * to_double($message.num));\n" +
-                        "end", null, null, null, null)));
+        when(ruleService.loadAll()).thenReturn(ImmutableList.of(RuleDao.create("valid_rule", null, "valid_rule", "valid_rule",
+                """
+                        rule "valid_rule"
+                        when
+                            has_field("num")
+                        then
+                            set_field("num_sqr", to_double($message.num) * to_double($message.num));
+                        end""", null, null, null, null)));
 
         when(pipelineService.loadAll()).thenReturn(Collections.singleton(
                 PipelineDao.create("p1", null, "title", "description",
-                        "pipeline \"pipeline\"\n" +
-                                "stage 0 match all\n" +
-                                "    rule \"valid_rule\";\n" +
-                                "end\n",
+                        """
+                                pipeline "pipeline"
+                                stage 0 match all
+                                    rule "valid_rule";
+                                end
+                                """,
                         Tools.nowUTC(),
                         null)
         ));


### PR DESCRIPTION
Note: This is a backport of #https://github.com/Graylog2/graylog2-server/pull/25024 to `6.3`.

/nocl under the hood perf improvement

<!--- Provide a general summary of your changes in the Title above -->
Uses a more favorable data structure to improve perf of pipeline processing

## Description
<!--- Describe your changes in detail -->
`Message.getStreamsUnmodifiable()` returns `Collections.unmodifiableSet(this.streams)` — a lightweight view instead of the `ImmutableSet.copyOf()` that `Message.getStreams()` uses. This avoids allocating and populating a new set on every call, which matters in hot paths like `PipelineInterpreter.process()` where the set is immediately iterated and discarded.                       
                                                                                                                           
The advantage declines with increasing stream count because `ImmutableSet` is a dense array-backed structure with excellent cache locality for iteration, while the view exposes the underlying HashSet's sparse bucket layout. As streams grow, the iteration cost dominates and ImmutableSet's compact layout partially offsets the copy overhead.

Thread safety is not a concern because `Message` is `@NotThreadSafe` — it is only accessed from a single thread at a time. The only risk with a view is same-thread mutation during iteration, which doesn't occur at either `PipelineInterpreter` call site.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pipeline interpreter is a hot path that is worth optimizing. Benchmarking suggests significant gains with real world stream counts.

## Benchmarks

```
========================================================================
  Comparison: before (baseline) vs after (candidate)
========================================================================
  Messages: baseline=10000, candidate=10000

  --- 1 streams ---
  Metric                           Baseline    Candidate     Change
  ----------------------------------------------------------------
  Pipeline mean...............     0.2440ms     0.1000ms     -59.0%
  Process buffer mean.........     2.8280ms     1.4940ms     -47.2%
  Send rate (msg/s)...........          498          724     +45.5%
  Messages processed..........        10000        10000
  Pipeline executions.........      10000.0      10000.0

  --- 5 streams ---
  Metric                           Baseline    Candidate     Change
  ----------------------------------------------------------------
  Pipeline mean...............     0.1940ms     0.1000ms     -48.5%
  Process buffer mean.........     2.4630ms     1.5840ms     -35.7%
  Send rate (msg/s)...........          568          750     +32.1%
  Messages processed..........        10000        10000
  Pipeline executions.........      10000.0      10000.0

  --- 10 streams ---
  Metric                           Baseline    Candidate     Change
  ----------------------------------------------------------------
  Pipeline mean...............     0.2310ms     0.1350ms     -41.6%
  Process buffer mean.........     2.2510ms     1.8110ms     -19.5%
  Send rate (msg/s)...........          610          661      +8.3%
  Messages processed..........        10000        10000
  Pipeline executions.........      10000.0      10000.0

========================================================================
  Note: Negative % change in latency metrics = improvement (faster).
========================================================================

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
