### PR TITLE
Render Alerts & Events histogram in the user's timezone

### DIFF
--- a/changelog/unreleased/pr-25744.toml
+++ b/changelog/unreleased/pr-25744.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Render Alerts & Events histogram in the user's configured timezone so its x-axis matches the events table below."
+
+pulls = ["25744"]

--- a/graylog2-web-interface/src/components/events/EventsHistogram.tsx
+++ b/graylog2-web-interface/src/components/events/EventsHistogram.tsx
@@ -34,7 +34,7 @@ import type ColorMapper from 'views/components/visualizations/ColorMapper';
 import type { MiddleSectionProps } from 'components/common/PaginatedEntityTable/PaginatedEntityTable';
 import useUserDateTime from 'hooks/useUserDateTime';
 import { toUTCFromTz } from 'util/DateTime';
-import type { DateTime, DateTimeFormats } from 'util/DateTime';
+import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
 import useOnRefresh from 'components/common/PaginatedEntityTable/useOnRefresh';
@@ -57,7 +57,7 @@ const GraphContainer = styled.div`
 
 type ResultPromise = ReturnType<typeof fetchEventsHistogram>;
 
-type FormatTime = (time: DateTime, format?: DateTimeFormats) => string;
+type FormatTime = UserDateTimeContextType['formatTime'];
 
 const generateChart = (
   type: 'Alerts' | 'Events',

--- a/graylog2-web-interface/src/components/events/EventsHistogram.tsx
+++ b/graylog2-web-interface/src/components/events/EventsHistogram.tsx
@@ -33,7 +33,8 @@ import GenericPlot, { type PlotLayout, type ChartConfig } from 'views/components
 import type ColorMapper from 'views/components/visualizations/ColorMapper';
 import type { MiddleSectionProps } from 'components/common/PaginatedEntityTable/PaginatedEntityTable';
 import useUserDateTime from 'hooks/useUserDateTime';
-import { toUTCFromTz, adjustFormat } from 'util/DateTime';
+import { toUTCFromTz } from 'util/DateTime';
+import type { DateTime, DateTimeFormats } from 'util/DateTime';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { isTypeRelativeWithStartOnly } from 'views/typeGuards/timeRange';
 import useOnRefresh from 'components/common/PaginatedEntityTable/useOnRefresh';
@@ -56,11 +57,14 @@ const GraphContainer = styled.div`
 
 type ResultPromise = ReturnType<typeof fetchEventsHistogram>;
 
+type FormatTime = (time: DateTime, format?: DateTimeFormats) => string;
+
 const generateChart = (
   type: 'Alerts' | 'Events',
   buckets: Awaited<ResultPromise>['results']['buckets']['alerts' | 'events'],
+  formatTime: FormatTime,
 ) => {
-  const x = buckets.map((b) => b.start_date);
+  const x = buckets.map((b) => formatTime(b.start_date, 'internal'));
   const y = buckets.map((b) => b.count);
 
   return {
@@ -108,32 +112,34 @@ const layout: Partial<PlotLayout> = {
   legend: { y: yLegendPosition(height) },
 };
 
-const prepareTimeRangeForGraph = (timerange: TimeRange) => {
+const prepareTimeRangeForGraph = (timerange: TimeRange, formatTime: FormatTime) => {
   if (isTypeRelativeWithStartOnly(timerange)) {
-    const from = moment().utc().subtract(timerange.range, 'seconds');
+    const from = moment().subtract(timerange.range, 'seconds');
     const to = moment();
 
-    return [adjustFormat(from, 'internal'), adjustFormat(to, 'internal')];
+    return [formatTime(from, 'internal'), formatTime(to, 'internal')];
   }
 
-  return [timerange.from, timerange.to];
+  return [formatTime(timerange.from, 'internal'), formatTime(timerange.to, 'internal')];
 };
 
 const EventsGraph = ({
   data: { results, timerange },
   alerts,
   onZoom,
+  formatTime,
 }: {
   data: Awaited<ResultPromise>;
   alerts: 'include' | 'exclude' | 'only';
   onZoom: (from: string, to: string) => void;
+  formatTime: FormatTime;
 }) => {
   const chartData = useMemo(
     () => [
-      ...(['include', 'exclude'].includes(alerts) ? [generateChart('Events', results.buckets.events)] : []),
-      ...(['include', 'only'].includes(alerts) ? [generateChart('Alerts', results.buckets.alerts)] : []),
+      ...(['include', 'exclude'].includes(alerts) ? [generateChart('Events', results.buckets.events, formatTime)] : []),
+      ...(['include', 'only'].includes(alerts) ? [generateChart('Alerts', results.buckets.alerts, formatTime)] : []),
     ],
-    [alerts, results.buckets.alerts, results.buckets.events],
+    [alerts, results.buckets.alerts, results.buckets.events, formatTime],
   );
 
   const _layout = useMemo(
@@ -141,10 +147,10 @@ const EventsGraph = ({
       ...layout,
       xaxis: {
         ...layout.xaxis,
-        range: prepareTimeRangeForGraph(timerange),
+        range: prepareTimeRangeForGraph(timerange, formatTime),
       },
     }),
-    [timerange],
+    [timerange, formatTime],
   );
 
   return (
@@ -197,7 +203,7 @@ const EventsHistogram = ({ searchParams, setFilters, eventsHistogramFetcher = fe
     return <Alert bsStyle="danger">Loading events histogram failed: {error?.message ?? 'Unknown error'}</Alert>;
   }
 
-  return <EventsGraph data={data} alerts={alerts} onZoom={onZoom} />;
+  return <EventsGraph data={data} alerts={alerts} onZoom={onZoom} formatTime={formatTime} />;
 };
 
 export default EventsHistogram;


### PR DESCRIPTION
## Description
The histogram axis formatted bucket timestamps and range bounds using UTC (and browser-local in Plotly), while the events table below formatted the same timestamps in the user's configured Graylog timezone. This caused a visual offset between the graph and the table whenever those differed.

Route both bucket x values and the axis range through formatTime so the histogram uses the same timezone pipeline as the table.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13839

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/13839

## How Has This Been Tested?
Manually.

## Screenshots
<img width="1902" height="557" alt="image" src="https://github.com/user-attachments/assets/a13013d5-6dd0-4e03-88cd-492bee5d6d4b" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

