### PR TITLE
Fix array-of-unknown schema rendering in generated OpenAPI spec for nullable fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/CustomModelConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/CustomModelConverter.java
@@ -139,6 +139,12 @@ public class CustomModelConverter extends ModelResolver {
                 return new ObjectSchema()
                         .addProperty("start", new IntegerSchema())
                         .addProperty("length", new IntegerSchema());
+            } else if (Object.class.equals(rawClass)) {
+                // Raw Object (e.g. List<Object>, Map<String, Object>) means "any value".
+                // In OpenAPI 3.1 / JSON Schema this is expressed as an empty schema (no "type" field).
+                // Without this, swagger-core emits a schema with "type": null, which breaks consumers
+                // like openapi-explorer.
+                return new Schema<>();
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/CustomModelConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/CustomModelConverter.java
@@ -148,7 +148,45 @@ public class CustomModelConverter extends ModelResolver {
             }
         }
 
-        return super.resolve(annotatedType, new CustomConverterContext(context), next);
+        final Schema<?> resolved = super.resolve(annotatedType, new CustomConverterContext(context), next);
+        stripNullFromNullableUnknownArray(resolved);
+        return resolved;
+    }
+
+    /**
+     * When swagger generates a schema for a {@code @Nullable List<Object>} (or similar nullable collection of raw
+     * Object), it emits {@code "type": ["array", "null"]} with {@code "items": {}}. The OpenAPI 3.1 union form is
+     * technically valid but renders as garbage in openapi-explorer (e.g. {@code "array,null of undefined"}).
+     * Since the items are already "any value" — and "any value" trivially includes null — dropping {@code "null"}
+     * from the type union loses no real semantics for this case. Strip it.
+     */
+    private static void stripNullFromNullableUnknownArray(Schema<?> schema) {
+        if (schema == null) {
+            return;
+        }
+        final var types = schema.getTypes();
+        if (types == null || types.size() <= 1 || !types.contains("array") || !types.contains("null")) {
+            return;
+        }
+        final var items = schema.getItems();
+        if (items == null || !isUnknownSchema(items)) {
+            return;
+        }
+        final var stripped = new java.util.LinkedHashSet<>(types);
+        stripped.remove("null");
+        schema.setTypes(stripped);
+    }
+
+    // True when the schema imposes no constraints — i.e. an empty "any value" schema.
+    private static boolean isUnknownSchema(Schema<?> schema) {
+        return schema.getType() == null
+                && (schema.getTypes() == null || schema.getTypes().isEmpty())
+                && schema.get$ref() == null
+                && (schema.getProperties() == null || schema.getProperties().isEmpty())
+                && schema.getAllOf() == null
+                && schema.getOneOf() == null
+                && schema.getAnyOf() == null
+                && schema.getItems() == null;
     }
 
     // helper to clone the given AnnotatedType with a replacement "inner" type

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenAPIContextFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenAPIContextFactoryTest.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.graylog.plugins.views.search.rest.SearchTypeExecutionState;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.Version;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -41,6 +42,7 @@ import org.graylog2.shared.rest.PublicCloudAPI;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -262,10 +264,32 @@ class OpenAPIContextFactoryTest {
             assertThat(value).isNotNull();
             assertThat(value.getTypes()).isNull();
             assertThat(value.getType()).isNull();
-        } catch (AssertionError | NullPointerException e) {
+
+            // Verify the *serialized* JSON does not contain "type": null for the items or value schemas.
+            final var json = Json31.pretty(generatedDescription);
+            final var tree = new ObjectMapper().readTree(json);
+            final var responseNode = tree.at("/components/schemas/org.graylog2.shared.rest.documentation.openapi.OpenAPIContextFactoryTest.RawObjectResponse");
+            final var itemsNode = responseNode.at("/properties/values/items");
+            assertThat(itemsNode.has("type")).as("items schema should not have a type field, got: %s", itemsNode).isFalse();
+            final var valueNode = responseNode.at("/properties/value");
+            assertThat(valueNode.has("type")).as("value schema should not have a type field, got: %s", valueNode).isFalse();
+
+            // Verify the real SearchTypeExecutionState#searchAfter (the original bug reproducer). The field is
+            // @Nullable List<Object>; swagger emits "type": ["array", "null"] with empty items. We strip "null"
+            // from the type union since items are already "any value" — the OpenAPI 3.1 union form rendered as
+            // garbage in openapi-explorer.
+            final var stesNode = tree.at("/components/schemas/org.graylog.plugins.views.search.rest.SearchTypeExecutionState");
+            assertThat(stesNode.isMissingNode()).as("SearchTypeExecutionState should be in the OpenAPI components").isFalse();
+            final var afterNode = stesNode.at("/properties/after");
+            assertThat(afterNode.isMissingNode()).as("after property should exist on SearchTypeExecutionState").isFalse();
+            assertThat(afterNode.at("/type").asText()).as("after.type should be a single string \"array\", got: %s", afterNode).isEqualTo("array");
+            final var afterItemsNode = afterNode.at("/items");
+            assertThat(afterItemsNode.isMissingNode()).as("after.items should exist on SearchTypeExecutionState").isFalse();
+            assertThat(afterItemsNode.has("type")).as("after.items should not have a type field, got: %s", afterItemsNode).isFalse();
+        } catch (AssertionError | NullPointerException | IOException e) {
             System.err.println("Test failed. Full OpenAPI description:");
             System.err.println(Json31.pretty(generatedDescription));
-            throw e;
+            throw new AssertionError(e);
         }
     }
 
