### PR TITLE
Update AGENTS.md with frontend and test hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Frontend
 
-The web interface lives in `graylog2-web-interface/` and has its own conventions. Before modifying frontend code, you must read `graylog2-web-interface/AGENTS.md` and follow its conventions.
+The web interface lives in `graylog2-web-interface/` and has its own conventions. Before modifying frontend code (including tests and linting), you must read `graylog2-web-interface/AGENTS.md` and follow its conventions. Run any `yarn` commands from the `graylog2-web-interface/` directory.
 
 ## Build Commands
 

--- a/graylog2-web-interface/AGENTS.md
+++ b/graylog2-web-interface/AGENTS.md
@@ -33,7 +33,7 @@ yarn build
 yarn test
 
 # Run a specific test
-yarn test --testPathPattern=<pattern>
+yarn test --testPathPatterns=<pattern>
 
 # Type check
 yarn tsc
@@ -56,6 +56,8 @@ yarn format
 # Pre-PR verification (run before considering work complete)
 yarn tsc && yarn lint:changes && yarn test
 ```
+
+Depending on the scope of the operation, the output might be too verbose. You might want to redirect the output to a tmp file and then grep it. No need to do this for smaller scopes.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Clarify that frontend conventions apply to tests and linting too, and note the correct `yarn` working directory.
- Fix `--testPathPattern` → `--testPathPatterns` (plural).
- Add tip about redirecting verbose output to a tmp file for large-scope operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)