### PR TITLE
Use GiB on traffic charts. Mention UTC as time for calculation (`6.2`)

### DIFF
--- a/changelog/unreleased/issue-24982.toml
+++ b/changelog/unreleased/issue-24982.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Use GiB units for defining traffic limits in the chart. Add a label indicating that limits are calculated in UTC."
+
+issues = ["24982"]
+pulls = ["24983"]

--- a/graylog2-web-interface/src/components/common/Graph/TrafficGraph.tsx
+++ b/graylog2-web-interface/src/components/common/Graph/TrafficGraph.tsx
@@ -14,18 +14,30 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 
 import { Spinner } from 'components/common';
 import type { PlotLayout } from 'views/components/visualizations/GenericPlot';
 import GenericPlot from 'views/components/visualizations/GenericPlot';
 import AppConfig from 'util/AppConfig';
+import {
+  getHoverTemplateSettings,
+  getFormatSettingsByData,
+} from 'views/components/visualizations/utils/chartLayoutGenerators';
+import FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';
 
 type Props = {
   traffic: { [key: string]: number };
   width: number;
   trafficLimit?: number;
+};
+
+
+type GeneratedLayout = {
+  range: [number, number];
+  tickvals: Array<number>;
+  ticktext: Array<string>;
 };
 
 const GraphWrapper = styled.div<{
@@ -44,6 +56,12 @@ const TrafficGraph = ({ width, traffic, trafficLimit = undefined }: Props) => {
   const getMaxDailyValue = (arr) => arr.reduce((a, b) => Math.max(a, b));
 
   const range = getMaxDailyValue(Object.values(traffic));
+
+  const yValues = Object.values(traffic);
+  const valuesToGetFormatSettings = useMemo(
+    () => (trafficLimit ? [...yValues, trafficLimit] : yValues),
+    [trafficLimit, yValues],
+  );
 
   if (!traffic) {
     return <Spinner />;
@@ -89,9 +107,14 @@ const TrafficGraph = ({ width, traffic, trafficLimit = undefined }: Props) => {
     {
       type: 'bar',
       x: Object.keys(traffic),
-      y: Object.values(traffic),
+      y: yValues,
+      ...getHoverTemplateSettings({
+        convertedValues: yValues,
+        unit: FieldUnit.fromJSON({ abbrev: 'b', unit_type: 'binary_size' }),
+      }),
     },
   ];
+
 
   const layout: Partial<PlotLayout> = {
     showlegend: false,
@@ -101,7 +124,7 @@ const TrafficGraph = ({ width, traffic, trafficLimit = undefined }: Props) => {
     xaxis: {
       type: 'date',
       title: {
-        text: 'Time',
+        text: 'Time shown in UTC',
       },
     },
     hovermode: 'x',
@@ -116,6 +139,7 @@ const TrafficGraph = ({ width, traffic, trafficLimit = undefined }: Props) => {
       rangemode: 'tozero',
       hoverformat: '.4s',
       tickformat: 's',
+      ...(getFormatSettingsByData('binary_size', valuesToGetFormatSettings) as GeneratedLayout),
     },
     updatemenus: [
       {

--- a/graylog2-web-interface/src/components/common/Graph/TrafficGraphWithDaySelect.tsx
+++ b/graylog2-web-interface/src/components/common/Graph/TrafficGraphWithDaySelect.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useMemo } from 'react';
 import reduce from 'lodash/reduce';
 import styled, { css } from 'styled-components';
+
 import { Input } from 'components/bootstrap';
 import { Spinner } from 'components/common';
 import { formatTrafficData } from 'util/TrafficUtils';

--- a/graylog2-web-interface/src/components/common/Graph/TrafficGraphWithDaySelect.tsx
+++ b/graylog2-web-interface/src/components/common/Graph/TrafficGraphWithDaySelect.tsx
@@ -15,10 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useMemo } from 'react';
 import reduce from 'lodash/reduce';
 import styled, { css } from 'styled-components';
-
-import NumberUtils from 'util/NumberUtils';
 import { Input } from 'components/bootstrap';
 import { Spinner } from 'components/common';
 import { formatTrafficData } from 'util/TrafficUtils';
@@ -30,6 +29,8 @@ import useLocation from 'routing/useLocation';
 import type { Traffic } from 'components/common/Graph/types';
 import { DAYS } from 'components/common/Graph/types';
 import useGraphDays from 'components/common/Graph/contexts/useGraphDays';
+import { getPrettifiedValue } from 'views/components/visualizations/utils/unitConverters';
+import formatValueWithUnitLabel from 'views/components/visualizations/utils/formatValueWithUnitLabel';
 
 const StyledH3 = styled.h3(
   ({ theme }) => css`
@@ -86,12 +87,21 @@ const TrafficGraphWithDaySelect = ({ traffic, trafficLimit, title }: Props) => {
   let sumOutput = null;
   let trafficGraph = <Spinner />;
 
+
+  const bytesOut = reduce(traffic, (result, value) => result + value);
+
+  const formattedTotalTraffic = useMemo(() => {
+    const prettified = getPrettifiedValue(bytesOut, { abbrev: 'b', unitType: 'binary_size' });
+
+    return formatValueWithUnitLabel(prettified?.value, prettified.unit.abbrev);
+  }, [bytesOut]);
+
   if (traffic) {
-    const bytesOut = reduce(traffic, (result, value) => result + value);
+
 
     sumOutput = (
       <small>
-        Last {graphDays} days: {NumberUtils.formatBytes(bytesOut)}
+        Last {graphDays} days: {formattedTotalTraffic}
       </small>
     );
 

--- a/graylog2-web-interface/src/util/TrafficUtils.ts
+++ b/graylog2-web-interface/src/util/TrafficUtils.ts
@@ -26,7 +26,7 @@ type Traffic = {
 
 export const formatTrafficData = (traffic: Traffic) => {
   const ndx = crossfilter(map(traffic, (value, key) => ({ ts: key, bytes: value })));
-  const dailyTraffic = ndx.dimension((d) => moment(d.ts).format('YYYY-MM-DD'));
+  const dailyTraffic = ndx.dimension((d) => moment.utc(d.ts).format('YYYY-MM-DD'));
 
   const dailySums = dailyTraffic.group().reduceSum((d) => d.bytes);
   const t = mapKeys(dailySums.all(), (entry) => moment.utc(entry.key, 'YYYY-MM-DD').toISOString());

--- a/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/units/FieldUnitPopover.tsx
@@ -24,7 +24,7 @@ import Popover from 'components/common/Popover';
 import { HoverForHelp, ModalButtonToolbar } from 'components/common';
 import { Alert, Button, Input } from 'components/bootstrap';
 import type { Unit } from 'views/components/visualizations/utils/unitConverters';
-import { mappedUnitsFromJSON as units } from 'views/components/visualizations/utils/unitConverters';
+import { mappedUnitsFromJSONForAggregation as units } from 'views/components/visualizations/utils/unitConverters';
 import type { FieldUnitsFormValues } from 'views/types';
 import type FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';
 import getUnitTextLabel from 'views/components/visualizations/utils/getUnitTextLabel';

--- a/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/unitConverters.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/__tests__/unitConverters.test.ts
@@ -70,6 +70,22 @@ describe('Unit converter functions', () => {
       });
     });
 
+    it('for binary_size should convert bigger unit to bytes', () => {
+      const result = convertValueToBaseUnit(1, { abbrev: 'KiB', unitType: 'binary_size' });
+
+      expect(result).toEqual({
+        value: 1024,
+        unit: {
+          type: 'base',
+          abbrev: 'b',
+          name: 'byte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: undefined,
+        },
+      });
+    });
+
     it('for percent should convert bigger unit to decimal percent', () => {
       const result = convertValueToBaseUnit(50, { abbrev: '%', unitType: 'percent' });
 
@@ -200,6 +216,75 @@ describe('Unit converter functions', () => {
       });
     });
 
+    it('for binary_size should convert smaller unit (KiB) to bigger (GiB)', () => {
+      const result = convertValueToUnit(
+        1048576,
+        { abbrev: 'KiB', unitType: 'binary_size' },
+        { abbrev: 'GiB', unitType: 'binary_size' },
+      );
+
+      expect(result).toEqual({
+        value: 1,
+        unit: {
+          type: 'derived',
+          abbrev: 'GiB',
+          name: 'gibibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1073741824,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should convert bytes to GiB', () => {
+      const result = convertValueToUnit(
+        3221225472,
+        { abbrev: 'b', unitType: 'binary_size' },
+        { abbrev: 'GiB', unitType: 'binary_size' },
+      );
+
+      expect(result).toEqual({
+        value: 3,
+        unit: {
+          type: 'derived',
+          abbrev: 'GiB',
+          name: 'gibibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1073741824,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should convert bytes to MiB', () => {
+      const result = convertValueToUnit(
+        1572864,
+        { abbrev: 'b', unitType: 'binary_size' },
+        { abbrev: 'MiB', unitType: 'binary_size' },
+      );
+
+      expect(result).toEqual({
+        value: 1.5,
+        unit: {
+          type: 'derived',
+          abbrev: 'MiB',
+          name: 'mebibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1048576,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
     it('return nulls when some params where missed', () => {
       const result1 = convertValueToUnit(50, { abbrev: 'Gb', unitType: 'size' }, undefined);
       const result2 = convertValueToUnit(50, undefined, { abbrev: 'Gb', unitType: 'size' });
@@ -294,6 +379,82 @@ describe('Unit converter functions', () => {
           useInPrettier: true,
           conversion: {
             value: 1000000000,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should convert smaller then 1 value to the value with lower unit', () => {
+      const result = getPrettifiedValue(0.5, { abbrev: 'GiB', unitType: 'binary_size' });
+
+      expect(result).toEqual({
+        value: 512,
+        unit: {
+          type: 'derived',
+          abbrev: 'MiB',
+          name: 'mebibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1048576,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should convert bigger then 1 value to the value with higher unit', () => {
+      const result = getPrettifiedValue(2048, { abbrev: 'MiB', unitType: 'binary_size' });
+
+      expect(result).toEqual({
+        value: 2,
+        unit: {
+          type: 'derived',
+          abbrev: 'GiB',
+          name: 'gibibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1073741824,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should prettify larger bytes to GiB', () => {
+      const result = getPrettifiedValue(3221225472, { abbrev: 'b', unitType: 'binary_size' });
+
+      expect(result).toEqual({
+        value: 3,
+        unit: {
+          type: 'derived',
+          abbrev: 'GiB',
+          name: 'gibibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1073741824,
+            action: 'MULTIPLY',
+          },
+        },
+      });
+    });
+
+    it('for binary_size should prettify larger bytes to MiB', () => {
+      const result = getPrettifiedValue(1572864, { abbrev: 'b', unitType: 'binary_size' });
+
+      expect(result).toEqual({
+        value: 1.5,
+        unit: {
+          type: 'derived',
+          abbrev: 'MiB',
+          name: 'mebibyte',
+          unitType: 'binary_size',
+          useInPrettier: true,
+          conversion: {
+            value: 1048576,
             action: 'MULTIPLY',
           },
         },

--- a/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
@@ -107,7 +107,7 @@ const getFormatSettingsWithCustomTickVals = (values: Array<any>, fieldType: Fiel
   };
 };
 
-const getFormatSettingsByData = (unitTypeKey: FieldUnitType | DefaultAxisKey, values: Array<any>) => {
+export const getFormatSettingsByData = (unitTypeKey: FieldUnitType | DefaultAxisKey, values: Array<any>) => {
   switch (unitTypeKey) {
     case 'percent':
       return {
@@ -115,6 +115,8 @@ const getFormatSettingsByData = (unitTypeKey: FieldUnitType | DefaultAxisKey, va
       };
     case 'size':
       return getFormatSettingsWithCustomTickVals(values, 'size');
+    case 'binary_size':
+      return getFormatSettingsWithCustomTickVals(values, 'binary_size');
     case 'time':
       return getFormatSettingsWithCustomTickVals(values, 'time');
     default:
@@ -301,13 +303,17 @@ const getHoverTexts = ({ convertedValues, unit }: { convertedValues: Array<any>;
 export const getHoverTemplateSettings = ({
   convertedValues,
   unit,
-  name,
+  name = undefined,
 }: {
   convertedValues: Array<any>;
   unit: FieldUnit;
-  name: string;
+  name?: string;
 }): { text: Array<string>; hovertemplate: string; meta: string } | {} => {
-  if (unit?.unitType === 'time' || unit?.unitType === 'size') {
+  if (
+    unit?.unitType === 'time' ||
+    unit?.unitType === 'size' ||
+    unit?.unitType === 'binary_size'
+  ) {
     return {
       text: getHoverTexts({ convertedValues, unit }),
       hovertemplate: '%{text}<br><extra>%{meta}</extra>',

--- a/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/chartLayoutGenerators.ts
@@ -316,7 +316,7 @@ export const getHoverTemplateSettings = ({
   ) {
     return {
       text: getHoverTexts({ convertedValues, unit }),
-      hovertemplate: '%{text}<br><extra>%{meta}</extra>',
+      hovertemplate: `%{text}<br>${name ? '<extra>%{meta}</extra>' : '<extra></extra>'}`,
       meta: name,
     };
   }

--- a/graylog2-web-interface/src/views/components/visualizations/utils/unitConverters.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/utils/unitConverters.ts
@@ -28,6 +28,45 @@ import supportedUnits from '../../../../../../graylog2-server/src/main/resources
 
 type UnitConversionAction = 'MULTIPLY' | 'DIVIDE';
 
+const binarySize = [
+  {
+    'type': 'base',
+    'abbrev': 'b',
+    'name': 'byte',
+    'unit_type': 'binary_size',
+  },
+  {
+    'type': 'derived',
+    'abbrev': 'KiB',
+    'name': 'kibibyte',
+    'unit_type': 'binary_size',
+    'conversion': {
+      'value': 1024,
+      'action': 'MULTIPLY',
+    },
+  },
+  {
+    'type': 'derived',
+    'abbrev': 'MiB',
+    'name': 'mebibyte',
+    'unit_type': 'binary_size',
+    'conversion': {
+      'value': 1048576,
+      'action': 'MULTIPLY',
+    },
+  },
+  {
+    'type': 'derived',
+    'abbrev': 'GiB',
+    'name': 'gibibyte',
+    'unit_type': 'binary_size',
+    'conversion': {
+      'value': 1073741824,
+      'action': 'MULTIPLY',
+    },
+  },
+];
+
 const sourceUnits = supportedUnits.units as FieldUnitTypesJson;
 export type UnitJson = {
   type: 'base' | 'derived';
@@ -70,9 +109,17 @@ const unitFromJson = (unitJson: UnitJson): Unit => ({
   conversion: unitJson.conversion,
   useInPrettier: isUnitUsableInPrettier(unitJson),
 });
-export const mappedUnitsFromJSON: FieldUnitTypes = <FieldUnitTypes>(
+
+export const mappedUnitsFromJSONForAggregation: FieldUnitTypes = <FieldUnitTypes>(
   mapValues(
     sourceUnits,
+    (unitsJson: Array<UnitJson>): Array<Unit> => unitsJson.map((unitJson: UnitJson): Unit => unitFromJson(unitJson)),
+  )
+);
+
+export const mappedUnitsFromJSON: FieldUnitTypes = <FieldUnitTypes>(
+  mapValues(
+    { ...sourceUnits, binary_size: binarySize },
     (unitsJson: Array<UnitJson>): Array<Unit> => unitsJson.map((unitJson: UnitJson): Unit => unitFromJson(unitJson)),
   )
 );

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -488,7 +488,7 @@ export interface WidgetCreator {
   icon: React.ComponentType<{}>;
 }
 
-export type FieldUnitType = 'size' | 'time' | 'percent';
+export type FieldUnitType = 'size' | 'time' | 'percent' | 'binary_size';
 
 export type FieldUnitsFormValues = Record<string, { abbrev: string; unitType: FieldUnitType }>;
 


### PR DESCRIPTION
Please note, this is a backport of https://github.com/Graylog2/graylog2-server/pull/24983 for `6.2`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
With this PR, we add a new ram_size unit to our unit conversion functionality and use it for the traffic chart. Also we add label to clarify that we are using UTC

<img width="1117" height="357" alt="Screenshot 2026-02-11 at 14 59 42" src="https://github.com/user-attachments/assets/f84f7486-3f82-4ca4-adcd-529a23445dd2" />


## Motivation and Context
fix: #24982 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

