### PR TITLE
Fix/os3/sorting on metrics does not break when used with timestamp grouping

### DIFF
--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandler.java
@@ -90,9 +90,12 @@ public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
 
                 DateHistogramAggregation.Builder aggBuilder = DateHistogramAggregation.builder()
                         .field(timeField)
-                        .order(mapOrders(ordering.orders()))
                         .format(DATE_TIME_FORMAT)
                         .timeZone(timeZone);
+                final HistogramOrder histogramOrder = mapOrders(ordering.orders());
+                if (histogramOrder != null) {
+                    aggBuilder.order(histogramOrder);
+                }
                 setInterval(aggBuilder, dateHistogramInterval);
 
                 DateHistogramAggregation aggregation = aggBuilder.build();
@@ -116,14 +119,20 @@ public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
 
     private HistogramOrder mapOrders(List<BucketOrder> orders) {
         HistogramOrder.Builder builder = HistogramOrder.builder();
-        orders.forEach(order -> {
+        boolean hasOrders = false;
+        for (BucketOrder order : orders) {
             if (order.type() == BucketOrder.Type.KEY) {
                 builder.key(order.order());
+                hasOrders = true;
             } else if (order.type() == BucketOrder.Type.COUNT) {
                 builder.count(order.order());
+                hasOrders = true;
             }
-        });
-        return builder.build();
+            // Note: AGGREGATION type ordering is not supported by HistogramOrder in the opensearch-java client.
+            // When only AGGREGATION orders are present, we return null to avoid sending an empty "order": {}
+            // which OpenSearch 3.x rejects with: [date_histogram] failed to parse field [order]
+        }
+        return hasOrders ? builder.build() : null;
     }
 
     private boolean isAllMessages(final TimeRange timerange) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandler.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandler.java
@@ -29,10 +29,12 @@ import org.graylog.storage.opensearch3.views.searchtypes.pivot.OSPivotBucketSpec
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.PivotBucket;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.AutoDateHistogramAggregation;
+import org.opensearch.client.opensearch._types.aggregations.BucketSortAggregation;
 import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramBucket;
@@ -42,7 +44,10 @@ import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
@@ -99,10 +104,20 @@ public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
                 setInterval(aggBuilder, dateHistogramInterval);
 
                 DateHistogramAggregation aggregation = aggBuilder.build();
+
+                // HistogramOrder only supports _key and _count ordering. For metric-based
+                // (AGGREGATION type) ordering, we use a bucket_sort pipeline aggregation.
+                final Map<String, Aggregation> allSortingAggs = new LinkedHashMap<>(ordering.sortingAggregations());
+                final List<SortOptions> bucketSortOptions = buildBucketSortOptions(ordering.orders());
+                if (!bucketSortOptions.isEmpty()) {
+                    allSortingAggs.put("bucket_sort_order", Aggregation.of(a ->
+                            a.bucketSort(BucketSortAggregation.of(bs -> bs.sort(bucketSortOptions)))));
+                }
+
                 MutableNamedAggregationBuilder builder = new MutableNamedAggregationBuilder(
                         name,
                         Aggregation.builder().dateHistogram(aggregation)
-                                .aggregations(ordering.sortingAggregations())
+                                .aggregations(allSortingAggs)
                 );
                 if (root == null && leaf == null) {
                     root = builder;
@@ -128,11 +143,19 @@ public class OSTimeHandler extends OSPivotBucketSpecHandler<Time> {
                 builder.count(order.order());
                 hasOrders = true;
             }
-            // Note: AGGREGATION type ordering is not supported by HistogramOrder in the opensearch-java client.
-            // When only AGGREGATION orders are present, we return null to avoid sending an empty "order": {}
-            // which OpenSearch 3.x rejects with: [date_histogram] failed to parse field [order]
+            // AGGREGATION type ordering is handled separately via bucket_sort pipeline aggregation,
+            // because HistogramOrder only supports _key and _count.
         }
+        // Return null when no KEY/COUNT orders to avoid an empty "order": {} which
+        // OpenSearch 3.x rejects with: [date_histogram] failed to parse field [order]
         return hasOrders ? builder.build() : null;
