### PR TITLE
Guard against undefined event in remediation steps sidebar

### DIFF
--- a/changelog/unreleased/pr-26026.toml
+++ b/changelog/unreleased/pr-26026.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix TypeError in remediation steps sidebar when the event is still loading."
+issues = ["Graylog2/graylog-plugin-enterprise#14259"]
+pulls = ["26026"]

--- a/changelog/unreleased/pr-26026.toml
+++ b/changelog/unreleased/pr-26026.toml
@@ -1,4 +1,4 @@
 type = "f"
-message = "Fix TypeError in remediation steps sidebar when the event is still loading."
+message = "Fix event definition procedure in sidebar when security license is absent."
 issues = ["Graylog2/graylog-plugin-enterprise#14259"]
 pulls = ["26026"]

--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/RemediationSteps.test.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/RemediationSteps.test.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import type { Event, EventsAdditionalData } from 'components/events/events/types';
+
+import RemediationSteps from './RemediationSteps';
+
+const emptyMeta = { context: { event_definitions: {} } } as unknown as EventsAdditionalData;
+
+describe('RemediationSteps', () => {
+  it('renders fallback without throwing when event is undefined and no security license is present', () => {
+    render(
+      <RemediationSteps event={undefined as unknown as Event} meta={emptyMeta} eventDefinitionEventProcedureId="" />,
+    );
+
+    expect(screen.getByText('No remediation steps')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/RemediationSteps.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/RemediationSteps.tsx
@@ -59,7 +59,7 @@ const RemediationSteps = ({ event, meta, eventDefinitionEventProcedureId }: Prop
   return validSecurityLicense ? (
     <EventProcedureRenderer eventProcedureId={eventDefinitionEventProcedureId} eventId={event?.id} />
   ) : (
-    <RemediationStepRenderer meta={meta} eventDefinitionId={event.event_definition_id} />
+    <RemediationStepRenderer meta={meta} eventDefinitionId={event?.event_definition_id} />
   );
 };
 export default RemediationSteps;


### PR DESCRIPTION
**Note:** This needs a backport to `7.1`.

## Description

Use optional chaining when reading `event_definition_id` in `RemediationSteps`, so the legacy `RemediationStepRenderer` path no longer throws when `event` is undefined.

## Motivation and Context

`RemediationSteps` can be rendered in cases where `event` is `undefined`. The non-licensed branch dereferenced `event.event_definition_id` directly and crashed with a TypeError. The licensed branch already handles this via `event?.id`.

Fixes Graylog2/graylog-plugin-enterprise#14259.

## How Has This Been Tested?

Manual: reproduced the crash on the bulk replay sidebar with an unlicensed instance, applied the patch, and confirmed the sidebar renders without errors while events load.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.