@@ -410,11 +434,11 @@ class OpenAPIContextFactoryTest {
         @NoAuditEvent("Test")
         @GET
         public RawObjectResponse get() {
-            return new RawObjectResponse(List.of("a", 1), new Object());
+            return new RawObjectResponse(List.of("a", 1), new Object(), null);
         }
     }
 
-    public record RawObjectResponse(List<Object> values, Object value) {}
+    public record RawObjectResponse(List<Object> values, Object value, SearchTypeExecutionState searchTypeExecutionState) {}
 
     public record TestRequest(
             String name,

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenAPIContextFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenAPIContextFactoryTest.java
@@ -41,6 +41,7 @@ import org.graylog2.shared.rest.PublicCloudAPI;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -60,7 +61,8 @@ class OpenAPIContextFactoryTest {
     static void beforeAll() {
         final Map<String, Set<Class<? extends PluginRestResource>>> pluginRestResources =
                 Map.of("my.plugin.id", Set.of(TestResource.class, TestResource2.class,
-                        NotPublicCloudResource.class, SchemaConflictResource.class, ImmutableMapsResource.class));
+                        NotPublicCloudResource.class, SchemaConflictResource.class, ImmutableMapsResource.class,
+                        RawObjectResource.class));
 
         objectMapper = new ObjectMapperProvider().get();
         objectMapper.registerSubtypes(
@@ -92,7 +94,8 @@ class OpenAPIContextFactoryTest {
             // Verify that paths and schemas are generated
             assertThat(generatedDescription.getPaths()).containsOnlyKeys("/test", "/plugins/my.plugin.id/test",
                     "/plugins/my.plugin.id/subtypes", "/plugins/my.plugin.id/response-schema-name-conflict/pkg1",
-                    "/plugins/my.plugin.id/response-schema-name-conflict/pkg2", "/plugins/my.plugin.id/immutable-maps");
+                    "/plugins/my.plugin.id/response-schema-name-conflict/pkg2", "/plugins/my.plugin.id/immutable-maps",
+                    "/plugins/my.plugin.id/raw-object");
             assertThat(generatedDescription.getComponents().getSchemas()).isNotEmpty();
         } catch (AssertionError | NullPointerException e) {
             System.err.println("Test failed. Full OpenAPI description:");
@@ -239,6 +242,34 @@ class OpenAPIContextFactoryTest {
     }
 
     @Test
+    void rawObjectIsResolvedAsAnyValueSchema() {
+        try {
+            // List<Object> / raw Object means "any value" in JSON Schema. In OpenAPI 3.1 that is an empty
+            // schema with no "type" set. Without the workaround in CustomModelConverter, swagger-core emits
+            // schemas with a null/invalid type for raw Object, which breaks consumers like openapi-explorer.
+            final Schema<?> responseSchema = generatedDescription.getComponents().getSchemas()
+                    .get("org.graylog2.shared.rest.documentation.openapi.OpenAPIContextFactoryTest.RawObjectResponse");
+            assertThat(responseSchema).isNotNull();
+
+            final var values = (Schema<?>) responseSchema.getProperties().get("values");
+            assertThat(values.getTypes()).containsExactly("array");
+            final var itemsSchema = (Schema<?>) values.getItems();
+            assertThat(itemsSchema).isNotNull();
+            assertThat(itemsSchema.getTypes()).isNull();
+            assertThat(itemsSchema.getType()).isNull();
+
+            final var value = (Schema<?>) responseSchema.getProperties().get("value");
+            assertThat(value).isNotNull();
+            assertThat(value.getTypes()).isNull();
+            assertThat(value.getType()).isNull();
+        } catch (AssertionError | NullPointerException e) {
+            System.err.println("Test failed. Full OpenAPI description:");
+            System.err.println(Json31.pretty(generatedDescription));
+            throw e;
+        }
+    }
+
+    @Test
     void usesMapSchemaForImmutableMaps() {
         try {
             // Verify ChildType1 has allOf with ParentType reference
@@ -369,6 +400,21 @@ class OpenAPIContextFactoryTest {
             return ImmutableMap.of("key", true);
         }
     }
+
+    @PublicCloudAPI
+    @Path("/raw-object")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public static class RawObjectResource implements PluginRestResource {
+
+        @NoAuditEvent("Test")
+        @GET
+        public RawObjectResponse get() {
+            return new RawObjectResponse(List.of("a", 1), new Object());
+        }
+    }
+
+    public record RawObjectResponse(List<Object> values, Object value) {}
 
     public record TestRequest(
             String name,


### PR DESCRIPTION
**Note:** This needs a backport to `7.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Raw `Object` (e.g. `List<Object>`, `Map<String, Object>`) was being emitted with `type: null`, which is invalid OpenAPI 3.1 and breaks consumers like openapi-explorer. Intercept it in `CustomModelConverter` and return an empty schema instead — the JSON Schema form for "any value".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.