### PR TITLE
Fix null message in events

### DIFF
--- a/changelog/unreleased/pr-26188.toml
+++ b/changelog/unreleased/pr-26188.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "fix potential null messages in events after event summary template transformation."
+issues = []
+pulls = ["26188"]

--- a/graylog2-server/src/main/java/org/graylog/events/event/EventDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/event/EventDto.java
@@ -89,6 +89,7 @@ public abstract class EventDto {
     public abstract Set<String> sourceStreams();
 
     @JsonProperty(FIELD_MESSAGE)
+    @Nullable
     public abstract String message();
 
     @JsonProperty(FIELD_SOURCE)

--- a/graylog2-server/src/main/java/org/graylog/events/processor/modifier/EventSummaryModifier.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/modifier/EventSummaryModifier.java
@@ -64,7 +64,8 @@ public class EventSummaryModifier implements EventModifier {
 
             final ImmutableMap<String, Object> dataModel = dataModelBuilder.build();
 
-            event.setMessage(templateEngine.transform(eventDefinition.eventSummaryTemplate(), dataModel));
+            final var message = templateEngine.transform(eventDefinition.eventSummaryTemplate(), dataModel);
+            event.setMessage(Strings.isNullOrEmpty(message) ? "(empty message after event summary template transformation)" : message);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/modifier/EventSummaryModifier.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/modifier/EventSummaryModifier.java
@@ -34,6 +34,7 @@ import static org.graylog.events.notifications.EventNotificationModelData.FIELD_
 
 public class EventSummaryModifier implements EventModifier {
     private final Engine templateEngine;
+    public static final String EMPTY_MESSAGE_AFTER_TRANSFORMATION = "(empty message after event summary template transformation)";
 
     @Inject
     public EventSummaryModifier(Engine templateEngine) {
@@ -65,7 +66,7 @@ public class EventSummaryModifier implements EventModifier {
             final ImmutableMap<String, Object> dataModel = dataModelBuilder.build();
 
             final var message = templateEngine.transform(eventDefinition.eventSummaryTemplate(), dataModel);
-            event.setMessage(Strings.isNullOrEmpty(message) ? "(empty message after event summary template transformation)" : message);
+            event.setMessage(Strings.isNullOrEmpty(message) ? EMPTY_MESSAGE_AFTER_TRANSFORMATION : message);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/processor/modifier/EventSummaryModifierTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/modifier/EventSummaryModifierTest.java
@@ -40,6 +40,7 @@ import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.events.processor.modifier.EventSummaryModifier.EMPTY_MESSAGE_AFTER_TRANSFORMATION;
 
 class EventSummaryModifierTest {
     private static final int SEARCH_WINDOW_MS = 30000;
@@ -110,6 +111,28 @@ class EventSummaryModifierTest {
         modifier.accept(eventWithContext, eventDefinitionDto);
 
         assertThat(event.getMessage()).isEqualTo("jane failed to login 5 times");
+    }
+
+    @Test
+    void emptyTemplateResultReplacedByDefaultString() throws Exception {
+        final EventDefinitionDto eventDefinitionDto = buildEventDefinitionDto(ImmutableSet.of(), ImmutableList.of(), null, emptyList())
+                .toBuilder()
+                .eventSummaryTemplate("${fields.does_not_exist}")
+                .build();
+
+        final EventSummaryModifier modifier = new EventSummaryModifier(new Engine());
+
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final TestEvent event = new TestEvent(now);
+        event.setField("user", FieldValue.string("jane"));
+
+        final Message message = messageFactory.createMessage("message", "src", now);
+        message.addField("aggregation_value_count", 5);
+
+        final EventWithContext eventWithContext = EventWithContext.create(event, message);
+        modifier.accept(eventWithContext, eventDefinitionDto);
+
+        assertThat(event.getMessage()).isEqualTo(EMPTY_MESSAGE_AFTER_TRANSFORMATION);
     }
 
     private EventDefinitionDto buildEventDefinitionDto(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes two things happening with events:
- if the event summary template after transformation returns an empty string `""`, the event written to the indexer ends up as a `null` value in the message attribute. (OpenSearch behaviour, not further researched, why it's like that. But we definitely send a `""`)

This is now fixed by adding a default message that makes clear that you need to improve your event definition.

- the `null` value in an event.message attribute created errors loading them into the Alerts/Events table. 

This is not an issue when loading it into the regular search so I added `@Nullable` to ease the contract for the loading of events in other contexts. The FE works fine without a message.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

