### PR TITLE
Limit beats packet compressed and decompressed sizes

### DIFF
--- a/changelog/unreleased/pr-26139.toml
+++ b/changelog/unreleased/pr-26139.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Add safeguards for beats protocol frame parsing."
+
+pulls = ["26139"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
@@ -64,6 +64,10 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
         FRAME_WINDOW_SIZE
     }
 
+    private static final int MAX_JSON_FRAME_BYTES = 16 * 1024 * 1024;
+    private static final int MAX_DATA_PAIRS = 1024;
+    private static final int MAX_DATA_ITEM_BYTES = 1024 * 1024;
+
     private long windowSize;
     private long sequenceNum;
 
@@ -165,6 +169,9 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
         LOG.trace("Received sequence number {}", sequenceNum);
 
         final int jsonLength = Ints.saturatedCast(channelBuffer.readUnsignedInt());
+        if (jsonLength > MAX_JSON_FRAME_BYTES) {
+            throw new IllegalStateException("JSON frame size " + jsonLength + " exceeds maximum " + MAX_JSON_FRAME_BYTES);
+        }
 
         final ByteBuf buffer = channelBuffer.readBytes(jsonLength);
         sendACK(channel);
@@ -211,6 +218,9 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
         LOG.trace("Received sequence number {}", sequenceNum);
 
         final int pairs = Ints.saturatedCast(channelBuffer.readUnsignedInt());
