### PR TITLE
Fix API browser by rolling back swagger version

### DIFF
--- a/changelog/unreleased/pr-26104.toml
+++ b/changelog/unreleased/pr-26104.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix API browser by rolling back swagger version."
+
+pulls = ["26104"]

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <siv-mode.version>1.6.1</siv-mode.version>
         <slf4j.version>2.0.18</slf4j.version>
         <streamex.version>0.8.4</streamex.version>
-        <swagger.version>2.2.50</swagger.version>
+        <swagger.version>2.2.43</swagger.version>
         <swagger-parser.version>2.1.41</swagger-parser.version>
         <syslog4j.version>0.9.63</syslog4j.version>
         <threeten-extra.version>1.8.0</threeten-extra.version>


### PR DESCRIPTION
Roll back swagger to version 2.2.43. This fixes the built-in API browser.

We'll lose some improvements to nullability, however those are responsible for generating invalid specs. See https://github.com/swagger-api/swagger-core/issues/5115

Requires a backport to `7.1`