### PR TITLE
Fix inclusion correct inclusion of "_first" and "_last" into sorting direction in OpenSearch 3 client usage

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7.java
@@ -264,7 +264,7 @@ public class MoreSearchAdapterES7 implements MoreSearchAdapter {
         return QueryBuilders.multiMatchQuery(value, field);
     }
 
-    private List<FieldSortBuilder> createSorting(Sorting sorting) {
+    List<FieldSortBuilder> createSorting(Sorting sorting) {
         final SortOrder order = SortOrder.valueOf(sorting.getUppercasedDirection());
         final List<FieldSortBuilder> sortBuilders;
         if (EventDto.FIELD_TIMERANGE_START.equals(sorting.getField())) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7Test.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MoreSearchAdapterES7Test.java
@@ -20,14 +20,31 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.MultiMatc
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.RangeQueryBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.sort.FieldSortBuilder;
+import org.graylog2.indexer.searches.Sorting;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class MoreSearchAdapterES7Test {
     private static final String FIELD = "field";
     private static final String VALUE = "100";
+    private MoreSearchAdapterES7 adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new MoreSearchAdapterES7(
+                null,
+                null,  // opensearchClient - not needed for sorting tests
+                true,  // allowLeadingWildcard
+                null  // multiChunkResultRetriever - not needed for sorting tests
+        );
+    }
 
     @Test
     void testBuildExtraFilter() {
@@ -36,6 +53,45 @@ class MoreSearchAdapterES7Test {
         verifyFilter("<100", QueryBuilders.rangeQuery(FIELD).lt(VALUE), RangeQueryBuilder.class);
         verifyFilter(">100", QueryBuilders.rangeQuery(FIELD).gt(VALUE), RangeQueryBuilder.class);
         verifyFilter(VALUE, QueryBuilders.multiMatchQuery(VALUE, FIELD), MultiMatchQueryBuilder.class);
+    }
+
+    @Test
+    void testSortingWithUnmappedTypeAscShouldUseMissingFirst() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC, "date");
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isEqualTo("_first");
+    }
+
+    @Test
+    void testSortingWithUnmappedTypeDescShouldUseMissingLast() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.DESC, "date");
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isEqualTo("_last");
+    }
+
+    @Test
+    void testSortingWithoutUnmappedTypeShouldHaveNoMissingValue() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC);
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isNull();
     }
 
     private static void verifyFilter(String value, QueryBuilder expectedFilter, Class<? extends QueryBuilder> expectedFilterClass) {

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2.java
@@ -263,7 +263,7 @@ public class MoreSearchAdapterOS2 implements MoreSearchAdapter {
         return QueryBuilders.multiMatchQuery(value, field);
     }
 
-    private List<FieldSortBuilder> createSorting(Sorting sorting) {
+    List<FieldSortBuilder> createSorting(Sorting sorting) {
         final SortOrder order = SortOrder.valueOf(sorting.getUppercasedDirection());
         final List<FieldSortBuilder> sortBuilders;
         if (EventDto.FIELD_TIMERANGE_START.equals(sorting.getField())) {

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2Test.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/MoreSearchAdapterOS2Test.java
@@ -20,14 +20,31 @@ import org.graylog.shaded.opensearch2.org.opensearch.index.query.MultiMatchQuery
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.RangeQueryBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.sort.FieldSortBuilder;
+import org.graylog2.indexer.searches.Sorting;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class MoreSearchAdapterOS2Test {
     private static final String FIELD = "field";
     private static final String VALUE = "100";
+    private MoreSearchAdapterOS2 adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new MoreSearchAdapterOS2(
+                null,  // opensearchClient - not needed for sorting tests
+                true,  // allowLeadingWildcard
+                null,  // multiChunkResultRetriever - not needed for sorting tests
+                null
+        );
+    }
 
     @Test
     void testBuildExtraFilter() {
@@ -36,6 +53,45 @@ class MoreSearchAdapterOS2Test {
         verifyFilter("<100", QueryBuilders.rangeQuery(FIELD).lt(VALUE), RangeQueryBuilder.class);
         verifyFilter(">100", QueryBuilders.rangeQuery(FIELD).gt(VALUE), RangeQueryBuilder.class);
         verifyFilter(VALUE, QueryBuilders.multiMatchQuery(VALUE, FIELD), MultiMatchQueryBuilder.class);
+    }
+
+    @Test
+    void testSortingWithUnmappedTypeAscShouldUseMissingFirst() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC, "date");
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isEqualTo("_first");
+    }
+
+    @Test
+    void testSortingWithUnmappedTypeDescShouldUseMissingLast() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.DESC, "date");
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isEqualTo("_last");
+    }
+
+    @Test
+    void testSortingWithoutUnmappedTypeShouldHaveNoMissingValue() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC);
+
+        // When
+        final List<FieldSortBuilder> sortOptions = adapter.createSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).missing()).isNull();
     }
 
     private static void verifyFilter(String value, QueryBuilder expectedFilter, Class<? extends QueryBuilder> expectedFilterClass) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
