### PR TITLE
Add shared Sanitize component for DOMPurify-wrapped HTML

### DIFF
--- a/graylog2-web-interface/src/components/common/Sanitize.md
+++ b/graylog2-web-interface/src/components/common/Sanitize.md
@@ -1,0 +1,34 @@
+Renders sanitized HTML inside a `<span>`. Use it anywhere you would otherwise reach for `dangerouslySetInnerHTML` — the component wraps `DOMPurify.sanitize` and owns the single `react/no-danger` eslint-disable.
+
+Safe HTML passes through untouched:
+
+```js
+<Sanitize html="<b>bold</b> and <i>italic</i>" />
+```
+
+Malicious input is stripped:
+
+```js
+<Sanitize html={'hello<script>alert(1)</script>world'} />
+```
+
+Nullish input renders an empty span:
+
+```js
+<Sanitize html={null} />
+```
+
+Any standard HTML attribute is forwarded to the rendered span:
+
+```js
+<Sanitize html="feed title" className="feed-title" title="Open article" />
+```
+
+Pass a `config` object for non-default `DOMPurify` profiles (e.g. SVG content):
+
+```js
+<Sanitize
+  html='<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><circle cx="12" cy="12" r="10" fill="currentColor" /></svg>'
+  config={{ USE_PROFILES: { svg: true } }}
+/>
+```

--- a/graylog2-web-interface/src/components/common/Sanitize.test.tsx
+++ b/graylog2-web-interface/src/components/common/Sanitize.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import Sanitize from './Sanitize';
+
+const TEST_ID = 'sanitize-target';
+
+describe('Sanitize', () => {
+  it('renders safe HTML inside a span', () => {
+    render(<Sanitize html="<b>bold</b> and <i>italic</i>" data-testid={TEST_ID} />);
+
+    const span = screen.getByTestId(TEST_ID);
+
+    expect(span.innerHTML).toBe('<b>bold</b> and <i>italic</i>');
+  });
+
+  it('strips <script> tags', () => {
+    render(<Sanitize html={'hello<script>alert(1)</script>world'} data-testid={TEST_ID} />);
+
+    const span = screen.getByTestId(TEST_ID);
+
+    expect(span.innerHTML).not.toContain('<script');
+    expect(span.textContent).toBe('helloworld');
+  });
+
+  it('strips inline event handlers', () => {
+    render(<Sanitize html={'<img src="x" onerror="alert(1)" alt="broken" />'} data-testid={TEST_ID} />);
+
+    const img = screen.getByAltText('broken');
+
+    expect(img.getAttribute('onerror')).toBeNull();
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+  ])('renders an empty span for %s', (_label, input) => {
+    render(<Sanitize html={input} data-testid={TEST_ID} />);
+
+    const span = screen.getByTestId(TEST_ID);
+
+    expect(span.innerHTML).toBe('');
+  });
+
+  it('passes HTML attributes through to the span', () => {
+    render(<Sanitize html="hello" className="my-class" title="tooltip" data-testid={TEST_ID} />);
+
+    const span = screen.getByTestId(TEST_ID);
+
+    expect(span.getAttribute('class')).toBe('my-class');
+    expect(span.getAttribute('title')).toBe('tooltip');
+    expect(span.tagName).toBe('SPAN');
+  });
+
+  it('honors a custom config that strips all tags', () => {
+    render(<Sanitize html="<b>keep text</b>" config={{ ALLOWED_TAGS: [] }} data-testid={TEST_ID} />);
+
+    const span = screen.getByTestId(TEST_ID);
+
+    expect(span.innerHTML).not.toContain('<b');
+    expect(span.textContent).toBe('keep text');
+  });
+});

--- a/graylog2-web-interface/src/components/common/Sanitize.tsx
+++ b/graylog2-web-interface/src/components/common/Sanitize.tsx
@@ -14,10 +14,20 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as React from 'react';
 import { useMemo } from 'react';
+import DOMPurify from 'dompurify';
 
-import AppConfig from 'util/AppConfig';
+type Props = {
+  html: string | null | undefined;
+  config?: DOMPurify.Config;
+} & Omit<React.HTMLAttributes<HTMLSpanElement>, 'dangerouslySetInnerHTML' | 'children'>;
 
-const useCustomLogo = (theme: 'dark' | 'light') => useMemo(() => AppConfig?.branding?.()?.logo?.[theme], [theme]);
+const Sanitize = ({ html, config = undefined, ...rest }: Props) => {
+  const sanitized = useMemo(() => DOMPurify.sanitize(html ?? '', config ?? {}), [html, config]);
 
-export default useCustomLogo;
+  // eslint-disable-next-line react/no-danger
+  return <span {...rest} dangerouslySetInnerHTML={{ __html: sanitized }} />;
+};
+
+export default Sanitize;

