### PR TITLE
Fixing serializing message body for details in error processing stream.

### DIFF
--- a/changelog/unreleased/pr-25906.toml
+++ b/changelog/unreleased/pr-25906.toml
@@ -1,0 +1,3 @@
+type = "f"
+message = "Fix serializing message body for details in error processing stream."
+pulls = ["25906"]

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.test.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.test.tsx
@@ -75,4 +75,17 @@ describe('TypeSpecificValue', () => {
 
     await screen.findByText('Input 1');
   });
+
+  // Regression: error processing stream's message body details may contain BigInt values
+  // (deserialized by json-with-bigint), which native JSON.stringify cannot serialize.
+  it('should render object values containing BigInts without crashing', async () => {
+    const value = {
+      message: 'failed to process',
+      size: BigInt('9223372036854775807'),
+    };
+
+    render(<TypeSpecificValue field="gl2_processing_error" value={value} />);
+
+    await screen.findByText(/9223372036854775807/);
+  });
 });

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.tsx
@@ -19,6 +19,7 @@ import { useMemo } from 'react';
 import trim from 'lodash/trim';
 import trunc from 'lodash/truncate';
 
+import * as JSON from 'util/json';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import { getPrettifiedValue } from 'views/components/visualizations/utils/unitConverters';
 import type FieldUnit from 'views/logic/aggregationbuilder/FieldUnit';


### PR DESCRIPTION
**Note:** This needs a backport to `7.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue resulting in an error when a user expands a message in the `Processing and Indexing Failures` stream, if the message has at least one field containing a numeric value that is larger than `Number.MAX_SAFE_INTEGER`. In this case, it will be deserialized as `BigInt` (to preserve numeric precision), but attempted to render using native `JSON.stringify`, resulting in a `TypeError: Do not know how to serialize a BigInt`.

This PR is fixing this by using `JSON.stringify` from `json-with-bigint`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.