### PR TITLE
Relative and keyword time ranges support in entity tables

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/TimeRangeFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/TimeRangeFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.database.filtering;
+
+import com.mongodb.client.model.Filters;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.graylog2.database.filtering.inmemory.InMemoryFilterable;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+public record TimeRangeFilter(String field, TimeRange timeRange) implements Filter {
+
+    @Override
+    public Bson toBson() {
+        List<Bson> rangeFilters = new ArrayList<>(2);
+        final var from = timeRange.getFrom();
+        final var to = timeRange.getTo();
+        if (from != null) {
+            rangeFilters.add(Filters.gte(field(), from.toDate())); //MongoDB does not like Joda
+        }
+        if (to != null) {
+            rangeFilters.add(Filters.lte(field(), to.toDate())); //MongoDB does not like Joda
+        }
+        if (!rangeFilters.isEmpty()) {
+            return Filters.and(rangeFilters);
+        } else {
+            return new BsonDocument();
+        }
+    }
+
+    @Override
+    public Predicate<InMemoryFilterable> toPredicate() {
+        //TODO: we do not have a use case for that, but maybe this one needs to be implemented for future use cases...
+        throw new UnsupportedOperationException("RangeFilters are only supported in MongoDB-based filtering, not in in-memory filtering.");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/SingleFilterParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/filtering/inmemory/SingleFilterParser.java
@@ -20,6 +20,10 @@ import org.graylog2.database.filtering.BsonFilterCreatorFilter;
 import org.graylog2.database.filtering.Filter;
 import org.graylog2.database.filtering.RangeFilter;
 import org.graylog2.database.filtering.SingleValueFilter;
+import org.graylog2.database.filtering.TimeRangeFilter;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.rest.resources.entities.EntityAttribute;
 import org.graylog2.search.SearchQueryField;
 import org.joda.time.DateTime;
@@ -30,8 +34,10 @@ public class SingleFilterParser {
 
     public static final String FIELD_AND_VALUE_SEPARATOR = ":";
     public static final String RANGE_VALUES_SEPARATOR = "><";
+    public static final String TIME_RANGE_TYPE_SEPARATOR = "@";
     public static final String WRONG_FILTER_EXPR_FORMAT_ERROR_MSG =
             "Wrong filter expression, <field_name>" + FIELD_AND_VALUE_SEPARATOR + "<field_value> format should be used";
+    private static final String UNKNOWN_TIME_RANGE_TYPE_ERROR_MSG = "Unknown time range type: ";
 
     public Filter parseSingleExpression(final String filterExpression, final List<EntityAttribute> attributes) {
         if (!filterExpression.contains(FIELD_AND_VALUE_SEPARATOR)) {
@@ -51,27 +57,10 @@ public class SingleFilterParser {
         final EntityAttribute attributeMetaData = getAttributeMetaData(attributes, fieldPart);
 
         final SearchQueryField.Type fieldType = attributeMetaData.type();
-        if (isRangeValueExpression(valuePart, fieldType)) {
-            if (valuePart.equals(RANGE_VALUES_SEPARATOR)) {
-                // could probably also return an empty BSON here, but just for consistency:
-                return new RangeFilter(attributeMetaData.id(), null, null);
-            } else if (valuePart.startsWith(RANGE_VALUES_SEPARATOR)) {
-                return new RangeFilter(attributeMetaData.id(),
-                        null,
-                        extractValue(fieldType, valuePart.substring(RANGE_VALUES_SEPARATOR.length()))
-                );
-            } else if (valuePart.endsWith(RANGE_VALUES_SEPARATOR)) {
-                return new RangeFilter(attributeMetaData.id(),
-                        extractValue(fieldType, valuePart.substring(0, valuePart.length() - RANGE_VALUES_SEPARATOR.length())),
-                        null
-                );
-            } else {
-                final String[] ranges = valuePart.split(RANGE_VALUES_SEPARATOR);
-                return new RangeFilter(attributeMetaData.id(),
-                        extractValue(fieldType, ranges[0]),
-                        extractValue(fieldType, ranges[1])
-                );
-            }
+        if (isTimeRangeValueExpression(valuePart, fieldType)) {
+            return createTimeRangeFilter(valuePart, attributeMetaData, fieldType);
+        } else if (isRangeValueExpression(valuePart, fieldType)) {
+            return createRangeFilter(valuePart, attributeMetaData, fieldType);
         } else if (attributeMetaData.bsonFilterCreator() != null) {
             final String dbField = attributeMetaData.dbField() != null ? attributeMetaData.dbField() : attributeMetaData.id();
             return new BsonFilterCreatorFilter(dbField, attributeMetaData.bsonFilterCreator(), fieldType, extractValue(fieldType, valuePart));
@@ -81,7 +70,63 @@ public class SingleFilterParser {
 
     }
 
-    private Object extractValue(SearchQueryField.Type fieldType, String valuePart) {
+    private Filter createTimeRangeFilter(final String valuePart,
+                                         final EntityAttribute attributeMetaData,
+                                         final SearchQueryField.Type fieldType) {
+        final String[] split = valuePart.split(TIME_RANGE_TYPE_SEPARATOR, 2);
+        final String type = split[0]; //its existence has already been verified in isTimeRangeValueExpression
+        final String innerValuePart = split[1];
+
+        return switch (type) {
+            case AbsoluteRange.ABSOLUTE ->
+                    createRangeFilter(innerValuePart, attributeMetaData, fieldType); // we can simply use existing RangeFilter
+            case RelativeRange.RELATIVE -> createRelativeTimeRangeFilter(attributeMetaData, innerValuePart);
+            case KeywordRange.KEYWORD ->
+                    new TimeRangeFilter(attributeMetaData.id(), KeywordRange.create(innerValuePart, null));
+            default -> throw new IllegalArgumentException(UNKNOWN_TIME_RANGE_TYPE_ERROR_MSG + type);
+        };
+
+    }
+
+    private TimeRangeFilter createRelativeTimeRangeFilter(final EntityAttribute attributeMetaData, final String valuePart) {
+        if (!valuePart.contains(RANGE_VALUES_SEPARATOR)) {
+            int range = Integer.parseInt(valuePart);
+            return new TimeRangeFilter(attributeMetaData.id(), RelativeRange.Builder.builder().range(range).build());
+        } else {
+            final String[] ranges = valuePart.split(RANGE_VALUES_SEPARATOR);
+            int from = Integer.parseInt(ranges[0]);
+            int to = Integer.parseInt(ranges[1]);
+            return new TimeRangeFilter(attributeMetaData.id(), RelativeRange.Builder.builder().from(from).to(to).build());
+        }
+
+    }
+
+    private Filter createRangeFilter(final String valuePart,
+                                     final EntityAttribute attributeMetaData,
+                                     final SearchQueryField.Type fieldType) {
+        if (valuePart.equals(RANGE_VALUES_SEPARATOR)) {
+            // could probably also return an empty BSON here, but just for consistency:
+            return new RangeFilter(attributeMetaData.id(), null, null);
+        } else if (valuePart.startsWith(RANGE_VALUES_SEPARATOR)) {
+            return new RangeFilter(attributeMetaData.id(),
+                    null,
+                    extractValue(fieldType, valuePart.substring(RANGE_VALUES_SEPARATOR.length()))
+            );
+        } else if (valuePart.endsWith(RANGE_VALUES_SEPARATOR)) {
+            return new RangeFilter(attributeMetaData.id(),
+                    extractValue(fieldType, valuePart.substring(0, valuePart.length() - RANGE_VALUES_SEPARATOR.length())),
+                    null
+            );
+        } else {
+            final String[] ranges = valuePart.split(RANGE_VALUES_SEPARATOR);
+            return new RangeFilter(attributeMetaData.id(),
+                    extractValue(fieldType, ranges[0]),
+                    extractValue(fieldType, ranges[1])
+            );
+        }
+    }
+
+    private Object extractValue(final SearchQueryField.Type fieldType, final String valuePart) {
         final Object converted = fieldType.getMongoValueConverter().apply(valuePart);
         if (converted instanceof DateTime && fieldType == SearchQueryField.Type.DATE) {
             return ((DateTime) converted).toDate(); //MongoDB does not like Joda
@@ -111,8 +156,16 @@ public class SingleFilterParser {
 
     }
 
-    private boolean isRangeValueExpression(String valuePart, SearchQueryField.Type fieldType) {
+    private boolean isRangeValueExpression(final String valuePart, final SearchQueryField.Type fieldType) {
         return SearchQueryField.Type.NUMERIC_TYPES.contains(fieldType) && valuePart.contains(RANGE_VALUES_SEPARATOR);
+    }
+
+    private boolean isTimeRangeValueExpression(final String valuePart, final SearchQueryField.Type fieldType) {
+        return SearchQueryField.Type.DATE.equals(fieldType) && (
+                valuePart.startsWith(AbsoluteRange.ABSOLUTE + TIME_RANGE_TYPE_SEPARATOR) ||
+                        valuePart.startsWith(RelativeRange.RELATIVE + TIME_RANGE_TYPE_SEPARATOR) ||
+                        valuePart.startsWith(KeywordRange.KEYWORD + TIME_RANGE_TYPE_SEPARATOR)
+        );
     }
 
     private boolean isFilterable(final EntityAttribute attr) {

--- a/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/SingleFilterParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/filtering/inmemory/SingleFilterParserTest.java
@@ -19,6 +19,10 @@ package org.graylog2.database.filtering.inmemory;
 import org.bson.types.ObjectId;
 import org.graylog2.database.filtering.RangeFilter;
 import org.graylog2.database.filtering.SingleValueFilter;
+import org.graylog2.database.filtering.TimeRangeFilter;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.rest.resources.entities.EntityAttribute;
 import org.graylog2.search.SearchQueryField;
 import org.joda.time.DateTime;
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.graylog2.database.filtering.inmemory.SingleFilterParser.RANGE_VALUES_SEPARATOR;
+import static org.graylog2.database.filtering.inmemory.SingleFilterParser.TIME_RANGE_TYPE_SEPARATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SingleFilterParserTest {
@@ -124,6 +129,14 @@ class SingleFilterParserTest {
                 toTest.parseSingleExpression("created_at:" + RANGE_VALUES_SEPARATOR,
                         entityAttributes
                 ));
+
+        //works the same if absolute time range type is specified explicitly
+        assertEquals(
+                new RangeFilter("created_at", null, null),
+
+                toTest.parseSingleExpression("created_at:" + AbsoluteRange.ABSOLUTE + TIME_RANGE_TYPE_SEPARATOR + RANGE_VALUES_SEPARATOR,
+                        entityAttributes
+                ));
     }
 
     @Test
@@ -145,6 +158,18 @@ class SingleFilterParserTest {
                 ),
 
                 toTest.parseSingleExpression("created_at:" + fromString + RANGE_VALUES_SEPARATOR + toString,
+                        entityAttributes
+                ));
+
+        //works the same if absolute time range type is specified explicitly
+        assertEquals(
+                new RangeFilter("created_at",
+                        new DateTime(2012, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate(),
+                        new DateTime(2022, 12, 12, 12, 12, 12, DateTimeZone.UTC).toDate()
+                ),
+
+                toTest.parseSingleExpression("created_at:" + AbsoluteRange.ABSOLUTE + TIME_RANGE_TYPE_SEPARATOR +
+                                fromString + RANGE_VALUES_SEPARATOR + toString,
                         entityAttributes
                 ));
     }
@@ -172,6 +197,58 @@ class SingleFilterParserTest {
                 toTest.parseSingleExpression("created_at:" + RANGE_VALUES_SEPARATOR + dateString,
                         entityAttributes
                 ));
+
+        //works the same if absolute time range type is specified explicitly
+        assertEquals(
+                new RangeFilter("created_at", dateObject.toDate(), null),
+                toTest.parseSingleExpression("created_at:" + AbsoluteRange.ABSOLUTE + TIME_RANGE_TYPE_SEPARATOR + dateString + RANGE_VALUES_SEPARATOR,
+                        entityAttributes
+                ));
+
+        assertEquals(
+                new RangeFilter("created_at", null, dateObject.toDate()),
+                toTest.parseSingleExpression("created_at:" + AbsoluteRange.ABSOLUTE + TIME_RANGE_TYPE_SEPARATOR + RANGE_VALUES_SEPARATOR + dateString,
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForRelativeTimeRange() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new TimeRangeFilter("created_at", RelativeRange.create(300)),
+                toTest.parseSingleExpression("created_at:" + RelativeRange.RELATIVE + TIME_RANGE_TYPE_SEPARATOR + "300",
+                        entityAttributes
+                ));
+
+        assertEquals(
+                new TimeRangeFilter("created_at", RelativeRange.Builder.builder().from(1500).to(300).build()),
+                toTest.parseSingleExpression("created_at:" + RelativeRange.RELATIVE + TIME_RANGE_TYPE_SEPARATOR + "1500" + RANGE_VALUES_SEPARATOR + "300",
+                        entityAttributes
+                ));
+    }
+
+    @Test
+    void parsesFilterExpressionCorrectlyForKeywordTimeRange() {
+        final List<EntityAttribute> entityAttributes = List.of(EntityAttribute.builder()
+                .id("created_at")
+                .title("Creation Date")
+                .type(SearchQueryField.Type.DATE)
+                .filterable(true)
+                .build());
+
+        assertEquals(
+                new TimeRangeFilter("created_at", KeywordRange.create("last 5 minutes", null)),
+                toTest.parseSingleExpression("created_at:" + KeywordRange.KEYWORD + TIME_RANGE_TYPE_SEPARATOR + "last 5 minutes",
+                        entityAttributes
+                ));
+
     }
 
     @Test


### PR DESCRIPTION
## Description
Relative and keyword time ranges support in entity tables.

BE code created by human.
It allows to create 5 types of time range filters:
- relative@300
- relative@300><200
- keyword@Last+five+minutes
- absolute@2024-05-01T12%3A10%3A41.000%2B00%3A00><2026-05-11T12%3A15%3A46.624%2B00%3A00
- 2024-05-01T12%3A10%3A41.000%2B00%3A00><2026-05-11T12%3A15%3A46.624%2B00%3A00

/nocl -> new feature

## How Has This Been Tested?
With new unit tests.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

