### PR TITLE
Preserve entity IDs on content-pack upgrade and report EntitySource type (7.0)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventDefinitionEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventDefinitionEntity.java
@@ -177,6 +177,16 @@ public abstract class EventDefinitionEntity extends ScopedContentPackEntity impl
 
     @Override
     public EventDefinitionDto toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+        return toNativeEntity(parameters, nativeEntities, EventDefinitionDto.builder());
+    }
+
+    /**
+     * Applies the content-pack fields onto the given builder. Pass {@code existing.toBuilder()} on the
+     * upgrade path so fields the pack doesn't carry (e.g. {@code id}, {@code state}) keep their stored values.
+     */
+    public EventDefinitionDto toNativeEntity(Map<String, ValueReference> parameters,
+                                             Map<EntityDescriptor, Object> nativeEntities,
+                                             EventDefinitionDto.Builder builder) {
         final ImmutableList<EventNotificationHandler.Config> notificationList = ImmutableList.copyOf(
                 notifications().stream()
                         .map(notification -> notification.toNativeEntity(parameters, nativeEntities))
@@ -195,7 +205,7 @@ public abstract class EventDefinitionEntity extends ScopedContentPackEntity impl
                 throw new MissingNativeEntityException(procedureDescriptor);
             }
         }
-        return EventDefinitionDto.builder()
+        return builder
                 .scope(scope() != null ? scope().asString(parameters) : DefaultEntityScope.NAME)
                 .title(title().asString(parameters))
                 .updatedAt(updatedAt())

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -27,6 +27,7 @@ import com.google.common.graph.MutableGraph;
 import jakarta.inject.Inject;
 import org.graylog.events.contentpack.entities.EventDefinitionEntity;
 import org.graylog.events.processor.DBEventDefinitionService;
+import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.events.processor.EventDefinitionHandler;
 import org.graylog.events.processor.EventProcessorExecutionJob;
@@ -37,6 +38,7 @@ import org.graylog.security.GrantDTO;
 import org.graylog.security.entities.EntityRegistrar;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.facades.EntityFacade;
+import org.graylog2.contentpacks.facades.UpdatableEntityFacade;
 import org.graylog2.contentpacks.model.EntityPermissions;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelTypes;
