### PR TITLE
RootAccountRealm is the first realm to touch when checking permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
@@ -62,9 +62,9 @@ public class DefaultSecurityManagerProvider implements Provider<DefaultSecurityM
         }
 
         List<Realm> authorizingRealms = new ArrayList<>();
-        authorizingRealms.addAll(authorizingOnlyRealms.values());
         // root account realm might be deactivated and won't be present in that case
         orderedAuthenticatingRealms.getRootAccountRealm().ifPresent(authorizingRealms::add);
+        authorizingRealms.addAll(authorizingOnlyRealms.values());
 
         final ModularRealmAuthorizer authorizer = new ModularRealmAuthorizer(authorizingRealms);
 


### PR DESCRIPTION
## Description
RootAccountRealm is the first realm to touch when checking permissions.
/nocl Not visible by the user, performance improvement

## Motivation and Context
Because RootAccountRealm was added as the last realm, for admin user we have touched the MongoDB way too often for permission check (visible as many invocations of MongoDbAuthorizationRealm.doGetAuthorizationInfo()).

Now `ModularRealmAuthorizer` starts with an easy check and can, in most cases, return `true` quickly for admin.

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

