### PR TITLE
Fix Manage Extractors link for local inputs

### DIFF
--- a/changelog/unreleased/pr-25907.toml
+++ b/changelog/unreleased/pr-25907.toml
@@ -1,0 +1,3 @@
+type = "f"
+message = "Fix broken `Manage extractors` link for local inputs on the Inputs overview page."
+pulls = ["25907"]

--- a/graylog2-web-interface/src/components/inputs/InputsOveriew/InputsActions.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputsOveriew/InputsActions.test.tsx
@@ -116,7 +116,6 @@ const renderSUT = (input = baseInput, extraProps = {}) =>
       input={input as any}
       inputTypes={{} as any}
       inputTypeDescriptions={inputTypeDescriptions}
-      currentNode={null}
       {...extraProps}
     />,
   );
@@ -318,10 +317,13 @@ describe('InputsActions', () => {
     renderSUT(input);
     await openMoreActions();
 
-    expect(screen.getByText('Manage extractors')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Manage extractors' })).toHaveAttribute(
+      'href',
+      '/system/inputs/glob1/extractors',
+    );
   });
 
-  it('shows Manage extractors (local) when input is local', async () => {
+  it('links Manage extractors to the input node for local inputs', async () => {
     const input = {
       ...baseInput,
       id: 'loc1',
@@ -333,7 +335,10 @@ describe('InputsActions', () => {
     renderSUT(input);
     await openMoreActions();
 
-    expect(screen.getByText('Manage extractors')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Manage extractors' })).toHaveAttribute(
+      'href',
+      '/system/inputs/node-1/loc1/extractors',
+    );
   });
 
   it('shows Delete input and is able to delete input on confirmation', async () => {

--- a/graylog2-web-interface/src/components/inputs/InputsOveriew/InputsActions.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputsOveriew/InputsActions.tsx
@@ -42,25 +42,13 @@ type Props = {
   input: Input;
   inputTypes: InputTypesSummary;
   inputTypeDescriptions: InputTypeDescriptionsResponse;
-  currentNode: {
-    node?: {
-      cluster_id: string;
-      hostname: string;
-      is_leader: boolean;
-      is_master: boolean;
-      last_seen: string;
-      node_id: string;
-      short_node_id: string;
-      transport_address: string;
-    };
-  };
 };
 
 const FORWARDER_SERVICE_INPUT = 'org.graylog.plugins.forwarder.input.ForwarderServiceInput';
 const GL2_FORWARDER_INPUT = 'gl2_forwarder_input';
 const GL2_SOURCE_INPUT = 'gl2_source_input';
 
-const InputsActions = ({ input, inputTypes: _, inputTypeDescriptions, currentNode }: Props) => {
+const InputsActions = ({ input, inputTypes: _, inputTypeDescriptions }: Props) => {
   const [showConfirmDeleteDialog, setShowConfirmDeleteDialog] = useState<boolean>(false);
   const [showStaticFieldForm, setShowStaticFieldForm] = useState<boolean>(false);
   const [showConfigurationForm, setShowConfigurationForm] = useState<boolean>(false);
@@ -177,7 +165,7 @@ const InputsActions = ({ input, inputTypes: _, inputTypeDescriptions, currentNod
                 to={
                   input.global
                     ? Routes.global_input_extractors(input.id)
-                    : Routes.local_input_extractors(currentNode?.node?.node_id, input.id)
+                    : Routes.local_input_extractors(input.node, input.id)
                 }>
                 <MenuItem
                   onClick={() => {

--- a/graylog2-web-interface/src/components/inputs/InputsOveriew/useTableElements.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputsOveriew/useTableElements.tsx
@@ -35,7 +35,6 @@ const useTableElements = ({
         input={listItem}
         inputTypes={inputTypes}
         inputTypeDescriptions={inputTypeDescriptions}
-        currentNode={null}
       />
     ),
     [inputTypes, inputTypeDescriptions],


### PR DESCRIPTION
**Note:** This needs a backport to `7.1`.

## Description

The `Manage extractors` action on the Inputs overview page generated an invalid URL for local (non-global) inputs because it relied on a `currentNode` prop that was always passed as `null` from `useTableElements`. Clicking the link routed to a malformed path with `undefined` in place of the node ID.

The fix uses the input's own `node` field to build the local extractors route and removes the unused `currentNode` prop from `InputsActions`.

## Motivation and Context

Users could not reach the extractors page for local inputs from the new inputs overview — the link was broken.

## How Has This Been Tested?

Manually verified that the `Manage extractors` link now resolves to a valid local-input extractors URL for non-global inputs and continues to use the global route for global inputs.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.