### PR TITLE
Fix issue when change event definition from Create Events for Definition if to Filter has results

### DIFF
--- a/changelog/unreleased/issue-22866.toml
+++ b/changelog/unreleased/issue-22866.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix switching event definitions between aggregation and filter conditions so stale aggregation settings are cleared and previous aggregation conditions can be restored when switching back."
+
+pulls = ["25643"]
+issues = ["22866", "22115"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'wrappedTestingLibrary';
+import { defaultUser } from 'defaultMockValues';
+
+import { simpleEventDefinition } from 'fixtures/eventDefinition';
+
+import FilterAggregationForm from './FilterAggregationForm';
+
+jest.mock('./FilterForm', () => () => <div>Filter form</div>);
+jest.mock('./FilterPreviewContainer', () => () => <div>Filter preview</div>);
+jest.mock('./AggregationForm', () => () => <div>Aggregation form</div>);
+
+describe('FilterAggregationForm', () => {
+  const aggregationConfig = {
+    ...simpleEventDefinition.config,
+    group_by: ['source'],
+    series: [{ id: 'count()', type: 'count', field: '' }],
+    conditions: { expression: { expr: 'number', value: 5 } },
+    event_limit: 1000,
+  };
+
+  const renderForm = (config = aggregationConfig, onChange = jest.fn()) =>
+    render(
+      <FilterAggregationForm
+        entityTypes={{ aggregation_functions: [] }}
+        eventDefinition={{ ...simpleEventDefinition, config }}
+        streams={[]}
+        validation={{ errors: {} }}
+        currentUser={defaultUser}
+        onChange={onChange}
+      />,
+    );
+
+  it('clears aggregation settings when switching to filter', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    renderForm(aggregationConfig, onChange);
+
+    await user.click(screen.getByLabelText('Filter has results'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      'config',
+      expect.objectContaining({
+        group_by: [],
+        series: [],
+        conditions: { expression: null },
+      }),
+    );
+  });
+
+  it('restores previous aggregation settings when switching back to aggregation', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    renderForm(aggregationConfig, onChange);
+
+    await user.click(screen.getByLabelText('Filter has results'));
+    await user.click(screen.getByLabelText('Aggregation of results reaches a threshold'));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      'config',
+      expect.objectContaining({
+        group_by: aggregationConfig.group_by,
+        series: aggregationConfig.series,
+        conditions: aggregationConfig.conditions,
+      }),
+    );
+  });
+});

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import { useCallback, useState } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
+import pick from 'lodash/pick';
 
 import { Col, ControlLabel, FormGroup, Input, Radio, Row } from 'components/bootstrap';
 import * as FormsUtils from 'util/FormsUtils';
@@ -48,10 +49,10 @@ const initialFilterConfig = {
   use_cron_scheduling: false,
 };
 
-const initialAggregationConfig = {
+const initialAggregationConfig: Partial<EventDefinition['config']> = {
   group_by: [],
   series: [],
-  conditions: {},
+  conditions: { expression: null },
 };
 
 type Props = {
@@ -71,7 +72,9 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
   const [conditionType, setConditionType] = useState(
     isEmpty(group_by) && isEmpty(series) && isEmpty(expression) ? conditionTypes.FILTER : conditionTypes.AGGREGATION,
   );
-  const [existingAggregationConfig, setExistingAggregationConfig] = useState<EventDefinition['config'] | undefined>();
+  const [existingAggregationConfig, setExistingAggregationConfig] = useState<
+    Partial<EventDefinition['config']> | undefined
+  >();
 
   const propagateConfigChange = useCallback(
     (config: EventDefinition['config']) => {
@@ -94,26 +97,18 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
       const nextConditionType = Number(FormsUtils.getValueFromInput(event.target as HTMLInputElement));
 
       setConditionType(nextConditionType);
-      let newExistingAggregationConfig;
 
-      if (nextConditionType === conditionTypes.FILTER) {
-        // Store existing data temporarily in state, to restore it in case the type change was accidental
-        Object.keys(initialAggregationConfig).forEach((key) => {
-          newExistingAggregationConfig[key] = eventDefinition.config[key];
-        });
+      const switchingToFilter = nextConditionType === conditionTypes.FILTER;
+      if (!switchingToFilter && !existingAggregationConfig) return;
 
-        const nextConfig = { ...eventDefinition.config, ...initialAggregationConfig };
+      const updatedAggregationConfig = switchingToFilter ? initialAggregationConfig : existingAggregationConfig;
+      const nextConfig: EventDefinition['config'] = { ...eventDefinition.config, ...updatedAggregationConfig };
+      propagateConfigChange(nextConfig);
 
-        propagateConfigChange(nextConfig as EventDefinition['config']);
-      } else if (existingAggregationConfig) {
-        // Reset aggregation data from state if it exists
-        const nextConfig = { ...eventDefinition.config, ...existingAggregationConfig };
-
-        propagateConfigChange(nextConfig);
-        newExistingAggregationConfig = undefined;
-      }
-
-      setExistingAggregationConfig(newExistingAggregationConfig);
+      const newSnapshot = switchingToFilter
+        ? pick(eventDefinition.config, Object.keys(initialAggregationConfig))
+        : undefined;
+      setExistingAggregationConfig(newSnapshot);
     },
     [eventDefinition.config, existingAggregationConfig, propagateConfigChange],
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes the event definition condition toggle when switching between aggregation and `Filter has results`.

The UI now clears aggregation-only settings when switching to filter mode, keeps a temporary snapshot of the previous aggregation config, and restores it when switching back to aggregation. This prevents stale aggregation conditions from blocking saves after the condition type changes.

This should also address the behavior reported in `#22115`.

## Motivation and Context
fix: #22866 
fix: #22115 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

