### PR TITLE
Fix revoke token ownership (`6.3`)

### DIFF
--- a/changelog/unreleased/ghsa-j769-9gv9-65gr.toml
+++ b/changelog/unreleased/ghsa-j769-9gv9-65gr.toml
@@ -1,0 +1,2 @@
+type = "s"
+message = "Fix IDOR in access-token revocation endpoint. See [GHSA-j769-9gv9-65gr](https://github.com/Graylog2/graylog2-server/security/advisories/GHSA-j769-9gv9-65gr) for details."

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -747,24 +747,25 @@ public class UsersResource extends RestResource {
     public void revokeToken(
             @ApiParam(name = "userId", required = true) @PathParam("userId") String userId,
             @ApiParam(name = "idOrToken", required = true) @PathParam("idOrToken") String idOrToken) {
-        final User user = loadUserById(userId);
-        final String username = user.getName();
-        if (!isPermitted(USERS_TOKENREMOVE, username)) {
-            throw new ForbiddenException("Not allowed to remove tokens for user " + username);
-        }
+        // The user must be logged in already, so we check the permission based on that info and the username of the
+        // token to be deleted. That way, the `userId`-parameter is indeed unused. Removing it would be a breaking change.
 
         // The endpoint supports both, deletion by token ID and deletion by using the token value itself.
         // The latter should not be used anymore because the plain text token will be part of the URL and URLs
         // will most probably be logged. We keep the old behavior for backwards compatibility.
         // TODO: Remove support for old behavior in 4.0
         final AccessToken accessToken = Optional.ofNullable(accessTokenService.loadById(idOrToken))
-                .orElse(accessTokenService.load(idOrToken));
+                .orElseGet(() -> accessTokenService.load(idOrToken));
 
-        if (accessToken != null) {
-            accessTokenService.destroy(accessToken);
-        } else {
-            throw new NotFoundException("Couldn't find access token for user " + username);
+        if (accessToken == null) {
+            throw new NotFoundException("Couldn't find access token for user.");
         }
+
+        if (!isPermitted(USERS_TOKENREMOVE, accessToken.getUserName())) {
+            throw new ForbiddenException("Not allowed to remove token for user " + accessToken.getUserName());
+        }
+
+        accessTokenService.destroy(accessToken);
     }
 
     private User loadUserById(String userId) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
@@ -72,6 +72,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.graylog2.shared.security.RestPermissions.USERS_TOKENCREATE;
+import static org.graylog2.shared.security.RestPermissions.USERS_TOKENREMOVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -248,6 +249,65 @@ public class UsersResourceTest {
             verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
+    }
+
+    @Test
+    public void usersCanRevokeTheirOwnToken() {
+        final AccessToken accessToken = prepareRevokeMocks(USERNAME, true, true);
+        try {
+            usersResource.revokeToken(USERNAME, TOKEN_NAME);
+        } finally {
+            verify(accessTokenService).loadById(TOKEN_NAME);
+            verify(accessTokenService).destroy(accessToken);
+            verifyNoMoreInteractions(clusterConfigService, accessTokenService);
+        }
+    }
+
+    @Test
+    public void revokingWithoutPermissionThrowsForbidden() {
+        prepareRevokeMocks(USERNAME, false, true);
+        try {
+            assertThrows(ForbiddenException.class, () -> usersResource.revokeToken(USERNAME, TOKEN_NAME));
+        } finally {
+            verify(accessTokenService).loadById(TOKEN_NAME);
+            verifyNoMoreInteractions(clusterConfigService, accessTokenService);
+        }
+    }
+
+    @Test
+    public void usersCanNotRevokeOtherUsersToken() {
+        final String accessingUser = "Dee-Dee";
+        prepareRevokeMocks(accessingUser, true, true);
+        try {
+            assertThrows(ForbiddenException.class, () -> usersResource.revokeToken(accessingUser, TOKEN_NAME));
+        } finally {
+            verify(accessTokenService).loadById(TOKEN_NAME);
+            verifyNoMoreInteractions(clusterConfigService, accessTokenService);
+        }
+    }
+
+    @Test
+    public void revokingNonExistingTokenThrowsNotFound() {
+        prepareRevokeMocks(USERNAME, true, false);
+        try {
+            assertThrows(jakarta.ws.rs.NotFoundException.class, () -> usersResource.revokeToken(USERNAME, TOKEN_NAME));
+        } finally {
+            verify(accessTokenService).loadById(TOKEN_NAME);
+            verify(accessTokenService).load(TOKEN_NAME);
+            verifyNoMoreInteractions(clusterConfigService, accessTokenService);
+        }
+    }
+
+    private AccessToken prepareRevokeMocks(String urlUser, boolean hasPermission, boolean tokenExists) {
+        // Assuming that the token-owner is always USERNAME.
+        final AccessToken accessToken = tokenExists ? mock(AccessToken.class) : null;
+        if (tokenExists) {
+            when(accessToken.getUserName()).thenReturn(USERNAME);
+        }
+        when(userManagementService.loadById(urlUser)).thenReturn(userImplFactory.create(Map.of(UserImpl.USERNAME, urlUser)));
+        when(subject.isPermitted(USERS_TOKENREMOVE + ":" + urlUser)).thenReturn(hasPermission);
+        when(accessTokenService.loadById(TOKEN_NAME)).thenReturn(accessToken);
+        return accessToken;
     }
 
     @Test


### PR DESCRIPTION
This is a backport of #26049 to `6.3`.

<!--- Provide a general summary of your changes in the Title above -->
Users with permission `USERS_TOKENREMOVE` were able to remove any existing token, regardless if they own it or now.

## Description
<!--- Describe your changes in detail -->
`DELETE /users/{userId}/tokens/{idOrToken}` only checked that the caller had `users:tokenremove:{URL-userId}`, it never verified the loaded token actually belonged to that user. Since every authenticated user is auto-granted `users:tokenremove:{self}` by `Permissions.userSelfEditPermissions`, any user could put their own ID in the URL and revoke any token in the system (admin tokens included) as long as they could guess or enumerate the token ID. The fallback branch accepts the plaintext token value, so a value leaked via access logs could be revoked the same way.

After loading the token, we now reject with 404 when it's missing _or_ when its owner doesn't match the URL user. Returning 404 in both cases avoids disclosing which token IDs exist under other users. The permission check is unchanged.

As additional change, loading the token via `.orElse()` was changed to `.orElseGet()` to stop accessTokenService.load(idOrToken) from running when loadById already returned a match.                                                                                         


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-tests added which cover: owner revoking their own token, missing permission (resulting in `ForbiddenException`), cross-user attempt (`NotFoundException`), and unknown token id (`NotFoundException`).                                                          

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.                                                               
