### PR TITLE
Fix Event Key column showing blank in Events Overview Widget

### DIFF
--- a/changelog/unreleased/pr-25586.toml
+++ b/changelog/unreleased/pr-25586.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix Event Key column showing blank values in Events Overview Widget."
+
+issues = ["13374"]
+pulls = ["25586"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/CommonEventSummary.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/CommonEventSummary.java
@@ -35,6 +35,7 @@ public interface CommonEventSummary {
     String FIELD_ALERT = "alert";
     String FIELD_EVENT_DEFINITION_ID = "event_definition_id";
 
+    String FIELD_KEY = "key";
     String FIELD_PRIORITY = "priority";
     String FIELD_EVENT_KEYS = "event_keys";
     String FIELD_REPLAY_INFO = "replay_info";
@@ -56,6 +57,10 @@ public interface CommonEventSummary {
 
     @JsonProperty(FIELD_EVENT_DEFINITION_ID)
     String eventDefinitionId();
+
+    @Nullable
+    @JsonProperty(FIELD_KEY)
+    String key();
 
     @JsonProperty(FIELD_PRIORITY)
     Long priority();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventSummary.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventSummary.java
@@ -44,6 +44,7 @@ public abstract class EventSummary implements CommonEventSummary {
                 .timestamp(event.eventTimestamp())
                 .eventDefinitionId(event.eventDefinitionId())
                 .priority(event.priority())
+                .key(event.key())
                 .eventKeys(event.keyTuple())
                 .replayInfo(event.replayInfo())
                 .rawEvent(event)
@@ -81,6 +82,9 @@ public abstract class EventSummary implements CommonEventSummary {
 
         @JsonProperty(FIELD_EVENT_DEFINITION_ID)
         public abstract Builder eventDefinitionId(String eventDefinitionId);
+
+        @JsonProperty(FIELD_KEY)
+        public abstract Builder key(@Nullable String key);
 
         @JsonProperty(FIELD_PRIORITY)
         public abstract Builder priority(Long priority);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/eventlist/EventSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/eventlist/EventSummaryTest.java
@@ -33,30 +33,25 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventSummaryTest {
-
-    private EventDto buildTestEvent(DateTime timestamp, String key) {
-        return EventDto.builder()
+    @Test
+    public void testParseRawEvent() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final var streams = Set.of("stream-id-1", "stream-id-2");
+        final var rawEvent = EventDto.builder()
                 .id("dead-beef")
                 .message("message")
-                .sourceStreams(Set.of("stream-id-1", "stream-id-2"))
-                .eventTimestamp(timestamp)
+                .sourceStreams(streams)
+                .eventTimestamp(now)
                 .alert(false)
                 .eventDefinitionId("deadbeef")
                 .priority(2)
-                .key(key)
-                .keyTuple(key != null ? List.of(key) : List.of())
+                .keyTuple(List.of())
                 .eventDefinitionType("aggregation-v1")
-                .processingTimestamp(timestamp)
+                .processingTimestamp(now)
                 .streams(Set.of())
                 .source("localhost")
                 .fields(Map.of())
                 .build();
-    }
-
-    @Test
-    public void testParseRawEvent() {
-        final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final var rawEvent = buildTestEvent(now, null);
 
         EventSummary eventSummary = EventSummary.parse(rawEvent);
         assertThat(eventSummary.id()).isEqualTo("dead-beef");
@@ -70,7 +65,22 @@ public class EventSummaryTest {
     @Test
     public void parseShouldPreserveEventKey() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final var rawEvent = buildTestEvent(now, "testkey_1");
+        final var rawEvent = EventDto.builder()
+                .id("dead-beef")
+                .message("message")
+                .sourceStreams(Set.of("stream-id-1"))
+                .eventTimestamp(now)
+                .alert(false)
+                .eventDefinitionId("deadbeef")
+                .priority(2)
+                .key("testkey_1")
+                .keyTuple(List.of("testkey_1"))
+                .eventDefinitionType("aggregation-v1")
+                .processingTimestamp(now)
+                .streams(Set.of())
+                .source("localhost")
+                .fields(Map.of())
+                .build();
 
         EventSummary eventSummary = EventSummary.parse(rawEvent);
         assertThat(eventSummary.key()).isEqualTo("testkey_1");
@@ -79,7 +89,21 @@ public class EventSummaryTest {
     @Test
     public void parseShouldHandleNullEventKey() {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final var rawEvent = buildTestEvent(now, null);
+        final var rawEvent = EventDto.builder()
+                .id("dead-beef")
+                .message("message")
+                .sourceStreams(Set.of("stream-id-1"))
+                .eventTimestamp(now)
+                .alert(false)
+                .eventDefinitionId("deadbeef")
+                .priority(2)
+                .keyTuple(List.of())
+                .eventDefinitionType("aggregation-v1")
+                .processingTimestamp(now)
+                .streams(Set.of())
+                .source("localhost")
+                .fields(Map.of())
+                .build();
 
         EventSummary eventSummary = EventSummary.parse(rawEvent);
         assertThat(eventSummary.key()).isNull();
@@ -89,7 +113,22 @@ public class EventSummaryTest {
     public void serializedJsonShouldContainKeyField() throws Exception {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final var rawEvent = buildTestEvent(now, "testkey_1");
+        final var rawEvent = EventDto.builder()
+                .id("dead-beef")
+                .message("message")
+                .sourceStreams(Set.of("stream-id-1"))
+                .eventTimestamp(now)
+                .alert(false)
+                .eventDefinitionId("deadbeef")
+                .priority(2)
+                .key("testkey_1")
+                .keyTuple(List.of("testkey_1"))
+                .eventDefinitionType("aggregation-v1")
+                .processingTimestamp(now)
+                .streams(Set.of())
+                .source("localhost")
+                .fields(Map.of())
+                .build();
 
         EventSummary eventSummary = EventSummary.parse(rawEvent);
         final String json = objectMapper.writeValueAsString(eventSummary);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/eventlist/EventSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/eventlist/EventSummaryTest.java
@@ -16,10 +16,12 @@
  */
 package org.graylog.plugins.views.search.searchtypes.eventlist;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.events.event.EventDto;
 import org.graylog.plugins.views.search.searchtypes.events.EventSummary;
 import org.graylog2.plugin.Tools;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -31,25 +33,30 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EventSummaryTest {
-    @Test
-    public void testParseRawEvent() {
-        final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final var streams = Set.of("stream-id-1", "stream-id-2");
-        final var rawEvent = EventDto.builder()
+
+    private EventDto buildTestEvent(DateTime timestamp, String key) {
+        return EventDto.builder()
                 .id("dead-beef")
                 .message("message")
-                .sourceStreams(streams)
-                .eventTimestamp(now)
+                .sourceStreams(Set.of("stream-id-1", "stream-id-2"))
+                .eventTimestamp(timestamp)
                 .alert(false)
                 .eventDefinitionId("deadbeef")
                 .priority(2)
-                .keyTuple(List.of())
+                .key(key)
+                .keyTuple(key != null ? List.of(key) : List.of())
                 .eventDefinitionType("aggregation-v1")
-                .processingTimestamp(now)
+                .processingTimestamp(timestamp)
                 .streams(Set.of())
                 .source("localhost")
                 .fields(Map.of())
                 .build();
+    }
+
+    @Test
+    public void testParseRawEvent() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final var rawEvent = buildTestEvent(now, null);
 
         EventSummary eventSummary = EventSummary.parse(rawEvent);
         assertThat(eventSummary.id()).isEqualTo("dead-beef");
@@ -58,5 +65,34 @@ public class EventSummaryTest {
         assertThat(eventSummary.timestamp().toString(Tools.ES_DATE_FORMAT_FORMATTER))
                 .isEqualTo(now.toString(Tools.ES_DATE_FORMAT_FORMATTER));
         assertThat(eventSummary.alert()).isEqualTo(false);
+    }
+
+    @Test
+    public void parseShouldPreserveEventKey() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final var rawEvent = buildTestEvent(now, "testkey_1");
+
+        EventSummary eventSummary = EventSummary.parse(rawEvent);
+        assertThat(eventSummary.key()).isEqualTo("testkey_1");
+    }
+
+    @Test
+    public void parseShouldHandleNullEventKey() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final var rawEvent = buildTestEvent(now, null);
+
+        EventSummary eventSummary = EventSummary.parse(rawEvent);
+        assertThat(eventSummary.key()).isNull();
+    }
+
+    @Test
+    public void serializedJsonShouldContainKeyField() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final var rawEvent = buildTestEvent(now, "testkey_1");
+
+        EventSummary eventSummary = EventSummary.parse(rawEvent);
+        final String json = objectMapper.writeValueAsString(eventSummary);
+        assertThat(json).contains("\"key\":\"testkey_1\"");
     }
 }

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTableRow.test.tsx
@@ -30,6 +30,7 @@ jest.mock('hooks/useCurrentUser');
 const event = {
   id: 'event-id-1',
   event_definition_id: 'event-definition-id-1',
+  key: 'testkey_1',
   name: 'Event 1',
   status: null,
   assigned_to: null,

--- a/graylog2-web-interface/src/views/components/widgets/events/types.ts
+++ b/graylog2-web-interface/src/views/components/widgets/events/types.ts
@@ -22,6 +22,7 @@ export type EventListItem = {
   created_at: string;
   event_definition_id: string;
   id: string;
+  key: string | null;
   name: string;
   priority: number;
   status: string | null;


### PR DESCRIPTION
## Description
The Event Key column in the Events Overview Widget shows blank values. `EventSummary` was missing the `key` field from `EventDto`, so the JSON response contained `event_keys` (a list) but not the `key` string that the frontend attribute expected.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/13824

## Motivation and Context
Users adding the Key column to the Events Overview Widget see empty cells, even though the Event detail view correctly displays the key.

## How Has This Been Tested?
- Added backend unit tests (`EventSummaryTest`) verifying key parsing, null handling, and JSON serialization
- Frontend TypeScript compilation and existing tests pass
- Cross-repo Maven compilation verified

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.