### PR TITLE
Handle events overview when event definition is missing (`6.3`)

### DIFF
--- a/changelog/unreleased/pr-25548.toml
+++ b/changelog/unreleased/pr-25548.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Show event definition ID instead of throwing errors in the Events Overview widget when the event definition has been deleted"
+
+pulls = ["25548"]
+issues = ["graylog-plugin-enterprise#13756"]

--- a/graylog2-web-interface/src/components/events/events/hooks/useEventDefinition.tsx
+++ b/graylog2-web-interface/src/components/events/events/hooks/useEventDefinition.tsx
@@ -19,21 +19,20 @@ import { useQuery } from '@tanstack/react-query';
 import fetch from 'logic/rest/FetchProvider';
 import { qualifyUrl } from 'util/URLUtils';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
-import { defaultOnError } from 'util/conditional/onError';
 
 export const fetchEventDefinitionDetails = async (eventDefinitionId: string): Promise<EventDefinition> =>
   fetch('GET', qualifyUrl(`/events/definitions/${eventDefinitionId}`));
 
 const useEventDefinition = (eventDefId: string, enabled = true) => {
-  const { data, isFetching, isInitialLoading } = useQuery({
+  const { data, isFetching, isInitialLoading, isError } = useQuery({
     queryKey: ['get-event-definition-details', eventDefId],
-    queryFn: () => defaultOnError(fetchEventDefinitionDetails(eventDefId), 'Loading archives failed with status'),
+    queryFn: () => fetchEventDefinitionDetails(eventDefId),
     retry: 0,
     keepPreviousData: true,
     enabled: !!eventDefId && enabled,
   });
 
-  return { data, isFetching, isInitialLoading };
+  return { data, isFetching, isInitialLoading, isError };
 };
 
 export default useEventDefinition;

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventDetails.test.tsx
@@ -55,7 +55,7 @@ describe('EventDetails', () => {
     );
 
     asMock(useCurrentUser).mockReturnValue(adminUser);
-    asMock(useEventDefinition).mockReturnValue({ data: undefined, isFetching: false, isInitialLoading: false });
+    asMock(useEventDefinition).mockReturnValue({ data: undefined, isFetching: false, isInitialLoading: false, isError: false });
 
     asMock(useEventById).mockImplementation(() => ({
       data: mockEventData.event,
@@ -90,6 +90,7 @@ describe('EventDetails', () => {
       data: mockEventDefinitionTwoAggregations,
       isFetching: false,
       isInitialLoading: false,
+      isError: false,
     });
 
     renderEventDetails();

--- a/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/filters/EventDefinitionName.tsx
@@ -31,26 +31,22 @@ type Props = {
 const EventDefinitionName = ({ eventDefinitionId, displayAsLink = true }: Props) => {
   const currentUser = useCurrentUser();
   const canViewDefinition = isPermitted(currentUser.permissions, `eventdefinitions:read:${eventDefinitionId}`);
-  const { data: eventDefinition, isFetching } = useEventDefinition(eventDefinitionId, canViewDefinition);
+  const { data: eventDefinition, isFetching, isError } = useEventDefinition(eventDefinitionId, canViewDefinition);
   const title = eventDefinition?.title ?? eventDefinitionId;
 
   if (isFetching) {
     return <Spinner />;
   }
 
-  if (!displayAsLink || !canViewDefinition) {
+  if (!displayAsLink || !canViewDefinition || !eventDefinition || isError) {
     return <>{title}</>;
   }
 
-  if (eventDefinition) {
-    return (
-      <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)} target="_blank">
-        {title}
-      </Link>
-    );
-  }
-
-  return null;
+  return (
+    <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)} target="_blank">
+      {title}
+    </Link>
+  );
 };
 
 export default EventDefinitionName;


### PR DESCRIPTION
Note: This is a backport of #25548 to `6.3`.

## Description

When an event definition is deleted, the Events Overview widget on the search page would throw errors and show error toast notifications if the event definition column was displayed. This change gracefully handles missing event definitions by falling back to displaying the raw event definition ID — matching the existing behavior on the Alerts page.

## Motivation and Context

Fixes [graylog-plugin-enterprise#13756](https://github.com/Graylog2/graylog-plugin-enterprise/issues/13756)

When users delete event definitions, existing events still reference the old definition ID. The `EventDefinitionName` component would attempt to fetch the deleted definition, get a 404, and the `defaultOnError` wrapper would display an error toast for every affected row. Additionally, the component returned `null` for the cell content when `displayAsLink` was true, leaving empty cells.

## Changes

- **`EventDefinitionName.tsx`**: When the event definition fetch fails or returns no data, render the event definition ID as plain text instead of returning `null`
- **`useEventDefinition.tsx`** (in `components/events/events/hooks/`): Removed `defaultOnError` wrapper to prevent error toast notifications on expected 404s; exposed `isError` from the query
- **`EventDetails.test.tsx`**: Updated mocks to include the new `isError` field

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
