### PR TITLE
Improve parse_json documentation for depth parameter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/json/JsonParse.java
@@ -45,7 +45,7 @@ public class JsonParse extends AbstractFunction<JsonNode> {
     public JsonParse(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper.copy().configure(ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
         valueParam = ParameterDescriptor.string("value").description("The string to parse as a JSON tree").build();
-        depthParam = ParameterDescriptor.integer("depth").optional().description("Number of levels to parse. Default: no limit").build();
+        depthParam = ParameterDescriptor.integer("depth").optional().description("Number of levels to parse. If > 0, container nodes below that level are deleted from the parsed tree. If omitted or 0, depth is unlimited.").build();
     }
 
     @Override
@@ -73,7 +73,7 @@ public class JsonParse extends AbstractFunction<JsonNode> {
                 .name(NAME)
                 .returnType(JsonNode.class)
                 .params(of(valueParam, depthParam))
-                .description("Parses a string as a JSON tree")
+                .description("Parses the value string as JSON, returning the resulting JSON tree. Optionally specify the number of levels to parse. If depth > 0, nodes below that level are deleted from the parsed tree. If omitted or set to 0, depth is unlimited.")
                 .build();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -578,6 +578,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(evaluatedMessage.getField("store")).isInstanceOf(Map.class);
         assertThat(evaluatedMessage.getField("expensive")).isEqualTo(10);
         assertThat(evaluatedMessage.getField("escaped")).isEqualTo("a \t +");
+        assertThat(evaluatedMessage.getField("top")).isEqualTo("val");
+        assertThat(evaluatedMessage.getField("nested")).isNull();
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/json.txt
@@ -20,4 +20,8 @@ then
   // Don't fail on nested input
   let nested_json = parse_json(to_string($message.nested_json));
   set_fields(to_map(nested_json));
+
+  // Parse with depth limit: nodes below the specified depth are removed
+  let depth_json = parse_json("{\"top\":\"val\",\"nested\":{\"inner\":\"ignored\"}}", 1);
+  set_fields(to_map(depth_json));
 end


### PR DESCRIPTION
The `parse_json` function's optional `depth` parameter was not adequately documented, leaving users unclear about its behavior and purpose.

This update clarifies:
- What the parameter does: controls how many levels deep to parse into the JSON structure
- The behavior when depth > 0: container nodes below that level are deleted from the parsed tree
- The behavior when omitted or 0: depth remains unlimited

Updated both the parameter and function descriptions to provide clear, actionable documentation. Also added test assertions to verify the depth parameter behavior.

Fixes #25108