### PR TITLE
Improve Collector certificate handling

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
@@ -177,7 +177,7 @@ public class CollectorCaService {
 
                 if (needsRenewal(curServerCert, now)) {
                     LOG.info("Renewing OTLP server certificate <{}> (expires {})", curServerCert.fingerprint(), curServerCert.notAfter());
-                    final var newServerCert = certificateService.save(createServerCert(builder, signingCert));
+                    final var newServerCert = certificateService.insert(createServerCert(builder, signingCert));
                     collectorsConfigService.save(ensureConfig().toBuilder()
                             .otlpServerCertId(newServerCert.id())
                             .build());

--- a/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
@@ -235,7 +235,7 @@ public class CollectorCaService {
         return entries.stream()
                 .filter(entry -> needle.fingerprint().equals(entry.fingerprint()))
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(() -> new IllegalArgumentException("No entry found with fingerprint: " + needle.fingerprint()));
     }
 
     private CertificateEntry createRootCert(CertificateBuilder builder) throws Exception {

--- a/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/CollectorCaService.java
@@ -32,8 +32,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
@@ -157,15 +159,17 @@ public class CollectorCaService {
                 final var curSigningCert = hierarchy.signingCert();
 
                 LOG.info("Renewing signing certificate <{}> (expires {})", curSigningCert.fingerprint(), curSigningCert.notAfter());
-                final var newSigningCert = certificateService.save(createSigningCert(builder, hierarchy.caCert()));
+                final var newSigningCert = createSigningCert(builder, hierarchy.caCert());
 
                 // Cascading renewal: re-issue OTLP server cert with the new signing cert
                 LOG.info("Re-issuing OTLP server certificate (signing cert renewed)");
-                final var newServerCert = certificateService.save(createServerCert(builder, newSigningCert));
+                final var newServerCert = createServerCert(builder, newSigningCert);
+
+                final var result = certificateService.insert(List.of(newSigningCert, newServerCert));
 
                 collectorsConfigService.save(ensureConfig().toBuilder()
-                        .signingCertId(newSigningCert.id())
-                        .otlpServerCertId(newServerCert.id())
+                        .signingCertId(selectByFingerprint(result, newSigningCert).id())
+                        .otlpServerCertId(selectByFingerprint(result, newServerCert).id())
                         .build());
             } else {
                 final var signingCert = hierarchy.signingCert();
@@ -209,16 +213,30 @@ public class CollectorCaService {
         try {
             final var builder = certificateService.builder();
 
-            final CertificateEntry caCert = certificateService.save(createRootCert(builder));
-            final CertificateEntry signingCert = certificateService.save(createSigningCert(builder, caCert));
-            final CertificateEntry serverCert = certificateService.save(createServerCert(builder, signingCert));
+            final var caCert = createRootCert(builder);
+            final var signingCert = createSigningCert(builder, caCert);
+            final var serverCert = createServerCert(builder, signingCert);
 
-            return new CaHierarchy(caCert, signingCert, serverCert);
+            final var result = certificateService.insert(List.of(caCert, signingCert, serverCert));
+
+            return new CaHierarchy(
+                    selectByFingerprint(result, caCert),
+                    selectByFingerprint(result, signingCert),
+                    selectByFingerprint(result, serverCert)
+            );
         } catch (Exception e) {
             throw new RuntimeException("Failed to create Collectors CA hierarchy", e);
         }
     }
 
+    private static CertificateEntry selectByFingerprint(Collection<CertificateEntry> entries, CertificateEntry needle) {
+        requireNonNull(needle, "needle can't be null");
+
+        return entries.stream()
+                .filter(entry -> needle.fingerprint().equals(entry.fingerprint()))
+                .findFirst()
+                .orElseThrow();
+    }
 
     private CertificateEntry createRootCert(CertificateBuilder builder) throws Exception {
         return builder.createRootCa(CA_CERT_CN, Algorithm.ED25519, CA_CERT_VALIDITY);

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateBuilder.java
@@ -52,9 +52,9 @@ import java.io.StringWriter;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.SecureRandom;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -482,8 +482,8 @@ public class CertificateBuilder {
                 encryptedValueService.encrypt(privateKeyPem),
                 certificatePem,
                 issuerChain,
-                null, // subjectDn - extracted on save
-                null, // issuerDn - extracted on save
+                certificate.getSubjectX500Principal().getName(),
+                certificate.getIssuerX500Principal().getName(),
                 certificate.getNotBefore().toInstant(),
                 certificate.getNotAfter().toInstant(),
                 Instant.now(clock)

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateEntry.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateEntry.java
@@ -56,11 +56,9 @@ public record CertificateEntry(
         @JsonProperty(FIELD_ISSUER_CHAIN)
         List<String> issuerChain,
 
-        @Nullable
         @JsonProperty(FIELD_SUBJECT_DN)
         String subjectDn,
 
-        @Nullable
         @JsonProperty(FIELD_ISSUER_DN)
         String issuerDn,
 

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
@@ -26,8 +26,6 @@ import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.security.encryption.EncryptedValueService;
 import org.graylog2.web.customization.CustomizationConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -48,7 +46,6 @@ import static org.graylog2.database.utils.MongoUtils.insertedIdsAsString;
 @Singleton
 public class CertificateService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CertificateService.class);
     private static final String COLLECTION_NAME = "pki_certificates";
 
     private final MongoCollection<CertificateEntry> collection;
@@ -132,7 +129,7 @@ public class CertificateService {
             throw new IllegalArgumentException("no entry should have an ID");
         }
 
-        final var ids = insertedIdsAsString(collection.insertMany(List.copyOf(entries)));
+        final var ids = insertedIdsAsString(collection.insertMany(entries));
 
         // Map the returned IDs to the given entries in order.
         return IntStream.range(0, entries.size())

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
@@ -19,10 +19,8 @@ package org.graylog.security.pki;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
-import com.mongodb.client.model.ReplaceOptions;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import org.bson.types.ObjectId;
 import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
@@ -103,25 +101,18 @@ public class CertificateService {
     }
 
     /**
-     * Saves a certificate entry to the database.
-     * If the entry has a null ID, it will be inserted as a new document.
-     * If the entry has an existing ID, it will replace the existing document.
+     * Inserts a new certificate entry into the database. If the given entity has a non-null ID, the method throws
+     * and exception.
      *
      * @param entry the certificate entry to save
      * @return the saved certificate entry with its ID
+     * @throws IllegalArgumentException when the given entry has a non-null ID
      */
-    public CertificateEntry save(CertificateEntry entry) {
-        // TODO: Switch CertificateEntry to BuildableMongoEntity and use MongoUtils#save
+    public CertificateEntry insert(CertificateEntry entry) {
         if (entry.id() == null) {
-            final String insertedId = insertedIdAsString(collection.insertOne(entry));
-            return entry.withId(insertedId);
+            return entry.withId(insertedIdAsString(collection.insertOne(entry)));
         } else {
-            collection.replaceOne(
-                    Filters.eq("_id", new ObjectId(entry.id())),
-                    entry,
-                    new ReplaceOptions().upsert(false)
-            );
-            return entry;
+            throw new IllegalArgumentException("new certificate entry should not have an ID");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
@@ -33,10 +33,12 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import static org.graylog2.database.utils.MongoUtils.insertedIdAsString;
+import static org.graylog2.database.utils.MongoUtils.insertedIds;
 
 /**
  * Service for managing certificate entries in MongoDB.
@@ -121,6 +123,28 @@ public class CertificateService {
             );
             return entry;
         }
+    }
+
+    /**
+     * Insert the given new certificate entries into the database. If any of the given entries has a non-null ID, the
+     * method throws an exception.
+     *
+     * @param entries the new entries to insert
+     * @return the inserted entries
+     * @throws IllegalArgumentException when any of the given entries has a non-null ID
+     */
+    public List<CertificateEntry> insert(Collection<CertificateEntry> entries) {
+        if (entries.isEmpty()) {
+            return List.of();
+        }
+        if (entries.stream().anyMatch(entry -> entry.id() != null)) {
+            throw new IllegalArgumentException("no entry should have an ID");
+        }
+
+        final var ids = insertedIds(collection.insertMany(List.copyOf(entries)));
+
+        // Just fetching the new entries is less error-prone than mapping the inserted IDs to the given entries.
+        return collection.find(Filters.in("_id", ids)).into(new ArrayList<>(ids.size()));
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
@@ -31,7 +31,6 @@ import org.graylog2.web.customization.CustomizationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.security.cert.X509Certificate;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,42 +109,16 @@ public class CertificateService {
      * @return the saved certificate entry with its ID
      */
     public CertificateEntry save(CertificateEntry entry) {
-        final CertificateEntry enriched = enrichWithDn(entry);
-        if (enriched.id() == null) {
-            final String insertedId = insertedIdAsString(collection.insertOne(enriched));
-            return enriched.withId(insertedId);
+        // TODO: Switch CertificateEntry to BuildableMongoEntity and use MongoUtils#save
+        if (entry.id() == null) {
+            final String insertedId = insertedIdAsString(collection.insertOne(entry));
+            return entry.withId(insertedId);
         } else {
             collection.replaceOne(
-                    Filters.eq("_id", new ObjectId(enriched.id())),
-                    enriched,
+                    Filters.eq("_id", new ObjectId(entry.id())),
+                    entry,
                     new ReplaceOptions().upsert(false)
             );
-            return enriched;
-        }
-    }
-
-    private CertificateEntry enrichWithDn(CertificateEntry entry) {
-        if (entry.subjectDn() != null && entry.issuerDn() != null) {
-            return entry;
-        }
-        try {
-            final X509Certificate cert = PemUtils.parseCertificate(entry.certificate());
-            return new CertificateEntry(
-                    entry.id(),
-                    entry.fingerprint(),
-                    entry.subjectKeyIdentifier(),
-                    entry.authorityKeyIdentifier(),
-                    entry.privateKey(),
-                    entry.certificate(),
-                    entry.issuerChain(),
-                    cert.getSubjectX500Principal().getName(),
-                    cert.getIssuerX500Principal().getName(),
-                    entry.notBefore(),
-                    entry.notAfter(),
-                    entry.createdAt()
-            );
-        } catch (Exception e) {
-            LOG.warn("Failed to extract DN from certificate: {}", e.getMessage());
             return entry;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateService.java
@@ -31,12 +31,12 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.graylog2.database.utils.MongoUtils.insertedIdAsString;
-import static org.graylog2.database.utils.MongoUtils.insertedIds;
+import static org.graylog2.database.utils.MongoUtils.insertedIdsAsString;
 
 /**
  * Service for managing certificate entries in MongoDB.
@@ -91,7 +91,7 @@ public class CertificateService {
      * <pre>{@code
      * CertificateEntry rootCa = certificateService.builder()
      *     .createRootCa("My Root CA", Algorithm.ED25519, Duration.ofDays(3650));
-     * rootCa = certificateService.save(rootCa);
+     * rootCa = certificateService.insert(rootCa);
      * }</pre>
      *
      * @return a new CertificateBuilder instance
@@ -102,7 +102,7 @@ public class CertificateService {
 
     /**
      * Inserts a new certificate entry into the database. If the given entity has a non-null ID, the method throws
-     * and exception.
+     * an exception.
      *
      * @param entry the certificate entry to save
      * @return the saved certificate entry with its ID
@@ -124,7 +124,7 @@ public class CertificateService {
      * @return the inserted entries
      * @throws IllegalArgumentException when any of the given entries has a non-null ID
      */
-    public List<CertificateEntry> insert(Collection<CertificateEntry> entries) {
+    public List<CertificateEntry> insert(List<CertificateEntry> entries) {
         if (entries.isEmpty()) {
             return List.of();
         }
@@ -132,10 +132,12 @@ public class CertificateService {
             throw new IllegalArgumentException("no entry should have an ID");
         }
 
-        final var ids = insertedIds(collection.insertMany(List.copyOf(entries)));
+        final var ids = insertedIdsAsString(collection.insertMany(List.copyOf(entries)));
 
-        // Just fetching the new entries is less error-prone than mapping the inserted IDs to the given entries.
-        return collection.find(Filters.in("_id", ids)).into(new ArrayList<>(ids.size()));
+        // Map the returned IDs to the given entries in order.
+        return IntStream.range(0, entries.size())
+                .mapToObj(idx -> entries.get(idx).withId(ids.get(idx)))
+                .toList();
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -94,14 +94,13 @@ public class MongoUtils<T extends MongoEntity> {
      * @return a list of the inserted object IDs. Fails if the IDs are not stored as {@link ObjectId}.
      */
     public static List<ObjectId> insertedIds(@Nonnull InsertManyResult result) {
-        final var ids = result.getInsertedIds().values();
-        if (ids.stream().anyMatch(Objects::isNull)) {
+        final var entries = result.getInsertedIds().entrySet();
+        if (entries.stream().map(Map.Entry::getValue).anyMatch(Objects::isNull)) {
             // This should only happen when inserting RawBsonDocuments
             throw new IllegalArgumentException("One of the inserted IDs is null. Make sure that you are inserting documents of " +
                     "type <? extends MongoEntity>.");
         }
-        return result.getInsertedIds().entrySet()
-                .stream()
+        return entries.stream()
                 .sorted(Comparator.comparingInt(Map.Entry::getKey))
                 .map(Map.Entry::getValue)
                 .map(value -> value.asObjectId().getValue())

--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -27,6 +27,7 @@ import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
 import jakarta.annotation.Nonnull;
 import org.bson.BsonValue;
@@ -38,9 +39,11 @@ import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoEntity;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,7 +62,7 @@ public class MongoUtils<T extends MongoEntity> {
     }
 
     /**
-     * Extract the inserted id of type {@link ObjectId} from the insert result.
+     * Extract the inserted ID of type {@link ObjectId} from the insert result.
      *
      * @param result Result object for inserting a document of type MongoEntity.
      * @return the inserted object ID. Fails if the id was not stored as an {@link ObjectId}.
@@ -75,13 +78,44 @@ public class MongoUtils<T extends MongoEntity> {
     }
 
     /**
-     * Extract the inserted id as a String from the insert result.
+     * Extract the inserted ID as a String from the insert result.
      *
      * @param result Result object for inserting a document of type MongoEntity.
      * @return the inserted object ID as string. Fails if the id was not stored as an {@link ObjectId}.
      */
     public static String insertedIdAsString(@Nonnull InsertOneResult result) {
         return insertedId(result).toHexString();
+    }
+
+    /**
+     * Extract the inserted IDs of type {@link ObjectId} from the insert result.
+     *
+     * @param result Result object for inserting many documents of type MongoEntity.
+     * @return a list of the inserted object IDs. Fails if the IDs are not stored as {@link ObjectId}.
+     */
+    public static List<ObjectId> insertedIds(@Nonnull InsertManyResult result) {
+        final var ids = result.getInsertedIds().values();
+        if (ids.stream().anyMatch(Objects::isNull)) {
+            // This should only happen when inserting RawBsonDocuments
+            throw new IllegalArgumentException("One of the inserted IDs is null. Make sure that you are inserting documents of " +
+                    "type <? extends MongoEntity>.");
+        }
+        return result.getInsertedIds().entrySet()
+                .stream()
+                .sorted(Comparator.comparingInt(Map.Entry::getKey))
+                .map(Map.Entry::getValue)
+                .map(value -> value.asObjectId().getValue())
+                .toList();
+    }
+
+    /**
+     * Extract the inserted IDs of type {@link ObjectId} from the insert result as strings.
+     *
+     * @param result Result object for inserting many documents of type MongoEntity.
+     * @return a list of the inserted object IDs as strings. Fails if the IDs are not stored as {@link ObjectId}.
+     */
+    public static List<String> insertedIdsAsString(@Nonnull InsertManyResult result) {
+        return insertedIds(result).stream().map(ObjectId::toHexString).toList();
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
@@ -173,21 +173,22 @@ class CertificateServiceTest {
 
     @Test
     void insertReturnsInsertedEntries() throws Exception {
-        final List<CertificateEntry> entries = List.of(
-                createCertificateEntry(null, "1"),
-                createCertificateEntry(null, "2"),
-                createCertificateEntry(null, "3")
-        );
+        final var newEntry1 = createCertificateEntry(null, "1");
+        final var newEntry2 = createCertificateEntry(null, "2");
+        final var newEntry3 = createCertificateEntry(null, "3");
+        final List<CertificateEntry> entries = List.of(newEntry1, newEntry2, newEntry3);
 
         final var insertedEntries = certificateService.insert(entries);
 
         assertThat(insertedEntries).hasSize(3);
 
-        assertThat(certificateService.findAll()).satisfiesExactly(
+        assertThat(insertedEntries).satisfiesExactly(
                 entry1 -> assertThat(entry1.subjectDn()).isEqualTo("O=Graylog,CN=1"),
                 entry2 -> assertThat(entry2.subjectDn()).isEqualTo("O=Graylog,CN=2"),
                 entry3 -> assertThat(entry3.subjectDn()).isEqualTo("O=Graylog,CN=3")
-        ).containsAll(insertedEntries);
+        );
+
+        assertThat(certificateService.findAll()).containsAll(insertedEntries);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
@@ -193,6 +193,42 @@ class CertificateServiceTest {
     }
 
     @Test
+    void insertReturnsInsertedEntries() throws Exception {
+        final List<CertificateEntry> entries = List.of(
+                createCertificateEntry(null, "1"),
+                createCertificateEntry(null, "2"),
+                createCertificateEntry(null, "3")
+        );
+
+        final var insertedEntries = certificateService.insert(entries);
+
+        assertThat(insertedEntries).hasSize(3);
+
+        assertThat(certificateService.findAll()).satisfiesExactly(
+                entry1 -> assertThat(entry1.subjectDn()).isEqualTo("O=Graylog,CN=1"),
+                entry2 -> assertThat(entry2.subjectDn()).isEqualTo("O=Graylog,CN=2"),
+                entry3 -> assertThat(entry3.subjectDn()).isEqualTo("O=Graylog,CN=3")
+        ).containsAll(insertedEntries);
+    }
+
+    @Test
+    void insertRejectsEntriesWithId() throws Exception {
+        final List<CertificateEntry> entries = List.of(
+                createCertificateEntry(null, "1"),
+                createCertificateEntry("64a7f8b9c0d1e2f3a4b5c6d7", "2")
+        );
+
+        assertThatThrownBy(() -> certificateService.insert(entries)).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(certificateService.findAll()).isEmpty();
+    }
+
+    @Test
+    void insertEmptyCollectionReturnsZero() {
+        assertThat(certificateService.insert(List.of())).isEmpty();
+    }
+
+    @Test
     void integrationTestWithBuilder() throws Exception {
         // Test the full workflow: create cert with builder, save, retrieve
         final CertificateEntry rootCa = certificateService.save(

--- a/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
@@ -17,6 +17,7 @@
 package org.graylog.security.pki;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoWriteException;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.testing.TestClocks;
 import org.graylog.testing.mongodb.MongoDBExtension;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link CertificateService} CRUD operations.
@@ -81,18 +83,18 @@ class CertificateServiceTest {
     }
 
     @Test
-    void saveInsertsCertificateEntryWithNullId() {
-        final CertificateEntry entry = createCertificateEntry(null, "SHA256:fingerprint1");
+    void saveInsertsCertificateEntryWithNullId() throws Exception {
+        final CertificateEntry entry = createCertificateEntry();
 
         final CertificateEntry saved = certificateService.save(entry);
 
         assertThat(saved.id()).isNotNull();
-        assertThat(saved.fingerprint()).isEqualTo("SHA256:fingerprint1");
+        assertThat(saved.fingerprint()).isEqualTo(entry.fingerprint());
     }
 
     @Test
-    void saveReplacesCertificateEntryWithExistingId() {
-        final CertificateEntry original = createCertificateEntry(null, "SHA256:original");
+    void saveReplacesCertificateEntryWithExistingId() throws Exception {
+        final CertificateEntry original = createCertificateEntry();
         final CertificateEntry saved = certificateService.save(original);
         final String savedId = saved.id();
 
@@ -104,8 +106,8 @@ class CertificateServiceTest {
                 createEncryptedValue(),
                 "-----BEGIN CERTIFICATE-----\nUPDATED\n-----END CERTIFICATE-----",
                 List.of(),
-                null,
-                null,
+                "subject-dn",
+                "issuer-dn",
                 Instant.parse("2024-01-01T00:00:00Z"),
                 Instant.parse("2025-01-01T00:00:00Z"),
                 Instant.parse("2024-01-01T00:00:00Z")
@@ -125,15 +127,15 @@ class CertificateServiceTest {
     }
 
     @Test
-    void findByIdReturnsSavedCertificateEntry() {
-        final CertificateEntry entry = createCertificateEntry(null, "SHA256:findbyid");
+    void findByIdReturnsSavedCertificateEntry() throws Exception {
+        final CertificateEntry entry = createCertificateEntry();
         final CertificateEntry saved = certificateService.save(entry);
 
         final Optional<CertificateEntry> result = certificateService.findById(saved.id());
 
         assertThat(result).isPresent();
         assertThat(result.get().id()).isEqualTo(saved.id());
-        assertThat(result.get().fingerprint()).isEqualTo("SHA256:findbyid");
+        assertThat(result.get().fingerprint()).isEqualTo(entry.fingerprint());
     }
 
     @Test
@@ -143,45 +145,21 @@ class CertificateServiceTest {
     }
 
     @Test
-    void findByFingerprintReturnsSavedCertificateEntry() {
-        final CertificateEntry entry = createCertificateEntry(null, "SHA256:byfingerprint");
+    void findByFingerprintReturnsSavedCertificateEntry() throws Exception {
+        final CertificateEntry entry = certificateService.save(createCertificateEntry());
+
+        final Optional<CertificateEntry> result = certificateService.findByFingerprint(entry.fingerprint());
+
+        assertThat(result).get().satisfies(found -> assertThat(found.id()).isEqualTo(entry.id()));
+    }
+
+    @Test
+    void fingerprintIsUnique() throws Exception {
+        final CertificateEntry entry = createCertificateEntry();
         certificateService.save(entry);
 
-        final Optional<CertificateEntry> result = certificateService.findByFingerprint("SHA256:byfingerprint");
-
-        assertThat(result).isPresent();
-        assertThat(result.get().fingerprint()).isEqualTo("SHA256:byfingerprint");
-    }
-
-    @Test
-    void fingerprintIsUnique() {
-        final CertificateEntry entry1 = createCertificateEntry(null, "SHA256:unique");
-        certificateService.save(entry1);
-
-        final CertificateEntry entry2 = createCertificateEntry(null, "SHA256:unique");
-
-        org.junit.jupiter.api.Assertions.assertThrows(
-                com.mongodb.MongoWriteException.class,
-                () -> certificateService.save(entry2)
-        );
-    }
-
-    @Test
-    void saveExtractsSubjectAndIssuerDn() throws Exception {
-        final CertificateEntry rootCa = certificateService.builder()
-                .createRootCa("Test Root CA", Algorithm.ED25519, Duration.ofDays(365));
-
-        assertThat(rootCa.subjectDn()).isNull();
-        assertThat(rootCa.issuerDn()).isNull();
-
-        final CertificateEntry saved = certificateService.save(rootCa);
-
-        assertThat(saved.subjectDn()).contains("Test Root CA");
-        assertThat(saved.issuerDn()).contains("Test Root CA"); // self-signed
-
-        final CertificateEntry loaded = certificateService.findById(saved.id()).orElseThrow();
-        assertThat(loaded.subjectDn()).isEqualTo(saved.subjectDn());
-        assertThat(loaded.issuerDn()).isEqualTo(saved.issuerDn());
+        assertThatThrownBy(() -> certificateService.save(entry.withId(null)))
+                .isInstanceOf(MongoWriteException.class);
     }
 
     @Test
@@ -229,21 +207,12 @@ class CertificateServiceTest {
         assertThat(retrieved.get().fingerprint()).isEqualTo(rootCa.fingerprint());
     }
 
-    private CertificateEntry createCertificateEntry(String id, String fingerprint) {
-        return new CertificateEntry(
-                id,
-                fingerprint,
-                "ski",
-                Optional.of("aki"),
-                createEncryptedValue(),
-                "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----",
-                List.of("-----BEGIN CERTIFICATE-----\nISSUER\n-----END CERTIFICATE-----"),
-                null,
-                null,
-                Instant.parse("2024-01-01T00:00:00Z"),
-                Instant.parse("2025-01-01T00:00:00Z"),
-                Instant.parse("2024-01-01T00:00:00Z")
-        );
+    private CertificateEntry createCertificateEntry() throws Exception {
+        return createCertificateEntry(null, "common-name");
+    }
+
+    private CertificateEntry createCertificateEntry(String id, String commonName) throws Exception {
+        return certificateService.builder().createRootCa(commonName, Algorithm.ED25519, Duration.ofDays(1)).withId(id);
     }
 
     private EncryptedValue createEncryptedValue() {

--- a/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
@@ -25,7 +25,6 @@ import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.jackson.InputConfigurationBeanDeserializerModifier;
-import org.graylog2.security.encryption.EncryptedValue;
 import org.graylog2.security.encryption.EncryptedValueService;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.web.customization.CustomizationConfig;
@@ -229,14 +228,5 @@ class CertificateServiceTest {
 
     private CertificateEntry createCertificateEntry(String id, String commonName) throws Exception {
         return certificateService.builder().createRootCa(commonName, Algorithm.ED25519, Duration.ofDays(1)).withId(id);
-    }
-
-    private EncryptedValue createEncryptedValue() {
-        return EncryptedValue.builder()
-                .value("2d043f9a7d5a5a7537d3e93c93c5dc40")
-                .salt("c93c0263bfc3713d")
-                .isKeepValue(false)
-                .isDeleteValue(false)
-                .build();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/CertificateServiceTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -83,41 +82,21 @@ class CertificateServiceTest {
     }
 
     @Test
-    void saveInsertsCertificateEntryWithNullId() throws Exception {
+    void insertInsertsCertificateEntryWithNullId() throws Exception {
         final CertificateEntry entry = createCertificateEntry();
 
-        final CertificateEntry saved = certificateService.save(entry);
+        final CertificateEntry saved = certificateService.insert(entry);
 
         assertThat(saved.id()).isNotNull();
         assertThat(saved.fingerprint()).isEqualTo(entry.fingerprint());
     }
 
     @Test
-    void saveReplacesCertificateEntryWithExistingId() throws Exception {
+    void insertCertificateWithExistingIdFails() throws Exception {
         final CertificateEntry original = createCertificateEntry();
-        final CertificateEntry saved = certificateService.save(original);
-        final String savedId = saved.id();
+        final CertificateEntry saved = certificateService.insert(original);
 
-        final CertificateEntry updated = new CertificateEntry(
-                savedId,
-                "SHA256:updated",
-                "ski",
-                Optional.of("aki"),
-                createEncryptedValue(),
-                "-----BEGIN CERTIFICATE-----\nUPDATED\n-----END CERTIFICATE-----",
-                List.of(),
-                "subject-dn",
-                "issuer-dn",
-                Instant.parse("2024-01-01T00:00:00Z"),
-                Instant.parse("2025-01-01T00:00:00Z"),
-                Instant.parse("2024-01-01T00:00:00Z")
-        );
-
-        final CertificateEntry result = certificateService.save(updated);
-
-        assertThat(result.id()).isEqualTo(savedId);
-        assertThat(result.fingerprint()).isEqualTo("SHA256:updated");
-        assertThat(result.certificate()).isEqualTo("-----BEGIN CERTIFICATE-----\nUPDATED\n-----END CERTIFICATE-----");
+        assertThatThrownBy(() -> certificateService.insert(saved)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -129,7 +108,7 @@ class CertificateServiceTest {
     @Test
     void findByIdReturnsSavedCertificateEntry() throws Exception {
         final CertificateEntry entry = createCertificateEntry();
-        final CertificateEntry saved = certificateService.save(entry);
+        final CertificateEntry saved = certificateService.insert(entry);
 
         final Optional<CertificateEntry> result = certificateService.findById(saved.id());
 
@@ -146,7 +125,7 @@ class CertificateServiceTest {
 
     @Test
     void findByFingerprintReturnsSavedCertificateEntry() throws Exception {
-        final CertificateEntry entry = certificateService.save(createCertificateEntry());
+        final CertificateEntry entry = certificateService.insert(createCertificateEntry());
 
         final Optional<CertificateEntry> result = certificateService.findByFingerprint(entry.fingerprint());
 
@@ -156,20 +135,20 @@ class CertificateServiceTest {
     @Test
     void fingerprintIsUnique() throws Exception {
         final CertificateEntry entry = createCertificateEntry();
-        certificateService.save(entry);
+        certificateService.insert(entry);
 
-        assertThatThrownBy(() -> certificateService.save(entry.withId(null)))
+        assertThatThrownBy(() -> certificateService.insert(entry.withId(null)))
                 .isInstanceOf(MongoWriteException.class);
     }
 
     @Test
     void saveExtractsDnForIntermediateCa() throws Exception {
-        final CertificateEntry rootCa = certificateService.save(
+        final CertificateEntry rootCa = certificateService.insert(
                 certificateService.builder().createRootCa("Root", Algorithm.ED25519, Duration.ofDays(365)));
 
         final CertificateEntry intermediate = certificateService.builder()
                 .createIntermediateCa("Intermediate", rootCa, Duration.ofDays(180));
-        final CertificateEntry saved = certificateService.save(intermediate);
+        final CertificateEntry saved = certificateService.insert(intermediate);
 
         assertThat(saved.subjectDn()).contains("Intermediate");
         assertThat(saved.issuerDn()).contains("Root");
@@ -182,7 +161,7 @@ class CertificateServiceTest {
 
     @Test
     void findBySubjectKeyIdentifierReturnsSavedCertificateEntry() throws Exception {
-        final CertificateEntry saved = certificateService.save(
+        final CertificateEntry saved = certificateService.insert(
                 certificateService.builder().createRootCa("SKI Test CA", Algorithm.ED25519, Duration.ofDays(365)));
 
         final var result = certificateService.findBySubjectKeyIdentifier(saved.subjectKeyIdentifier());
@@ -231,7 +210,7 @@ class CertificateServiceTest {
     @Test
     void integrationTestWithBuilder() throws Exception {
         // Test the full workflow: create cert with builder, save, retrieve
-        final CertificateEntry rootCa = certificateService.save(
+        final CertificateEntry rootCa = certificateService.insert(
                 certificateService.builder().createRootCa("Test CA", Algorithm.ED25519, Duration.ofDays(365))
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/utils/MongoUtilsTest.java
@@ -56,6 +56,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.graylog2.database.utils.MongoUtils.idEq;
 import static org.graylog2.database.utils.MongoUtils.insertedId;
 import static org.graylog2.database.utils.MongoUtils.insertedIdAsString;
+import static org.graylog2.database.utils.MongoUtils.insertedIds;
+import static org.graylog2.database.utils.MongoUtils.insertedIdsAsString;
 import static org.graylog2.database.utils.MongoUtils.stringIdsIn;
 
 @ExtendWith(MongoDBExtension.class)
@@ -104,6 +106,58 @@ class MongoUtilsTest {
         final var rawCollection = mongoCollections.nonEntityCollection("raw_bson_test", RawBsonDocument.class);
         final RawBsonDocument doc = RawBsonDocument.parse("{\"name\":\"a\"}");
         assertThatThrownBy(() -> insertedId(rawCollection.insertOne(doc)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MongoEntity");
+    }
+
+    @Test
+    void testInsertedIds() {
+        final var idZero = new ObjectId("000000000000000000000000");
+        final var id1 = new ObjectId("000000000000000000000001");
+        final var id2 = new ObjectId("000000000000000000000002");
+
+        final var dto1 = new DTO(id1.toHexString(), "a");
+        final var dto2 = new DTO(id2.toHexString(), "b");
+        final var nullIdDto1 = new DTO(null, "a");
+        final var nullIdDto2 = new DTO(null, "b");
+
+        assertThat(insertedIds(collection.insertMany(List.of(dto1, dto2)))).isEqualTo(List.of(id1, id2));
+
+        assertThat(insertedIds(collection.insertMany(List.of(nullIdDto1, nullIdDto2))))
+                .satisfiesExactly(
+                        insertedId1 -> assertThat(insertedId1).isGreaterThan(idZero),
+                        insertedId2 -> assertThat(insertedId2).isGreaterThan(idZero)
+                );
+    }
+
+    @Test
+    void testInsertedIdsAsString() {
+        final var idZero = new ObjectId("000000000000000000000000");
+        final var id1 = new ObjectId("000000000000000000000001");
+        final var id2 = new ObjectId("000000000000000000000002");
+
+        final var dto1 = new DTO(id1.toHexString(), "a");
+        final var dto2 = new DTO(id2.toHexString(), "b");
+        final var nullIdDto1 = new DTO(null, "a");
+        final var nullIdDto2 = new DTO(null, "b");
+
+        assertThat(insertedIdsAsString(collection.insertMany(List.of(dto1, dto2))))
+                .isEqualTo(List.of(id1.toHexString(), id2.toHexString()));
+
+        assertThat(insertedIdsAsString(collection.insertMany(List.of(nullIdDto1, nullIdDto2))))
+                .satisfiesExactly(
+                        insertedId1 -> assertThat(insertedId1).isGreaterThan(idZero.toHexString()),
+                        insertedId2 -> assertThat(insertedId2).isGreaterThan(idZero.toHexString())
+                );
+    }
+
+    @Test
+    void testNullInsertedIds() {
+        final var rawCollection = mongoCollections.nonEntityCollection("raw_bson_test", RawBsonDocument.class);
+        final var doc1 = RawBsonDocument.parse("{\"name\":\"a\"}");
+        final var doc2 = RawBsonDocument.parse("{\"name\":\"b\"}");
+
+        assertThatThrownBy(() -> insertedIds(rawCollection.insertMany(List.of(doc1, doc2))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("MongoEntity");
     }


### PR DESCRIPTION
  - Replace `CertificateService#save` (insert-or-replace) with `#insert` that only supports new entries                     
  - Move subject/issuer DN extraction from save-time into `CertificateBuilder`, so `CertificateEntry` fields are fully populated at creation
  - Add `CertificateService#insert(List<CertificateEntry>)` for batch inserts, used by `CollectorCaService` to persist entire CA hierarchies in one call                    
  - Add `MongoUtils#insertedIds` / `#insertedIdsAsString` helpers for `InsertManyResult`

/nocl Updates to an unreleased feature