### PR TITLE
Properly align dropdown button for showing more dashboard tabs.

### DIFF
--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -155,6 +155,14 @@ const QueryTab = styled(NavItem)`
   }
 `;
 
+const NewTabLi = ({ onClick }: { onClick: () => void }) => (
+  <li className={NEW_TAB_BUTTON_CLASS}>
+    <Button bsStyle="transparent" title="Create New Page" onClick={onClick}>
+      <Icon name="add" />
+    </Button>
+  </li>
+);
+
 const MoreTabsLi = ({ menuItems }: { menuItems: OrderedSet<React.ReactNode> }) => (
   <li className={MORE_TABS_LI_CLASS}>
     <MoreActionsMenu
@@ -411,22 +419,17 @@ const AdaptableQueryTabs = ({
 
         {currentTabs.lockedItems.toArray()}
 
-        <li className={NEW_TAB_BUTTON_CLASS}>
-          <Button
-            bsStyle="transparent"
-            title="Create New Page"
-            onClick={() => {
-              sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_PAGE, {
-                app_pathname: 'dashboard',
-                app_section: 'dashboard',
-                app_action_value: 'dashboard-create-page-button',
-              });
+        <NewTabLi
+          onClick={() => {
+            sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_PAGE, {
+              app_pathname: 'dashboard',
+              app_section: 'dashboard',
+              app_action_value: 'dashboard-create-page-button',
+            });
 
-              onSelect('new');
-            }}>
-            <Icon name="add" />
-          </Button>
-        </li>
+            onSelect('new');
+          }}
+        />
       </StyledQueryNav>
       <Button
         bsStyle="transparent"

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -24,7 +24,7 @@ import UserNotification from 'util/UserNotification';
 import type { QueryId } from 'views/logic/queries/Query';
 import type QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
 import { Nav, NavItem, MenuItem, Button } from 'components/bootstrap';
-import { Icon, IconButton } from 'components/common';
+import { Icon } from 'components/common';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
 import CopyToDashboardForm from 'views/components/widgets/CopyToDashboardForm';
@@ -76,10 +76,22 @@ const MORE_TABS_BUTTON_CLASS = 'query-tabs-more';
 const MORE_TABS_LI_CLASS = 'query-tabs-more-li';
 const NEW_TAB_BUTTON_CLASS = 'query-tab-create';
 
+const tabButtonStyles = css`
+  height: 100%;
+  width: auto;
+  padding: 10px 15px;
+  // same color as IconButton
+  color: ${({ theme }) => theme.colors.gray[60]};
+`;
+
 const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  .query-config-btn {
+    ${tabButtonStyles}
+  }
 `;
 
 const StyledQueryNav = styled(Nav)(
@@ -108,7 +120,7 @@ const StyledQueryNav = styled(Nav)(
 
       > li.${MORE_TABS_LI_CLASS} > button,
       > li.${NEW_TAB_BUTTON_CLASS} > button {
-        padding: 10px 15px;
+        ${tabButtonStyles}
       }
 
       > li.active {
@@ -145,7 +157,7 @@ const QueryTab = styled(NavItem)`
 
 const NewTabLi = ({ onClick }: { onClick: () => void }) => (
   <li className={NEW_TAB_BUTTON_CLASS}>
-    <Button title="Create New Page" onClick={onClick} bsStyle="transparent">
+    <Button bsStyle="transparent" title="Create New Page" onClick={onClick}>
       <Icon name="add" />
     </Button>
   </li>
@@ -157,7 +169,6 @@ const MoreTabsLi = ({ menuItems }: { menuItems: OrderedSet<React.ReactNode> }) =
       className={MORE_TABS_BUTTON_CLASS}
       id="query-tabs-more"
       aria-label="More Dashboard Pages"
-      bsStyle="transparent"
       keepMounted
       pullRight>
       {menuItems.toArray()}
@@ -420,9 +431,9 @@ const AdaptableQueryTabs = ({
           }}
         />
       </StyledQueryNav>
-      <IconButton
+      <Button
+        bsStyle="transparent"
         title="Open pages configuration"
-        name="settings"
         ref={queriesConfigBtn}
         className="query-config-btn"
         onClick={() => {
@@ -433,8 +444,9 @@ const AdaptableQueryTabs = ({
           });
 
           setShowConfigurationModal(true);
-        }}
-      />
+        }}>
+        <Icon name="settings" />
+      </Button>
       {showConfigurationModal && (
         <AdaptableQueryTabsConfiguration
           show={showConfigurationModal}

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -23,7 +23,7 @@ import { OrderedSet } from 'immutable';
 import UserNotification from 'util/UserNotification';
 import type { QueryId } from 'views/logic/queries/Query';
 import type QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
-import { Nav, NavItem, MenuItem } from 'components/bootstrap';
+import { Nav, NavItem, MenuItem, Button } from 'components/bootstrap';
 import { Icon, IconButton } from 'components/common';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import AdaptableQueryTabsConfiguration from 'views/components/AdaptableQueryTabsConfiguration';
@@ -106,6 +106,11 @@ const StyledQueryNav = styled(Nav)(
         }
       }
 
+      > li.${MORE_TABS_LI_CLASS} > button,
+      > li.${NEW_TAB_BUTTON_CLASS} > button {
+        padding: 10px 15px;
+      }
+
       > li.active {
         display: flex;
         flex-direction: column;
@@ -128,10 +133,6 @@ const StyledQueryNav = styled(Nav)(
           }
         }
       }
