### PR TITLE
OR instead of AND extra filters on non-range fields (`6.2`)

### DIFF
--- a/changelog/unreleased/pr-25447.toml
+++ b/changelog/unreleased/pr-25447.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed event search extra filters being incorrectly applied as ANDed together."
+
+issues = ["Graylog2/graylog-plugin-enterprise#13434"]
+pulls = ["25447"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -217,12 +217,21 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
                 .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
                 .filter(requireNonNull(TimeRangeQueryFactory.create(timerange)));
 
-        extraFilters.entrySet()
-                .stream()
-                .flatMap(extraFilter -> extraFilter.getValue()
-                        .stream()
-                        .map(value -> buildExtraFilter(extraFilter.getKey(), value)))
-                .forEach(filter::filter);
+        extraFilters.forEach((field, values) -> {
+            values.stream()
+                    .filter(MoreSearchAdapter::isRangeValue)
+                    .map(value -> buildExtraFilter(field, value))
+                    .forEach(filter::filter);
+            final var termQueries = values.stream()
+                    .filter(v -> !MoreSearchAdapter.isRangeValue(v))
+                    .map(value -> buildExtraFilter(field, value))
+                    .toList();
+            if (!termQueries.isEmpty()) {
+                final BoolQueryBuilder shouldQuery = boolQuery().minimumShouldMatch(1);
+                termQueries.forEach(shouldQuery::should);
+                filter.filter(shouldQuery);
+            }
+        });
 
         if (!isNullOrEmpty(filterString)) {
             filter.filter(queryStringQuery(filterString));

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -217,12 +217,21 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
                 .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
                 .filter(requireNonNull(TimeRangeQueryFactory.create(timerange)));
 
-        extraFilters.entrySet()
-                .stream()
-                .flatMap(extraFilter -> extraFilter.getValue()
-                        .stream()
-                        .map(value -> buildExtraFilter(extraFilter.getKey(), value)))
-                .forEach(filter::filter);
+        extraFilters.forEach((field, values) -> {
+            values.stream()
+                    .filter(MoreSearchAdapter::isRangeValue)
+                    .map(value -> buildExtraFilter(field, value))
+                    .forEach(filter::filter);
+            final var termQueries = values.stream()
+                    .filter(v -> !MoreSearchAdapter.isRangeValue(v))
+                    .map(value -> buildExtraFilter(field, value))
+                    .toList();
+            if (!termQueries.isEmpty()) {
+                final BoolQueryBuilder shouldQuery = boolQuery().minimumShouldMatch(1);
+                termQueries.forEach(shouldQuery::should);
+                filter.filter(shouldQuery);
+            }
+        });
 
         if (!isNullOrEmpty(filterString)) {
             filter.filter(queryStringQuery(filterString));

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -48,4 +48,8 @@ public interface MoreSearchAdapter {
 
     void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams,
                       List<UsedSearchFilter> filters, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
+
+    static boolean isRangeValue(String value) {
+        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchAdapterIT.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -198,6 +199,29 @@ public abstract class MoreSearchAdapterIT extends ElasticsearchBaseTest {
         toTest.scrollEvents("*", RelativeRange.allTime(), Set.of("unavailable"), ALL_STREAMS, Collections.emptyList(), batchSize,
                 getCountingAndCollectingScrollEventsCallback(count, allResults));
         assertThat(allResults).isEmpty();
+    }
+
+    @Test
+    public void eventSearchWithExtraFiltersSingleTermValue() {
+        // Baseline: a single term value filters to the matching subset
+        final Map<String, Set<String>> extraFilters = Map.of("message", Set.of("Hi"));
+        final MoreSearch.Result result = toTest.eventSearch("*",
+                RelativeRange.allTime(),
+                Set.of(INDEX_NAME),
+                Sorting.DEFAULT, 1, 10, ALL_STREAMS, "", Set.of(), extraFilters);
+
+        assertThat(result.results()).hasSize(4); // messages 1-4 have "Hi"
+    }
+
+    @Test
+    public void eventSearchWithMultipleTermExtraFiltersOrsValuesForSameField() {
+        final Map<String, Set<String>> extraFilters = Map.of("message", Set.of("Hi", "Ahoj"));
+        final MoreSearch.Result result = toTest.eventSearch("*",
+                RelativeRange.allTime(),
+                Set.of(INDEX_NAME),
+                Sorting.DEFAULT, 1, 10, ALL_STREAMS, "", Set.of(), extraFilters);
+
+        assertThat(result.results()).hasSize(7);
     }
 
     @Nonnull


### PR DESCRIPTION
Note: This is a backport of #25447 to `6.2`.

## Description
Use OR logic on extraFilters supplied to event searches instead of AND logic. Currently, adding multiple filters for `Event Definition Type`, `Associated Assets`, or `Tactic/Technique` ANDs the supplied filters. For `Event Definition Type`, this always results in an empty search result. For the other two fields, it only returns events that have all supplied filters as values for the field.

## Motivation and Context
closes Graylog2/graylog-plugin-enterprise#13434

## How Has This Been Tested?
dev testing, unit tests, integration test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)