### PR TITLE
Fix flaky datanode upgrade adapter it

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/datanode/DatanodeUpgradeServiceAdapterIT.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/datanode/DatanodeUpgradeServiceAdapterIT.java
@@ -23,7 +23,6 @@ import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.github.zafarkhaja.semver.Version;
-import io.restassured.response.ValidatableResponse;
 import org.assertj.core.api.Assertions;
 import org.graylog.plugins.datanode.dto.ClusterState;
 import org.graylog.plugins.datanode.dto.FlushResponse;
@@ -58,20 +57,20 @@ public abstract class DatanodeUpgradeServiceAdapterIT {
     @Test
     void testUpgradeOperations() {
         Assertions.assertThat(upgradeAdapter.getClusterState())
-                .satisfies(expectedState(HealthStatus.Green, ShardReplication.ALL))
+                .satisfies(expectedReplicationStatus(ShardReplication.ALL))
                 .satisfies(nodeDetails(indexerVersion()));
 
         Assertions.assertThat(upgradeAdapter.disableShardReplication())
                 .satisfies(this::successfulFlush);
 
         Assertions.assertThat(upgradeAdapter.getClusterState())
-                .satisfies(expectedState(HealthStatus.Green, ShardReplication.PRIMARIES));
+                .satisfies(expectedReplicationStatus(ShardReplication.PRIMARIES));
 
         Assertions.assertThat(upgradeAdapter.enableShardReplication())
                 .satisfies(this::successfulFlush);
 
         Assertions.assertThat(upgradeAdapter.getClusterState())
-                .satisfies(expectedState(HealthStatus.Green, ShardReplication.ALL));
+                .satisfies(expectedReplicationStatus(ShardReplication.ALL));
     }
 
     private void waitForGreenClusterState(DatanodeUpgradeServiceAdapter upgradeAdapter) throws ExecutionException, RetryException {
@@ -109,9 +108,8 @@ public abstract class DatanodeUpgradeServiceAdapterIT {
                 });
     }
 
-    private Consumer<ClusterState> expectedState(HealthStatus status, ShardReplication shardReplication) {
+    private Consumer<ClusterState> expectedReplicationStatus(ShardReplication shardReplication) {
         return clusterState -> {
-            Assertions.assertThat(clusterState.status()).isEqualTo(status);
             Assertions.assertThat(clusterState.shardReplication()).isEqualTo(shardReplication);
         };
     }


### PR DESCRIPTION
## Description
Removes the check for health status green from the it as only the shard replication status is relevant for the functionality and we cannot guarantee that no other prior test puts the OS in another health state. 

/nocl internal

## Motivation and Context
fixes flaky test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

