### PR TITLE
Entity list preferences- simple layouts variants fetching endpoint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -43,10 +43,13 @@ import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
+import org.graylog2.rest.resources.entities.preferences.model.PredefinedLayoutVariant;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 import org.graylog2.shared.rest.PublicCloudAPI;
+
+import java.util.List;
 
 @RequiresAuthentication
 @PublicCloudAPI
@@ -126,6 +129,28 @@ public class EntityListPreferencesResource {
         } else {
             return usersPreferences.preferences();
         }
+    }
+
+    @GET
+    @Path("/list_predefined/{entity_list_id}")
+    @Timed
+    @Operation(summary = "List predefined layout variants for entity list with given id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "List of predefined layout variants retrieved successfully",
+                         content = @Content(schema = @Schema(implementation = PredefinedLayoutVariant[].class)))
+    })
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<PredefinedLayoutVariant> listPredefined(@Parameter(name = "entity_list_id", required = true)
+                                                        @PathParam("entity_list_id") @NotEmpty String entityListId) {
+
+        return entityListPreferencesService
+                .getPredefinedForEntityList(entityListId)
+                .stream()
+                .map(pref -> new PredefinedLayoutVariant(pref.preferencesId().layoutVariant(),
+                        pref.preferencesId().entityListId(),
+                        "TBD"))
+                .toList();
+
     }
 
     private String obtainLayoutVariant(final String layoutVariant) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -49,6 +49,7 @@ import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPr
 import org.graylog2.rest.resources.entities.preferences.service.EntityListPreferencesService;
 import org.graylog2.shared.rest.PublicCloudAPI;
 
+import java.util.Comparator;
 import java.util.List;
 
 @RequiresAuthentication
