### PR TITLE
Fix switching event definition from aggregation to filter mode (`7.0`)

### DIFF
--- a/changelog/unreleased/issue-22115.toml
+++ b/changelog/unreleased/issue-22115.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix inability to switch event definition from aggregation to filter-only."
+
+pulls = ["25569"]
+issues = ["22115"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import FormWarningsProvider from 'contexts/FormWarningsProvider';
+import { simpleEventDefinition } from 'fixtures/eventDefinition';
+import { adminUser } from 'fixtures/users';
+
+import FilterAggregationForm from './FilterAggregationForm';
+
+describe('FilterAggregationForm', () => {
+  const defaultProps = {
+    eventDefinition: simpleEventDefinition,
+    onChange: jest.fn(),
+    entityTypes: { aggregation_functions: [] },
+    streams: [],
+    currentUser: adminUser,
+    validation: { errors: {} },
+  };
+
+  const aggregationEventDefinition = {
+    ...simpleEventDefinition,
+    config: {
+      ...simpleEventDefinition.config,
+      group_by: ['source'],
+      series: [{ id: 'series-1', function: 'count', field: 'timestamp' }],
+      conditions: {
+        expression: {
+          expr: '<',
+          left: { expr: 'number-ref', ref: 'series-1' },
+          right: { expr: 'number', value: 100 },
+        },
+      },
+    },
+  };
+
+  const renderForm = (props = {}) => render(
+    <FormWarningsProvider>
+      <FilterAggregationForm {...defaultProps} {...props} />
+    </FormWarningsProvider>,
+  );
+
+  it('should clear aggregation config when switching from aggregation to filter mode', async () => {
+    const onChange = jest.fn();
+
+    renderForm({ eventDefinition: aggregationEventDefinition, onChange });
+
+    const filterRadio = await screen.findByLabelText('Filter has results');
+
+    await userEvent.click(filterRadio);
+
+    expect(onChange).toHaveBeenCalledWith('config', expect.objectContaining({
+      group_by: [],
+      series: [],
+      conditions: {},
+    }));
+  });
+
+  it('should restore aggregation config when switching back from filter to aggregation mode', async () => {
+    const onChange = jest.fn();
+
+    const { rerender } = renderForm({
+      eventDefinition: aggregationEventDefinition,
+      onChange,
+    });
+
+    // Switch to filter mode
+    const filterRadio = await screen.findByLabelText('Filter has results');
+
+    await userEvent.click(filterRadio);
+
+    expect(onChange).toHaveBeenCalledWith('config', expect.objectContaining({
+      group_by: [],
+      series: [],
+      conditions: {},
+    }));
+
+    // Simulate parent updating eventDefinition with the cleared config
+    const clearedConfig = onChange.mock.calls[0][1];
+    const clearedEventDefinition = {
+      ...aggregationEventDefinition,
+      config: clearedConfig,
+    };
+
+    rerender(
+      <FormWarningsProvider>
+        <FilterAggregationForm
+          {...defaultProps}
+          eventDefinition={clearedEventDefinition}
+          onChange={onChange}
+        />
+      </FormWarningsProvider>,
+    );
+
+    // Switch back to aggregation mode
+    const aggregationRadio = await screen.findByLabelText('Aggregation of results reaches a threshold');
+
+    await userEvent.click(aggregationRadio);
+
+    expect(onChange).toHaveBeenLastCalledWith('config', expect.objectContaining({
+      group_by: ['source'],
+      series: [{ id: 'series-1', function: 'count', field: 'timestamp' }],
+      conditions: expect.objectContaining({
+        expression: expect.objectContaining({ expr: '<' }),
+      }),
+    }));
+  });
+});

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -161,11 +160,8 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
                   type="number"
                   bsStyle={validation.errors.event_limit ? 'error' : null}
                   help={
-                    get(
-                      validation,
-                      'errors.event_limit',
-                      'Maximum number of events to be created per execution of this event definition. Excess events will be suppressed.',
-                    ) as string
+                    (validation.errors.event_limit
+                      ?? 'Maximum number of events to be created per execution of this event definition. Excess events will be suppressed.') as string
                   }
                   value={eventDefinition.config.event_limit}
                   onChange={handleConfigChange}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.tsx
@@ -95,26 +95,23 @@ const FilterAggregationForm = ({ entityTypes, eventDefinition, streams, validati
       const nextConditionType = Number(FormsUtils.getValueFromInput(event.target));
 
       setConditionType(nextConditionType);
-      let newExistingAggregationConfig;
-
       if (nextConditionType === conditionTypes.FILTER) {
         // Store existing data temporarily in state, to restore it in case the type change was accidental
-        Object.keys(initialAggregationConfig).forEach((key) => {
-          newExistingAggregationConfig[key] = eventDefinition.config[key];
-        });
+        const savedAggregationConfig = Object.fromEntries(
+          Object.keys(initialAggregationConfig).map((key) => [key, eventDefinition.config[key]]),
+        ) as EventDefinition['config'];
 
         const nextConfig = { ...eventDefinition.config, ...initialAggregationConfig };
 
         propagateConfigChange(nextConfig as EventDefinition['config']);
+        setExistingAggregationConfig(savedAggregationConfig);
       } else if (existingAggregationConfig) {
         // Reset aggregation data from state if it exists
         const nextConfig = { ...eventDefinition.config, ...existingAggregationConfig };
 
         propagateConfigChange(nextConfig);
-        newExistingAggregationConfig = undefined;
+        setExistingAggregationConfig(undefined);
       }
-
-      setExistingAggregationConfig(newExistingAggregationConfig);
     },
     [eventDefinition.config, existingAggregationConfig, propagateConfigChange],
   );


### PR DESCRIPTION
Note: This is a backport of #25569 to `7.0`.

## Summary
- Fixes an uninitialized variable in `FilterAggregationForm.handleTypeChange` that caused a `TypeError` when switching an event definition from "Aggregation of results reaches a threshold" to "Filter has results"
- The `newExistingAggregationConfig` variable was declared but never initialized, so property assignments on `undefined` silently failed, preventing the mode switch from working
- Adds test coverage for the type switching logic

Closes #22115

## Test plan
- [ ] Create an event definition with "Aggregation of results reaches a threshold" and save it
- [ ] Edit the event definition and switch to "Filter has results"
- [ ] Verify the switch succeeds and the definition can be saved
- [ ] Switch back to "Aggregation" and verify the previous aggregation config is restored