### PR TITLE
Fix ClusterStatsApi

### DIFF
--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/stats/ClusterStatsApi.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/stats/ClusterStatsApi.java
@@ -16,15 +16,14 @@
  */
 package org.graylog.storage.opensearch3.stats;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.inject.Inject;
 import org.graylog.storage.opensearch3.OfficialOpensearchClient;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
-import org.opensearch.client.opensearch.cluster.ClusterStatsRequest;
-import org.opensearch.client.opensearch.cluster.ClusterStatsResponse;
-import org.opensearch.client.opensearch.cluster.stats.IndexMetric;
-import org.opensearch.client.opensearch.cluster.stats.Metric;
+import org.opensearch.client.opensearch.generic.Request;
+import org.opensearch.client.opensearch.generic.Requests;
 
-import java.util.List;
+import java.util.Map;
 
 public class ClusterStatsApi {
     private final OfficialOpensearchClient officialOpensearchClient;
@@ -35,13 +34,20 @@ public class ClusterStatsApi {
     }
 
     public IndexSetStats clusterStats() {
-        final ClusterStatsRequest request = ClusterStatsRequest.builder()
-                .nodeId("_all")
-                .metric(List.of(Metric.Indices))
-                .indexMetric(List.of(IndexMetric.Store, IndexMetric.Docs))
+        // the new filter-by-request-path of ClusterStatsRequest is only available in OS >= 2.18.
+        // so we have to resort to using the undocumented, but working (as of 3.5.0) filter_path request parameter
+        // with a generic api request.
+        final Request request = Requests.builder()
+                .method("GET")
+                .endpoint("/_cluster/stats")
+                .query(Map.of("filter_path", "indices.count,indices.docs.count,indices.store.size_in_bytes"))
                 .build();
+        JsonNode stats = officialOpensearchClient.performRequest(request, "Couldn't read OpensSearch cluster stats");
 
-        final ClusterStatsResponse stats = officialOpensearchClient.sync(c -> c.cluster().stats(request), "Couldn't read OpensSearch cluster stats");
-        return IndexSetStats.create(stats.indices().count(), stats.indices().docs().count(), stats.indices().store().sizeInBytes());
+        final long indicesCount = stats.path("indices").path("count").asLong();
+        final long docsCount = stats.path("indices").path("docs").path("count").asLong();
+        final long sizeBytes = stats.path("indices").path("store").path("size_in_bytes").asLong();
+
+        return IndexSetStats.create(indicesCount, docsCount, sizeBytes);
     }
 }


### PR DESCRIPTION
## Description
In OpenSearch 2.18 a new format for filtering cluster stats in the request path has been introduced.
This format is used by the OS java client. Since this is incompatible with previous versions, this PR uses a 
generic api call to apply the filtering using `filter_path` which is not available in the typed java client.

/nocl fixes regression introduced during client migration

## Motivation and Context
fixes https://github.com/Graylog2/graylog2-server/issues/25315

## How Has This Been Tested?
existing IT
retrieving cluster stats in Graylog UI
manually by calling the endpoint with the parameters in ES 7.10, OS 1.3, 2.15, 2.19 and 3.5

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

