### PR TITLE
Wrap long node names in input state overlays

### DIFF
--- a/changelog/unreleased/issue-25939.toml
+++ b/changelog/unreleased/issue-25939.toml
@@ -1,0 +1,3 @@
+type = "fixed"
+message = "Allow long node names to wrap in the input state badge overlay."
+issues = ["25939"]

--- a/graylog2-web-interface/src/components/inputs/InputStateBadge.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateBadge.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { asMock } from 'helpers/mocking';
+import type { InputStates } from 'hooks/useInputsStates';
+import type { InputSummary } from 'hooks/usePaginatedInputs';
+import { useStore } from 'stores/connect';
+
+import InputStateBadge from './InputStateBadge';
+
+jest.mock('stores/connect', () => ({ useStore: jest.fn() }));
+jest.mock('stores/nodes/NodesStore', () => ({ NodesStore: {} }));
+jest.mock('components/common', () => ({
+  LinkToNode: ({ nodeId }: { nodeId: string }) => nodeId,
+  OverlayTrigger: ({ children, overlay }: { children: React.ReactNode; overlay: React.ReactNode }) => (
+    <>
+      {children}
+      <div data-testid="input-state-overlay">{overlay}</div>
+    </>
+  ),
+  Spinner: () => <span>Loading...</span>,
+}));
+
+const input: InputSummary = {
+  creator_user_id: 'user-1',
+  node: 'node-1',
+  name: 'input-1',
+  created_at: '2026-01-01T00:00:00.000Z',
+  global: false,
+  attributes: {},
+  id: 'input-1',
+  title: 'Input',
+  type: 'org.graylog2.inputs.gelf.tcp.GELFTCPInput',
+  content_pack: '',
+  static_fields: {},
+};
+
+const nodeId = 'graylog-server-with-a-very-long-fully-qualified-domain-name.example.com';
+
+const inputStates: InputStates = {
+  [input.id]: {
+    [nodeId]: {
+      state: 'RUNNING',
+      id: input.id,
+      detailed_message: null,
+      message_input: input,
+    },
+  },
+};
+
+describe('InputStateBadge', () => {
+  beforeEach(() => {
+    asMock(useStore).mockReturnValue({
+      nodes: {
+        [nodeId]: {
+          node_id: nodeId,
+          short_node_id: 'server-1',
+          hostname: nodeId,
+          is_leader: false,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows long node names in the state overlay to wrap', () => {
+    render(<InputStateBadge input={input} inputStates={inputStates} />);
+
+    const stateLine = screen.getByText(`${nodeId}: RUNNING`);
+
+    expect(stateLine).toHaveStyleRule('display', 'block');
+    expect(stateLine).toHaveStyleRule('overflow-wrap', 'anywhere');
+    expect(stateLine).toHaveStyleRule('white-space', 'normal');
+  });
+});

--- a/graylog2-web-interface/src/components/inputs/InputStateBadge.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateBadge.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import styled, { css } from 'styled-components';
 
 import { OverlayTrigger, LinkToNode, Spinner } from 'components/common';
 import { Label } from 'components/bootstrap';
@@ -30,6 +31,15 @@ type Props = {
 };
 
 const comparator = new InputStateComparator();
+
+const NodeState = styled.small(
+  ({ theme }) => css`
+    display: block;
+    overflow-wrap: anywhere;
+    padding: ${theme.spacings.xxs} 0;
+    white-space: normal;
+  `,
+);
 
 const getLabelClassForState = (sortedStates, input: InputSummary, nodes: { [nodeId: string]: NodeInfo }) => {
   const nodesWithKnownState = sortedStates.reduce((numberOfNodes, state) => numberOfNodes + state.count, 0);
@@ -89,10 +99,9 @@ const InputStateBadge = ({ input, inputStates = undefined }: Props) => {
   if (sorted.length > 0) {
     const popOverText = sorted.map((state) =>
       sortedInputStates[state.state].map((node) => (
-        <small key={`${input.id}-state-${state.state}-node-${node}`}>
+        <NodeState key={`${input.id}-state-${state.state}-node-${node}`}>
           <LinkToNode nodeId={node} />: {state.state}
-          <br />
-        </small>
+        </NodeState>
       )),
     );
 


### PR DESCRIPTION
## Description
Render each input state overlay row as a wrapping block so long node names stay within the popover bounds.

## Motivation and Context
Fixes #25939. Long node names, such as FQDNs, could overflow the `InputStateBadge` overlay on the inputs overview page.

## How Has This Been Tested?
- `yarn test --testPathPatterns=src/components/inputs/InputStateBadge.test.tsx --maxWorkers=2`
- `yarn lint:path src/components/inputs/InputStateBadge.tsx src/components/inputs/InputStateBadge.test.tsx`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.