### PR TITLE
fix7.0(13453): Changed default value from null to undefined

### DIFF
--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.ts
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.ts
@@ -130,7 +130,7 @@ export const LookupTablesStore = singletonStore('core.LookupTables', () =>
     table: null,
     cache: null,
     dataAdapter: null,
-    tables: null,
+    tables: undefined,
     caches: null,
     dataAdapters: null,
     lookupResult: null,


### PR DESCRIPTION
Changed default value from `null` to `undefined` to take the default value set on the component

closes: Graylog2/graylog-plugin-enterprise#13453

/nocl

<!--- Provide a general summary of your changes in the Title above -->
The bug was because the value set in Redux state was `null`. `null` gets passed and the default values set in the component is ignore. Changing the default value in the sate to `undefined` allows us to set a default in the component.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