-
-      > li.${MORE_TABS_BUTTON_CLASS}, > li.${MORE_TABS_BUTTON_CLASS} a {
-        cursor: pointer;
-      }
     }
   `,
 );
@@ -142,13 +143,21 @@ const QueryTab = styled(NavItem)`
   }
 `;
 
+const NewTabLi = ({ onClick }: { onClick: () => void }) => (
+  <li className={NEW_TAB_BUTTON_CLASS}>
+    <Button title="Create New Page" onClick={onClick} bsStyle="transparent">
+      <Icon name="add" />
+    </Button>
+  </li>
+);
+
 const MoreTabsLi = ({ menuItems }: { menuItems: OrderedSet<React.ReactNode> }) => (
   <li className={MORE_TABS_LI_CLASS}>
     <MoreActionsMenu
       className={MORE_TABS_BUTTON_CLASS}
       id="query-tabs-more"
       aria-label="More Dashboard Pages"
-      bsStyle="link"
+      bsStyle="transparent"
       keepMounted
       pullRight>
       {menuItems.toArray()}
@@ -399,10 +408,7 @@ const AdaptableQueryTabs = ({
 
         {currentTabs.lockedItems.toArray()}
 
-        <QueryTab
-          key="new"
-          eventKey="new"
-          title="Create New Page"
+        <NewTabLi
           onClick={() => {
             sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_PAGE, {
               app_pathname: 'dashboard',
@@ -412,9 +418,7 @@ const AdaptableQueryTabs = ({
 
             onSelect('new');
           }}
-          className={NEW_TAB_BUTTON_CLASS}>
-          <Icon name="add" />
-        </QueryTab>
+        />
       </StyledQueryNav>
       <IconButton
         title="Open pages configuration"

--- a/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
+++ b/graylog2-web-interface/src/views/components/AdaptableQueryTabs.tsx
@@ -155,14 +155,6 @@ const QueryTab = styled(NavItem)`
   }
 `;
 
-const NewTabLi = ({ onClick }: { onClick: () => void }) => (
-  <li className={NEW_TAB_BUTTON_CLASS}>
-    <Button bsStyle="transparent" title="Create New Page" onClick={onClick}>
-      <Icon name="add" />
-    </Button>
-  </li>
-);
-
 const MoreTabsLi = ({ menuItems }: { menuItems: OrderedSet<React.ReactNode> }) => (
   <li className={MORE_TABS_LI_CLASS}>
     <MoreActionsMenu
@@ -419,17 +411,22 @@ const AdaptableQueryTabs = ({
 
         {currentTabs.lockedItems.toArray()}
 
-        <NewTabLi
-          onClick={() => {
-            sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_PAGE, {
-              app_pathname: 'dashboard',
-              app_section: 'dashboard',
-              app_action_value: 'dashboard-create-page-button',
-            });
+        <li className={NEW_TAB_BUTTON_CLASS}>
+          <Button
+            bsStyle="transparent"
+            title="Create New Page"
+            onClick={() => {
+              sendTelemetry(TELEMETRY_EVENT_TYPE.DASHBOARD_ACTION.DASHBOARD_CREATE_PAGE, {
+                app_pathname: 'dashboard',
+                app_section: 'dashboard',
+                app_action_value: 'dashboard-create-page-button',
+              });
 
-            onSelect('new');
-          }}
-        />
+              onSelect('new');
+            }}>
+            <Icon name="add" />
+          </Button>
+        </li>
       </StyledQueryNav>
       <Button
         bsStyle="transparent"

--- a/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/DashboardActionsMenu.tsx
@@ -172,7 +172,7 @@ const DashboardActionsMenu = () => {
         />
       )}
       {showDropDownButton && (
-        <MoreActionsMenu id="query-tab-actions-dropdown" pullRight keepMounted solid>
+        <MoreActionsMenu id="query-tab-actions-dropdown" pullRight keepMounted>
           {dashboardActions.length > 0 && (
             <>
               {dashboardActions}

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -252,7 +252,7 @@ const SearchActionsMenu = () => {
         bsStyle="default"
         disabledInfo={isNew && 'Only saved searches can be shared.'}
       />
-      <MoreActionsMenu aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight solid>
+      <MoreActionsMenu aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight>
         <MenuItem onSelect={toggleMetadataEdit} disabled={!isAllowedToEdit} icon="edit">
           Edit metadata
         </MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR unifies and fixes the styling of buttons in the dashboard tabs bar.

Before
<img width="261" height="116" alt="image" src="https://github.com/user-attachments/assets/f5366b37-61be-453c-9564-684c95770ae6" />


After
<img width="302" height="130" alt="image" src="https://github.com/user-attachments/assets/6b9ee5e6-97fd-4b62-8bd2-437ac1cef058" />


/nocl
