### PR TITLE
Fix regression with alerts table not updating on auto refresh.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/PaginatedEntityTable.tsx
@@ -30,6 +30,7 @@ import type { UrlQueryFilters } from 'components/common/EntityFilters/types';
 import TableFetchContextProvider from 'components/common/PaginatedEntityTable/TableFetchContextProvider';
 import type { PaginatedResponse, FetchOptions } from 'components/common/PaginatedEntityTable/useFetchEntities';
 import useFetchEntities from 'components/common/PaginatedEntityTable/useFetchEntities';
+import useOnRefresh from 'components/common/PaginatedEntityTable/useOnRefresh';
 import type { PaginationQueryParameterResult } from 'hooks/usePaginationQueryParameter';
 import Slicing, { type SliceRenderers } from 'components/common/PaginatedEntityTable/slicing';
 import type { FetchSlices } from 'components/common/PaginatedEntityTable/slicing/useFetchSlices';
@@ -136,6 +137,7 @@ const PaginatedEntityTableInner = <T extends EntityBase, M = unknown>({
     humanName,
     fetchOptions: reactQueryOptions,
   });
+  useOnRefresh(refetch);
 
   useEffect(() => {
     if (!onDataLoaded || isLoadingEntities) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The line that re-executes the alerts overview search request on auto refresh, has been removed accidentally.

I changed our existing e2e tests to ensure they fail when no search is executed on refresh.

/nocl - unreleased bug
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13619

