### PR TITLE
Fix FortiGate syslog parser handling of quoted values (`6.3`)

### DIFF
--- a/changelog/unreleased/ghsa-gqr6-r77p-c2pj.toml
+++ b/changelog/unreleased/ghsa-gqr6-r77p-c2pj.toml
@@ -1,0 +1,2 @@
+type = "s"
+message = "Fix FortiGate syslog parser handling of quoted values. [GHSA-gqr6-r77p-c2pj](https://github.com/Graylog2/graylog2-server/security/advisories/GHSA-gqr6-r77p-c2pj)"

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -453,6 +453,45 @@ public class SyslogCodecTest {
     }
 
     @Test
+    public void testFortiGateTopLevelFieldsAreNotOverriddenByMatchingKeysInsideQuotedValues() {
+        final String msg = "<99>date=2026-06-12 time=13:17:12 devname=\"FW1\" tz=+00:00 "
+                + "srcip=10.0.0.1 dstip=10.0.0.2 "
+                + "url=\"/?srcip=127.0.0.1&dstip=127.0.0.1\"";
+
+        final Message message = codec.decodeSafe(buildRawMessage(msg)).get();
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("srcip")).isEqualTo("10.0.0.1");
+        assertThat(message.getField("dstip")).isEqualTo("10.0.0.2");
+        assertThat(message.getField("url")).isEqualTo("/?srcip=127.0.0.1&dstip=127.0.0.1");
+    }
+
+    @Test
+    public void testFortiGateBackslashEscapedQuoteInsideQuotedValueDoesNotTerminateTheValue() {
+        final String msg = "<99>date=2026-06-12 time=13:17:12 devname=\"FW1\" tz=+00:00 "
+                + "srcip=10.0.0.1 "
+                + "url=\"/test?\\\"srcip=127.0.0.1\"";
+
+        final Message message = codec.decodeSafe(buildRawMessage(msg)).get();
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("srcip")).isEqualTo("10.0.0.1");
+        assertThat(message.getField("url")).isEqualTo("/test?\\\"srcip=127.0.0.1");
+    }
+
+    @Test
+    public void testFortiGateUsesTopLevelDateAndTimeWhenMatchingKeysAppearInsideQuotedValues() {
+        final String msg = "<99>date=2026-06-12 time=13:17:12 devname=\"FW1\" tz=+00:00 "
+                + "url=\"/?date=invalid&time=1&tz=Z\"";
+
+        final Message message = codec.decodeSafe(buildRawMessage(msg)).get();
+
+        assertThat(message).isNotNull();
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2026, 6, 12, 13, 17, 12, DateTimeZone.UTC));
+        assertThat(message.getField("url")).isEqualTo("/?date=invalid&time=1&tz=Z");
+    }
+
+    @Test
     public void testDefaultTimezoneConfig() {
         when(configuration.getString("timezone")).thenReturn("MST");
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <streamex.version>0.8.3</streamex.version>
         <swagger.version>1.6.16</swagger.version>
-        <syslog4j.version>0.9.61</syslog4j.version>
+        <syslog4j.version>0.9.63</syslog4j.version>
         <threeten-extra.version>1.8.0</threeten-extra.version>
         <ulid.version>8.3.0</ulid.version>
         <unboundid-ldap.version>7.0.3</unboundid-ldap.version>


### PR DESCRIPTION
This is a backport of #26050 to `6.3` (manually created due to conflicts).

<!--- Provide a general summary of your changes in the Title above -->
Depends on https://github.com/graylog-labs/syslog4j-graylog2/pull/56

## Description

The FortiGate syslog parser doesn't respect quoted values, allowing log evasion. Any `key=value` text appearing inside a quoted value, most commonly inside `url="..."`, is re-parsed as a top-level field, which can:
- overwrite existing fields (e.g. `srcip`, `dstip`) to suppress attribution data.
- corrupt parse-time fields (`date`, `time`, `tz`), causing the entire message to be discarded.

## Fix

Fixed upstream in https://github.com/graylog-labs/syslog4j-graylog2/pull/56. The parser now consumes the entire quoted value in a single match.

This PR bumps `syslog4j` to `0.9.63` to pick up the fix.

## How Has This Been Tested?

`SyslogCodecTest` should cover both issues. To reproduce manually, start a Syslog input at `127.0.0.1:514` and run:

**PoC 1 (removal of internal fields):**
```
echo '<45>date='"$(date -u +%F)"' time='"$(date -u +%T)"' devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=10.31.110.152 srcport=45748 srcintf="IF" dstip=192.178.50.65 dstport=443 dstintf="IF" sessionid=1122686199 status=close policyid=77 dstcountry="COUNTRY" srccountry="COUNTRY" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app="SSL_TLSv1.2" appcat="Network.Service" applist="ACLNAME" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack="SSL" hostname="HOSTNAME" url="http://www.example.com/whatever.php?srcip=127.0.0.1"' | nc 127.0.0.1 514
```
**Expected behavior:**
- `srcip` is preserved as `10.31.110.152`.
- `url` field is parsed as is (`http://www.example.com/whatever.php?srcip=127.0.0.1`).


**PoC 2 (message dropping):**
```
echo '<45>date='"$(date -u +%F)"' time='"$(date -u +%T)"' devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=10.31.110.152 srcport=45748 srcintf="IF" dstip=192.178.50.65 dstport=443 dstintf="IF" sessionid=1122686199 status=close policyid=77 dstcountry="COUNTRY" srccountry="COUNTRY" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app="SSL_TLSv1.2" appcat="Network.Service" applist="ACLNAME" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack="SSL" hostname="HOSTNAME" url="http://www.example.com/whatever.php?time=1"' | nc 127.0.0.1 514
```
**Expected behavior:**
- Message is not discarded (no `DateTimeParseException` in the server).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

