### PR TITLE
Fix yarn not found in scheduled CI workflows

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -71,5 +71,5 @@ jobs:
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg workflow "${{ github.workflow }}" \
-              --arg error "$RUN_URL" \
-              '{workflow: $workflow, error: $error}')"
+              --arg run_url "$RUN_URL" \
+              '{workflow: $workflow, run_url: $run_url}')"

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -64,19 +64,12 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          GH_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK: ${{ secrets.WORKFLOW_FAILURE_SLACK_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ERROR=$(gh run view ${{ github.run_id }} --log-failed 2>/dev/null | tail -c 2500 || true)
-          if [ -z "$ERROR" ]; then
-            ERROR="Workflow failed. See: $RUN_URL"
-          else
-            ERROR="$ERROR"$'\n\nFull log: '"$RUN_URL"
-          fi
           curl -X POST "$SLACK_WEBHOOK" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg workflow "${{ github.workflow }}" \
-              --arg error "$ERROR" \
+              --arg error "$RUN_URL" \
               '{workflow: $workflow, error: $error}')"

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Install dependencies
         run: yarn install
       - name: Updating browserslist db

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Install yarn
+        run: npm install -g yarn
       - name: Install dependencies
         run: yarn install
       - name: Updating browserslist db

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -60,3 +60,23 @@ jobs:
           -f initial_actor="Dr. Lint-a-lot"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_GRAYLOG_PROJECT_INTERNAL_WORKFLOW_RW }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK: ${{ secrets.WORKFLOW_FAILURE_SLACK_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ERROR=$(gh run view ${{ github.run_id }} --log-failed 2>/dev/null | tail -c 2500 || true)
+          if [ -z "$ERROR" ]; then
+            ERROR="Workflow failed. See: $RUN_URL"
+          else
+            ERROR="$ERROR"$'\n\nFull log: '"$RUN_URL"
+          fi
+          curl -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg workflow "${{ github.workflow }}" \
+              --arg error "$ERROR" \
+              '{workflow: $workflow, error: $error}')"

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -57,3 +57,23 @@ jobs:
           -f initial_actor="Dr. Lint-a-lot"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_GRAYLOG_PROJECT_INTERNAL_WORKFLOW_RW }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK: ${{ secrets.WORKFLOW_FAILURE_SLACK_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ERROR=$(gh run view ${{ github.run_id }} --log-failed 2>/dev/null | tail -c 2500 || true)
+          if [ -z "$ERROR" ]; then
+            ERROR="Workflow failed. See: $RUN_URL"
+          else
+            ERROR="$ERROR"$'\n\nFull log: '"$RUN_URL"
+          fi
+          curl -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg workflow "${{ github.workflow }}" \
+              --arg error "$ERROR" \
+              '{workflow: $workflow, error: $error}')"

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -68,5 +68,5 @@ jobs:
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg workflow "${{ github.workflow }}" \
-              --arg error "$RUN_URL" \
-              '{workflow: $workflow, error: $error}')"
+              --arg run_url "$RUN_URL" \
+              '{workflow: $workflow, run_url: $run_url}')"

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Install yarn
+        run: npm install -g yarn
       - name: Install dependencies
         run: yarn install
       - name: Create/Update Pull Request

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -61,19 +61,12 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          GH_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK: ${{ secrets.WORKFLOW_FAILURE_SLACK_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ERROR=$(gh run view ${{ github.run_id }} --log-failed 2>/dev/null | tail -c 2500 || true)
-          if [ -z "$ERROR" ]; then
-            ERROR="Workflow failed. See: $RUN_URL"
-          else
-            ERROR="$ERROR"$'\n\nFull log: '"$RUN_URL"
-          fi
           curl -X POST "$SLACK_WEBHOOK" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg workflow "${{ github.workflow }}" \
-              --arg error "$ERROR" \
+              --arg error "$RUN_URL" \
               '{workflow: $workflow, error: $error}')"

--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -14,7 +14,11 @@ jobs:
         working-directory: graylog2-web-interface
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Install dependencies
         run: yarn install
       - name: Create/Update Pull Request


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v4` (Node 24) to `update-browserslist-db.yml` and `updating-lockfile.yml` workflows, which fail with `yarn: command not found` on the `ubuntu-slim` runner.
- Bump `actions/checkout` from v3 to v4 in `updating-lockfile.yml`.

/nocl No user-facing change

## Test plan
- [ ] Manually trigger `Update browserslist DB` workflow and verify it passes
- [ ] Manually trigger `Updating yarn lockfile` workflow and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)