### PR TITLE
OR instead of AND extra filters on non-range fields

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -52,7 +52,6 @@ import org.graylog2.indexer.results.ResultChunk;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.ChunkCommand;
 import org.graylog2.indexer.searches.Sorting;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -222,11 +221,11 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
 
         extraFilters.forEach((field, values) -> {
             values.stream()
-                    .filter(MoreSearchAdapterES7::isRangeValue)
+                    .filter(MoreSearchAdapter::isRangeValue)
                     .map(value -> buildExtraFilter(field, value))
-                    .forEach(q -> filter.filter(q));
+                    .forEach(filter::filter);
             final var termQueries = values.stream()
-                    .filter(v -> !isRangeValue(v))
+                    .filter(v -> !MoreSearchAdapter.isRangeValue(v))
                     .map(value -> buildExtraFilter(field, value))
                     .toList();
             if (!termQueries.isEmpty()) {
@@ -247,10 +246,6 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
         }
 
         return filter;
-    }
-
-    static boolean isRangeValue(String value) {
-        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
     }
 
     static QueryBuilder buildExtraFilter(String field, String value) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7Test.java
@@ -23,25 +23,11 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.RangeQuer
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MoreSearchAdapterES7Test {
     private static final String FIELD = "field";
     private static final String VALUE = "100";
-
-    @Test
-    void testIsRangeValue() {
-        assertTrue(MoreSearchAdapterES7.isRangeValue("<=100"));
-        assertTrue(MoreSearchAdapterES7.isRangeValue(">=100"));
-        assertTrue(MoreSearchAdapterES7.isRangeValue("<100"));
-        assertTrue(MoreSearchAdapterES7.isRangeValue(">100"));
-        assertFalse(MoreSearchAdapterES7.isRangeValue("sigma"));
-        assertFalse(MoreSearchAdapterES7.isRangeValue("aggregation"));
-        assertFalse(MoreSearchAdapterES7.isRangeValue("100"));
-        assertFalse(MoreSearchAdapterES7.isRangeValue(""));
-    }
 
     @Test
     void testBuildExtraFilter() {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -52,7 +52,6 @@ import org.graylog2.indexer.results.ResultChunk;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.ChunkCommand;
 import org.graylog2.indexer.searches.Sorting;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -222,11 +221,11 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
 
         extraFilters.forEach((field, values) -> {
             values.stream()
-                    .filter(MoreSearchAdapterOS2::isRangeValue)
+                    .filter(MoreSearchAdapter::isRangeValue)
                     .map(value -> buildExtraFilter(field, value))
-                    .forEach(q -> filter.filter(q));
+                    .forEach(filter::filter);
             final var termQueries = values.stream()
-                    .filter(v -> !isRangeValue(v))
+                    .filter(v -> !MoreSearchAdapter.isRangeValue(v))
                     .map(value -> buildExtraFilter(field, value))
                     .toList();
             if (!termQueries.isEmpty()) {
@@ -246,10 +245,6 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
             filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
         }
         return filter;
-    }
-
-    static boolean isRangeValue(String value) {
-        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
     }
 
     static QueryBuilder buildExtraFilter(String field, String value) {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2Test.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2Test.java
@@ -23,25 +23,11 @@ import org.graylog.shaded.opensearch2.org.opensearch.index.query.RangeQueryBuild
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MoreSearchAdapterOS2Test {
     private static final String FIELD = "field";
     private static final String VALUE = "100";
-
-    @Test
-    void testIsRangeValue() {
-        assertTrue(MoreSearchAdapterOS2.isRangeValue("<=100"));
-        assertTrue(MoreSearchAdapterOS2.isRangeValue(">=100"));
-        assertTrue(MoreSearchAdapterOS2.isRangeValue("<100"));
-        assertTrue(MoreSearchAdapterOS2.isRangeValue(">100"));
-        assertFalse(MoreSearchAdapterOS2.isRangeValue("sigma"));
-        assertFalse(MoreSearchAdapterOS2.isRangeValue("aggregation"));
-        assertFalse(MoreSearchAdapterOS2.isRangeValue("100"));
-        assertFalse(MoreSearchAdapterOS2.isRangeValue(""));
-    }
 
     @Test
     void testBuildExtraFilter() {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
@@ -160,11 +160,11 @@ public class MoreSearchAdapterOS implements MoreSearchAdapter {
 
         extraFilters.forEach((field, values) -> {
             values.stream()
-                    .filter(MoreSearchAdapterOS::isRangeValue)
+                    .filter(MoreSearchAdapter::isRangeValue)
                     .map(value -> buildExtraFilter(field, value))
                     .forEach(boolQuery::filter);
             final var termQueries = values.stream()
-                    .filter(v -> !isRangeValue(v))
+                    .filter(v -> !MoreSearchAdapter.isRangeValue(v))
                     .map(value -> buildExtraFilter(field, value))
                     .toList();
             if (!termQueries.isEmpty()) {
@@ -280,10 +280,6 @@ public class MoreSearchAdapterOS implements MoreSearchAdapter {
         });
 
         return new MoreSearch.Histogram(new MoreSearch.Histogram.EventsBuckets(events, alerts));
-    }
-
-    static boolean isRangeValue(String value) {
-        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
     }
 
     static Query buildExtraFilter(String field, String value) {

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/MoreSearchAdapterOSTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/MoreSearchAdapterOSTest.java
@@ -18,6 +18,7 @@ package org.graylog.storage.opensearch3;
 
 import org.assertj.core.api.Assertions;
 import org.graylog.events.event.EventDto;
+import org.graylog.events.search.MoreSearchAdapter;
  import org.graylog2.indexer.searches.Sorting;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,14 +48,14 @@ class MoreSearchAdapterOSTest {
 
     @Test
     void testIsRangeValue() {
-        assertThat(MoreSearchAdapterOS.isRangeValue("<=100")).isTrue();
-        assertThat(MoreSearchAdapterOS.isRangeValue(">=100")).isTrue();
-        assertThat(MoreSearchAdapterOS.isRangeValue("<100")).isTrue();
-        assertThat(MoreSearchAdapterOS.isRangeValue(">100")).isTrue();
-        assertThat(MoreSearchAdapterOS.isRangeValue("sigma")).isFalse();
-        assertThat(MoreSearchAdapterOS.isRangeValue("aggregation")).isFalse();
-        assertThat(MoreSearchAdapterOS.isRangeValue("100")).isFalse();
-        assertThat(MoreSearchAdapterOS.isRangeValue("")).isFalse();
+        assertThat(MoreSearchAdapter.isRangeValue("<=100")).isTrue();
+        assertThat(MoreSearchAdapter.isRangeValue(">=100")).isTrue();
+        assertThat(MoreSearchAdapter.isRangeValue("<100")).isTrue();
+        assertThat(MoreSearchAdapter.isRangeValue(">100")).isTrue();
+        assertThat(MoreSearchAdapter.isRangeValue("sigma")).isFalse();
+        assertThat(MoreSearchAdapter.isRangeValue("aggregation")).isFalse();
+        assertThat(MoreSearchAdapter.isRangeValue("100")).isFalse();
+        assertThat(MoreSearchAdapter.isRangeValue("")).isFalse();
     }
 
     @Test

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -79,4 +79,8 @@ public interface MoreSearchAdapter {
         return commandBuilder
                 .build();
     }
+
+    static boolean isRangeValue(String value) {
+        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Use OR logic on extraFilters supplied to event searches instead of AND logic. Currently, adding multiple filters for `Event Definition Type`, `Associated Assets`, or `Tactic/Technique` ANDs the supplied filters. For `Event Definition Type`, this always results in an empty search result. For the other two fields, it only returns events that have all supplied filters as values for the field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes Graylog2/graylog-plugin-enterprise#13434
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dev testing, unit tests, integration test
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

