### PR TITLE
Fix event details sidebar cutting off long values

### DIFF
--- a/graylog2-web-interface/src/components/events/events/EventDetailsTable.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetailsTable.tsx
@@ -23,8 +23,15 @@ import type { ColumnRenderersByAttribute, EntityBase } from 'components/common/E
 import DefaultColumnRenderers from 'components/common/EntityDataTable/DefaultColumnRenderers';
 import type { Attribute } from 'stores/PaginationTypes';
 
-const TD = styled.td`
+const LabelTD = styled.td`
   white-space: nowrap;
+`;
+
+const ValueTD = styled.td`
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 0;
+  width: 100%;
 `;
 
 type Props<T extends EntityBase, M = EventsAdditionalData> = {
@@ -53,11 +60,11 @@ const EventDetailsTable = <E extends EntityBase = Event>({
         return (
           <tr key={attribute.id}>
             {attribute.title && (
-              <TD>
+              <LabelTD>
                 <b>{attribute.title}</b>
-              </TD>
+              </LabelTD>
             )}
-            <td>{renderCell ? renderCell(value, event, meta, eventProcedureId) : value}</td>
+            <ValueTD>{renderCell ? renderCell(value, event, meta, eventProcedureId) : value}</ValueTD>
           </tr>
         );
       })}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add word-breaking to value cells in EventDetailsTable so long strings like IDs, keys, and field values wrap instead of overflowing the sidebar container.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

/nocl WIP Feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
<img width="814" height="1767" alt="image" src="https://github.com/user-attachments/assets/2cf20089-4aef-4fd0-9369-a975aab5fe66" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.