### PR TITLE
Fix extractors being deleted when an input is started or stopped

### DIFF
--- a/changelog/unreleased/issue-26009.toml
+++ b/changelog/unreleased/issue-26009.toml
@@ -2,4 +2,4 @@ type = "fixed"
 message = "Fix extractors being deleted when an input is started, stopped, or updated."
 
 issues = ["26009"]
-pulls = [""]
+pulls = ["26198"]

--- a/changelog/unreleased/issue-26009.toml
+++ b/changelog/unreleased/issue-26009.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fix extractors being deleted when an input is started, stopped, or updated."
+
+issues = ["26009"]
+pulls = [""]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputImpl.java
@@ -120,6 +120,15 @@ public abstract class InputImpl implements Input, MongoEntity {
         return result;
     }
 
+    /**
+     * The embedded extractor documents. They are modified through targeted update operations (see
+     * {@code InputServiceImpl#addExtractor} etc.) and only modeled here so that they survive full document
+     * replacements when saving an input.
+     */
+    @Nullable
+    @JsonProperty(EMBEDDED_EXTRACTORS)
+    public abstract List<Map<String, Object>> getEmbeddedExtractors();
+
     @NotNull
     @JsonProperty(FIELD_TYPE)
     public abstract String getType();
@@ -179,6 +188,9 @@ public abstract class InputImpl implements Input, MongoEntity {
         @JsonProperty(EMBEDDED_STATIC_FIELDS)
         public abstract Builder setEmbeddedStaticFields(List<Map<String, String>> staticFields);
 
+        @JsonProperty(EMBEDDED_EXTRACTORS)
+        public abstract Builder setEmbeddedExtractors(List<Map<String, Object>> extractors);
+
         @JsonProperty(FIELD_TYPE)
         public abstract Builder setType(String type);
 
@@ -224,6 +236,11 @@ public abstract class InputImpl implements Input, MongoEntity {
         final List<Map<String, String>> staticFields = getEmbeddedStaticFields();
         if (staticFields != null && !getStaticFields().isEmpty()) {
             doc.put(EMBEDDED_STATIC_FIELDS, getEmbeddedStaticFields());
+        }
+
+        final List<Map<String, Object>> extractors = getEmbeddedExtractors();
+        if (extractors != null && !extractors.isEmpty()) {
+            doc.put(EMBEDDED_EXTRACTORS, extractors);
         }
 
         if (getContentPack() != null) {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -296,6 +296,11 @@ public class InputServiceImpl implements InputService {
             builder.setEmbeddedStaticFields(staticFields);
         }
 
+        final List<Map<String, Object>> extractors = (List<Map<String, Object>>) fields.get(InputImpl.EMBEDDED_EXTRACTORS);
+        if (extractors != null && !extractors.isEmpty()) {
+            builder.setEmbeddedExtractors(extractors);
+        }
+
         if (!isGlobal) {
             builder.setNodeId((String) fields.get(MessageInput.FIELD_NODE_ID));
         }
@@ -762,8 +767,12 @@ public class InputServiceImpl implements InputService {
 
     @Override
     public void persistDesiredState(Input input, IOState.Type desiredState) throws ValidationException {
-        final Input updatedInput = input.withDesiredState(desiredState);
-        saveWithoutEvents(updatedInput);
+        // Use a targeted update instead of saving the whole input to avoid overwriting concurrent changes
+        // to other parts of the input document.
+        collection.updateOne(
+                MongoUtils.idEq(input.getId()),
+                Updates.set(InputImpl.FIELD_DESIRED_STATE, desiredState.name())
+        );
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputServiceImplTest.java
@@ -448,6 +448,7 @@ public class InputServiceImplTest {
                 .setEmbeddedStaticFields(List.of(
                         Map.of(InputImpl.FIELD_STATIC_FIELD_KEY, "static_key",
                                 InputImpl.FIELD_STATIC_FIELD_VALUE, "static_value")))
+                .setEmbeddedExtractors(List.of(createCopyInputExtractor().getPersistedFields()))
                 .build();
 
         final String id = inputService.save(input);
@@ -466,10 +467,62 @@ public class InputServiceImplTest {
                 InputImpl.FIELD_GLOBAL,
                 InputImpl.FIELD_CONFIGURATION,
                 InputImpl.EMBEDDED_STATIC_FIELDS,
+                InputImpl.EMBEDDED_EXTRACTORS,
                 InputImpl.FIELD_DESIRED_STATE,
                 InputImpl.FIELD_CONTENT_PACK,
                 InputImpl.FIELD_NODE_ID
         );
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/Graylog2/graylog2-server/issues/26009">#26009</a>:
+     * persisting the desired state when starting or stopping an input must not delete its extractors.
+     */
+    @Test
+    void persistDesiredStateKeepsExtractors() throws Exception {
+        final Input input = inputService.find(inputService.save(createTestInput()));
+        inputService.addExtractor(input, createCopyInputExtractor());
+
+        inputService.persistDesiredState(input, IOState.Type.STOPPED);
+
+        assertThat(inputService.extractorCountByInputId(List.of(input.getId())))
+                .containsEntry(input.getId(), 1);
+        assertThat(inputService.find(input.getId()).getDesiredState()).isEqualTo(IOState.Type.STOPPED);
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/Graylog2/graylog2-server/issues/26009">#26009</a>:
+     * saving an input that was loaded from the database must round-trip the embedded extractors.
+     */
+    @Test
+    void saveKeepsExtractors() throws Exception {
+        final Input input = inputService.find(inputService.save(createTestInput()));
+        inputService.addExtractor(input, createCopyInputExtractor());
+
+        inputService.save(inputService.find(input.getId()));
+
+        assertThat(inputService.extractorCountByInputId(List.of(input.getId())))
+                .containsEntry(input.getId(), 1);
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/Graylog2/graylog2-server/issues/26009">#26009</a>:
+     * the input update flow in {@code InputsResource} merges via the {@code getFields()} Map view and
+     * re-creates the input from the merged map. Extractors must survive this round-trip, too.
+     */
+    @Test
+    void updateViaFieldsMapKeepsExtractors() throws Exception {
+        final Input input = inputService.find(inputService.save(createTestInput()));
+        inputService.addExtractor(input, createCopyInputExtractor());
+
+        final Input reloaded = inputService.find(input.getId());
+        final Map<String, Object> mergedFields = new HashMap<>(reloaded.getFields());
+        mergedFields.put(MessageInput.FIELD_TITLE, "updated title");
+        inputService.update(inputService.create(reloaded.getId(), mergedFields));
+
+        assertThat(inputService.extractorCountByInputId(List.of(input.getId())))
+                .containsEntry(input.getId(), 1);
+        assertThat(inputService.find(input.getId()).getTitle()).isEqualTo("updated title");
     }
 
     @Test


### PR DESCRIPTION
Closes #26009

## Description

Since 7.1.0, extractors were deleted whenever an input was started, stopped, or updated. This was a regression from the `PersistedImpl` to AutoValue migration of `InputImpl` (#24057): the new entity did not model the  embedded `extractors` array, so loading an input silently discarded its extractors, and saving via `replaceOne` then persisted the loss by replacing the whole document. Starting/stopping an input triggers such a save since #25338 (`persistDesiredState`), and updating an input had the same effect through the `getFields()` merge in  `InputsResource`.

Fixed by modeling the embedded extractor documents on `InputImpl` (analogous to the embedded static fields) so they survive full document round-trips, carrying them through `getFields()` and `buildFromMap()`, and turning `persistDesiredState()` into a targeted update of the `desired_state` field so state changes no longer rewrite the whole document.

Verified that we did not perform any other such migrations in 7.1.

## How Tested

  - New regression tests in `InputServiceImplTest`: `persistDesiredStateKeepsExtractors`, `saveKeepsExtractors`,  `updateViaFieldsMapKeepsExtractors`
  - Extended the `persistedDocumentContainsOnlyExpectedFields` contract test to cover the `extractors` field

Manual testing: create an input, add an extractor to it, then stop and start the input from the Inputs page.  The extractor must still be listed afterwards. Also edit the input (e.g. change the title) and save, then  verify the extractor is still present.

## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Refactoring (non-breaking change)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have requested a documentation update.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.