### PR TITLE
Fix CpuMetricsCell percent handling

### DIFF
--- a/changelog/unreleased/pr-25710.toml
+++ b/changelog/unreleased/pr-25710.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix CpuMetricsCell percent handling"
+
+issues = ["Graylog2/graylog-plugin-enterprise#13934"]
+pulls = ["25710"]

--- a/graylog2-web-interface/src/components/cluster-configuration/shared-components/CpuMetricsCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/shared-components/CpuMetricsCell.tsx
@@ -28,35 +28,23 @@ type Props = {
   dangerThreshold?: number;
 };
 
-const formatNumberValue = (value: number | undefined | null, suffix = '') =>
-  value == null ? '' : `${NumberUtils.formatNumber(value)}${suffix}`;
-
-const toRatio = (percent: number | undefined | null) => {
-  if (percent == null) {
-    return null;
-  }
-
-  return percent > 1 ? percent / 100 : percent;
-};
-
 const CpuMetricsCell = ({
   loadAverage = null,
   cpuPercent = null,
   warningThreshold = Number.NaN,
   dangerThreshold = Number.NaN,
 }: Props) => {
-  const loadLabel = formatNumberValue(loadAverage);
-  const percentLabel = formatNumberValue(cpuPercent, '%');
-  const percentIndicator =
-    cpuPercent == null ? null : buildRatioIndicator(toRatio(cpuPercent), warningThreshold, dangerThreshold);
-
-  if (!loadLabel && !percentLabel && !percentIndicator) {
+  if (cpuPercent == null && loadAverage == null) {
     return <MetricPlaceholder />;
   }
 
+  const loadLabel = loadAverage == null ? null : NumberUtils.formatNumber(loadAverage);
+
   return (
     <MetricsColumn>
-      {(percentIndicator || percentLabel) && <MetricsRow>{percentIndicator ?? <span>{percentLabel}</span>}</MetricsRow>}
+      {cpuPercent != null && (
+        <MetricsRow>{buildRatioIndicator(cpuPercent / 100, warningThreshold, dangerThreshold)}</MetricsRow>
+      )}
       {loadLabel && (
         <MetricsRow>
           <span>Load (1m)</span>


### PR DESCRIPTION
## Description
Treat CPU metrics as 0..100 percentages and simplifiy the component render logic 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13934

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

