### PR TITLE
Forwarder download link configurable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/customization/Config.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/customization/Config.java
@@ -53,7 +53,8 @@ public record Config(
     public record Resources(@JsonProperty("stream_rule_matcher_code") Optional<ResourceItem> streamRuleMatcherCode,
                             @JsonProperty("contact_support") Optional<ResourceItem> contactSupport,
                             @JsonProperty("contact_us") Optional<ResourceItem> contactUs,
-                            Optional<ResourceItem> marketplace
+                            Optional<ResourceItem> marketplace,
+                            @JsonProperty("forwarder_download_url") Optional<ResourceItem> forwarderDownloadUrl
                             ) {
         public record ResourceItem(Optional<Boolean> enabled, Optional<String> url) {}
     }

--- a/graylog2-web-interface/src/brand-customization/useResourceCustomization.ts
+++ b/graylog2-web-interface/src/brand-customization/useResourceCustomization.ts
@@ -25,6 +25,7 @@ const defaultResourcesUrls: Record<BrandingResourceKey, string> = {
   contact_support: 'https://support.graylog.org/portal',
   contact_us: 'https://www.graylog.org/community-support/',
   marketplace: 'https://marketplace.graylog.org/',
+  forwarder_download_url: 'https://www.graylog.org/downloads/',
 };
 
 const useResourceCustomization = (brandingKey: BrandingResourceKey): BrandingResource => {

--- a/graylog2-web-interface/src/util/AppConfig.ts
+++ b/graylog2-web-interface/src/util/AppConfig.ts
@@ -25,7 +25,7 @@ declare global {
 }
 
 export type BrandingResource = { enabled?: boolean; url?: string | undefined };
-export type BrandingResourceKey = 'stream_rule_matcher_code' | 'contact_support' | 'contact_us' | 'marketplace';
+export type BrandingResourceKey = 'stream_rule_matcher_code' | 'contact_support' | 'contact_us' | 'marketplace' | 'forwarder_download_url';
 
 export type BrandingResources = Record<BrandingResourceKey, BrandingResource>;
 type FeatureToggle = { enabled?: boolean };


### PR DESCRIPTION
Forwarder download link configurable via whitelabel/rebranding config object in cluster_config.

/nocl changelog added in the enterprise PR
/jpd Graylog2/graylog-plugin-enterprise#13770

## Description

## Motivation and Context
Part of https://github.com/Graylog2/graylog-plugin-enterprise/issues/13684

## How Has This Been Tested?
Manually


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

