### PR TITLE
MCP: Shielding against NPR in map creation from possible null values in stream description attribute

### DIFF
--- a/changelog/unreleased/pr-25767.toml
+++ b/changelog/unreleased/pr-25767.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix MCP(ListStreamsTool): NPE when a stream has 'null' description."
+
+issues = ["25214"]
+pulls = ["25767"]

--- a/graylog2-server/src/main/java/org/graylog/mcp/tools/ListStreamsTool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/tools/ListStreamsTool.java
@@ -28,6 +28,7 @@ import org.graylog2.streams.StreamService;
 import org.graylog2.web.customization.CustomizationConfig;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.graylog2.shared.utilities.StringUtils.f;
 
@@ -64,7 +65,7 @@ public class ListStreamsTool extends Tool<ListStreamsTool.Parameters, String> {
                             .map(stream -> Map.of(
                                     "id", stream.getId(),
                                     "title", stream.getTitle(),
-                                    "description", stream.getDescription(),
+                                    "description", Optional.ofNullable(stream.getDescription()).orElse(""),
                                     "disabled", stream.getDisabled(),
                                     "matching_type", stream.getMatchingType(),
                                     "created_at", stream.getCreatedAt(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Prior to this PR, a null value in a stream description (which is allowed per the class definitions of the implementations) would lead to a NPE on map creation during calling the ListTool. This PR adds correct handling of the `null` value. Because MCP might always expect a filled description, `null` is not left out but converted to `""` instead.

fixes https://github.com/Graylog2/graylog2-server/issues/25214

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