--- a/graylog2-web-interface/src/components/common/Sanitize.tsx
+++ b/graylog2-web-interface/src/components/common/Sanitize.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useMemo } from 'react';
 import DOMPurify from 'dompurify';
 
 type Props = {
@@ -24,7 +23,7 @@ type Props = {
 } & Omit<React.HTMLAttributes<HTMLSpanElement>, 'dangerouslySetInnerHTML' | 'children'>;
 
 const Sanitize = ({ html, config = undefined, ...rest }: Props) => {
-  const sanitized = useMemo(() => DOMPurify.sanitize(html ?? '', config ?? {}), [html, config]);
+  const sanitized = DOMPurify.sanitize(html ?? '', config ?? {});
 
   // eslint-disable-next-line react/no-danger
   return <span {...rest} dangerouslySetInnerHTML={{ __html: sanitized }} />;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -113,6 +113,7 @@ export { default as ReadOnlyFormGroup } from './ReadOnlyFormGroup';
 export { default as RelativeTime } from './RelativeTime';
 export { default as RestrictedAccessTooltip } from './RestrictedAccessTooltip';
 export { default as RingProgress } from './RingProgress';
+export { default as Sanitize } from './Sanitize';
 export { default as ScrollButton } from './ScrollButton';
 export { default as Skeleton } from './Skeleton';
 export { default as SearchForm } from './SearchForm';

--- a/graylog2-web-interface/src/components/content-stream/ContentStreamReleasesSection.tsx
+++ b/graylog2-web-interface/src/components/content-stream/ContentStreamReleasesSection.tsx
@@ -18,10 +18,9 @@ import React from 'react';
 import type { DefaultTheme } from 'styled-components';
 import styled, { css } from 'styled-components';
 import isEmpty from 'lodash/isEmpty';
-import DOMPurify from 'dompurify';
 
 import { ListGroup, ListGroupItem, Label, Alert } from 'components/bootstrap';
-import { RelativeTime, Spinner, ExternalLink } from 'components/common';
+import { RelativeTime, Sanitize, Spinner, ExternalLink } from 'components/common';
 import type { FeedItem } from 'components/content-stream/hook/useContentStream';
 import useContentStream from 'components/content-stream/hook/useContentStream';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -44,8 +43,6 @@ export const StyledLabel = styled(Label)`
   width: 110px;
   display: block;
 `;
-
-const _sanitizeText = (text = '') => DOMPurify.sanitize(text);
 
 const ContentStreamReleasesSection = () => {
   const path = 'release-info';
@@ -83,8 +80,7 @@ const ContentStreamReleasesSection = () => {
       {feedList.map((feed) => (
         <StyledListGroupItem key={feed?.guid['#text'] || feed?.title}>
           <a href={feed?.link} onClick={() => handleSendTelemetry(feed)} target="_blank" rel="noreferrer">
-            {/* eslint-disable-next-line react/no-danger */}
-            <span dangerouslySetInnerHTML={{ __html: _sanitizeText(feed?.title) }} />
+            <Sanitize html={feed?.title} />
           </a>
           {feed?.pubDate ? (
             <LastOpenedTime>

--- a/graylog2-web-interface/src/components/content-stream/news/ContentStreamNewsItem.tsx
+++ b/graylog2-web-interface/src/components/content-stream/news/ContentStreamNewsItem.tsx
@@ -17,9 +17,8 @@
 import React from 'react';
 import type { DefaultTheme } from 'styled-components';
 import styled, { css } from 'styled-components';
-import DOMPurify from 'dompurify';
 
-import { Carousel, Timestamp } from 'components/common';
+import { Carousel, Sanitize, Timestamp } from 'components/common';
 import { Panel } from 'components/bootstrap';
 import type { FeedItem, FeedMediaContent } from 'components/content-stream/hook/useContentStream';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -62,7 +61,6 @@ const StyledPanel = styled(Panel)(
     border-radius: ${theme.spacings.xxs};
   `,
 );
-const _sanitizeText = (text) => DOMPurify.sanitize(text);
 
 const getImage = (media: FeedMediaContent | Array<FeedMediaContent>) =>
   Array.isArray(media) ? media?.[0]?.attr_url : media?.attr_url;
@@ -90,12 +88,11 @@ const ContentStreamNewsItem = ({ feed }: Props) => {
 
         <StyledPanelBody>
           <a href={feed?.link} target="_blank" onClick={() => handleSendTelemetry()} rel="noreferrer">
-            {/* eslint-disable-next-line react/no-danger */}
-            <span dangerouslySetInnerHTML={{ __html: _sanitizeText(feed?.title) }} />
+            <Sanitize html={feed?.title} />
           </a>
         </StyledPanelBody>
         <StyledPanelFooter>
-          <Timestamp dateTime={_sanitizeText(feed?.pubDate)} format="shortReadable" />
+          <Timestamp dateTime={feed?.pubDate} format="shortReadable" />
         </StyledPanelFooter>
       </StyledPanel>
     </Carousel.Slide>

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -20,6 +20,7 @@ import styled, { css } from 'styled-components';
 import DOMPurify from 'dompurify';
 
 import LoginBox from 'components/login/LoginBox';
+import { Sanitize } from 'components/common';
 import PublicNotifications from 'components/common/PublicNotifications';
 import backgroundImage from 'images/auth/login-bg.svg';
 import { Logo } from 'components/navigation/NavigationBrand';
@@ -107,7 +108,9 @@ const CustomizableLogo = () => {
   const customLogo = useCustomLogo(colorScheme);
 
   return customLogo ? (
-    <CustomLogo dangerouslySetInnerHTML={{ __html: customLogo }} />
+    <CustomLogo>
+      <Sanitize html={customLogo} />
+    </CustomLogo>
   ) : (
     <LogoContainer>
       <Logo color="#03C3FF" />

--- a/graylog2-web-interface/src/components/navigation/NavIcon.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavIcon.tsx
@@ -16,12 +16,10 @@
  */
 
 import * as React from 'react';
-import DOMPurify from 'dompurify';
 import styled from 'styled-components';
-import { useMemo } from 'react';
 
 import useNavigationCustomization from 'brand-customization/useNavigationCustomization';
-import { Icon } from 'components/common';
+import { Icon, Sanitize } from 'components/common';
 import type { IconName } from 'components/common/Icon';
 import type { Branding } from 'util/AppConfig';
 import { MAX_NAV_ICON_WIDTH } from 'theme/constants';
@@ -48,15 +46,8 @@ const SvgContainer = styled.div`
 
 const useCustomIcon = (type: NavIconType) => {
   const navigationCustomization = useNavigationCustomization();
-  const customIcon = navigationCustomization?.[type]?.icon;
 
-  return useMemo(() => {
-    if (customIcon) {
-      return DOMPurify.sanitize(customIcon);
-    }
-
-    return null;
-  }, [customIcon]);
+  return navigationCustomization?.[type]?.icon ?? null;
 };
 
 type Props = {
@@ -68,7 +59,11 @@ const NavIcon = ({ type, title = undefined }: Props) => {
   const customSvgIcon = useCustomIcon(type);
 
   if (customSvgIcon) {
-    return <SvgContainer dangerouslySetInnerHTML={{ __html: customSvgIcon }} title={title} />;
+    return (
+      <SvgContainer title={title}>
+        <Sanitize html={customSvgIcon} />
+      </SvgContainer>
+    );
   }
 
   return <Icon name={DEFAULT_ICONS[type]} size="lg" title={title} />;

--- a/graylog2-web-interface/src/components/navigation/NavigationBrand.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationBrand.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
 
+import { Sanitize } from 'components/common';
 import { NAV_LOGO_HEIGHT, MAX_NAV_LOGO_WIDTH } from 'theme/constants';
 import useCustomLogo from 'brand-customization/useCustomLogo';
 
@@ -78,7 +79,13 @@ const NavigationBrand = () => {
   const theme = useTheme();
   const customLogo = useCustomLogo(theme.mode);
 
-  if (customLogo) return <StyledSvgContainer dangerouslySetInnerHTML={{ __html: customLogo }} />;
+  if (customLogo) {
+    return (
+      <StyledSvgContainer>
+        <Sanitize html={customLogo} />
+      </StyledSvgContainer>
+    );
+  }
 
   return <Logo color={theme.colors.brand.logo} />;
 };

--- a/graylog2-web-interface/src/components/navigation/NavigationBrand.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationBrand.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { Sanitize } from 'components/common';
+import Sanitize from 'components/common/Sanitize';
 import { NAV_LOGO_HEIGHT, MAX_NAV_LOGO_WIDTH } from 'theme/constants';
 import useCustomLogo from 'brand-customization/useCustomLogo';
 

--- a/graylog2-web-interface/src/components/notifications/Notification.tsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.tsx
@@ -16,10 +16,9 @@
  */
 import * as React from 'react';
 import styled, { css } from 'styled-components';
-import DOMPurify from 'dompurify';
 
 import { Alert } from 'components/bootstrap';
-import { RelativeTime, Spinner } from 'components/common';
+import { RelativeTime, Sanitize, Spinner } from 'components/common';
 import type { NotificationType } from 'components/notifications/types';
 import useNotificationDelete from 'components/notifications/useNotificationDelete';
 
@@ -50,8 +49,6 @@ const NotificationTimestamp = styled.span(
   `,
 );
 
-const _sanitizeDescription = (description: string) => DOMPurify.sanitize(description);
-
 const Notification = ({ notification }: Props) => {
   const message = useNotificationMessage(notification);
   const deleteNotification = useNotificationDelete();
@@ -67,23 +64,21 @@ const Notification = ({ notification }: Props) => {
     return <Spinner />;
   }
 
-  /* eslint-disable react/no-danger */
   return (
     <StyledAlert
       bsStyle="danger"
       title={
         <>
-          <div dangerouslySetInnerHTML={{ __html: _sanitizeDescription(message?.title) }} />
+          <Sanitize html={message?.title} />
           <NotificationTimestamp>
             (triggered <RelativeTime dateTime={notification.timestamp} />)
           </NotificationTimestamp>
         </>
       }
       onDismiss={_onClose}>
-      <div
-        dangerouslySetInnerHTML={{ __html: _sanitizeDescription(message?.description) }}
-        className="notification-description"
-      />
+      <div className="notification-description">
+        <Sanitize html={message?.description} />
+      </div>
     </StyledAlert>
   );
 };


### PR DESCRIPTION
## Description

Adds a shared `Sanitize` component under `components/common` that wraps `DOMPurify.sanitize` and renders the result in a `<span>`. Migrates the seven `dangerouslySetInnerHTML` call sites in the web interface to use it:

- `components/notifications/Notification.tsx` (alert title + body)
- `components/content-stream/news/ContentStreamNewsItem.tsx` (RSS feed title)
- `components/content-stream/ContentStreamReleasesSection.tsx` (RSS feed title)
- `components/navigation/NavigationBrand.tsx` (custom brand logo SVG)
- `components/navigation/NavIcon.tsx` (custom nav icon SVG)
- `components/login/LoginChrome.tsx` (custom brand logo SVG)

`useCustomLogo` and the inline `useCustomIcon` no longer sanitize themselves — they return the raw branding string, and the render site wraps it in `<Sanitize>`. The single `react/no-danger` eslint-disable now lives inside `Sanitize.tsx`.

Out of scope: `Markdown.tsx` (uses `html-react-parser`), `MarkdownEditor/BaseEditor.tsx` (on-blur normalization, not a render path), and the `loginBackground` SVG-data-URL path in `LoginChrome.tsx` (not `dangerouslySetInnerHTML`).

/nocl Internal refactoring.

## Motivation and Context

Each of the seven call sites previously ran `DOMPurify.sanitize` inline, via a local `_sanitize*` helper, or via a hook that pre-sanitized. The pattern was duplicated, the `react/no-danger` disable comments were inconsistent (file-level in one place, per-line in others, absent in the SVG renderers), and sanitization happened at inconsistent layers. A single component gives us one audit surface for "is this input sanitized?" and removes per-site lint disables.

## Usage

Import from `components/common` and pass the untrusted string via the `html` prop:

```tsx
import { Sanitize } from 'components/common';

<Sanitize html={message?.title} />
```

Any standard HTML attribute can be forwarded to the rendered `<span>`:

```tsx
<Sanitize html={feed?.title} className="feed-title" title="Open article" />
```

For SVG or other non-default sanitizer profiles, pass a `config` object (forwarded to `DOMPurify.sanitize`):

```tsx
<Sanitize
  html={customLogo}
  config={{ USE_PROFILES: { svg: true }, ADD_TAGS: ['use'], ADD_ATTR: ['xlink:href'] }}
/>
```

`html` accepts `string | null | undefined`; nullish values render an empty span.

## How Has This Been Tested?

- `yarn tsc`
- `yarn test --testPathPatterns=Sanitize` — 8 new tests cover safe HTML, `<script>` stripping, inline event handler stripping, `null`/`undefined`/empty input, attribute passthrough, and custom `config`
- `yarn test --testPathPatterns='Notification|ContentStream|NavIcon|NavigationBrand|LoginChrome|useCustomLogo'` — 31 regressions green
- `yarn lint:path` on all edited files — clean
- Grep confirms `dangerouslySetInnerHTML` now only appears in `components/common/Sanitize.tsx`

## Screenshots (if appropriate):

## Types of changes

- [x] Refactoring (non-breaking change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.