### PR TITLE
Fix silent shard failures in CustomOpenSearchClient search

### DIFF
--- a/changelog/unreleased/pr-25797.toml
+++ b/changelog/unreleased/pr-25797.toml
@@ -1,0 +1,3 @@
+type = "f"
+message = "Surface partial shard failures from searches instead of silently returning incomplete results."
+pulls = ["25797"]

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/client/CustomOpenSearchClient.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/client/CustomOpenSearchClient.java
@@ -18,7 +18,10 @@ package org.graylog.storage.opensearch3.client;
 
 import org.graylog.storage.opensearch3.OSSerializationUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardStatistics;
 import org.opensearch.client.opensearch.core.MsearchResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -26,6 +29,7 @@ import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
 import org.opensearch.client.transport.OpenSearchTransport;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public class CustomOpenSearchClient extends OpenSearchClient {
 
@@ -43,7 +47,9 @@ public class CustomOpenSearchClient extends OpenSearchClient {
 
         // msearch doesn't support scroll and slice, we can't switch to msearch in this case!
         if (request.scroll() != null || request.slice() != null) {
-            return super.search(request, tDocumentClass);
+            final SearchResponse<TDocument> response = super.search(request, tDocumentClass);
+            throwOnShardFailures(response.shards());
+            return response;
         }
 
         final MsearchResponse<TDocument> multiSearchResponse = super.msearch(req -> req.searches(OSSerializationUtils.toMsearch(request)), tDocumentClass);
@@ -51,7 +57,25 @@ public class CustomOpenSearchClient extends OpenSearchClient {
         if (resp.isFailure()) {
             throw new OpenSearchException(resp.failure());
         }
-        // if it's not failure, then it has to be a result, right?
-        return resp.result();
+        final SearchResponse<TDocument> result = resp.result();
+        throwOnShardFailures(result.shards());
+        return result;
+    }
+
+    static void throwOnShardFailures(ShardStatistics shards) {
+        if (shards.failed() <= 0) {
+            return;
+        }
+        final var reason = String.format(Locale.ROOT, "%d of %d shards failed", shards.failed(), shards.total());
+        final var rootCauses = shards.failures().stream()
+                .map(ShardFailure::reason)
+                .toList();
+        throw new OpenSearchException(ErrorResponse.of(r -> r
+                .status(500)
+                .error(cause -> cause
+                        .type("shard_failure")
+                        .reason(reason)
+                        .causedBy(rootCauses.getFirst())
+                        .rootCause(rootCauses))));
     }
 }

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/client/CustomOpenSearchClientTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/client/CustomOpenSearchClientTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch3.client;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardStatistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CustomOpenSearchClientTest {
+
+    @Test
+    void throwOnShardFailuresDoesNothingWhenAllShardsSucceeded() {
+        final ShardStatistics shards = ShardStatistics.of(b -> b.total(5).successful(5).failed(0));
+
+        assertThatCode(() -> CustomOpenSearchClient.throwOnShardFailures(shards)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void throwOnShardFailuresThrowsWhenAnyShardFailed() {
+        final ShardFailure failure = ShardFailure.of(b -> b
+                .index("graylog_0")
+                .shard(2)
+                .reason(ErrorCause.of(c -> c.type("query_shard_exception").reason("parse error")))
+        );
+        final ShardStatistics shards = ShardStatistics.of(b -> b
+                .total(5)
+                .successful(4)
+                .failed(1)
+                .failures(failure)
+        );
+
+        assertThatThrownBy(() -> CustomOpenSearchClient.throwOnShardFailures(shards))
+                .isInstanceOf(OpenSearchException.class)
+                .satisfies(thrown -> {
+                    final var ex = (OpenSearchException) thrown;
+                    assertThat(ex.status()).isEqualTo(500);
+                    assertThat(ex.error().type()).isEqualTo("shard_failure");
+                    assertThat(ex.error().reason()).isEqualTo("1 of 5 shards failed");
+                    assertThat(ex.error().rootCause()).singleElement().satisfies(rc -> {
+                        assertThat(rc.type()).isEqualTo("query_shard_exception");
+                        assertThat(rc.reason()).isEqualTo("parse error");
+                    });
+                    assertThat(ex.error().causedBy()).satisfies(cb -> {
+                        assertThat(cb.type()).isEqualTo("query_shard_exception");
+                        assertThat(cb.reason()).isEqualTo("parse error");
+                    });
+                });
+    }
+}


### PR DESCRIPTION
## Description

`CustomOpenSearchClient.search` previously only threw when the *complete* search request failed. When only *some* shards failed, the partial `SearchResponse` was returned as a success, so downstream code operated on incomplete results without any indication that data was missing.

After this change, shard-level failures are detected via `response.shards().failed() > 0` on both code paths (scroll/slice and the msearch-wrapped path), and an `OpenSearchException` is thrown. The exception's `ErrorResponse` carries:

- `status` = 500
- `error.type` = `"shard_failure"`
- `error.reason` = `"N of M shards failed"`
- `error.rootCause` = every failed shard's `ErrorCause`
- `error.causedBy` = the first shard's `ErrorCause`

This mirrors the shape OpenSearch itself uses for errors with multiple root causes.

## Motivation and Context

Partial shard failures turning into silent success meant users could see results that looked complete but were missing data — a correctness issue that's hard to notice and harder to diagnose. The handling is now consistent with the existing behavior when the whole request fails.

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/13804

## How Has This Been Tested?

New unit tests in `CustomOpenSearchClientTest`:

- `throwOnShardFailuresDoesNothingWhenAllShardsSucceeded`
- `throwOnShardFailuresThrowsWhenAnyShardFailed` — asserts the exception carries the expected status, type, reason, `rootCause`, and `causedBy`.

Run with:

```
./mvnw test -pl :graylog-storage-opensearch3 -Dtest=CustomOpenSearchClientTest
```

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.