### PR TITLE
Fix missing X-Requested-By header in API browser try-it-out

### DIFF
--- a/changelog/unreleased/pr-25933.toml
+++ b/changelog/unreleased/pr-25933.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix missing `X-Requested-By` header on API browser try-it-out requests, which caused CSRF rejections."
+issues = ["25931"]
+pulls = ["25933"]

--- a/graylog2-web-interface/src/pages/ApiBrowserPage.tsx
+++ b/graylog2-web-interface/src/pages/ApiBrowserPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useRef, useEffect, useState } from 'react';
+import { useCallback, useRef, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import styled, { css } from 'styled-components';
 
@@ -109,8 +109,10 @@ const addRequestedByHeader = (event: CustomEvent) => {
   event.detail.request.headers.append('X-Requested-By', 'API Browser');
 };
 
+type ExplorerElement = HTMLElement & { loadSpec: (spec: object) => void };
+
 const ApiBrowserPage = () => {
-  const explorerRef = useRef<HTMLElement & { loadSpec: (spec: object) => void }>(null);
+  const explorerRef = useRef<ExplorerElement | null>(null);
   const [loaded, setLoaded] = useState(false);
   const {
     data: spec,
@@ -128,23 +130,17 @@ const ApiBrowserPage = () => {
     });
   }, []);
 
-  useEffect(() => {
-    const el = explorerRef.current;
+  const attachExplorer = useCallback((el: ExplorerElement | null) => {
+    explorerRef.current = el;
 
     if (el) {
       el.addEventListener('request', addRequestedByHeader);
     }
-
-    return () => {
-      if (el) {
-        el.removeEventListener('request', addRequestedByHeader);
-      }
-    };
-  }, [loaded]);
+  }, []);
 
   useEffect(() => {
     if (loaded && !loadingSpec && !isError) {
-      explorerRef.current.loadSpec(spec);
+      explorerRef.current?.loadSpec(spec);
     }
   }, [isError, loaded, loadingSpec, spec]);
 
@@ -164,7 +160,7 @@ const ApiBrowserPage = () => {
     <DocumentTitle title="API Browser">
       <StyledExplorerContainer>
         {/* @ts-ignore - openapi-explorer is a web component */}
-        <openapi-explorer ref={explorerRef} server-url="api/" hide-authentication hide-server-selection>
+        <openapi-explorer ref={attachExplorer} server-url="api/" hide-authentication hide-server-selection>
           <DownloadSpecSelect />
           {/* @ts-ignore - openapi-explorer is a web component */}
         </openapi-explorer>


### PR DESCRIPTION
## Description

Fix the `request` event listener in `ApiBrowserPage` so the `X-Requested-By: API Browser` header is reliably attached to every try-it-out request from the new `openapi-explorer`-based API browser.

## Motivation and Context

Fixes #25931. The listener was registered in a `useEffect` keyed only on `loaded`, but `<openapi-explorer>` is only mounted once both the dynamic chunk has loaded **and** the spec fetch has resolved. If the spec finished after the chunk, `loaded` flipped while the early-return for `loadingSpec` still kept the element out of the DOM, the effect ran against a `null` ref, and the listener was never attached. When `loadingSpec` later flipped and the explorer mounted, the effect did not re-run and try-it-out requests went out without `X-Requested-By`, tripping Graylog's CSRF protection.

Replacing the effect with a `useCallback` ref attaches the listener at the exact moment the element mounts, regardless of which async source resolved last.

## How Has This Been Tested?

- `yarn tsc` passes
- `yarn lint:path src/pages/ApiBrowserPage.tsx` passes
- Manually exercised the API browser: try-it-out requests now include `X-Requested-By: API Browser` and succeed

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.