### PR TITLE
Update ExecuteNotification to use new /alerts route

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/procedures/ExecuteNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/procedures/ExecuteNotification.java
@@ -65,7 +65,7 @@ public class ExecuteNotification extends Action {
         @Override
         public URIBuilder getLink(EventDto event) {
             final TemplateURI.Builder uriBuilder = new TemplateURI.Builder();
-            uriBuilder.setPath("security/security-events/alerts");
+            uriBuilder.setPath("alerts");
             uriBuilder.addParameter("query", "id:" + event.id());
             return uriBuilder.build().getLinkPath();
         }

--- a/graylog2-server/src/test/java/org/graylog/events/procedures/ActionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/procedures/ActionTest.java
@@ -85,9 +85,19 @@ public class ActionTest {
     public void testExecuteNotificationGetLink() {
         when(event.id()).thenReturn(ID);
 
-        String actionText = executeNotificationConfig().getLink(event).toString();
+        final String actionText = executeNotificationConfig().getLink(event).toString();
 
-        assertThat(actionText).contains("/security/security-events/alerts?query=id%3A" + ID);
+        assertThat(actionText).contains("/alerts?query=id%3A" + ID);
+    }
+
+    @Test
+    public void testExecuteNotificationGetLinkUsesAlertsRoute() {
+        when(event.id()).thenReturn(ID);
+
+        final String link = executeNotificationConfig().getLink(event).toString();
+
+        assertThat(link).doesNotContain("security-events");
+        assertThat(link).startsWith("/alerts");
     }
 
     private ExecuteNotification.Config executeNotificationConfig() {


### PR DESCRIPTION
## Description

The Security Events UI routes are being consolidated into the core Alerts routes (https://github.com/Graylog2/graylog-plugin-enterprise/pull/13275, documented in https://github.com/Graylog2/graylog2-server/pull/25065).                    
But, `ExecuteNotification.Config.getLink()` still generates links using the removed `/security/security-events/alerts` path. After the migration, users clicking through from an event procedure notification action would land on a non-existent page.

This PR updates the hardcoded route and adds a test to guard against regression.

Closes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13320
/nocl see https://github.com/Graylog2/graylog-plugin-enterprise/pull/13275#issuecomment-3937061728
## Related

- https://github.com/Graylog2/graylog2-server/pull/25065 — UPGRADING.md documentation for the route migration
- https://github.com/Graylog2/graylog-plugin-enterprise/pull/13275 — enterprise-side route migration