### PR TITLE
Add tag autocomplete to event definition edit page

### DIFF
--- a/changelog/unreleased/pr-25896.toml
+++ b/changelog/unreleased/pr-25896.toml
@@ -1,4 +1,4 @@
 type = "a"
 message = "Ability to assign tags to event definitions."
 
-pulls = ["25896"]
+pulls = ["25896", "25940"]

--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
@@ -17,12 +17,18 @@
 package org.graylog.events.processor;
 
 import com.google.errorprone.annotations.MustBeClosed;
+import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
 import com.mongodb.client.model.Updates;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
+import org.bson.Document;
 import org.bson.conversions.Bson;
+import com.mongodb.client.model.Projections;
+import org.bson.types.ObjectId;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.plugins.views.search.searchfilters.db.SearchFiltersReFetcher;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
@@ -44,11 +50,13 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -70,6 +78,7 @@ public class DBEventDefinitionService {
     private static final String ILLUMINATE_SCOPE_NAME = "ILLUMINATE";
 
     private final MongoCollection<EventDefinitionDto> collection;
+    private final com.mongodb.client.MongoCollection<Document> documentCollection;
     private final MongoUtils<EventDefinitionDto> mongoUtils;
     private final ScopedEntityMongoUtils<EventDefinitionDto> scopedEntityMongoUtils;
     private final MongoPaginationHelper<EventDefinitionDto> paginationHelper;
@@ -84,6 +93,7 @@ public class DBEventDefinitionService {
                                     EntityScopeService entityScopeService,
                                     SearchFiltersReFetcher searchFiltersRefetcher) {
         this.collection = mongoCollections.collection(COLLECTION_NAME, EventDefinitionDto.class);
+        this.documentCollection = mongoCollections.nonEntityCollection(COLLECTION_NAME, Document.class);
         this.mongoUtils = mongoCollections.utils(collection);
         this.scopedEntityMongoUtils = mongoCollections.scopedEntityUtils(collection, entityScopeService);
         this.paginationHelper = mongoCollections.paginationHelper(collection);
@@ -262,6 +272,75 @@ public class DBEventDefinitionService {
         collection.updateMany(
                 Filters.eq(EventDefinitionDto.FIELD_EVENT_PROCEDURE, procedureId),
                 Updates.unset(EventDefinitionDto.FIELD_EVENT_PROCEDURE));
+    }
+
+    /**
+     * Returns distinct tag values across all event definitions, optionally narrowed by
+     * case-insensitive prefix.
+     */
+    public List<String> suggestTags(@Nullable String prefix, int limit) {
+        return runTagAggregation(prefix, limit, null);
+    }
+
+    /**
+     * Returns distinct tag values across the event definitions identified by {@code permittedIds},
+     * optionally narrowed by case-insensitive prefix. Use this overload when the caller does not
+     * have unrestricted read; pre-enumerate the IDs via {@link #findPermittedIds}.
+     */
+    public List<String> suggestTags(@Nullable String prefix, int limit, List<ObjectId> permittedIds) {
+        if (permittedIds.isEmpty()) {
+            return List.of();
+        }
+        return runTagAggregation(prefix, limit, Filters.in("_id", permittedIds));
+    }
+
+    private List<String> runTagAggregation(@Nullable String prefix, int limit, @Nullable Bson permissionMatch) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        final List<Bson> pipeline = new ArrayList<>();
+        if (permissionMatch != null) {
+            pipeline.add(Aggregates.match(permissionMatch));
+        }
+        pipeline.add(Aggregates.unwind("$" + EventDefinitionDto.FIELD_TAGS));
+        if (prefix != null && !prefix.isBlank()) {
+            final String pattern = "^" + Pattern.quote(prefix.toLowerCase(Locale.ROOT));
+            pipeline.add(Aggregates.match(Filters.regex(EventDefinitionDto.FIELD_TAGS, pattern, "i")));
+        }
+        pipeline.add(Aggregates.group("$" + EventDefinitionDto.FIELD_TAGS));
+        pipeline.add(Aggregates.sort(Sorts.ascending("_id")));
+        pipeline.add(Aggregates.limit(limit));
+
+        final List<String> result = new ArrayList<>();
+        try (var cursor = collection.aggregate(pipeline, Document.class).cursor()) {
+            while (cursor.hasNext()) {
+                result.add(cursor.next().getString("_id"));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the IDs of event definitions that pass {@code idIsPermitted}. Projects only {@code _id}
+     * to keep the wire payload small.
+     *
+     * <p><b>Cost:</b> O(N) over the full event-definitions collection per call. Only invoke this
+     * after confirming the caller lacks unrestricted read; do not use it for users that already
+     * hold {@code EVENT_DEFINITIONS_READ}.
+     */
+    public List<ObjectId> findPermittedIds(Predicate<String> idIsPermitted) {
+        final List<ObjectId> permitted = new ArrayList<>();
+        try (var cursor = documentCollection.find()
+                                            .projection(Projections.include("_id"))
+                                            .cursor()) {
+            while (cursor.hasNext()) {
+                final ObjectId id = cursor.next().getObjectId("_id");
+                if (idIsPermitted.test(id.toHexString())) {
+                    permitted.add(id);
+                }
+            }
+        }
+        return permitted;
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -122,6 +122,8 @@ import static org.graylog2.shared.utilities.StringUtils.f;
 public class EventDefinitionsResource extends RestResource implements PluginRestResource {
     private static final Logger LOG = LoggerFactory.getLogger(EventDefinitionsResource.class);
 
+    private static final int TAG_SUGGESTIONS_MAX_LIMIT = 100;
+
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create("_id", SearchQueryField.Type.OBJECT_ID))
             .put("title", SearchQueryField.create(EventDefinitionDto.FIELD_TITLE))
@@ -249,6 +251,24 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         return PageListResponse.create(query, definitionDtos.pagination(),
                 definitionDtos.pagination().total(), sort, order, eventDefinitionDtos, attributes, settings);
     }
+
+    @GET
+    @Path("/tags")
+    @Operation(summary = "Suggest tag values across event definitions, optionally narrowed by case-insensitive prefix")
+    public TagSuggestionsResponse suggestTags(@Parameter(name = "prefix") @QueryParam("prefix") @DefaultValue("") String prefix,
+                                              @Parameter(name = "limit") @QueryParam("limit") @DefaultValue("10") int limit) {
+        final int boundedLimit = Math.max(1, Math.min(limit, TAG_SUGGESTIONS_MAX_LIMIT));
+
+        if (isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)) {
+            return new TagSuggestionsResponse(dbService.suggestTags(prefix, boundedLimit));
+        }
+
+        final var permittedIds = dbService.findPermittedIds(
+                id -> isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, id));
+        return new TagSuggestionsResponse(dbService.suggestTags(prefix, boundedLimit, permittedIds));
+    }
+
+    public record TagSuggestionsResponse(@JsonProperty("tags") List<String> tags) { }
 
     @GET
     @Operation(summary = "List event definitions")

--- a/graylog2-server/src/test/java/org/graylog/events/processor/DBEventDefinitionServiceSuggestTagsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/DBEventDefinitionServiceSuggestTagsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.events.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.mongodb.client.model.Filters;
+import org.bson.types.ObjectId;
+import org.graylog.events.TestEventProcessorConfig;
+import org.graylog.events.notifications.EventNotificationSettings;
+import org.graylog.events.processor.storage.PersistToStreamsStorageHandler;
+import org.graylog.plugins.views.search.searchfilters.db.IgnoreSearchFilters;
+import org.graylog.security.entities.EntityRegistrar;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.entities.DefaultEntityScope;
+import org.graylog2.database.entities.EntityScope;
+import org.graylog2.database.entities.EntityScopeService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(MongoDBExtension.class)
+public class DBEventDefinitionServiceSuggestTagsTest {
+    private static final Set<EntityScope> ENTITY_SCOPES = Collections.singleton(new DefaultEntityScope());
+
+    @Mock
+    private DBEventProcessorStateService stateService;
+
+    private DBEventDefinitionService dbService;
+
+    @BeforeEach
+    public void setUp(MongoDBTestService dbTestService) {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        objectMapper.registerSubtypes(new NamedType(TestEventProcessorConfig.class, TestEventProcessorConfig.TYPE_NAME));
+        objectMapper.registerSubtypes(new NamedType(PersistToStreamsStorageHandler.Config.class, PersistToStreamsStorageHandler.Config.TYPE_NAME));
+        final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
+        this.dbService = new DBEventDefinitionService(
+                new MongoCollections(mapperProvider, dbTestService.mongoConnection()),
+                stateService,
+                mock(EntityRegistrar.class),
+                new EntityScopeService(ENTITY_SCOPES),
+                new IgnoreSearchFilters());
+    }
+
+    @Test
+    public void emptyCollectionReturnsEmptyList() {
+        assertThat(dbService.suggestTags(null, 100)).isEmpty();
+    }
+
+    @Test
+    public void distinctSortedUnionAcrossEventDefinitions() {
+        save("a", ImmutableSet.of("phishing", "lateral-movement"));
+        save("b", ImmutableSet.of("phishing", "exfiltration"));
+        save("c", ImmutableSet.of("persistence"));
+
+        assertThat(dbService.suggestTags(null, 100))
+                .containsExactly("exfiltration", "lateral-movement", "persistence", "phishing");
+    }
+
+    @Test
+    public void prefixMatchIsCaseInsensitive() {
+        save("a", ImmutableSet.of("phishing"));
+        save("b", ImmutableSet.of("persistence"));
+
+        assertThat(dbService.suggestTags("ph", 100)).containsExactly("phishing");
+        assertThat(dbService.suggestTags("PH", 100)).containsExactly("phishing");
+    }
+
+    @Test
+    public void prefixWithRegexMetaIsEscaped() {
+        save("a", ImmutableSet.of("phishing", "lateral-movement", "persistence"));
+
+        assertThat(dbService.suggestTags("*", 100)).isEmpty();
+        assertThat(dbService.suggestTags("[a-z]", 100)).isEmpty();
+        assertThat(dbService.suggestTags(".", 100)).isEmpty();
+    }
+
+    @Test
+    public void limitIsApplied() {
+        save("a", ImmutableSet.of("a-tag", "b-tag", "c-tag", "d-tag"));
+
+        assertThat(dbService.suggestTags(null, 2)).containsExactly("a-tag", "b-tag");
+    }
+
+    @Test
+    public void blankPrefixIsTreatedAsNoFilter() {
+        save("a", ImmutableSet.of("phishing"));
+
+        assertThat(dbService.suggestTags("", 100)).containsExactly("phishing");
+        assertThat(dbService.suggestTags("   ", 100)).containsExactly("phishing");
+    }
+
+    @Test
+    public void restrictedToPermittedIdsNarrowsResults() {
+        final String idA = save("a", ImmutableSet.of("phishing", "lateral-movement"));
+        save("b", ImmutableSet.of("exfiltration"));
+
+        assertThat(dbService.suggestTags(null, 100, List.of(new ObjectId(idA))))
+                .containsExactly("lateral-movement", "phishing");
+    }
+
+    @Test
+    public void emptyPermittedIdsReturnsEmpty() {
+        save("a", ImmutableSet.of("phishing"));
+
+        assertThat(dbService.suggestTags(null, 100, List.of())).isEmpty();
+    }
+
+    @Test
+    public void findPermittedIdsRespectsPredicate() {
+        final String idA = save("a", ImmutableSet.of("phishing"));
+        final String idB = save("b", ImmutableSet.of("exfiltration"));
+
+        // Predicate that only permits idA.
+        final var permitted = dbService.findPermittedIds(idA::equals);
+        assertThat(permitted).containsExactly(new ObjectId(idA));
+
+        // Predicate that permits everyone.
+        assertThat(dbService.findPermittedIds(id -> true))
+                .containsExactlyInAnyOrder(new ObjectId(idA), new ObjectId(idB));
+    }
+
+    private String save(String title, ImmutableSet<String> tags) {
+        final EventDefinitionDto dto = EventDefinitionDto.builder()
+                .title(title)
+                .description("test")
+                .priority(1)
+                .alert(false)
+                .keySpec(ImmutableList.of())
+                .config(TestEventProcessorConfig.builder()
+                        .message("test")
+                        .searchWithinMs(1000)
+                        .executeEveryMs(1000)
+                        .build())
+                .notificationSettings(EventNotificationSettings.withGracePeriod(0))
+                .tags(tags)
+                .build();
+        return dbService.save(dto).id();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
@@ -38,7 +38,6 @@ import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -110,8 +109,7 @@ public class EventDefinitionsResourceTest {
     @Test
     public void suggestTagsWithGlobalReadDoesNotEnumeratePermittedIds() {
         when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
-        when(dbService.suggestTags(eq("ph"), eq(10), eq(null)))
-                .thenReturn(List.of("phishing"));
+        when(dbService.suggestTags(eq("ph"), eq(10))).thenReturn(List.of("phishing"));
 
         final var response = resource.suggestTags("ph", 10);
 
@@ -120,59 +118,50 @@ public class EventDefinitionsResourceTest {
     }
 
     @Test
-    public void suggestTagsWithoutGlobalReadEnumeratesAndPushesInClause() {
+    public void suggestTagsWithoutGlobalReadEnumeratesAndPassesPermittedIds() {
         when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(false);
         final var permittedId = new ObjectId();
         when(dbService.findPermittedIds(any())).thenReturn(List.of(permittedId));
-        when(dbService.suggestTags(eq(""), eq(10), any()))
+        when(dbService.suggestTags(eq(""), eq(10), eq(List.of(permittedId))))
                 .thenReturn(List.of("phishing"));
 
         final var response = resource.suggestTags("", 10);
 
         Assertions.assertThat(response.tags()).containsExactly("phishing");
         verify(dbService).findPermittedIds(any());
-
-        final ArgumentCaptor<org.bson.conversions.Bson> filterCaptor = ArgumentCaptor.forClass(org.bson.conversions.Bson.class);
-        verify(dbService).suggestTags(eq(""), eq(10), filterCaptor.capture());
-        // Render the Bson against the default codec registry and assert the $in array carries the permitted IDs.
-        final org.bson.BsonDocument rendered = filterCaptor.getValue()
-                .toBsonDocument(org.bson.BsonDocument.class, org.bson.codecs.configuration.CodecRegistries
-                        .fromProviders(new org.bson.codecs.BsonValueCodecProvider()));
-        Assertions.assertThat(rendered.getDocument("_id").getArray("$in"))
-                .containsExactly(new org.bson.BsonObjectId(permittedId));
+        verify(dbService).suggestTags(eq(""), eq(10), eq(List.of(permittedId)));
     }
 
     @Test
-    public void suggestTagsWithoutGlobalReadAndNoPermittedIdsShortCircuits() {
+    public void suggestTagsWithoutGlobalReadAndNoPermittedIdsReturnsEmpty() {
         when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(false);
         when(dbService.findPermittedIds(any())).thenReturn(List.of());
+        when(dbService.suggestTags(eq(""), eq(10), eq(List.of()))).thenReturn(List.of());
 
         final var response = resource.suggestTags("", 10);
 
         Assertions.assertThat(response.tags()).isEmpty();
-        verify(dbService, never()).suggestTags(any(), org.mockito.ArgumentMatchers.anyInt(), any());
+        verify(dbService).suggestTags(eq(""), eq(10), eq(List.of()));
     }
 
     @Test
     public void suggestTagsClampsLimitAboveMax() {
         when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
-        when(dbService.suggestTags(eq(""), eq(100), eq(null)))
-                .thenReturn(List.of());
+        when(dbService.suggestTags(eq(""), eq(100))).thenReturn(List.of());
 
         resource.suggestTags("", 99999);
 
-        verify(dbService).suggestTags(eq(""), eq(100), eq(null));
+        verify(dbService).suggestTags(eq(""), eq(100));
     }
 
     @Test
     public void suggestTagsClampsLimitBelowOne() {
         when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
-        when(dbService.suggestTags(eq(""), eq(1), eq(null)))
-                .thenReturn(List.of());
+        when(dbService.suggestTags(eq(""), eq(1))).thenReturn(List.of());
 
         resource.suggestTags("", 0);
 
-        verify(dbService).suggestTags(eq(""), eq(1), eq(null));
+        verify(dbService).suggestTags(eq(""), eq(1));
     }
 
     static EventDefinitionDto eventDefinitionDto(EventProcessorConfig config) {

--- a/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
@@ -19,6 +19,9 @@ package org.graylog.events.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import jakarta.ws.rs.ForbiddenException;
+import org.apache.shiro.subject.Subject;
+import org.assertj.core.api.Assertions;
+import org.bson.types.ObjectId;
 import org.graylog.events.context.EventDefinitionContextService;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.DBEventDefinitionService;
@@ -31,16 +34,25 @@ import org.graylog.events.processor.EventProcessorEngine;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityService;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @MockitoSettings(strictness = Strictness.WARN)
@@ -71,12 +83,12 @@ public class EventDefinitionsResourceTest {
     EntitySharesService entitySharesService;
 
     EventDefinitionsResource resource;
+    Subject subject;
 
     @BeforeEach
     public void setup() {
-        resource = new EventDefinitionsResource(
-                dbService, eventDefinitionHandler, contextService, engine, recentActivityService,
-                auditEventSender, objectMapper, new DefaultEventResolver(), new EventDefinitionConfiguration(), entitySharesService);
+        subject = mock(Subject.class);
+        resource = new TestEventDefinitionsResource(subject);
         when(config1.type()).thenReturn(CONFIG_TYPE_1);
         when(config2.type()).thenReturn(CONFIG_TYPE_2);
     }
@@ -95,6 +107,74 @@ public class EventDefinitionsResourceTest {
                 resource.checkProcessorConfig(eventDefinitionDto(config1), eventDefinitionDto(config2)));
     }
 
+    @Test
+    public void suggestTagsWithGlobalReadDoesNotEnumeratePermittedIds() {
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
+        when(dbService.suggestTags(eq("ph"), eq(10), eq(null)))
+                .thenReturn(List.of("phishing"));
+
+        final var response = resource.suggestTags("ph", 10);
+
+        Assertions.assertThat(response.tags()).containsExactly("phishing");
+        verify(dbService, never()).findPermittedIds(any());
+    }
+
+    @Test
+    public void suggestTagsWithoutGlobalReadEnumeratesAndPushesInClause() {
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(false);
+        final var permittedId = new ObjectId();
+        when(dbService.findPermittedIds(any())).thenReturn(List.of(permittedId));
+        when(dbService.suggestTags(eq(""), eq(10), any()))
+                .thenReturn(List.of("phishing"));
+
+        final var response = resource.suggestTags("", 10);
+
+        Assertions.assertThat(response.tags()).containsExactly("phishing");
+        verify(dbService).findPermittedIds(any());
+
+        final ArgumentCaptor<org.bson.conversions.Bson> filterCaptor = ArgumentCaptor.forClass(org.bson.conversions.Bson.class);
+        verify(dbService).suggestTags(eq(""), eq(10), filterCaptor.capture());
+        // Render the Bson against the default codec registry and assert the $in array carries the permitted IDs.
+        final org.bson.BsonDocument rendered = filterCaptor.getValue()
+                .toBsonDocument(org.bson.BsonDocument.class, org.bson.codecs.configuration.CodecRegistries
+                        .fromProviders(new org.bson.codecs.BsonValueCodecProvider()));
+        Assertions.assertThat(rendered.getDocument("_id").getArray("$in"))
+                .containsExactly(new org.bson.BsonObjectId(permittedId));
+    }
+
+    @Test
+    public void suggestTagsWithoutGlobalReadAndNoPermittedIdsShortCircuits() {
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(false);
+        when(dbService.findPermittedIds(any())).thenReturn(List.of());
+
+        final var response = resource.suggestTags("", 10);
+
+        Assertions.assertThat(response.tags()).isEmpty();
+        verify(dbService, never()).suggestTags(any(), org.mockito.ArgumentMatchers.anyInt(), any());
+    }
+
+    @Test
+    public void suggestTagsClampsLimitAboveMax() {
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
+        when(dbService.suggestTags(eq(""), eq(100), eq(null)))
+                .thenReturn(List.of());
+
+        resource.suggestTags("", 99999);
+
+        verify(dbService).suggestTags(eq(""), eq(100), eq(null));
+    }
+
+    @Test
+    public void suggestTagsClampsLimitBelowOne() {
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ)).thenReturn(true);
+        when(dbService.suggestTags(eq(""), eq(1), eq(null)))
+                .thenReturn(List.of());
+
+        resource.suggestTags("", 0);
+
+        verify(dbService).suggestTags(eq(""), eq(1), eq(null));
+    }
+
     static EventDefinitionDto eventDefinitionDto(EventProcessorConfig config) {
         return EventDefinitionDto.builder()
                 .title("Test")
@@ -108,5 +188,25 @@ public class EventDefinitionsResourceTest {
                         .backlogSize(0)
                         .build())
                 .build();
+    }
+
+    /**
+     * Subclass of {@link EventDefinitionsResource} that returns a configurable Shiro {@link Subject}
+     * so tests can stub permission checks. Mirrors the override pattern used in
+     * {@code RestResourceBaseTest}.
+     */
+    private class TestEventDefinitionsResource extends EventDefinitionsResource {
+        private final Subject subject;
+
+        TestEventDefinitionsResource(Subject subject) {
+            super(dbService, eventDefinitionHandler, contextService, engine, recentActivityService,
+                    auditEventSender, objectMapper, new DefaultEventResolver(), new EventDefinitionConfiguration(), entitySharesService);
+            this.subject = subject;
+        }
+
+        @Override
+        protected Subject getSubject() {
+            return subject;
+        }
     }
 }

--- a/graylog2-web-interface/src/components/common/InputList/InputList.test.tsx
+++ b/graylog2-web-interface/src/components/common/InputList/InputList.test.tsx
@@ -133,4 +133,78 @@ describe('InputList Component', () => {
     await userEvent.type(rawInput, 'dir3');
     await userEvent.keyboard('{Tab}');
   });
+
+  describe('with suggestions', () => {
+    const renderWithSuggestions = ({
+      suggestions,
+      onSuggestionsInputChange,
+      values = [],
+    }: {
+      suggestions: string[];
+      onSuggestionsInputChange?: (input: string) => void;
+      values?: string[];
+    }) => {
+      const Input = ({ ...props }: InputProps) => <components.Input title="testListInput" {...props} />;
+
+      return render(
+        <InputList
+          id="testList"
+          name="testList"
+          values={values}
+          onChange={() => {}}
+          suggestions={suggestions}
+          onSuggestionsInputChange={onSuggestionsInputChange}
+          components={{ Input }}
+        />,
+      );
+    };
+
+    it('shows suggestions in the dropdown menu when input is focused', async () => {
+      renderWithSuggestions({ suggestions: ['phishing', 'persistence', 'lateral-movement'] });
+
+      await userEvent.click(screen.getByTitle(/testListInput/i));
+
+      expect(await screen.findByText(/phishing/i)).toBeVisible();
+      expect(screen.getByText(/persistence/i)).toBeVisible();
+      expect(screen.getByText(/lateral-movement/i)).toBeVisible();
+    });
+
+    it('selecting a suggestion adds it as a value', async () => {
+      const checkOnChange = jest.fn();
+
+      render(
+        <InputList
+          id="testList"
+          name="testList"
+          values={[]}
+          onChange={checkOnChange}
+          suggestions={['phishing']}
+          components={{
+            Input: (props: InputProps) => <components.Input title="testListInput" {...props} />,
+          }}
+        />,
+      );
+
+      await userEvent.click(screen.getByTitle(/testListInput/i));
+      await userEvent.click(await screen.findByText(/phishing/i));
+
+      expect(checkOnChange).toHaveBeenCalled();
+      const lastCall = checkOnChange.mock.calls.at(-1)?.[0];
+      expect(lastCall.target.name).toEqual('testList');
+      expect(lastCall.target.value).toEqual(['phishing']);
+    });
+
+    it('forwards typed input to onSuggestionsInputChange', async () => {
+      const onInputChange = jest.fn();
+
+      renderWithSuggestions({ suggestions: [], onSuggestionsInputChange: onInputChange });
+
+      await userEvent.type(screen.getByTitle(/testListInput/i), 'ph');
+
+      // react-select fires onInputChange per character
+      const observed = onInputChange.mock.calls.map((c) => c[0]);
+      expect(observed).toContain('p');
+      expect(observed).toContain('ph');
+    });
+  });
 });

--- a/graylog2-web-interface/src/components/common/InputList/InputList.tsx
+++ b/graylog2-web-interface/src/components/common/InputList/InputList.tsx
@@ -15,16 +15,16 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import {useLayoutEffect, useRef, useState} from 'react';
+import type {CreatableProps} from 'react-select/creatable';
 import CreatableSelect from 'react-select/creatable';
-import type { CreatableProps } from 'react-select/creatable';
 
-import { InputDescription } from 'components/common';
-import { FormGroup, ControlLabel } from 'components/bootstrap';
+import {InputDescription} from 'components/common';
+import {FormGroup, ControlLabel} from 'components/bootstrap';
 
 import useInputListStyles from './useInputListStyles';
-import { GenericChangeEvent } from './InputList.types';
-import type { GenericTarget } from './InputList.types';
+import type {GenericTarget} from './InputList.types';
+import {GenericChangeEvent} from './InputList.types';
 
 interface Option {
   readonly label: string | number;
@@ -73,6 +73,9 @@ const InputList = ({
 
   useLayoutEffect(() => setValue(values.map((val: string | number) => createOption(val))), [values]);
 
+  const suggestionsEnabled = suggestions !== undefined;
+  const options = suggestionsEnabled ? suggestions.map(createOption) : undefined;
+
   const dispatchOnChange = (newValue: Option[]) => {
     const newList = newValue.map((item: Option) => item.value);
     const event = new GenericChangeEvent<(string | number)[]>('change');
@@ -85,6 +88,9 @@ const InputList = ({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    // When suggestions are enabled, defer to react-select's native Enter/Tab handling so the
+    // menu stays open after committing a value (isMulti behavior).
+    if (suggestionsEnabled) return;
     if (!inputValue) return;
 
     if (event.key === 'Enter' || event.key === 'Tab') {
@@ -106,9 +112,6 @@ const InputList = ({
     onSuggestionsInputChange?.(newValue);
   };
 
-  const suggestionsEnabled = suggestions !== undefined;
-  const options = suggestionsEnabled ? suggestions.map(createOption) : undefined;
-
   return (
     <FormGroup controlId={rest.id ? rest.id : name} validationState={error ? 'error' : bsStyle}>
       {label && <ControlLabel>{label}</ControlLabel>}
@@ -121,6 +124,7 @@ const InputList = ({
         options={options}
         isLoading={isLoadingSuggestions}
         formatCreateLabel={suggestionsEnabled ? (input) => `Add "${input}"` : undefined}
+        closeMenuOnSelect={suggestionsEnabled ? false : undefined}
         onChange={handleOnChange}
         onInputChange={handleInputChange}
         onKeyDown={handleKeyDown}

--- a/graylog2-web-interface/src/components/common/InputList/InputList.tsx
+++ b/graylog2-web-interface/src/components/common/InputList/InputList.tsx
@@ -45,6 +45,11 @@ type Props = CreatableProps<any, boolean, any> & {
   bsStyle?: 'success' | 'warning' | 'error' | null;
   error?: React.ReactNode;
   help?: React.ReactNode;
+  // When `suggestions` is provided, the dropdown menu opens on input. When omitted,
+  // existing consumers are unaffected: no menu, no dropdown indicator.
+  suggestions?: ReadonlyArray<string | number>;
+  onSuggestionsInputChange?: (input: string) => void;
+  isLoadingSuggestions?: boolean;
 };
 
 const InputList = ({
@@ -56,6 +61,9 @@ const InputList = ({
   bsStyle = null,
   error = null,
   help = null,
+  suggestions,
+  onSuggestionsInputChange,
+  isLoadingSuggestions,
   ...rest
 }: Props) => {
   const { inputListTheme, styles } = useInputListStyles(size);
@@ -93,17 +101,28 @@ const InputList = ({
     dispatchOnChange(newValue);
   };
 
+  const handleInputChange = (newValue: string) => {
+    setInputValue(newValue);
+    onSuggestionsInputChange?.(newValue);
+  };
+
+  const suggestionsEnabled = suggestions !== undefined;
+  const options = suggestionsEnabled ? suggestions.map(createOption) : undefined;
+
   return (
     <FormGroup controlId={rest.id ? rest.id : name} validationState={error ? 'error' : bsStyle}>
       {label && <ControlLabel>{label}</ControlLabel>}
       <CreatableSelect
         ref={inputRef}
-        components={{ DropdownIndicator: null }}
+        components={suggestionsEnabled ? undefined : { DropdownIndicator: null }}
         inputValue={inputValue}
         isMulti
-        menuIsOpen={false}
+        menuIsOpen={suggestionsEnabled ? undefined : false}
+        options={options}
+        isLoading={isLoadingSuggestions}
+        formatCreateLabel={suggestionsEnabled ? (input) => `Add "${input}"` : undefined}
         onChange={handleOnChange}
-        onInputChange={(newValue: string) => setInputValue(newValue)}
+        onInputChange={handleInputChange}
         onKeyDown={handleKeyDown}
         value={value}
         styles={styles(!error)}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
@@ -16,10 +16,21 @@
  */
 import * as React from 'react';
 import { useState } from 'react';
-import { render, screen } from 'wrappedTestingLibrary';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
+import { EventsDefinitions } from '@graylog/server-api';
 
 import TagsEditor from 'components/event-definitions/event-definition-form/TagsEditor';
+
+jest.mock('@graylog/server-api', () => ({
+  EventsDefinitions: {
+    suggestTags: jest.fn(),
+  },
+}));
+
+const mockedSuggestTags = EventsDefinitions.suggestTags as jest.MockedFunction<
+  typeof EventsDefinitions.suggestTags
+>;
 
 const Harness = ({ initial = [] as string[], onChange = (_: string[]) => {} }) => {
   const [tags, setTags] = useState<string[]>(initial);
@@ -33,6 +44,11 @@ const Harness = ({ initial = [] as string[], onChange = (_: string[]) => {} }) =
 };
 
 describe('TagsEditor', () => {
+  beforeEach(() => {
+    mockedSuggestTags.mockReset();
+    mockedSuggestTags.mockResolvedValue({ tags: [] });
+  });
+
   it('renders existing tags as chips', () => {
     render(<Harness initial={['phishing', 'lateral-movement']} />);
 
@@ -60,5 +76,62 @@ describe('TagsEditor', () => {
     await userEvent.keyboard('{Enter}');
 
     expect(onChange).toHaveBeenLastCalledWith(['phishing']);
+  });
+
+  describe('autocomplete', () => {
+    it('shows suggestions from the suggestTags endpoint when input is focused', async () => {
+      mockedSuggestTags.mockResolvedValue({
+        tags: ['phishing', 'lateral-movement', 'persistence'],
+      });
+
+      render(<Harness />);
+
+      await userEvent.click(screen.getByRole('combobox'));
+
+      expect(await screen.findByText(/phishing/i)).toBeVisible();
+      expect(screen.getByText(/lateral-movement/i)).toBeVisible();
+      expect(screen.getByText(/persistence/i)).toBeVisible();
+    });
+
+    it('hides already-selected tags from the suggestion list', async () => {
+      mockedSuggestTags.mockResolvedValue({
+        tags: ['phishing', 'lateral-movement'],
+      });
+
+      render(<Harness initial={['phishing']} />);
+
+      // Selected chip remains visible
+      expect(screen.getByText('phishing')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('combobox'));
+      expect(await screen.findByText(/lateral-movement/i)).toBeVisible();
+      // The suggestion list should not contain a duplicate "phishing" entry —
+      // the only "phishing" text is the selected chip.
+      expect(screen.getAllByText(/^phishing$/i)).toHaveLength(1);
+    });
+
+    it('queries the endpoint with the typed prefix', async () => {
+      mockedSuggestTags.mockResolvedValue({ tags: [] });
+
+      render(<Harness />);
+
+      await userEvent.type(screen.getByRole('combobox'), 'ph');
+
+      await waitFor(() => {
+        expect(mockedSuggestTags).toHaveBeenCalledWith('ph', expect.any(Number));
+      });
+    });
+
+    it('selecting a suggestion adds it as a tag', async () => {
+      mockedSuggestTags.mockResolvedValue({ tags: ['phishing'] });
+      const onChange = jest.fn();
+
+      render(<Harness onChange={onChange} />);
+
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.click(await screen.findByText(/phishing/i));
+
+      expect(onChange).toHaveBeenLastCalledWith(['phishing']);
+    });
   });
 });

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
@@ -67,15 +67,15 @@ describe('TagsEditor', () => {
     expect(onChange).toHaveBeenLastCalledWith(['phishing']);
   });
 
-  it('dedupes case-insensitively', async () => {
-    const onChange = jest.fn();
-    render(<Harness initial={['phishing']} onChange={onChange} />);
+  it('does not offer an "Add" affordance for a duplicate (case-insensitive)', async () => {
+    render(<Harness initial={['phishing']} />);
 
     const input = screen.getByRole('combobox');
     await userEvent.type(input, 'PHISHING');
-    await userEvent.keyboard('{Enter}');
 
-    expect(onChange).toHaveBeenLastCalledWith(['phishing']);
+    // react-select's CreatableSelect compares case-insensitively against selected values,
+    // so the "Add ..." option is suppressed when the typed input matches an existing tag.
+    expect(screen.queryByText(/Add "PHISHING"/i)).not.toBeInTheDocument();
   });
 
   describe('autocomplete', () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
@@ -15,8 +15,12 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useState } from 'react';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { EventsDefinitions } from '@graylog/server-api';
 
 import { InputList } from 'components/common';
+import useDebouncedValue from 'hooks/useDebouncedValue';
 
 // Mirror of TagNormalizer on the server. Keep in sync.
 const normalizeTag = (raw: string): string => raw.trim().toLowerCase();
@@ -24,6 +28,9 @@ const normalizeTag = (raw: string): string => raw.trim().toLowerCase();
 // Mirror of EventDefinitionDto.MAX_TAGS / MAX_TAG_LENGTH. Keep in sync.
 const MAX_TAGS = 64;
 const MAX_TAG_LENGTH = 128;
+
+const SUGGESTION_LIMIT = 50;
+const DEBOUNCE_MS = 300;
 
 type Props = {
   tags: ReadonlyArray<string>;
@@ -35,6 +42,18 @@ type Props = {
 const HELP_TEXT = 'Press Enter or Tab to add. Tags are lowercased and deduplicated.';
 
 const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) => {
+  const [input, setInput] = useState('');
+  const [debouncedInput] = useDebouncedValue(input, DEBOUNCE_MS);
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['event-definitions', 'tag-suggestions', debouncedInput],
+    queryFn: () => EventsDefinitions.suggestTags(debouncedInput, SUGGESTION_LIMIT),
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+    enabled: !disabled,
+  });
+  const suggestions = (data?.tags ?? []).filter((s: string) => !tags.includes(s));
+
   const handleChange = (event: React.ChangeEvent<{ value: (string | number)[] }>) => {
     const raw = event.target.value as (string | number)[];
     const normalized = raw
@@ -56,6 +75,9 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
       error={error}
       isClearable
       isDisabled={disabled}
+      suggestions={disabled ? undefined : suggestions}
+      onSuggestionsInputChange={setInput}
+      isLoadingSuggestions={isFetching}
     />
   );
 };


### PR DESCRIPTION
Adds autocomplete to the Tags input on the event definition wizard. Helps see which tags are already in use for convenience and to prevent drift.

Compliment to https://github.com/Graylog2/graylog2-server/pull/25896 (the parent tags PR)
Closes #14110

/jpd Graylog2/graylog-plugin-enterprise#14162

<img width="1258" height="526" alt="image" src="https://github.com/user-attachments/assets/74f4262e-07ac-4acc-bdbd-6c8d766fafe2" />


https://github.com/user-attachments/assets/94878774-3a32-4a0f-9a71-01a7318988dc

## Approach

- New `GET /events/definitions/tags?prefix=&limit=` endpoint. Returns `{"tags": [...]}` with up to 100 distinct values, default 10, case-insensitive prefix match.
- Backed by a Mongo aggregation against `event_definitions` (`$unwind` → optional prefix `$match` → `$group "$tags"` → `$sort` → `$limit`). Prefix is escaped via `Pattern.quote` and lowercased.
- Limit defaults and cap aligned with the existing `SuggestionsResource` precedent (`SUGGESTIONS_COUNT_MAX = 100`, default 10).
- Permission handling is a hybrid:
  - If the caller has unrestricted `eventdefinitions:read`, the aggregation runs over all event defs (no extra filter, single Mongo round trip).
  - Otherwise, the resource pre-enumerates the IDs the caller can read via `findPermittedIds(...)`, then calls the overload `suggestTags(prefix, limit, permittedIds)` which prepends an `$in` `$match` to the pipeline. This is required for App Owner-based roles.
- Frontend: `InputList` gains opt-in `suggestions` / `onSuggestionsInputChange` / `isLoadingSuggestions` props. When omitted, behavior is unchanged so existing consumers aren't affected.
- `TagsEditor` wires `useDebouncedValue` (300ms) + `useQuery` against the new endpoint. Already-selected tags are filtered from the dropdown. The "Create" affordance is relabeled to `Add "..."` so it's clear we're not creating a separate entity.

## Caveats

- Query cost for share-only event definitions users. `findPermittedIds` does a full-collection `_id` projection + per-row Shiro check on each request from a user without unrestricted read (e.g. App Owner roles). At the typical scale (≤1k event defs) this is well under 10ms and a few KB of wire transfer, but could grow with scale. This seems the be the best option to enforce tag visibility control based on event definitions that the user has access to, which seems like an essential requirement. 
- **No multikey index on `tags`.** The aggregation does a full-collection unwind + prefix match + group on every (debounced) keystroke. At the current scale (≤1k event defs × ≤64 tags) this runs in microseconds — an index would save effectively nothing and add write overhead on every event-def save. There's also a coupling: the prefix match uses a case-insensitive regex, which can't use a B-tree index without a matching collation; tags are already normalized to lowercase server-side, so dropping the `i` flag would unlock index-assisted matching when an index is eventually added. Worth revisiting if profiling on a large deployment shows scan cost becoming measurable; probably not before.

## Local Testing

- `DBEventDefinitionServiceSuggestTagsTest` — distinct/sorted union, case-insensitive prefix, regex meta escaping (`*`, `[a-z]`, `.`), limit clamp, blank prefix as no-filter, `restrictedTo` narrows, empty permitted-ids returns empty, `findPermittedIds` predicate honored.
- `EventDefinitionsResourceTest` — config-type checks plus 4 new cases for `/tags`: global-read path skips `findPermittedIds`, share-only path enumerates IDs and the `$in` filter contains the captured ID, empty permitted-set short-circuits without calling `suggestTags`, limit clamping at both ends.

Frontend Jest:
- `InputList.test.tsx` — suggestions render in dropdown on focus, click-to-add, typed input forwards to `onSuggestionsInputChange`.
- `TagsEditor.test.tsx` — suggestions appear from the new endpoint, already-selected tags hidden, prefix forwarded, click-to-add.

Manual smoke (event-def wizard):
- Created event defs via API with overlapping tag sets (`phishing`, `lateral-movement`, `credential-access`, `brute-force`, `authentication`, `exfiltration`, `persistence`, `privilege-escalation`).
- Focus → dropdown shows existing tags
- Type `cre` → narrows to `credential-access`, `credentials`
- Type a new tag → `Add "..."` affordance, Enter creates the chip
- Already-selected tags don't appear in the dropdown

**Permission verification (via REST):**
- Admin: returns the full distinct tag set across all event defs.
- Share-only user (granted view on one event def): returns only that event def's tags. Prefix searches outside its tag set return empty.
- No-permissions user: returns empty (short-circuits without a Mongo round trip).

Assisted with Claude