### PR TITLE
Enable Collectors feature flag by default

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -119,7 +119,7 @@ opensearch3_client=on
 collector_otlp_traffic_dump=off
 
 # Enable the new Collectors
-collectors=off
+collectors=on
 
 # Use new sidebar for investigations instead of legacy drawer
 investigation_right_sidebar=on


### PR DESCRIPTION
Collectors is a beta feature so we keep the feature flag for now.

/nocl Update to unreleased feature

