### PR TITLE
Hide API browser redirect in OpenAPI description

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/ApiBrowserRedirectResource.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.shared.rest.resources.documentation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -34,6 +35,7 @@ import static java.util.Objects.requireNonNull;
  * new frontend route at {@code /api-browser}, so that existing bookmarks keep
  * working after the server-side Swagger UI was removed.
  */
+@Hidden
 @Path("/api-browser{route: .*}")
 public class ApiBrowserRedirectResource {
     private final HttpConfiguration httpConfiguration;


### PR DESCRIPTION
Prevents a validation error of the generated API description like the following:

- paths.'/api-browser{route}'. Declared path parameter route needs to be defined as a path parameter in path or operation level

This is an addition to https://github.com/Graylog2/graylog2-server/pull/26093

/nocl