### PR TITLE
Remove "Graylog" from input field description

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -152,7 +152,7 @@ public class CloudTrailInput extends MessageInput {
                     CK_POLLING_INTERVAL,
                     "Polling interval",
                     1,
-                    "Determines how often Graylog will check for SQS notifications. The smallest allowable interval is 1 minute.",
+                    "Determines how often to check for SQS notifications. The smallest allowable interval is 1 minute.",
                     ConfigurationField.Optional.OPTIONAL));
             r.addField(new TextField(
                     CK_ASSUME_ROLE_ARN,


### PR DESCRIPTION
I stumbled on this literal instance of "Graylog". Removing for compliance with branding.

/nocl