### PR TITLE
Make StreamServiceImpl a singleton

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamCache.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.streams;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.graylog2.database.MongoCollection;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.database.entities.ImmutableSystemScope;
+import org.graylog2.streams.events.StreamsChangedEvent;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.mongodb.client.model.Filters.eq;
+import static org.graylog2.database.entities.ScopedEntity.FIELD_SCOPE;
+import static org.graylog2.database.utils.MongoUtils.idEq;
+import static org.graylog2.database.utils.MongoUtils.stream;
+import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+/**
+ * Singleton cache for stream metadata (titles and system stream IDs).
+ * <p>
+ * Registers with {@link EventBus} for cache invalidation on stream changes.
+ * Singleton to not leak instances via the EventBus.
+ */
+@Singleton
+public class StreamCache {
+
+    private static final String SYSTEM_STREAM_IDS_KEY = "systemStreamIds";
+
+    private final LoadingCache<String, String> titleCache;
+    private final LoadingCache<String, Set<String>> systemStreamIdsCache;
+
+    @Inject
+    public StreamCache(MongoCollections mongoCollections, EventBus eventBus) {
+        final MongoCollection<StreamDTO> collection =
+                mongoCollections.collection(StreamServiceImpl.COLLECTION_NAME, StreamDTO.class);
+
+        this.titleCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(Duration.ofSeconds(10))
+                .build(new CacheLoader<>() {
+                    @Nonnull
+                    @Override
+                    public String load(@Nonnull String streamId) throws NotFoundException {
+                        try (var s = stream(collection.find(idEq(streamId)))) {
+                            return s.map(StreamDTO::title)
+                                    .findFirst()
+                                    .orElseThrow(() -> new NotFoundException(f("Couldn't find stream %s", streamId)));
+                        }
+                    }
+                });
+
+        this.systemStreamIdsCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(Duration.ofSeconds(10))
+                .build(new CacheLoader<>() {
+                    @Nonnull
+                    @Override
+                    public Set<String> load(@Nonnull String ignored) {
+                        try (var s = stream(collection.find(eq(FIELD_SCOPE, ImmutableSystemScope.NAME)))) {
+                            return s.map(StreamDTO::id).collect(Collectors.toUnmodifiableSet());
+                        }
+                    }
+                });
+
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    public void handleStreamsChanged(StreamsChangedEvent event) {
+        event.streamIds().forEach(titleCache::invalidate);
+        systemStreamIdsCache.invalidateAll();
+    }
+
+    @Nullable
+    public String streamTitleFromCache(String streamId) {
+        try {
+            return titleCache.get(streamId);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Set<String> getSystemStreamIds(boolean includeDefaultStream) {
+        final Set<String> ids = systemStreamIdsCache.getUnchecked(SYSTEM_STREAM_IDS_KEY);
+        return includeDefaultStream ? Sets.union(ids, Set.of(DEFAULT_STREAM_ID)) : ids;
+    }
+
+    public void invalidateTitle(String streamId) {
+        titleCache.invalidate(streamId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -29,6 +29,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -44,9 +45,9 @@ import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.database.utils.ScopedEntityMongoUtils;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.indexset.IndexSet;
-import org.graylog2.indexer.indexset.MongoIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.MongoIndexSet;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
@@ -62,6 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,7 +74,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -95,6 +96,9 @@ import static org.graylog2.streams.StreamImpl.FIELD_INDEX_SET_ID;
 import static org.graylog2.streams.StreamImpl.FIELD_OUTPUTS;
 import static org.graylog2.streams.StreamImpl.FIELD_TITLE;
 
+// This class registers with EventBus. If not bound as singleton, it would need lifecycle management to avoid leaking objects in the EventBus.
+
+@Singleton
 public class StreamServiceImpl implements StreamService {
     private static final Logger LOG = LoggerFactory.getLogger(StreamServiceImpl.class);
     public static final String COLLECTION_NAME = "streams";
@@ -110,7 +114,7 @@ public class StreamServiceImpl implements StreamService {
     private final Set<StreamDeletionGuard> streamDeletionGuards;
     private final EntityScopeService scopeService;
     private final LoadingCache<String, String> streamTitleCache;
-    private Set<String> systemStreamIds;
+    private volatile Set<String> systemStreamIds;
 
     @Inject
     public StreamServiceImpl(MongoCollections mongoCollections,
@@ -151,7 +155,7 @@ public class StreamServiceImpl implements StreamService {
         };
 
         this.streamTitleCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(10, TimeUnit.SECONDS)
+                .expireAfterAccess(Duration.ofSeconds(10))
                 .build(streamTitleLoader);
 
     }
@@ -159,6 +163,7 @@ public class StreamServiceImpl implements StreamService {
     @Subscribe
     public void handleStreamsChanged(StreamsChangedEvent event) {
         event.streamIds().forEach(streamTitleCache::invalidate);
+        systemStreamIds = null;
     }
 
     @Nullable

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -114,7 +114,7 @@ public class StreamServiceImpl implements StreamService {
     private final Set<StreamDeletionGuard> streamDeletionGuards;
     private final EntityScopeService scopeService;
     private final LoadingCache<String, String> streamTitleCache;
-    private volatile Set<String> systemStreamIds;
+    private final LoadingCache<Boolean, Set<String>> systemStreamIdsCache;
 
     @Inject
     public StreamServiceImpl(MongoCollections mongoCollections,
@@ -158,12 +158,32 @@ public class StreamServiceImpl implements StreamService {
                 .expireAfterAccess(Duration.ofSeconds(10))
                 .build(streamTitleLoader);
 
+        this.systemStreamIdsCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(Duration.ofSeconds(10))
+                .build(new CacheLoader<>() {
+                    @Nonnull
+                    @Override
+                    public Set<String> load(@Nonnull Boolean includeDefaultStream) {
+                        final Set<String> ids;
+                        try (var stream = streamAllDTOs()) {
+                            ids = stream
+                                    .filter(s -> ImmutableSystemScope.NAME.equals(s.getScope()))
+                                    .map(Stream::getId)
+                                    .collect(Collectors.toSet());
+                        }
+                        if (includeDefaultStream) {
+                            return java.util.stream.Stream.concat(ids.stream(),
+                                    java.util.stream.Stream.of(DEFAULT_STREAM_ID)).collect(Collectors.toSet());
+                        }
+                        return ids;
+                    }
+                });
     }
 
     @Subscribe
     public void handleStreamsChanged(StreamsChangedEvent event) {
         event.streamIds().forEach(streamTitleCache::invalidate);
-        systemStreamIds = null;
+        systemStreamIdsCache.invalidateAll();
     }
 
     @Nullable
@@ -208,16 +228,7 @@ public class StreamServiceImpl implements StreamService {
 
     @Override
     public Set<String> getSystemStreamIds(boolean includeDefaultStream) {
-        if (systemStreamIds == null) {
-            try (var stream = streamAllDTOs()) {
-                systemStreamIds = stream
-                        .filter(s -> ImmutableSystemScope.NAME.equals(s.getScope()))
-                        .map(Stream::getId)
-                        .collect(Collectors.toSet());
-            }
-        }
-        return includeDefaultStream ? java.util.stream.Stream.concat(systemStreamIds.stream(),
-                java.util.stream.Stream.of(DEFAULT_STREAM_ID)).collect(Collectors.toSet()) : systemStreamIds;
+        return systemStreamIdsCache.getUnchecked(includeDefaultStream);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -135,7 +135,6 @@ public class StreamServiceImpl implements StreamService {
         this.streamDeletionGuards = streamDeletionGuards;
         this.scopeService = scopeService;
 
-        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
         eventBus.register(this);
 
         final CacheLoader<String, String> streamTitleLoader = new CacheLoader<>() {

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -139,8 +139,6 @@ public class StreamServiceImpl implements StreamService {
         this.streamDeletionGuards = streamDeletionGuards;
         this.scopeService = scopeService;
 
-        eventBus.register(this);
-
         final CacheLoader<String, String> streamTitleLoader = new CacheLoader<>() {
             @Nonnull
             @Override
@@ -178,6 +176,10 @@ public class StreamServiceImpl implements StreamService {
                         return ids;
                     }
                 });
+
+        // Register with EventBus last, after all fields are initialized, to avoid
+        // NPE if a StreamsChangedEvent arrives during construction.
+        eventBus.register(this);
     }
 
     @Subscribe

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -17,19 +17,12 @@
 package org.graylog2.streams;
 
 import com.google.common.base.Strings;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.result.UpdateResult;
-import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -63,7 +56,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -88,17 +80,12 @@ import static org.graylog2.database.utils.MongoUtils.idEq;
 import static org.graylog2.database.utils.MongoUtils.idsIn;
 import static org.graylog2.database.utils.MongoUtils.stream;
 import static org.graylog2.database.utils.MongoUtils.stringIdsIn;
-import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
-import static org.graylog2.shared.utilities.StringUtils.f;
 import static org.graylog2.streams.StreamImpl.FIELD_CATEGORIES;
 import static org.graylog2.streams.StreamImpl.FIELD_DISABLED;
 import static org.graylog2.streams.StreamImpl.FIELD_INDEX_SET_ID;
 import static org.graylog2.streams.StreamImpl.FIELD_OUTPUTS;
 import static org.graylog2.streams.StreamImpl.FIELD_TITLE;
 
-// This class registers with EventBus. If not bound as singleton, it would need lifecycle management to avoid leaking objects in the EventBus.
-
-@Singleton
 public class StreamServiceImpl implements StreamService {
     private static final Logger LOG = LoggerFactory.getLogger(StreamServiceImpl.class);
     public static final String COLLECTION_NAME = "streams";
@@ -113,8 +100,7 @@ public class StreamServiceImpl implements StreamService {
     private final ClusterEventBus clusterEventBus;
     private final Set<StreamDeletionGuard> streamDeletionGuards;
     private final EntityScopeService scopeService;
-    private final LoadingCache<String, String> streamTitleCache;
-    private final LoadingCache<Boolean, Set<String>> systemStreamIdsCache;
+    private final StreamCache streamCache;
 
     @Inject
     public StreamServiceImpl(MongoCollections mongoCollections,
@@ -126,7 +112,7 @@ public class StreamServiceImpl implements StreamService {
                              ClusterEventBus clusterEventBus,
                              Set<StreamDeletionGuard> streamDeletionGuards,
                              EntityScopeService scopeService,
-                             EventBus eventBus) {
+                             StreamCache streamCache) {
         this.collection = mongoCollections.collection(COLLECTION_NAME, StreamDTO.class);
         this.mongoUtils = mongoCollections.utils(collection);
         this.scopedMongoUtils = mongoCollections.scopedEntityUtils(collection, scopeService);
@@ -138,54 +124,7 @@ public class StreamServiceImpl implements StreamService {
         this.clusterEventBus = clusterEventBus;
         this.streamDeletionGuards = streamDeletionGuards;
         this.scopeService = scopeService;
-
-        final CacheLoader<String, String> streamTitleLoader = new CacheLoader<>() {
-            @Nonnull
-            @Override
-            public String load(@Nonnull String streamId) throws NotFoundException {
-                String title = loadStreamTitles(List.of(streamId)).get(streamId);
-                if (title != null) {
-                    return title;
-                } else {
-                    throw new NotFoundException(f("Couldn't find stream %s", streamId));
-                }
-            }
-        };
-
-        this.streamTitleCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(Duration.ofSeconds(10))
-                .build(streamTitleLoader);
-
-        this.systemStreamIdsCache = CacheBuilder.newBuilder()
-                .expireAfterAccess(Duration.ofSeconds(10))
-                .build(new CacheLoader<>() {
-                    @Nonnull
-                    @Override
-                    public Set<String> load(@Nonnull Boolean includeDefaultStream) {
-                        final Set<String> ids;
-                        try (var stream = streamAllDTOs()) {
-                            ids = stream
-                                    .filter(s -> ImmutableSystemScope.NAME.equals(s.getScope()))
-                                    .map(Stream::getId)
-                                    .collect(Collectors.toSet());
-                        }
-                        if (includeDefaultStream) {
-                            return java.util.stream.Stream.concat(ids.stream(),
-                                    java.util.stream.Stream.of(DEFAULT_STREAM_ID)).collect(Collectors.toSet());
-                        }
-                        return ids;
-                    }
-                });
-
-        // Register with EventBus last, after all fields are initialized, to avoid
-        // NPE if a StreamsChangedEvent arrives during construction.
-        eventBus.register(this);
-    }
-
-    @Subscribe
-    public void handleStreamsChanged(StreamsChangedEvent event) {
-        event.streamIds().forEach(streamTitleCache::invalidate);
-        systemStreamIdsCache.invalidateAll();
+        this.streamCache = streamCache;
     }
 
     @Nullable
@@ -230,7 +169,7 @@ public class StreamServiceImpl implements StreamService {
 
     @Override
     public Set<String> getSystemStreamIds(boolean includeDefaultStream) {
-        return systemStreamIdsCache.getUnchecked(includeDefaultStream);
+        return streamCache.getSystemStreamIds(includeDefaultStream);
     }
 
     @Override
@@ -270,11 +209,7 @@ public class StreamServiceImpl implements StreamService {
     @Override
     @Nullable
     public String streamTitleFromCache(String streamId) {
-        try {
-            return streamTitleCache.get(streamId);
-        } catch (Exception e) {
-            return null;
-        }
+        return streamCache.streamTitleFromCache(streamId);
     }
 
     @Override
@@ -578,7 +513,7 @@ public class StreamServiceImpl implements StreamService {
 
         final Stream updatedStream = streamBuilder.build();
         save(updatedStream);
-        streamTitleCache.invalidate(streamId);
+        streamCache.invalidateTitle(streamId);
         if (streamRenamedEvent != null) {
             clusterEventBus.post(streamRenamedEvent);
         }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -16,9 +16,9 @@
  */
 package org.graylog2.streams;
 
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
-import jakarta.inject.Singleton;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.streams.filters.DestinationFilterCreationValidator;
 import org.graylog2.streams.input.StreamRuleInputsProvider;
@@ -29,8 +29,8 @@ public class StreamsModule extends Graylog2Module {
     @Override
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
-        bind(StreamService.class).to(StreamServiceImpl.class).in(Singleton.class);
-        bind(FavoriteFieldsService.class).asEagerSingleton();
+        bind(StreamService.class).to(StreamServiceImpl.class).in(Scopes.SINGLETON);
+        bind(FavoriteFieldsService.class).to(FavoriteFieldsServiceImpl.class);
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);
         uriBinder.addBinding().to(StreamRuleServerInputsProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -18,6 +18,7 @@ package org.graylog2.streams;
 
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
+import jakarta.inject.Singleton;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.streams.filters.DestinationFilterCreationValidator;
 import org.graylog2.streams.input.StreamRuleInputsProvider;
@@ -28,7 +29,7 @@ public class StreamsModule extends Graylog2Module {
     @Override
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
-        bind(StreamService.class).to(StreamServiceImpl.class);
+        bind(StreamService.class).to(StreamServiceImpl.class).in(Singleton.class);
         bind(FavoriteFieldsService.class).to(FavoriteFieldsServiceImpl.class);
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -30,7 +30,7 @@ public class StreamsModule extends Graylog2Module {
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
         bind(StreamService.class).to(StreamServiceImpl.class).in(Singleton.class);
-        bind(FavoriteFieldsService.class).to(FavoriteFieldsServiceImpl.class);
+        bind(FavoriteFieldsService.class).asEagerSingleton();
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);
         uriBinder.addBinding().to(StreamRuleServerInputsProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamsModule.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.streams;
 
-import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog2.plugin.inject.Graylog2Module;
@@ -29,7 +28,7 @@ public class StreamsModule extends Graylog2Module {
     @Override
     protected void configure() {
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
-        bind(StreamService.class).to(StreamServiceImpl.class).in(Scopes.SINGLETON);
+        bind(StreamService.class).to(StreamServiceImpl.class);
         bind(FavoriteFieldsService.class).to(FavoriteFieldsServiceImpl.class);
 
         Multibinder<StreamRuleInputsProvider> uriBinder = Multibinder.newSetBinder(binder(), StreamRuleInputsProvider.class);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -62,6 +62,7 @@ import org.graylog2.streams.StreamMock;
 import org.graylog2.streams.StreamRuleImpl;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamRuleServiceImpl;
+import org.graylog2.streams.StreamCache;
 import org.graylog2.streams.StreamService;
 import org.graylog2.streams.StreamServiceImpl;
 import org.graylog2.streams.matchers.StreamRuleMock;
@@ -123,7 +124,7 @@ public class StreamCatalogTest {
                 clusterEventBus,
                 Set.of(),
                 new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())),
-                new EventBus());
+                new StreamCache(mongoCollections, new EventBus()));
         when(outputService.load("5adf239e4b900a0fdb4e5197")).thenReturn(
                 OutputImpl.create("5adf239e4b900a0fdb4e5197", "Title", "Type", "admin", Collections.emptyMap(), new Date(1524654085L), null)
         );

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamFacadeTest.java
@@ -56,6 +56,7 @@ import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamMock;
 import org.graylog2.streams.StreamRuleImpl;
 import org.graylog2.streams.StreamRuleService;
+import org.graylog2.streams.StreamCache;
 import org.graylog2.streams.StreamService;
 import org.graylog2.streams.StreamServiceImpl;
 import org.graylog2.streams.matchers.StreamRuleMock;
@@ -103,7 +104,8 @@ public class StreamFacadeTest {
         final Set<EntityScope> entityScopes = Set.of(new DefaultEntityScope(), new ImmutableSystemScope(), new NonDeletableSystemScope());
         streamService = new StreamServiceImpl(mongoCollections, streamRuleService,
                 mock(OutputService.class), indexSetService, mock(MongoIndexSet.Factory.class), mock(EntityRegistrar.class),
-                mock(ClusterEventBus.class), Set.of(), new EntityScopeService(entityScopes), new EventBus());
+                mock(ClusterEventBus.class), Set.of(), new EntityScopeService(entityScopes),
+                new StreamCache(mongoCollections, new EventBus()));
         this.facade = new StreamFacade(objectMapper, streamService, streamRuleService, indexSetService, userService, favoriteFieldsService);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/streams/FavoriteFieldsServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/FavoriteFieldsServiceImplTest.java
@@ -50,7 +50,9 @@ class FavoriteFieldsServiceImplTest {
         final MongoCollections mongoCollections = new MongoCollections(new MongoJackObjectMapperProvider(new ObjectMapperProvider().get()), mongodb.mongoConnection());
         final var streamService = new StreamServiceImpl(mongoCollections, mock(StreamRuleService.class),
                 mock(OutputService.class), mock(IndexSetService.class), mock(MongoIndexSet.Factory.class),
-                mock(EntityRegistrar.class), mock(ClusterEventBus.class), Set.of(), new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())), new EventBus());
+                mock(EntityRegistrar.class), mock(ClusterEventBus.class), Set.of(),
+                new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())),
+                new StreamCache(mongoCollections, new EventBus()));
         this.favoriteFieldsService = new FavoriteFieldsServiceImpl(mongoCollections, streamService);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -17,6 +17,9 @@
 package org.graylog2.streams;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.graylog.security.entities.EntityRegistrar;
 import org.graylog.testing.mongodb.MongoDBExtension;
@@ -27,14 +30,13 @@ import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.database.entities.EntityScopeService;
 import org.graylog2.database.entities.ImmutableSystemScope;
 import org.graylog2.events.ClusterEventBus;
-import org.graylog2.indexer.indexset.MongoIndexSet;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.MongoIndexSet;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.streams.requests.UpdateStreamRequest;
 import org.graylog2.streams.events.StreamsChangedEvent;
-import com.google.common.eventbus.EventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,11 +76,17 @@ public class StreamServiceImplTest {
     ClusterEventBus eventBus;
 
     private StreamService streamService;
+    private MongoCollections mongoCollections;
+    private EventBus localEventBus;
 
     @BeforeEach
     public void setUp(MongoCollections mongoCollections) throws Exception {
+        this.mongoCollections = mongoCollections;
+        this.localEventBus = new EventBus();
         this.streamService = new StreamServiceImpl(mongoCollections, streamRuleService,
-                outputService, indexSetService, factory, entityRegistrar, eventBus, Set.of(), new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())), new EventBus());
+                outputService, indexSetService, factory, entityRegistrar, eventBus, Set.of(),
+                new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())),
+                localEventBus);
     }
 
     @Test
@@ -173,5 +181,27 @@ public class StreamServiceImplTest {
                 "illuminate_streams", 2L,
                 "user_streams", 1L
         ));
+    }
+
+    @Test
+    @MongoDBFixtures("systemAndDefaultStreams.json")
+    public void systemStreamIdsCacheIsInvalidatedOnStreamChange() {
+        final String systemStreamId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+        // First call lazily computes and caches the system stream IDs
+        assertThat(streamService.getSystemStreamIds(false)).containsExactly(systemStreamId);
+
+        // Delete the system stream directly in MongoDB, bypassing StreamService
+        mongoCollections.nonEntityCollection("streams", Document.class)
+                .deleteOne(Filters.eq("_id", new ObjectId(systemStreamId)));
+
+        // Cached value is still returned (stale)
+        assertThat(streamService.getSystemStreamIds(false)).containsExactly(systemStreamId);
+
+        // Simulate a stream change event, which invalidates the cache
+        localEventBus.post(StreamsChangedEvent.create(systemStreamId));
+
+        // Cache is invalidated; next call recomputes from DB
+        assertThat(streamService.getSystemStreamIds(false)).isEmpty();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -78,15 +78,17 @@ public class StreamServiceImplTest {
     private StreamService streamService;
     private MongoCollections mongoCollections;
     private EventBus localEventBus;
+    private StreamCache streamCache;
 
     @BeforeEach
     public void setUp(MongoCollections mongoCollections) throws Exception {
         this.mongoCollections = mongoCollections;
         this.localEventBus = new EventBus();
+        this.streamCache = new StreamCache(mongoCollections, localEventBus);
         this.streamService = new StreamServiceImpl(mongoCollections, streamRuleService,
                 outputService, indexSetService, factory, entityRegistrar, eventBus, Set.of(),
                 new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope())),
-                localEventBus);
+                streamCache);
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/streams/systemAndDefaultStreams.json
+++ b/graylog2-server/src/test/resources/org/graylog2/streams/systemAndDefaultStreams.json
@@ -1,0 +1,26 @@
+{
+  "streams": [
+    {
+      "_id": {"$oid": "aaaaaaaaaaaaaaaaaaaaaaaa"},
+      "_scope": "GRAYLOG_IMMUTABLE_SCOPE",
+      "creator_user_id": "admin",
+      "index_set_id": "586bb9288e82bf5e2c9ab68d",
+      "matching_type": "AND",
+      "description": "A system stream",
+      "created_at": {"$date": "2025-10-08T14:09:03.197+00:00"},
+      "disabled": false,
+      "title": "System Stream"
+    },
+    {
+      "_id": {"$oid": "bbbbbbbbbbbbbbbbbbbbbbbb"},
+      "_scope": "DEFAULT",
+      "creator_user_id": "admin",
+      "index_set_id": "586bb9288e82bf5e2c9ab68d",
+      "matching_type": "AND",
+      "description": "A regular stream",
+      "created_at": {"$date": "2025-10-08T14:09:03.197+00:00"},
+      "disabled": false,
+      "title": "Regular Stream"
+    }
+  ]
+}


### PR DESCRIPTION
/nocl unreleased
/prd Graylog2/graylog-plugin-enterprise#14207

## Description

StreamServiceImpl is bound in StreamsModule meaning Guice creates a fresh instance for every injection point. Each instance calls eventBus.register(this) in the constructor which gives the EventBus a strong reference to that instance; every injected StreamService is pinned in memory forever by the EventBus's subscriber registry, eventually leading to OOM.

This extracts the two caches (stream titles and system stream IDs) and the EventBus subscription into a new @Singleton StreamCache. StreamServiceImpl delegates to the cache and no longer registers with the EventBus.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #25686 
