### PR TITLE
Remove eager mongodb nodes provider, blocking server startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -85,7 +85,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         Multibinder<MongodbNodesService> mongodbNodesServices = Multibinder.newSetBinder(binder(), MongodbNodesService.class);
         mongodbNodesServices.addBinding().to(ReplicaSetMongodbNodes.class);
         mongodbNodesServices.addBinding().to(StandaloneNodeMongodbNodes.class);
-        bind(new TypeLiteral<List<MongodbNode>>() {}).toProvider(MongodbNodesProvider.class).asEagerSingleton();
 
         bind(ServerNodePaginatedService.class).asEagerSingleton();
         bind(IndexRangeService.class).to(MongoIndexRangeService.class).asEagerSingleton();


### PR DESCRIPTION
/nocl

Eager nodes provider could fail during server startup, if the mongodb user doesn't have permissions to run the serverStatus command

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

