### PR TITLE
Fix duplicate Authorization header in lockfile workflow

### DIFF
--- a/.github/workflows/updating-lockfile.yml
+++ b/.github/workflows/updating-lockfile.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Description
Add `persist-credentials: false` to the `actions/checkout@v6` step in `.github/workflows/updating-lockfile.yml`.

## Motivation and Context
The workflow was failing with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/Graylog2/graylog2-server/': The requested URL returned error: 400
```

`actions/checkout@v6` and `peter-evans/create-pull-request` both configure `http.extraheader` with an Authorization header, so git sends two Authorization headers and GitHub rejects the push with HTTP 400. Disabling credential persistence on checkout leaves only the `peter-evans/create-pull-request` token in place.

See peter-evans/create-pull-request#4272 and actions/checkout#2299.

## How Has This Been Tested?
Not tested locally — the workflow only runs on `ubuntu-slim` via scheduled cron and `workflow_dispatch`. Will verify by running the workflow manually after merge.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl CI workflow fix with no user-facing impact.