### PR TITLE
Escape key closes saved search modal

### DIFF
--- a/changelog/unreleased/pr-26011.toml
+++ b/changelog/unreleased/pr-26011.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix save search popover not closeable with Esc key"
+
+pulls = ["26011"]

--- a/graylog2-web-interface/src/components/common/Popover.tsx
+++ b/graylog2-web-interface/src/components/common/Popover.tsx
@@ -15,13 +15,40 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Popover as MantinePopover } from '@mantine/core';
 import styled, { css, useTheme } from 'styled-components';
 
 import { borderColor } from 'theme/utils/borderStyles';
 
-const Popover = ({ ...props }: React.ComponentProps<typeof MantinePopover>) => {
+const Popover = ({ opened, onDismiss, onChange, ...props }: React.ComponentProps<typeof MantinePopover>) => {
   const theme = useTheme();
+  const dismissedByMantineRef = useRef(false);
+
+  const handleDismiss = useCallback(() => {
+    dismissedByMantineRef.current = true;
+    onDismiss?.();
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!opened) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+
+      if (dismissedByMantineRef.current) {
+        dismissedByMantineRef.current = false;
+        return;
+      }
+
+      onDismiss?.();
+      onChange?.(false);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [opened, onDismiss, onChange]);
 
   const arrowBackground =
     !props.position || props.position.startsWith('bottom')
@@ -40,7 +67,7 @@ const Popover = ({ ...props }: React.ComponentProps<typeof MantinePopover>) => {
     },
   });
 
-  return <MantinePopover styles={styles} zIndex={1060} {...props} />;
+  return <MantinePopover styles={styles} zIndex={1060} opened={opened} onDismiss={handleDismiss} onChange={onChange} {...props} />;
 };
 
 type DropdownProps = Omit<React.ComponentProps<typeof MantinePopover.Dropdown>, 'title'> & {

--- a/graylog2-web-interface/src/components/common/Popover.tsx
+++ b/graylog2-web-interface/src/components/common/Popover.tsx
@@ -38,6 +38,7 @@ const Popover = ({ opened, onDismiss, onChange, ...props }: React.ComponentProps
 
       if (dismissedByMantineRef.current) {
         dismissedByMantineRef.current = false;
+
         return;
       }
 

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchForm.tsx
@@ -75,7 +75,7 @@ const SavedSearchForm = ({
   const _saveAsSearch = useCallback(() => saveAsSearch(title, sharePayload), [saveAsSearch, title, sharePayload]);
 
   return (
-    <Popover position="left" width={500} opened={show} withArrow withinPortal>
+    <Popover position="left" width={500} opened={show} onDismiss={toggleModal} withArrow withinPortal>
       <Popover.Target>{children}</Popover.Target>
       <StyledPopoverDropdown title="Name of search" id="saved-search-popover">
         <form onSubmit={stopEvent}>


### PR DESCRIPTION
## Description
Escape key closes saved search modal.

## Motivation and Context
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13590

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

