### PR TITLE
Fix numeric ordering of pipeline stages

### DIFF
--- a/changelog/unreleased/issue-24957.toml
+++ b/changelog/unreleased/issue-24957.toml
@@ -1,0 +1,3 @@
+type = "fixed"
+message = "Fix pipeline stage badges being sorted lexicographically instead of numerically."
+issues = ["24957"]

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.test.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { PipelineType } from 'components/pipelines/types';
+
+import getUsedStages from './PipelineStages';
+
+const pipelineWithStages = (stages: Array<number>): PipelineType => ({
+  id: 'pipeline-1',
+  title: 'Pipeline',
+  description: 'Pipeline description',
+  source: '',
+  created_at: '2024-01-01T00:00:00.000Z',
+  modified_at: '2024-01-01T00:00:00.000Z',
+  stages: stages.map((stage) => ({ stage, match: 'EITHER', rules: [] })),
+  errors: null,
+  has_deprecated_functions: false,
+  _scope: 'DEFAULT',
+});
+
+describe('PipelineListItem', () => {
+  it('sorts used stages numerically', () => {
+    expect(getUsedStages([pipelineWithStages([1, 100]), pipelineWithStages([3, 2])])).toEqual([1, 2, 3, 100]);
+  });
+
+  it('removes duplicate used stages', () => {
+    expect(getUsedStages([pipelineWithStages([2, 1]), pipelineWithStages([1, 2])])).toEqual([1, 2]);
+  });
+});

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
@@ -25,12 +25,12 @@ import { Button, Label } from 'components/bootstrap';
 import type { PipelineType } from 'components/pipelines/types';
 import type { PipelineConnectionsType } from 'hooks/usePipelineConnections';
 import type { Stream } from 'logic/streams/types';
-import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import useGetPermissionsByScope from 'hooks/useScopePermissions';
 import RuleDeprecationInfo from 'components/rules/RuleDeprecationInfo';
 import usePermissions from 'hooks/usePermissions';
 
 import PipelineProcessingErrors from './PipelineProcessingErrors';
+import getUsedStages from './PipelineStages';
 
 import ButtonToolbar from '../bootstrap/ButtonToolbar';
 
@@ -76,9 +76,6 @@ const DefaultLabel = styled(Label)(
   `,
 );
 
-const getStagesWithoutDuplicates = (pipelineStages: Array<number>, usedStagesAcc: Array<number> = []) =>
-  Array.from(new Set([...usedStagesAcc, ...pipelineStages]));
-
 const PipelineListItem = ({ pipeline, pipelines, connections, streams, onDeletePipeline }: Props) => {
   const { isPermitted } = usePermissions();
   const { loadingScopePermissions, scopePermissions } = useGetPermissionsByScope(pipeline);
@@ -90,25 +87,17 @@ const PipelineListItem = ({ pipeline, pipelines, connections, streams, onDeleteP
   const _formatStages = () => {
     const stageNumbers = stages.map((stage) => stage.stage);
 
-    return pipelines
-      .map(({ stages: pipelineStages }) => pipelineStages.map(({ stage }) => stage))
-      .reduce(
-        (usedStagesAcc: number[], pipelineStages: number[]) =>
-          getStagesWithoutDuplicates(pipelineStages, usedStagesAcc),
-        [],
-      )
-      .sort(naturalSort)
-      .map((usedStage) => {
-        if (stageNumbers.indexOf(usedStage) === -1) {
-          return (
-            <PipelineStage key={`${pipeline.id}-stage${usedStage}`} $idle>
-              Idle
-            </PipelineStage>
-          );
-        }
+    return getUsedStages(pipelines).map((usedStage) => {
+      if (stageNumbers.indexOf(usedStage) === -1) {
+        return (
+          <PipelineStage key={`${pipeline.id}-stage${usedStage}`} $idle>
+            Idle
+          </PipelineStage>
+        );
+      }
 
-        return <PipelineStage key={`${pipeline.id}-stage${usedStage}`}>Stage {usedStage}</PipelineStage>;
-      });
+      return <PipelineStage key={`${pipeline.id}-stage${usedStage}`}>Stage {usedStage}</PipelineStage>;
+    });
   };
   if (loadingScopePermissions) {
     return <Spinner text="Loading pipeline..." />;

--- a/graylog2-web-interface/src/components/pipelines/PipelineStages.ts
+++ b/graylog2-web-interface/src/components/pipelines/PipelineStages.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { PipelineType } from 'components/pipelines/types';
+
+const getStagesWithoutDuplicates = (pipelineStages: Array<number>, usedStagesAcc: Array<number> = []) =>
+  Array.from(new Set([...usedStagesAcc, ...pipelineStages]));
+
+const getUsedStages = (pipelines: Array<PipelineType>) =>
+  pipelines
+    .map(({ stages: pipelineStages }) => pipelineStages.map(({ stage }) => stage))
+    .reduce(
+      (usedStagesAcc: number[], pipelineStages: number[]) => getStagesWithoutDuplicates(pipelineStages, usedStagesAcc),
+      [],
+    )
+    .sort((stage1, stage2) => stage1 - stage2);
+
+export default getUsedStages;


### PR DESCRIPTION
## Description
Fix the pipeline overview stage badges so used stage numbers are sorted numerically instead of through the default string comparator.

## Motivation and Context
Fixes #24957. Pipeline stages are processed numerically, but the UI displayed stages like `1, 100, 2` because `DefaultCompare` uses non-numeric collation for this path.

## How Has This Been Tested?
- `yarn test --testPathPatterns=src/components/pipelines/PipelineListItem.test.tsx --maxWorkers=2`
- `yarn lint:path src/components/pipelines/PipelineListItem.tsx src/components/pipelines/PipelineStages.ts src/components/pipelines/PipelineListItem.test.tsx`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.