### PR TITLE
Automatically dismiss datanode version mismatch notifications

### DIFF
--- a/changelog/unreleased/issue-24718.toml
+++ b/changelog/unreleased/issue-24718.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed a bug where the Data Node version mismatch notification was never automatically cleared after all Data Nodes returned to a matching version"
+
+pulls = ["25879"]
+issues = ["24718"]

--- a/graylog2-server/src/main/java/org/graylog2/periodical/DataNodeHousekeepingPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/DataNodeHousekeepingPeriodical.java
@@ -60,6 +60,8 @@ public class DataNodeHousekeepingPeriodical extends Periodical {
                     .addType(Notification.Type.DATA_NODE_VERSION_MISMATCH)
                     .addSeverity(Notification.Severity.NORMAL);
             notificationService.publishIfFirst(notification);
+        } else {
+            notificationService.fixed(Notification.Type.DATA_NODE_VERSION_MISMATCH);
         }
 
     }

--- a/graylog2-server/src/test/java/org/graylog2/periodical/DataNodeHousekeepingPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/DataNodeHousekeepingPeriodicalTest.java
@@ -54,7 +54,7 @@ class DataNodeHousekeepingPeriodicalTest {
     void testDropOutdatedCalled() {
         periodical.doRun();
         verify(nodeService).dropOutdated();
-        verifyNoInteractions(notificationService);
+        verify(notificationService).fixed(Notification.Type.DATA_NODE_VERSION_MISMATCH);
     }
 
     @Test
@@ -81,7 +81,7 @@ class DataNodeHousekeepingPeriodicalTest {
         when(sameVersion2.isCompatibleWithVersion()).thenReturn(true);
         when(nodeService.allActive()).thenReturn(Map.of("node1", sameVersion, "node2", sameVersion2));
         periodical.doRun();
-        verifyNoInteractions(notificationService);
+        verify(notificationService).fixed(Notification.Type.DATA_NODE_VERSION_MISMATCH);
     }
 
 


### PR DESCRIPTION
## Description
Automatically dismiss datanode version mismatch notification if there are no mismatch conditions observed anymore.

## Motivation and Context
Fixes https://github.com/Graylog2/graylog2-server/issues/24718 
Removes confusion in cases where current setup is completely unified, running the same version of sever and datanode, but one old and outdated notification suggests otherwise.

## How Has This Been Tested?
Extended unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

