### PR TITLE
Fix null rule ID crash in pipeline metadata migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineAnalyzer.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineAnalyzer.java
@@ -129,7 +129,7 @@ public class PipelineAnalyzer {
                     List<Rule> stageRules = stage.getRules();
                     if (stageRules == null) continue;
                     for (Rule rule : stageRules) {
-                        if (rule == null) continue;
+                        if (rule == null || rule.id() == null) continue;
                         ruleSet.add(rule.id());
                         ruleTitles.put(rule.id(), rule.name());
                         boolean ruleHasReferences = analyzeRule(

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineAnalyzerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineAnalyzerTest.java
@@ -49,6 +49,7 @@ import static org.graylog.plugins.pipelineprocessor.processors.PipelineTestUtil.
 import static org.graylog.plugins.pipelineprocessor.processors.PipelineTestUtil.STREAM2_TITLE;
 import static org.graylog.plugins.pipelineprocessor.processors.PipelineTestUtil.STREAM3_ID;
 import static org.graylog.plugins.pipelineprocessor.processors.PipelineTestUtil.STREAM3_TITLE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -215,6 +216,32 @@ class PipelineAnalyzerTest {
                 .orElseThrow();
 
         assertEquals(Set.of(FromInput.NAME), metadataDao.functions());
+    }
+
+    @Test
+    void skipsRuleWithNullId() {
+        // Simulates an unresolved rule — referenced by name in pipeline source but deleted from DB
+        Rule unresolvedRule = mock(Rule.class);
+        when(unresolvedRule.id()).thenReturn(null);
+        when(unresolvedRule.name()).thenReturn("deleted_rule");
+        when(unresolvedRule.when()).thenReturn(mock(LogicalExpression.class));
+        when(unresolvedRule.then()).thenReturn(List.of());
+
+        final Pipeline pipeline = testUtil.createPipelineWithRules("pipeline_with_null_id_rule",
+                List.of(testUtil.ALWAYS_TRUE, unresolvedRule));
+
+        pipelineAnalyzer.analyzePipelines(
+                ImmutableMap.of(pipeline.id(), pipeline), ruleRecords, routingRuleRecords);
+
+        final PipelineRulesMetadataDao metadataDao = ruleRecords.stream()
+                .filter(dao -> dao.pipelineId().equals(pipeline.id()))
+                .findFirst()
+                .orElseThrow();
+
+        // The unresolved rule should be skipped — only ALWAYS_TRUE should be in the metadata
+        assertThat(metadataDao.rules()).containsExactly(PipelineTestUtil.ALWAYS_TRUE_ID);
+        assertThat(metadataDao.ruleTitlesById()).containsKey(PipelineTestUtil.ALWAYS_TRUE_ID);
+        assertThat(metadataDao.ruleTitlesById()).doesNotContainKey(null);
     }
 
     private Pipeline createPipelineWithFailingRule() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes a crash during the startup pipeline metadata migration when a pipeline references a rule that was deleted from the database.                                    
                                                                                                                 
The `PipelineAnalyzer` iterates rules in each pipeline stage. When a rule is referenced by name in the pipeline
source but no longer exists in the database, the resolved `Rule` object has a `null` ID. The code at
`PipelineAnalyzer.java:134` put this null ID as a key into `ruleTitlesById`, which Jackson cannot serialize to BSON, causing:                                         

MongoJsonMappingException: Null key for a Map not allowed in JSON                                              
   
This was introduced in #25053 which added `ruleTitlesById` to `PipelineRulesMetadataDao`. Previously, rule IDs 
were only added to a `Set<String>` which silently accepts null.                                                
   
### Fix                                                                                                        
Skip rules with `null` ID — matching the pre-existing behavior for null rule objects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

/nocl

