### PR TITLE
Fix sidecar server config loading (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26200.toml
+++ b/changelog/unreleased/pr-26200.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix Sidecar config not being loaded from the Graylog server configuration file."
+
+pulls = ["26200"]

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -43,6 +43,7 @@ import org.graylog.plugins.map.config.GeoIpProcessorConfig;
 import org.graylog.plugins.netflow.NetFlowPluginModule;
 import org.graylog.plugins.pipelineprocessor.PipelineConfig;
 import org.graylog.plugins.sidecar.SidecarModule;
+import org.graylog.plugins.sidecar.common.SidecarPluginConfiguration;
 import org.graylog.plugins.views.ViewsBindings;
 import org.graylog.plugins.views.ViewsConfig;
 import org.graylog.plugins.views.search.rest.scriptingapi.ScriptingApiModule;
@@ -150,6 +151,7 @@ public class Server extends ServerBootstrap {
     private final ContentStreamConfiguration contentStreamConfiguration = new ContentStreamConfiguration();
     private final DnsLookupAdapterConfiguration dnsLookupAdapterConfiguration = new DnsLookupAdapterConfiguration();
     private final EventDefinitionConfiguration eventDefinitionConfiguration = new EventDefinitionConfiguration();
+    private final SidecarPluginConfiguration sidecarPluginConfiguration = new SidecarPluginConfiguration();
 
     @Option(name = {"-l", "--local"}, description = "Run Graylog in local mode. Only interesting for Graylog developers.")
     private boolean local = false;
@@ -244,7 +246,8 @@ public class Server extends ServerBootstrap {
                 telemetryConfiguration,
                 contentStreamConfiguration,
                 dnsLookupAdapterConfiguration,
-                eventDefinitionConfiguration);
+                eventDefinitionConfiguration,
+                sidecarPluginConfiguration);
     }
 
     @Override


### PR DESCRIPTION
Note: This is a backport of https://github.com/Graylog2/graylog2-server/pull/26200 to `7.0`. (manually created due to conflicts)

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes an issue with `SidecarPluginConfiguration` not being registered as a server config bean. Its `sidecar_*` settings in `graylog.conf` were ignored and always fell back to default values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

