### PR TITLE
Default channels for windows event log source allow empty custom channel list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
@@ -42,6 +42,7 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 public abstract class WindowsEventLogReceiverConfig implements CollectorReceiverConfig, CollectorStanzaReceiver {
     public static final String RECEIVER_TYPE = "windowseventlog";
 
+    // if you change this, also update SourceFormModal.tsx!
     private static final List<String> DEFAULT_CHANNELS = List.of(
             "Application",
             "System",

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
@@ -63,6 +63,9 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("WindowsEventLogSourceConfig: " + e.getMessage());
         }
+        if (!includeDefaultChannels() && channels().isEmpty()) {
+            throw new IllegalArgumentException("At least one channel needs to be set when include_default_channels is false");
+        }
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/collectors/db/SourceConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/db/SourceConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SourceConfigTest {
@@ -88,6 +89,15 @@ class SourceConfigTest {
     void fileSourceValidation() {
         final var config = FileSourceConfig.builder().paths(List.of()).readMode("tail").build();
         assertThatThrownBy(config::validate).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void windowsEventLogValidation() {
+        final var configInvalid = WindowsEventLogSourceConfig.builder().includeDefaultChannels(false).channels(List.of()).build();
+        assertThatThrownBy(configInvalid::validate).isInstanceOf(IllegalArgumentException.class);
+
+        final WindowsEventLogSourceConfig defaultsEmptyChannels = WindowsEventLogSourceConfig.builder().includeDefaultChannels(true).channels(List.of()).build();
+        assertThatNoException().isThrownBy(defaultsEmptyChannels::validate);
     }
 
 

--- a/graylog2-web-interface/src/components/collectors/sources/SourceFormModal.tsx
+++ b/graylog2-web-interface/src/components/collectors/sources/SourceFormModal.tsx
@@ -163,12 +163,14 @@ const WindowsEventLogConfigFields = ({
             .filter(Boolean),
         })
       }
-      required
+      required={!config.include_default_channels}
     />
     <Input
       id="win-include-default-channels"
       type="checkbox"
       label="Include default channels"
+      // if you update this, also update WindowsEventLogReceiverConfig.java
+      help="Defaults are: Application, System, Security, Setup, Microsoft-Windows-Windows Defender/Operational, Microsoft-Windows-TerminalServices-LocalSessionManager/Operational, Microsoft-Windows-PowerShell/Operational, Windows PowerShell"
       checked={config.include_default_channels}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
         setFieldValue('config', { ...config, include_default_channels: e.target.checked })


### PR DESCRIPTION
Don't require channels if defaults are selected, and properly validate the cases.

/nocl unreleased feature
Fixes #25607 