@@ -146,9 +147,11 @@ public class EntityListPreferencesResource {
         return entityListPreferencesService
                 .getPredefinedForEntityList(entityListId)
                 .stream()
-                .map(pref -> new PredefinedLayoutVariant(pref.preferencesId().layoutVariant(),
+                .sorted(Comparator.nullsFirst(Comparator.comparing(pref -> pref.preferences().priority())))
+                .map(pref -> new PredefinedLayoutVariant(
+                        pref.preferencesId().layoutVariant(),
                         pref.preferencesId().entityListId(),
-                        "TBD"))
+                        pref.preferences().displayName()))
                 .toList();
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
@@ -24,16 +24,19 @@ import java.util.Map;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
-public record EntityListPreferences(@JsonProperty("attributes") Map<String, Attribute> attributes,
+public record EntityListPreferences(@JsonProperty("display_name") String displayName,
+                                    @JsonProperty("attributes") Map<String, Attribute> attributes,
                                     @JsonProperty("order") List<String> order,
                                     @JsonProperty("per_page") Integer perPage,
                                     @JsonProperty("sort") SortPreferences sort,
                                     @JsonProperty("slicing") SlicingPreferences slicing,
-                                    @JsonProperty("custom_preferences") Map<String, Object> customPreferences) {
+                                    @JsonProperty("custom_preferences") Map<String, Object> customPreferences,
+                                    @JsonProperty("priority") Integer priority,
+                                    @JsonProperty("filters") List<String> filters) {
 
     public enum DisplayStatus {
         show,
-        hide;
+        hide
     }
 
     @JsonInclude(JsonInclude.Include.NON_ABSENT)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/EntityListPreferences.java
@@ -18,12 +18,10 @@ package org.graylog2.rest.resources.entities.preferences.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Functions;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 public record EntityListPreferences(@JsonProperty("attributes") Map<String, Attribute> attributes,
@@ -32,11 +30,6 @@ public record EntityListPreferences(@JsonProperty("attributes") Map<String, Attr
                                     @JsonProperty("sort") SortPreferences sort,
                                     @JsonProperty("slicing") SlicingPreferences slicing,
                                     @JsonProperty("custom_preferences") Map<String, Object> customPreferences) {
-
-    public static EntityListPreferences create(List<String> attributes, Integer perPage, SortPreferences sort) {
-        return new EntityListPreferences(attributes.stream()
-                .collect(Collectors.toMap(Functions.identity(), attribute -> new Attribute(DisplayStatus.show, Optional.empty()))), attributes, perPage, sort, null, Map.of());
-    }
 
     public enum DisplayStatus {
         show,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/PredefinedLayoutVariant.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/PredefinedLayoutVariant.java
@@ -14,20 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-package org.graylog2.rest.resources.entities.preferences.service;
+package org.graylog2.rest.resources.entities.preferences.model;
 
-import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
-import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
-
-public interface EntityListPreferencesService {
-
-    StoredEntityListPreferences get(final StoredEntityListPreferencesId preferencesId);
-
-    List<StoredEntityListPreferences> getPredefinedForEntityList(final String entityListId);
-
-    boolean save(final StoredEntityListPreferences preferences);
-
-    int deleteAllForUser(final String userId);
+public record PredefinedLayoutVariant(@JsonProperty("layout_variant") String layoutVariant,
+                                      @JsonProperty("entity_list_id") String entityListId,
+                                      @JsonProperty("display_name") String displayName) {
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/model/StoredEntityListPreferencesId.java
@@ -33,17 +33,19 @@ import javax.annotation.Nullable;
 public abstract class StoredEntityListPreferencesId {
 
     public static final String USER_ID_SUB_FIELD = "user_id";
+    public static final String ENTITY_LIST_ID_SUB_FIELD = "entity_list_id";
+    public static final String LAYOUT_VARIANT_SUB_FIELD = "layout_variant";
     public static final String GENERAL_LAYOUT_VARIANT = "#general#";
 
     @Nullable
     @JsonProperty(USER_ID_SUB_FIELD)
     public abstract String userId();
 
-    @JsonProperty("entity_list_id")
+    @JsonProperty(ENTITY_LIST_ID_SUB_FIELD)
     public abstract String entityListId();
 
     @Nullable
-    @JsonProperty("layout_variant")
+    @JsonProperty(LAYOUT_VARIANT_SUB_FIELD)
     public abstract String layoutVariant();
 
     @JsonCreator
@@ -58,10 +60,10 @@ public abstract class StoredEntityListPreferencesId {
         @JsonProperty(USER_ID_SUB_FIELD)
         public abstract Builder userId(@Nullable final String userId);
 
-        @JsonProperty("entity_list_id")
+        @JsonProperty(ENTITY_LIST_ID_SUB_FIELD)
         public abstract Builder entityListId(final String entityListId);
 
-        @JsonProperty("layout_variant")
+        @JsonProperty(LAYOUT_VARIANT_SUB_FIELD)
         public abstract Builder layoutVariant(@Nullable final String layoutVariant);
 
         public abstract StoredEntityListPreferencesId build();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImpl.java
@@ -25,6 +25,11 @@ import org.graylog2.database.MongoCollections;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferences;
 import org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId.ENTITY_LIST_ID_SUB_FIELD;
+import static org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId.LAYOUT_VARIANT_SUB_FIELD;
 import static org.graylog2.rest.resources.entities.preferences.model.StoredEntityListPreferencesId.USER_ID_SUB_FIELD;
 
 public class EntityListPreferencesServiceImpl implements EntityListPreferencesService {
@@ -42,6 +47,18 @@ public class EntityListPreferencesServiceImpl implements EntityListPreferencesSe
     @Override
     public StoredEntityListPreferences get(final StoredEntityListPreferencesId preferencesId) {
         return collection.find(Filters.eq("_id", preferencesId)).first();
+    }
+
+    @Override
+    public List<StoredEntityListPreferences> getPredefinedForEntityList(final String entityListId) {
+        return collection.find(
+                        Filters.and(
+                                Filters.eq("_id." + ENTITY_LIST_ID_SUB_FIELD, entityListId),
+                                Filters.exists("_id." + LAYOUT_VARIANT_SUB_FIELD),
+                                Filters.exists("_id." + USER_ID_SUB_FIELD, false)
+                        )
+                )
+                .into(new ArrayList<>());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/listeners/EntityListPreferencesCleanerOnUserDeletionTest.java
@@ -33,9 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MongoDBExtension.class)
@@ -44,14 +43,13 @@ import static org.mockito.Mockito.verify;
 class EntityListPreferencesCleanerOnUserDeletionTest {
     private AsyncEventBus eventBus;
     private EntityListPreferencesService service;
-    @SuppressWarnings("unused")
-    private EntityListPreferencesCleanerOnUserDeletion listener;
 
     @BeforeEach
+    @SuppressWarnings("unused")
     void setUp(MongoCollections mongoCollections) {
         this.eventBus = new AsyncEventBus(MoreExecutors.directExecutor());
         this.service = Mockito.spy(new EntityListPreferencesServiceImpl(mongoCollections));
-        this.listener = new EntityListPreferencesCleanerOnUserDeletion(eventBus, service);
+        final EntityListPreferencesCleanerOnUserDeletion listener = new EntityListPreferencesCleanerOnUserDeletion(eventBus, service);
     }
 
     @Test
@@ -65,7 +63,7 @@ class EntityListPreferencesCleanerOnUserDeletionTest {
                 .build();
         service.save(StoredEntityListPreferences.builder()
                 .preferencesId(preferenceId1)
-                .preferences(EntityListPreferences.create(List.of(), 42, null))
+                .preferences(mock(EntityListPreferences.class))
                 .build());
 
         final StoredEntityListPreferencesId preferenceId2 = StoredEntityListPreferencesId.builder()
@@ -74,7 +72,7 @@ class EntityListPreferencesCleanerOnUserDeletionTest {
                 .build();
         service.save(StoredEntityListPreferences.builder()
                 .preferencesId(preferenceId2)
-                .preferences(EntityListPreferences.create(List.of(), 42, null))
+                .preferences(mock(EntityListPreferences.class))
                 .build());
 
         //verify they are present

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -171,7 +171,7 @@ public class EntityListPreferencesServiceImplTest {
         assertThat(predefined).isNotNull().containsExactlyInAnyOrder(predefinedLayout1, predefinedLayout2);
     }
 
-    public static EntityListPreferences createSimplifiedPreferencesForTest(final List<String> attributes, final SortPreferences sort) {
+    private static EntityListPreferences createSimplifiedPreferencesForTest(final List<String> attributes, final SortPreferences sort) {
         return new EntityListPreferences(
                 "For test",
                 attributes.stream().collect(Collectors.toMap(Functions.identity(), attribute -> new EntityListPreferences.Attribute(EntityListPreferences.DisplayStatus.show, Optional.empty()))),

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -68,12 +68,15 @@ public class EntityListPreferencesServiceImplTest {
                 .preferencesId(existingId)
                 .preferences(
                         new EntityListPreferences(
+                                "My List",
                                 Map.of("title", new EntityListPreferences.Attribute(EntityListPreferences.DisplayStatus.show, Optional.of(13))),
                                 List.of(),
                                 42,
                                 new SortPreferences("title", ASC),
                                 new SlicingPreferences("status", "Alphabetical", ASC),
-                                Map.of()
+                                Map.of(),
+                                0,
+                                List.of()
                         )
                 )
                 .build();
@@ -170,12 +173,15 @@ public class EntityListPreferencesServiceImplTest {
 
     public static EntityListPreferences createSimplifiedPreferencesForTest(final List<String> attributes, final SortPreferences sort) {
         return new EntityListPreferences(
+                "For test",
                 attributes.stream().collect(Collectors.toMap(Functions.identity(), attribute -> new EntityListPreferences.Attribute(EntityListPreferences.DisplayStatus.show, Optional.empty()))),
                 attributes,
                 42,
                 sort,
                 null,
-                Map.of());
+                Map.of(),
+                13,
+                List.of());
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.resources.entities.preferences.service;
 
+import com.google.common.base.Functions;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.rest.resources.entities.preferences.model.EntityListPreferences;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog2.rest.resources.entities.preferences.model.SortOrder.ASC;
@@ -92,7 +94,7 @@ public class EntityListPreferencesServiceImplTest {
         //update with save
         StoredEntityListPreferences updatedPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(EntityListPreferences.create(List.of("title", "description", "owner"), 13, new SortPreferences("title", DESC)))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title", "description", "owner"), new SortPreferences("title", DESC)))
                 .build();
         saved = toTest.save(updatedPreference);
         assertThat(saved).isTrue();
@@ -104,7 +106,7 @@ public class EntityListPreferencesServiceImplTest {
         //update with some values cleaned
         updatedPreference = StoredEntityListPreferences.builder()
                 .preferencesId(existingId)
-                .preferences(EntityListPreferences.create(List.of("title", "description", "owner"), null, null))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title", "description", "owner"), null))
                 .build();
         saved = toTest.save(updatedPreference);
         assertThat(saved).isTrue();
@@ -122,7 +124,7 @@ public class EntityListPreferencesServiceImplTest {
                         .entityListId("list")
                         .userId("user")
                         .build())
-                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title"), new SortPreferences("title", ASC)))
                 .build();
 
         boolean saved = toTest.save(usersPreference);
@@ -133,7 +135,7 @@ public class EntityListPreferencesServiceImplTest {
                         .entityListId("list")
                         .layoutVariant("layout_1")
                         .build())
-                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title"), new SortPreferences("title", ASC)))
                 .build();
 
         saved = toTest.save(predefinedLayout1);
@@ -144,7 +146,7 @@ public class EntityListPreferencesServiceImplTest {
                         .entityListId("list")
                         .layoutVariant("layout_2")
                         .build())
-                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title"), new SortPreferences("title", ASC)))
                 .build();
 
         saved = toTest.save(predefinedLayout2);
@@ -155,7 +157,7 @@ public class EntityListPreferencesServiceImplTest {
                         .entityListId("different_list")
                         .layoutVariant("layout_2")
                         .build())
-                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .preferences(createSimplifiedPreferencesForTest(List.of("title"), new SortPreferences("title", ASC)))
                 .build();
 
         saved = toTest.save(predefinedLayoutForDifferentEntityList);
@@ -164,6 +166,16 @@ public class EntityListPreferencesServiceImplTest {
         final List<StoredEntityListPreferences> predefined = toTest.getPredefinedForEntityList("list");
 
         assertThat(predefined).isNotNull().containsExactlyInAnyOrder(predefinedLayout1, predefinedLayout2);
+    }
+
+    public static EntityListPreferences createSimplifiedPreferencesForTest(final List<String> attributes, final SortPreferences sort) {
+        return new EntityListPreferences(
+                attributes.stream().collect(Collectors.toMap(Functions.identity(), attribute -> new EntityListPreferences.Attribute(EntityListPreferences.DisplayStatus.show, Optional.empty()))),
+                attributes,
+                42,
+                sort,
+                null,
+                Map.of());
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/entities/preferences/service/EntityListPreferencesServiceImplTest.java
@@ -115,4 +115,55 @@ public class EntityListPreferencesServiceImplTest {
         assertThat(storedEntityListPreferences.preferences().slicing()).isNull();
     }
 
+    @Test
+    public void fetchesPredefinedLayouts() {
+        final StoredEntityListPreferences usersPreference = StoredEntityListPreferences.builder()
+                .preferencesId(StoredEntityListPreferencesId.builder()
+                        .entityListId("list")
+                        .userId("user")
+                        .build())
+                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .build();
+
+        boolean saved = toTest.save(usersPreference);
+        assertThat(saved).isTrue();
+
+        final StoredEntityListPreferences predefinedLayout1 = StoredEntityListPreferences.builder()
+                .preferencesId(StoredEntityListPreferencesId.builder()
+                        .entityListId("list")
+                        .layoutVariant("layout_1")
+                        .build())
+                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .build();
+
+        saved = toTest.save(predefinedLayout1);
+        assertThat(saved).isTrue();
+
+        final StoredEntityListPreferences predefinedLayout2 = StoredEntityListPreferences.builder()
+                .preferencesId(StoredEntityListPreferencesId.builder()
+                        .entityListId("list")
+                        .layoutVariant("layout_2")
+                        .build())
+                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .build();
+
+        saved = toTest.save(predefinedLayout2);
+        assertThat(saved).isTrue();
+
+        final StoredEntityListPreferences predefinedLayoutForDifferentEntityList = StoredEntityListPreferences.builder()
+                .preferencesId(StoredEntityListPreferencesId.builder()
+                        .entityListId("different_list")
+                        .layoutVariant("layout_2")
+                        .build())
+                .preferences(EntityListPreferences.create(List.of("title"), 42, new SortPreferences("title", ASC)))
+                .build();
+
+        saved = toTest.save(predefinedLayoutForDifferentEntityList);
+        assertThat(saved).isTrue();
+
+        final List<StoredEntityListPreferences> predefined = toTest.getPredefinedForEntityList("list");
+
+        assertThat(predefined).isNotNull().containsExactlyInAnyOrder(predefinedLayout1, predefinedLayout2);
+    }
+
 }


### PR DESCRIPTION
## Description
Entity list preferences- simple layouts variants fetching endpoint.
It is beta version, it does not return metrics yet, so it does not need to require timestamp as input either.

Additional fields stored in preferences.

Removed create() method from preferences (it is used in tests only)
/nocl

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/14078 and https://github.com/Graylog2/graylog-plugin-enterprise/issues/14079

## How Has This Been Tested?
Manually and with new unit tests.

## Screenshots (if appropriate):
<img width="1227" height="738" alt="image" src="https://github.com/user-attachments/assets/d9244167-2d10-4eea-915e-74f0763b7303" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

