### PR TITLE
Fix BigInt serialization error in lookup table test flow

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.test.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.test.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import { createLookupTableAdapter } from 'fixtures/lookupTables';
@@ -23,11 +24,17 @@ import { asMock } from 'helpers/mocking';
 import useScopePermissions from 'hooks/useScopePermissions';
 import type { GenericEntityType } from 'logic/lookup-tables/types';
 import { ModalProvider } from 'components/lookup-tables/contexts/ModalContext';
+import { LookupTableDataAdaptersActions } from 'stores/lookup-tables/LookupTableDataAdaptersStore';
 
 import CSVFileAdapterSummary from './adapters/CSVFileAdapterSummary';
 import DataAdapter from './DataAdapter';
 
 jest.mock('hooks/useScopePermissions');
+jest.mock('stores/lookup-tables/LookupTableDataAdaptersStore', () => ({
+  LookupTableDataAdaptersActions: {
+    lookup: jest.fn(),
+  },
+}));
 
 PluginStore.register(
   new PluginManifest(
@@ -84,5 +91,38 @@ describe('DataAdapter', () => {
     renderedDataAdapter('ILLUMINATE');
 
     expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+  });
+
+  // Regression: PR #23432 introduced json-with-bigint which deserializes large numbers as BigInt.
+  // DataAdapter used native JSON.stringify to render lookup results, which throws
+  // "TypeError: Do not know how to serialize a BigInt" for values like AD's accountExpires.
+  // Introduced by: 5cb51acdcceb660c2cc75fc8c0ad48a17b543334 (2026-03-19)
+  it('should render lookup results containing BigInt values without crashing', async () => {
+    const lookupResultWithBigInt = {
+      single_value: 'testuser',
+      multi_value: {
+        sAMAccountName: 'testuser',
+        accountExpires: BigInt('9223372036854775807'),
+        pwdLastSet: BigInt('134185088795495957'),
+        displayName: 'Test User',
+      },
+      has_error: false,
+      ttl: 1000,
+    };
+
+    asMock(LookupTableDataAdaptersActions.lookup).mockResolvedValue(lookupResultWithBigInt);
+
+    renderedDataAdapter('DEFAULT');
+
+    const keyInput = screen.getByLabelText(/key/i);
+    const lookupButton = screen.getByRole('button', { name: /look up/i });
+
+    await userEvent.type(keyInput, 'testuser');
+    await userEvent.click(lookupButton);
+
+    await screen.findByText(/lookup result/i);
+
+    expect(screen.getByText(/9223372036854775807/)).toBeInTheDocument();
+    expect(screen.getByText(/testuser/)).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { JSONStringify } from 'json-with-bigint';
 
 import Routes from 'routing/Routes';
 import usePluginEntities from 'hooks/usePluginEntities';
@@ -114,7 +115,7 @@ const DataAdapter = ({ dataAdapter, noEdit = false }: Props) => {
         {lookupResult && (
           <div>
             <h4>Lookup result</h4>
-            <pre>{JSON.stringify(lookupResult, null, 2)}</pre>
+            <pre>{JSONStringify(lookupResult, null, 2)}</pre>
           </div>
         )}
       </Col>

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-view/test-lookup.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-view/test-lookup.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { useState, useMemo } from 'react';
 import styled from 'styled-components';
+import { JSONStringify } from 'json-with-bigint';
 
 import useProductName from 'brand-customization/useProductName';
 import { useErrorsContext } from 'components/lookup-tables/contexts/ErrorsContext';
@@ -68,7 +69,7 @@ function TestLookup({ table }: Props) {
   const dataPreview = useMemo(() => {
     if (total === 0) return 'No results to show';
 
-    return JSON.stringify(results, null, 2);
+    return JSONStringify(results, null, 2);
   }, [results, total]);
 
   const onChange = (event: React.BaseSyntheticEvent) => {
@@ -94,7 +95,7 @@ function TestLookup({ table }: Props) {
 
     if (lookupKey.valid) {
       testLookupTableKey({ tableName: table.name, key: lookupKey.value }).then((resp: any) => {
-        setLookupResult(JSON.stringify(resp, null, 2));
+        setLookupResult(JSONStringify(resp, null, 2));
         setLookupKey({ value: '', valid: false });
       });
     }


### PR DESCRIPTION
## Summary
- `DataAdapter.tsx` and `test-lookup.tsx` used native `JSON.stringify` to display lookup results, which throws `TypeError: Do not know how to serialize a BigInt`
- PR #23432 changed `FetchProvider.ts` to parse API responses with `JSONParse` from `json-with-bigint` (large numbers become `BigInt`), but these two files were not update)
- The AD adapter is specifically affected because it returns values like `accountExpires: 9223372036854775807` (Long.MAX_VALUE) which exceed `Number.MAX_SAFE_INTEGER`
- standard `ttl` field for any adapter was also affected.
- Replaced `JSON.stringify` with `JSONStringify` from `json-with-bigint` in both files
- Added a regression test that verifies BigInt values render without crashing

Error when looking up adapter cal

<img width="1457" height="1085" alt="image" src="https://github.com/user-attachments/assets/f463d1bf-5d90-4ae3-9be6-117f60806754" />

Appears to have been introduced when https://github.com/Graylog2/graylog2-server/pull/23432 was merged.

/nocl fixed unreleased error
## Test plan
- [ ] Configure an Active Directory User Lookup data adapter pointing at an AD server
- [ ] Perform a test lookup — verify the result displays without crashing
- [ ] Verify the lookup table test page (`test-lookup.tsx`) also handles BigInt values
- [ ] Run `npx jest -- 'components/lookup-tables/DataAdapter.test.tsx'` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)