+    }
+
+    private List<SortOptions> buildBucketSortOptions(List<BucketOrder> orders) {
+        return orders.stream()
+                .filter(order -> order.type() == BucketOrder.Type.AGGREGATION)
+                .map(order -> SortOptions.of(s -> s.field(f -> f.field(order.name()).order(order.order()))))
+                .collect(Collectors.toList());
     }
 
     private boolean isAllMessages(final TimeRange timerange) {

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandlerTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/buckets/OSTimeHandlerTest.java
@@ -20,10 +20,13 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.engine.PivotAggsContext;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSort;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.AutoInterval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.DateInterval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Interval;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Time;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.MutableNamedAggregationBuilder;
@@ -34,9 +37,11 @@ import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,6 +118,58 @@ class OSTimeHandlerTest {
         assertEquals("foobar", builtAggregation.autoDateHistogram().field());
         assertEquals(DATE_TIME_FORMAT, builtAggregation.autoDateHistogram().format());
 
+    }
+
+    @Test
+    public void metricSortOnDateHistogramUsesBucketSort() throws InvalidRangeParametersException {
+        when(interval.toDateInterval(any())).thenReturn(DateInterval.days(1));
+        when(pivot.timerange()).thenReturn(Optional.empty());
+        when(query.timerange()).thenReturn(RelativeRange.create(300));
+
+        final Average avgSeries = Average.builder().field("some_field").build();
+        when(pivot.series()).thenReturn(List.of(avgSeries));
+        when(pivot.sort()).thenReturn(List.of(
+                SeriesSort.create("avg(some_field)", SortSpec.Direction.Descending)
+        ));
+        when(queryContext.seriesName(any(), any())).thenReturn("avg-some_field");
+
+        final var result = osTimeHandler.doCreateAggregation(
+                BucketSpecHandler.Direction.Row, "foobar", pivot, time, queryContext, query);
+
+        Aggregation agg = result.root().build();
+
+        // date_histogram should have no order (null) to avoid empty "order": {}
+        assertThat(agg.dateHistogram().order()).isNull();
+
+        // should contain a bucket_sort pipeline aggregation for the metric ordering
+        assertThat(agg.aggregations()).containsKey("bucket_sort_order");
+        assertThat(agg.aggregations().get("bucket_sort_order").isBucketSort()).isTrue();
+
+        var bucketSort = agg.aggregations().get("bucket_sort_order").bucketSort();
+        assertThat(bucketSort.sort()).hasSize(1);
+        assertThat(bucketSort.sort().getFirst().field().field()).isEqualTo("avg-some_field");
+        assertThat(bucketSort.sort().getFirst().field().order()).isEqualTo(SortOrder.Desc);
+    }
+
+    @Test
+    public void defaultSortUsesHistogramOrderWithNoExtraBucketSort() throws InvalidRangeParametersException {
+        when(interval.toDateInterval(any())).thenReturn(DateInterval.days(1));
+        when(pivot.timerange()).thenReturn(Optional.empty());
+        when(query.timerange()).thenReturn(RelativeRange.create(300));
+        when(pivot.sort()).thenReturn(List.of());
+        when(pivot.series()).thenReturn(List.of());
+
+        final var result = osTimeHandler.doCreateAggregation(
+                BucketSpecHandler.Direction.Row, "foobar", pivot, time, queryContext, query);
+
+        Aggregation agg = result.root().build();
+
+        // default sort: _key ascending via HistogramOrder
+        assertThat(agg.dateHistogram().order()).isNotNull();
+        assertThat(agg.dateHistogram().order().key()).isEqualTo(SortOrder.Asc);
+
+        // no bucket_sort needed for default ordering
+        assertThat(agg.aggregations()).doesNotContainKey("bucket_sort_order");
     }
 
 }


### PR DESCRIPTION
## Description
/nocl (OS3 is just about being released, so no one has experienced the problem hopefully)
Fixes https://github.com/Graylog2/graylog2-server/issues/25545

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

