### PR TITLE
Backport: Update netty to 4.2.13.Final

### DIFF
--- a/changelog/unreleased/pr-25972.toml
+++ b/changelog/unreleased/pr-25972.toml
@@ -1,0 +1,21 @@
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "s"
+message = "Update netty to 4.2.13, addressing multiple advisories"
+
+issues = [""]
+pulls = ["25972"]
+
+details.user = """
+The following security advisories are addressed with this change:
+ * [GHSA-f6hv-jmp6-3vwv](https://github.com/advisories/GHSA-f6hv-jmp6-3vwv)
+ * [GHSA-rwm7-x88c-3g2p](https://github.com/advisories/GHSA-rwm7-x88c-3g2p)
+ * [GHSA-cm33-6792-r9fm](https://github.com/advisories/GHSA-cm33-6792-r9fm)
+ * [GHSA-57rv-r2g8-2cj3](https://github.com/advisories/GHSA-57rv-r2g8-2cj3)
+ * [GHSA-38f8-5428-x5cv](https://github.com/advisories/GHSA-38f8-5428-x5cv)
+ * [GHSA-m4cv-j2px-7723](https://github.com/advisories/GHSA-m4cv-j2px-7723)
+ * [GHSA-xxqh-mfjm-7mv9](https://github.com/advisories/GHSA-xxqh-mfjm-7mv9)
+ * [GHSA-v8h7-rr48-vmmv](https://github.com/advisories/GHSA-v8h7-rr48-vmmv)
+ * [GHSA-mj4r-2hfc-f8p6](https://github.com/advisories/GHSA-mj4r-2hfc-f8p6)
+ * [GHSA-45q3-82m4-75jr](https://github.com/advisories/GHSA-45q3-82m4-75jr)
+"""
+

--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,8 @@
         <mongodb-driver.version>5.6.1</mongodb-driver.version>
         <mongojack.version>5.0.3</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.2.7.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.74.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.2.13.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.77.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>5.2.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.55.0</opentelemetry.version>


### PR DESCRIPTION
## Description
Updates Netty to 4.2.13 to include recent CVE fixes.

Backport from #25972 

## Linked dependabot alerts:
* https://github.com/Graylog2/graylog2-server/security/dependabot/572
* https://github.com/Graylog2/graylog2-server/security/dependabot/491
* https://github.com/Graylog2/graylog2-server/security/dependabot/549
* https://github.com/Graylog2/graylog2-server/security/dependabot/554
* https://github.com/Graylog2/graylog2-server/security/dependabot/550
* https://github.com/Graylog2/graylog2-server/security/dependabot/551

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

