### PR TITLE
Only offer slicing for columns which have required permission.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/SliceHeaderControls.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/SliceHeaderControls.tsx
@@ -25,6 +25,7 @@ import { defaultCompare } from 'logic/DefaultCompare';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { IconButton } from 'components/common';
+import usePermissions from 'hooks/usePermissions';
 
 const SliceHeader = styled.div(
   ({ theme }) => css`
@@ -61,8 +62,9 @@ const SliceHeaderControls = ({
   columnSchemas,
   onChangeSlicing,
 }: Props) => {
+  const { isPermitted } = usePermissions();
   const sliceableColumns = columnSchemas
-    .filter((schema) => schema.sliceable)
+    .filter((schema) => schema.sliceable && isPermitted(schema.permissions))
     .sort(({ title: title1 }, { title: title2 }) => defaultCompare(title1, title2));
   const sendTelemetry = useSendTelemetry();
   const onSliceColumn = (columnId: string) => {

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/Slicing.test.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/Slicing.test.tsx
@@ -17,20 +17,30 @@
 import * as React from 'react';
 import { screen, render, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
+import { defaultUser } from 'defaultMockValues';
 
+import { asMock } from 'helpers/mocking';
 import type { SearchParams } from 'stores/PaginationTypes';
 import TableFetchContext, { type ContextValue } from 'components/common/PaginatedEntityTable/TableFetchContext';
+import type { ColumnSchema } from 'components/common/EntityDataTable/types';
+import useCurrentUser from 'hooks/useCurrentUser';
 
 import Slicing from './index';
 
 jest.mock('logic/telemetry/useSendTelemetry', () => () => jest.fn());
+jest.mock('hooks/useCurrentUser');
 
 describe('Slicing', () => {
-  const columnSchemas = [
+  const columnSchemas: Array<ColumnSchema> = [
     { id: 'title', title: 'Title', type: 'STRING' as const, sliceable: true },
-    { id: 'status', title: 'Status', type: 'STRING' as const, sliceable: true },
+    { id: 'status', title: 'Status', type: 'STRING' as const, sliceable: true, permissions: ['streams:read'] },
+    { id: 'owner', title: 'Owner', type: 'STRING' as const, sliceable: true, permissions: ['roles:read'] },
     { id: 'description', title: 'Description', type: 'STRING' as const, sliceable: false },
   ];
+
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(defaultUser);
+  });
 
   const renderSUT = (
     props: Partial<React.ComponentProps<typeof Slicing>> = {},
@@ -73,8 +83,22 @@ describe('Slicing', () => {
     await userEvent.click(button);
 
     await screen.findByRole('menuitem', { name: /title/i });
+    await screen.findByRole('menuitem', { name: /owner/i });
     await screen.findByRole('menuitem', { name: /status/i });
     expect(screen.queryByRole('menuitem', { name: /description/i })).not.toBeInTheDocument();
+  });
+
+  it('hides slice options for columns without the required permissions', async () => {
+    asMock(useCurrentUser).mockReturnValue(defaultUser.toBuilder().permissions(['streams:read']).build());
+
+    renderSUT();
+
+    const button = await screen.findByRole('button', { name: /status/i });
+    await userEvent.click(button);
+
+    await screen.findByRole('menuitem', { name: /title/i });
+    await screen.findByRole('menuitem', { name: /status/i });
+    expect(screen.queryByRole('menuitem', { name: /owner/i })).not.toBeInTheDocument();
   });
 
   it('selects a slice', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change the column select in the slices section only contain columns which the user has access to.

<img width="353" height="241" alt="image" src="https://github.com/user-attachments/assets/f024c6e2-e418-4438-a4fe-ffdef096a3da" />

/nocl - unreleased feature
