### PR TITLE
Use enum for read-mode/start-at values in all Collector DTOs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/CollectorReadMode.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/CollectorReadMode.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.collectors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Common values for the receiver "start_at" config field.
+ */
+public enum CollectorReadMode {
+    @JsonProperty("beginning")
+    BEGINNING,
+    @JsonProperty("end")
+    END
+}

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.extension.FileStorageExtensionConfig;
 
 import java.util.List;
@@ -73,9 +74,8 @@ public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, 
 
     // TODO: Configure offset storage - otherwise, offsets will only be tracked in memory!
 
-    @Nullable
     @JsonProperty("start_at")
-    public abstract String startAt();
+    public abstract CollectorReadMode startAt();
 
     @Nullable
     @JsonProperty("multiline")
@@ -95,7 +95,8 @@ public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, 
                 .includeFileOwnerGroupName(true)
                 .includeFileRecordNumber(true)
                 .includeFileRecordOffset(true)
-                .storage(FileStorageExtensionConfig.defaultInstance().name());
+                .storage(FileStorageExtensionConfig.defaultInstance().name())
+                .startAt(CollectorReadMode.END);
     }
 
     @AutoValue.Builder
@@ -123,7 +124,7 @@ public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, 
 
         public abstract Builder includeFileRecordOffset(boolean includeFileRecordOffset);
 
-        public abstract Builder startAt(@Nullable String startAt);
+        public abstract Builder startAt(CollectorReadMode startAt);
 
         public abstract Builder multiline(@Nullable CollectorReceiverMultilineConfig multiline);
 

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/JournaldReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/JournaldReceiverConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.extension.FileStorageExtensionConfig;
 
 import java.util.List;