@@ -302,27 +302,26 @@ public class MoreSearchAdapterOS implements MoreSearchAdapter {
         if (EventDto.FIELD_TIMERANGE_START.equals(sorting.getField())) {
             // When sorting by timerange start, add two separate sort clauses
             return List.of(
-                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(EventDto.FIELD_TIMERANGE_START).order(order), sorting))),
-                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(EventDto.FIELD_TIMERANGE_END).order(order), sorting)))
+                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(EventDto.FIELD_TIMERANGE_START).order(order), sorting, order))),
+                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(EventDto.FIELD_TIMERANGE_END).order(order), sorting, order)))
             );
         } else {
             return List.of(
-                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(sorting.getField()).order(order), sorting)))
+                    SortOptions.of(builder -> builder.field(sort -> withUnmapped(sort.field(sorting.getField()).order(order), sorting, order)))
             );
         }
     }
 
-    private FieldSort.Builder withUnmapped(FieldSort.Builder builder, Sorting sorting) {
+    private FieldSort.Builder withUnmapped(FieldSort.Builder builder, Sorting sorting, org.opensearch.client.opensearch._types.SortOrder order) {
         return sorting.getUnmappedType()
                 .map(unmappedType -> builder
                         .unmappedType(fieldType(unmappedType))
-                        .missing(missingValue(sorting)))
+                        .missing(missingValue(order)))
                 .orElse(builder);
     }
 
-    private FieldValue missingValue(Sorting sorting) {
-        final boolean first = SortOrder.Asc.name().equalsIgnoreCase(sorting.getUppercasedDirection());
-        return FieldValue.of(first ? "_first" : "_last");
+    private FieldValue missingValue(org.opensearch.client.opensearch._types.SortOrder order) {
+        return FieldValue.of(order.equals(SortOrder.Asc) ? "_first" : "_last");
     }
 
     private FieldType fieldType(String typeName) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/MoreSearchAdapterOS.java
@@ -321,7 +321,7 @@ public class MoreSearchAdapterOS implements MoreSearchAdapter {
     }
 
     private FieldValue missingValue(Sorting sorting) {
-        final boolean first = sorting.getUppercasedDirection().equals(SortOrder.Asc.name());
+        final boolean first = SortOrder.Asc.name().equalsIgnoreCase(sorting.getUppercasedDirection());
         return FieldValue.of(first ? "_first" : "_last");
     }
 

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/MoreSearchAdapterOSTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/MoreSearchAdapterOSTest.java
@@ -109,6 +109,45 @@ class MoreSearchAdapterOSTest {
         assertThat(sortOptionsDesc.get(0).field().order().jsonValue()).isEqualTo("desc");
     }
 
+    @Test
+    void testSortingWithUnmappedTypeAscShouldUseMissingFirst() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC, "date");
+
+        // When
+        final List<SortOptions> sortOptions = adapter.newCreateSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).field().missing().stringValue()).isEqualTo("_first");
+    }
+
+    @Test
+    void testSortingWithUnmappedTypeDescShouldUseMissingLast() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.DESC, "date");
+
+        // When
+        final List<SortOptions> sortOptions = adapter.newCreateSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).field().missing().stringValue()).isEqualTo("_last");
+    }
+
+    @Test
+    void testSortingWithoutUnmappedTypeShouldHaveNoMissingValue() {
+        // Given
+        final Sorting sorting = new Sorting("some_field", Sorting.Direction.ASC);
+
+        // When
+        final List<SortOptions> sortOptions = adapter.newCreateSorting(sorting);
+
+        // Then
+        assertThat(sortOptions).hasSize(1);
+        assertThat(sortOptions.get(0).field().missing()).isNull();
+    }
+
     private static void verifyFilter(String value, Query expected) {
         Query generatedQuery = MoreSearchAdapterOS.buildExtraFilter(FIELD, value);
         Assertions.assertThat(generatedQuery)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
@@ -65,15 +65,4 @@ public class Sorting {
     public Optional<String> getUnmappedType() {
         return Optional.ofNullable(this.unmappedType);
     }
-
-    public static Sorting fromApiParam(String param) {
-        if (param == null || !param.contains(":")) {
-            throw new IllegalArgumentException("Invalid sorting parameter: " + param);
-        }
-
-        String[] parts = param.split(":");
-
-        return new Sorting(parts[0], Direction.valueOf(parts[1].toUpperCase(Locale.ENGLISH)));
-    }
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Due to a mistake in the string comparison, the `_first` and `_last` setting was not correct in the OS3 client usage.
I find the usage of `getUppercaseDirection()` unfortunate as we know, the string is lowercase in the client library. But I did not want to introduce a new method and opted for making both comparisons in this class at least work the same.

I also remove `fromApiParam()` which is not used at all.

to my reviewers: I'm open to suggestions to make this more readable.

/nocl as it's in unreleased feature

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

