### PR TITLE
Ignore serialization of entityObjects field in ContentPackUninstallation (`6.2`)

### DIFF
--- a/changelog/unreleased/issue-22059.toml
+++ b/changelog/unreleased/issue-22059.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed error message when content packs are successfully uninstalled."
+
+pulls = ["25448"]
+issues = ["22059"]

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -30,7 +31,6 @@ import javax.annotation.Nullable;
 @JsonDeserialize(builder = ContentPackUninstallation.Builder.class)
 public abstract class ContentPackUninstallation {
     private static final String FIELD_ENTITIES = "entities";
-    private static final String FIELD_ENTITY_OBJECTS = "entity_objects";
     private static final String FIELD_FAILED_ENTITIES = "failed_entities";
     private static final String FIELD_SKIPPED_ENTITIES = "skipped_entities";
 
@@ -38,7 +38,7 @@ public abstract class ContentPackUninstallation {
     public abstract ImmutableSet<NativeEntityDescriptor> entities();
 
     @Nullable
-    @JsonProperty(FIELD_ENTITY_OBJECTS)
+    @JsonIgnore
     public abstract ImmutableMap<ModelId, Object> entityObjects();
 
     @JsonProperty(FIELD_FAILED_ENTITIES)
@@ -63,7 +63,6 @@ public abstract class ContentPackUninstallation {
         @JsonProperty(FIELD_ENTITIES)
         public abstract Builder entities(ImmutableSet<NativeEntityDescriptor> entities);
 
-        @JsonProperty(FIELD_ENTITY_OBJECTS)
         public abstract Builder entityObjects(ImmutableMap<ModelId, Object> entityObjects);
 
         @JsonProperty(FIELD_FAILED_ENTITIES)


### PR DESCRIPTION
Note: This is a backport of #25448 to `6.2`.

## Description
<!--- Describe your changes in detail -->
Ignore serialization of the `entityObjects` field in `ContentPackUninstallation` to prevent irrelevant serialization error when a content pack is successfully uninstalled. The field is populated directly from the `ContentPackService.uninstallContentPack()` and only needed in memory afterwards. Therefore, it does not need to be serialized. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

closes #22059 
closes customer issue Graylog2/support#197

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dev testing
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
