### PR TITLE
Migrate `HelpBlock` from Bootstrap to custom implementation.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/HelpBlock.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/HelpBlock.tsx
@@ -14,11 +14,9 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-// eslint-disable-next-line no-restricted-imports
-import { HelpBlock as BootstrapHelpBlock } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
 
-const HelpBlock = styled(BootstrapHelpBlock)(
+const HelpBlock = styled.div(
   ({ theme }) => css`
     display: block;
     margin-top: 5px;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.tsx
@@ -20,7 +20,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 import upperFirst from 'lodash/upperFirst';
 
-import { ColorPickerPopover, FormSubmit, Select, SourceCodeEditor } from 'components/common';
+import { ColorPickerPopover, FormSubmit, InputDescription, Select, SourceCodeEditor } from 'components/common';
 import { Button, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row, Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
@@ -260,10 +260,10 @@ const ConfigurationForm = ({
       return (
         <>
           <FormControl.Static>{_formatCollector(collector)}</FormControl.Static>
-          <HelpBlock bsClass="warning">
-            <b>Note:</b> Log Collector cannot change while the Configuration is in use. Clone the Configuration to test
-            it using another Collector.
-          </HelpBlock>
+          <InputDescription
+            error="Log Collector cannot change while the Configuration is in use. Clone the Configuration to test
+            it using another Collector."
+          />
         </>
       );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are migrating our Bootstrap based components to Mantine. For the `HelpBlock`, we can just use a custom implementation, because we were already overriding all its bootstrap stylings.

/nocl - refactoring
