### PR TITLE
Fix missing redirect to new API browser

### DIFF
--- a/changelog/unreleased/pr-26093.toml
+++ b/changelog/unreleased/pr-26093.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Add missing redirect to new API browser."
+
+pulls = ["26093"]

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResourcesSharedModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResourcesSharedModule.java
@@ -18,6 +18,7 @@ package org.graylog2.shared.rest.resources;
 
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.shared.rest.documentation.openapi.OpenApiResource;
+import org.graylog2.shared.rest.resources.documentation.ApiBrowserRedirectResource;
 import org.graylog2.shared.rest.resources.documentation.DocumentationResource;
 import org.graylog2.shared.rest.resources.system.LoadBalancerStatusResource;
 import org.graylog2.shared.rest.resources.system.MetricsResource;
@@ -32,6 +33,7 @@ public class RestResourcesSharedModule extends Graylog2Module {
     protected void configure() {
         addSystemRestResource(OpenApiResource.class);
         addSystemRestResource(DocumentationResource.class);
+        addSystemRestResource(ApiBrowserRedirectResource.class);
         addSystemRestResource(CodecTypesResource.class);
         addSystemRestResource(InputTypesResource.class);
         addSystemRestResource(LoadBalancerStatusResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.resources.documentation;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.RestTools;
+
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Redirects the old API browser URLs (served under the REST API prefix) to the
+ * new frontend route at {@code /api-browser}, so that existing bookmarks keep
+ * working after the server-side Swagger UI was removed.
+ */
+@Path("/api-browser{route: .*}")
+public class ApiBrowserRedirectResource {
+    private final HttpConfiguration httpConfiguration;
+
+    @Inject
+    public ApiBrowserRedirectResource(HttpConfiguration httpConfiguration) {
+        this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
+    }
+
+    @GET
+    public Response redirect(@Context HttpHeaders httpHeaders) {
+        final URI base = RestTools.buildExternalUri(httpHeaders.getRequestHeaders(),
+                httpConfiguration.getHttpExternalUri());
+        return Response.status(Response.Status.MOVED_PERMANENTLY)
+                .location(base.resolve("api-browser"))
+                .build();
+    }
+}


### PR DESCRIPTION
Adds a redirect from the old `/api/api-browser` route to `/api-browser` so that bookmarks to the old page still lead to a working API browser.

The old API browser was served from underneath the `/api` path and was not part of the frontend react app. The new API browser is integrated in the react app, so the backend has to serve a redirect to the frontend route.

Requires a backport to `7.1`