### PR TITLE
Add "dashboard was updated" banner for concurrent editors

### DIFF
--- a/changelog/unreleased/issue-25848.toml
+++ b/changelog/unreleased/issue-25848.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Show a banner when a dashboard was updated by another user, allowing the viewer to reload and see the latest changes."
+
+issues = ["25848"]
+pulls = ["25859"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -68,6 +68,7 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
     public static final String FIELD_CREATED_AT = "created_at";
     public static final String FIELD_OWNER = "owner";
     public static final String FIELD_SKIP_NO_STREAMS_CHECK = "skip_no_streams_check";
+    public static final String FIELD_VIEW_ID = "view_id";
 
     // generated during build to help quickly find a parameter by name.
     private ImmutableMap<String, Parameter> parameterIndex;
@@ -99,6 +100,14 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
 
     @JsonProperty(FIELD_SKIP_NO_STREAMS_CHECK)
     public abstract boolean skipNoStreamsCheck();
+
+    @Nullable
+    @JsonProperty(FIELD_VIEW_ID)
+    public abstract Optional<String> viewId();
+
+    public Search withViewId(@Nonnull String viewId) {
+        return toBuilder().viewId(Optional.of(viewId)).build();
+    }
 
     @Override
     @JsonIgnore
@@ -295,6 +304,9 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
         @JsonProperty(FIELD_SKIP_NO_STREAMS_CHECK)
         public abstract Builder skipNoStreamsCheck(boolean skipNoStreamsCheck);
 
+        @JsonProperty(FIELD_VIEW_ID)
+        public abstract Builder viewId(Optional<String> viewId);
+
         abstract Search autoBuild();
 
         @JsonCreator
@@ -303,7 +315,8 @@ public abstract class Search implements ContentPackable<SearchEntity>, Parameter
                     .requires(Collections.emptyMap())
                     .createdAt(DateTime.now(DateTimeZone.UTC))
                     .parameters(ImmutableSet.of())
-                    .skipNoStreamsCheck(false);
+                    .skipNoStreamsCheck(false)
+                    .viewId(Optional.empty());
         }
 
         public Search build() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
@@ -80,7 +80,18 @@ public class SearchDomain {
             throw new PermissionException("Unable to update search with id <" + search.id() + ">, already exists and user is not permitted to overwrite it.");
         }
 
