### PR TITLE
Improve event replay sidebar: fix meta loading, support title-less table rows

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/SidebarEventDefinitionDetails.ts
+++ b/graylog2-web-interface/src/components/event-definitions/SidebarEventDefinitionDetails.ts
@@ -17,7 +17,7 @@
 const SidebarEventDefinitionDetails = (id: string) =>
   ({
     id: 'event-definition-details',
-    title: 'Event Definition Details',
+    title: 'Definition Details',
     componentKey: 'replay-search-sidebar',
     props: { alertId: undefined, definitionId: id },
   }) as const;

--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/hooks/useEventsAdditionalData.ts
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/hooks/useEventsAdditionalData.ts
@@ -21,7 +21,7 @@ const useEventsAdditionalData = ({ eventData, definitionId = null }: { eventData
   const eventDefinitionId = definitionId ?? eventData?.event_definition_id;
   const { data, isLoading: isLoadingEventDefinition } = useEventDefinition(eventDefinitionId);
 
-  const meta: EventsAdditionalData = isLoadingEventDefinition
+  const meta: EventsAdditionalData = !isLoadingEventDefinition
     ? {
         context: {
           event_definitions: {

--- a/graylog2-web-interface/src/components/events/events/EventDetailsTable.tsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetailsTable.tsx
@@ -64,7 +64,7 @@ const EventDetailsTable = <E extends EntityBase = Event>({
                 <b>{attribute.title}</b>
               </LabelTD>
             )}
-            <ValueTD>{renderCell ? renderCell(value, event, meta, eventProcedureId) : value}</ValueTD>
+            <ValueTD colSpan={attribute.title ? undefined : 2}>{renderCell ? renderCell(value, event, meta, eventProcedureId) : value}</ValueTD>
           </tr>
         );
       })}


### PR DESCRIPTION
## Description
- Fix inverted condition in `useEventsAdditionalData`: `meta` was being populated while loading and set to `null` when done, which is backwards
- Add `colSpan={2}` to `ValueTD` in `EventDetailsTable` when an attribute has no title, so the value cell spans both columns instead of breaking the table layout
- Shorten sidebar title from "Event Definition Details" to "Definition Details" in `SidebarEventDefinitionDetails`

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/13931
/nocl new feature

## Motivation and Context
These changes support the enterprise-side sidebar reorganization for https://github.com/Graylog2/graylog-plugin-enterprise/issues/13797

The `useEventsAdditionalData` bug meant meta context was never available when the table rendered.

## How Has This Been Tested?
Manual testing via the event replay sidebar. No existing tests for the affected files.

## Screenshots (if appropriate):
See enterprise PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)