### PR TITLE
Enforce clusterconfiguration:read permission on Cluster Configuration endpoints (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-25754.toml
+++ b/changelog/unreleased/pr-25754.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Enforce clusterconfiguration:read permission on Cluster Configuration API endpoints"
+
+pulls = ["25754"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
@@ -41,6 +42,7 @@ import org.graylog2.plugin.system.NodeId;
 import org.graylog2.rest.models.system.cluster.responses.NodeSummary;
 import org.graylog2.rest.models.system.cluster.responses.NodeSummaryList;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,6 +84,7 @@ public class ClusterResource extends RestResource {
     @GET
     @Timed
     @Path("/node")
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIGURATION_READ)
     @ApiOperation(value = "Information about this node.",
                   notes = "This is returning information of this node in context to its state in the cluster. " +
                           "Use the system API of the node itself to get system information.")
@@ -92,6 +95,7 @@ public class ClusterResource extends RestResource {
     @GET
     @Timed
     @Path("/nodes/{nodeId}")
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIGURATION_READ)
     @ApiOperation(value = "Information about a node.",
                   notes = "This is returning information of a node in context to its state in the cluster. " +
                           "Use the system API of the node itself to get system information.")

--- a/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
+++ b/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
@@ -14,7 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { DocumentTitle, PageHeader } from 'components/common';
 import { Col, Row } from 'components/bootstrap';
@@ -25,8 +26,13 @@ import type { SearchParams } from 'stores/PaginationTypes';
 import ClusterConfigurationPageNavigation from 'components/cluster-configuration/ClusterConfigurationPageNavigation';
 import HideOnCloud from 'util/conditional/HideOnCloud';
 import IndexerClusterHealth from 'components/indexers/IndexerClusterHealth';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
+import Routes from 'routing/Routes';
 
 const ClusterConfigurationPage = () => {
+  const currentUser = useCurrentUser();
+  const navigate = useNavigate();
   const clusterNodes = useClusterNodes();
   const searchParams: SearchParams = {
     query: '',
@@ -34,6 +40,12 @@ const ClusterConfigurationPage = () => {
     pageSize: 0,
     sort: { attributeId: 'hostname', direction: 'asc' },
   };
+
+  useEffect(() => {
+    if (!isPermitted(currentUser.permissions, 'clusterconfiguration:read')) {
+      navigate(Routes.NOTFOUND);
+    }
+  }, [currentUser.permissions, navigate]);
 
   return (
     <DocumentTitle title="Cluster Configuration">


### PR DESCRIPTION
Note: This is a backport of #25754 to `7.0`.

Relates to Graylog2/glc-bd-documents#85

## Description

After the upgrade from 6.3 to 7.0, the "Cluster Configuration Reader" role was introduced in #23248 to restrict access to the Cluster Configuration page. However, the `clusterconfiguration:read` permission was only enforced on the **navigation menu item** — the `ClusterResource` REST endpoints had no permission checks, allowing any authenticated user to access `/system/cluster` data directly.

This PR adds `@RequiresPermissions(RestPermissions.CLUSTER_CONFIGURATION_READ)` to these `ClusterResource` GET endpoints:
- `GET /system/cluster/node`
- `GET /system/cluster/nodes/{nodeId}`

The PR also adds a frontend route guard on `ClusterConfigurationPage` to redirect users without `clusterconfiguration:read` to a 404.

## How Tested
- Manual: log in as a user without the "Cluster Configuration Reader" role and call `/api/system/cluster/nodes` — should now return 403

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.