### PR TITLE
Skip system notifications polling for users without notifications:read permission

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.tsx
@@ -26,7 +26,6 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import useLocation from 'routing/useLocation';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 import useNotifications from 'components/notifications/useNotifications';
-import { alice } from 'fixtures/users';
 
 jest.mock('./ScratchpadToggle', () => mockComponent('ScratchpadToggle'));
 jest.mock('hooks/useCurrentUser');
@@ -63,14 +62,17 @@ describe('Navigation', () => {
     await screen.findByRole('button', { name: /user menu for administrator/i });
   });
 
-  it('shows notification badge for users with notifications:read permission', async () => {
+  it('shows notification badge when there are notifications', async () => {
     render(<SUT />);
 
     await screen.findByTestId('notification-badge');
   });
 
-  it('does not show notification badge for users without notifications:read permission', async () => {
-    asMock(useCurrentUser).mockReturnValue(alice);
+  it('does not show notification badge when there are no notifications', async () => {
+    asMock(useNotifications).mockReturnValue({
+      data: { total: 0, notifications: [] },
+      isLoading: false,
+    });
 
     render(<SUT />);
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.tsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import styled, { css } from 'styled-components';
 
 import useLocation from 'routing/useLocation';
-import { IfPermitted, Link, LinkContainer } from 'components/common';
+import { Link, LinkContainer } from 'components/common';
 import AppConfig from 'util/AppConfig';
 import { Navbar, Nav } from 'components/bootstrap';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
@@ -79,9 +79,7 @@ const Navigation = React.memo(({ pathname }: Props) => {
       <Navbar.Collapse>
         <MainNavbar pathname={pathname} />
 
-        <IfPermitted permissions="notifications:read">
-          <NotificationBadge />
-        </IfPermitted>
+        <NotificationBadge />
 
         <Nav pullRight className="header-meta-nav">
           {AppConfig.isFeatureEnabled(FEATURE_FLAG) ? <QuickJumpModalContainer /> : null}

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.test.tsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.test.tsx
@@ -15,15 +15,19 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import Immutable from 'immutable';
 import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 
 import { asMock } from 'helpers/mocking';
+import { adminUser } from 'fixtures/users';
+import useCurrentUser from 'hooks/useCurrentUser';
 import useNotifications from 'components/notifications/useNotifications';
 
 import NotificationBadge from './NotificationBadge';
 
 const BADGE_ID = 'notification-badge';
 
+jest.mock('hooks/useCurrentUser');
 jest.mock('components/notifications/useNotifications');
 
 const notificationFixture = {
@@ -47,6 +51,21 @@ const setNotificationCount = (count: number) =>
   });
 
 describe('NotificationBadge', () => {
+  beforeEach(() => {
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
+  it('renders nothing when user has no notification permissions', () => {
+    const userWithoutPermissions = adminUser.toBuilder().permissions(Immutable.List(['dashboards:read'])).build();
+    asMock(useCurrentUser).mockReturnValue(userWithoutPermissions);
+    asMock(useNotifications).mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<NotificationBadge />);
+
+    expect(useNotifications).toHaveBeenCalledWith({ enabled: false });
+    expect(screen.queryByTestId(BADGE_ID)).not.toBeInTheDocument();
+  });
+
   it('renders nothing when there are no notifications', () => {
     setNotificationCount(0);
 

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.tsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.tsx
@@ -19,11 +19,16 @@ import styled from 'styled-components';
 
 import { LinkContainer } from 'components/common';
 import { Badge, Nav } from 'components/bootstrap';
+import useCurrentUser from 'hooks/useCurrentUser';
+import useNotifications from 'components/notifications/useNotifications';
 import Routes from 'routing/Routes';
 import { NAV_ITEM_HEIGHT } from 'theme/constants';
-import useNotifications from 'components/notifications/useNotifications';
+import type * as Immutable from 'immutable';
 
 import InactiveNavItem from './InactiveNavItem';
+
+const hasNotificationPermission = (permissions: Immutable.List<string>): boolean =>
+  permissions.some((p) => p === '*' || p === 'notifications:*' || p.startsWith('notifications:read'));
 
 const StyledNav = styled(Nav)`
   > li > a {
@@ -43,9 +48,11 @@ const StyledInactiveNavItem = styled(InactiveNavItem)`
 `;
 
 const NotificationBadge = () => {
-  const { data, isLoading } = useNotifications();
+  const currentUser = useCurrentUser();
+  const enabled = hasNotificationPermission(currentUser.permissions);
+  const { data, isLoading } = useNotifications({ enabled });
 
-  return isLoading || data.total === 0 ? null : (
+  return isLoading || !data || data.total === 0 ? null : (
     <StyledNav navbar>
       <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
         <StyledInactiveNavItem>

--- a/graylog2-web-interface/src/components/notifications/useNotifications.ts
+++ b/graylog2-web-interface/src/components/notifications/useNotifications.ts
@@ -23,11 +23,12 @@ import { NOTIFICATIONS_QUERY_KEY } from 'components/notifications/constants';
 const POLL_INTERVAL = 3000;
 
 const fetchNotifications = () => SystemNotifications.listNotifications({ requestShouldExtendSession: false });
-const useNotifications = () => {
+const useNotifications = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const { data, isLoading } = useQuery({
     queryKey: NOTIFICATIONS_QUERY_KEY,
     queryFn: fetchNotifications,
     refetchInterval: POLL_INTERVAL,
+    enabled,
   });
 
   return { data, isLoading };


### PR DESCRIPTION
## Description

Move the notification permission check from an `<IfPermitted permissions="notifications:read">` wrapper in `Navigation.tsx` into the `NotificationBadge` component itself. The badge now checks the current user's permissions for any notification read access (`*`, `notifications:*`, or `notifications:read:*`) and passes an `enabled` flag to `useNotifications()`, which forwards it to React Query. When disabled, the query never executes — no polling, no network requests.

## Motivation and Context

The original `<IfPermitted permissions="notifications:read">` wrapper required the blanket `notifications:read` permission. Users who only had type-specific permissions like `notifications:read:deflector_migration` would never see the badge, even though the backend would return notifications for them.

Simply removing the wrapper (so the badge always renders) fixes visibility but still polls `GET /api/system/notifications` every 3 seconds for users with zero notification permissions — unnecessary network traffic and server load.

This approach solves both problems: users with any notification read permission see the badge and get polling; users with none see nothing and generate no traffic.

## How Has This Been Tested?

- **`NotificationBadge.test.tsx`**: Added test verifying that a user without notification permissions causes `useNotifications` to be called with `{ enabled: false }` and the badge is not rendered. Existing tests continue to pass for users with permissions.
- **`Navigation.test.tsx`**: Updated tests to check badge visibility based on notification data instead of permissions (the permission gating now lives in `NotificationBadge`, not `Navigation`).

All existing and new tests pass.

Fixes Graylog2/graylog-plugin-enterprise#10902

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.