### PR TITLE
Fix memory-leak in replaced data-adapters and caches (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-25078.toml
+++ b/changelog/unreleased/pr-25078.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix memory-leak when updating data-adapters and caches."
+
+issues = ["25077"]
+pulls = ["25078"]

--- a/graylog2-server/src/test/java/org/graylog2/lookup/LookupTableServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/LookupTableServiceTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.lookup;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +25,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
@@ -83,72 +83,72 @@ public class LookupTableServiceTest {
 
     @Test
     public void functionSetStringList() {
-        function.setStringList("key", ImmutableList.of("hello", "world"));
+        function.setStringList("key", List.of("hello", "world"));
         function.setStringList("key", Arrays.asList("with", "empty", "", "and", null));
 
         assertThatThrownBy(() -> function.setStringList("key", null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> function.setStringList(null, ImmutableList.of("none"))).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> function.setStringList(null, List.of("none"))).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> function.setStringList(null, null)).isInstanceOf(NullPointerException.class);
 
-        verify(table, times(1)).setStringList("key", ImmutableList.of("hello", "world"));
-        verify(table, times(1)).setStringList("key", ImmutableList.of("with", "empty", "and"));
+        verify(table, times(1)).setStringList("key", List.of("hello", "world"));
+        verify(table, times(1)).setStringList("key", List.of("with", "empty", "and"));
 
         verify(table, never()).setStringList("key", null);
-        verify(table, never()).setStringList(null, ImmutableList.of("none"));
+        verify(table, never()).setStringList(null, List.of("none"));
         verify(table, never()).setStringList(null, null);
         verify(table, never()).setStringList("key", Arrays.asList("with", "empty", "", "and", null));
     }
 
     @Test
     public void functionSetStringListWithTtl() {
-        function.setStringListWithTtl("key", ImmutableList.of("hello", "world"), 500L);
+        function.setStringListWithTtl("key", List.of("hello", "world"), 500L);
         function.setStringListWithTtl("key", Arrays.asList("with", "empty", "", "and", null), 500L);
 
         assertThatThrownBy(() -> function.setStringListWithTtl("key", null, 500L)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> function.setStringListWithTtl(null, ImmutableList.of("none"), 500L)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> function.setStringListWithTtl(null, List.of("none"), 500L)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> function.setStringListWithTtl(null, null, 500L)).isInstanceOf(NullPointerException.class);
 
-        verify(table, times(1)).setStringListWithTtl("key", ImmutableList.of("hello", "world"), 500L);
-        verify(table, times(1)).setStringListWithTtl("key", ImmutableList.of("with", "empty", "and"), 500L);
+        verify(table, times(1)).setStringListWithTtl("key", List.of("hello", "world"), 500L);
+        verify(table, times(1)).setStringListWithTtl("key", List.of("with", "empty", "and"), 500L);
 
         verify(table, never()).setStringListWithTtl("key", null, 500L);
-        verify(table, never()).setStringListWithTtl(null, ImmutableList.of("none"), 500L);
+        verify(table, never()).setStringListWithTtl(null, List.of("none"), 500L);
         verify(table, never()).setStringListWithTtl(null, null, 500L);
         verify(table, never()).setStringListWithTtl("key", Arrays.asList("with", "empty", "", "and", null), 500L);
     }
 
     @Test
     public void functionAddStringList() {
-        function.addStringList("key", ImmutableList.of("hello", "world"), false);
+        function.addStringList("key", List.of("hello", "world"), false);
         function.addStringList("key", Arrays.asList("with", "empty", "", "and", null), false);
 
         assertThatThrownBy(() -> function.addStringList("key", null, false)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> function.addStringList(null, ImmutableList.of("none"), false)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> function.addStringList(null, List.of("none"), false)).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> function.addStringList(null, null, false)).isInstanceOf(NullPointerException.class);
 
-        verify(table, times(1)).addStringList("key", ImmutableList.of("hello", "world"), false);
-        verify(table, times(1)).addStringList("key", ImmutableList.of("with", "empty", "and"), false);
+        verify(table, times(1)).addStringList("key", List.of("hello", "world"), false);
+        verify(table, times(1)).addStringList("key", List.of("with", "empty", "and"), false);
 
         verify(table, never()).addStringList("key", null, false);
-        verify(table, never()).addStringList(null, ImmutableList.of("none"), false);
+        verify(table, never()).addStringList(null, List.of("none"), false);
         verify(table, never()).addStringList(null, null, false);
         verify(table, never()).addStringList("key", Arrays.asList("with", "empty", "", "and", null), false);
     }
 
     @Test
     public void functionRemoveStringList() {
-        function.removeStringList("key", ImmutableList.of("hello", "world"));
+        function.removeStringList("key", List.of("hello", "world"));
         function.removeStringList("key", Arrays.asList("with", "empty", "", "and", null));
 
         assertThatThrownBy(() -> function.removeStringList("key", null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> function.removeStringList(null, ImmutableList.of("none"))).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> function.removeStringList(null, List.of("none"))).isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> function.removeStringList(null, null)).isInstanceOf(NullPointerException.class);
 
