### PR TITLE
Fix permission check in NavigationItem

### DIFF
--- a/graylog2-web-interface/src/components/navigation/NavigationItem.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationItem.tsx
@@ -32,12 +32,12 @@ const shouldRender = (
   requiredPermissions: Permission | Array<Permission> | undefined,
   userPermissions: Immutable.List<Permission>,
 ) => {
-  if (requiredFeatureFlag) {
-    return AppConfig.isFeatureEnabled(requiredFeatureFlag);
+  if (requiredFeatureFlag && !AppConfig.isFeatureEnabled(requiredFeatureFlag)) {
+    return false;
   }
 
-  if (requiredPermissions) {
-    return isPermitted(userPermissions, requiredPermissions);
+  if (requiredPermissions && !isPermitted(userPermissions, requiredPermissions)) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
The component didn't do a permission check when "requiredFeatureFlag" was set. That means a nav item gated by a feature flag was never checked for required permissions.

/nocl Internal change

