### PR TITLE
Remove TerminalServices event log channel from defaults

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfig.java
@@ -50,7 +50,6 @@ public abstract class WindowsEventLogReceiverConfig implements CollectorReceiver
             "Security",
             "Setup",
             "Microsoft-Windows-Windows Defender/Operational",
-            "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational",
             "Microsoft-Windows-PowerShell/Operational",
             "Windows PowerShell"
     );

--- a/graylog2-server/src/test/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/config/receiver/WindowsEventLogReceiverConfigTest.java
@@ -40,7 +40,6 @@ class WindowsEventLogReceiverConfigTest {
                 "Security",
                 "Setup",
                 "Microsoft-Windows-Windows Defender/Operational",
-                "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational",
                 "Microsoft-Windows-PowerShell/Operational",
                 "Windows PowerShell",
                 "ForwardedEvents"
@@ -57,7 +56,6 @@ class WindowsEventLogReceiverConfigTest {
                 "Security",
                 "Setup",
                 "Microsoft-Windows-Windows Defender/Operational",
-                "Microsoft-Windows-TerminalServices-LocalSessionManager/Operational",
                 "Microsoft-Windows-PowerShell/Operational",
                 "Windows PowerShell",
                 "ForwardedEvents"

--- a/graylog2-web-interface/src/components/collectors/sources/SourceFormModal.tsx
+++ b/graylog2-web-interface/src/components/collectors/sources/SourceFormModal.tsx
@@ -190,7 +190,7 @@ const WindowsEventLogConfigFields = ({
       type="checkbox"
       label="Include default channels"
       // if you update this, also update WindowsEventLogReceiverConfig.java
-      help="Defaults are: Application, System, Security, Setup, Microsoft-Windows-Windows Defender/Operational, Microsoft-Windows-TerminalServices-LocalSessionManager/Operational, Microsoft-Windows-PowerShell/Operational, Windows PowerShell"
+      help="Defaults are: Application, System, Security, Setup, Microsoft-Windows-Windows Defender/Operational, Microsoft-Windows-PowerShell/Operational, Windows PowerShell"
       checked={config.include_default_channels}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
         setFieldValue('config', { ...config, include_default_channels: e.target.checked })


### PR DESCRIPTION
We ran into weird bookmark issues with this channel.

/nocl Update to unreleased feature.