-        verify(table, times(1)).removeStringList("key", ImmutableList.of("hello", "world"));
-        verify(table, times(1)).removeStringList("key", ImmutableList.of("with", "empty", "and"));
+        verify(table, times(1)).removeStringList("key", List.of("hello", "world"));
+        verify(table, times(1)).removeStringList("key", List.of("with", "empty", "and"));
 
         verify(table, never()).removeStringList("key", null);
-        verify(table, never()).removeStringList(null, ImmutableList.of("none"));
+        verify(table, never()).removeStringList(null, List.of("none"));
         verify(table, never()).removeStringList(null, null);
         verify(table, never()).removeStringList("key", Arrays.asList("with", "empty", "", "and", null));
     }

--- a/graylog2-server/src/test/java/org/graylog2/lookup/ServiceListenerCleanupTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/ServiceListenerCleanupTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.lookup;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.Service;
+import org.graylog2.lookup.dto.CacheDto;
+import org.graylog2.lookup.dto.DataAdapterDto;
+import org.graylog2.plugin.lookup.FallbackAdapterConfig;
+import org.graylog2.plugin.lookup.FallbackCacheConfig;
+import org.graylog2.plugin.lookup.LookupCache;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceListenerCleanupTest {
+
+    @Mock
+    private ScheduledExecutorService scheduler;
+    @Mock
+    private EventBus eventBus;
+    @Mock
+    private LookupTableConfigService configService;
+    @Mock
+    private Consumer<LookupDataAdapter> adapterConsumer;
+    @Mock
+    private Consumer<LookupCache> cacheConsumer;
+
+    private LookupTableService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LookupTableService(
+                configService, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(),
+                scheduler, eventBus);
+    }
+
+    //=============================
+    // Testing DataAdapterListener:
+    //=============================
+
+    @Test
+    void replacedAdapterConsumerIsUnsetAfterRunning() {
+        final var dto = DataAdapterDto.builder()
+                .id("id").name("name").title("t").description("d")
+                .config(new FallbackAdapterConfig()).build();
+
+        final var adapter = mock(LookupDataAdapter.class);
+        final var latch = new CountDownLatch(1);
+
+        final var listener = service.new DataAdapterListener(dto, adapter, latch, adapterConsumer);
+        listener.running();
+
+        assertThat(listener.isReplacedAdapterConsumerSet()).isFalse();
+    }
+
+    @Test
+    void replacedAdapterConsumerIsUnsetAfterFailed() {
+        final var dto = DataAdapterDto.builder()
+                .id("id").name("name").title("t").description("d")
+                .config(new FallbackAdapterConfig()).build();
+
+        final var adapter = mock(LookupDataAdapter.class);
+        final var latch = new CountDownLatch(1);
+
+        final var listener = service.new DataAdapterListener(dto, adapter, latch, adapterConsumer);
+
+        listener.failed(Service.State.STARTING, new RuntimeException("boom"));
+
+        assertThat(listener.isReplacedAdapterConsumerSet()).isFalse();
+    }
+
+    //=======================
+    // Testing CacheListener:
+    //=======================
+
+    @Test
+    void replacedCacheConsumerIsUnsetAfterRunning() {
+        final var dto = CacheDto.builder()
+                .id("id").name("name").title("t").description("d")
+                .config(new FallbackCacheConfig()).build();
+
+        final var cache = mock(LookupCache.class);
+        final var latch = new CountDownLatch(1);
+
+        final var listener = service.new CacheListener(dto, cache, latch, cacheConsumer);
+        listener.running();
+
+        assertThat(listener.isReplacedCacheConsumerSet()).isFalse();
+    }
+
+    @Test
+    void replacedCacheConsumerIsUnsetAfterFailed() {
+        final var dto = CacheDto.builder()
+                .id("id").name("name").title("t").description("d")
+                .config(new FallbackCacheConfig()).build();
+
+        final var cache = mock(LookupCache.class);
+        final var latch = new CountDownLatch(1);
+
+        final var listener = service.new CacheListener(dto, cache, latch, cacheConsumer);
+
+        listener.failed(Service.State.STARTING, new RuntimeException("boom"));
+
+        assertThat(listener.isReplacedCacheConsumerSet()).isFalse();
+    }
+}


### PR DESCRIPTION
Note: This is a backport of #25078 to `7.0`.

As described in #25077, an update to a data-adapter or cache leaves the previously running service in memory. Especially for services that keep a lot of objects and are updated often, this has a big effect.

## Description
<!--- Describe your changes in detail -->
Once the Listener for the data-adapter or cache is done, it cuts the connection which otherwise would keep a connection to the previous service.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
/resolves #25077 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- A unit-test was added to make sure the connection is cut both on success and failure.
- Locally uploading several 20M-sized CSV-files to the same data-adapter, continually updating it. After some rounds taking a heap-dump and verifying there's not chain of adapters, but only the one currently running.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.