-        return dbService.save(search.withOwner(searchUser.username()));
+        // Strip any user-supplied viewId — this field is managed exclusively by the system
+        return dbService.save(search
+                .withOwner(searchUser.username())
+                .toBuilder()
+                .viewId(Optional.empty())
+                .build());
+    }
+
+    public void setAssociatedView(String searchId, String viewId) {
+        dbService.get(searchId).ifPresent(search ->
+            dbService.save(search.withViewId(viewId))
+        );
     }
 
     private boolean hasReadPermissionFor(SearchPermissions searchPermissions, Predicate<ViewDTO> viewReadPermission, Search search) {
@@ -93,10 +104,16 @@ public class SearchDomain {
         views.addAll(viewService.forSearch(search.id()));
         views.addAll(viewResolvers.values().stream()
                 .flatMap(viewResolver -> viewResolver.getBySearchId(search.id()).stream()).collect(Collectors.toSet()));
-        if (views.isEmpty()) {
-            return false;
+
+        if (!views.isEmpty()) {
+            return views.stream().anyMatch(viewReadPermission);
         }
 
-        return views.stream().anyMatch(viewReadPermission);
+        // Fallback: search was previously associated with a view (now uses a newer search object).
+        // Allow if the user can still read that view.
+        return search.viewId()
+                .flatMap(vid -> viewService.get(vid))
+                .map(viewReadPermission::test)
+                .orElse(false);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchJob.java
@@ -28,6 +28,8 @@ import one.util.streamex.EntryStream;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog.plugins.views.search.rest.ExecutionInfo;
 
+import org.joda.time.DateTime;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +59,13 @@ public class SearchJob implements ParameterProvider {
     private Set<SearchError> errors = Sets.newHashSet();
 
     private final Integer cancelAfterSeconds;
+
+    @JsonProperty("view_last_updated_at")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private DateTime viewLastUpdatedAt;
+
+    public DateTime getViewLastUpdatedAt() { return viewLastUpdatedAt; }
+    public void setViewLastUpdatedAt(DateTime v) { this.viewLastUpdatedAt = v; }
 
     public SearchJob(String id,
                      Search search,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -51,6 +51,8 @@ import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.SearchExecutor;
 import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.indexer.searches.SearchesClusterConfig;
@@ -65,6 +67,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @PublicCloudAPI
@@ -83,20 +86,22 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private final SearchExecutor searchExecutor;
     private final SearchJobService searchJobService;
     private final EventBus serverEventBus;
-
     private final ClusterConfigService clusterConfigService;
+    private final ViewService viewService;
 
     @Inject
     public SearchResource(final SearchDomain searchDomain,
                           final SearchExecutor searchExecutor,
                           final SearchJobService searchJobService,
                           final EventBus serverEventBus,
-                          final ClusterConfigService clusterConfigService) {
+                          final ClusterConfigService clusterConfigService,
+                          final ViewService viewService) {
         this.searchDomain = searchDomain;
         this.searchExecutor = searchExecutor;
         this.searchJobService = searchJobService;
         this.serverEventBus = serverEventBus;
         this.clusterConfigService = clusterConfigService;
+        this.viewService = viewService;
     }
 
     @POST
@@ -178,6 +183,14 @@ public class SearchResource extends RestResource implements PluginRestResource {
                 ExecutionState.empty().withDefaultQueryCancellationIfNotSpecified(searchesClusterConfig) : executionState.withDefaultQueryCancellationIfNotSpecified(searchesClusterConfig);
 
         final SearchJob searchJob = searchExecutor.executeAsync(id, searchUser, enrichedExecutionState);
+
+        final Search jobSearch = searchJob.getSearch();
+        Optional<ViewDTO> associatedView = jobSearch.viewId()
+                .flatMap(viewId -> viewService.get(viewId));
+        if (associatedView.isEmpty()) {
+            associatedView = viewService.forSearch(id).stream().findFirst();
+        }
+        associatedView.map(ViewDTO::lastUpdatedAt).ifPresent(searchJob::setViewLastUpdatedAt);
 
         postAuditEvent(searchJob);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -397,6 +397,14 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final ViewDTO updatedDTO = dto.toBuilder().id(id).build();
         validateDto(updatedDTO, searchUser);
 
+        // When search_id changes, tag the old search with this view ID so
+        // in-flight executions by other users still pass the permission check.
+        dbService.get(id).ifPresent(existing -> {
+            if (!existing.searchId().equals(updatedDTO.searchId())) {
+                searchDomain.setAssociatedView(existing.searchId(), id);
+            }
+        });
+
         var result = dbService.update(updatedDTO);
         recentActivityService.update(result.id(), result.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH, searchUser);
         updateViewSharing(createEntityRequest, searchUser, result);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchDomainTest.java
@@ -184,6 +184,77 @@ public class SearchDomainTest {
     }
 
     @Test
+    public void loadsSearchIfSearchIsPermittedViaAssociatedView() {
+        final String viewId = "some-view-id";
+        final Search search = Search.builder()
+                .id(UUID.randomUUID().toString())
+                .owner("someone else")
+                .viewId(Optional.of(viewId))
+                .build();
+        allSearchesInDb.add(search);
+        when(dbService.get(search.id())).thenReturn(Optional.of(search));
+        final SearchUser searchUser = mock(SearchUser.class);
+        final ViewDTO viewDTO = mock(ViewDTO.class);
+        when(viewService.forSearch(anyString())).thenReturn(ImmutableList.of());
+        when(viewService.get(viewId)).thenReturn(Optional.of(viewDTO));
+        when(searchUser.canReadView(viewDTO)).thenReturn(true);
+
+        final Optional<Search> result = sut.getForUser(search.id(), searchUser);
+
+        assertThat(result).isEqualTo(Optional.of(search));
+    }
+
+    @Test
+    public void throwsPermissionExceptionIfAssociatedViewNotReadableByUser() {
+        final String viewId = "some-view-id";
+        final Search search = Search.builder()
+                .id(UUID.randomUUID().toString())
+                .owner("someone else")
+                .viewId(Optional.of(viewId))
+                .build();
+        allSearchesInDb.add(search);
+        when(dbService.get(search.id())).thenReturn(Optional.of(search));
+        final SearchUser searchUser = mock(SearchUser.class);
+        final ViewDTO viewDTO = mock(ViewDTO.class);
+        when(viewService.forSearch(anyString())).thenReturn(ImmutableList.of());
+        when(viewService.get(viewId)).thenReturn(Optional.of(viewDTO));
+        when(searchUser.canReadView(viewDTO)).thenReturn(false);
+
+        assertThatExceptionOfType(PermissionException.class)
+                .isThrownBy(() -> sut.getForUser(search.id(), searchUser));
+    }
+
+    @Test
+    public void saveForUserStripsUserSuppliedViewId() {
+        final Search search = Search.builder()
+                .id(UUID.randomUUID().toString())
+                .owner(null)
+                .viewId(Optional.of("attacker-supplied-view"))
+                .build();
+        when(dbService.get(search.id())).thenReturn(Optional.of(search));
+        final SearchUser searchUser = mock(SearchUser.class);
+        when(searchUser.username()).thenReturn("alice");
+        when(searchUser.isAdmin()).thenReturn(true);
+
+        sut.saveForUser(search, searchUser);
+
+        final ArgumentCaptor<Search> savedCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(dbService, times(1)).save(savedCaptor.capture());
+        assertThat(savedCaptor.getValue().viewId()).isEmpty();
+    }
+
+    @Test
+    public void setAssociatedViewPersistsViewIdOnSearch() {
+        final Search search = mockSearchWithOwner("alice");
+
+        sut.setAssociatedView(search.id(), "view-123");
+
+        final ArgumentCaptor<Search> savedCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(dbService, times(1)).save(savedCaptor.capture());
+        assertThat(savedCaptor.getValue().viewId()).contains("view-123");
+    }
+
+    @Test
     public void guardExceptionOnPostLeadsTo403() {
         final Search search = mockSearchWithOwner("someone");
         final SearchUser searchUser = mock(SearchUser.class);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceExecutionTest.java
@@ -35,6 +35,7 @@ import org.graylog.plugins.views.search.engine.validation.PluggableSearchValidat
 import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.system.NodeId;
@@ -92,6 +93,9 @@ public class SearchResourceExecutionTest {
     @Mock
     private StreamService streamService;
 
+    @Mock
+    private ViewService viewService;
+
     private final NodeId nodeId = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
 
     private SearchResource searchResource;
@@ -107,7 +111,7 @@ public class SearchResourceExecutionTest {
                 new PluggableSearchValidation(executionGuard, Collections.emptySet()),
                 new PluggableSearchNormalization(Collections.emptySet(), streamService));
 
-        this.searchResource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService) {
+        this.searchResource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService, viewService) {
             @Override
             protected User getCurrentUser() {
                 return currentUser;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -29,6 +29,7 @@ import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.SearchExecutor;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog2.plugin.database.users.User;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -74,7 +75,12 @@ public class SearchResourceTest {
 
 
     private SearchResource makeResource(SearchDomain searchDomain) {
-        return new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService, viewService);
+        return new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService, viewService) {
+            @Override
+            protected User getCurrentUser() {
+                return mock(User.class);
+            }
+        };
     }
 
     @Test
@@ -133,14 +139,12 @@ public class SearchResourceTest {
         final DateTime updatedAt = DateTime.now(DateTimeZone.UTC);
         final Search search = Search.builder().id("search-id").viewId(Optional.of(viewId)).build();
         final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
-        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
         when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
         final ViewDTO view = mock(ViewDTO.class);
         when(view.lastUpdatedAt()).thenReturn(updatedAt);
         when(viewService.get(viewId)).thenReturn(Optional.of(view));
-        when(viewService.forSearch(any())).thenReturn(List.of());
 
-        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+        final Response response = makeResource(mock(SearchDomain.class)).executeQuery("search-id", null, searchUser);
         final SearchJob returned = (SearchJob) response.getEntity();
 
         assertThat(returned.getViewLastUpdatedAt()).isEqualTo(updatedAt);
@@ -151,14 +155,12 @@ public class SearchResourceTest {
         final DateTime updatedAt = DateTime.now(DateTimeZone.UTC);
         final Search search = Search.builder().id("search-id").build();
         final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
-        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
         when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
         final ViewDTO view = mock(ViewDTO.class);
         when(view.lastUpdatedAt()).thenReturn(updatedAt);
-        when(viewService.get(any())).thenReturn(Optional.empty());
         when(viewService.forSearch("search-id")).thenReturn(List.of(view));
 
-        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+        final Response response = makeResource(mock(SearchDomain.class)).executeQuery("search-id", null, searchUser);
 
         assertThat(((SearchJob) response.getEntity()).getViewLastUpdatedAt()).isEqualTo(updatedAt);
     }
@@ -167,12 +169,10 @@ public class SearchResourceTest {
     public void executeQueryLeavesViewLastUpdatedAtNullWhenNoViewFound() {
         final Search search = Search.builder().id("search-id").build();
         final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
-        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
         when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
-        when(viewService.get(any())).thenReturn(Optional.empty());
         when(viewService.forSearch(any())).thenReturn(List.of());
 
-        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+        final Response response = makeResource(mock(SearchDomain.class)).executeQuery("search-id", null, searchUser);
 
         assertThat(((SearchJob) response.getEntity()).getViewLastUpdatedAt()).isNull();
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/SearchResourceTest.java
@@ -24,19 +24,25 @@ import org.assertj.core.api.Assertions;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchDomain;
+import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.SearchExecutor;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.plugin.system.SimpleNodeId;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,8 +67,15 @@ public class SearchResourceTest {
     @Mock
     private ClusterConfigService clusterConfigService;
 
+    @Mock
+    private ViewService viewService;
+
     private final NodeId nodeId = new SimpleNodeId("5ca1ab1e-0000-4000-a000-000000000000");
 
+
+    private SearchResource makeResource(SearchDomain searchDomain) {
+        return new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService, viewService);
+    }
 
     @Test
     public void testBuilderGeneratesSearchId() {
@@ -86,7 +99,7 @@ public class SearchResourceTest {
                 .build();
 
         final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
-        final SearchResource resource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService);
+        final SearchResource resource = makeResource(searchDomain);
         final SearchDTO returnedSearch = resource.getSearch(search.id(), searchUser);
 
         assertThat(returnedSearch.id()).isEqualTo(search.id());
@@ -95,7 +108,7 @@ public class SearchResourceTest {
     @Test
     public void getSearchThrowsNotFoundIfSearchDoesntExist() {
         final SearchDomain searchDomain = mockSearchDomain(Optional.empty());
-        final SearchResource resource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService);
+        final SearchResource resource = makeResource(searchDomain);
         assertThatExceptionOfType(NotFoundException.class)
                 .isThrownBy(() -> resource.getSearch("god", searchUser))
                 .withMessageContaining("god");
@@ -108,10 +121,60 @@ public class SearchResourceTest {
         final SearchDomain searchDomain = mock(SearchDomain.class);
         when(searchDomain.saveForUser(any(), any())).thenReturn(search.toSearch());
 
-        final SearchResource resource = new SearchResource(searchDomain, searchExecutor, searchJobService, eventBus, clusterConfigService);
+        final SearchResource resource = makeResource(searchDomain);
         final Response response = resource.createSearch(search, searchUser);
 
         Assertions.assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
+    }
+
+    @Test
+    public void executeQuerySetsViewLastUpdatedAtFromSearchViewId() {
+        final String viewId = "view-123";
+        final DateTime updatedAt = DateTime.now(DateTimeZone.UTC);
+        final Search search = Search.builder().id("search-id").viewId(Optional.of(viewId)).build();
+        final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
+        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
+        when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
+        final ViewDTO view = mock(ViewDTO.class);
+        when(view.lastUpdatedAt()).thenReturn(updatedAt);
+        when(viewService.get(viewId)).thenReturn(Optional.of(view));
+        when(viewService.forSearch(any())).thenReturn(List.of());
+
+        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+        final SearchJob returned = (SearchJob) response.getEntity();
+
+        assertThat(returned.getViewLastUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    public void executeQuerySetsViewLastUpdatedAtViaForSearchFallback() {
+        final DateTime updatedAt = DateTime.now(DateTimeZone.UTC);
+        final Search search = Search.builder().id("search-id").build();
+        final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
+        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
+        when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
+        final ViewDTO view = mock(ViewDTO.class);
+        when(view.lastUpdatedAt()).thenReturn(updatedAt);
+        when(viewService.get(any())).thenReturn(Optional.empty());
+        when(viewService.forSearch("search-id")).thenReturn(List.of(view));
+
+        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+
+        assertThat(((SearchJob) response.getEntity()).getViewLastUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    public void executeQueryLeavesViewLastUpdatedAtNullWhenNoViewFound() {
+        final Search search = Search.builder().id("search-id").build();
+        final SearchJob job = new SearchJob("job-id", search, "owner", "node-1");
+        final SearchDomain searchDomain = mockSearchDomain(Optional.of(search));
+        when(searchExecutor.executeAsync(eq("search-id"), any(), any())).thenReturn(job);
+        when(viewService.get(any())).thenReturn(Optional.empty());
+        when(viewService.forSearch(any())).thenReturn(List.of());
+
+        final Response response = makeResource(searchDomain).executeQuery("search-id", null, searchUser);
+
+        assertThat(((SearchJob) response.getEntity()).getViewLastUpdatedAt()).isNull();
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -75,6 +75,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -440,6 +441,39 @@ public class ViewsResourceTest {
                 .hasMessageContaining("Failed to resolve view:test-resolver__invalid-view-id");
     }
 
+    @Test
+    public void callsSetAssociatedViewWhenSearchIdChanges() {
+        final String oldSearchId = "old-search-id";
+        final String newSearchId = "new-search-id";
+        final ViewDTO existingView = ViewDTO.builder()
+                .id(VIEW_ID).searchId(oldSearchId).title("test")
+                .state(Collections.emptyMap()).build();
+        final Search oldSearch = Search.builder().id(oldSearchId).queries(ImmutableSet.of()).build();
+        final Search newSearch = Search.builder().id(newSearchId).queries(ImmutableSet.of()).build();
+        final ViewService viewService = mockViewService(existingView);
+        when(viewService.update(any())).thenReturn(existingView.toBuilder().searchId(newSearchId).build());
+        final SearchDomain searchDomain = mock(SearchDomain.class);
+
+        final ViewDTO updatedViewDto = existingView.toBuilder().searchId(newSearchId).build();
+        createViewsResource(viewService, searchDomain, oldSearch, newSearch)
+                .update(VIEW_ID, CreateEntityRequest.create(updatedViewDto, null), SEARCH_USER);
+
+        verify(searchDomain).setAssociatedView(oldSearchId, VIEW_ID);
+    }
+
+    @Test
+    public void doesNotCallSetAssociatedViewWhenSearchIdUnchanged() {
+        final ViewDTO existingView = TEST_DASHBOARD_VIEW; // searchId = SEARCH_ID
+        final ViewService viewService = mockViewService(existingView);
+        when(viewService.update(any())).thenReturn(existingView);
+        final SearchDomain searchDomain = mock(SearchDomain.class);
+
+        createViewsResource(viewService, searchDomain, SEARCH)
+                .update(VIEW_ID, CreateEntityRequest.create(existingView, null), SEARCH_USER);
+
+        verify(searchDomain, never()).setAssociatedView(any(), any());
+    }
+
     private ViewsResource createViewsResource(final ViewService viewService, final StartPageService startPageService, final RecentActivityService recentActivityService, final ClusterEventBus clusterEventBus, ReferencedSearchFiltersHelper referencedSearchFiltersHelper, SearchFilterVisibilityChecker searchFilterVisibilityChecker, final Map<String, ViewResolver> viewResolvers, Search... existingSearches) {
 
         final SearchDomain searchDomain = mock(SearchDomain.class);
@@ -459,6 +493,22 @@ public class ViewsResourceTest {
             protected User getCurrentUser() {
                 return mock(User.class);
             }
+        };
+    }
+
+    private ViewsResource createViewsResource(final ViewService viewService,
+                                               final SearchDomain searchDomain,
+                                               Search... existingSearches) {
+        for (Search search : existingSearches) {
+            when(searchDomain.getForUser(eq(search.id()), eq(SEARCH_USER))).thenReturn(Optional.of(search));
+        }
+        return new ViewsResource(viewService, mock(StartPageService.class),
+                mock(RecentActivityService.class), mock(ClusterEventBus.class), searchDomain,
+                EMPTY_VIEW_RESOLVERS, EMPTY_SEARCH_FILTER_VISIBILITY_CHECKER,
+                new ReferencedSearchFiltersHelper(), mock(AuditEventSender.class),
+                mock(ObjectMapper.class), mock(EntitySharesService.class), mock(EntitySourceService.class)) {
+            @Override protected Subject getSubject() { return mock(Subject.class); }
+            @Override protected User getCurrentUser() { return mock(User.class); }
         };
     }
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -213,9 +213,7 @@ const Search = ({ forceSideBarPinned = false }: Props) => {
                                     <IfInteractive>
                                       <HeaderElements />
                                       {InfoBar && <InfoBar />}
-                                      <IfDashboard>
-                                        <ViewUpdateBanner />
-                                      </IfDashboard>
+                                      <ViewUpdateBanner />
                                       <IfDashboard>
                                         {!editingWidget && <DashboardSearchBar scrollContainer={scrollContainer} />}
                                       </IfDashboard>

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -26,6 +26,7 @@ import HeaderElements from 'views/components/HeaderElements';
 import QueryBarElements from 'views/components/QueryBarElements';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
+import ViewUpdateBanner from 'views/components/dashboard/ViewUpdateBanner';
 import QueryBar from 'views/components/QueryBar';
 import { FieldsOverview } from 'views/components/sidebar';
 import DashboardSearchBar from 'views/components/DashboardSearchBar';
@@ -212,6 +213,9 @@ const Search = ({ forceSideBarPinned = false }: Props) => {
                                     <IfInteractive>
                                       <HeaderElements />
                                       {InfoBar && <InfoBar />}
+                                      <IfDashboard>
+                                        <ViewUpdateBanner />
+                                      </IfDashboard>
                                       <IfDashboard>
                                         {!editingWidget && <DashboardSearchBar scrollContainer={scrollContainer} />}
                                       </IfDashboard>

--- a/graylog2-web-interface/src/views/components/dashboard/ViewUpdateBanner.test.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/ViewUpdateBanner.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import { asMock } from 'helpers/mocking';
+import useViewsSelector from 'views/stores/useViewsSelector';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import { getView } from 'views/api/views';
+import ViewDeserializer from 'views/logic/views/ViewDeserializer';
+import useView from 'views/hooks/useView';
+import View from 'views/logic/views/View';
+import type { ViewJson } from 'views/logic/views/View';
+
+import ViewUpdateBanner from './ViewUpdateBanner';
+
+jest.mock('views/stores/useViewsSelector');
+jest.mock('views/stores/useViewsDispatch');
+jest.mock('views/hooks/useView');
+jest.mock('views/api/views');
+jest.mock('views/logic/views/ViewDeserializer');
+
+describe('ViewUpdateBanner', () => {
+  const mockDispatch = jest.fn();
+  const mockView = View.create().toBuilder().id('view-id-1').build();
+
+  beforeEach(() => {
+    asMock(useViewsDispatch).mockReturnValue(mockDispatch);
+    asMock(useView).mockReturnValue(mockView);
+    asMock(useViewsSelector).mockReturnValue(undefined);
+  });
+
+  it('renders nothing when serverViewLastUpdatedAt is undefined', () => {
+    render(<ViewUpdateBanner />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows banner when serverViewLastUpdatedAt is set', () => {
+    asMock(useViewsSelector).mockReturnValue('2024-01-01T12:00:00.000Z');
+    render(<ViewUpdateBanner />);
+    expect(screen.getByText(/updated by another user/i)).toBeInTheDocument();
+  });
+
+  it('dispatches setServerViewLastUpdatedAt(undefined) when dismissed', async () => {
+    asMock(useViewsSelector).mockReturnValue('2024-01-01T12:00:00.000Z');
+    render(<ViewUpdateBanner />);
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ payload: undefined }));
+  });
+
+  it('calls getView and dispatches loadView when Reload is clicked', async () => {
+    asMock(useViewsSelector).mockReturnValue('2024-01-01T12:00:00.000Z');
+    const freshViewJson = { id: mockView.id } as unknown as ViewJson;
+    const freshView = View.create().toBuilder().id('view-id-1').build();
+    asMock(getView).mockResolvedValue(freshViewJson);
+    asMock(ViewDeserializer).mockResolvedValue(freshView);
+    mockDispatch.mockResolvedValue(undefined);
+
+    render(<ViewUpdateBanner />);
+    await userEvent.click(screen.getByRole('button', { name: /reload/i }));
+
+    await waitFor(() => expect(getView).toHaveBeenCalledWith(mockView.id));
+    expect(ViewDeserializer).toHaveBeenCalledWith(freshViewJson);
+    expect(mockDispatch).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/graylog2-web-interface/src/views/components/dashboard/ViewUpdateBanner.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/ViewUpdateBanner.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { Alert, Button } from 'components/bootstrap';
+import useView from 'views/hooks/useView';
+import useViewsDispatch from 'views/stores/useViewsDispatch';
+import useViewsSelector from 'views/stores/useViewsSelector';
+import { loadView } from 'views/logic/slices/viewSlice';
+import { setServerViewLastUpdatedAt } from 'views/logic/slices/searchExecutionSlice';
+import { selectServerViewLastUpdatedAt } from 'views/logic/slices/searchExecutionSelectors';
+import { getView } from 'views/api/views';
+import ViewDeserializer from 'views/logic/views/ViewDeserializer';
+
+const BannerWrapper = styled.div`
+  margin-bottom: 8px;
+`;
+
+const ViewUpdateBanner = () => {
+  const view = useView();
+  const dispatch = useViewsDispatch();
+  const serverUpdatedAt = useViewsSelector(selectServerViewLastUpdatedAt);
+  const isStale = serverUpdatedAt !== undefined;
+
+  const viewId = view?.id;
+
+  const dismiss = useCallback(() => dispatch(setServerViewLastUpdatedAt(undefined)), [dispatch]);
+
+  const reload = useCallback(async () => {
+    dismiss();
+    const freshViewJson = await getView(viewId);
+    const freshView = await ViewDeserializer(freshViewJson);
+    dispatch(loadView(freshView));
+  }, [dismiss, viewId, dispatch]);
+
+  if (!isStale) return null;
+
+  return (
+    <BannerWrapper>
+      <Alert bsStyle="info" onDismiss={dismiss}>
+        This dashboard was updated by another user.{' '}
+        <Button bsSize="xs" bsStyle="primary" onClick={reload}>Reload</Button>
+      </Alert>
+    </BannerWrapper>
+  );
+};
+
+export default ViewUpdateBanner;

--- a/graylog2-web-interface/src/views/logic/slices/executeJobResult.ts
+++ b/graylog2-web-interface/src/views/logic/slices/executeJobResult.ts
@@ -59,7 +59,7 @@ export type StartJobType = (
 export const startJob: StartJobType = async (search, searchTypesToSearch, executionStateParam, keepQueries = []) => {
   const executionState = buildSearchExecutionState(searchTypesToSearch, executionStateParam, keepQueries);
 
-  return runStartJob(search, executionState).then((res) => ({ asyncSearchId: res.id, nodeId: res.executing_node }));
+  return runStartJob(search, executionState).then((res) => ({ asyncSearchId: res.id, nodeId: res.executing_node, viewLastUpdatedAt: res.view_last_updated_at }));
 };
 
 const getDelayTime = (depth: number = 1): number => {

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSelectors.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSelectors.ts
@@ -36,3 +36,7 @@ export const selectParameterBindings = createSelector(
   selectSearchExecutionState,
   (executionState) => executionState.parameterBindings,
 );
+export const selectServerViewLastUpdatedAt = createSelector(
+  selectSearchExecutionRoot,
+  (state) => state.serverViewLastUpdatedAt,
+);

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -241,7 +241,7 @@ export const executeWithExecutionState =
         return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery]);
       })
       .then((jobIds: JobIds) => {
-        if (jobIds.viewLastUpdatedAt) {
+        if (jobIds?.viewLastUpdatedAt) {
           const view = selectView(getState());
           if (view?.lastUpdatedAt && new Date(jobIds.viewLastUpdatedAt) > view.lastUpdatedAt) {
             dispatch(setServerViewLastUpdatedAt(jobIds.viewLastUpdatedAt));

--- a/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
+++ b/graylog2-web-interface/src/views/logic/slices/searchExecutionSlice.ts
@@ -32,7 +32,7 @@ import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { SearchParser } from 'views/logic/slices/searchMetadataSlice';
 import { parseSearch } from 'views/logic/slices/searchMetadataSlice';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
-import { selectParameters } from 'views/logic/slices/viewSelectors';
+import { selectParameters, selectView } from 'views/logic/slices/viewSelectors';
 import {
   selectGlobalOverride,
   selectSearchTypesToSearch,
@@ -56,6 +56,7 @@ const initialState = {
   isLoading: false,
   result: undefined,
   jobIds: null,
+  serverViewLastUpdatedAt: undefined as string | undefined,
 };
 
 const searchExecutionSlice = createSlice({
@@ -120,6 +121,10 @@ const searchExecutionSlice = createSlice({
       ...state,
       jobIds: action.payload,
     }),
+    setServerViewLastUpdatedAt: (state, action: PayloadAction<string | undefined>) => ({
+      ...state,
+      serverViewLastUpdatedAt: action.payload,
+    }),
   },
 });
 
@@ -133,6 +138,7 @@ export const {
   setParameterValues,
   setParameterBindings,
   setJobIds,
+  setServerViewLastUpdatedAt,
 } = searchExecutionSlice.actions;
 
 export const searchExecutionSliceReducer = searchExecutionSlice.reducer;
@@ -225,7 +231,7 @@ export const executeWithExecutionState =
     perPage?: number;
     stopPolling?: (progress: number) => boolean;
   }) =>
-  async (dispatch: ViewsDispatch) => {
+  (dispatch: ViewsDispatch, getState: () => RootState) => {
     dispatch(loading());
 
     return dispatch(parseSearch(search, searchExecutors.parse))
@@ -234,9 +240,16 @@ export const executeWithExecutionState =
 
         return searchExecutors.startJob(search, searchTypesToSearch, executionState, [activeQuery]);
       })
-      .then((jobIds: JobIds) =>
-        dispatch(executeSearchJob({ searchExecutors, jobIds, widgetMapping, page, perPage, stopPolling })),
-      )
+      .then((jobIds: JobIds) => {
+        if (jobIds.viewLastUpdatedAt) {
+          const view = selectView(getState());
+          if (view?.lastUpdatedAt && new Date(jobIds.viewLastUpdatedAt) > view.lastUpdatedAt) {
+            dispatch(setServerViewLastUpdatedAt(jobIds.viewLastUpdatedAt));
+          }
+        }
+
+        return dispatch(executeSearchJob({ searchExecutors, jobIds, widgetMapping, page, perPage, stopPolling }));
+      })
       .catch((error) => {
         dispatch(cancelExecutedJob());
         dispatch(stopLoading());

--- a/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.ts
@@ -16,8 +16,9 @@
  */
 import UserNotification from 'util/UserNotification';
 import type View from 'views/logic/views/View';
+import type { ViewJson } from 'views/logic/views/View';
 import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
-import { setIsNew, setIsDirty } from 'views/logic/slices/viewSlice';
+import { setIsNew, setIsDirty, setView } from 'views/logic/slices/viewSlice';
 import type FetchError from 'logic/errors/FetchError';
 import type { EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import { updateView } from 'views/api/views';
@@ -29,7 +30,11 @@ const _extractErrorMessage = (error: FetchError) =>
 
 export default (view: View, entityShare?: EntitySharePayload) => async (dispatch: ViewsDispatch) => {
   try {
-    await updateView(view, entityShare);
+    const savedViewJson = (await updateView(view, entityShare)) as unknown as ViewJson;
+    const lastUpdatedAt = savedViewJson?.last_updated_at ? new Date(savedViewJson.last_updated_at) : undefined;
+    if (lastUpdatedAt) {
+      dispatch(setView(view.toBuilder().lastUpdatedAt(lastUpdatedAt).build()));
+    }
     dispatch(setIsNew(false));
     dispatch(setIsDirty(false));
     UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!');

--- a/graylog2-web-interface/src/views/stores/SearchJobs.ts
+++ b/graylog2-web-interface/src/views/stores/SearchJobs.ts
@@ -53,11 +53,13 @@ export type SearchJobType = {
 export type JobIdsJson = {
   id: string;
   executing_node: string;
+  view_last_updated_at?: string;
 };
 
 export type JobIds = {
   asyncSearchId: string;
   nodeId: string;
+  viewLastUpdatedAt?: string;
 };
 
 export function runStartJob(search: Search, executionState: SearchExecutionState): Promise<JobIdsJson> {

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -549,6 +549,7 @@ export interface SearchExecution {
   isLoading: boolean;
   searchTypesToSearch: Array<string>;
   jobIds?: JobIds | null;
+  serverViewLastUpdatedAt?: string;
 }
 
 export interface SearchMetadataState {


### PR DESCRIPTION
## Description

  This PR bundles two related changes that together give User B a reliable, informative experience when a dashboard is edited by User A while they have it open.

  **1. Fix 403 "Missing Permissions" on execute after a dashboard edit (backend)**

  When User A edits a dashboard tab the frontend creates a new search object (S2) and updates the view's `search_id`. The old search (S1) becomes orphaned — no view references it — so User B's in-flight execution of S1 fails
   the permission check with a 403.

  Root cause: `SearchDomain.hasReadPermissionFor` only checks `viewService.forSearch`, which returns empty once the view no longer references S1.

  Fix: when `PUT /views/{id}` detaches the old search, `setAssociatedView` writes the view ID onto that search as a `view_id` back-reference. The permission check falls back to this reference when `forSearch` returns
  nothing, allowing any user who can read the view to still execute the old search. `viewId` is stripped in `saveForUser` so users cannot inject an arbitrary `view_id` via the search API to escalate permissions.

  **2. "Dashboard was updated" banner (frontend)**

  Each execute response (`POST /views/search/{id}/execute`) now carries the view's current `last_updated_at`. The frontend compares it against the locally loaded `view.lastUpdatedAt`; if newer, an info banner appears: *"This
   dashboard was updated by another user."* with a **Reload** button and a dismiss option. No additional polling requests are needed.

  `OnSaveViewAction` now captures `last_updated_at` from the PUT response and updates the Redux view state, so the saving user's own subsequent executions compare equal timestamps and never trigger the banner.

  ## Motivation and Context

  Without fix 1, User B silently gets no results after User A edits a tab. Without fix 2, User B has no way to know a reload is needed even when execution succeeds.

  ## How Has This Been Tested?

  - Manual end-to-end: two browsers on the same dashboard — User A edits and saves, User B's next auto-refresh succeeds and shows the banner. Reload and dismiss both work as expected.
  - Verified the saving user (User A) does **not** see the banner.
  - Backend: new unit tests in `SearchDomainTest` and `ViewsResourceTest` for the permission fix; three new tests in `SearchResourceTest` for `view_last_updated_at`.
  - Frontend: `ViewUpdateBanner.test.tsx` with four cases (hidden, shown, dismiss, reload). `tsc --noEmit` and ESLint pass clean.

  ## Screenshots (if appropriate):
<img width="1800" height="767" alt="Bildschirmfoto 2026-04-29 um 14 31 44" src="https://github.com/user-attachments/assets/3aa0d600-b20a-490a-977d-3a658e9f41a5" />

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Refactoring (non-breaking change)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have requested a documentation update.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.