### PR TITLE
Fix EventBus deadlock on transient MongoDB failures

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -74,7 +74,8 @@ public class MongoDbConfiguration {
 
     public MongoClientURI getMongoClientURI() {
         final MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder()
-                .connectionsPerHost(getMaxConnections());
+                .connectionsPerHost(getMaxConnections())
+                .socketTimeout(60000);
 
         return new MongoClientURI(uri, mongoClientOptionsBuilder);
     }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -18,6 +18,7 @@ package org.graylog2.events;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -157,6 +158,7 @@ public class ClusterEventPeriodical extends Periodical {
     }
 
     @Subscribe
+    @AllowConcurrentEvents
     public void publishClusterEvent(Object event) {
         if (event instanceof DeadEvent) {
             LOG.debug("Skipping DeadEvent on cluster event bus");

--- a/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
@@ -47,6 +47,14 @@ public class MongoDbConfigurationTest {
     }
 
     @Test
+    public void defaultSocketTimeoutIs60Seconds() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        new JadConfig(new InMemoryRepository(), configuration).process();
+
+        assertEquals(60000, configuration.getMongoClientURI().getOptions().getSocketTimeout());
+    }
+
+    @Test
     public void validateSucceedsIfUriIsMissing() throws RepositoryException, ValidationException {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(Collections.emptyMap()), configuration).process();


### PR DESCRIPTION
## Description
Added socket timeout to MongoDB client and enabled concurrent event handling in ClusterEventPeriodical. Prevents the system from hanging when MongoDB goes down.

## Motivation and Context
Fixes #25591

When MongoDB or DNS fails, connections would hang with no timeout and deadlock the event bus. This sets a 60-second socket timeout so operations fail fast instead of waiting forever. Also added @AllowConcurrentEvents so the event handler doesn't block on sequential processing.

## How Has This Been Tested?
Added a test for the socket timeout. Tested locally by taking down MongoDB to verify the system recovers without deadlocking.

## Screenshots (if appropriate)
N/A

## Types of changes
Bug fix

## Checklist
- [x] Code follows style guidelines
- [x] Tests added
- [x] Tested with MongoDB down, no deadlocks