### PR TITLE
Replace react-bootstrap jumbotron with custom implementation.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Jumbotron.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Jumbotron.tsx
@@ -14,15 +14,24 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React, { forwardRef } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
-// eslint-disable-next-line no-restricted-imports
-import { Jumbotron as BootstrapJumbotron } from 'react-bootstrap';
 
-export const StyledJumbotron = styled(BootstrapJumbotron)(
+import { RowContentStyles } from 'components/bootstrap/Row';
+
+export const Container = styled.div(
   ({ theme }) => css`
-    color: ${theme.colors.text.primary};
-    background-color: ${theme.colors.global.contentBackground};
+    ${RowContentStyles}
+
+    padding: ${theme.spacings.lg} ${theme.spacings.md};
+
+    @media (min-width: ${theme.breakpoints.min.sm}) {
+      padding: ${theme.spacings.xl} ${theme.spacings.lg};
+    }
+
+    @media (min-width: ${theme.breakpoints.min.md}) {
+      padding: ${theme.spacings.xl};
+    }
 
     h2 {
       font-weight: bold;
@@ -36,10 +45,13 @@ export const StyledJumbotron = styled(BootstrapJumbotron)(
   `,
 );
 
-const Jumbotron = forwardRef(
-  (props: React.ComponentPropsWithoutRef<typeof BootstrapJumbotron>, ref: React.Ref<any>) => (
-    <StyledJumbotron ref={ref} {...props} />
-  ),
+type JumbotronProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const Jumbotron = ({ children, className = undefined }: JumbotronProps) => (
+  <Container className={className}>{children}</Container>
 );
 
 export default Jumbotron;

--- a/graylog2-web-interface/src/components/errors/ErrorJumbotron.tsx
+++ b/graylog2-web-interface/src/components/errors/ErrorJumbotron.tsx
@@ -24,8 +24,8 @@ import useProductName, { DEFAULT_PRODUCT_NAME } from 'brand-customization/usePro
 
 const H1 = styled.h1(
   ({ theme }) => css`
-    font-size: ${theme.fonts.size.extraLarge};
-    margin-bottom: 15px;
+    font-size: ${theme.fonts.size.huge};
+    margin-bottom: ${theme.spacings.md};
   `,
 );
 

--- a/graylog2-web-interface/src/views/components/Query.tsx
+++ b/graylog2-web-interface/src/views/components/Query.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled, { css } from 'styled-components';
 
 import DocsHelper from 'util/DocsHelper';
 import { Jumbotron } from 'components/bootstrap';
@@ -26,22 +25,11 @@ import WidgetGrid from 'views/components/WidgetGrid';
 import useWidgets from 'views/hooks/useWidgets';
 import usePluggableUpsellWrapper from 'hooks/usePluggableUpsellWrapper';
 
-const StyledJumbotron = styled(Jumbotron)(
-  ({ theme }) => css`
-    .container-fluid & {
-      border: 1px solid ${theme.colors.gray[80]};
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-      margin-bottom: 0;
-    }
-  `,
-);
-
 const NoWidgetsInfo = () => {
   const UpsellWrapper = usePluggableUpsellWrapper();
 
   return (
-    <StyledJumbotron>
+    <Jumbotron>
       <h2>
         <IfDashboard>This dashboard has no widgets yet</IfDashboard>
         <IfSearch>There are no widgets defined to visualize the search result</IfSearch>
@@ -89,7 +77,7 @@ const NoWidgetsInfo = () => {
         You can also have a look at the <DocumentationLink page={DocsHelper.PAGES.DASHBOARDS} text="documentation" />,
         to learn more about the widget creation.
       </p>
-    </StyledJumbotron>
+    </Jumbotron>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -177,6 +177,7 @@ const Search = ({ forceSideBarPinned = false }: Props) => {
   return (
     <>
       <SynchronizationComponent />
+      {/*{test.test}*/}
       <ViewsFieldActionsProvider>
         <ExternalValueActionsProvider>
           <SearchExplainContextProvider>

--- a/graylog2-web-interface/src/views/components/Search.tsx
+++ b/graylog2-web-interface/src/views/components/Search.tsx
@@ -177,7 +177,6 @@ const Search = ({ forceSideBarPinned = false }: Props) => {
   return (
     <>
       <SynchronizationComponent />
-      {/*{test.test}*/}
       <ViewsFieldActionsProvider>
         <ExternalValueActionsProvider>
           <SearchExplainContextProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are migrating our Bootstrap based components to Mantine. There is no good Mantine alternative for the `Jumbotron`. Since it is a simple component it was possible to replace the Boostrap `Jumbotron` with a custom implementation.


/nocl - refactoring
