### PR TITLE
Make link button behave more like an actual anchor element.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -140,10 +140,16 @@ const activeStyles = (themeColors: DefaultTheme['colors'], bsStyle: StyleProps) 
 // Other link styles are defined in e.g. the size specific function
 const linkStyles = css`
   vertical-align: baseline;
+  user-select: text;
 
   &:hover {
     background: transparent;
     text-decoration: underline;
+  }
+
+  .mantine-Button-label {
+    white-space: normal;
+    text-align: left;
   }
 `;
 

--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -148,6 +148,7 @@ const linkStyles = css`
   }
 
   .mantine-Button-label {
+    word-break: break-word;
     white-space: normal;
     text-align: left;
   }

--- a/graylog2-web-interface/src/components/layout/RightSidebar/SidebarNavigationLink.tsx
+++ b/graylog2-web-interface/src/components/layout/RightSidebar/SidebarNavigationLink.tsx
@@ -19,37 +19,12 @@ import styled, { css } from 'styled-components';
 
 import useRightSidebar from 'hooks/useRightSidebar';
 import type { RightSidebarContent } from 'contexts/RightSidebarContext';
+import { Button } from 'components/bootstrap';
 
 type Props = {
   content: RightSidebarContent;
   children: React.ReactNode;
 };
-
-const StyledButton = styled.button(
-  ({ theme }) => css`
-    background: none;
-    border: none;
-    padding: 0;
-    color: ${theme.colors.variant.primary};
-    cursor: pointer;
-    font-size: inherit;
-    font-family: inherit;
-
-    :hover {
-      color: ${theme.colors.variant.dark.primary};
-    }
-
-    :focus-visible {
-      outline: 2px solid ${theme.colors.variant.primary};
-      outline-offset: 2px;
-      border-radius: 2px;
-    }
-
-    :active {
-      color: ${theme.colors.variant.darker.primary};
-    }
-  `,
-);
 
 const SidebarNavigationLink = ({ content, children }: Props) => {
   const { openSidebar } = useRightSidebar();
@@ -59,9 +34,9 @@ const SidebarNavigationLink = ({ content, children }: Props) => {
   };
 
   return (
-    <StyledButton type="button" onClick={handleClick}>
+    <Button bsStyle="link" onClick={handleClick}>
       {children}
-    </StyledButton>
+    </Button>
   );
 };
 

--- a/graylog2-web-interface/src/components/layout/RightSidebar/SidebarNavigationLink.tsx
+++ b/graylog2-web-interface/src/components/layout/RightSidebar/SidebarNavigationLink.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import styled, { css } from 'styled-components';
 
 import useRightSidebar from 'hooks/useRightSidebar';
 import type { RightSidebarContent } from 'contexts/RightSidebarContext';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `Button` component has a `link` variant. when it is set the button looks like an `a` (anchor element). This PR improves the link button styles further to fix how we break and align text.

Unfortunately it was not possible to display the button "completely" inline. When it is displayed inside a text, it will still break differently compared with an anchor.

Related to "Make sure that longer asset names can wrap into multiple lines." part in https://github.com/Graylog2/graylog-plugin-enterprise/issues/13712

/nocl - small UI improement