### PR TITLE
Update testcontainers to 1.21.4 to work with newer Docker versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <mockito.version>5.20.0</mockito.version>
         <restassured.version>5.5.6</restassured.version>
         <system-rules.version>1.19.0</system-rules.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <testcontainers.opensearch.version>3.0.2</testcontainers.opensearch.version>
         <graalvm.version>25.0.0</graalvm.version>
 


### PR DESCRIPTION
/nocl Test infrastructure