### PR TITLE
Avoid hook call inside useMemo in ReplaySearchSidebar

### DIFF
--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.test.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import usePluginEntities from 'hooks/usePluginEntities';
+import type { EventDefinitionSideBarDetailsProps, EventReplaySideBarDetailsProps } from 'views/types';
+
+import ReplaySearchSidebar from './ReplaySearchSidebar';
+
+jest.mock('hooks/usePluginEntities');
+
+jest.mock('components/events/ReplaySearchSidebar/GeneralEventSideBar', () => ({
+  __esModule: true,
+  default: ({ alertId, definitionId }: EventReplaySideBarDetailsProps) => (
+    <div data-testid="general-sidebar">
+      general:{alertId}:{definitionId ?? ''}
+    </div>
+  ),
+}));
+
+const PluginComponent = ({ alertId, definitionId }: EventReplaySideBarDetailsProps) => (
+  <div data-testid="plugin-sidebar">
+    plugin:{alertId}:{definitionId ?? ''}
+  </div>
+);
+
+const PluginDefinitionComponent = ({ definitionId }: EventDefinitionSideBarDetailsProps) => (
+  <div data-testid="plugin-definition-sidebar">definition:{definitionId}</div>
+);
+
+const mockSideBarDetails = (plugin: unknown) => {
+  asMock(usePluginEntities).mockImplementation(
+    (entityKey) =>
+      ({
+        'views.components.eventReplay.sideBarDetails': plugin ? [plugin] : [],
+      })[entityKey as string],
+  );
+};
+
+describe('ReplaySearchSidebar', () => {
+  beforeEach(() => {
+    asMock(usePluginEntities).mockReturnValue([]);
+  });
+
+  it('renders GeneralEventSideBar when no plugin is registered', () => {
+    render(<ReplaySearchSidebar alertId="alert-1" definitionId="def-1" />);
+
+    expect(screen.getByTestId('general-sidebar')).toHaveTextContent('general:alert-1:def-1');
+    expect(screen.queryByTestId('plugin-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('renders the plugin component when a plugin is registered', () => {
+    mockSideBarDetails({ key: 'test', component: PluginComponent });
+
+    render(<ReplaySearchSidebar alertId="alert-1" definitionId="def-1" />);
+
+    expect(screen.getByTestId('plugin-sidebar')).toHaveTextContent('plugin:alert-1:def-1');
+    expect(screen.queryByTestId('general-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('falls back to GeneralEventSideBar when useCondition returns false', () => {
+    mockSideBarDetails({
+      key: 'test',
+      component: PluginComponent,
+      useCondition: () => false,
+    });
+
+    render(<ReplaySearchSidebar alertId="alert-1" />);
+
+    expect(screen.getByTestId('general-sidebar')).toHaveTextContent('general:alert-1:');
+    expect(screen.queryByTestId('plugin-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('uses the plugin component when useCondition returns true', () => {
+    mockSideBarDetails({
+      key: 'test',
+      component: PluginComponent,
+      useCondition: () => true,
+    });
+
+    render(<ReplaySearchSidebar alertId="alert-1" />);
+
+    expect(screen.getByTestId('plugin-sidebar')).toBeInTheDocument();
+  });
+
+  it('renders eventDefinitionComponent when called without an alertId', () => {
+    mockSideBarDetails({
+      key: 'test',
+      component: PluginComponent,
+      eventDefinitionComponent: PluginDefinitionComponent,
+    });
+
+    render(<ReplaySearchSidebar alertId="" definitionId="def-1" />);
+
+    expect(screen.getByTestId('plugin-definition-sidebar')).toHaveTextContent('definition:def-1');
+    expect(screen.queryByTestId('plugin-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the plugin component when no eventDefinitionComponent is registered', () => {
+    mockSideBarDetails({ key: 'test', component: PluginComponent });
+
+    render(<ReplaySearchSidebar alertId="" definitionId="def-1" />);
+
+    expect(screen.getByTestId('plugin-sidebar')).toHaveTextContent('plugin::def-1');
+    expect(screen.queryByTestId('plugin-definition-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('uses the plugin component (not the eventDefinitionComponent) when alertId is present', () => {
+    mockSideBarDetails({
+      key: 'test',
+      component: PluginComponent,
+      eventDefinitionComponent: PluginDefinitionComponent,
+    });
+
+    render(<ReplaySearchSidebar alertId="alert-1" definitionId="def-1" />);
+
+    expect(screen.getByTestId('plugin-sidebar')).toHaveTextContent('plugin:alert-1:def-1');
+    expect(screen.queryByTestId('plugin-definition-sidebar')).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.tsx
+++ b/graylog2-web-interface/src/components/events/ReplaySearchSidebar/ReplaySearchSidebar.tsx
@@ -14,11 +14,10 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { useMemo } from 'react';
+import * as React from 'react';
 
 import usePluginEntities from 'hooks/usePluginEntities';
 import GeneralEventSideBar from 'components/events/ReplaySearchSidebar/GeneralEventSideBar';
-import type { EventDefinitionSideBarDetailsProps, EventReplaySideBarDetailsProps } from 'views/types';
 
 type Props = {
   alertId: string;
@@ -28,30 +27,19 @@ type Props = {
 const ReplaySearchSidebar = ({ alertId, definitionId = undefined }: Props) => {
   const sideBarDetailsPlugin = usePluginEntities('views.components.eventReplay.sideBarDetails');
   const isEventDefinition = !alertId && !!definitionId;
+  const sideBarDetails = sideBarDetailsPlugin[0];
+  const hasPlugin = typeof sideBarDetails?.useCondition === 'function' ? sideBarDetails.useCondition() : true;
 
-  const EventDefSideBar = useMemo<React.ComponentType<EventDefinitionSideBarDetailsProps> | null>(() => {
-    const sideBarDetails = sideBarDetailsPlugin[0];
-    const hasPlugin = typeof sideBarDetails?.useCondition === 'function' ? sideBarDetails.useCondition() : true;
+  const EventDefSideBar =
+    hasPlugin && sideBarDetails?.eventDefinitionComponent ? sideBarDetails.eventDefinitionComponent : null;
 
-    if (hasPlugin && sideBarDetails?.eventDefinitionComponent) return sideBarDetails.eventDefinitionComponent;
+  const EventSideBarDetails = hasPlugin && !!sideBarDetails?.component ? sideBarDetails.component : GeneralEventSideBar;
 
-    return null;
-  }, [sideBarDetailsPlugin]);
-
-  const EventSideBarDetails = useMemo<React.ComponentType<EventReplaySideBarDetailsProps>>(() => {
-    const sideBarDetails = sideBarDetailsPlugin[0];
-    const hasPlugin = typeof sideBarDetails?.useCondition === 'function' ? sideBarDetails.useCondition() : true;
-
-    if (hasPlugin && !!sideBarDetails?.component) return sideBarDetails.component;
-
-    return GeneralEventSideBar;
-  }, [sideBarDetailsPlugin]);
-
-  if (isEventDefinition && EventDefSideBar) {
-    return <EventDefSideBar definitionId={definitionId} />;
-  }
-
-  return <EventSideBarDetails alertId={alertId} definitionId={definitionId} />;
+  return isEventDefinition && EventDefSideBar ? (
+    <EventDefSideBar definitionId={definitionId} />
+  ) : (
+    <EventSideBarDetails alertId={alertId} definitionId={definitionId} />
+  );
 };
 
 export default ReplaySearchSidebar;


### PR DESCRIPTION
## Description
Simplify `ReplaySearchSidebar` by hoisting the sidebar-details plugin lookup and `useCondition` call out of the `useMemo` callbacks and into the component body. Derive the `EventDefSideBar` and `EventSideBarDetails` selections inline.

/nocl Internal refactor with no user-visible behavior change.

## Motivation and Context
Calling the plugin-provided `useCondition` hook from inside `useMemo` violated the React rules-of-hooks and triggered ESLint warnings. The memoization is not required anymore due to our use of the React Compiler.

## How Has This Been Tested?
Verified the component still renders the correct sidebar (`EventDefSideBar` for event-definition replays, otherwise the plugin-provided component or `GeneralEventSideBar`) and that the hooks warning no longer fires.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

