### PR TITLE
Bumping mcp version to 1.1.1 for 7.0

### DIFF
--- a/changelog/unreleased/pr-25748.toml
+++ b/changelog/unreleased/pr-25748.toml
@@ -1,0 +1,7 @@
+type = "f"
+message = "Bump the mcp library to a newer version that supports the elicitation parameter in the format."
+
+issues = ["25322"]
+pulls = ["25748"]
+
+

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/McpService.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/McpService.java
@@ -197,10 +197,11 @@ public class McpService {
                                         });
                                 auditEventSender.success(auditActor, AuditEventType.create(MCP_TOOL_CALL),
                                         auditContext);
-                                return Optional.of(new McpSchema.CallToolResult(
-                                        List.of(new McpSchema.TextContent(objectMapper.writeValueAsString(result))),
-                                        false,
-                                        structuredContent));
+                                return Optional.of(McpSchema.CallToolResult.builder()
+                                        .content(List.of(new McpSchema.TextContent(objectMapper.writeValueAsString(result))))
+                                        .isError(false)
+                                        .structuredContent(structuredContent)
+                                        .build());
                             } catch (JsonProcessingException e) {
                                 auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL),
                                         auditContext);
@@ -209,15 +210,24 @@ public class McpService {
                         } else {
                             // no schema, just return the string representation directly
                             auditEventSender.success(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
-                            return Optional.of(new McpSchema.CallToolResult(result.toString(), false));
+                            return Optional.of(McpSchema.CallToolResult.builder()
+                                    .content(List.of(new McpSchema.TextContent(result.toString())))
+                                    .isError(false)
+                                    .build());
                         }
                     } catch (Exception e) {
                         auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
-                        return Optional.of(new McpSchema.CallToolResult(f("Tool call failed: %s", e.getMessage()), true));
+                        return Optional.of(McpSchema.CallToolResult.builder()
+                                .content(List.of(new McpSchema.TextContent(f("Tool call failed: %s", e.getMessage()))))
+                                .isError(true)
+                                .build());
                     }
                 } else {
                     auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
-                    return Optional.of(new McpSchema.CallToolResult("Unknown tool named: " + callToolRequest.name(), true));
+                    return Optional.of(McpSchema.CallToolResult.builder()
+                            .content(List.of(new McpSchema.TextContent("Unknown tool named: " + callToolRequest.name())))
+                            .isError(true)
+                            .build());
                 }
             }
             case McpSchema.METHOD_PROMPT_LIST -> {

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <jjwt.version>0.13.0</jjwt.version>
         <stateless4j.version>2.6.0</stateless4j.version>
         <poi.version>5.4.1</poi.version>
-        <mcp-bom.version>0.17.1</mcp-bom.version>
+        <mcp-bom.version>1.0.0</mcp-bom.version>
         <json-schema-generator.version>4.38.0</json-schema-generator.version>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <jjwt.version>0.13.0</jjwt.version>
         <stateless4j.version>2.6.0</stateless4j.version>
         <poi.version>5.4.1</poi.version>
-        <mcp-bom.version>1.0.0</mcp-bom.version>
+        <mcp-bom.version>1.1.1</mcp-bom.version>
         <json-schema-generator.version>4.38.0</json-schema-generator.version>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <jjwt.version>0.13.0</jjwt.version>
         <stateless4j.version>2.6.0</stateless4j.version>
         <poi.version>5.4.1</poi.version>
-        <mcp-bom.version>0.16.1</mcp-bom.version>
+        <mcp-bom.version>0.17.1</mcp-bom.version>
         <json-schema-generator.version>4.38.0</json-schema-generator.version>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <jjwt.version>0.13.0</jjwt.version>
         <stateless4j.version>2.6.0</stateless4j.version>
         <poi.version>5.4.1</poi.version>
-        <mcp-bom.version>0.14.1</mcp-bom.version>
+        <mcp-bom.version>0.16.1</mcp-bom.version>
         <json-schema-generator.version>4.38.0</json-schema-generator.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The version of the mcp library prior to this PR used in 7.0 seems to not support the Elicitation parameter. This seems to be a problem with current Claude versions. With the introduction of 7.1 and a newer version of the client library, the problem seems to be solved. So it seems reasonable to bump the version in 7.0 for the next bugfix release.

fixes https://github.com/Graylog2/graylog2-server/issues/25322

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

