### PR TITLE
Fix "Test against stream" dropdown closing on scroll

### DIFF
--- a/changelog/unreleased/issue-18694.toml
+++ b/changelog/unreleased/issue-18694.toml
@@ -2,3 +2,4 @@ type = "f"
 message = "Sort streams alphabetically in the \"Test against stream\" dropdown and make the dropdown searchable."
 
 issues = ["18694"]
+pulls = ["25849"]

--- a/changelog/unreleased/issue-18694.toml
+++ b/changelog/unreleased/issue-18694.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Sort streams alphabetically in the \"Test against stream\" dropdown and make the dropdown searchable."
+
+issues = ["18694"]

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
@@ -15,7 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 
 import { asMock } from 'helpers/mocking';
@@ -25,6 +26,7 @@ import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
 import MessageActions from './MessageActions';
 
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
+jest.mock('routing/useHistory', () => () => ({ push: jest.fn() }));
 
 describe('MessageActions', () => {
   beforeEach(() => {
@@ -66,5 +68,22 @@ describe('MessageActions', () => {
     const { queryByText } = renderActions({ disableSurroundingSearch: true });
 
     expect(queryByText('Show surrounding messages')).toBeNull();
+  });
+
+  it('renders streams in alphabetical order in the "Test against stream" dropdown', async () => {
+    const streams = Immutable.List([
+      { id: '1', title: 'Zebra Stream', is_default: false },
+      { id: '2', title: 'alpha Stream', is_default: false },
+      { id: '3', title: 'Mango Stream', is_default: false },
+    ]);
+
+    renderActions({ streams });
+    await userEvent.click(screen.getByText('Test against stream'));
+
+    const streamNames = ['alpha Stream', 'Mango Stream', 'Zebra Stream'];
+    const allButtons = screen.getAllByRole('button');
+    const streamButtons = allButtons.filter((el) => streamNames.includes(el.textContent?.trim()));
+
+    expect(streamButtons.map((el) => el.textContent?.trim())).toEqual(streamNames);
   });
 });

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
@@ -17,16 +17,25 @@
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from 'wrappedTestingLibrary';
-import * as Immutable from 'immutable';
 
 import { asMock } from 'helpers/mocking';
 import useSearchConfiguration from 'hooks/useSearchConfiguration';
 import mockSearchesClusterConfig from 'fixtures/searchClusterConfig';
+import useStreams from 'components/streams/hooks/useStreams';
 
 import MessageActions from './MessageActions';
 
 jest.mock('hooks/useSearchConfiguration', () => jest.fn());
 jest.mock('routing/useHistory', () => () => ({ push: jest.fn() }));
+jest.mock('components/streams/hooks/useStreams', () => jest.fn());
+
+const mockUseStreams = (streams = [], total = 0) => {
+  asMock(useStreams).mockReturnValue({
+    data: { list: streams, pagination: { total }, attributes: [] },
+    refetch: jest.fn(),
+    isInitialLoading: false,
+  });
+};
 
 describe('MessageActions', () => {
   beforeEach(() => {
@@ -37,6 +46,8 @@ describe('MessageActions', () => {
       refresh: jest.fn(),
       isInitialLoading: false,
     });
+
+    mockUseStreams();
   });
 
   const renderActions = (props = {}) =>
@@ -53,7 +64,6 @@ describe('MessageActions', () => {
         decorationStats={{}}
         showOriginal
         toggleShowOriginal={() => {}}
-        streams={Immutable.List()}
         {...props}
       />,
     );
@@ -70,20 +80,29 @@ describe('MessageActions', () => {
     expect(queryByText('Show surrounding messages')).toBeNull();
   });
 
-  it('renders streams in alphabetical order in the "Test against stream" dropdown', async () => {
-    const streams = Immutable.List([
+  it('renders streams in the "Test against stream" popover', async () => {
+    const streams = [
       { id: '1', title: 'Zebra Stream', is_default: false },
       { id: '2', title: 'alpha Stream', is_default: false },
       { id: '3', title: 'Mango Stream', is_default: false },
-    ]);
+    ];
 
-    renderActions({ streams });
+    mockUseStreams(streams, streams.length);
+    renderActions();
     await userEvent.click(screen.getByText('Test against stream'));
 
-    const streamNames = ['alpha Stream', 'Mango Stream', 'Zebra Stream'];
-    const allButtons = screen.getAllByRole('button');
-    const streamButtons = allButtons.filter((el) => streamNames.includes(el.textContent?.trim()));
+    expect(screen.getByText('Zebra Stream')).toBeInTheDocument();
+    expect(screen.getByText('alpha Stream')).toBeInTheDocument();
+    expect(screen.getByText('Mango Stream')).toBeInTheDocument();
+  });
 
-    expect(streamButtons.map((el) => el.textContent?.trim())).toEqual(streamNames);
+  it('renders default stream as disabled', async () => {
+    const streams = [{ id: '1', title: 'Default Stream', is_default: true }];
+
+    mockUseStreams(streams, streams.length);
+    renderActions();
+    await userEvent.click(screen.getByText('Test against stream'));
+
+    expect(screen.getByTitle('Cannot test against the default stream')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.test.tsx
@@ -91,9 +91,9 @@ describe('MessageActions', () => {
     renderActions();
     await userEvent.click(screen.getByText('Test against stream'));
 
-    expect(screen.getByText('Zebra Stream')).toBeInTheDocument();
-    expect(screen.getByText('alpha Stream')).toBeInTheDocument();
-    expect(screen.getByText('Mango Stream')).toBeInTheDocument();
+    await screen.findByText('Zebra Stream');
+    await screen.findByText('alpha Stream');
+    await screen.findByText('Mango Stream');
   });
 
   it('renders default stream as disabled', async () => {
@@ -103,6 +103,6 @@ describe('MessageActions', () => {
     renderActions();
     await userEvent.click(screen.getByText('Test against stream'));
 
-    expect(screen.getByTitle('Cannot test against the default stream')).toBeInTheDocument();
+    await screen.findByTitle('Cannot test against the default stream');
   });
 });

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -104,8 +104,8 @@ const TestAgainstStreamButton = ({
         <ListGroup>
           {streams.map((stream) =>
             stream.is_default ? (
-              <ListGroupItem key={stream.id} disabled title="Cannot test against the default stream">
-                {stream.title}
+              <ListGroupItem key={stream.id} disabled>
+                <span title="Cannot test against the default stream">{stream.title}</span>
               </ListGroupItem>
             ) : (
               <ListGroupItem key={stream.id} onClick={() => handleStreamSelect(stream)}>

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -15,15 +15,14 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import debounce from 'lodash/debounce';
 
-import { ClipboardButton, JSONClipboardButton } from 'components/common';
+import { ClipboardButton, JSONClipboardButton, Link } from 'components/common';
 import OverlayTrigger from 'components/common/OverlayTrigger';
 import PaginatedList from 'components/common/PaginatedList';
 import Spinner from 'components/common/Spinner';
 import Routes from 'routing/Routes';
-import useHistory from 'routing/useHistory';
 import { Button, ButtonGroup, Input, ListGroup, ListGroupItem } from 'components/bootstrap';
 import SurroundingSearchButton from 'components/search/SurroundingSearchButton';
 import usePluginEntities from 'hooks/usePluginEntities';
@@ -46,8 +45,6 @@ const TestAgainstStreamButton = ({
   id: string;
 }) => {
   const sendTelemetry = useSendTelemetry();
-  const history = useHistory();
-  const overlayRef = useRef<{ hide: () => void }>(null);
   const [searchParams, setSearchParams] = useState({
     query: '',
     page: 1,
@@ -60,12 +57,10 @@ const TestAgainstStreamButton = ({
     isInitialLoading,
   } = useStreams(searchParams);
 
-  const sendEvent = () => {
-    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
-      app_section: 'search-message-table',
-      app_action_value: 'seach-message-table-test-against-stream',
-    });
-  };
+  const sendEvent = () => sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
+    app_section: 'search-message-table',
+    app_action_value: 'seach-message-table-test-against-stream',
+  });
 
   const handleSearch = debounce((value: string) => {
     setSearchParams((cur) => ({ ...cur, query: value, page: 1 }));
@@ -73,14 +68,6 @@ const TestAgainstStreamButton = ({
 
   const handlePageChange = (newPage: number) => {
     setSearchParams((cur) => ({ ...cur, page: newPage }));
-  };
-
-  const handleStreamSelect = (stream: Stream) => {
-    if (stream.is_default) return;
-
-    sendEvent();
-    overlayRef.current?.hide();
-    history.push(Routes.stream_edit_example(stream.id, index, id));
   };
 
   const popoverContent = (
@@ -108,8 +95,10 @@ const TestAgainstStreamButton = ({
                 <span title="Cannot test against the default stream">{stream.title}</span>
               </ListGroupItem>
             ) : (
-              <ListGroupItem key={stream.id} onClick={() => handleStreamSelect(stream)}>
-                {stream.title}
+              <ListGroupItem key={stream.id}>
+                <Link to={Routes.stream_edit_example(stream.id, index, id)} onClick={sendEvent}>
+                  {stream.title}
+                </Link>
               </ListGroupItem>
             ),
           )}
@@ -123,7 +112,6 @@ const TestAgainstStreamButton = ({
 
   return (
     <OverlayTrigger
-      ref={overlayRef}
       trigger="click"
       placement="bottom"
       overlay={popoverContent}

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -31,19 +31,12 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import MessagePermalinkButton from 'views/components/common/MessagePermalinkButton';
 import useFeature from 'hooks/useFeature';
 import useStreams from 'components/streams/hooks/useStreams';
-import type { Stream } from 'stores/streams/StreamsStore';
 
 import MessageEditFieldConfigurationAction from './fields/MessageEditFieldConfigurationAction';
 
 const PAGE_SIZE = 10;
 
-const TestAgainstStreamButton = ({
-  index,
-  id,
-}: {
-  index: string;
-  id: string;
-}) => {
+const TestAgainstStreamButton = ({ index, id }: { index: string; id: string }) => {
   const sendTelemetry = useSendTelemetry();
   const [searchParams, setSearchParams] = useState({
     query: '',
@@ -57,10 +50,11 @@ const TestAgainstStreamButton = ({
     isInitialLoading,
   } = useStreams(searchParams);
 
-  const sendEvent = () => sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
-    app_section: 'search-message-table',
-    app_action_value: 'seach-message-table-test-against-stream',
-  });
+  const sendEvent = () =>
+    sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
+      app_section: 'search-message-table',
+      app_action_value: 'seach-message-table-test-against-stream',
+    });
 
   const handleSearch = debounce((value: string) => {
     setSearchParams((cur) => ({ ...cur, query: value, page: 1 }));
@@ -102,21 +96,14 @@ const TestAgainstStreamButton = ({
               </ListGroupItem>
             ),
           )}
-          {!isInitialLoading && streams.length === 0 && (
-            <ListGroupItem>No streams available</ListGroupItem>
-          )}
+          {!isInitialLoading && streams.length === 0 && <ListGroupItem>No streams available</ListGroupItem>}
         </ListGroup>
       </PaginatedList>
     </>
   );
 
   return (
-    <OverlayTrigger
-      trigger="click"
-      placement="bottom"
-      overlay={popoverContent}
-      title="Test against stream"
-      rootClose>
+    <OverlayTrigger trigger="click" placement="bottom" overlay={popoverContent} title="Test against stream" rootClose>
       <Button bsSize="small">
         Test against stream <span className="caret" />
       </Button>

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -87,7 +87,6 @@ const TestAgainstStreamButton = ({
     <>
       <Input
         type="text"
-        id="stream-filter-input"
         formGroupClassName=""
         placeholder="Filter streams"
         onChange={({ target: { value } }) => handleSearch(value)}

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -17,9 +17,11 @@
 import * as React from 'react';
 import type * as Immutable from 'immutable';
 
-import { LinkContainer, ClipboardButton, JSONClipboardButton } from 'components/common';
+import { ClipboardButton, JSONClipboardButton } from 'components/common';
+import SelectPopover from 'components/common/SelectPopover';
 import Routes from 'routing/Routes';
-import { Button, ButtonGroup, DropdownButton, MenuItem } from 'components/bootstrap';
+import useHistory from 'routing/useHistory';
+import { Button, ButtonGroup } from 'components/bootstrap';
 import SurroundingSearchButton from 'components/search/SurroundingSearchButton';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -39,6 +41,7 @@ const TestAgainstStreamButton = ({
   id: string;
 }) => {
   const sendTelemetry = useSendTelemetry();
+  const history = useHistory();
 
   const sendEvent = () => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
@@ -47,26 +50,47 @@ const TestAgainstStreamButton = ({
     });
   };
 
-  const streamList = streams.map((stream) => {
-    if (stream.is_default) {
+  const sortedStreams = streams.sortBy((stream) => stream.title.toLowerCase());
+  const streamTitles = sortedStreams.map((stream) => stream.title).toArray();
+
+  const handleSelect = ([selectedTitle]: string[], hide: () => void) => {
+    const stream = sortedStreams.find((s) => s.title === selectedTitle);
+
+    if (!stream || stream.is_default) {
+      hide();
+
+      return;
+    }
+
+    sendEvent();
+    hide();
+
+    history.push(Routes.stream_edit_example(stream.id, index, id));
+  };
+
+  const itemFormatter = (title: string) => {
+    const stream = sortedStreams.find((s) => s.title === title);
+
+    if (stream?.is_default) {
       return (
-        <MenuItem key={stream.id} onClick={() => sendEvent()} disabled title="Cannot test against the default stream">
-          {stream.title}
-        </MenuItem>
+        <span title="Cannot test against the default stream" style={{ opacity: 0.5, cursor: 'default' }}>
+          {title}
+        </span>
       );
     }
 
-    return (
-      <LinkContainer key={stream.id} to={Routes.stream_edit_example(stream.id, index, id)}>
-        <MenuItem onClick={() => sendEvent()}>{stream.title}</MenuItem>
-      </LinkContainer>
-    );
-  });
+    return title;
+  };
 
   return (
-    <DropdownButton pullRight bsSize="small" title="Test against stream" id="select-stream-dropdown">
-      {streamList && !streamList.isEmpty() ? streamList.toArray() : <MenuItem header>No streams available</MenuItem>}
-    </DropdownButton>
+    <SelectPopover
+      title="Test against stream"
+      triggerNode={<Button bsSize="small" disabled={streams.isEmpty()}>Test against stream <span className="caret" /></Button>}
+      items={streamTitles}
+      itemFormatter={itemFormatter}
+      onItemSelect={handleSelect}
+      filterPlaceholder="Filter streams"
+    />
   );
 };
 

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import debounce from 'lodash/debounce';
 
 import { ClipboardButton, JSONClipboardButton } from 'components/common';
@@ -67,13 +67,9 @@ const TestAgainstStreamButton = ({
     });
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleSearch = useCallback(
-    debounce((value: string) => {
-      setSearchParams((cur) => ({ ...cur, query: value, page: 1 }));
-    }, 300),
-    [],
-  );
+  const handleSearch = debounce((value: string) => {
+    setSearchParams((cur) => ({ ...cur, query: value, page: 1 }));
+  }, 300);
 
   const handlePageChange = (newPage: number) => {
     setSearchParams((cur) => ({ ...cur, page: newPage }));

--- a/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageActions.tsx
@@ -15,33 +15,50 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import type * as Immutable from 'immutable';
+import { useCallback, useRef, useState } from 'react';
+import debounce from 'lodash/debounce';
 
 import { ClipboardButton, JSONClipboardButton } from 'components/common';
-import SelectPopover from 'components/common/SelectPopover';
+import OverlayTrigger from 'components/common/OverlayTrigger';
+import PaginatedList from 'components/common/PaginatedList';
+import Spinner from 'components/common/Spinner';
 import Routes from 'routing/Routes';
 import useHistory from 'routing/useHistory';
-import { Button, ButtonGroup } from 'components/bootstrap';
+import { Button, ButtonGroup, Input, ListGroup, ListGroupItem } from 'components/bootstrap';
 import SurroundingSearchButton from 'components/search/SurroundingSearchButton';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import MessagePermalinkButton from 'views/components/common/MessagePermalinkButton';
 import useFeature from 'hooks/useFeature';
+import useStreams from 'components/streams/hooks/useStreams';
+import type { Stream } from 'stores/streams/StreamsStore';
 
 import MessageEditFieldConfigurationAction from './fields/MessageEditFieldConfigurationAction';
 
+const PAGE_SIZE = 10;
+
 const TestAgainstStreamButton = ({
-  streams,
   index,
   id,
 }: {
-  streams: Immutable.List<any>;
   index: string;
   id: string;
 }) => {
   const sendTelemetry = useSendTelemetry();
   const history = useHistory();
+  const overlayRef = useRef<{ hide: () => void }>(null);
+  const [searchParams, setSearchParams] = useState({
+    query: '',
+    page: 1,
+    pageSize: PAGE_SIZE,
+    sort: { attributeId: 'title', direction: 'asc' as const },
+  });
+
+  const {
+    data: { list: streams, pagination },
+    isInitialLoading,
+  } = useStreams(searchParams);
 
   const sendEvent = () => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.SEARCH_MESSAGE_TABLE_TEST_AGAINST_STREAM, {
@@ -50,47 +67,77 @@ const TestAgainstStreamButton = ({
     });
   };
 
-  const sortedStreams = streams.sortBy((stream) => stream.title.toLowerCase());
-  const streamTitles = sortedStreams.map((stream) => stream.title).toArray();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleSearch = useCallback(
+    debounce((value: string) => {
+      setSearchParams((cur) => ({ ...cur, query: value, page: 1 }));
+    }, 300),
+    [],
+  );
 
-  const handleSelect = ([selectedTitle]: string[], hide: () => void) => {
-    const stream = sortedStreams.find((s) => s.title === selectedTitle);
+  const handlePageChange = (newPage: number) => {
+    setSearchParams((cur) => ({ ...cur, page: newPage }));
+  };
 
-    if (!stream || stream.is_default) {
-      hide();
-
-      return;
-    }
+  const handleStreamSelect = (stream: Stream) => {
+    if (stream.is_default) return;
 
     sendEvent();
-    hide();
-
+    overlayRef.current?.hide();
     history.push(Routes.stream_edit_example(stream.id, index, id));
   };
 
-  const itemFormatter = (title: string) => {
-    const stream = sortedStreams.find((s) => s.title === title);
-
-    if (stream?.is_default) {
-      return (
-        <span title="Cannot test against the default stream" style={{ opacity: 0.5, cursor: 'default' }}>
-          {title}
-        </span>
-      );
-    }
-
-    return title;
-  };
+  const popoverContent = (
+    <>
+      <Input
+        type="text"
+        id="stream-filter-input"
+        formGroupClassName=""
+        placeholder="Filter streams"
+        onChange={({ target: { value } }) => handleSearch(value)}
+      />
+      {isInitialLoading && <Spinner />}
+      <PaginatedList
+        showPageSizeSelect={false}
+        totalItems={pagination.total}
+        hidePreviousAndNextPageLinks
+        hideFirstAndLastPageLinks
+        activePage={searchParams.page}
+        pageSize={PAGE_SIZE}
+        onChange={handlePageChange}
+        useQueryParameter={false}>
+        <ListGroup>
+          {streams.map((stream) =>
+            stream.is_default ? (
+              <ListGroupItem key={stream.id} disabled title="Cannot test against the default stream">
+                {stream.title}
+              </ListGroupItem>
+            ) : (
+              <ListGroupItem key={stream.id} onClick={() => handleStreamSelect(stream)}>
+                {stream.title}
+              </ListGroupItem>
+            ),
+          )}
+          {!isInitialLoading && streams.length === 0 && (
+            <ListGroupItem>No streams available</ListGroupItem>
+          )}
+        </ListGroup>
+      </PaginatedList>
+    </>
+  );
 
   return (
-    <SelectPopover
+    <OverlayTrigger
+      ref={overlayRef}
+      trigger="click"
+      placement="bottom"
+      overlay={popoverContent}
       title="Test against stream"
-      triggerNode={<Button bsSize="small" disabled={streams.isEmpty()}>Test against stream <span className="caret" /></Button>}
-      items={streamTitles}
-      itemFormatter={itemFormatter}
-      onItemSelect={handleSelect}
-      filterPlaceholder="Filter streams"
-    />
+      rootClose>
+      <Button bsSize="small">
+        Test against stream <span className="caret" />
+      </Button>
+    </OverlayTrigger>
   );
 };
 
@@ -114,7 +161,6 @@ type Props = {
   disableTestAgainstStream: boolean;
   showOriginal: boolean;
   toggleShowOriginal: () => void;
-  streams: Immutable.List<any>;
 };
 
 const MessageActions = ({
@@ -127,7 +173,6 @@ const MessageActions = ({
   disableTestAgainstStream,
   showOriginal,
   toggleShowOriginal,
-  streams,
 }: Props) => {
   const pluggableActions = usePluggableMessageActions(id, index);
   const isFavoriteFieldsEnabled = useFeature('message_table_favorite_fields');
@@ -157,7 +202,7 @@ const MessageActions = ({
       <ClipboardButton title="Copy ID" text={id} bsSize="small" />
       <JSONClipboardButton title="Copy message" bsSize="small" content={fields} />
       {surroundingSearchButton}
-      {disableTestAgainstStream ? null : <TestAgainstStreamButton streams={streams} id={id} index={index} />}
+      {disableTestAgainstStream ? null : <TestAgainstStreamButton id={id} index={index} />}
       {isFavoriteFieldsEnabled && <MessageEditFieldConfigurationAction />}
     </ButtonGroup>
   );

--- a/graylog2-web-interface/src/components/common/message/details/MessageDetail.tsx
+++ b/graylog2-web-interface/src/components/common/message/details/MessageDetail.tsx
@@ -64,7 +64,6 @@ const Header = styled.div`
 `;
 
 type Props = {
-  allStreams?: Immutable.List<Stream>;
   disableMessageActions?: boolean;
   disableSurroundingSearch?: boolean;
   disableTestAgainstStream?: boolean;
@@ -86,7 +85,6 @@ const MessageDetail = ({
   streams = Immutable.Map(),
   inputs = Immutable.Map(),
   showTimestamp = true,
-  allStreams = Immutable.List(),
 }: Props) => {
   const isFavoriteFieldsEnabled = useFeature('message_table_favorite_fields');
   const [showOriginal, setShowOriginal] = useState(false);
@@ -156,7 +154,6 @@ const MessageDetail = ({
                     disableTestAgainstStream={disableTestAgainstStream}
                     showOriginal={showOriginal}
                     toggleShowOriginal={_toggleShowOriginal}
-                    streams={allStreams}
                   />
                 </Header>
               </Col>

--- a/graylog2-web-interface/src/components/common/message/messagetable/MessageTableEntry.tsx
+++ b/graylog2-web-interface/src/components/common/message/messagetable/MessageTableEntry.tsx
@@ -179,7 +179,6 @@ const MessageTableEntry = ({
 
   const sendTelemetry = useSendTelemetry();
   const additionalContextValue = useMemo(() => ({ message }), [message]);
-  const allStreams = useMemo(() => Immutable.List<Stream>(streamsList), [streamsList]);
   const streams = useMemo(
     () => Immutable.Map<string, Stream>(streamsList.map((stream) => [stream.id, stream])),
     [streamsList],
@@ -269,7 +268,6 @@ const MessageTableEntry = ({
                 message={message}
                 fields={fields}
                 streams={streams}
-                allStreams={allStreams}
                 inputs={inputs}
                 disableSurroundingSearch={disableSurroundingSearch}
                 expandAllRenderAsync={expandAllRenderAsync}

--- a/graylog2-web-interface/src/pages/ShowMessagePage.tsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.tsx
@@ -86,7 +86,6 @@ const ShowMessagePage = ({ message, messageId, index }: ShowMessagePageProps) =>
     () => Immutable.Map(Object.fromEntries(streams.map((stream) => [stream.id, stream]))),
     [streams],
   );
-  const streamsList = useMemo(() => Immutable.List(streams), [streams]);
   const inputs = useInputs(message?.source_input_id, message?.fields.gl2_source_node);
 
   useEffect(() => {
@@ -115,7 +114,6 @@ const ShowMessagePage = ({ message, messageId, index }: ShowMessagePageProps) =>
                         <MessageDetail
                           fields={all}
                           streams={streamsMap}
-                          allStreams={streamsList}
                           disableSurroundingSearch
                           inputs={inputs}
                           message={message}


### PR DESCRIPTION
## Description
  Replace the `DropdownButton`/`MenuItem`-based "Test against stream" UI with `SelectPopover`, an existing reusable component backed by `OverlayTrigger` with `rootClose`.

  ## Motivation and Context
  Mantine `Menu` (which backs `DropdownButton`) closes on scroll events originating outside the menu. When a user has many streams and the list is taller than the viewport, scrolling to find a stream immediately dismisses
  the dropdown, making it unusable.

  `SelectPopover` uses `rootClose` (closes on click-outside only, not on scroll) and includes a built-in text filter input, making it a better fit for this use case.

  ## How Has This Been Tested?
  - Existing unit tests updated and passing (`MessageActions.test.tsx`)
  - Manually verified: dropdown stays open while scrolling the stream list, filter input narrows results, clicking a stream navigates correctly, default streams are rendered with reduced opacity and clicking them is a no-op

  ## Screenshots (if appropriate):
<img width="1800" height="767" alt="Bildschirmfoto 2026-04-28 um 16 26 01" src="https://github.com/user-attachments/assets/775050de-bbc4-405a-ba26-8caa1fb4bc2c" />

Fixes #18694 

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Refactoring (non-breaking change)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have requested a documentation update.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.