### PR TITLE
Update default rules metrics sampling rate

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineConfig.java
@@ -31,13 +31,12 @@ public class PipelineConfig implements PluginConfigBean {
 
     @Documentation("""
             Controls how often Graylog records pipeline rule debug timer samples.
-            The default, 1, records every invocation.
-            Use a higher value, for example 10, to record roughly one out of every 10 invocations.
-            This can reduce overhead on busy clusters with many rules.
+            The default, 100, records roughly one out of every 100 invocations.
+            Use 1 to record every invocation.
             Use the same value on every node. Changes require a JVM restart.
             """)
     @Parameter(value = "rule_metrics_sample_rate", validators = PositiveIntegerValidator.class)
-    private int ruleMetricsSampleRate = 1;
+    private int ruleMetricsSampleRate = 100;
 
     public int getRuleMetricsSampleRate() {
         return ruleMetricsSampleRate;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -490,11 +490,10 @@ output_fault_penalty_seconds = 30
 #processbuffer_processors = 5
 
 # Controls how often Graylog records pipeline rule debug timer samples.
-# The default, 1, records every invocation.
-# Use a higher value, for example 10, to record roughly one out of every 10 invocations.
-# This can reduce overhead on busy clusters with many rules.
+# The default, 100, records roughly one out of every 100 invocations.
+# Use 1 to record every invocation.
 # Use the same value on every node. Changes require a JVM restart.
-#rule_metrics_sample_rate = 1
+#rule_metrics_sample_rate = 100
 
 # Number of output buffer processors running in parallel.
 # By default, the value will be determined automatically based on the number of CPU cores available to the JVM, using


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

/nocl
Relates to https://github.com/Graylog2/graylog2-server/pull/25953

## Description
Changed the default `rule_metrics_sample_rate` from `1` to `100`, so Graylog records roughly one in every 100 rule invocations by default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

