### PR TITLE
Sidebar: fix and refinements for event definition replay

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/replay-search/EventDefinitionReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/EventDefinitionReplaySearch.tsx
@@ -50,6 +50,13 @@ const legacySearchPageLayout: Partial<LayoutState> = {
   },
 };
 
+const searchPageLayout: Partial<LayoutState> = {
+  sidebar: {
+    isShown: true,
+    initialSectionCollapsed: true
+  }
+};
+
 const EventDefinitionReplaySearch = ({ eventDefinitionMappedData }: Props) => {
   const { eventDefinition, aggregations } = eventDefinitionMappedData;
   const { openSidebar } = useRightSidebar();
@@ -78,7 +85,7 @@ const EventDefinitionReplaySearch = ({ eventDefinitionMappedData }: Props) => {
 
   return (
     <ReplaySearchContext.Provider value={replaySearchContext}>
-      <ReplaySearch view={view} searchPageLayout={isRightSidebarEnabled ? undefined : legacySearchPageLayout} />
+      <ReplaySearch view={view} searchPageLayout={isRightSidebarEnabled ? searchPageLayout : legacySearchPageLayout} />
     </ReplaySearchContext.Provider>
   );
 };

--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.tsx
@@ -18,7 +18,7 @@ import React, { useMemo } from 'react';
 
 import usePluginEntities from 'hooks/usePluginEntities';
 import GeneralEventSideBar from 'components/events/ReplaySearchSidebar/GeneralEventSideBar';
-import type { EventReplaySideBarDetailsProps } from 'views/types';
+import type { EventDefinitionSideBarDetailsProps, EventReplaySideBarDetailsProps } from 'views/types';
 
 type Props = {
   alertId: string;
@@ -27,16 +27,29 @@ type Props = {
 
 const ReplaySearchSidebar = ({ alertId, definitionId = undefined }: Props) => {
   const sideBarDetailsPlugin = usePluginEntities('views.components.eventReplay.sideBarDetails');
+  const isEventDefinition = !alertId && !!definitionId;
+
+  const EventDefSideBar = useMemo<React.ComponentType<EventDefinitionSideBarDetailsProps> | null>(() => {
+    const sideBarDetails = sideBarDetailsPlugin[0];
+    const hasPlugin = typeof sideBarDetails?.useCondition === 'function' ? sideBarDetails.useCondition() : true;
+
+    if (hasPlugin && sideBarDetails?.eventDefinitionComponent) return sideBarDetails.eventDefinitionComponent;
+
+    return null;
+  }, [sideBarDetailsPlugin]);
 
   const EventSideBarDetails = useMemo<React.ComponentType<EventReplaySideBarDetailsProps>>(() => {
     const sideBarDetails = sideBarDetailsPlugin[0];
-
     const hasPlugin = typeof sideBarDetails?.useCondition === 'function' ? sideBarDetails.useCondition() : true;
 
     if (hasPlugin && !!sideBarDetails?.component) return sideBarDetails.component;
 
     return GeneralEventSideBar;
   }, [sideBarDetailsPlugin]);
+
+  if (isEventDefinition && EventDefSideBar) {
+    return <EventDefSideBar definitionId={definitionId} />;
+  }
 
   return <EventSideBarDetails alertId={alertId} definitionId={definitionId} />;
 };

--- a/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
+++ b/graylog2-web-interface/src/components/events/bulk-replay/EventListItem.tsx
@@ -60,6 +60,7 @@ const Summary = styled.span<SummaryProps>(
   ({ theme, $done }) => css`
     color: ${$done ? theme.colors.text.secondary : theme.colors.text.primary};
     flex-grow: 1;
+    overflow-wrap: anywhere;
   `,
 );
 

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -631,8 +631,13 @@ export type EventReplaySideBarDetailsProps = {
   definitionId?: string;
 };
 
+export type EventDefinitionSideBarDetailsProps = {
+  definitionId: string;
+};
+
 export type EventReplaySideBarPlugin = {
   component: React.ComponentType<EventReplaySideBarDetailsProps>;
+  eventDefinitionComponent?: React.ComponentType<EventDefinitionSideBarDetailsProps>;
   key: string;
   useCondition?: () => boolean;
 };


### PR DESCRIPTION
## Description
- Extracted a new `EventDefinitionSideBarDetailsProps` type and `eventDefinitionComponent` plugin slot in `EventReplaySideBarPlugin`, so the event-definition-only sidebar can be rendered by a dedicated component with its own state.
- Updated `ReplaySearchSidebar` to branch between the event-definition component and the standard event sidebar, each resolved via `useMemo`.
- Collapsed the left sidebar by default when viewing event definition replay searches (`EventDefinitionReplaySearch`).
- Fixed long event names overflowing in the bulk replay `EventListItem` summary with `overflow-wrap: anywhere`.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/13959
/nocl new feature

## Motivation and Context
When switching between event and event-definition views in the replay search sidebar, the shared `selectedSegment` state could become stale. Splitting into separate components lets React unmount/mount naturally, resetting segment state without workarounds.

## How Has This Been Tested?
Manual testing. Existing tests unaffected.

## Screenshots (if appropriate):
N/A — companion GPE PR has the visible UI changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (non-breaking change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.