### PR TITLE
Cluster config page: unnecessary horizontal scrollbar fix

### DIFF
--- a/graylog2-web-interface/src/components/cluster-configuration/shared-components/ClusterNodesSectionWrapper.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/shared-components/ClusterNodesSectionWrapper.tsx
@@ -53,6 +53,7 @@ const TableWrapper = styled.div.withConfig({
       div#scroll-container {
         max-height: ${maxHeight};
         overflow-y: auto;
+        scrollbar-gutter: stable;
       }
 
       div#scroll-container table thead {

--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -57,6 +57,7 @@ const TableWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow-x: auto;
+  min-width: 0;
   width: 100%;
 `;
 


### PR DESCRIPTION
I couldn't reproduce it on Chrome and Firefox (on Mac), I added a potential fix:

`min-width: 0` lets the flex item shrink properly. 
`scrollbar-gutter: stable` prevents layout shift from the vertical scrollbar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog2-server/issues/25371
/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

