### PR TITLE
Fix duplicate Authorization header in browserslist workflow

### DIFF
--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Description

Set `persist-credentials: false` on the `actions/checkout@v6` step in `.github/workflows/update-browserslist-db.yml` so only `peter-evans/create-pull-request` manages git credentials for the push. Same fix as #25753 applied to the lockfile workflow.

## Motivation and Context

`actions/checkout@v6` and `peter-evans/create-pull-request` both configure `http.extraheader` with an `Authorization` token. With both active, git sends two `Authorization` headers and GitHub rejects the push:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/…': The requested URL returned error: 400
```

Upstream context: `peter-evans/create-pull-request#4272`.

## How Has This Been Tested?

Change is confined to a workflow file; validated by comparing with the lockfile-workflow fix in #25753, which was verified in production.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl CI workflow fix, no user-facing impact