### PR TITLE
Make typed apply method public in MCP Tool base class

### DIFF
--- a/changelog/unreleased/pr-26228.toml
+++ b/changelog/unreleased/pr-26228.toml
@@ -1,5 +1,0 @@
-type = "changed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
-message = "Make Tool.apply method with typed parameters available to call directly by widening its visibility"
-
-issues = [""]
-pulls = ["26228"]

--- a/changelog/unreleased/pr-26228.toml
+++ b/changelog/unreleased/pr-26228.toml
@@ -1,0 +1,5 @@
+type = "changed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Make Tool.apply method with typed parameters available to call directly by widening its visibility"
+
+issues = [""]
+pulls = ["26228"]

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
@@ -143,6 +143,7 @@ public abstract class Tool<P, O> {
      * Calls the tool implementation with the raw parameter map.
      * Internally this will get converted into the actual parameter type for type safety.
      *
+     * @param permissionHelper provides permission checks and user identity for the calling user
      * @param parameterMap raw parameter map
      * @return the return value of the tool call
      */
@@ -151,5 +152,12 @@ public abstract class Tool<P, O> {
         return apply(permissionHelper, p);
     }
 
-    protected abstract O apply(PermissionHelper permissionHelper, P parameters);
+    /**
+     * Executes the tool logic with typed parameters and the caller's permission context.
+     *
+     * @param permissionHelper provides permission checks and user identity for the calling user
+     * @param parameters the deserialized, tool-specific parameter object
+     * @return the tool's result, typically a JSON string or structured response object
+     */
+    public abstract O apply(PermissionHelper permissionHelper, P parameters);
 }

--- a/graylog2-server/src/main/java/org/graylog/mcp/tools/ListFieldsTool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/tools/ListFieldsTool.java
@@ -67,7 +67,7 @@ public class ListFieldsTool extends Tool<ListFieldsTool.Parameters, ListFieldsTo
     }
 
     @Override
-    protected Result apply(final PermissionHelper permissionHelper, final ListFieldsTool.Parameters parameters) {
+    public Result apply(final PermissionHelper permissionHelper, final ListFieldsTool.Parameters parameters) {
         final Set<String> messageStreamIds = permissionHelper.getSearchUser().streams().loadAllMessageStreams();
         Set<String> filteredMessageStreamIds = messageStreamIds;
         if (parameters.streams() != null && !parameters.streams().isEmpty()) {


### PR DESCRIPTION
## Summary
- Widens the abstract `apply(PermissionHelper, P)` method in `Tool<P, O>` from `protected` to `public`, allowing direct invocation with typed parameters from outside the class hierarchy.
- Updates `ListFieldsTool` (the only g2s tool that was still `protected`) to match.
- Adds `@param`/`@return` javadoc to both `apply` overloads.

## Motivation
MCP tools encapsulate reusable business logic (permission checks, query building, response formatting) that other components need to call directly with already-typed parameters. The `protected` visibility forced consumers to either create adapter subclasses solely for visibility bridging, or roundtrip through the `Map<String, Object>` overload unnecessarily.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/14384
/nocl internal refactor

## Test plan
- [x] Cross-repo compilation passes (`mvnw compile -Dskip.web.build=true`)
- [x] Existing `McpServiceTest` passes (uses mock on the `Map` overload, unaffected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)