### PR TITLE
Fix datanode metrics permissions for cluster configuration reader role

### DIFF
--- a/changelog/unreleased/pr-25624.toml
+++ b/changelog/unreleased/pr-25624.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix data node metrics permissions for cluster configuration reader role."
+
+issues = ["Graylog2/graylog-plugin-enterprise#13538"]
+pulls = ["25624"]

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datanode/ProxyRequestAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datanode/ProxyRequestAdapter.java
@@ -17,13 +17,18 @@
 package org.graylog2.indexer.datanode;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.apache.shiro.subject.Subject;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 public interface ProxyRequestAdapter {
     record ProxyRequest(String method, String path, InputStream body, String hostname,
-                        MultivaluedMap<String, String> queryParameters) {}
+                        MultivaluedMap<String, String> queryParameters, Subject subject) {
+        public ProxyRequest(String method, String path, InputStream body, String hostname, MultivaluedMap<String, String> queryParameters) {
+            this(method, path, body, hostname, queryParameters, null);
+        }
+    }
 
     record ProxyResponse(int status, InputStream response, String contentType) {}
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
@@ -54,12 +54,16 @@ import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 @RequiresPermissions(RestPermissions.DATANODE_REST_PROXY)
 public class DataNodeRestApiProxyResource extends RestResource {
     private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
-            request -> request.path().startsWith("indices-directory") && "GET".equals(request.method()),
-            request -> request.path().startsWith("logs") && "GET".equals(request.method()),
-            request -> request.path().startsWith("metrics") && "GET".equals(request.method()),
-            request -> request.path().startsWith("metrics") && "POST".equals(request.method()),
-            request -> request.path().startsWith("connection-check") && "POST".equals(request.method())
+            request -> isAllowed(request, "indices-directory", "GET", RestPermissions.DATANODE_MIGRATION),
+            request -> isAllowed(request, "logs", "GET", RestPermissions.CLUSTER_CONFIGURATION_READ),
+            request -> isAllowed(request, "metrics", "GET", RestPermissions.CLUSTER_CONFIGURATION_READ),
+            request -> isAllowed(request, "metrics", "POST", RestPermissions.CLUSTER_CONFIGURATION_READ),
+            request -> isAllowed(request, "connection-check", "POST", RestPermissions.CLUSTER_CONFIGURATION_READ)
     );
+
+    private static boolean isAllowed(ProxyRequestAdapter.ProxyRequest request, String path, String method, String permission) {
+        return request.path().startsWith(path) && method.equals(request.method()) && (request.subject() != null && request.subject().isPermitted(permission));
+    }
 
     private final DatanodeRestApiProxy proxyRequestAdapter;
     private final boolean enableAllowlist;
@@ -117,7 +121,7 @@ public class DataNodeRestApiProxyResource extends RestResource {
     }
 
     private Response request(ContainerRequestContext context, String path, String hostname) throws IOException {
-        final var request = new ProxyRequestAdapter.ProxyRequest(context.getMethod(), path, context.getEntityStream(), hostname, context.getUriInfo().getQueryParameters());
+        final var request = new ProxyRequestAdapter.ProxyRequest(context.getMethod(), path, context.getEntityStream(), hostname, context.getUriInfo().getQueryParameters(), getSubject());
         if (enableAllowlist && allowList.stream().noneMatch(condition -> condition.test(request))) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("This request is not allowed.")

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -394,7 +394,7 @@ public class RestPermissions implements PluginPermissions {
                     RestPermissions.USERS_READ, RestPermissions.USERS_LIST
             )),
             BuiltinRole.create("Cluster Configuration Reader", "Allows viewing the Cluster Configuration page", ImmutableSet.of(
-                    RestPermissions.CLUSTER_CONFIGURATION_READ
+                    RestPermissions.CLUSTER_CONFIGURATION_READ, RestPermissions.DATANODE_REST_PROXY
             )),
             BuiltinRole.create("API Browser Reader", "Allows viewing the API browser page", ImmutableSet.of(
                     RestPermissions.API_BROWSER_READ


### PR DESCRIPTION
## Description
Add access to datanode rest proxy for Cluster Configuration Reader role for accessing datanode information.
Also adds another, more granular permission check for the individual endpoints listed in the allowlist. 

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/13538

## How Has This Been Tested?
view cluster configuration page with user having cluster configuration reader role only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

