### PR TITLE
Change FilelogReceiverConfig#RECEIVER_TYPE to "file_log"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/CollectorReceiverMultilineConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/CollectorReceiverMultilineConfig.java
@@ -22,7 +22,7 @@ import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
 
 /**
- * Multiline configuration for otel collector receivers (filelog, tcplog, udplog).
+ * Multiline configuration for OTel collector receivers (file_log, tcp_log, udp_log).
  */
 @AutoValue
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
@@ -36,7 +36,7 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 @AutoValue
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, CollectorStanzaReceiver {
-    public static final String RECEIVER_TYPE = "filelog";
+    public static final String RECEIVER_TYPE = "file_log";
 
     public String type() {
         return RECEIVER_TYPE;

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
@@ -29,9 +29,9 @@ import java.util.List;
 import static org.graylog2.shared.utilities.StringUtils.f;
 
 /**
- * Otel collector filelog receiver configuration.
+ * OTel collector file_log receiver configuration.
  *
- * @see <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver">filelog receiver</a>
+ * @see <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver">file_log receiver</a>
  */
 @AutoValue
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -93,7 +93,7 @@ public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, 
 
     public static Builder builder(String id) {
         return new AutoValue_FilelogReceiverConfig.Builder()
-                .name(f("filelog/%s", id))
+                .name(f("file_log/%s", id))
                 .includeFileName(true)
                 .includeFilePath(true)
                 .includeFileNameResolved(true)

--- a/graylog2-server/src/test/java/org/graylog/collectors/config/operator/AddOperatorConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/config/operator/AddOperatorConfigTest.java
@@ -24,12 +24,12 @@ class AddOperatorConfigTest {
 
     @Test
     void createsStringAttributeOperator() {
-        final var operator = AddOperatorConfig.forAttribute("glc.receiver.type", "filelog");
+        final var operator = AddOperatorConfig.forAttribute("glc.receiver.type", "file_log");
 
         assertThat(operator.type()).isEqualTo("add");
         assertThat(operator.field()).isEqualTo("attributes[\"glc.receiver.type\"]");
         assertThat(operator.value().isTextual()).isTrue();
-        assertThat(operator.value().textValue()).isEqualTo("filelog");
+        assertThat(operator.value().textValue()).isEqualTo("file_log");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/collectors/config/processor/ResourceProcessorConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/config/processor/ResourceProcessorConfigTest.java
@@ -29,20 +29,20 @@ class ResourceProcessorConfigTest {
 
     @Test
     void builderCreatesResourceProcessorName() {
-        final var config = ResourceProcessorConfig.builder("filelog")
+        final var config = ResourceProcessorConfig.builder("file_log")
                 .attributes(List.of(ResourceProcessorConfig.Attribute.upsert("a", "b")))
                 .build();
 
-        assertThat(config.name()).isEqualTo("resource/filelog");
+        assertThat(config.name()).isEqualTo("resource/file_log");
     }
 
     @Test
     void collectorComponentAttributeUsesDefaultKeyAndUpsertAction() {
-        final var attribute = ResourceProcessorConfig.collectorComponentAttribute("filelog");
+        final var attribute = ResourceProcessorConfig.collectorComponentAttribute("file_log");
 
         assertThat(attribute.key()).isEqualTo(CollectorAttributes.COLLECTOR_RECEIVER_TYPE);
         assertThat(attribute.value().isTextual()).isTrue();
-        assertThat(attribute.value().textValue()).isEqualTo("filelog");
+        assertThat(attribute.value().textValue()).isEqualTo("file_log");
         assertThat(attribute.action()).isEqualTo(ResourceProcessorConfig.Action.UPSERT);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class CollectorIngestCodecTest {
 
-    private static final String TEST_RECEIVER_TYPE = "filelog";
+    private static final String TEST_RECEIVER_TYPE = "file_log";
     private static final String TEST_INSTANCE_UID = "test-agent";
 
     private final MessageFactory messageFactory = new TestMessageFactory();
@@ -366,7 +366,7 @@ class CollectorIngestCodecTest {
     void setsReceiverTypeField() {
         final var codecWithProcessor = new CollectorIngestCodec(
                 Configuration.EMPTY_CONFIGURATION, messageFactory, dumpWriter, typeConverter,
-                Map.of("filelog", log -> Map.of(EventFields.EVENT_LOG_NAME, "test.log")));
+                Map.of("file_log", log -> Map.of(EventFields.EVENT_LOG_NAME, "test.log")));
 
         final var logRecord = LogRecord.newBuilder()
                 .setBody(AnyValue.newBuilder().setStringValue("test"))
@@ -381,7 +381,7 @@ class CollectorIngestCodecTest {
                 .build();
         final var collectorRecord = CollectorJournal.Record.newBuilder()
                 .setOtelRecord(otelRecord)
-                .setCollectorReceiverType("filelog")
+                .setCollectorReceiverType("file_log")
                 .setCollectorInstanceUid(TEST_INSTANCE_UID)
                 .build();
 
@@ -389,7 +389,7 @@ class CollectorIngestCodecTest {
         final var decoded = codecWithProcessor.decodeSafe(rawMessage);
 
         assertThat(decoded).isPresent();
-        assertThat(decoded.get().getField(CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE)).isEqualTo("filelog");
+        assertThat(decoded.get().getField(CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE)).isEqualTo("file_log");
         assertThat(decoded.get().getField(EventFields.EVENT_LOG_NAME)).isEqualTo("test.log");
     }
 

--- a/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
@@ -390,7 +390,6 @@ class CollectorIngestCodecTest {
 
         assertThat(decoded).isPresent();
         assertThat(decoded.get().getField("collector_receiver_type")).isEqualTo("file_log");
-        assertThat(decoded.get().getField("collector_receiver_type")).isEqualTo("filelog");
         assertThat(decoded.get().getField(EventFields.EVENT_LOG_NAME)).isEqualTo("test.log");
     }
 

--- a/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorJournalRecordFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorJournalRecordFactoryTest.java
@@ -37,7 +37,7 @@ class CollectorJournalRecordFactoryTest {
                         .setResource(Resource.newBuilder()
                                 .addAttributes(KeyValue.newBuilder()
                                         .setKey(CollectorAttributes.COLLECTOR_RECEIVER_TYPE)
-                                        .setValue(AnyValue.newBuilder().setStringValue("filelog"))))
+                                        .setValue(AnyValue.newBuilder().setStringValue("file_log"))))
                         .addScopeLogs(ScopeLogs.newBuilder()
                                 .addLogRecords(LogRecord.newBuilder()
                                         .setBody(AnyValue.newBuilder().setStringValue("hello")))))
@@ -48,7 +48,7 @@ class CollectorJournalRecordFactoryTest {
         assertThat(records).hasSize(1);
         final var record = records.get(0);
         assertThat(record.getCollectorInstanceUid()).isEqualTo("agent-42");
-        assertThat(record.getCollectorReceiverType()).isEqualTo("filelog");
+        assertThat(record.getCollectorReceiverType()).isEqualTo("file_log");
         assertThat(record.getOtelRecord().getLog().getLogRecord().getBody().getStringValue()).isEqualTo("hello");
     }
 
@@ -74,7 +74,7 @@ class CollectorJournalRecordFactoryTest {
                         .setResource(Resource.newBuilder()
                                 .addAttributes(KeyValue.newBuilder()
                                         .setKey(CollectorAttributes.COLLECTOR_RECEIVER_TYPE)
-                                        .setValue(AnyValue.newBuilder().setStringValue("filelog"))))
+                                        .setValue(AnyValue.newBuilder().setStringValue("file_log"))))
                         .addScopeLogs(ScopeLogs.newBuilder()
                                 .addLogRecords(LogRecord.newBuilder()
                                         .setBody(AnyValue.newBuilder().setStringValue("file log")))))
@@ -91,7 +91,7 @@ class CollectorJournalRecordFactoryTest {
         final var records = CollectorJournalRecordFactory.createFromRequest(request, "agent-1");
 
         assertThat(records).hasSize(2);
-        assertThat(records.get(0).getCollectorReceiverType()).isEqualTo("filelog");
+        assertThat(records.get(0).getCollectorReceiverType()).isEqualTo("file_log");
         assertThat(records.get(1).getCollectorReceiverType()).isEqualTo("journald");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/collectors/input/processor/CollectorLogRecordProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/input/processor/CollectorLogRecordProcessorTest.java
@@ -130,7 +130,7 @@ class CollectorLogRecordProcessorTest {
     void extractsReceiverLifecycleAttributes() {
         final var log = OTelJournal.Log.newBuilder()
                 .setLogRecord(LogRecord.newBuilder()
-                        .addAttributes(kv("otelcol.component.id", "filelog/699c94e23f694890ac6bd6c9"))
+                        .addAttributes(kv("otelcol.component.id", "file_log/699c94e23f694890ac6bd6c9"))
                         .addAttributes(kv("otelcol.component.kind", "receiver"))
                         .addAttributes(kv("otelcol.signal", "logs"))
                         .addAttributes(kv("component", "fileconsumer"))
@@ -139,7 +139,7 @@ class CollectorLogRecordProcessorTest {
                 .build();
         final var result = processor.process(log);
         assertThat(result)
-                .containsEntry("collector_component_id", "filelog/699c94e23f694890ac6bd6c9")
+                .containsEntry("collector_component_id", "file_log/699c94e23f694890ac6bd6c9")
                 .containsEntry("collector_component_kind", "receiver")
                 .containsEntry("collector_signal", "logs")
                 .containsEntry("collector_component", "fileconsumer")


### PR DESCRIPTION
The old "filelog" type is deprecated since collector-contrib 0.150.0.

Requires Collector rev https://github.com/Graylog2/collector-sidecar/commit/3106e78979f6d1c5b3c51899393f140b0abe4fd4 or later.

/nocl Update to unreleased feature.