+        if (pairs > MAX_DATA_PAIRS) {
+            throw new IllegalStateException("Data frame pair count " + pairs + " exceeds maximum " + MAX_DATA_PAIRS);
+        }
         final JsonFactory jsonFactory = new JsonFactory();
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (final JsonGenerator jg = jsonFactory.createGenerator(outputStream)) {
@@ -231,6 +241,9 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
 
     private String parseDataItem(ByteBuf buf) {
         int length = Ints.saturatedCast(buf.readUnsignedInt());
+        if (length > MAX_DATA_ITEM_BYTES) {
+            throw new IllegalStateException("Data item size " + length + " exceeds maximum " + MAX_DATA_ITEM_BYTES);
+        }
         final ByteBuf item = buf.readSlice(length);
         return item.toString(StandardCharsets.UTF_8);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
@@ -19,9 +19,9 @@ package org.graylog.plugins.beats;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,7 +29,6 @@ import io.netty.handler.codec.ReplayingDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,6 +63,8 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
         FRAME_WINDOW_SIZE
     }
 
+    public static final int DEFAULT_MAX_COMPRESSED_PAYLOAD_SIZE = 16 * 1024 * 1024;
+    public static final int DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE = 64 * 1024 * 1024;
     private static final int MAX_JSON_FRAME_BYTES = 16 * 1024 * 1024;
     private static final int MAX_DATA_PAIRS = 1024;
     private static final int MAX_DATA_ITEM_BYTES = 1024 * 1024;
@@ -71,8 +72,17 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
     private long windowSize;
     private long sequenceNum;
 
+    private final int maxCompressedPayloadSize;
+    private final int maxDecompressedPayloadSize;
+
     public BeatsFrameDecoder() {
+        this(DEFAULT_MAX_COMPRESSED_PAYLOAD_SIZE, DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE);
+    }
+
+    public BeatsFrameDecoder(int maxCompressedPayloadBytes, int maxDecompressedPayloadBytes) {
         super(DecodingState.PROTOCOL_VERSION);
+        this.maxCompressedPayloadSize = maxCompressedPayloadBytes;
+        this.maxDecompressedPayloadSize = maxDecompressedPayloadBytes;
     }
 
     @Override
@@ -183,13 +193,31 @@ public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.Decodi
      * @see <a href="https://github.com/logstash-plugins/logstash-input-beats/blob/master/PROTOCOL.md#compressed-frame-type">'compressed' frame type</a>
      */
     private Collection<ByteBuf> processCompressedFrame(Channel channel, ByteBuf channelBuffer) throws Exception {
-        final long payloadLength = channelBuffer.readUnsignedInt();
-        final byte[] data = new byte[(int) payloadLength];
-        channelBuffer.readBytes(data);
-        try (final ByteArrayInputStream dataStream = new ByteArrayInputStream(data);
-             final InputStream in = new InflaterInputStream(dataStream)) {
-            final ByteBuf buffer = Unpooled.wrappedBuffer(ByteStreams.toByteArray(in));
-            return processCompressedDataFrames(channel, buffer);
+        final int payloadLength = Ints.saturatedCast(channelBuffer.readUnsignedInt());
+        if (payloadLength > maxCompressedPayloadSize) {
+            throw new IllegalStateException("Compressed payload size " + payloadLength + " exceeds maximum " + maxCompressedPayloadSize);
+        }
+        // payload buffer is released by the ByteBufInputStream below (argument releaseOnClose: true)
+        final ByteBuf payload = channelBuffer.readRetainedSlice(payloadLength);
+        try (final InputStream in = new InflaterInputStream(new ByteBufInputStream(payload, true))) {
+            // released below
+            final ByteBuf decompressed = channel.alloc().buffer();
+            // decompress the payload in small chunks so we can stop reading once we hit the configured maximum
+            // without having a gigantic copy in memory
+            try {
+                final byte[] chunk = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = in.read(chunk)) != -1) {
+                    if (decompressed.readableBytes() + bytesRead > maxDecompressedPayloadSize) {
+                        throw new IllegalStateException("Decompressed payload size " + (decompressed.readableBytes() + bytesRead) +
+                                " exceeds maximum " + maxDecompressedPayloadSize);
+                    }
+                    decompressed.writeBytes(chunk, 0, bytesRead);
+                }
+                return processCompressedDataFrames(channel, decompressed);
+            } finally {
+                decompressed.release();
+            }
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
@@ -25,6 +25,7 @@ import org.graylog2.inputs.transports.netty.EventLoopGroupFactory;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.NumberField;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
@@ -40,6 +41,13 @@ import java.util.LinkedHashMap;
 import java.util.concurrent.Callable;
 
 public class BeatsTransport extends AbstractTcpTransport {
+
+    private static final String CK_MAX_COMPRESSED_PAYLOAD_SIZE = "max_compressed_payload_size";
+    private static final String CK_MAX_DECOMPRESSED_PAYLOAD_SIZE = "max_decompressed_payload_size";
+    private final int maxCompressedPayloadSize;
+    private final int maxDecompressedPayloadSize;
+
+
     @Inject
     public BeatsTransport(@Assisted Configuration configuration,
                           EventLoopGroup eventLoopGroup,
@@ -50,12 +58,14 @@ public class BeatsTransport extends AbstractTcpTransport {
                           TLSProtocolsConfiguration tlsConfiguration,
                           EncryptedValueService encryptedValueService) {
         super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, tlsConfiguration, encryptedValueService);
+        maxCompressedPayloadSize = configuration.getInt(CK_MAX_COMPRESSED_PAYLOAD_SIZE, BeatsFrameDecoder.DEFAULT_MAX_COMPRESSED_PAYLOAD_SIZE);
+        maxDecompressedPayloadSize = configuration.getInt(CK_MAX_DECOMPRESSED_PAYLOAD_SIZE, BeatsFrameDecoder.DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE);
     }
 
     @Override
     protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getCustomChildChannelHandlers(MessageInput input) {
         final LinkedHashMap<String, Callable<? extends ChannelHandler>> handlers = new LinkedHashMap<>(super.getCustomChildChannelHandlers(input));
-        handlers.put("beats", BeatsFrameDecoder::new);
+        handlers.put("beats", () -> new BeatsFrameDecoder(maxCompressedPayloadSize, maxDecompressedPayloadSize));
 
         return handlers;
     }
@@ -77,6 +87,22 @@ public class BeatsTransport extends AbstractTcpTransport {
             if (cr.containsField(NettyTransport.CK_PORT)) {
                 cr.getField(NettyTransport.CK_PORT).setDefaultValue(5044);
             }
+            cr.addField(new NumberField(
+                    CK_MAX_COMPRESSED_PAYLOAD_SIZE,
+                    "Maximum allowed compressed payload size",
+                    BeatsFrameDecoder.DEFAULT_MAX_COMPRESSED_PAYLOAD_SIZE,
+                    "Payloads larger than this value are rejected. If you use a non-default bulk_max_size " +
+                            "and have large messages, check that this value is sufficient.",
+                    NumberField.Attribute.ONLY_POSITIVE
+            ));
+            cr.addField(new NumberField(
+                    CK_MAX_DECOMPRESSED_PAYLOAD_SIZE,
+                    "Maximum allowed decompressed payload size",
+                    BeatsFrameDecoder.DEFAULT_MAX_DECOMPRESSED_PAYLOAD_SIZE,
+                    "If a payload after decompressing it exceeds this size, it is rejected. This protects against " +
+                            "decompression attacks and rarely needs to be adjusted.",
+                    NumberField.Attribute.ONLY_POSITIVE
+            ));
             return cr;
         }
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.logging.LoggingHandler;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.zip.Deflater;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class BeatsFrameDecoderTest {
     private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
@@ -237,5 +239,47 @@ public class BeatsFrameDecoderTest {
         final long seqNum = buffer.readUnsignedInt();
         assertThat(buffer.readableBytes()).isEqualTo(0);
         return seqNum;
+    }
+
+    @Test
+    public void rejectsJsonFrameExceedingLengthLimit() {
+        final byte[] oversizedJson = ("{\"message\":\"" + "X".repeat(16 * 1024 * 1024) + "\"}")
+                .getBytes(StandardCharsets.UTF_8);
+
+        final ByteBuf frame = buildJsonFrame(oversizedJson, 0);
+
+        assertThatThrownBy(() -> {
+            channel.writeInbound(frame);
+            channel.checkException();
+        }).isInstanceOf(DecoderException.class);
+    }
+
+    @Test
+    public void rejectsDataFrameExceedingPairLimit() {
+        final ByteBuf frame = Unpooled.buffer();
+        frame.writeByte('2');
+        frame.writeByte('D');
+        frame.writeInt(0);
+        frame.writeInt(1025);
+
+        assertThatThrownBy(() -> {
+            channel.writeInbound(frame);
+            channel.checkException();
+        }).isInstanceOf(DecoderException.class);
+    }
+
+    @Test
+    public void rejectsDataItemExceedingLengthLimit() {
+        final ByteBuf frame = Unpooled.buffer();
+        frame.writeByte('2');
+        frame.writeByte('D');
+        frame.writeInt(0);
+        frame.writeInt(1);
+        frame.writeInt(1024 * 1024 + 1);
+
+        assertThatThrownBy(() -> {
+            channel.writeInbound(frame);
+            channel.checkException();
+        }).isInstanceOf(DecoderException.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
@@ -28,6 +28,7 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.zip.Deflater;
@@ -42,7 +43,7 @@ public class BeatsFrameDecoderTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        decoder = new BeatsFrameDecoder();
+        decoder = new BeatsFrameDecoder(1024, 10*1024);
         channel = new EmbeddedChannel(new LoggingHandler(), decoder);
     }
 
@@ -280,6 +281,88 @@ public class BeatsFrameDecoderTest {
         assertThatThrownBy(() -> {
             channel.writeInbound(frame);
             channel.checkException();
+        }).isInstanceOf(DecoderException.class);
+    }
+
+    // --- Compressed frame limit tests ---
+
+    private static EmbeddedChannel channelWith(BeatsFrameDecoder decoder) {
+        return new EmbeddedChannel(new LoggingHandler(), decoder);
+    }
+
+    private static byte[] buildInnerJsonFrameBytes(int count, byte[] jsonBytes) {
+        final ByteBuf inner = Unpooled.buffer();
+        for (int i = 0; i < count; i++) {
+            inner.writeByte('2');
+            inner.writeByte('J');
+            inner.writeInt(i);
+            inner.writeInt(jsonBytes.length);
+            inner.writeBytes(jsonBytes);
+        }
+        final byte[] result = new byte[inner.readableBytes()];
+        inner.readBytes(result);
+        inner.release();
+        return result;
+    }
+
+    private static ByteBuf buildCompressedFrameFromPayload(byte[] uncompressedPayload) {
+        final Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION);
+        deflater.setInput(uncompressedPayload);
+        deflater.finish();
+
+        final ByteArrayOutputStream compressedOut = new ByteArrayOutputStream();
+        final byte[] buf = new byte[1024];
+        while (!deflater.finished()) {
+            final int count = deflater.deflate(buf);
+            compressedOut.write(buf, 0, count);
+        }
+        deflater.end();
+        final byte[] compressed = compressedOut.toByteArray();
+
+        final ByteBuf frame = Unpooled.buffer(6 + compressed.length);
+        frame.writeByte('2');
+        frame.writeByte('C');
+        frame.writeInt(compressed.length);
+        frame.writeBytes(compressed);
+        return frame;
+    }
+
+    @Test
+    public void rejectsCompressedFrameWithOversizedCompressedPayload() {
+        final int maxCompressed = 64;
+        final BeatsFrameDecoder limitedDecoder = new BeatsFrameDecoder(maxCompressed, 64 * 1024 * 1024);
+        final EmbeddedChannel ch = channelWith(limitedDecoder);
+
+        final byte[] innerPayload = buildInnerJsonFrameBytes(50,
+                "{\"k\":\"v\"}".getBytes(StandardCharsets.UTF_8));
+        final ByteBuf frame = buildCompressedFrameFromPayload(innerPayload);
+
+        final int compressedSize = frame.readableBytes() - 6;
+        assertThat(compressedSize)
+                .as("compressed payload must exceed limit for this test to be valid")
+                .isGreaterThan(maxCompressed);
+
+        assertThatThrownBy(() -> {
+            ch.writeInbound(frame);
+            ch.checkException();
+        }).isInstanceOf(DecoderException.class);
+    }
+
+    @Test
+    public void rejectsCompressedFrameExceedingDecompressionLimit() {
+        final int maxDecompressed = 256;
+        final BeatsFrameDecoder limitedDecoder = new BeatsFrameDecoder(16 * 1024 * 1024, maxDecompressed);
+        final EmbeddedChannel ch = channelWith(limitedDecoder);
+
+        final byte[] innerPayload = buildInnerJsonFrameBytes(20,
+                "{\"m\":\"AAAA\"}".getBytes(StandardCharsets.UTF_8));
+        assertThat(innerPayload.length).isGreaterThan(maxDecompressed);
+
+        final ByteBuf frame = buildCompressedFrameFromPayload(innerPayload);
+
+        assertThatThrownBy(() -> {
+            ch.writeInbound(frame);
+            ch.checkException();
         }).isInstanceOf(DecoderException.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsFrameDecoderTest.java
@@ -43,7 +43,7 @@ public class BeatsFrameDecoderTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        decoder = new BeatsFrameDecoder(1024, 10*1024);
+        decoder = new BeatsFrameDecoder();
         channel = new EmbeddedChannel(new LoggingHandler(), decoder);
     }
 


### PR DESCRIPTION
## Description
When dealing with compressed beats payloads, we haven't limited their size.
Now we have individual limits for the sizes of the compressed and decompressed payload buffers.

For the decompressed buffer we now also avoid an unnecessary copy and check for exceeding the configured limit during decompression, which can help avoiding pathological decompression bombs.

## Motivation and Context
Without limits and due to eager allocation it was possible to exhaust the available memory.
The defaults should be sensible for running with default beats batch sizes, but they are configurable per input in case users need higher limits (at the expense of more memory usage).

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