@@ -35,13 +36,6 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class JournaldReceiverConfig implements CollectorReceiverConfig, CollectorStanzaReceiver {
     public static final String RECEIVER_TYPE = "journald";
-
-    public enum StartAt {
-        @JsonProperty("beginning")
-        BEGINNING,
-        @JsonProperty("end")
-        END
-    }
 
     public enum Priority {
         @JsonProperty("emerg")
@@ -75,7 +69,7 @@ public abstract class JournaldReceiverConfig implements CollectorReceiverConfig,
 
     // Available options: "beginning", "end"
     @JsonProperty("start_at")
-    public abstract StartAt startAt();
+    public abstract CollectorReadMode startAt();
 
     @JsonProperty("storage")
     public abstract String storage();
@@ -83,7 +77,7 @@ public abstract class JournaldReceiverConfig implements CollectorReceiverConfig,
     public static Builder builder(String id) {
         return new AutoValue_JournaldReceiverConfig.Builder()
                 .name(f("journald/%s", id))
-                .startAt(StartAt.END)
+                .startAt(CollectorReadMode.END)
                 .storage(FileStorageExtensionConfig.defaultInstance().name())
                 .priority(Priority.INFO);
     }
@@ -96,7 +90,7 @@ public abstract class JournaldReceiverConfig implements CollectorReceiverConfig,
 
         public abstract Builder matches(@Nullable List<String> matches);
 
-        public abstract Builder startAt(StartAt startAt);
+        public abstract Builder startAt(CollectorReadMode startAt);
 
         public abstract Builder storage(String storage);
 

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.GoDurationSerializer;
 import org.graylog.collectors.config.extension.FileStorageExtensionConfig;
 
@@ -50,13 +51,6 @@ public abstract class WindowsEventLogReceiverConfig implements CollectorReceiver
             "Microsoft-Windows-PowerShell/Operational",
             "Windows PowerShell"
     );
-
-    public enum StartAt {
-        @JsonProperty("beginning")
-        BEGINNING,
-        @JsonProperty("end")
-        END
-    }
 
     public String type() {
         return RECEIVER_TYPE;
@@ -88,7 +82,7 @@ public abstract class WindowsEventLogReceiverConfig implements CollectorReceiver
     public abstract int maxEventsPerPoll();
 
     @JsonProperty("start_at")
-    public abstract StartAt startAt();
+    public abstract CollectorReadMode startAt();
 
     @JsonProperty("raw")
     public abstract boolean raw();
@@ -104,7 +98,7 @@ public abstract class WindowsEventLogReceiverConfig implements CollectorReceiver
                 .name(f("windowseventlog/%s", id))
                 .channels(List.of())
                 .includeDefaultChannels(true)
-                .startAt(StartAt.END)
+                .startAt(CollectorReadMode.END)
                 .maxReads(100)
                 .pollInterval(Duration.ofSeconds(1))
                 .maxEventsPerPoll(0)
@@ -121,7 +115,7 @@ public abstract class WindowsEventLogReceiverConfig implements CollectorReceiver
 
         public abstract Builder includeDefaultChannels(boolean includeDefaultChannels);
 
-        public abstract Builder startAt(StartAt startAt);
+        public abstract Builder startAt(CollectorReadMode startAt);
 
         public abstract Builder maxReads(int maxReads);
 

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/FileSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/FileSourceConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.FilelogReceiverConfig;
 
@@ -42,7 +43,7 @@ public abstract class FileSourceConfig implements SourceConfig {
     public abstract List<String> paths();
 
     @JsonProperty("read_mode")
-    public abstract String readMode();
+    public abstract CollectorReadMode readMode();
 
     @Nullable
     @JsonProperty("multiline")
@@ -56,9 +57,6 @@ public abstract class FileSourceConfig implements SourceConfig {
     public void validate() {
         if (paths() == null || paths().isEmpty()) {
             throw new IllegalArgumentException("FileSourceConfig requires at least one path");
-        }
-        if (readMode() == null || readMode().isBlank()) {
-            throw new IllegalArgumentException("FileSourceConfig requires a non-blank read_mode");
         }
     }
 
@@ -75,7 +73,9 @@ public abstract class FileSourceConfig implements SourceConfig {
     public abstract static class Builder {
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_FileSourceConfig.Builder().type(TYPE_NAME);
+            return new AutoValue_FileSourceConfig.Builder()
+                    .type(TYPE_NAME)
+                    .readMode(CollectorReadMode.END);
         }
 
         @JsonProperty(TYPE_FIELD)
@@ -85,7 +85,7 @@ public abstract class FileSourceConfig implements SourceConfig {
         public abstract Builder paths(List<String> paths);
 
         @JsonProperty("read_mode")
-        public abstract Builder readMode(String readMode);
+        public abstract Builder readMode(CollectorReadMode readMode);
 
         @JsonProperty("multiline")
         public abstract Builder multiline(@Nullable MultilineConfig multiline);

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/JournaldSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/JournaldSourceConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.JournaldReceiverConfig;
 
@@ -40,7 +41,7 @@ public abstract class JournaldSourceConfig implements SourceConfig {
     public abstract String type();
 
     @JsonProperty("read_mode")
-    public abstract String readMode();
+    public abstract CollectorReadMode readMode();
 
     @JsonProperty("priority")
     public abstract String priority();
@@ -56,7 +57,6 @@ public abstract class JournaldSourceConfig implements SourceConfig {
     public void validate() {
         try {
             JournaldReceiverConfig.Priority.valueOf(priority().toUpperCase(Locale.ROOT));
-            JournaldReceiverConfig.StartAt.valueOf(readMode().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("JournaldSourceConfig: " + e.getMessage());
         }
@@ -65,7 +65,7 @@ public abstract class JournaldSourceConfig implements SourceConfig {
     @Override
     public Optional<CollectorReceiverConfig> toReceiverConfig(String id) {
         return Optional.of(JournaldReceiverConfig.builder(id)
-                .startAt(JournaldReceiverConfig.StartAt.valueOf(readMode().toUpperCase(Locale.ROOT)))
+                .startAt(readMode())
                 .priority(JournaldReceiverConfig.Priority.valueOf(priority().toUpperCase(Locale.ROOT)))
                 .matches(matchPattern().map(List::of).orElse(null))
                 .build());
@@ -78,14 +78,14 @@ public abstract class JournaldSourceConfig implements SourceConfig {
             return new AutoValue_JournaldSourceConfig.Builder()
                     .type(TYPE_NAME)
                     .priority("INFO")
-                    .readMode("end");
+                    .readMode(CollectorReadMode.END);
         }
 
         @JsonProperty(TYPE_FIELD)
         public abstract Builder type(String type);
 
         @JsonProperty("read_mode")
-        public abstract Builder readMode(String readMode);
+        public abstract Builder readMode(CollectorReadMode readMode);
 
         @JsonProperty("priority")
         public abstract Builder priority(String priority);

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
@@ -21,14 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.WindowsEventLogReceiverConfig;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @AutoValue
 @JsonTypeName(WindowsEventLogSourceConfig.TYPE_NAME)
@@ -47,7 +45,7 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
     public abstract boolean includeDefaultChannels();
 
     @JsonProperty("read_mode")
-    public abstract String readMode();
+    public abstract CollectorReadMode readMode();
 
     public static Builder builder() {
         return Builder.create();
@@ -55,14 +53,6 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
 
     @Override
     public void validate() {
-        if (isBlank(readMode())) {
-            throw new IllegalArgumentException("WindowsEventLogSourceConfig requires a non-blank read_mode");
-        }
-        try {
-            WindowsEventLogReceiverConfig.StartAt.valueOf(readMode().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("WindowsEventLogSourceConfig: " + e.getMessage());
-        }
     }
 
     @Override
@@ -70,7 +60,7 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
         return Optional.of(WindowsEventLogReceiverConfig.builder(id)
                 .channels(channels())
                 .includeDefaultChannels(includeDefaultChannels())
-                .startAt(WindowsEventLogReceiverConfig.StartAt.valueOf(readMode().toUpperCase(Locale.ROOT)))
+                .startAt(readMode())
                 .build());
     }
 
@@ -82,7 +72,7 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
                     .type(TYPE_NAME)
                     .channels(List.of())
                     .includeDefaultChannels(true)
-                    .readMode("end");
+                    .readMode(CollectorReadMode.END);
         }
 
         @JsonProperty(TYPE_FIELD)
@@ -95,7 +85,7 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
         public abstract Builder includeDefaultChannels(boolean includeDefaultChannels);
 
         @JsonProperty("read_mode")
-        public abstract Builder readMode(String readMode);
+        public abstract Builder readMode(CollectorReadMode readMode);
 
         public abstract WindowsEventLogSourceConfig build();
     }

--- a/graylog2-server/src/test/java/org/graylog/collectors/FleetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/FleetServiceTest.java
@@ -67,7 +67,7 @@ class FleetServiceTest {
     }
 
     private SourceConfig validFileConfig() {
-        return FileSourceConfig.builder().paths(List.of("/var/log/syslog")).readMode("tail").build();
+        return FileSourceConfig.builder().paths(List.of("/var/log/syslog")).readMode(CollectorReadMode.END).build();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/collectors/SourceServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/SourceServiceTest.java
@@ -68,7 +68,7 @@ class SourceServiceTest {
     }
 
     private SourceConfig validFileConfig() {
-        return FileSourceConfig.builder().paths(List.of("/var/log/syslog")).readMode("tail").build();
+        return FileSourceConfig.builder().paths(List.of("/var/log/syslog")).readMode(CollectorReadMode.END).build();
     }
 
     @Test
@@ -127,7 +127,7 @@ class SourceServiceTest {
         FleetDTO fleet = fleetService.create("test-fleet", "A test fleet", null);
         SourceDTO created = sourceService.create(fleet.id(), "my-source", "Original desc", true, validFileConfig());
 
-        SourceConfig newConfig = FileSourceConfig.builder().paths(List.of("/var/log/auth.log")).readMode("tail").build();
+        SourceConfig newConfig = FileSourceConfig.builder().paths(List.of("/var/log/auth.log")).readMode(CollectorReadMode.END).build();
         Optional<SourceDTO> updated = sourceService.update(fleet.id(), created.id(), "updated-source", "Updated desc", false, newConfig);
 
         assertThat(updated).isPresent();
@@ -249,7 +249,7 @@ class SourceServiceTest {
     @Test
     void createSourceWithInvalidConfigThrows() {
         FleetDTO fleet = fleetService.create("test-fleet", "A test fleet", null);
-        SourceConfig invalidConfig = FileSourceConfig.builder().paths(List.of()).readMode("tail").build();
+        SourceConfig invalidConfig = FileSourceConfig.builder().paths(List.of()).readMode(CollectorReadMode.END).build();
 
         assertThatThrownBy(() -> sourceService.create(fleet.id(), "my-source", "A source", true, invalidConfig))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/graylog2-server/src/test/java/org/graylog/collectors/db/SourceConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/db/SourceConfigTest.java
@@ -18,6 +18,7 @@ package org.graylog.collectors.db;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class SourceConfigTest {
                 {
                     "type": "file",
                     "paths": ["/var/log/syslog", "/var/log/auth.log"],
-                    "read_mode": "tail",
+                    "read_mode": "end",
                     "multiline": {
                         "pattern": "^\\\\d{4}-",
                         "negate": true
@@ -60,7 +61,7 @@ class SourceConfigTest {
         final var fileConfig = (FileSourceConfig) config;
         assertThat(fileConfig.type()).isEqualTo("file");
         assertThat(fileConfig.paths()).containsExactly("/var/log/syslog", "/var/log/auth.log");
-        assertThat(fileConfig.readMode()).isEqualTo("tail");
+        assertThat(fileConfig.readMode()).isEqualTo(CollectorReadMode.END);
         assertThat(fileConfig.multiline()).isNotNull();
         assertThat(fileConfig.multiline().pattern()).isEqualTo("^\\d{4}-");
         assertThat(fileConfig.multiline().negate()).isTrue();
@@ -86,7 +87,7 @@ class SourceConfigTest {
 
     @Test
     void fileSourceValidation() {
-        final var config = FileSourceConfig.builder().paths(List.of()).readMode("tail").build();
+        final var config = FileSourceConfig.builder().paths(List.of()).readMode(CollectorReadMode.END).build();
         assertThatThrownBy(config::validate).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -95,7 +96,7 @@ class SourceConfigTest {
     void jsonRoundTrip() throws Exception {
         final var original = FileSourceConfig.builder()
                 .paths(List.of("/var/log/syslog"))
-                .readMode("tail")
+                .readMode(CollectorReadMode.END)
                 .multiline(new MultilineConfig("^\\d{4}-", true))
                 .build();
 
@@ -109,7 +110,7 @@ class SourceConfigTest {
     void serializationIncludesTypeField() throws Exception {
         final var config = FileSourceConfig.builder()
                 .paths(List.of("/var/log/syslog"))
-                .readMode("tail")
+                .readMode(CollectorReadMode.END)
                 .build();
 
         final var json = objectMapper.writeValueAsString(config);

--- a/graylog2-server/src/test/java/org/graylog/collectors/db/SourceDTOTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/db/SourceDTOTest.java
@@ -18,6 +18,7 @@ package org.graylog.collectors.db;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.graylog.collectors.CollectorReadMode;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ class SourceDTOTest {
                 .enabled(true)
                 .config(FileSourceConfig.builder()
                         .paths(List.of("/var/log/syslog"))
-                        .readMode("tail")
+                        .readMode(CollectorReadMode.END)
                         .multiline(new MultilineConfig("^\\d{4}-", true))
                         .build())
                 .build();
@@ -77,7 +78,7 @@ class SourceDTOTest {
                 .fleetId("fleet-1")
                 .name("File")
                 .description("File reader")
-                .config(FileSourceConfig.builder().paths(List.of("/var/log/messages")).readMode("tail").build())
+                .config(FileSourceConfig.builder().paths(List.of("/var/log/messages")).readMode(CollectorReadMode.END).build())
                 .build();
 
         assertThat(source.config().type()).isEqualTo("file");
@@ -89,7 +90,7 @@ class SourceDTOTest {
                 .fleetId("fleet-1")
                 .name("Test source")
                 .description("Testing defaults")
-                .config(FileSourceConfig.builder().paths(List.of("/var/log/test")).readMode("tail").build())
+                .config(FileSourceConfig.builder().paths(List.of("/var/log/test")).readMode(CollectorReadMode.END).build())
                 .build();
 
         assertThat(source.enabled()).isTrue();


### PR DESCRIPTION
We previously used a mixture of strings and enums.

Fixes #25637 

/nocl Updates to unreleased feature

