### PR TITLE
Introduce `URIHelper` for request-scoped self-referencing URLs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/URIHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/URIHelper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest;
+
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Resolves request-scoped, self-referencing URIs against the server's external base URI.
+ * <p>
+ * The base URI is derived from {@code HttpConfiguration#getHttpExternalUri()} and the
+ * {@code X-Graylog-Server-URL} override header (see {@link RestTools#buildExternalUri}).
+ * Inject via {@code @Context URIHelper uriHelper} in JAX-RS resource methods; per-request
+ * wiring is provided by {@link URIHelperFactory} / {@link URIHelperBinder}.
+ */
+public class URIHelper {
+    private final URI baseUri;
+
+    public URIHelper(URI baseUri) {
+        this.baseUri = requireNonNull(baseUri, "baseUri");
+    }
+
+    /**
+     * The trailing-slash-terminated base URI used for resolution.
+     */
+    public URI baseUri() {
+        return baseUri;
+    }
+
+    /**
+     * Resolve a path against the base URI. Relative paths resolve against the base; absolute
+     * URIs are returned as-is by {@link URI#resolve(String)}.
+     */
+    public URI resolve(String path) {
+        return baseUri.resolve(path);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/URIHelperBinder.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/URIHelperBinder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+/**
+ * Binds {@link URIHelperFactory} as the request-scoped provider for {@link URIHelper}, so that
+ * resource methods can declare {@code @Context URIHelper uriHelper}.
+ */
+public class URIHelperBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        bindFactory(URIHelperFactory.class)
+                .to(URIHelper.class)
+                .in(RequestScoped.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/URIHelperFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/URIHelperFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.glassfish.hk2.api.Factory;
+import org.graylog2.configuration.HttpConfiguration;
+
+/**
+ * HK2 factory that produces a request-scoped {@link URIHelper} pre-populated with the external
+ * base URI for the current request.
+ */
+public class URIHelperFactory implements Factory<URIHelper> {
+
+    // Use a Provider so we resolve headers at request time, not at factory-construction time.
+    @Context
+    private Provider<HttpHeaders> httpHeadersProvider;
+
+    private final HttpConfiguration httpConfiguration;
+
+    @Inject
+    public URIHelperFactory(HttpConfiguration httpConfiguration) {
+        this.httpConfiguration = httpConfiguration;
+    }
+
+    @Override
+    public URIHelper provide() {
+        final var headers = httpHeadersProvider.get();
+        final var baseUri = RestTools.buildExternalUri(
+                headers.getRequestHeaders(), httpConfiguration.getHttpExternalUri());
+        return new URIHelper(baseUri);
+    }
+
+    @Override
+    public void dispose(URIHelper instance) {
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -54,6 +54,7 @@ import org.graylog2.jersey.PrefixAddingModelProcessor;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.rest.URIHelperBinder;
 import org.graylog2.rest.resources.system.SlidingExpirationCookieFilter;
 import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.ContentTypeOptionFilter;
@@ -298,6 +299,7 @@ public class JerseyService extends AbstractIdleService {
                     }
                 })
                 .register(new UserContextBinder())
+                .register(new URIHelperBinder())
                 .register(MultiPartFeature.class)
                 .registerClasses(systemRestResources)
                 .registerResources(additionalResources);

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/OpenApiResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/openapi/OpenApiResource.java
@@ -28,13 +28,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.rest.MoreMediaTypes;
-import org.graylog2.rest.RestTools;
+import org.graylog2.rest.URIHelper;
 
 import java.net.URI;
 
@@ -57,18 +56,16 @@ import java.net.URI;
 public class OpenApiResource {
 
     private final OpenApiContext context;
-    private final HttpConfiguration httpConfiguration;
 
     @Inject
-    public OpenApiResource(OpenAPIContextFactory contextFactory, HttpConfiguration httpConfiguration) {
+    public OpenApiResource(OpenAPIContextFactory contextFactory) {
         this.context = contextFactory.getOrCreate(OpenApiContext.OPENAPI_CONTEXT_ID_DEFAULT);
-        this.httpConfiguration = httpConfiguration;
     }
 
     @GET
     @Produces({MediaType.APPLICATION_JSON, MoreMediaTypes.APPLICATION_YAML})
     @Operation(hidden = true)
-    public Response getOpenApi(@Context HttpHeaders headers,
+    public Response getOpenApi(@Context URIHelper uriHelper,
                                @PathParam("ext") String ext) throws Exception {
         final boolean yaml = ".yaml".equals(ext);
         final var mapper = yaml ? context.getOutputYamlMapper() : context.getOutputJsonMapper();
@@ -79,15 +76,9 @@ public class OpenApiResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        final String output = serializeWithServerUrl(openAPI, mapper, resolveServerUrl(headers));
+        final String output = serializeWithServerUrl(openAPI, mapper, uriHelper.resolve(HttpConfiguration.PATH_API));
 
         return Response.ok(output).type(mediaType).build();
-    }
-
-    private URI resolveServerUrl(HttpHeaders headers) {
-        final var baseUri = RestTools.buildExternalUri(
-                headers.getRequestHeaders(), httpConfiguration.getHttpExternalUri());
-        return baseUri.resolve(HttpConfiguration.PATH_API);
     }
 
     private String serializeWithServerUrl(OpenAPI openAPI, ObjectMapper mapper, URI serverUrl)

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
@@ -16,18 +16,11 @@
  */
 package org.graylog2.shared.rest.resources.documentation;
 
-import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
-import org.graylog2.configuration.HttpConfiguration;
-import org.graylog2.rest.RestTools;
-
-import java.net.URI;
-
-import static java.util.Objects.requireNonNull;
+import org.graylog2.rest.URIHelper;
 
 /**
  * Redirects the old API browser URLs (served under the REST API prefix) to the
@@ -36,19 +29,11 @@ import static java.util.Objects.requireNonNull;
  */
 @Path("/api-browser{route: .*}")
 public class ApiBrowserRedirectResource {
-    private final HttpConfiguration httpConfiguration;
-
-    @Inject
-    public ApiBrowserRedirectResource(HttpConfiguration httpConfiguration) {
-        this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
-    }
 
     @GET
-    public Response redirect(@Context HttpHeaders httpHeaders) {
-        final URI base = RestTools.buildExternalUri(httpHeaders.getRequestHeaders(),
-                httpConfiguration.getHttpExternalUri());
+    public Response redirect(@Context URIHelper uriHelper) {
         return Response.status(Response.Status.MOVED_PERMANENTLY)
-                .location(base.resolve("api-browser"))
+                .location(uriHelper.resolve("api-browser"))
                 .build();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/URIHelperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/URIHelperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class URIHelperTest {
+
+    @Test
+    void resolvesRelativePathAgainstBaseUri() {
+        final var helper = new URIHelper(URI.create("https://example.com/graylog/"));
+
+        assertThat(helper.resolve("api/openapi")).isEqualTo(URI.create("https://example.com/graylog/api/openapi"));
+    }
+
+    @Test
+    void returnsAbsoluteUriUnchanged() {
+        // URI#resolve returns the argument unchanged when it is itself absolute
+        final var helper = new URIHelper(URI.create("https://example.com/"));
+
+        assertThat(helper.resolve("https://other.example.com/foo"))
+                .isEqualTo(URI.create("https://other.example.com/foo"));
+    }
+
+    @Test
+    void exposesBaseUri() {
+        final var base = URI.create("https://example.com/graylog/");
+        final var helper = new URIHelper(base);
+
+        assertThat(helper.baseUri()).isEqualTo(base);
+    }
+
+    @Test
+    void requiresNonNullBaseUri() {
+        assertThatNullPointerException().isThrownBy(() -> new URIHelper(null));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenApiResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/documentation/openapi/OpenApiResourceTest.java
@@ -23,9 +23,7 @@ import io.swagger.v3.oas.integration.api.OpenApiContext;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.URIHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +31,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
@@ -48,12 +45,6 @@ class OpenApiResourceTest {
     @Mock
     private OpenApiContext openApiContext;
 
-    @Mock
-    private HttpConfiguration httpConfiguration;
-
-    @Mock
-    private HttpHeaders httpHeaders;
-
     private OpenApiResource resource;
     private OpenAPI cachedOpenAPI;
 
@@ -67,18 +58,17 @@ class OpenApiResourceTest {
         when(openApiContext.read()).thenReturn(cachedOpenAPI);
         lenient().when(openApiContext.getOutputJsonMapper()).thenReturn(Json31.mapper());
         lenient().when(openApiContext.getOutputYamlMapper()).thenReturn(Yaml31.mapper());
-        lenient().when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://localhost:9000/"));
 
-        resource = new OpenApiResource(contextFactory, httpConfiguration);
+        resource = new OpenApiResource(contextFactory);
+    }
+
+    private static URIHelper uriHelper(String baseUri) {
+        return new URIHelper(URI.create(baseUri));
     }
 
     @Test
     void setsAbsoluteServerUrlFromOverrideHeader() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        headers.put(HttpConfiguration.OVERRIDE_HEADER, List.of("https://example.com/graylog/"));
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-
-        final var response = resource.getOpenApi(httpHeaders, null);
+        final var response = resource.getOpenApi(uriHelper("https://example.com/graylog/"), null);
         final var json = response.getEntity().toString();
         final var tree = new ObjectMapper().readTree(json);
 
@@ -86,12 +76,8 @@ class OpenApiResourceTest {
     }
 
     @Test
-    void fallsBackToExternalUriWhenNoHeader() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("https://external.example.com/"));
-
-        final var response = resource.getOpenApi(httpHeaders, null);
+    void usesProvidedBaseUri() throws Exception {
+        final var response = resource.getOpenApi(uriHelper("https://external.example.com/"), null);
         final var json = response.getEntity().toString();
         final var tree = new ObjectMapper().readTree(json);
 
@@ -99,25 +85,8 @@ class OpenApiResourceTest {
     }
 
     @Test
-    void fallsBackToPublishUriWhenNoHeaderOrExternalUri() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://10.0.0.1:9000/"));
-
-        final var response = resource.getOpenApi(httpHeaders, null);
-        final var json = response.getEntity().toString();
-        final var tree = new ObjectMapper().readTree(json);
-
-        assertThat(tree.at("/servers/0/url").asText()).isEqualTo("http://10.0.0.1:9000/api/");
-    }
-
-    @Test
     void doesNotMutateCachedOpenAPIModel() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        headers.put(HttpConfiguration.OVERRIDE_HEADER, List.of("https://example.com/graylog/"));
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-
-        resource.getOpenApi(httpHeaders, null);
+        resource.getOpenApi(uriHelper("https://example.com/graylog/"), null);
 
         // The cached model should still have the original /api/ server URL
         assertThat(cachedOpenAPI.getServers()).hasSize(1);
@@ -126,11 +95,7 @@ class OpenApiResourceTest {
 
     @Test
     void returnsYamlWhenExtIsYaml() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://localhost:9000/"));
-
-        final var response = resource.getOpenApi(httpHeaders, ".yaml");
+        final var response = resource.getOpenApi(uriHelper("http://localhost:9000/"), ".yaml");
         final var yaml = response.getEntity().toString();
 
         // YAML should not start with '{' (that would be JSON)
@@ -143,11 +108,7 @@ class OpenApiResourceTest {
 
     @Test
     void returnsJsonWhenExtIsNull() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://localhost:9000/"));
-
-        final var response = resource.getOpenApi(httpHeaders, null);
+        final var response = resource.getOpenApi(uriHelper("http://localhost:9000/"), null);
         final var json = response.getEntity().toString();
 
         // Verify it's valid JSON by parsing it
@@ -159,18 +120,14 @@ class OpenApiResourceTest {
     void returns404WhenOpenAPIModelIsNull() throws Exception {
         when(openApiContext.read()).thenReturn(null);
 
-        final var response = resource.getOpenApi(httpHeaders, null);
+        final var response = resource.getOpenApi(uriHelper("http://localhost:9000/"), null);
 
         assertThat(response.getStatus()).isEqualTo(404);
     }
 
     @Test
     void prettyPrintsJsonOutput() throws Exception {
-        final var headers = new MultivaluedHashMap<String, String>();
-        when(httpHeaders.getRequestHeaders()).thenReturn(headers);
-        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://localhost:9000/"));
-
-        final var response = resource.getOpenApi(httpHeaders, null);
+        final var response = resource.getOpenApi(uriHelper("http://localhost:9000/"), null);
         final var json = response.getEntity().toString();
 
         // Pretty-printed JSON contains newlines and indentation


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Several REST resources repeated the same dance to build a self-referencing base URL: call `RestTools.buildExternalUri` with the request headers and `HttpConfiguration#getHttpExternalUri`, then resolve a path against the result. Wrap this in a request-scoped `URIHelper` that can be injected via `@Context`.

Refactor `ApiBrowserRedirectResource` and `OpenApiResource` as the first users. 

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.