### PR TITLE
Do not fetch metrics when browser is hidden

### DIFF
--- a/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.ts
+++ b/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.ts
@@ -45,7 +45,11 @@ export const GlobalThroughputStore = singletonStore('core.GlobalThroughput', () 
       MetricsActions.addGlobal(this.metrics.input);
       MetricsActions.addGlobal(this.metrics.output);
       this.listenTo(MetricsStore, this.updateMetrics);
-      setInterval(MetricsActions.list, this.INTERVAL);
+      setInterval(() => {
+        if (!document.hidden) {
+          MetricsActions.list();
+        }
+      }, this.INTERVAL);
     },
 
     getInitialState() {


### PR DESCRIPTION
## Description
Do not fetch metrics when browser is hidden.
/nocl

## Motivation and Context
Performance improvement.
It seems that in other places in the code polling stops when browser is hidden, metrics is simply an (forgotten?) exception.

## How Has This Been Tested?
Tested via side effect - stopped noticing regular permission checks in MongoDbAuthorizationRealm on hidden/minimalized browser/browser tab.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