@@ -62,7 +64,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
+public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto>, UpdatableEntityFacade<EventDefinitionDto> {
     private static final Logger LOG = LoggerFactory.getLogger(EventDefinitionFacade.class);
 
     private final ObjectMapper objectMapper;
@@ -162,6 +164,27 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
 
         return eventDefinition.map(eventDefinitionDto ->
                 NativeEntity.create(nativeEntityDescriptor, eventDefinitionDto));
+    }
+
+    @Override
+    public void updateNativeEntity(Entity entity, NativeEntity<EventDefinitionDto> existingEntity,
+                                   Map<String, ValueReference> parameters,
+                                   Map<EntityDescriptor, Object> nativeEntities, String username) {
+        if (!(entity instanceof EntityV1 entityV1)) {
+            return;
+        }
+        final EventDefinitionDto existing = existingEntity.entity();
+        final EventDefinitionEntity eventDefinitionEntity = objectMapper.convertValue(entityV1.data(),
+                EventDefinitionEntity.class);
+        // Seed with the existing entity so fields the pack doesn't carry (id, state, ...) keep their
+        // stored values; guard scope since the mutability bypass below would otherwise let the pack change it.
+        final EventDefinitionDto updated = eventDefinitionEntity
+                .toNativeEntity(parameters, nativeEntities, existing.toBuilder())
+                .toBuilder().scope(existing.scope()).build();
+        // Scheduling follows the user's enabled/disabled choice, not the pack's is_scheduled flag.
+        final boolean schedule = existing.state() == EventDefinition.State.ENABLED;
+        // checkMutability = false: installer-driven write, must rewrite immutable Illuminate content in place.
+        eventDefinitionHandler.update(updated, schedule, false);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
@@ -112,6 +112,17 @@ public class DBEventDefinitionService {
     }
 
     public EventDefinitionDto save(final EventDefinitionDto entity) {
+        return save(entity, true);
+    }
+
+    /**
+     * Save an event definition, optionally bypassing the scope mutability check.
+     *
+     * <p>Passing {@code checkMutability = false} is intended only for system-driven writes such as
+     * Illuminate content-pack upgrades, which must rewrite the content of immutable Illuminate-scoped
+     * definitions in place (to preserve their IDs). Never pass {@code false} for user-initiated API requests.</p>
+     */
+    public EventDefinitionDto save(final EventDefinitionDto entity, final boolean checkMutability) {
         EventDefinitionDto enrichedWithUpdateDate = entity
                 .toBuilder()
                 .updatedAt(DateTime.now(DateTimeZone.UTC))
@@ -119,8 +130,10 @@ public class DBEventDefinitionService {
         if (enrichedWithUpdateDate.id() == null) {
             final String id = scopedEntityMongoUtils.create(enrichedWithUpdateDate);
             enrichedWithUpdateDate = enrichedWithUpdateDate.toBuilder().id(id).build();
-        } else {
+        } else if (checkMutability) {
             scopedEntityMongoUtils.update(enrichedWithUpdateDate);
+        } else {
+            scopedEntityMongoUtils.forceUpdate(enrichedWithUpdateDate);
         }
         return getEventDefinitionWithRefetchedFilters(enrichedWithUpdateDate);
     }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionHandler.java
@@ -158,10 +158,20 @@ public class EventDefinitionHandler {
      * @return the updated event definition
      */
     public EventDefinitionDto update(EventDefinitionDto updatedEventDefinition, boolean schedule) {
+        return update(updatedEventDefinition, schedule, true);
+    }
+
+    /**
+     * Like {@link #update(EventDefinitionDto, boolean)}, but allows bypassing the scope mutability check.
+     * Only system-driven writes such as the Illuminate content-pack upgrade path should pass
+     * {@code checkMutability = false}: that path must rewrite the content of immutable Illuminate-scoped
+     * definitions in place to preserve their IDs.
+     */
+    public EventDefinitionDto update(EventDefinitionDto updatedEventDefinition, boolean schedule, boolean checkMutability) {
         // Grab the old record so we can revert to it if something goes wrong
         final Optional<EventDefinitionDto> oldEventDefinition = eventDefinitionService.get(updatedEventDefinition.id());
 
-        final EventDefinitionDto eventDefinition = updateEventDefinition(updatedEventDefinition);
+        final EventDefinitionDto eventDefinition = updateEventDefinition(updatedEventDefinition, checkMutability);
 
         try {
             if (schedule) {
@@ -177,7 +187,7 @@ public class EventDefinitionHandler {
             // Cleanup if anything goes wrong
             LOG.error("Reverting to old event definition <{}/{}> because of an error updating the job definition",
                     eventDefinition.id(), eventDefinition.title(), e);
-            oldEventDefinition.ifPresent(eventDefinitionService::save);
+            oldEventDefinition.ifPresent(dto -> eventDefinitionService.save(dto, checkMutability));
             throw e;
         }
 
@@ -309,8 +319,8 @@ public class EventDefinitionHandler {
                 .orElseThrow(() -> new IllegalArgumentException("Event definition <" + eventDefinitionId + "> doesn't exist"));
     }
 
-    private EventDefinitionDto updateEventDefinition(EventDefinitionDto updatedEventDefinition) {
-        final EventDefinitionDto eventDefinition = eventDefinitionService.save(updatedEventDefinition);
+    private EventDefinitionDto updateEventDefinition(EventDefinitionDto updatedEventDefinition, boolean checkMutability) {
+        final EventDefinitionDto eventDefinition = eventDefinitionService.save(updatedEventDefinition, checkMutability);
         LOG.debug("Updated event definition <{}/{}>", eventDefinition.id(), eventDefinition.title());
         return eventDefinition;
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -47,10 +47,12 @@ import org.graylog2.contentpacks.exceptions.UnexpectedEntitiesException;
 import org.graylog2.contentpacks.facades.EntityWithExcerptFacade;
 import org.graylog2.contentpacks.facades.StreamFacade;
 import org.graylog2.contentpacks.facades.UnsupportedEntityFacade;
+import org.graylog2.contentpacks.facades.UpdatableEntityFacade;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackInstallation;
 import org.graylog2.contentpacks.model.ContentPackUninstallDetails;
 import org.graylog2.contentpacks.model.ContentPackUninstallation;
+import org.graylog2.contentpacks.model.ContentPackUpgrade;
 import org.graylog2.contentpacks.model.ContentPackV1;
 import org.graylog2.contentpacks.model.EntityPermissions;
 import org.graylog2.contentpacks.model.LegacyContentPack;
@@ -239,6 +241,152 @@ public class ContentPackService {
         return contentPackInstallationPersistenceService.insert(installation);
     }
 
+    public ContentPackUpgrade upgradeContentPack(ContentPack contentPack,
+                                                 ContentPackInstallation oldInstallation,
+                                                 Map<String, ValueReference> parameters,
+                                                 String comment,
+                                                 String username,
+                                                 EntityShareRequest shareRequest) {
+        return UserContext.runAs(username, userService, () -> {
+            try {
+                final var userContext = new UserContext.Factory(userService).create();
+                return upgradeContentPack(contentPack, oldInstallation, parameters, comment, userContext, shareRequest);
+            } catch (UserContextMissingException e) {
+                throw new IllegalArgumentException("User Context missing", e);
+            }
+        });
+    }
+
+    public ContentPackUpgrade upgradeContentPack(ContentPack contentPack,
+                                                 ContentPackInstallation oldInstallation,
+                                                 Map<String, ValueReference> parameters,
+                                                 String comment,
+                                                 UserContext userContext,
+                                                 EntityShareRequest shareRequest) {
+        if (contentPack instanceof ContentPackV1 contentPackV1) {
+            return upgradeContentPack(contentPackV1, oldInstallation, parameters, comment, userContext, shareRequest);
+        } else {
+            throw new IllegalArgumentException("Unsupported content pack version: " + contentPack.version());
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private ContentPackUpgrade upgradeContentPack(ContentPackV1 contentPack,
+                                                  ContentPackInstallation oldInstallation,
+                                                  Map<String, ValueReference> parameters,
+                                                  String comment,
+                                                  UserContext userContext,
+                                                  EntityShareRequest shareRequest) {
+        ensureConstraints(contentPack.constraints());
+
+        final Map<ModelId, NativeEntityDescriptor> oldEntityMapping = new HashMap<>();
+        for (NativeEntityDescriptor descriptor : oldInstallation.entities()) {
+            oldEntityMapping.put(descriptor.contentPackEntityId(), descriptor);
+        }
+
+        final Entity rootEntity = EntityV1.createRoot(contentPack);
+        final ImmutableMap<String, ValueReference> validatedParameters = validateParameters(parameters, contentPack.parameters());
+        final ImmutableGraph<Entity> dependencyGraph = buildEntityGraph(rootEntity, contentPack.entities(), validatedParameters);
+
+        final Traverser<Entity> entityTraverser = Traverser.forGraph(dependencyGraph);
+        final Iterable<Entity> entitiesInOrder = entityTraverser.depthFirstPostOrder(rootEntity);
+
+        final Map<EntityDescriptor, Object> createdEntities = new LinkedHashMap<>();
+        final Map<EntityDescriptor, Object> allEntities = getMapWithSystemStreamEntities();
+        final ImmutableSet.Builder<NativeEntityDescriptor> allEntityDescriptors = ImmutableSet.builder();
+
+        final Map<ModelId, Object> oldEntityObjects = new HashMap<>();
+
+        try {
+            for (Entity entity : entitiesInOrder) {
+                if (entity.equals(rootEntity)) {
+                    continue;
+                }
+
+                final EntityDescriptor entityDescriptor = entity.toEntityDescriptor();
+                final EntityWithExcerptFacade<?, ?> typedFacade = entityFacades.getOrDefault(entity.type(), UnsupportedEntityFacade.INSTANCE);
+                final EntityWithExcerptFacade facade = typedFacade;
+
+                typedFacade.getCreatePermissions(entity).ifPresent(p -> checkPermissions(p, userContext));
+
+                if (configuration.isCloud() && entity.type().equals(INPUT_V1) && entity instanceof EntityV1 entityV1) {
+                    final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
+                    String className = inputEntity.type().asString();
+                    Class inputClass = Class.forName(className);
+                    if (inputClass.getAnnotation(CloudCompatible.class) == null) {
+                        LOG.warn("Ignoring incompatible input {} in cloud", className);
+                        continue;
+                    }
+                }
+
+                final NativeEntityDescriptor oldDescriptor = oldEntityMapping.get(entity.id());
+                if (oldDescriptor != null) {
+                    final Optional<NativeEntity<?>> existingEntity = (Optional) facade.loadNativeEntity(oldDescriptor);
+                    if (existingEntity.isPresent()) {
+                        final NativeEntity nativeEntity = existingEntity.get();
+                        oldEntityObjects.put(entity.id(), nativeEntity.entity());
+
+                        if (facade instanceof UpdatableEntityFacade updatableFacade) {
+                            LOG.trace("Updating existing entity for {} (preserving ID {})", entityDescriptor, oldDescriptor.id());
+                            updatableFacade.updateNativeEntity(entity, nativeEntity, validatedParameters, allEntities, userContext.getUser().getName());
+                            allEntityDescriptors.add(nativeEntity.descriptor());
+                            allEntities.put(entityDescriptor, nativeEntity.entity());
+                        } else {
+                            // The facade doesn't support in-place updates, so fall back to
+                            // delete-and-recreate: content stays fresh, but the ID changes.
+                            LOG.debug("Entity type {} does not support in-place update, recreating entity {}",
+                                    entity.type(), entityDescriptor);
+                            facade.delete(nativeEntity.entity());
+                            final NativeEntity<?> recreatedEntity = facade.createNativeEntity(entity, validatedParameters, allEntities, userContext.getUser().getName());
+                            allEntityDescriptors.add(recreatedEntity.descriptor());
+                            createdEntities.put(entityDescriptor, recreatedEntity.entity());
+                            allEntities.put(entityDescriptor, recreatedEntity.entity());
+                        }
+                    } else {
+                        LOG.trace("Old entity {} no longer exists in DB, creating new", entityDescriptor);
+                        final NativeEntity<?> createdEntity = facade.createNativeEntity(entity, validatedParameters, allEntities, userContext.getUser().getName());
+                        allEntityDescriptors.add(createdEntity.descriptor());
+                        createdEntities.put(entityDescriptor, createdEntity.entity());
+                        allEntities.put(entityDescriptor, createdEntity.entity());
+                    }
+                } else {
+                    LOG.trace("Creating new entity for {}", entityDescriptor);
+                    final NativeEntity<?> createdEntity = facade.createNativeEntity(entity, validatedParameters, allEntities, userContext.getUser().getName());
+                    allEntityDescriptors.add(createdEntity.descriptor());
+                    createdEntities.put(entityDescriptor, createdEntity.entity());
+                    allEntities.put(entityDescriptor, createdEntity.entity());
+                }
+            }
+        } catch (Exception e) {
+            rollback(createdEntities);
+            throw new ContentPackException("Failed to upgrade content pack <" + contentPack.id() + "/" + contentPack.revision() + ">", e);
+        }
+
+        final ContentPackInstallation installation = ContentPackInstallation.builder()
+                .contentPackId(contentPack.id())
+                .contentPackRevision(contentPack.revision())
+                .parameters(validatedParameters)
+                .comment(comment)
+                .entities(allEntityDescriptors.build())
+                .createdAt(Instant.now())
+                .createdBy(userContext.getUser().getName())
+                .build();
+
+        shareEntities(installation, shareRequest, userContext);
+
+        final ContentPackInstallation persistedInstallation = contentPackInstallationPersistenceService.insert(installation);
+
+        final ContentPackUninstallation oldEntitySnapshots = ContentPackUninstallation.builder()
+                .entities(ImmutableSet.copyOf(oldEntityMapping.values()))
+                .entityObjects(ImmutableMap.copyOf(oldEntityObjects))
+                .failedEntities(ImmutableSet.of())
+                .skippedEntities(ImmutableSet.of())
+                .entityGrants(ImmutableMap.of())
+                .build();
+
+        return new ContentPackUpgrade(persistedInstallation, oldEntitySnapshots);
+    }
+
     public void shareEntities(ContentPackInstallation installation, EntityShareRequest shareRequest, UserContext userContext) {
         if (shareRequest.isEmpty()) {
             return;
@@ -410,6 +558,22 @@ public class ContentPackService {
                 .failedEntities(ImmutableSet.copyOf(failedEntities))
                 .entityGrants(ImmutableMap.copyOf(entityGrants))
                 .build();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void deleteNativeEntity(NativeEntityDescriptor descriptor) {
+        final EntityWithExcerptFacade facade = entityFacades.getOrDefault(descriptor.type(), UnsupportedEntityFacade.INSTANCE);
+        final Optional nativeEntity = facade.loadNativeEntity(descriptor);
+        if (nativeEntity.isPresent()) {
+            try {
+                facade.delete(((NativeEntity) nativeEntity.get()).entity());
+                LOG.debug("Deleted native entity {}", descriptor);
+            } catch (Exception e) {
+                LOG.warn("Failed to delete native entity {}", descriptor, e);
+            }
+        } else {
+            LOG.debug("Native entity {} not found, nothing to delete", descriptor);
+        }
     }
 
     private ImmutableGraph<Entity> buildEntityGraph(Entity rootEntity,

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamReferenceFacade.java
@@ -51,7 +51,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public class StreamReferenceFacade extends StreamFacade {
+public class StreamReferenceFacade extends StreamFacade implements UpdatableEntityFacade<Stream> {
     private static final Logger LOG = LoggerFactory.getLogger(StreamReferenceFacade.class);
 
     public static final ModelType TYPE_V1 = ModelTypes.STREAM_REF_V1;
@@ -186,5 +186,18 @@ public class StreamReferenceFacade extends StreamFacade {
     @Override
     public Optional<EntityPermissions> getCreatePermissions(Entity entity) {
         return EntityPermissions.of(RestPermissions.STREAMS_CREATE);
+    }
+
+    /**
+     * Deliberate no-op: a stream reference only points at an existing stream resolved by title.
+     * The stream itself is created and maintained outside the content pack (e.g. by the Illuminate
+     * bundle installer), so there is no content to update in place on upgrade.
+     */
+    @Override
+    public void updateNativeEntity(Entity entity,
+                                   NativeEntity<Stream> existingEntity,
+                                   Map<String, ValueReference> parameters,
+                                   Map<EntityDescriptor, Object> nativeEntities,
+                                   String username) {
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UpdatableEntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UpdatableEntityFacade.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.contentpacks.facades;
+
+import org.graylog2.contentpacks.model.entities.Entity;
+import org.graylog2.contentpacks.model.entities.EntityDescriptor;
+import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import java.util.Map;
+
+/**
+ * Capability interface for facades that support updating an existing native entity in place
+ * during a content pack upgrade, preserving the entity's ID.
+ *
+ * <p>During a content pack upgrade ({@link org.graylog2.contentpacks.ContentPackService#upgradeContentPack}),
+ * a facade that implements this interface has its existing native entity updated in place, preserving
+ * the entity's ID. A facade that does not implement it falls back to delete-and-recreate: the content
+ * is still refreshed from the new revision, but the entity gets a new ID.</p>
+ *
+ * <p>Any entity type shipped in a content pack whose ID must survive upgrades (e.g. Illuminate
+ * spotlight-pack types such as event definitions, dashboards, and stream references) must therefore
+ * opt in — even if the implementation deliberately leaves the entity untouched (see
+ * {@link StreamReferenceFacade}). Types not shipped in upgradable packs, or for which a new ID on
+ * upgrade is acceptable, can simply omit it.</p>
+ */
+public interface UpdatableEntityFacade<EntityClass> {
+
+    /**
+     * Update an existing native entity's content from the content pack entity, preserving its ID.
+     *
+     * @param entity         the content pack entity carrying the new content
+     * @param existingEntity the existing native entity to update in place
+     * @param parameters     user-provided parameters to resolve parameters in the entity model
+     * @param nativeEntities existing native entities to reference during the update
+     * @param username       the name of the user performing the upgrade
+     */
+    void updateNativeEntity(Entity entity,
+                            NativeEntity<EntityClass> existingEntity,
+                            Map<String, ValueReference> parameters,
+                            Map<EntityDescriptor, Object> nativeEntities,
+                            String username);
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
@@ -66,7 +66,7 @@ import java.util.stream.Stream;
 
 import static org.graylog2.contentpacks.facades.StreamReferenceFacade.resolveStreamEntity;
 
-public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, ViewSummaryDTO> {
+public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, ViewSummaryDTO>, UpdatableEntityFacade<ViewDTO> {
     private static final Logger LOG = LoggerFactory.getLogger(ViewFacade.class);
 
     private final ObjectMapper objectMapper;
@@ -161,6 +161,32 @@ public abstract class ViewFacade implements EntityWithExcerptFacade<ViewDTO, Vie
     public Optional<NativeEntity<ViewDTO>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
         Optional<ViewDTO> optionalViewDTO = viewService.get(nativeEntityDescriptor.id().id());
         return optionalViewDTO.map(viewDTO -> NativeEntity.create(nativeEntityDescriptor, viewDTO));
+    }
+
+    @Override
+    public void updateNativeEntity(Entity entity, NativeEntity<ViewDTO> existingEntity,
+                                   Map<String, ValueReference> parameters,
+                                   Map<EntityDescriptor, Object> nativeEntities, String username) {
+        ensureV1(entity);
+        final EntityV1 entityV1 = (EntityV1) entity;
+        final ViewDTO existingView = existingEntity.entity();
+        final ViewEntity viewEntity = objectMapper.convertValue(entityV1.data(), ViewEntity.class);
+
+        final Map<String, ViewStateDTO> viewStateMap = new LinkedHashMap<>(viewEntity.state().size());
+        for (Map.Entry<String, ViewStateEntity> entry : viewEntity.state().entrySet()) {
+            viewStateMap.put(entry.getKey(), entry.getValue().toNativeEntity(parameters, nativeEntities));
+        }
+
+        final ViewDTO.Builder viewBuilder = viewEntity.toNativeEntity(parameters, nativeEntities);
+        viewBuilder.id(existingView.id());
+        viewBuilder.state(viewStateMap);
+
+        final Search search = viewEntity.search().toNativeEntity(parameters, nativeEntities);
+        final Search searchWithId = search.toBuilder().id(existingView.searchId()).build();
+        searchDbService.save(searchWithId);
+
+        viewBuilder.searchId(existingView.searchId());
+        viewService.update(viewBuilder.build());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUpgrade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUpgrade.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.contentpacks.model;
+
+/**
+ * Result of {@link org.graylog2.contentpacks.ContentPackService#upgradeContentPack}.
+ * Bundles the new installation with a snapshot of old entity state captured before the
+ * in-place update, so callers can preserve user customizations (notifications, search filters, etc.).
+ */
+public record ContentPackUpgrade(ContentPackInstallation installation, ContentPackUninstallation oldEntitySnapshots) {
+}

--- a/graylog2-server/src/main/java/org/graylog2/database/entities/source/DBEntitySourceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/source/DBEntitySourceService.java
@@ -56,12 +56,6 @@ public class DBEntitySourceService {
         collection.insertOne(entitySource);
     }
 
-    public void updateParentId(String oldParentId, String newParentId) {
-        final Bson filterByParentId = eq(EntitySource.FIELD_PARENT_ID, oldParentId);
-        final Bson updateParentId = set(EntitySource.FIELD_PARENT_ID, newParentId);
-        collection.updateMany(filterByParentId, updateParentId);
-    }
-
     public void deleteByEntityId(String entityId) {
         bulkDeleteByEntityId(Set.of(entityId));
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySource.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySource.java
@@ -39,6 +39,7 @@ public abstract class EntitySource implements MongoEntity {
     // Entity types
     public static final String VIEW_TYPE = "view";
     public static final String EVENT_DEFINITION_TYPE = "event_definition";
+    public static final String REPORT_TYPE = "report";
 
     public static final String FIELD_ID = "id";
     public static final String FIELD_SOURCE = "source";

--- a/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySourceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/entities/source/EntitySourceService.java
@@ -37,10 +37,6 @@ public class EntitySourceService {
         dbEntitySourceService.deleteByEntityId(entityId);
     }
 
-    public void handleEntityIdChange(String oldEntityId, String newEntityId) {
-        dbEntitySourceService.updateParentId(oldEntityId, newEntityId);
-    }
-
     public void bulkDeleteByEntityId(Set<String> entityIds) {
         dbEntitySourceService.bulkDeleteByEntityId(entityIds);
     }

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
@@ -38,9 +38,11 @@ import org.graylog.events.notifications.NotificationDto;
 import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
 import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.DBEventProcessorStateService;
+import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog.events.processor.EventDefinitionHandler;
 import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog.events.processor.EventProcessorExecutionJob;
 import org.graylog.events.processor.aggregation.AggregationConditions;
 import org.graylog.events.processor.aggregation.AggregationEventProcessorConfig;
 import org.graylog.events.processor.storage.PersistToStreamsStorageHandler;
@@ -70,6 +72,7 @@ import org.graylog2.database.MongoCollections;
 import org.graylog2.database.entities.DefaultEntityScope;
 import org.graylog2.database.entities.EntityScope;
 import org.graylog2.database.entities.EntityScopeService;
+import org.graylog2.database.entities.ImmutableSystemScope;
 import org.graylog2.database.entities.source.EntitySourceService;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.PluginMetaData;
@@ -89,7 +92,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -97,15 +99,17 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class EventDefinitionFacadeTest {
-    public static final Set<EntityScope> ENTITY_SCOPES = Collections.singleton(new DefaultEntityScope());
+    public static final Set<EntityScope> ENTITY_SCOPES = Set.of(new DefaultEntityScope(), new ImmutableSystemScope());
     private static final String REMEDIATION_STEPS = "remediation";
     @Rule
     public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
@@ -410,6 +414,198 @@ public class EventDefinitionFacadeTest {
         assertThat(graph).isNotNull();
         Set<Entity> expectedNodes = ImmutableSet.of(eventEntityV1, notificationV1);
         assertThat(graph.nodes()).isEqualTo(expectedNodes);
+    }
+
+    /**
+     * Content-pack upgrade of an immutable-scoped (e.g. Illuminate) event definition. This is the
+     * regression case: the entity is immutable to user-facing edits, but the installer must rewrite
+     * its content in place so the entity ID is preserved across an upgrade. Without the
+     * {@code checkMutability = false} bypass in the facade, this throws "Immutable entity cannot be
+     * modified".
+     */
+    @Test
+    public void updateNativeEntityRewritesImmutableScopedDefinitionInPlace() {
+        final EventDefinitionDto existing = persistDefinition(ImmutableSystemScope.NAME, "Illuminate rule v1");
+        assertThat(existing.id()).isNotNull();
+        assertThat(existing.scope()).isEqualTo(ImmutableSystemScope.NAME);
+
+        final NativeEntity<EventDefinitionDto> existingNative = NativeEntity.create(
+                NativeEntityDescriptor.create(ModelId.of("content-pack-id"), ModelId.of(existing.id()),
+                        ModelTypes.EVENT_DEFINITION_V1, existing.title()),
+                existing);
+
+        facade.updateNativeEntity(upgradedEntity("Illuminate rule v2"), existingNative,
+                ImmutableMap.of(), ImmutableMap.of(), "admin");
+
+        final Optional<EventDefinitionDto> reloaded = eventDefinitionService.get(existing.id());
+        assertThat(reloaded).isPresent();
+        assertThat(reloaded.get().id()).isEqualTo(existing.id());                 // ID preserved
+        assertThat(reloaded.get().title()).isEqualTo("Illuminate rule v2");       // content rewritten in place
+        assertThat(reloaded.get().scope()).isEqualTo(ImmutableSystemScope.NAME);  // scope preserved
+    }
+
+    /**
+     * The same upgrade path for an ordinary (mutable, default-scoped) event definition. Nothing about
+     * the bypass should change behaviour here: the ID is still preserved and the content updated.
+     */
+    @Test
+    public void updateNativeEntityRewritesDefaultScopedDefinitionInPlace() {
+        final EventDefinitionDto existing = persistDefinition(DefaultEntityScope.NAME, "Default rule v1");
+        assertThat(existing.id()).isNotNull();
+        assertThat(existing.scope()).isEqualTo(DefaultEntityScope.NAME);
+
+        final NativeEntity<EventDefinitionDto> existingNative = NativeEntity.create(
+                NativeEntityDescriptor.create(ModelId.of("content-pack-id"), ModelId.of(existing.id()),
+                        ModelTypes.EVENT_DEFINITION_V1, existing.title()),
+                existing);
+
+        facade.updateNativeEntity(upgradedEntity("Default rule v2"), existingNative,
+                ImmutableMap.of(), ImmutableMap.of(), "admin");
+
+        final Optional<EventDefinitionDto> reloaded = eventDefinitionService.get(existing.id());
+        assertThat(reloaded).isPresent();
+        assertThat(reloaded.get().id()).isEqualTo(existing.id());
+        assertThat(reloaded.get().title()).isEqualTo("Default rule v2");
+        assertThat(reloaded.get().scope()).isEqualTo(DefaultEntityScope.NAME);
+    }
+
+    @Test
+    public void updateNativeEntityPreservesEnabledState() {
+        final EventDefinitionDto existing = persistDefinition(ImmutableSystemScope.NAME, "Illuminate rule v1",
+                EventDefinition.State.ENABLED);
+
+        // The definition is enabled, so a scheduler job already exists for it.
+        when(jobSchedulerClock.nowUTC()).thenReturn(DateTime.now(DateTimeZone.UTC));
+        final var schedulerConfig = existing.config().toJobSchedulerConfig(existing, jobSchedulerClock).orElseThrow();
+        final JobDefinitionDto existingJob = JobDefinitionDto.builder()
+                .id("job-1")
+                .title(existing.title())
+                .description(existing.description())
+                .config(schedulerConfig.jobDefinitionConfig())
+                .build();
+        when(jobDefinitionService.getByConfigField(eq(EventProcessorExecutionJob.Config.FIELD_EVENT_DEFINITION_ID),
+                eq(existing.id()))).thenReturn(Optional.of(existingJob));
+        when(jobDefinitionService.save(any(JobDefinitionDto.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(jobTriggerService.getOneForJob("job-1")).thenReturn(Optional.empty());
+
+        facade.updateNativeEntity(upgradedEntity("Illuminate rule v2", true), nativeOf(existing),
+                ImmutableMap.of(), ImmutableMap.of(), "admin");
+
+        final Optional<EventDefinitionDto> reloaded = eventDefinitionService.get(existing.id());
+        assertThat(reloaded).isPresent();
+        assertThat(reloaded.get().state()).isEqualTo(EventDefinition.State.ENABLED);
+        assertThat(reloaded.get().title()).isEqualTo("Illuminate rule v2");
+    }
+
+    /**
+     * The inverse: the pack's is_scheduled flag must not re-enable a definition the user disabled.
+     */
+    @Test
+    public void updateNativeEntityDoesNotReEnableDisabledDefinition() {
+        final EventDefinitionDto existing = persistDefinition(ImmutableSystemScope.NAME, "Illuminate rule v1",
+                EventDefinition.State.DISABLED);
+
+        facade.updateNativeEntity(upgradedEntity("Illuminate rule v2", true), nativeOf(existing),
+                ImmutableMap.of(), ImmutableMap.of(), "admin");
+
+        final Optional<EventDefinitionDto> reloaded = eventDefinitionService.get(existing.id());
+        assertThat(reloaded).isPresent();
+        assertThat(reloaded.get().state()).isEqualTo(EventDefinition.State.DISABLED);
+        verify(jobDefinitionService, never()).save(any(JobDefinitionDto.class));
+    }
+
+    /**
+     * Guard rail: the bypass is scoped to the installer path only. A user-facing update (the default
+     * {@code checkMutability = true} save) of the same immutable entity must still be rejected, so we
+     * are not weakening the immutability contract for the public API.
+     */
+    @Test
+    public void immutableScopedDefinitionStillRejectsUserFacingUpdate() {
+        final EventDefinitionDto existing = persistDefinition(ImmutableSystemScope.NAME, "Illuminate rule v1");
+        final EventDefinitionDto handEdited = existing.toBuilder().title("hand-edited").build();
+
+        assertThatThrownBy(() -> eventDefinitionService.save(handEdited))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Immutable entity cannot be modified");
+    }
+
+    /**
+     * Persists a brand-new event definition with the given scope (creation is never blocked by the
+     * mutability check) and returns it with its generated ID.
+     */
+    private EventDefinitionDto persistDefinition(String scope, String title) {
+        return persistDefinition(scope, title, EventDefinition.State.DISABLED);
+    }
+
+    private EventDefinitionDto persistDefinition(String scope, String title, EventDefinition.State state) {
+        final EventDefinitionEntity entity = objectMapper.convertValue(upgradedEntity(title).data(),
+                EventDefinitionEntity.class);
+        final EventDefinitionDto dto = entity.toNativeEntity(ImmutableMap.of(), ImmutableMap.of())
+                .toBuilder()
+                .scope(scope)
+                .state(state)
+                .build();
+        return eventDefinitionService.save(dto);
+    }
+
+    private static NativeEntity<EventDefinitionDto> nativeOf(EventDefinitionDto existing) {
+        return NativeEntity.create(
+                NativeEntityDescriptor.create(ModelId.of("content-pack-id"), ModelId.of(existing.id()),
+                        ModelTypes.EVENT_DEFINITION_V1, existing.title()),
+                existing);
+    }
+
+    /**
+     * Builds the content-pack representation of an "upgraded" event definition with the given title.
+     * Defaults to not scheduled, so the handler's scheduling branch is a no-op against the mocked
+     * job services and tests stay focused on the persistence/scope behaviour.
+     */
+    private EntityV1 upgradedEntity(String title) {
+        return upgradedEntity(title, false);
+    }
+
+    private EntityV1 upgradedEntity(String title, boolean scheduled) {
+        final EventFieldSpec fieldSpec = EventFieldSpec.builder()
+                .dataType(FieldValueType.STRING)
+                .providers(ImmutableList.of(TemplateFieldValueProvider.Config.builder().template("template").build()))
+                .build();
+        final SeriesSpec series = Count.builder().id("id-count").field("field").build();
+        final AggregationConditions condition = AggregationConditions.builder()
+                .expression(Expr.Greater.create(Expr.NumberValue.create(2), Expr.NumberValue.create(1)))
+                .build();
+        final AggregationEventProcessorConfigEntity aggregationConfig = AggregationEventProcessorConfigEntity.builder()
+                .query(ValueReference.of("*"))
+                .streams(ImmutableSet.of())
+                .groupBy(ImmutableList.of("project"))
+                .series(ImmutableList.of(series).stream().map(SeriesSpecEntity::fromNativeEntity).toList())
+                .conditions(condition)
+                .executeEveryMs(60000L)
+                .searchWithinMs(60000L)
+                .build();
+
+        final EventDefinitionEntity eventDefinitionEntity = EventDefinitionEntity.builder()
+                .title(ValueReference.of(title))
+                .description(ValueReference.of("upgraded"))
+                .priority(ValueReference.of(1))
+                .config(aggregationConfig)
+                .alert(ValueReference.of(false))
+                .fieldSpec(ImmutableMap.of("fieldSpec", fieldSpec))
+                .keySpec(ImmutableList.of())
+                .notificationSettings(EventNotificationSettings.builder()
+                        .gracePeriodMs(60000)
+                        .backlogSize(0)
+                        .build())
+                .notifications(ImmutableList.of())
+                .storage(ImmutableList.of())
+                .isScheduled(ValueReference.of(scheduled))
+                .build();
+
+        final JsonNode data = objectMapper.convertValue(eventDefinitionEntity, JsonNode.class);
+        return EntityV1.builder()
+                .data(data)
+                .id(ModelId.of("content-pack-ref"))
+                .type(ModelTypes.EVENT_DEFINITION_V1)
+                .build();
     }
 
     static EventDefinitionDto validEventDefinitionDto(EventProcessorConfig config) {

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -72,6 +72,7 @@ import org.graylog2.contentpacks.facades.StreamFacade;
 import org.graylog2.contentpacks.model.ContentPackInstallation;
 import org.graylog2.contentpacks.model.ContentPackUninstallDetails;
 import org.graylog2.contentpacks.model.ContentPackUninstallation;
+import org.graylog2.contentpacks.model.ContentPackUpgrade;
 import org.graylog2.contentpacks.model.ContentPackV1;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
@@ -138,7 +139,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -452,6 +455,243 @@ public class ContentPackServiceTest {
 
         ContentPackUninstallation resultFailure = contentPackService.uninstallContentPack(contentPack, contentPackInstallation);
         assertThat(resultFailure).isEqualTo(expectFailure);
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"inputs:create"})
+    public void upgradeContentPackRecreatesNonUpdatableEntityType() throws Exception {
+        // GrokPatternFacade does not implement UpdatableEntityFacade, so an existing grok pattern
+        // falls back to delete-and-recreate on upgrade: content stays fresh, but the ID changes.
+        GrokPattern existingPattern = GrokPattern.builder().id("dead-beef1").name("NAME").pattern("\\w").build();
+        when(patternService.load("dead-beef1")).thenReturn(existingPattern);
+        GrokPattern recreatedPattern = GrokPattern.builder().id("recreated-id").name("NAME").pattern("\\w").build();
+        when(patternService.save(any())).thenReturn(recreatedPattern);
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+        when(contentPackInstallService.insert(any())).thenAnswer(i -> i.getArgument(0));
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        ContentPackUpgrade result = contentPackService.upgradeContentPack(
+                contentPack, contentPackInstallation, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY);
+
+        verify(patternService).delete("dead-beef1");
+
+        assertThat(result.installation().entities()).hasSize(1);
+        NativeEntityDescriptor descriptor = result.installation().entities().iterator().next();
+        assertThat(descriptor.id()).isEqualTo(ModelId.of("recreated-id"));
+        assertThat(descriptor.contentPackEntityId()).isEqualTo(ModelId.of("12345"));
+
+        // The old entity is still snapshotted for the preservation service.
+        assertThat(result.oldEntitySnapshots().entityObjects()).containsKey(ModelId.of("12345"));
+        assertThat(result.oldEntitySnapshots().entityObjects().get(ModelId.of("12345"))).isEqualTo(existingPattern);
+    }
+
+    @Test
+    @WithAuthorization(permissions = {ViewsRestPermissions.VIEW_CREATE, RestPermissions.EVENT_DEFINITIONS_CREATE})
+    public void upgradeContentPackWithMultipleEntityTypes() throws Exception {
+        ImmutableSet<Entity> entities = ImmutableSet.of(createTestViewEntity(), createTestEventDefinitionEntity());
+        ContentPackV1 newPack = ContentPackV1.builder()
+                .description("test")
+                .entities(entities)
+                .name("test")
+                .revision(2)
+                .summary("")
+                .vendor("")
+                .url(URI.create("http://graylog.com"))
+                .id(ModelId.of("dead-beef"))
+                .build();
+
+        NativeEntityDescriptor viewDescriptor = NativeEntityDescriptor.create(
+                ModelId.of("1"), "view-native-id", ModelTypes.SEARCH_V1, "title", false);
+        NativeEntityDescriptor eventDefDescriptor = NativeEntityDescriptor.create(
+                ModelId.of("beef-1337"), "eventdef-native-id", ModelTypes.EVENT_DEFINITION_V1, "title", false);
+
+        ContentPackInstallation oldInstall = ContentPackInstallation.builder()
+                .contentPackId(ModelId.of("dead-beef"))
+                .contentPackRevision(1)
+                .entities(ImmutableSet.of(viewDescriptor, eventDefDescriptor))
+                .comment("Installed")
+                .parameters(ImmutableMap.copyOf(Collections.emptyMap()))
+                .createdAt(Instant.now())
+                .createdBy("me")
+                .build();
+
+        when(streamService.getSystemStreamIds(true)).thenReturn(ALL_SYSTEM_STREAM_IDS);
+        for (String id : ALL_SYSTEM_STREAM_IDS) {
+            when(streamService.load(id)).thenReturn(createTestStream(id));
+            when(streamService.isSystemStream(id)).thenReturn(true);
+        }
+
+        ViewDTO existingView = ViewDTO.builder().id("view-native-id").title("title").searchId("search-id").state(Collections.emptyMap()).build();
+        when(viewService.get("view-native-id")).thenReturn(Optional.of(existingView));
+
+        EventDefinitionDto existingEventDef = createTestEventDefinitionDto().toBuilder().id("eventdef-native-id").build();
+        when(eventDefinitionService.get("eventdef-native-id")).thenReturn(Optional.of(existingEventDef));
+
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+        when(contentPackInstallService.insert(any())).thenAnswer(i -> i.getArgument(0));
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        ContentPackUpgrade result = contentPackService.upgradeContentPack(
+                newPack, oldInstall, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY);
+
+        assertThat(result.installation().entities()).hasSize(2);
+        Set<ModelId> preservedIds = result.installation().entities().stream()
+                .map(NativeEntityDescriptor::id)
+                .collect(Collectors.toSet());
+        assertThat(preservedIds).containsExactlyInAnyOrder(
+                ModelId.of("view-native-id"), ModelId.of("eventdef-native-id"));
+
+        assertThat(result.oldEntitySnapshots().entityObjects()).hasSize(2);
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"inputs:create"})
+    public void upgradeContentPackCreatesNewEntityWhenNotInOldInstallation() throws Exception {
+        GrokPattern savedPattern = GrokPattern.builder().id("new-id").name("NAME").pattern("\\w").build();
+        when(patternService.save(any())).thenReturn(savedPattern);
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+        when(contentPackInstallService.insert(any())).thenAnswer(i -> i.getArgument(0));
+
+        ContentPackInstallation emptyOldInstall = ContentPackInstallation.builder()
+                .contentPackId(ModelId.of("dead-beef"))
+                .contentPackRevision(0)
+                .entities(ImmutableSet.of())
+                .comment("Installed")
+                .parameters(ImmutableMap.copyOf(Collections.emptyMap()))
+                .createdAt(Instant.now())
+                .createdBy("me")
+                .build();
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        ContentPackUpgrade result = contentPackService.upgradeContentPack(
+                contentPack, emptyOldInstall, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY);
+
+        assertThat(result.installation().entities()).hasSize(1);
+        assertThat(result.oldEntitySnapshots().entityObjects()).isEmpty();
+        assertThat(result.oldEntitySnapshots().entities()).isEmpty();
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"inputs:create"})
+    public void upgradeContentPackFallsBackToCreateWhenOldEntityMissing() throws Exception {
+        when(patternService.load("dead-beef1")).thenThrow(new NotFoundException("Not found."));
+
+        GrokPattern newGrokPattern = GrokPattern.builder()
+                .id("new-id")
+                .pattern("\\w")
+                .name("NAME")
+                .build();
+        when(patternService.save(any())).thenReturn(newGrokPattern);
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+        when(contentPackInstallService.insert(any())).thenAnswer(i -> i.getArgument(0));
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        ContentPackUpgrade result = contentPackService.upgradeContentPack(
+                contentPack, contentPackInstallation, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY);
+
+        assertThat(result.installation().entities()).hasSize(1);
+        NativeEntityDescriptor descriptor = result.installation().entities().iterator().next();
+        assertThat(descriptor.id()).isEqualTo(ModelId.of("new-id"));
+
+        assertThat(result.oldEntitySnapshots().entityObjects()).isEmpty();
+        assertThat(result.oldEntitySnapshots().entities()).hasSize(1);
+        assertThat(result.oldEntitySnapshots().entities().iterator().next().id()).isEqualTo(ModelId.of("dead-beef1"));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {ViewsRestPermissions.VIEW_CREATE, "inputs:create"})
+    public void upgradeContentPackMixedExistingAndNewEntities() throws Exception {
+        // Existing entity: a view (updatable facade, update branch). New entity: a grok pattern
+        // (create branch, which does not require update support).
+        Map<String, String> entityData = new HashMap<>();
+        entityData.put("name", "NEW_PATTERN");
+        entityData.put("pattern", "\\d+");
+        EntityV1 newEntityV1 = EntityV1.builder()
+                .id(ModelId.of("entity-2"))
+                .type(ModelTypes.GROK_PATTERN_V1)
+                .data(objectMapper.convertValue(entityData, JsonNode.class))
+                .build();
+
+        ContentPackV1 newPack = ContentPackV1.builder()
+                .description("test")
+                .entities(ImmutableSet.of(createTestViewEntity(), newEntityV1))
+                .name("test")
+                .revision(2)
+                .summary("")
+                .vendor("")
+                .url(URI.create("http://graylog.com"))
+                .id(ModelId.of("dead-beef"))
+                .build();
+
+        NativeEntityDescriptor oldDescriptor = NativeEntityDescriptor.create(
+                ModelId.of("1"), "view-native-id", ModelTypes.SEARCH_V1, "title", false);
+        ContentPackInstallation oldInstall = ContentPackInstallation.builder()
+                .contentPackId(ModelId.of("dead-beef"))
+                .contentPackRevision(1)
+                .entities(ImmutableSet.of(oldDescriptor))
+                .comment("Installed")
+                .parameters(ImmutableMap.copyOf(Collections.emptyMap()))
+                .createdAt(Instant.now())
+                .createdBy("me")
+                .build();
+
+        when(streamService.getSystemStreamIds(true)).thenReturn(ALL_SYSTEM_STREAM_IDS);
+        for (String id : ALL_SYSTEM_STREAM_IDS) {
+            when(streamService.load(id)).thenReturn(createTestStream(id));
+            when(streamService.isSystemStream(id)).thenReturn(true);
+        }
+
+        ViewDTO existingView = ViewDTO.builder().id("view-native-id").title("title").searchId("search-id").state(Collections.emptyMap()).build();
+        when(viewService.get("view-native-id")).thenReturn(Optional.of(existingView));
+
+        GrokPattern newPattern = GrokPattern.builder().id("native-2").name("NEW_PATTERN").pattern("\\d+").build();
+        when(patternService.save(any())).thenReturn(newPattern);
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+        when(contentPackInstallService.insert(any())).thenAnswer(i -> i.getArgument(0));
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        ContentPackUpgrade result = contentPackService.upgradeContentPack(
+                newPack, oldInstall, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY);
+
+        assertThat(result.installation().entities()).hasSize(2);
+        Set<ModelId> nativeIds = result.installation().entities().stream()
+                .map(NativeEntityDescriptor::id)
+                .collect(Collectors.toSet());
+        assertThat(nativeIds).containsExactlyInAnyOrder(ModelId.of("view-native-id"), ModelId.of("native-2"));
+
+        assertThat(result.oldEntitySnapshots().entityObjects()).hasSize(1);
+        assertThat(result.oldEntitySnapshots().entityObjects()).containsKey(ModelId.of("1"));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"inputs:create"})
+    public void upgradeContentPackRollsBackNewlyCreatedEntitiesOnFailure() throws Exception {
+        when(patternService.save(any())).thenThrow(new RuntimeException("DB failure"));
+        when(mockUser.getName()).thenReturn(TEST_USER);
+        when(userService.loadById(any())).thenReturn(mockUser);
+
+        ContentPackInstallation emptyOldInstall = ContentPackInstallation.builder()
+                .contentPackId(ModelId.of("dead-beef"))
+                .contentPackRevision(0)
+                .entities(ImmutableSet.of())
+                .comment("Installed")
+                .parameters(ImmutableMap.copyOf(Collections.emptyMap()))
+                .createdAt(Instant.now())
+                .createdBy("me")
+                .build();
+
+        UserContext userContext = SecurityTestUtils.getUserContext(userService);
+        assertThatThrownBy(() -> contentPackService.upgradeContentPack(
+                contentPack, emptyOldInstall, Collections.emptyMap(), "Upgrade", userContext, EntityShareRequest.EMPTY))
+                .isInstanceOf(ContentPackException.class)
+                .hasMessageContaining("upgrade");
+
+        verify(patternService, never()).delete(any());
     }
 
     @Test


### PR DESCRIPTION
Backport of Graylog2/graylog2-server#25799 to `7.0`.

No merge conflicts.

/nocl - see enterprise PR

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/14387

Assisted with [Claude Code](https://claude.com/claude-code)
