### PR TITLE
Rename field `collector_source_type` to `collector_receiver_type`

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/CollectorLogsDestinationService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/CollectorLogsDestinationService.java
@@ -163,7 +163,7 @@ public class CollectorLogsDestinationService {
 
         final var rule = streamRuleService.create(Map.of(
                 StreamRuleImpl.FIELD_STREAM_ID, new ObjectId(Stream.COLLECTOR_SYSTEM_LOGS_STREAM_ID),
-                StreamRuleImpl.FIELD_FIELD, CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE,
+                StreamRuleImpl.FIELD_FIELD, CollectorIngestCodec.FIELD_COLLECTOR_RECEIVER_TYPE,
                 StreamRuleImpl.FIELD_TYPE, StreamRuleType.EXACT.toInteger(),
                 StreamRuleImpl.FIELD_VALUE, CollectorLogRecordProcessor.RECEIVER_TYPE,
                 StreamRuleImpl.FIELD_INVERTED, false,

--- a/graylog2-server/src/main/java/org/graylog/collectors/indexer/CollectorLogsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/indexer/CollectorLogsIndexMapping.java
@@ -74,7 +74,7 @@ public class CollectorLogsIndexMapping extends AbstractMapping {
                 .put("source", map().put("type", "keyword").build())
                 .put("streams", map().put("type", "keyword").build())
                 // Collector identification fields
-                .put(CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE, map().put("type", "keyword").build())
+                .put(CollectorIngestCodec.FIELD_COLLECTOR_RECEIVER_TYPE, map().put("type", "keyword").build())
                 .put(CollectorIngestCodec.FIELD_COLLECTOR_INSTANCE_UID, map().put("type", "keyword").build())
                 .put("gl2_source_collector", map().put("type", "keyword").build())
                 // Severity fields

--- a/graylog2-server/src/main/java/org/graylog/collectors/input/CollectorIngestCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/input/CollectorIngestCodec.java
@@ -59,7 +59,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class CollectorIngestCodec implements Codec {
     private static final Logger LOG = LoggerFactory.getLogger(CollectorIngestCodec.class);
     public static final String NAME = "CollectorIngest";
-    public static final String FIELD_COLLECTOR_SOURCE_TYPE = "collector_source_type";
+    public static final String FIELD_COLLECTOR_RECEIVER_TYPE = "collector_receiver_type";
     public static final String FIELD_COLLECTOR_INSTANCE_UID = "collector_instance_uid";
 
     private final Configuration configuration;
@@ -145,7 +145,7 @@ public class CollectorIngestCodec implements Codec {
 
         final Message message = messageFactory.createMessage(body, source, timestamp);
 
-        message.addField(FIELD_COLLECTOR_SOURCE_TYPE, receiverType);
+        message.addField(FIELD_COLLECTOR_RECEIVER_TYPE, receiverType);
 
         if (!instanceUid.isEmpty()) {
             message.addField(FIELD_COLLECTOR_INSTANCE_UID, instanceUid);

--- a/graylog2-server/src/main/java/org/graylog/collectors/migrations/V20260303120000_CollectorDEVMigrations.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/migrations/V20260303120000_CollectorDEVMigrations.java
@@ -34,6 +34,7 @@ import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamGuardException;
+import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,7 @@ public class V20260303120000_CollectorDEVMigrations extends Migration {
 
     private final MongoConnection mongoConnection;
     private final Provider<StreamService> streamServiceProvider;
+    private final Provider<StreamRuleService> streamRuleServiceProvider;
     private final Provider<IndexSetService> indexSetServiceProvider;
     private final Provider<IndexSetCleanupJob.Factory> indexSetCleanupJobFactoryProvider;
     private final Provider<UserService> userServiceProvider;
@@ -66,12 +68,14 @@ public class V20260303120000_CollectorDEVMigrations extends Migration {
     @Inject
     public V20260303120000_CollectorDEVMigrations(MongoConnection mongoConnection,
                                                   Provider<StreamService> streamServiceProvider,
+                                                  Provider<StreamRuleService> streamRuleServiceProvider,
                                                   Provider<IndexSetService> indexSetServiceProvider,
                                                   Provider<IndexSetCleanupJob.Factory> indexSetCleanupJobFactoryProvider,
                                                   Provider<UserService> userServiceProvider,
                                                   Provider<CollectorLogsDestinationService> logsDestinationServiceProvider) {
         this.mongoConnection = mongoConnection;
         this.streamServiceProvider = streamServiceProvider;
+        this.streamRuleServiceProvider = streamRuleServiceProvider;
         this.indexSetServiceProvider = indexSetServiceProvider;
         this.indexSetCleanupJobFactoryProvider = indexSetCleanupJobFactoryProvider;
         this.userServiceProvider = userServiceProvider;
@@ -91,6 +95,7 @@ public class V20260303120000_CollectorDEVMigrations extends Migration {
 
         migrateCollectorIngestConfig(db);
         removeLegacyCollectorLogsStream();
+        removeLegacyCollectorSourceTypeStreamRule();
 
         UserContext.<Void>runAs("admin", userServiceProvider.get(), () -> {
             logsDestinationServiceProvider.get().ensureExists();
@@ -168,6 +173,21 @@ public class V20260303120000_CollectorDEVMigrations extends Migration {
                 LOG.info("Backfilled bind_address/port on collector ingest input <{}>.", doc.getObjectId("_id"));
             }
         }
+    }
+
+    /**
+     * Removes any stream rule on the Collector System Logs stream that still uses the legacy
+     * {@code collector_source_type} field.
+     */
+    private void removeLegacyCollectorSourceTypeStreamRule() {
+        final var streamRuleService = streamRuleServiceProvider.get();
+
+        streamRuleService.loadForStreamId(Stream.COLLECTOR_SYSTEM_LOGS_STREAM_ID).stream()
+                .filter(rule -> "collector_source_type".equals(rule.getField()))
+                .forEach(rule -> {
+                    streamRuleService.destroy(rule);
+                    LOG.info("Removed legacy collector_source_type stream rule <{}> on Collector System Logs stream.", rule.getId());
+                });
     }
 
     private void removeLegacyCollectorLogsStream() {

--- a/graylog2-server/src/test/java/org/graylog/collectors/CollectorLogsDestinationServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/CollectorLogsDestinationServiceTest.java
@@ -19,7 +19,6 @@ package org.graylog.collectors;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.graylog.collectors.indexer.CollectorLogsIndexTemplateProvider;
-import org.graylog.collectors.input.CollectorIngestCodec;
 import org.graylog.collectors.input.processor.CollectorLogRecordProcessor;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.database.entities.ImmutableSystemScope;
@@ -188,7 +187,7 @@ class CollectorLogsDestinationServiceTest {
         final var ruleData = (java.util.Map<String, Object>) mapCaptor.getValue();
 
         assertThat(ruleData.get("stream_id")).hasToString(Stream.COLLECTOR_SYSTEM_LOGS_STREAM_ID);
-        assertThat(ruleData.get("field")).isEqualTo(CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE);
+        assertThat(ruleData.get("field")).isEqualTo("collector_receiver_type");
         assertThat(ruleData.get("type")).isEqualTo(StreamRuleType.EXACT.toInteger());
         assertThat(ruleData.get("value")).isEqualTo(CollectorLogRecordProcessor.RECEIVER_TYPE);
         assertThat(ruleData.get("inverted")).isEqualTo(false);

--- a/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/input/CollectorIngestCodecTest.java
@@ -389,7 +389,7 @@ class CollectorIngestCodecTest {
         final var decoded = codecWithProcessor.decodeSafe(rawMessage);
 
         assertThat(decoded).isPresent();
-        assertThat(decoded.get().getField(CollectorIngestCodec.FIELD_COLLECTOR_SOURCE_TYPE)).isEqualTo("filelog");
+        assertThat(decoded.get().getField("collector_receiver_type")).isEqualTo("filelog");
         assertThat(decoded.get().getField(EventFields.EVENT_LOG_NAME)).isEqualTo("test.log");
     }
 


### PR DESCRIPTION
Rename field `collector_source_type` to `collector_receiver_type` to better reflect what it actually is.

The field value won't match the type of our documents in the `sources` collection in all cases and the `collector_log` receiver type wouldn't have a corresponding source at all. Hence the rename.

/nocl unreleased feature