### PR TITLE
Adding a not equals search operator for MongoDB queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperator.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperator.java
@@ -38,6 +38,13 @@ public abstract class SearchQueryOperator {
         }
     }
 
+    public static class NotEquals extends SearchQueryOperator {
+        @Override
+        public Bson buildBson(String key, Object value) {
+            return Filters.ne(key, value);
+        }
+    }
+
     public static class Regexp extends SearchQueryOperator {
         @Override
         public Bson buildBson(String key, Object value) {

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperators.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperators.java
@@ -18,6 +18,7 @@ package org.graylog2.search;
 
 public class SearchQueryOperators {
     public static final SearchQueryOperator EQUALS = new SearchQueryOperator.Equals();
+    public static final SearchQueryOperator NOT_EQUALS = new SearchQueryOperator.NotEquals();
     public static final SearchQueryOperator GREATER = new SearchQueryOperator.Greater();
     public static final SearchQueryOperator GREATER_EQUALS = new SearchQueryOperator.GreaterEquals();
     public static final SearchQueryOperator LESS = new SearchQueryOperator.Less();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, our querying code for MongoDB could not use the not equals operator. This PR adds the operator.
First usage is in Enterprise code (see https://github.com/Graylog2/graylog-plugin-enterprise/pull/13379), so this PR is a small change that looks like not much.

/nocl as it's not a user facing change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

