### PR TITLE
Improve query parameter in event definition filter query workflow

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/DefaultEntityDependencyResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/DefaultEntityDependencyResolver.java
@@ -77,6 +77,11 @@ public class DefaultEntityDependencyResolver implements EntityDependencyResolver
                         dependencyGraph.predecessors(dependency).stream().anyMatch(
                                 predecessor -> !ModelTypes.STREAM_V1.equals(predecessor.type()))
                 )
+                // Ignore lookup tables, adapters, and caches as dependencies. Lookup tables don't have a corresponding
+                // GRN type registered and cannot be resolved for permission checks.
+                .filter(dependency -> !ModelTypes.LOOKUP_TABLE_V1.equals(dependency.type()) &&
+                        !ModelTypes.LOOKUP_ADAPTER_V1.equals(dependency.type()) &&
+                        !ModelTypes.LOOKUP_CACHE_V1.equals(dependency.type()))
                 // TODO: Work around from using the content pack dependency resolver:
                 //  We've added stream_title content pack entities in https://github.com/Graylog2/graylog2-server/pull/17089,
                 //  but in this context we want to return the actual dependent Stream to add additional permissions to.

--- a/graylog2-server/src/test/java/org/graylog/security/entities/DefaultEntityDependencyResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/entities/DefaultEntityDependencyResolverTest.java
@@ -28,7 +28,6 @@ import org.graylog.security.DBGrantService;
 import org.graylog.testing.GRNExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
-import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.contentpacks.ContentPackEntityResolver;
 import org.graylog2.contentpacks.model.ModelId;
@@ -74,7 +73,7 @@ class DefaultEntityDependencyResolverTest {
     }
 
     @Test
-    @DisplayName("Try a regular depency resolve")
+    @DisplayName("Try a regular dependency resolve")
     void resolve() {
         final String TEST_TITLE = "Test Stream Title";
         final EntityExcerpt streamExcerpt = EntityExcerpt.builder()
@@ -179,6 +178,35 @@ class DefaultEntityDependencyResolverTest {
         grnRegistry.registerType(GRNType.create("event_procedure"));
         final ImmutableSet<org.graylog.security.entities.EntityDescriptor> missingDependencies = entityDependencyResolver.resolve(definitionGrn);
         assertThat(missingDependencies).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Lookup table dependencies are ignored during resolve")
+    void resolveWithLookupTableDependency() {
+        final EntityDescriptor eventDefDescriptor = EntityDescriptor.builder()
+                .type(ModelTypes.EVENT_DEFINITION_V1).id(ModelId.of("54e3deadbeefdeadbeefafff")).build();
+        final EntityDescriptor lookupTableDescriptor = EntityDescriptor.builder()
+                .type(ModelTypes.LOOKUP_TABLE_V1).id(ModelId.of("54e3deadbeefdeadbeefaffe")).build();
+        final EntityDescriptor streamDescriptor = EntityDescriptor.builder()
+                .type(ModelTypes.STREAM_V1).id(ModelId.of("54e3deadbeefdeadbeefaffd")).build();
+
+        final var dependencyGraph = GraphBuilder.directed().<EntityDescriptor>build();
+        dependencyGraph.addNode(eventDefDescriptor);
+        dependencyGraph.putEdge(eventDefDescriptor, lookupTableDescriptor);
+        dependencyGraph.putEdge(eventDefDescriptor, streamDescriptor);
+        when(contentPackEntityResolver.resolveEntityDependencyGraph(any())).thenReturn(dependencyGraph);
+        when(contentPackEntityResolver.listAllEntityExcerpts()).thenReturn(ImmutableSet.of());
+        when(grnDescriptorService.getDescriptor(any(GRN.class))).thenAnswer(a -> {
+            GRN grnArg = a.getArgument(0);
+            return GRNDescriptor.builder().grn(grnArg).title("dummy").build();
+        });
+
+        final GRN eventDefGrn = grnRegistry.newGRN("event_definition", "54e3deadbeefdeadbeefafff");
+        final ImmutableSet<org.graylog.security.entities.EntityDescriptor> dependencies = entityDependencyResolver.resolve(eventDefGrn);
+
+        // The lookup_table dependency should be skipped, only the stream should remain
+        assertThat(dependencies).hasSize(1);
+        assertThat(dependencies.asList().get(0).id().toString()).isEqualTo("grn::::stream:54e3deadbeefdeadbeefaffd");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/security/entities/DefaultEntityDependencyResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/entities/DefaultEntityDependencyResolverTest.java
@@ -196,10 +196,6 @@ class DefaultEntityDependencyResolverTest {
         dependencyGraph.putEdge(eventDefDescriptor, streamDescriptor);
         when(contentPackEntityResolver.resolveEntityDependencyGraph(any())).thenReturn(dependencyGraph);
         when(contentPackEntityResolver.listAllEntityExcerpts()).thenReturn(ImmutableSet.of());
-        when(grnDescriptorService.getDescriptor(any(GRN.class))).thenAnswer(a -> {
-            GRN grnArg = a.getArgument(0);
-            return GRNDescriptor.builder().grn(grnArg).title("dummy").build();
-        });
 
         final GRN eventDefGrn = grnRegistry.newGRN("event_definition", "54e3deadbeefdeadbeefafff");
         final ImmutableSet<org.graylog.security.entities.EntityDescriptor> dependencies = entityDependencyResolver.resolve(eventDefGrn);

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.tsx
@@ -55,7 +55,9 @@ class EditQueryParameterModal extends React.Component<Props, State> {
   }
 
   openModal = () => {
-    this.setState({ showModal: true });
+    const { queryParameter } = this.props;
+
+    this.setState({ showModal: true, queryParameter });
   };
 
   _cleanState = () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.tsx
@@ -153,12 +153,16 @@ const useExecutePreview = (config: EventDefinition['config']) => {
     [executeJobResult, searchTypeId, startJob],
   );
 
+  const hasEmbryonicParams = config?.query_parameters?.some(
+    (param: LookupTableParameterJsonEmbryonic) => param.embryonic,
+  );
+
   useEffect(() => {
-    if (isPermittedToSeePreview(currentUser, config)) {
+    if (isPermittedToSeePreview(currentUser, config) && !hasEmbryonicParams) {
       const search = constructSearch(config, searchTypeId, queryId);
       executeSearch(search);
     }
-  }, [config, currentUser, executeSearch, queryId, searchTypeId]);
+  }, [config, currentUser, executeSearch, hasEmbryonicParams, queryId, searchTypeId]);
 
   return {
     errors: results?.result?.errors,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Skip dependency resolution of lookup tables, adapters, and caches in `DefaultEntityDependencyResolver` since they are not included in builtin GRN types (this was preventing Event Definitions with search query parameters from being saved by any user other than `local:admin`)
- Prevent executing event definition search preview if there is an undeclared query parameter (unnecessary errors were being thrown in the UI)
- Properly load newly created query parameters immediately after they are created (attempting to edit them immediately after creation opened a blank modal)

/nocl will include PR in the enterprise CL 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
in conjunction with Graylog2/graylog-plugin-enterprise#13966 fixing lookup table parameters in event definitions
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

