### PR TITLE
Fix cursor handling in `ClusterEventService`

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ClusterEventService extends AbstractExecutionThreadService {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterEventService.class);
@@ -64,7 +63,6 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     private final ObjectMapper objectMapper;
     private final EventBus serverEventBus;
     private final RestrictedChainingClassLoader chainingClassLoader;
-    private final AtomicReference<MongoCursor<ClusterEvent>> eventsCursor = new AtomicReference<>();
     private Offset offset;
 
     @Inject
@@ -123,9 +121,9 @@ public class ClusterEventService extends AbstractExecutionThreadService {
         while (isRunning()) {
             final var events = eventsIterable(this.offset)
                     .cursorType(CursorType.TailableAwait)
+                    .maxAwaitTime(1, TimeUnit.SECONDS)
                     .noCursorTimeout(true);
             try (final var cursor = events.iterator()) {
-                this.eventsCursor.set(cursor);
                 if (!isRunning()) {
                     return;
                 }
@@ -149,7 +147,7 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     @VisibleForTesting
     void iterateEvents(MongoCursor<ClusterEvent> cursor) {
         LOG.debug("Opened MongoDB cursor on \"{}\"", COLLECTION_NAME);
-        while (cursor.hasNext()) {
+        while (isRunning()) {
             final var clusterEvent = cursor.tryNext();
             if (clusterEvent != null) {
                 LOG.trace("Processing cluster event: {}", clusterEvent);
@@ -226,11 +224,4 @@ public class ClusterEventService extends AbstractExecutionThreadService {
         return null;
     }
 
-    @Override
-    protected void triggerShutdown() {
-        final var cursor = this.eventsCursor.get();
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -147,7 +147,7 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     @VisibleForTesting
     void iterateEvents(MongoCursor<ClusterEvent> cursor) {
         LOG.debug("Opened MongoDB cursor on \"{}\"", COLLECTION_NAME);
-        while (isRunning()) {
+        while (isRunning() && cursor.getServerCursor() != null) {
             final var clusterEvent = cursor.tryNext();
             if (clusterEvent != null) {
                 LOG.trace("Processing cluster event: {}", clusterEvent);

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -147,20 +147,24 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     @VisibleForTesting
     void iterateEvents(MongoCursor<ClusterEvent> cursor) {
         LOG.debug("Opened MongoDB cursor on \"{}\"", COLLECTION_NAME);
-        while (isRunning() && cursor.getServerCursor() != null) {
+        while (isRunning()) {
             final var clusterEvent = cursor.tryNext();
-            if (clusterEvent != null) {
-                LOG.trace("Processing cluster event: {}", clusterEvent);
-                Object payload = extractPayload(clusterEvent.payload(), clusterEvent.eventClass());
-                if (payload != null) {
-                    serverEventBus.post(payload);
-                } else {
-                    LOG.warn("Couldn't extract payload of cluster event with ID <{}>", clusterEvent.id());
-                    LOG.debug("Invalid payload in cluster event: {}", clusterEvent);
+            if (clusterEvent == null) {
+                if (cursor.getServerCursor() == null) {
+                    return;
                 }
-
-                this.offset = new Offset(clusterEvent.timestamp(), clusterEvent.id());
+                continue;
             }
+            LOG.trace("Processing cluster event: {}", clusterEvent);
+            Object payload = extractPayload(clusterEvent.payload(), clusterEvent.eventClass());
+            if (payload != null) {
+                serverEventBus.post(payload);
+            } else {
+                LOG.warn("Couldn't extract payload of cluster event with ID <{}>", clusterEvent.id());
+                LOG.debug("Invalid payload in cluster event: {}", clusterEvent);
+            }
+
+            this.offset = new Offset(clusterEvent.timestamp(), clusterEvent.id());
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
@@ -137,8 +137,8 @@ public class ClusterEventServiceTest {
 
     private void runService(Offset offset) {
         clusterEventService = spy(clusterEventService);
+        when(clusterEventService.isRunning()).thenReturn(true);
         try (final var cursor = clusterEventService.eventsIterable(offset).iterator()) {
-            when(clusterEventService.isRunning()).thenAnswer(inv -> cursor.hasNext());
             clusterEventService.iterateEvents(cursor);
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
@@ -53,7 +53,6 @@ import org.mockito.quality.Strictness;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,8 +60,10 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(MongoDBExtension.class)
@@ -131,7 +132,15 @@ public class ClusterEventServiceTest {
     }
 
     private void runService() {
-        clusterEventService.iterateEvents(clusterEventService.eventsIterable(initialOffset).iterator());
+        runService(initialOffset);
+    }
+
+    private void runService(Offset offset) {
+        clusterEventService = spy(clusterEventService);
+        try (final var cursor = clusterEventService.eventsIterable(offset).iterator()) {
+            when(clusterEventService.isRunning()).thenAnswer(inv -> cursor.hasNext());
+            clusterEventService.iterateEvents(cursor);
+        }
     }
 
     @Test
@@ -165,7 +174,7 @@ public class ClusterEventServiceTest {
 
         // Simulate a cursor reopen from the offset of the just-processed event.
         final var offsetAfterProcessing = new Offset(TIME.toDate(), lastId);
-        clusterEventService.iterateEvents(clusterEventService.eventsIterable(offsetAfterProcessing).iterator());
+        runService(offsetAfterProcessing);
 
         assertThat(handler.invocations).hasValue(0);
         verify(serverEventBus, never()).post(any(SimpleEvent.class));


### PR DESCRIPTION
## Description
The `ClusterEventService` opened a cursor with `TailableAwait`, causing it to always stay in the `cursor.hasNext()` while loop in `iterateEvents`. 
This replaces the loop condition with `isRunning()`. The `tryNext()` is sufficient as it will already null if no data is returned within `maxAwaitTime`. To make sure this is will not delay server shutdown `maxAwaitTime` is now set to 1s.

/nocl

## Motivation and Context
fixes https://github.com/Graylog2/graylog2-server/issues/25878

## How Has This Been Tested?
adjusted unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

