### PR TITLE
Add `CreatePage` and `CreateModal` components with pattern documentation

### DIFF
--- a/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
@@ -18,11 +18,21 @@ import React from 'react';
 import { DocsContainer as BaseDocsContainer } from '@storybook/addon-docs/blocks';
 import type { DocsContainerProps } from '@storybook/addon-docs/blocks';
 import { useDarkMode } from 'storybook-dark-mode';
+import { COLOR_SCHEME_DARK, COLOR_SCHEME_LIGHT } from '@graylog/sawmill';
+
+import GraylogThemeProvider from 'theme/GraylogThemeProvider';
+import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 import { darkTheme, lightTheme } from './storybook-theme';
 
 export const DocsContainer = (props: DocsContainerProps) => {
   const isDark = useDarkMode();
+  const colorScheme = isDark ? COLOR_SCHEME_DARK : COLOR_SCHEME_LIGHT;
 
-  return <BaseDocsContainer {...props} theme={isDark ? darkTheme : lightTheme} />;
+  return (
+    <GraylogThemeProvider initialThemeModeOverride={colorScheme} key={colorScheme} userIsLoggedIn>
+      <GlobalThemeStyles />
+      <BaseDocsContainer {...props} theme={isDark ? darkTheme : lightTheme} />
+    </GraylogThemeProvider>
+  );
 };

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
@@ -19,19 +19,25 @@ import { DocsContainer as BaseDocsContainer } from '@storybook/addon-docs/blocks
 import type { DocsContainerProps } from '@storybook/addon-docs/blocks';
 import { useDarkMode } from 'storybook-dark-mode';
 import { COLOR_SCHEME_DARK, COLOR_SCHEME_LIGHT } from '@graylog/sawmill';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
 
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 import { darkTheme, lightTheme } from './storybook-theme';
 
-const DocsFontOverride = createGlobalStyle`
-  p:not(.sb-anchor):not(.sb-unstyled),
-  li:not(.sb-unstyled) {
-    font-size: 1rem;
-  }
-`;
+const DocsOverride = createGlobalStyle(
+  ({ theme }) => css`
+    p:not(.sb-anchor):not(.sb-unstyled),
+    li:not(.sb-unstyled) {
+      font-size: 1rem;
+    }
+
+    .docs-story {
+      background-color: ${theme.colors.global.background};
+    }
+  `,
+);
 
 export const DocsContainer = (props: DocsContainerProps) => {
   const isDark = useDarkMode();
@@ -40,7 +46,7 @@ export const DocsContainer = (props: DocsContainerProps) => {
   return (
     <GraylogThemeProvider initialThemeModeOverride={colorScheme} key={colorScheme} userIsLoggedIn>
       <GlobalThemeStyles />
-      <DocsFontOverride />
+      <DocsOverride />
       <BaseDocsContainer {...props} theme={isDark ? darkTheme : lightTheme} />
     </GraylogThemeProvider>
   );

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/DocsContainer.tsx
@@ -19,11 +19,19 @@ import { DocsContainer as BaseDocsContainer } from '@storybook/addon-docs/blocks
 import type { DocsContainerProps } from '@storybook/addon-docs/blocks';
 import { useDarkMode } from 'storybook-dark-mode';
 import { COLOR_SCHEME_DARK, COLOR_SCHEME_LIGHT } from '@graylog/sawmill';
+import { createGlobalStyle } from 'styled-components';
 
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 import { darkTheme, lightTheme } from './storybook-theme';
+
+const DocsFontOverride = createGlobalStyle`
+  p:not(.sb-anchor):not(.sb-unstyled),
+  li:not(.sb-unstyled) {
+    font-size: 1rem;
+  }
+`;
 
 export const DocsContainer = (props: DocsContainerProps) => {
   const isDark = useDarkMode();
@@ -32,6 +40,7 @@ export const DocsContainer = (props: DocsContainerProps) => {
   return (
     <GraylogThemeProvider initialThemeModeOverride={colorScheme} key={colorScheme} userIsLoggedIn>
       <GlobalThemeStyles />
+      <DocsFontOverride />
       <BaseDocsContainer {...props} theme={isDark ? darkTheme : lightTheme} />
     </GraylogThemeProvider>
   );

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
@@ -25,7 +25,7 @@ const __dirname = path.dirname(__filename);
 const webInterfaceRoot = path.resolve(__dirname, '../../..');
 
 const config: StorybookConfig = {
-  stories: ['../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: ['../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)', '../stories/**/*.mdx'],
   addons: ['@storybook/addon-webpack5-compiler-swc', '@storybook/addon-docs', 'storybook-dark-mode'],
   framework: {
     name: '@storybook/react-webpack5',

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
@@ -16,13 +16,20 @@
  */
 // This file has been automatically migrated to valid ESM format by Storybook.
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { createRequire } from 'module';
 
 import type { StorybookConfig } from '@storybook/react-webpack5';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const webInterfaceRoot = path.resolve(__dirname, '../../..');
+
+const require = createRequire(pathToFileURL(__filename).href);
+const { createBootstrapLessRule, lessRule } = require(path.resolve(webInterfaceRoot, 'webpack/bootstrap-less'));
+
+// style-loader v4 (used by Storybook) dropped function support for `insert`; use a string selector instead
+const bootstrapLessRule = createBootstrapLessRule({ insert: 'head' });
 
 const config: StorybookConfig = {
   stories: ['../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)', '../stories/**/*.mdx'],
@@ -33,6 +40,14 @@ const config: StorybookConfig = {
   },
   webpackFinal: (sbConfig) => ({
     ...sbConfig,
+    module: {
+      ...sbConfig.module,
+      rules: [
+        ...(sbConfig.module?.rules ?? []),
+        bootstrapLessRule,
+        lessRule,
+      ],
+    },
     resolve: {
       ...sbConfig.resolve,
       modules: [

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/withGraylogTheme.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/withGraylogTheme.tsx
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
+import 'preload';
 import 'theme/theme-styles';
 import type { Decorator } from '@storybook/react';
 import { useDarkMode } from 'storybook-dark-mode';

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/withGraylogTheme.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/withGraylogTheme.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import 'preload';
 import 'theme/theme-styles';
+import 'bootstrap/less/bootstrap.less';
 import type { Decorator } from '@storybook/react';
 import { useDarkMode } from 'storybook-dark-mode';
 import { COLOR_SCHEME_DARK, COLOR_SCHEME_LIGHT } from '@graylog/sawmill';

--- a/graylog2-web-interface/docs/graylog-luma/package.json
+++ b/graylog2-web-interface/docs/graylog-luma/package.json
@@ -15,6 +15,7 @@
     "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
     "@storybook/react-webpack5": "^10.4.1",
     "eslint-plugin-storybook": "^10.4.1",
+    "mermaid": "^11.15.0",
     "storybook": "^10.4.1",
     "storybook-dark-mode": "^5.0.0",
     "typescript": "^5.8.2"

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */}
 
-import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Unstyled } from '@storybook/addon-docs/blocks';
 import { Alert } from 'components/bootstrap';
 import * as CreatingAnEntityStories from './CreatingAnEntity.stories';
 import Mermaid from './Mermaid';
@@ -56,7 +56,7 @@ Details page, toast shown\`"])
 
 Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation flow consistently.
 
-<Alert bsStyle="info"><strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate surface, then choose the appropriate method.</Alert>
+<Unstyled><Alert bsStyle="info"><strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate surface, then choose the appropriate method.</Alert></Unstyled>
 
 <Mermaid chart={DIAGRAM} />
 
@@ -76,7 +76,7 @@ Use a Modal when creation is part of the task the user is already performing and
 - Completion returns users to their previous location.
 - Successful creation closes the modal and shows a toast notification.
 
-<Canvas of={CreatingAnEntityStories.CurrentContextModal} />
+<Unstyled><Canvas of={CreatingAnEntityStories.CurrentContextModal} /></Unstyled>
 
 ### New Context: Page
 
@@ -90,9 +90,9 @@ Use a Page when creation benefits from a dedicated experience with its own focus
 - Successful creation navigates users to the newly created entity.
 - A toast notification communicates successful creation.
 
-<Canvas of={CreatingAnEntityStories.NewContextPage} />
+<Unstyled><Canvas of={CreatingAnEntityStories.NewContextPage} /></Unstyled>
 
-<Alert bsStyle="info">If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and Design before implementation. Context decisions affect navigation, workflow continuity, and long-term consistency across the product.</Alert>
+<Unstyled><Alert bsStyle="info">If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and Design before implementation. Context decisions affect navigation, workflow continuity, and long-term consistency across the product.</Alert></Unstyled>
 
 ## Choosing the Method
 

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
@@ -1,0 +1,127 @@
+{/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */}
+
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { Alert } from 'components/bootstrap';
+import * as CreatingAnEntityStories from './CreatingAnEntity.stories';
+import Mermaid from './Mermaid';
+
+export const DIAGRAM = `flowchart TD
+  A(["User's current view"])
+  A --> B{{"\`Should users remain
+in their current workflow?\`"}}
+  B -->|Yes| MODAL
+  B -->|No| PAGE
+
+  subgraph Surface["Surface"]
+    MODAL(["\`**Modal**
+Current context preserved\`"])
+    PAGE(["\`**Page**
+Dedicated creation experience\`"])
+  end
+
+  subgraph Method["Method"]
+    MW(["\`**Form or Wizard**
+Single-step or guided workflow\`"])
+    FW(["\`**Form or Wizard**
+Single-step or guided workflow\`"])
+  end
+
+  MODAL --> MW
+  PAGE --> FW
+
+  MW --> RC(["\`**Return to current workflow**
+Modal closes, toast shown\`"])
+  FW --> NC(["\`**Navigate to entity**
+Details page, toast shown\`"])
+`;
+
+<Meta of={CreatingAnEntityStories} />
+
+# Creating an Entity
+
+Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation flow consistently.
+
+<Alert bsStyle="info"><strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate surface, then choose the appropriate method.</Alert>
+
+<Mermaid chart={DIAGRAM} />
+
+## Choosing the Surface
+
+Choose the surface based on whether creation should happen within the user's current workflow or in a dedicated creation experience.
+
+### Current Context: Modal
+
+Use a Modal when creation is part of the task the user is already performing and they should be able to continue where they left off when creation is complete.
+
+**Characteristics**
+
+- Users remain in their current workflow.
+- The parent view remains visible.
+- Creation is completed without changing pages.
+- Completion returns users to their previous location.
+- Successful creation closes the modal and shows a toast notification.
+
+<Canvas of={CreatingAnEntityStories.CurrentContextModal} />
+
+### New Context: Page
+
+Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and destination.
+
+**Characteristics**
+
+- Users move into a focused creation experience.
+- The flow has its own URL and browser history entry.
+- Additional guidance, content, or validation can be accommodated.
+- Successful creation navigates users to the newly created entity.
+- A toast notification communicates successful creation.
+
+<Canvas of={CreatingAnEntityStories.NewContextPage} />
+
+<Alert bsStyle="info">If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and Design before implementation. Context decisions affect navigation, workflow continuity, and long-term consistency across the product.</Alert>
+
+## Choosing the Method
+
+After selecting the surface, choose the creation method. A Form and a Wizard can both be used in either a Modal or a Page.
+
+### Form
+
+Use a Form when users can reasonably complete creation in a single step.
+
+**Characteristics**
+
+- Fields can be displayed together.
+- There are no significant dependencies between steps.
+- The workflow is primarily data entry.
+
+### Wizard
+
+Use a Wizard when users benefit from progressive guidance and decision making.
+
+**Characteristics**
+
+- The flow contains multiple dependent decisions.
+- Information is naturally grouped into stages.
+- Showing everything at once would be overwhelming.
+- Users benefit from being guided through the process.
+
+### Avoid Wizards When
+
+- The only purpose is reducing scroll length.
+- Steps do not depend on one another.
+- Users would frequently need to jump between sections.
+- The workflow can be understood in a single view.

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -73,7 +73,7 @@ const StoryNavLink = ({ storyId, children }: { storyId: string; children: React.
     href="#"
     onClick={(e) => {
       e.preventDefault();
-      // eslint-disable-next-line no-underscore-dangle
+       
       (window as any).__STORYBOOK_ADDONS_CHANNEL__?.emit('selectStory', { storyId });
     }}>
     {children}
@@ -175,9 +175,7 @@ const CreateEntityPatternDoc = () => (
             own context, use a Page instead.
           </ContextBody>
 
-          <StoryNavLink storyId="patterns-creating-an-entity--current-context-modal">
-            View example →
-          </StoryNavLink>
+          <StoryNavLink storyId="patterns-creating-an-entity--current-context-modal">View example →</StoryNavLink>
 
           <RuleListHeading>Do</RuleListHeading>
           <RuleList>
@@ -198,9 +196,7 @@ const CreateEntityPatternDoc = () => (
             to.
           </ContextBody>
 
-          <StoryNavLink storyId="patterns-creating-an-entity--new-context-page">
-            View example →
-          </StoryNavLink>
+          <StoryNavLink storyId="patterns-creating-an-entity--new-context-page">View example →</StoryNavLink>
         </ContextCard>
       </SectionGroup>
 
@@ -300,8 +296,9 @@ export const NewContextPage: Story = {
     <CreatePage<StoryValues>
       entityName="Stream"
       overviewRoute="/streams"
+      detailsRoute={(id) => `/streams/${id}`}
       initialValues={{ title: '', description: '' }}
-      onSubmit={fn()}
+      onSubmit={async () => ({ id: 'new-stream-id' })}
       description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
       <FormFields />
     </CreatePage>

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { fn } from 'storybook/test';
+import { MemoryRouter } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { Input } from 'components/bootstrap';
+import { CreatePage } from 'components/common';
+
+import Mermaid from './Mermaid';
+
+// ─── Pattern Doc UI ───────────────────────────────────────────────────────────
+
+const DocContainer = styled.div`
+  max-width: 900px;
+`;
+
+const DocH1 = styled.h1`
+  margin: 0 0 ${({ theme }) => theme.spacings.xs};
+`;
+
+const DocH2 = styled.h2`
+  margin: 0 0 ${({ theme }) => theme.spacings.sm};
+`;
+
+const DocH3 = styled.h3`
+  margin: 0 0 ${({ theme }) => theme.spacings.sm};
+`;
+
+const DocLead = styled.p`
+  line-height: 1.6;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0 0 ${({ theme }) => theme.spacings.xl};
+`;
+
+const DiagramWrapper = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacings.xl};
+`;
+
+const ContextGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacings.lg};
+`;
+
+const ContextCard = styled.div``;
+
+const SectionGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ContextLabel = styled.p`
+  font-size: ${({ theme }) => theme.fonts.size.small};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0 0 ${({ theme }) => theme.spacings.xs};
+`;
+
+const ContextBody = styled.p`
+  line-height: 1.6;
+  margin: 0 0 ${({ theme }) => theme.spacings.md};
+`;
+
+const RuleListHeading = styled.p`
+  font-size: ${({ theme }) => theme.fonts.size.small};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0 0 ${({ theme }) => theme.spacings.xs};
+`;
+
+const RuleList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0 0 ${({ theme }) => theme.spacings.md};
+`;
+
+const RuleItem = styled.li<{ $type: 'do' | 'dont' }>`
+  padding: ${({ theme }) => theme.spacings.xs} 0;
+  padding-left: 1.4em;
+  position: relative;
+  line-height: 1.5;
+
+  &::before {
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+    ${({ $type }) => ($type === 'do' ? "content: '✓'; color: #22c55e;" : "content: '✕'; color: #ef4444;")}
+  }
+`;
+
+// ─── Flowchart ────────────────────────────────────────────────────────────────
+
+const DIAGRAM = `flowchart TD
+  A(["User's current view"])
+  A --> B{{"\`Must keep user
+in current context?\`"}}
+  B -->|Yes| MODAL(["\`**Modal**
+Current context preserved\`"])
+  B -->|No| PAGE(["\`**Page**
+New context, full focus\`"])
+  MODAL --> MW(["\`**Form or Wizard**
+No secondary context or workflow\`"])
+  PAGE --> FORM(["\`**Form**
+Static or dynamic fields\`"])
+  PAGE --> WIZARD(["\`**Wizard**
+Multi-step, guided flow\`"])
+  MW --> RC(["\`**Return to current context**
+Modal closes, toast shown\`"])
+  FORM & WIZARD --> NC(["\`**Navigate to new context**
+Detail page, list, or origin\`"])
+`;
+
+// ─── Pattern Overview Doc ────────────────────────────────────────────────────
+
+const CreateEntityPatternDoc = () => (
+  <DocContainer>
+    <DocH1>Creating an Entity</DocH1>
+    <DiagramWrapper>
+      <Mermaid chart={DIAGRAM} />
+    </DiagramWrapper>
+
+    <ContextGrid>
+      <SectionGroup>
+        <DocH2>Surface</DocH2>
+
+        <ContextCard>
+          <DocH3 id="current-context">Modal</DocH3>
+          <ContextBody>
+            Use a Modal to keep the user in their current context. The parent view stays visible, and on completion the
+            modal closes and returns the user to where they started. Use a Form or Wizard — if the workflow requires its
+            own context, use a Page instead.
+          </ContextBody>
+
+          <RuleListHeading>Do</RuleListHeading>
+          <RuleList>
+            <RuleItem $type="do">Show a toast notification on successful creation</RuleItem>
+          </RuleList>
+
+          <RuleListHeading>Do not</RuleListHeading>
+          <RuleList>
+            <RuleItem $type="dont">Open a modal on top of another modal</RuleItem>
+          </RuleList>
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3 id="new-context">Page</DocH3>
+          <ContextBody>
+            Use a Page when a context shift is appropriate. The user gets a dedicated creation experience and on
+            completion is taken to the entity detail page. Pages have a browser history entry and can be directly linked
+            to.
+          </ContextBody>
+        </ContextCard>
+      </SectionGroup>
+
+      <SectionGroup>
+        <DocH2>Method</DocH2>
+
+        <ContextCard>
+          <DocH3>Form vs Wizard</DocH3>
+          <ContextBody>
+            Use a Form for single-step creation with a manageable number of fields. Use a Wizard when creation involves
+            multiple dependent steps or too many fields to show at once.
+          </ContextBody>
+        </ContextCard>
+      </SectionGroup>
+    </ContextGrid>
+  </DocContainer>
+);
+
+// ─── Form fields used in the interactive example ─────────────────────────────
+
+type StoryValues = { title: string; description: string };
+
+const FormFields = () => (
+  <>
+    <Input
+      type="text"
+      id="title"
+      name="title"
+      label="Title"
+      placeholder="e.g. Production errors"
+      labelClassName="col-sm-3"
+      wrapperClassName="col-sm-9"
+      required
+    />
+    <Input
+      type="text"
+      id="description"
+      name="description"
+      label="Description"
+      placeholder="What does this stream collect?"
+      labelClassName="col-sm-3"
+      wrapperClassName="col-sm-9"
+    />
+  </>
+);
+
+// ─── Meta & Stories ───────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: 'Patterns/Creating an Entity',
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: () => <CreateEntityPatternDoc />,
+};
+
+export const NewContextPage: Story = {
+  name: 'New Context — Page',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  render: () => (
+    <CreatePage<StoryValues>
+      entityName="Stream"
+      overviewRoute="/streams"
+      initialValues={{ title: '', description: '' }}
+      onSubmit={fn()}
+      description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
+      <FormFields />
+    </CreatePage>
+  ),
+};

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -14,14 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { fn } from 'storybook/test';
 import { MemoryRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Input } from 'components/bootstrap';
-import { CreatePage } from 'components/common';
+import { Button, Input } from 'components/bootstrap';
+import { CreateModal, CreatePage } from 'components/common';
 
 import Mermaid from './Mermaid';
 
@@ -61,9 +61,32 @@ const ContextGrid = styled.div`
 
 const ContextCard = styled.div``;
 
+const StoryLinkAnchor = styled.a`
+  font-size: ${({ theme }) => theme.fonts.size.small};
+  display: inline-block;
+  margin-bottom: ${({ theme }) => theme.spacings.md};
+  cursor: pointer;
+`;
+
+const StoryNavLink = ({ storyId, children }: { storyId: string; children: React.ReactNode }) => (
+  <StoryLinkAnchor
+    href="#"
+    onClick={(e) => {
+      e.preventDefault();
+      // eslint-disable-next-line no-underscore-dangle
+      (window as any).__STORYBOOK_ADDONS_CHANNEL__?.emit('selectStory', { storyId });
+    }}>
+    {children}
+  </StoryLinkAnchor>
+);
+
 const SectionGroup = styled.div`
   display: flex;
   flex-direction: column;
+
+  ${ContextCard} + ${ContextCard} {
+    margin-top: ${({ theme }) => theme.spacings.lg};
+  }
 `;
 
 const ContextLabel = styled.p`
@@ -152,6 +175,10 @@ const CreateEntityPatternDoc = () => (
             own context, use a Page instead.
           </ContextBody>
 
+          <StoryNavLink storyId="patterns-creating-an-entity--current-context-modal">
+            View example →
+          </StoryNavLink>
+
           <RuleListHeading>Do</RuleListHeading>
           <RuleList>
             <RuleItem $type="do">Show a toast notification on successful creation</RuleItem>
@@ -170,6 +197,10 @@ const CreateEntityPatternDoc = () => (
             completion is taken to the entity detail page. Pages have a browser history entry and can be directly linked
             to.
           </ContextBody>
+
+          <StoryNavLink storyId="patterns-creating-an-entity--new-context-page">
+            View example →
+          </StoryNavLink>
         </ContextCard>
       </SectionGroup>
 
@@ -230,6 +261,27 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {
   render: () => <CreateEntityPatternDoc />,
+};
+
+export const CurrentContextModal: Story = {
+  name: 'Current Context — Modal',
+  render: () => {
+    const [show, setShow] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setShow(true)}>Create Stream</Button>
+        <CreateModal<StoryValues>
+          entityName="Stream"
+          show={show}
+          onClose={() => setShow(false)}
+          initialValues={{ title: '', description: '' }}
+          onSubmit={fn()}>
+          <FormFields />
+        </CreateModal>
+      </>
+    );
+  },
 };
 
 export const NewContextPage: Story = {

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -16,118 +16,10 @@
  */
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-import { Canvas } from '@storybook/addon-docs/blocks';
 import { MemoryRouter } from 'react-router-dom';
-import styled from 'styled-components';
 
-import { Alert, Button, Input } from 'components/bootstrap';
+import { Button, Input } from 'components/bootstrap';
 import { CreateModal, CreatePage } from 'components/common';
-
-import Mermaid from './Mermaid';
-
-// ─── Pattern Doc UI ───────────────────────────────────────────────────────────
-
-const DocContainer = styled.div`
-  max-width: 900px;
-  padding: 1rem;
-`;
-
-const DocH1 = styled.h1`
-  margin: 0 0 ${({ theme }) => theme.spacings.xs};
-`;
-
-const DocH2 = styled.h2`
-  margin: 0 0 ${({ theme }) => theme.spacings.sm};
-`;
-
-const DocH3 = styled.h3`
-  margin: 0 0 ${({ theme }) => theme.spacings.sm};
-`;
-
-const DocLead = styled.p`
-  line-height: 1.6;
-  margin: 0 0 ${({ theme }) => theme.spacings.xl};
-`;
-
-const DiagramWrapper = styled.div`
-  margin-bottom: ${({ theme }) => theme.spacings.xl};
-`;
-
-const ContextGrid = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacings.lg};
-`;
-
-const ContextCard = styled.div``;
-
-const SectionGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  ${ContextCard} + ${ContextCard} {
-    margin-top: ${({ theme }) => theme.spacings.lg};
-  }
-`;
-
-const ContextBody = styled.p`
-  line-height: 1.6;
-  margin: 0 0 ${({ theme }) => theme.spacings.md};
-`;
-
-const CharacteristicHeading = styled.p`
-  font-size: ${({ theme }) => theme.fonts.size.small};
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: ${({ theme }) => theme.colors.text.secondary};
-  margin: 0 0 ${({ theme }) => theme.spacings.xs};
-`;
-
-const CharacteristicList = styled.ul`
-  list-style-type: disc;
-  margin: 0 0 ${({ theme }) => theme.spacings.md};
-  padding-left: ${({ theme }) => theme.spacings.lg};
-
-  li {
-    line-height: 1.5;
-    margin-bottom: ${({ theme }) => theme.spacings.xs};
-  }
-`;
-
-// ─── Flowchart ────────────────────────────────────────────────────────────────
-
-const DIAGRAM = `flowchart TD
-  A(["User's current view"])
-  A --> B{{"\`Should users remain
-in their current workflow?\`"}}
-  B -->|Yes| MODAL
-  B -->|No| PAGE
-
-  subgraph Surface["Surface"]
-    MODAL(["\`**Modal**
-Current context preserved\`"])
-    PAGE(["\`**Page**
-Dedicated creation experience\`"])
-  end
-
-  subgraph Method["Method"]
-    MW(["\`**Form or Wizard**
-Single-step or guided workflow\`"])
-    FW(["\`**Form or Wizard**
-Single-step or guided workflow\`"])
-  end
-
-  MODAL --> MW
-  PAGE --> FW
-
-  MW --> RC(["\`**Return to current workflow**
-Modal closes, toast shown\`"])
-  FW --> NC(["\`**Navigate to entity**
-Details page, toast shown\`"])
-`;
-
-// ─── Form fields used in the interactive examples ─────────────────────────────
 
 type StoryValues = { title: string; description: string };
 
@@ -154,8 +46,6 @@ const FormFields = () => (
     />
   </>
 );
-
-// ─── Stories (hidden from sidebar, embedded via Canvas in the docs page) ──────
 
 export const CurrentContextModal: StoryObj = {
   tags: ['!dev'],
@@ -200,143 +90,9 @@ export const NewContextPage: StoryObj = {
   ),
 };
 
-// ─── Docs page ────────────────────────────────────────────────────────────────
-
-const CreateEntityPattern = () => (
-  <DocContainer>
-    <DocH1>Creating an Entity</DocH1>
-
-    <DocLead>
-      Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation
-      flow consistently.
-    </DocLead>
-
-    <Alert bsStyle="info">
-      <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
-      surface, then choose the appropriate method.
-    </Alert>
-
-    <DiagramWrapper>
-      <Mermaid chart={DIAGRAM} />
-    </DiagramWrapper>
-
-    <ContextGrid>
-      <SectionGroup>
-        <DocH2>Choosing the Surface</DocH2>
-
-        <ContextBody>
-          Choose the surface based on whether creation should happen within the user's current workflow or in a
-          dedicated creation experience.
-        </ContextBody>
-
-        <ContextCard>
-          <DocH3 id="current-context">Current Context: Modal</DocH3>
-
-          <ContextBody>
-            Use a Modal when creation is part of the task the user is already performing and they should be able to
-            continue where they left off when creation is complete.
-          </ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Users remain in their current workflow.</li>
-            <li>The parent view remains visible.</li>
-            <li>Creation is completed without changing pages.</li>
-            <li>Completion returns users to their previous location.</li>
-            <li>Successful creation closes the modal and shows a toast notification.</li>
-          </CharacteristicList>
-
-          <Canvas of={CurrentContextModal} />
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3 id="new-context">New Context: Page</DocH3>
-
-          <ContextBody>
-            Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
-            destination.
-          </ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Users move into a focused creation experience.</li>
-            <li>The flow has its own URL and browser history entry.</li>
-            <li>Additional guidance, content, or validation can be accommodated.</li>
-            <li>Successful creation navigates users to the newly created entity.</li>
-            <li>A toast notification communicates successful creation.</li>
-          </CharacteristicList>
-
-          <Canvas of={NewContextPage} />
-        </ContextCard>
-
-        <Alert bsStyle="info">
-          If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
-          Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
-          consistency across the product.
-        </Alert>
-      </SectionGroup>
-
-      <SectionGroup>
-        <DocH2>Choosing the Method</DocH2>
-
-        <ContextBody>
-          After selecting the surface, choose the creation method. A Form and a Wizard can both be used in either a
-          Modal or a Page.
-        </ContextBody>
-
-        <ContextCard>
-          <DocH3>Form</DocH3>
-
-          <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Fields can be displayed together.</li>
-            <li>There are no significant dependencies between steps.</li>
-            <li>The workflow is primarily data entry.</li>
-          </CharacteristicList>
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3>Wizard</DocH3>
-
-          <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>The flow contains multiple dependent decisions.</li>
-            <li>Information is naturally grouped into stages.</li>
-            <li>Showing everything at once would be overwhelming.</li>
-            <li>Users benefit from being guided through the process.</li>
-          </CharacteristicList>
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3>Avoid Wizards When</DocH3>
-
-          <CharacteristicList>
-            <li>The only purpose is reducing scroll length.</li>
-            <li>Steps do not depend on one another.</li>
-            <li>Users would frequently need to jump between sections.</li>
-            <li>The workflow can be understood in a single view.</li>
-          </CharacteristicList>
-        </ContextCard>
-      </SectionGroup>
-    </ContextGrid>
-  </DocContainer>
-);
-
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta: Meta = {
   title: 'Patterns/Creating an Entity',
-  tags: ['autodocs'],
-  parameters: {
-    layout: 'padded',
-    docs: {
-      page: CreateEntityPattern,
-    },
-  },
+  parameters: { layout: 'padded' },
 };
 
 export default meta;

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -16,7 +16,6 @@
  */
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-import { fn } from 'storybook/test';
 import { MemoryRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -60,25 +59,6 @@ const ContextGrid = styled.div`
 
 const ContextCard = styled.div``;
 
-const StoryLinkAnchor = styled.a`
-  font-size: ${({ theme }) => theme.fonts.size.small};
-  display: inline-block;
-  margin-bottom: ${({ theme }) => theme.spacings.md};
-  cursor: pointer;
-`;
-
-const StoryNavLink = ({ storyId, children }: { storyId: string; children: React.ReactNode }) => (
-  <StoryLinkAnchor
-    href="#"
-    onClick={(e) => {
-      e.preventDefault();
-
-      (window as any).__STORYBOOK_ADDONS_CHANNEL__?.emit('selectStory', { storyId });
-    }}>
-    {children}
-  </StoryLinkAnchor>
-);
-
 const SectionGroup = styled.div`
   display: flex;
   flex-direction: column;
@@ -113,6 +93,62 @@ const CharacteristicList = styled.ul`
   }
 `;
 
+const ExampleLabel = styled.p`
+  font-size: ${({ theme }) => theme.fonts.size.small};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0 0 ${({ theme }) => theme.spacings.xs};
+`;
+
+const ExampleWrapper = styled.div`
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 4px;
+  padding: ${({ theme }) => theme.spacings.md};
+  margin-bottom: ${({ theme }) => theme.spacings.xs};
+`;
+
+const PagePreviewWrapper = styled.div`
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 4px;
+  overflow-y: auto;
+  height: 520px;
+  margin-bottom: ${({ theme }) => theme.spacings.xs};
+`;
+
+const CodeDetails = styled.details`
+  margin-bottom: ${({ theme }) => theme.spacings.lg};
+
+  summary {
+    cursor: pointer;
+    font-size: ${({ theme }) => theme.fonts.size.small};
+    color: ${({ theme }) => theme.colors.text.secondary};
+    user-select: none;
+    list-style: none;
+
+    &::before {
+      content: '▶  Show code';
+    }
+  }
+
+  &[open] summary::before {
+    content: '▼  Hide code';
+  }
+`;
+
+const CodeBlock = styled.pre`
+  margin: ${({ theme }) => theme.spacings.xs} 0 0;
+  padding: ${({ theme }) => theme.spacings.md};
+  background: rgba(128, 128, 128, 0.07);
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  border-radius: 4px;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+`;
+
 // ─── Flowchart ────────────────────────────────────────────────────────────────
 
 const DIAGRAM = `flowchart TD
@@ -145,132 +181,35 @@ Modal closes, toast shown\`"])
 Details page, toast shown\`"])
 `;
 
-// ─── Pattern Overview Doc ────────────────────────────────────────────────────
+// ─── Code snippets ────────────────────────────────────────────────────────────
 
-const CreateEntityPatternDoc = () => (
-  <DocContainer>
-    <DocH1>Creating an Entity</DocH1>
+const MODAL_CODE = `const [show, setShow] = useState(false);
 
-    <DocLead>
-      Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation
-      flow consistently.
-    </DocLead>
+return (
+  <>
+    <Button onClick={() => setShow(true)}>Create Stream</Button>
+    <CreateModal
+      entityName="Stream"
+      show={show}
+      onClose={() => setShow(false)}
+      initialValues={{ title: '', description: '' }}
+      onSubmit={handleSubmit}>
+      <FormFields />
+    </CreateModal>
+  </>
+);`;
 
-    <Alert bsStyle="info">
-      <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
-      context, then choose the appropriate method.
-    </Alert>
+const PAGE_CODE = `<CreatePage
+  entityName="Stream"
+  overviewRoute="/streams"
+  detailsRoute={(id) => \`/streams/\${id}\`}
+  initialValues={{ title: '', description: '' }}
+  onSubmit={handleSubmit}
+  description="Streams route incoming messages into categories.">
+  <FormFields />
+</CreatePage>`;
 
-    <DiagramWrapper>
-      <Mermaid chart={DIAGRAM} />
-    </DiagramWrapper>
-
-    <ContextGrid>
-      <SectionGroup>
-        <DocH2>Choosing the Surface</DocH2>
-        <ContextBody>
-          Choose the surface based on whether creation should happen within the user’s current workflow or in a
-          dedicated creation experience.
-        </ContextBody>
-
-        <ContextCard>
-          <DocH3 id="current-context">Current Context: Modal</DocH3>
-
-          <ContextBody>
-            Use a Modal when creation is part of the task the user is already performing and they should be able to
-            continue where they left off when creation is complete.
-          </ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Users remain in their current workflow.</li>
-            <li>The parent view remains visible.</li>
-            <li>Creation is completed without changing pages.</li>
-            <li>Completion returns users to their previous location.</li>
-            <li>Successful creation closes the modal and shows a toast notification.</li>
-          </CharacteristicList>
-
-          <StoryNavLink storyId="patterns-creating-an-entity--current-context-modal">View example →</StoryNavLink>
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3 id="new-context">New Context: Page</DocH3>
-
-          <ContextBody>
-            Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
-            destination.
-          </ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Users move into a focused creation experience.</li>
-            <li>The flow has its own URL and browser history entry.</li>
-            <li>Additional guidance, content, or validation can be accommodated.</li>
-            <li>Successful creation navigates users to the newly created entity.</li>
-            <li>A toast notification communicates successful creation.</li>
-          </CharacteristicList>
-
-          <StoryNavLink storyId="patterns-creating-an-entity--new-context-page">View example →</StoryNavLink>
-        </ContextCard>
-
-        <Alert bsStyle="info">
-          If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
-          Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
-          consistency across the product.
-        </Alert>
-      </SectionGroup>
-
-      <SectionGroup>
-        <DocH2>Choosing the Method</DocH2>
-
-        <ContextBody>
-          After selecting the context, choose the creation method. A Form and a Wizard can both be used in either a
-          Modal or a Page.
-        </ContextBody>
-
-        <ContextCard>
-          <DocH3>Form</DocH3>
-
-          <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>Fields can be displayed together.</li>
-            <li>There are no significant dependencies between steps.</li>
-            <li>The workflow is primarily data entry.</li>
-          </CharacteristicList>
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3>Wizard</DocH3>
-
-          <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
-
-          <CharacteristicHeading>Characteristics</CharacteristicHeading>
-          <CharacteristicList>
-            <li>The flow contains multiple dependent decisions.</li>
-            <li>Information is naturally grouped into stages.</li>
-            <li>Showing everything at once would be overwhelming.</li>
-            <li>Users benefit from being guided through the process.</li>
-          </CharacteristicList>
-        </ContextCard>
-
-        <ContextCard>
-          <DocH3>Avoid Wizards When</DocH3>
-
-          <CharacteristicList>
-            <li>The only purpose is reducing scroll length.</li>
-            <li>Steps do not depend on one another.</li>
-            <li>Users would frequently need to jump between sections.</li>
-            <li>The workflow can be understood in a single view.</li>
-          </CharacteristicList>
-        </ContextCard>
-      </SectionGroup>
-    </ContextGrid>
-  </DocContainer>
-);
-
-// ─── Form fields used in the interactive example ─────────────────────────────
+// ─── Form fields used in the interactive examples ─────────────────────────────
 
 type StoryValues = { title: string; description: string };
 
@@ -298,6 +237,168 @@ const FormFields = () => (
   </>
 );
 
+// ─── Pattern Overview Doc ────────────────────────────────────────────────────
+
+const CreateEntityPatternDoc = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <DocContainer>
+      <DocH1>Creating an Entity</DocH1>
+
+      <DocLead>
+        Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a
+        creation flow consistently.
+      </DocLead>
+
+      <Alert bsStyle="info">
+        <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
+        surface, then choose the appropriate method.
+      </Alert>
+
+      <DiagramWrapper>
+        <Mermaid chart={DIAGRAM} />
+      </DiagramWrapper>
+
+      <ContextGrid>
+        <SectionGroup>
+          <DocH2>Choosing the Surface</DocH2>
+
+          <ContextBody>
+            Choose the surface based on whether creation should happen within the user's current workflow or in a
+            dedicated creation experience.
+          </ContextBody>
+
+          <ContextCard>
+            <DocH3 id="current-context">Current Context: Modal</DocH3>
+
+            <ContextBody>
+              Use a Modal when creation is part of the task the user is already performing and they should be able to
+              continue where they left off when creation is complete.
+            </ContextBody>
+
+            <CharacteristicHeading>Characteristics</CharacteristicHeading>
+            <CharacteristicList>
+              <li>Users remain in their current workflow.</li>
+              <li>The parent view remains visible.</li>
+              <li>Creation is completed without changing pages.</li>
+              <li>Completion returns users to their previous location.</li>
+              <li>Successful creation closes the modal and shows a toast notification.</li>
+            </CharacteristicList>
+
+            <ExampleLabel>Example</ExampleLabel>
+            <ExampleWrapper>
+              <Button onClick={() => setShowModal(true)}>Create Stream</Button>
+              <CreateModal<StoryValues>
+                entityName="Stream"
+                show={showModal}
+                onClose={() => setShowModal(false)}
+                initialValues={{ title: '', description: '' }}
+                onSubmit={async () => {}}>
+                <FormFields />
+              </CreateModal>
+            </ExampleWrapper>
+            <CodeDetails>
+              <summary />
+              <CodeBlock>{MODAL_CODE}</CodeBlock>
+            </CodeDetails>
+          </ContextCard>
+
+          <ContextCard>
+            <DocH3 id="new-context">New Context: Page</DocH3>
+
+            <ContextBody>
+              Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
+              destination.
+            </ContextBody>
+
+            <CharacteristicHeading>Characteristics</CharacteristicHeading>
+            <CharacteristicList>
+              <li>Users move into a focused creation experience.</li>
+              <li>The flow has its own URL and browser history entry.</li>
+              <li>Additional guidance, content, or validation can be accommodated.</li>
+              <li>Successful creation navigates users to the newly created entity.</li>
+              <li>A toast notification communicates successful creation.</li>
+            </CharacteristicList>
+
+            <ExampleLabel>Example</ExampleLabel>
+            <PagePreviewWrapper>
+              <MemoryRouter>
+                <CreatePage<StoryValues>
+                  entityName="Stream"
+                  overviewRoute="/streams"
+                  detailsRoute={(id) => `/streams/${id}`}
+                  initialValues={{ title: '', description: '' }}
+                  onSubmit={async () => ({ id: 'new-stream-id' })}
+                  description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
+                  <FormFields />
+                </CreatePage>
+              </MemoryRouter>
+            </PagePreviewWrapper>
+            <CodeDetails>
+              <summary />
+              <CodeBlock>{PAGE_CODE}</CodeBlock>
+            </CodeDetails>
+          </ContextCard>
+
+          <Alert bsStyle="info">
+            If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
+            Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
+            consistency across the product.
+          </Alert>
+        </SectionGroup>
+
+        <SectionGroup>
+          <DocH2>Choosing the Method</DocH2>
+
+          <ContextBody>
+            After selecting the surface, choose the creation method. A Form and a Wizard can both be used in either a
+            Modal or a Page.
+          </ContextBody>
+
+          <ContextCard>
+            <DocH3>Form</DocH3>
+
+            <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
+
+            <CharacteristicHeading>Characteristics</CharacteristicHeading>
+            <CharacteristicList>
+              <li>Fields can be displayed together.</li>
+              <li>There are no significant dependencies between steps.</li>
+              <li>The workflow is primarily data entry.</li>
+            </CharacteristicList>
+          </ContextCard>
+
+          <ContextCard>
+            <DocH3>Wizard</DocH3>
+
+            <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
+
+            <CharacteristicHeading>Characteristics</CharacteristicHeading>
+            <CharacteristicList>
+              <li>The flow contains multiple dependent decisions.</li>
+              <li>Information is naturally grouped into stages.</li>
+              <li>Showing everything at once would be overwhelming.</li>
+              <li>Users benefit from being guided through the process.</li>
+            </CharacteristicList>
+          </ContextCard>
+
+          <ContextCard>
+            <DocH3>Avoid Wizards When</DocH3>
+
+            <CharacteristicList>
+              <li>The only purpose is reducing scroll length.</li>
+              <li>Steps do not depend on one another.</li>
+              <li>Users would frequently need to jump between sections.</li>
+              <li>The workflow can be understood in a single view.</li>
+            </CharacteristicList>
+          </ContextCard>
+        </SectionGroup>
+      </ContextGrid>
+    </DocContainer>
+  );
+};
+
 // ─── Meta & Stories ───────────────────────────────────────────────────────────
 
 const meta: Meta = {
@@ -312,50 +413,4 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {
   render: () => <CreateEntityPatternDoc />,
-};
-
-export const CurrentContextModal: Story = {
-  name: 'Current Context — Modal',
-  render: () => {
-    const [show, setShow] = useState(false);
-
-    return (
-      <>
-        <Button onClick={() => setShow(true)}>Create Stream</Button>
-        <CreateModal<StoryValues>
-          entityName="Stream"
-          show={show}
-          onClose={() => setShow(false)}
-          initialValues={{ title: '', description: '' }}
-          onSubmit={fn()}>
-          <FormFields />
-        </CreateModal>
-      </>
-    );
-  },
-};
-
-export const NewContextPage: Story = {
-  name: 'New Context — Page',
-  parameters: {
-    layout: 'fullscreen',
-  },
-  decorators: [
-    (Story) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
-    ),
-  ],
-  render: () => (
-    <CreatePage<StoryValues>
-      entityName="Stream"
-      overviewRoute="/streams"
-      detailsRoute={(id) => `/streams/${id}`}
-      initialValues={{ title: '', description: '' }}
-      onSubmit={async () => ({ id: 'new-stream-id' })}
-      description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
-      <FormFields />
-    </CreatePage>
-  ),
 };

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -20,7 +20,7 @@ import { fn } from 'storybook/test';
 import { MemoryRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Button, Input } from 'components/bootstrap';
+import { Alert, Button, Input } from 'components/bootstrap';
 import { CreateModal, CreatePage } from 'components/common';
 
 import Mermaid from './Mermaid';
@@ -45,7 +45,6 @@ const DocH3 = styled.h3`
 
 const DocLead = styled.p`
   line-height: 1.6;
-  color: ${({ theme }) => theme.colors.text.secondary};
   margin: 0 0 ${({ theme }) => theme.spacings.xl};
 `;
 
@@ -73,7 +72,7 @@ const StoryNavLink = ({ storyId, children }: { storyId: string; children: React.
     href="#"
     onClick={(e) => {
       e.preventDefault();
-       
+
       (window as any).__STORYBOOK_ADDONS_CHANNEL__?.emit('selectStory', { storyId });
     }}>
     {children}
@@ -89,21 +88,12 @@ const SectionGroup = styled.div`
   }
 `;
 
-const ContextLabel = styled.p`
-  font-size: ${({ theme }) => theme.fonts.size.small};
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: ${({ theme }) => theme.colors.text.secondary};
-  margin: 0 0 ${({ theme }) => theme.spacings.xs};
-`;
-
 const ContextBody = styled.p`
   line-height: 1.6;
   margin: 0 0 ${({ theme }) => theme.spacings.md};
 `;
 
-const RuleListHeading = styled.p`
+const CharacteristicHeading = styled.p`
   font-size: ${({ theme }) => theme.fonts.size.small};
   font-weight: 600;
   text-transform: uppercase;
@@ -112,23 +102,14 @@ const RuleListHeading = styled.p`
   margin: 0 0 ${({ theme }) => theme.spacings.xs};
 `;
 
-const RuleList = styled.ul`
-  list-style: none;
-  padding: 0;
+const CharacteristicList = styled.ul`
+  list-style-type: disc;
   margin: 0 0 ${({ theme }) => theme.spacings.md};
-`;
+  padding-left: ${({ theme }) => theme.spacings.lg};
 
-const RuleItem = styled.li<{ $type: 'do' | 'dont' }>`
-  padding: ${({ theme }) => theme.spacings.xs} 0;
-  padding-left: 1.4em;
-  position: relative;
-  line-height: 1.5;
-
-  &::before {
-    position: absolute;
-    left: 0;
-    font-weight: 700;
-    ${({ $type }) => ($type === 'do' ? "content: '✓'; color: #22c55e;" : "content: '✕'; color: #ef4444;")}
+  li {
+    line-height: 1.5;
+    margin-bottom: ${({ theme }) => theme.spacings.xs};
   }
 `;
 
@@ -136,22 +117,32 @@ const RuleItem = styled.li<{ $type: 'do' | 'dont' }>`
 
 const DIAGRAM = `flowchart TD
   A(["User's current view"])
-  A --> B{{"\`Must keep user
-in current context?\`"}}
-  B -->|Yes| MODAL(["\`**Modal**
+  A --> B{{"\`Should users remain
+in their current workflow?\`"}}
+  B -->|Yes| MODAL
+  B -->|No| PAGE
+
+  subgraph Surface["Surface"]
+    MODAL(["\`**Modal**
 Current context preserved\`"])
-  B -->|No| PAGE(["\`**Page**
-New context, full focus\`"])
-  MODAL --> MW(["\`**Form or Wizard**
-No secondary context or workflow\`"])
-  PAGE --> FORM(["\`**Form**
-Static or dynamic fields\`"])
-  PAGE --> WIZARD(["\`**Wizard**
-Multi-step, guided flow\`"])
-  MW --> RC(["\`**Return to current context**
+    PAGE(["\`**Page**
+Dedicated creation experience\`"])
+  end
+
+  subgraph Method["Method"]
+    MW(["\`**Form or Wizard**
+Single-step or guided workflow\`"])
+    FW(["\`**Form or Wizard**
+Single-step or guided workflow\`"])
+  end
+
+  MODAL --> MW
+  PAGE --> FW
+
+  MW --> RC(["\`**Return to current workflow**
 Modal closes, toast shown\`"])
-  FORM & WIZARD --> NC(["\`**Navigate to new context**
-Detail page, list, or origin\`"])
+  FW --> NC(["\`**Navigate to entity**
+Details page, toast shown\`"])
 `;
 
 // ─── Pattern Overview Doc ────────────────────────────────────────────────────
@@ -159,56 +150,120 @@ Detail page, list, or origin\`"])
 const CreateEntityPatternDoc = () => (
   <DocContainer>
     <DocH1>Creating an Entity</DocH1>
+
+    <DocLead>
+      Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation
+      flow consistently.
+    </DocLead>
+
+    <Alert bsStyle="info">
+      <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
+      context, then choose the appropriate method.
+    </Alert>
+
     <DiagramWrapper>
       <Mermaid chart={DIAGRAM} />
     </DiagramWrapper>
 
     <ContextGrid>
       <SectionGroup>
-        <DocH2>Surface</DocH2>
+        <DocH2>Choosing the Surface</DocH2>
+        <ContextBody>
+          Choose the surface based on whether creation should happen within the user’s current workflow or in a
+          dedicated creation experience.
+        </ContextBody>
 
         <ContextCard>
-          <DocH3 id="current-context">Modal</DocH3>
+          <DocH3 id="current-context">Current Context: Modal</DocH3>
+
           <ContextBody>
-            Use a Modal to keep the user in their current context. The parent view stays visible, and on completion the
-            modal closes and returns the user to where they started. Use a Form or Wizard — if the workflow requires its
-            own context, use a Page instead.
+            Use a Modal when creation is part of the task the user is already performing and they should be able to
+            continue where they left off when creation is complete.
           </ContextBody>
 
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Users remain in their current workflow.</li>
+            <li>The parent view remains visible.</li>
+            <li>Creation is completed without changing pages.</li>
+            <li>Completion returns users to their previous location.</li>
+            <li>Successful creation closes the modal and shows a toast notification.</li>
+          </CharacteristicList>
+
           <StoryNavLink storyId="patterns-creating-an-entity--current-context-modal">View example →</StoryNavLink>
-
-          <RuleListHeading>Do</RuleListHeading>
-          <RuleList>
-            <RuleItem $type="do">Show a toast notification on successful creation</RuleItem>
-          </RuleList>
-
-          <RuleListHeading>Do not</RuleListHeading>
-          <RuleList>
-            <RuleItem $type="dont">Open a modal on top of another modal</RuleItem>
-          </RuleList>
         </ContextCard>
 
         <ContextCard>
-          <DocH3 id="new-context">Page</DocH3>
+          <DocH3 id="new-context">New Context: Page</DocH3>
+
           <ContextBody>
-            Use a Page when a context shift is appropriate. The user gets a dedicated creation experience and on
-            completion is taken to the entity detail page. Pages have a browser history entry and can be directly linked
-            to.
+            Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
+            destination.
           </ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Users move into a focused creation experience.</li>
+            <li>The flow has its own URL and browser history entry.</li>
+            <li>Additional guidance, content, or validation can be accommodated.</li>
+            <li>Successful creation navigates users to the newly created entity.</li>
+            <li>A toast notification communicates successful creation.</li>
+          </CharacteristicList>
 
           <StoryNavLink storyId="patterns-creating-an-entity--new-context-page">View example →</StoryNavLink>
         </ContextCard>
+
+        <Alert bsStyle="info">
+          If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
+          Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
+          consistency across the product.
+        </Alert>
       </SectionGroup>
 
       <SectionGroup>
-        <DocH2>Method</DocH2>
+        <DocH2>Choosing the Method</DocH2>
+
+        <ContextBody>
+          After selecting the context, choose the creation method. A Form and a Wizard can both be used in either a
+          Modal or a Page.
+        </ContextBody>
 
         <ContextCard>
-          <DocH3>Form vs Wizard</DocH3>
-          <ContextBody>
-            Use a Form for single-step creation with a manageable number of fields. Use a Wizard when creation involves
-            multiple dependent steps or too many fields to show at once.
-          </ContextBody>
+          <DocH3>Form</DocH3>
+
+          <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Fields can be displayed together.</li>
+            <li>There are no significant dependencies between steps.</li>
+            <li>The workflow is primarily data entry.</li>
+          </CharacteristicList>
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3>Wizard</DocH3>
+
+          <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>The flow contains multiple dependent decisions.</li>
+            <li>Information is naturally grouped into stages.</li>
+            <li>Showing everything at once would be overwhelming.</li>
+            <li>Users benefit from being guided through the process.</li>
+          </CharacteristicList>
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3>Avoid Wizards When</DocH3>
+
+          <CharacteristicList>
+            <li>The only purpose is reducing scroll length.</li>
+            <li>Steps do not depend on one another.</li>
+            <li>Users would frequently need to jump between sections.</li>
+            <li>The workflow can be understood in a single view.</li>
+          </CharacteristicList>
         </ContextCard>
       </SectionGroup>
     </ContextGrid>

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -16,6 +16,7 @@
  */
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { Canvas } from '@storybook/addon-docs/blocks';
 import { MemoryRouter } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -28,6 +29,7 @@ import Mermaid from './Mermaid';
 
 const DocContainer = styled.div`
   max-width: 900px;
+  padding: 1rem;
 `;
 
 const DocH1 = styled.h1`
@@ -93,62 +95,6 @@ const CharacteristicList = styled.ul`
   }
 `;
 
-const ExampleLabel = styled.p`
-  font-size: ${({ theme }) => theme.fonts.size.small};
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: ${({ theme }) => theme.colors.text.secondary};
-  margin: 0 0 ${({ theme }) => theme.spacings.xs};
-`;
-
-const ExampleWrapper = styled.div`
-  border: 1px solid rgba(128, 128, 128, 0.25);
-  border-radius: 4px;
-  padding: ${({ theme }) => theme.spacings.md};
-  margin-bottom: ${({ theme }) => theme.spacings.xs};
-`;
-
-const PagePreviewWrapper = styled.div`
-  border: 1px solid rgba(128, 128, 128, 0.25);
-  border-radius: 4px;
-  overflow-y: auto;
-  height: 520px;
-  margin-bottom: ${({ theme }) => theme.spacings.xs};
-`;
-
-const CodeDetails = styled.details`
-  margin-bottom: ${({ theme }) => theme.spacings.lg};
-
-  summary {
-    cursor: pointer;
-    font-size: ${({ theme }) => theme.fonts.size.small};
-    color: ${({ theme }) => theme.colors.text.secondary};
-    user-select: none;
-    list-style: none;
-
-    &::before {
-      content: '▶  Show code';
-    }
-  }
-
-  &[open] summary::before {
-    content: '▼  Hide code';
-  }
-`;
-
-const CodeBlock = styled.pre`
-  margin: ${({ theme }) => theme.spacings.xs} 0 0;
-  padding: ${({ theme }) => theme.spacings.md};
-  background: rgba(128, 128, 128, 0.07);
-  border: 1px solid rgba(128, 128, 128, 0.2);
-  border-radius: 4px;
-  font-size: 13px;
-  line-height: 1.5;
-  overflow-x: auto;
-  white-space: pre;
-`;
-
 // ─── Flowchart ────────────────────────────────────────────────────────────────
 
 const DIAGRAM = `flowchart TD
@@ -181,34 +127,6 @@ Modal closes, toast shown\`"])
 Details page, toast shown\`"])
 `;
 
-// ─── Code snippets ────────────────────────────────────────────────────────────
-
-const MODAL_CODE = `const [show, setShow] = useState(false);
-
-return (
-  <>
-    <Button onClick={() => setShow(true)}>Create Stream</Button>
-    <CreateModal
-      entityName="Stream"
-      show={show}
-      onClose={() => setShow(false)}
-      initialValues={{ title: '', description: '' }}
-      onSubmit={handleSubmit}>
-      <FormFields />
-    </CreateModal>
-  </>
-);`;
-
-const PAGE_CODE = `<CreatePage
-  entityName="Stream"
-  overviewRoute="/streams"
-  detailsRoute={(id) => \`/streams/\${id}\`}
-  initialValues={{ title: '', description: '' }}
-  onSubmit={handleSubmit}
-  description="Streams route incoming messages into categories.">
-  <FormFields />
-</CreatePage>`;
-
 // ─── Form fields used in the interactive examples ─────────────────────────────
 
 type StoryValues = { title: string; description: string };
@@ -237,180 +155,188 @@ const FormFields = () => (
   </>
 );
 
-// ─── Pattern Overview Doc ────────────────────────────────────────────────────
+// ─── Stories (hidden from sidebar, embedded via Canvas in the docs page) ──────
 
-const CreateEntityPatternDoc = () => {
-  const [showModal, setShowModal] = useState(false);
+export const CurrentContextModal: StoryObj = {
+  tags: ['!dev'],
+  render: () => {
+    const [show, setShow] = useState(false);
 
-  return (
-    <DocContainer>
-      <DocH1>Creating an Entity</DocH1>
-
-      <DocLead>
-        Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a
-        creation flow consistently.
-      </DocLead>
-
-      <Alert bsStyle="info">
-        <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
-        surface, then choose the appropriate method.
-      </Alert>
-
-      <DiagramWrapper>
-        <Mermaid chart={DIAGRAM} />
-      </DiagramWrapper>
-
-      <ContextGrid>
-        <SectionGroup>
-          <DocH2>Choosing the Surface</DocH2>
-
-          <ContextBody>
-            Choose the surface based on whether creation should happen within the user's current workflow or in a
-            dedicated creation experience.
-          </ContextBody>
-
-          <ContextCard>
-            <DocH3 id="current-context">Current Context: Modal</DocH3>
-
-            <ContextBody>
-              Use a Modal when creation is part of the task the user is already performing and they should be able to
-              continue where they left off when creation is complete.
-            </ContextBody>
-
-            <CharacteristicHeading>Characteristics</CharacteristicHeading>
-            <CharacteristicList>
-              <li>Users remain in their current workflow.</li>
-              <li>The parent view remains visible.</li>
-              <li>Creation is completed without changing pages.</li>
-              <li>Completion returns users to their previous location.</li>
-              <li>Successful creation closes the modal and shows a toast notification.</li>
-            </CharacteristicList>
-
-            <ExampleLabel>Example</ExampleLabel>
-            <ExampleWrapper>
-              <Button onClick={() => setShowModal(true)}>Create Stream</Button>
-              <CreateModal<StoryValues>
-                entityName="Stream"
-                show={showModal}
-                onClose={() => setShowModal(false)}
-                initialValues={{ title: '', description: '' }}
-                onSubmit={async () => {}}>
-                <FormFields />
-              </CreateModal>
-            </ExampleWrapper>
-            <CodeDetails>
-              <summary />
-              <CodeBlock>{MODAL_CODE}</CodeBlock>
-            </CodeDetails>
-          </ContextCard>
-
-          <ContextCard>
-            <DocH3 id="new-context">New Context: Page</DocH3>
-
-            <ContextBody>
-              Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
-              destination.
-            </ContextBody>
-
-            <CharacteristicHeading>Characteristics</CharacteristicHeading>
-            <CharacteristicList>
-              <li>Users move into a focused creation experience.</li>
-              <li>The flow has its own URL and browser history entry.</li>
-              <li>Additional guidance, content, or validation can be accommodated.</li>
-              <li>Successful creation navigates users to the newly created entity.</li>
-              <li>A toast notification communicates successful creation.</li>
-            </CharacteristicList>
-
-            <ExampleLabel>Example</ExampleLabel>
-            <PagePreviewWrapper>
-              <MemoryRouter>
-                <CreatePage<StoryValues>
-                  entityName="Stream"
-                  overviewRoute="/streams"
-                  detailsRoute={(id) => `/streams/${id}`}
-                  initialValues={{ title: '', description: '' }}
-                  onSubmit={async () => ({ id: 'new-stream-id' })}
-                  description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
-                  <FormFields />
-                </CreatePage>
-              </MemoryRouter>
-            </PagePreviewWrapper>
-            <CodeDetails>
-              <summary />
-              <CodeBlock>{PAGE_CODE}</CodeBlock>
-            </CodeDetails>
-          </ContextCard>
-
-          <Alert bsStyle="info">
-            If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
-            Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
-            consistency across the product.
-          </Alert>
-        </SectionGroup>
-
-        <SectionGroup>
-          <DocH2>Choosing the Method</DocH2>
-
-          <ContextBody>
-            After selecting the surface, choose the creation method. A Form and a Wizard can both be used in either a
-            Modal or a Page.
-          </ContextBody>
-
-          <ContextCard>
-            <DocH3>Form</DocH3>
-
-            <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
-
-            <CharacteristicHeading>Characteristics</CharacteristicHeading>
-            <CharacteristicList>
-              <li>Fields can be displayed together.</li>
-              <li>There are no significant dependencies between steps.</li>
-              <li>The workflow is primarily data entry.</li>
-            </CharacteristicList>
-          </ContextCard>
-
-          <ContextCard>
-            <DocH3>Wizard</DocH3>
-
-            <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
-
-            <CharacteristicHeading>Characteristics</CharacteristicHeading>
-            <CharacteristicList>
-              <li>The flow contains multiple dependent decisions.</li>
-              <li>Information is naturally grouped into stages.</li>
-              <li>Showing everything at once would be overwhelming.</li>
-              <li>Users benefit from being guided through the process.</li>
-            </CharacteristicList>
-          </ContextCard>
-
-          <ContextCard>
-            <DocH3>Avoid Wizards When</DocH3>
-
-            <CharacteristicList>
-              <li>The only purpose is reducing scroll length.</li>
-              <li>Steps do not depend on one another.</li>
-              <li>Users would frequently need to jump between sections.</li>
-              <li>The workflow can be understood in a single view.</li>
-            </CharacteristicList>
-          </ContextCard>
-        </SectionGroup>
-      </ContextGrid>
-    </DocContainer>
-  );
+    return (
+      <>
+        <Button onClick={() => setShow(true)}>Create Stream</Button>
+        <CreateModal<StoryValues>
+          entityName="Stream"
+          show={show}
+          onClose={() => setShow(false)}
+          initialValues={{ title: '', description: '' }}
+          onSubmit={async () => {}}>
+          <FormFields />
+        </CreateModal>
+      </>
+    );
+  },
 };
 
-// ─── Meta & Stories ───────────────────────────────────────────────────────────
+export const NewContextPage: StoryObj = {
+  tags: ['!dev'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  render: () => (
+    <CreatePage<StoryValues>
+      entityName="Stream"
+      overviewRoute="/streams"
+      detailsRoute={(id) => `/streams/${id}`}
+      initialValues={{ title: '', description: '' }}
+      onSubmit={async () => ({ id: 'new-stream-id' })}
+      description="Streams route incoming messages into categories. Route a message into a stream by applying matching rules.">
+      <FormFields />
+    </CreatePage>
+  ),
+};
+
+// ─── Docs page ────────────────────────────────────────────────────────────────
+
+const CreateEntityPattern = () => (
+  <DocContainer>
+    <DocH1>Creating an Entity</DocH1>
+
+    <DocLead>
+      Entity creation is a foundational interaction in Graylog. This guide helps you decide how to implement a creation
+      flow consistently.
+    </DocLead>
+
+    <Alert bsStyle="info">
+      <strong>Design principle:</strong> Entity creation is organized around two decisions: choose the appropriate
+      surface, then choose the appropriate method.
+    </Alert>
+
+    <DiagramWrapper>
+      <Mermaid chart={DIAGRAM} />
+    </DiagramWrapper>
+
+    <ContextGrid>
+      <SectionGroup>
+        <DocH2>Choosing the Surface</DocH2>
+
+        <ContextBody>
+          Choose the surface based on whether creation should happen within the user's current workflow or in a
+          dedicated creation experience.
+        </ContextBody>
+
+        <ContextCard>
+          <DocH3 id="current-context">Current Context: Modal</DocH3>
+
+          <ContextBody>
+            Use a Modal when creation is part of the task the user is already performing and they should be able to
+            continue where they left off when creation is complete.
+          </ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Users remain in their current workflow.</li>
+            <li>The parent view remains visible.</li>
+            <li>Creation is completed without changing pages.</li>
+            <li>Completion returns users to their previous location.</li>
+            <li>Successful creation closes the modal and shows a toast notification.</li>
+          </CharacteristicList>
+
+          <Canvas of={CurrentContextModal} />
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3 id="new-context">New Context: Page</DocH3>
+
+          <ContextBody>
+            Use a Page when creation benefits from a dedicated experience with its own focus, navigation state, and
+            destination.
+          </ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Users move into a focused creation experience.</li>
+            <li>The flow has its own URL and browser history entry.</li>
+            <li>Additional guidance, content, or validation can be accommodated.</li>
+            <li>Successful creation navigates users to the newly created entity.</li>
+            <li>A toast notification communicates successful creation.</li>
+          </CharacteristicList>
+
+          <Canvas of={NewContextPage} />
+        </ContextCard>
+
+        <Alert bsStyle="info">
+          If it is unclear whether creation belongs in the current context or a dedicated one, involve Product and
+          Design before implementation. Context decisions affect navigation, workflow continuity, and long-term
+          consistency across the product.
+        </Alert>
+      </SectionGroup>
+
+      <SectionGroup>
+        <DocH2>Choosing the Method</DocH2>
+
+        <ContextBody>
+          After selecting the surface, choose the creation method. A Form and a Wizard can both be used in either a
+          Modal or a Page.
+        </ContextBody>
+
+        <ContextCard>
+          <DocH3>Form</DocH3>
+
+          <ContextBody>Use a Form when users can reasonably complete creation in a single step.</ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>Fields can be displayed together.</li>
+            <li>There are no significant dependencies between steps.</li>
+            <li>The workflow is primarily data entry.</li>
+          </CharacteristicList>
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3>Wizard</DocH3>
+
+          <ContextBody>Use a Wizard when users benefit from progressive guidance and decision making.</ContextBody>
+
+          <CharacteristicHeading>Characteristics</CharacteristicHeading>
+          <CharacteristicList>
+            <li>The flow contains multiple dependent decisions.</li>
+            <li>Information is naturally grouped into stages.</li>
+            <li>Showing everything at once would be overwhelming.</li>
+            <li>Users benefit from being guided through the process.</li>
+          </CharacteristicList>
+        </ContextCard>
+
+        <ContextCard>
+          <DocH3>Avoid Wizards When</DocH3>
+
+          <CharacteristicList>
+            <li>The only purpose is reducing scroll length.</li>
+            <li>Steps do not depend on one another.</li>
+            <li>Users would frequently need to jump between sections.</li>
+            <li>The workflow can be understood in a single view.</li>
+          </CharacteristicList>
+        </ContextCard>
+      </SectionGroup>
+    </ContextGrid>
+  </DocContainer>
+);
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
 
 const meta: Meta = {
   title: 'Patterns/Creating an Entity',
+  tags: ['autodocs'],
   parameters: {
     layout: 'padded',
+    docs: {
+      page: CreateEntityPattern,
+    },
   },
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Overview: Story = {
-  render: () => <CreateEntityPatternDoc />,
-};

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.stories.tsx
@@ -73,7 +73,9 @@ export const NewContextPage: StoryObj = {
   decorators: [
     (Story) => (
       <MemoryRouter>
-        <Story />
+        <div className="container-fluid">
+          <Story />
+        </div>
       </MemoryRouter>
     ),
   ],

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/Mermaid.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/Mermaid.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React, { useEffect, useRef } from 'react';
+import mermaid from 'mermaid';
+
+mermaid.initialize({ startOnLoad: false, theme: 'neutral', fontFamily: 'inherit' });
+
+let _counter = 0;
+
+type Props = { chart: string };
+
+const Mermaid = ({ chart }: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const idRef = useRef(`mermaid-${++_counter}`);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    mermaid.render(idRef.current, chart).then(({ svg }) => {
+      if (containerRef.current) containerRef.current.innerHTML = svg;
+    });
+  }, [chart]);
+
+  return <div ref={containerRef} />;
+};
+
+export default Mermaid;

--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/Mermaid.tsx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/Mermaid.tsx
@@ -16,27 +16,59 @@
  */
 import React, { useEffect, useRef } from 'react';
 import mermaid from 'mermaid';
-
-mermaid.initialize({ startOnLoad: false, theme: 'neutral', fontFamily: 'inherit' });
+import styled, { useTheme } from 'styled-components';
+import { Unstyled } from '@storybook/addon-docs/blocks';
 
 let _counter = 0;
 
 type Props = { chart: string };
 
+const Container = styled.div(
+  ({ theme }) => `
+    display: flex;
+    justify-content: center;
+    margin-bottom: ${theme.spacings.lg};
+
+    .label {
+      font-weight: normal;
+    }
+
+    .cluster rect {
+      stroke-dasharray: 6, 4;
+    }
+  `,
+);
+
 const Mermaid = ({ chart }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const idRef = useRef(`mermaid-${++_counter}`);
+  const theme = useTheme();
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
+    if (!containerRef.current) return;
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: 'base',
+      fontFamily: 'inherit',
+      themeVariables: {
+        primaryColor: theme.colors.global.contentBackground,
+        primaryBorderColor: theme.colors.input.border,
+        primaryTextColor: theme.colors.text.primary,
+        lineColor: theme.colors.text.secondary,
+        edgeLabelBackground: theme.colors.global.contentBackground,
+        clusterBkg: 'transparent',
+        clusterBorder: theme.colors.input.border,
+        titleColor: theme.colors.text.primary,
+      },
+    });
 
     mermaid.render(idRef.current, chart).then(({ svg }) => {
       if (containerRef.current) containerRef.current.innerHTML = svg;
     });
-  }, [chart]);
+  }, [chart, theme]);
 
-  return <div ref={containerRef} />;
+  return <Unstyled><Container ref={containerRef} /></Unstyled>;
 };
 
 export default Mermaid;

--- a/graylog2-web-interface/docs/graylog-luma/yarn.lock
+++ b/graylog2-web-interface/docs/graylog-luma/yarn.lock
@@ -7,6 +7,14 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.4.tgz#2856c55443d3d461693f32d2b96fb6ea92e1ffa9"
   integrity sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==
 
+"@antfu/install-pkg@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+  dependencies:
+    package-manager-detector "^1.3.0"
+    tinyexec "^1.0.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -145,6 +153,16 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@braintree/sanitize-url@^7.1.1":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
+
+"@chevrotain/types@~11.1.1":
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
+  integrity sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
 
 "@emnapi/core@1.9.2":
   version "1.9.2"
@@ -305,6 +323,20 @@
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
+"@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^3.0.2":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@iconify/utils/-/utils-3.1.3.tgz#71efd68f9ed2ea3c91fd3a01c0032f70a87027b7"
+  integrity sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/types" "^2.0.0"
+    import-meta-resolve "^4.2.0"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -353,6 +385,13 @@
   integrity sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==
   dependencies:
     "@types/mdx" "^2.0.0"
+
+"@mermaid-js/parser@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mermaid-js/parser/-/parser-1.1.1.tgz#30f3ab68d816912e43f245a72a0d4081bf69d966"
+  integrity sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==
+  dependencies:
+    "@chevrotain/types" "~11.1.1"
 
 "@napi-rs/wasm-runtime@^1.1.1", "@napi-rs/wasm-runtime@^1.1.4":
   version "1.1.4"
@@ -836,6 +875,216 @@
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
 
+"@types/d3-array@*":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
@@ -866,6 +1115,11 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
@@ -898,6 +1152,11 @@
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@typescript-eslint/project-service@8.59.2":
   version "8.59.2"
@@ -958,6 +1217,14 @@
   dependencies:
     "@typescript-eslint/types" "8.59.2"
     eslint-visitor-keys "^5.0.0"
+
+"@upsetjs/venn.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz#3be192038cdda927aa4f8b22ab51af82abf47f34"
+  integrity sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
+  optionalDependencies:
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
 
 "@vitest/expect@3.2.4":
   version "3.2.4"
@@ -1396,6 +1663,11 @@ colorette@^2.0.10:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1420,6 +1692,20 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
+cose-base@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+  dependencies:
+    layout-base "^2.0.0"
 
 cosmiconfig@^8.2.0:
   version "8.3.6"
@@ -1471,6 +1757,309 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape-fcose@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+  dependencies:
+    cose-base "^2.2.0"
+
+cytoscape@^3.33.1:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.34.0.tgz#5fbe2eb1cf76b070a8ecd5647c35f65aa097c9c6"
+  integrity sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==
+
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-geo@3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-sankey@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+  dependencies:
+    d3-array "1 - 2"
+    d3-shape "^1.2.0"
+
+d3-scale-chromatic@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.9.0:
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.14:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz#1272276e26457cf3b97dac569f8f0531ec33c377"
+  integrity sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
+  dependencies:
+    d3 "^7.9.0"
+    lodash-es "^4.17.21"
+
+dayjs@^1.11.19:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
@@ -1511,6 +2100,13 @@ define-lazy-prop@^3.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
+delaunator@5:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.1.0.tgz#d13271fbf3aff6753f9ea6e235557f20901046ea"
+  integrity sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+  dependencies:
+    robust-predicates "^3.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -1550,6 +2146,13 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^3.3.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
+  integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -1616,6 +2219,11 @@ es-module-lexer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"
   integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
+
+es-toolkit@^1.45.1:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.47.0.tgz#846778dac47af951f9917363ec5a3b94beeb8ddc"
+  integrity sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==
 
 "esbuild@^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0":
   version "0.27.0"
@@ -1843,6 +2451,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+hachure-fill@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
+  integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -1899,6 +2512,13 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
@@ -1911,6 +2531,11 @@ import-fresh@^3.3.0:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-meta-resolve@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -1929,6 +2554,16 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2026,12 +2661,34 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+katex@^0.16.25:
+  version "0.16.47"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
+  integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+  dependencies:
+    commander "^8.3.0"
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+khroma@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+
+layout-base@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -2049,6 +2706,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash@^4.17.20, lodash@^4.17.21:
   version "4.18.1"
@@ -2093,6 +2755,11 @@ map-or-similar@^1.5.0:
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
   integrity sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==
 
+marked@^16.3.0:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
+
 memfs@^3.4.1, memfs@^3.4.12:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
@@ -2111,6 +2778,33 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+mermaid@^11.15.0:
+  version "11.15.0"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.15.0.tgz#b485c13ea5e1e74f3328c4bb00427bda87fa1c1e"
+  integrity sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==
+  dependencies:
+    "@braintree/sanitize-url" "^7.1.1"
+    "@iconify/utils" "^3.0.2"
+    "@mermaid-js/parser" "^1.1.1"
+    "@types/d3" "^7.4.3"
+    "@upsetjs/venn.js" "^2.0.0"
+    cytoscape "^3.33.1"
+    cytoscape-cose-bilkent "^4.1.0"
+    cytoscape-fcose "^2.2.0"
+    d3 "^7.9.0"
+    d3-sankey "^0.12.3"
+    dagre-d3-es "7.0.14"
+    dayjs "^1.11.19"
+    dompurify "^3.3.1"
+    es-toolkit "^1.45.1"
+    katex "^0.16.25"
+    khroma "^2.1.0"
+    marked "^16.3.0"
+    roughjs "^4.6.6"
+    stylis "^4.3.6"
+    ts-dedent "^2.2.0"
+    uuid "^11.1.0 || ^12 || ^13 || ^14.0.0"
 
 micromatch@^4.0.2:
   version "4.0.8"
@@ -2301,6 +2995,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-manager-detector@^1.3.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz#70d0cf0aa02c877eeaf66c4d984ede0be9130734"
+  integrity sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -2333,6 +3032,11 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+path-data-parser@0.1.0, path-data-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/path-data-parser/-/path-data-parser-0.1.0.tgz#8f5ba5cc70fc7becb3dcefaea08e2659aba60b8c"
+  integrity sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -2385,6 +3089,19 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+points-on-curve@0.2.0, points-on-curve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/points-on-curve/-/points-on-curve-0.2.0.tgz#7dbb98c43791859434284761330fa893cb81b4d1"
+  integrity sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
+
+points-on-path@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/points-on-path/-/points-on-path-0.2.1.tgz#553202b5424c53bed37135b318858eacff85dd52"
+  integrity sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
+  dependencies:
+    path-data-parser "0.1.0"
+    points-on-curve "0.2.0"
 
 postcss-modules-extract-imports@^3.1.0:
   version "3.1.0"
@@ -2569,10 +3286,35 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+
+roughjs@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/roughjs/-/roughjs-4.6.6.tgz#1059f49a5e0c80dee541a005b20cc322b222158b"
+  integrity sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
+  dependencies:
+    hachure-fill "^0.5.2"
+    path-data-parser "^0.1.0"
+    points-on-curve "^0.2.0"
+    points-on-path "^0.2.1"
+
 run-applescript@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
   integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 scheduler@^0.27.0:
   version "0.27.0"
@@ -2685,6 +3427,11 @@ style-loader@^4.0.0:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-4.0.0.tgz#0ea96e468f43c69600011e0589cb05c44f3b17a5"
   integrity sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==
 
+stylis@^4.3.6:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -2746,6 +3493,11 @@ tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
+tinyexec@^1.0.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
+
 tinyglobby@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -2776,7 +3528,7 @@ ts-api-utils@^2.5.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
-ts-dedent@^2.0.0:
+ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
@@ -2857,6 +3609,11 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
+
+"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 watchpack@^2.5.1:
   version "2.5.1"

--- a/graylog2-web-interface/src/components/common/CreateModal.tsx
+++ b/graylog2-web-interface/src/components/common/CreateModal.tsx
@@ -25,7 +25,6 @@ import ModalSubmit from 'components/common/ModalSubmit';
 type ContentProps = {
   entityName: string;
   onCancel: () => void;
-  disabledSubmit?: boolean;
   submitError: string | null;
   children: React.ReactNode;
 };
@@ -33,7 +32,6 @@ type ContentProps = {
 const CreateModalContent = ({
   entityName,
   onCancel,
-  disabledSubmit = false,
   submitError,
   children,
 }: ContentProps) => {
@@ -41,7 +39,7 @@ const CreateModalContent = ({
   const entityNameLower = entityName.toLowerCase();
 
   return (
-    <Form>
+    <Form className="form form-horizontal">
       <Modal.Header>
         <Modal.Title>Create {entityName}</Modal.Title>
       </Modal.Header>
@@ -61,7 +59,7 @@ const CreateModalContent = ({
           submitLoadingText={`Creating ${entityNameLower}...`}
           isSubmitting={isSubmitting}
           isAsyncSubmit
-          disabledSubmit={!isValid || isValidating || disabledSubmit}
+          disabledSubmit={!isValid || isValidating}
           onCancel={onCancel}
         />
       </Modal.Footer>
@@ -76,7 +74,6 @@ type Props<TValues extends object> = {
   initialValues: TValues;
   onSubmit: (values: TValues) => Promise<void>;
   validate?: (values: TValues) => FormikErrors<TValues> | Promise<FormikErrors<TValues>>;
-  disabledSubmit?: boolean;
   children: React.ReactNode;
 };
 
@@ -87,7 +84,6 @@ const CreateModal = <TValues extends object>({
   initialValues,
   onSubmit,
   validate = undefined,
-  disabledSubmit = false,
   children,
 }: Props<TValues>) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -113,7 +109,6 @@ const CreateModal = <TValues extends object>({
         <CreateModalContent
           entityName={entityName}
           onCancel={onClose}
-          disabledSubmit={disabledSubmit}
           submitError={submitError}>
           {children}
         </CreateModalContent>

--- a/graylog2-web-interface/src/components/common/CreateModal.tsx
+++ b/graylog2-web-interface/src/components/common/CreateModal.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState } from 'react';
+import type { FormikErrors } from 'formik';
+import { Formik, Form, useFormikContext } from 'formik';
+
+import { Alert, BootstrapModalWrapper, Modal } from 'components/bootstrap';
+import ModalSubmit from 'components/common/ModalSubmit';
+
+type ContentProps = {
+  entityName: string;
+  onCancel: () => void;
+  disabledSubmit?: boolean;
+  submitError: string | null;
+  children: React.ReactNode;
+};
+
+const CreateModalContent = ({
+  entityName,
+  onCancel,
+  disabledSubmit = false,
+  submitError,
+  children,
+}: ContentProps) => {
+  const { isSubmitting, isValidating, isValid } = useFormikContext();
+  const entityNameLower = entityName.toLowerCase();
+
+  return (
+    <Form>
+      <Modal.Header>
+        <Modal.Title>Create {entityName}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="container-fluid">
+          {children}
+          {submitError && (
+            <Alert bsStyle="danger" title="Failed to save">
+              {submitError}
+            </Alert>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <ModalSubmit
+          submitButtonText={`Create ${entityNameLower}`}
+          submitLoadingText={`Creating ${entityNameLower}...`}
+          isSubmitting={isSubmitting}
+          isAsyncSubmit
+          disabledSubmit={!isValid || isValidating || disabledSubmit}
+          onCancel={onCancel}
+        />
+      </Modal.Footer>
+    </Form>
+  );
+};
+
+type Props<TValues extends object> = {
+  entityName: string;
+  show: boolean;
+  onClose: () => void;
+  initialValues: TValues;
+  onSubmit: (values: TValues) => Promise<void>;
+  validate?: (values: TValues) => FormikErrors<TValues> | Promise<FormikErrors<TValues>>;
+  disabledSubmit?: boolean;
+  children: React.ReactNode;
+};
+
+const CreateModal = <TValues extends object>({
+  entityName,
+  show,
+  onClose,
+  initialValues,
+  onSubmit,
+  validate = undefined,
+  disabledSubmit = false,
+  children,
+}: Props<TValues>) => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleSubmit = async (values: TValues) => {
+    setSubmitError(null);
+
+    try {
+      await onSubmit(values);
+      onClose();
+    } catch (error) {
+      setSubmitError(error?.message ?? 'An error occurred. Please try again.');
+    }
+  };
+
+  return (
+    <BootstrapModalWrapper showModal={show} onHide={onClose}>
+      <Formik<TValues>
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        validate={validate}
+        validateOnBlur={false}>
+        <CreateModalContent
+          entityName={entityName}
+          onCancel={onClose}
+          disabledSubmit={disabledSubmit}
+          submitError={submitError}>
+          {children}
+        </CreateModalContent>
+      </Formik>
+    </BootstrapModalWrapper>
+  );
+};
+
+export default CreateModal;

--- a/graylog2-web-interface/src/components/common/CreatePage.tsx
+++ b/graylog2-web-interface/src/components/common/CreatePage.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState } from 'react';
+import type { FormikErrors } from 'formik';
+import { Formik, Form, useFormikContext } from 'formik';
+
+import useHistory from 'routing/useHistory';
+import { Alert, Col, Row } from 'components/bootstrap';
+import DocumentTitle from 'components/common/DocumentTitle';
+import FormSubmit from 'components/common/FormSubmit';
+import PageHeader from 'components/common/PageHeader';
+
+type ContentProps = {
+  entityName: string;
+  onCancel: () => void;
+  description?: React.ReactNode;
+  documentationLink?: { title: string; path: string };
+  disabledSubmit?: boolean;
+  submitError: string | null;
+  children: React.ReactNode;
+};
+
+const CreatePageContent = ({
+  entityName,
+  onCancel,
+  description = undefined,
+  documentationLink = undefined,
+  disabledSubmit = false,
+  submitError,
+  children,
+}: ContentProps) => {
+  const { isSubmitting, isValidating, isValid } = useFormikContext();
+  const title = `Create ${entityName}`;
+  const entityNameLower = entityName.toLowerCase();
+
+  return (
+    <DocumentTitle title={title}>
+      <PageHeader title={title} documentationLink={documentationLink}>
+        {description && <span>{description}</span>}
+      </PageHeader>
+      <Row className="content">
+        <Col lg={8}>
+          <Form className="form form-horizontal">
+            {children}
+            {submitError && (
+              <Row>
+                <Col xs={9} xsOffset={3}>
+                  <Alert bsStyle="danger" title="Failed to save">
+                    {submitError}
+                  </Alert>
+                </Col>
+              </Row>
+            )}
+            <Row>
+              <Col md={9} mdOffset={3}>
+                <FormSubmit
+                  submitButtonText={`Create ${entityNameLower}`}
+                  submitLoadingText={`Creating ${entityNameLower}...`}
+                  isSubmitting={isSubmitting}
+                  isAsyncSubmit
+                  disabledSubmit={!isValid || isValidating || disabledSubmit}
+                  onCancel={onCancel}
+                />
+              </Col>
+            </Row>
+          </Form>
+        </Col>
+      </Row>
+    </DocumentTitle>
+  );
+};
+
+type Props<TValues extends object> = {
+  entityName: string;
+  overviewRoute: string;
+  initialValues: TValues;
+  onSubmit: (values: TValues) => Promise<void>;
+  validate?: (values: TValues) => FormikErrors<TValues> | Promise<FormikErrors<TValues>>;
+  description?: React.ReactNode;
+  documentationLink?: { title: string; path: string };
+  disabledSubmit?: boolean;
+  children: React.ReactNode;
+};
+
+const CreatePage = <TValues extends object>({
+  entityName,
+  overviewRoute,
+  initialValues,
+  onSubmit,
+  validate = undefined,
+  description = undefined,
+  documentationLink = undefined,
+  disabledSubmit = false,
+  children,
+}: Props<TValues>) => {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const history = useHistory();
+
+  const handleCancel = () => history.push(overviewRoute);
+
+  const handleSubmit = async (values: TValues) => {
+    setSubmitError(null);
+
+    try {
+      await onSubmit(values);
+      history.push(overviewRoute);
+    } catch (error) {
+      setSubmitError(error?.message ?? 'An error occurred. Please try again.');
+    }
+  };
+
+  return (
+    <Formik<TValues>
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      validate={validate}
+      validateOnBlur={false}>
+      <CreatePageContent
+        entityName={entityName}
+        onCancel={handleCancel}
+        description={description}
+        documentationLink={documentationLink}
+        disabledSubmit={disabledSubmit}
+        submitError={submitError}>
+        {children}
+      </CreatePageContent>
+    </Formik>
+  );
+};
+
+export default CreatePage;

--- a/graylog2-web-interface/src/components/common/CreatePage.tsx
+++ b/graylog2-web-interface/src/components/common/CreatePage.tsx
@@ -109,7 +109,7 @@ const CreatePage = <TValues extends object>({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const history = useHistory();
 
-  const handleCancel = () => (history.length > 1 ? history.goBack() : history.push(overviewRoute));
+  const handleCancel = () => (window.history.length > 1 ? history.goBack() : history.push(overviewRoute));
 
   const handleSubmit = async (values: TValues) => {
     setSubmitError(null);

--- a/graylog2-web-interface/src/components/common/CreatePage.tsx
+++ b/graylog2-web-interface/src/components/common/CreatePage.tsx
@@ -30,7 +30,6 @@ type ContentProps = {
   onCancel: () => void;
   description?: React.ReactNode;
   documentationLink?: { title: string; path: string };
-  disabledSubmit?: boolean;
   submitError: string | null;
   children: React.ReactNode;
 };
@@ -40,7 +39,6 @@ const CreatePageContent = ({
   onCancel,
   description = undefined,
   documentationLink = undefined,
-  disabledSubmit = false,
   submitError,
   children,
 }: ContentProps) => {
@@ -73,7 +71,7 @@ const CreatePageContent = ({
                   submitLoadingText={`Creating ${entityNameLower}...`}
                   isSubmitting={isSubmitting}
                   isAsyncSubmit
-                  disabledSubmit={!isValid || isValidating || disabledSubmit}
+                  disabledSubmit={!isValid || isValidating}
                   onCancel={onCancel}
                 />
               </Col>
@@ -94,7 +92,6 @@ type Props<TValues extends object> = {
   validate?: (values: TValues) => FormikErrors<TValues> | Promise<FormikErrors<TValues>>;
   description?: React.ReactNode;
   documentationLink?: { title: string; path: string };
-  disabledSubmit?: boolean;
   children: React.ReactNode;
 };
 
@@ -107,13 +104,12 @@ const CreatePage = <TValues extends object>({
   validate = undefined,
   description = undefined,
   documentationLink = undefined,
-  disabledSubmit = false,
   children,
 }: Props<TValues>) => {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const history = useHistory();
 
-  const handleCancel = () => history.push(overviewRoute);
+  const handleCancel = () => (history.length > 1 ? history.goBack() : history.push(overviewRoute));
 
   const handleSubmit = async (values: TValues) => {
     setSubmitError(null);
@@ -133,7 +129,6 @@ const CreatePage = <TValues extends object>({
         onCancel={handleCancel}
         description={description}
         documentationLink={documentationLink}
-        disabledSubmit={disabledSubmit}
         submitError={submitError}>
         {children}
       </CreatePageContent>

--- a/graylog2-web-interface/src/components/common/CreatePage.tsx
+++ b/graylog2-web-interface/src/components/common/CreatePage.tsx
@@ -88,8 +88,9 @@ const CreatePageContent = ({
 type Props<TValues extends object> = {
   entityName: string;
   overviewRoute: string;
+  detailsRoute: (id: string) => string;
   initialValues: TValues;
-  onSubmit: (values: TValues) => Promise<void>;
+  onSubmit: (values: TValues) => Promise<{ id: string }>;
   validate?: (values: TValues) => FormikErrors<TValues> | Promise<FormikErrors<TValues>>;
   description?: React.ReactNode;
   documentationLink?: { title: string; path: string };
@@ -100,6 +101,7 @@ type Props<TValues extends object> = {
 const CreatePage = <TValues extends object>({
   entityName,
   overviewRoute,
+  detailsRoute,
   initialValues,
   onSubmit,
   validate = undefined,
@@ -117,19 +119,15 @@ const CreatePage = <TValues extends object>({
     setSubmitError(null);
 
     try {
-      await onSubmit(values);
-      history.push(overviewRoute);
+      const { id } = await onSubmit(values);
+      history.push(detailsRoute(id));
     } catch (error) {
       setSubmitError(error?.message ?? 'An error occurred. Please try again.');
     }
   };
 
   return (
-    <Formik<TValues>
-      initialValues={initialValues}
-      onSubmit={handleSubmit}
-      validate={validate}
-      validateOnBlur={false}>
+    <Formik<TValues> initialValues={initialValues} onSubmit={handleSubmit} validate={validate} validateOnBlur={false}>
       <CreatePageContent
         entityName={entityName}
         onCancel={handleCancel}

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -128,6 +128,7 @@ export { default as ShareButton } from './ShareButton';
 export { default as ShareMenuItem } from './ShareMenuItem';
 export { default as SortableList } from './SortableList';
 export { default as Stack } from './Stack';
+export { default as CreatePage } from './CreatePage';
 export { default as Spinner } from './Spinner';
 export { default as Spoiler } from './Spoiler';
 export { default as StatusIcon } from './StatusIcon';

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -128,6 +128,7 @@ export { default as ShareButton } from './ShareButton';
 export { default as ShareMenuItem } from './ShareMenuItem';
 export { default as SortableList } from './SortableList';
 export { default as Stack } from './Stack';
+export { default as CreateModal } from './CreateModal';
 export { default as CreatePage } from './CreatePage';
 export { default as Spinner } from './Spinner';
 export { default as Spoiler } from './Spoiler';

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -23,6 +23,7 @@ const { merge } = require('webpack-merge');
 
 const supportedBrowsers = require('./supportedBrowsers');
 const core = require('./webpack/core');
+const { bootstrapLessRule, lessRule } = require('./webpack/bootstrap-less');
 
 const ROOT_PATH = path.resolve(__dirname);
 const APP_PATH = path.resolve(ROOT_PATH, 'src');
@@ -30,7 +31,6 @@ const BUILD_PATH = path.resolve(ROOT_PATH, 'target/web/build');
 const TARGET = process.env.npm_lifecycle_event || 'build';
 process.env.BABEL_ENV = TARGET;
 
-const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
 const coreConfig = core.config(TARGET, APP_PATH, ROOT_PATH, ROOT_PATH, supportedBrowsers);
 
 const webpackConfig = merge(coreConfig, {
@@ -42,45 +42,7 @@ const webpackConfig = merge(coreConfig, {
     polyfill: [path.resolve(APP_PATH, 'polyfill.ts')],
   },
   module: {
-    rules: [
-      {
-        test: /bootstrap\.less$/,
-        use: [
-          {
-            loader: 'style-loader',
-            options: {
-              // implementation to insert at the top of the head tag: https://github.com/webpack-contrib/style-loader#function
-              insert: function insertAtTop(element) {
-                const parent = document.querySelector('head');
-                // @ts-ignore
-                const lastInsertedElement = window._lastElementInsertedByStyleLoader;
-
-                if (!lastInsertedElement) {
-                  parent.insertBefore(element, parent.firstChild);
-                } else if (lastInsertedElement.nextSibling) {
-                  parent.insertBefore(element, lastInsertedElement.nextSibling);
-                } else {
-                  parent.appendChild(element);
-                }
-
-                // @ts-ignore
-                window._lastElementInsertedByStyleLoader = element;
-              },
-            },
-          },
-          'css-loader',
-          {
-            loader: 'less-loader',
-            options: {
-              lessOptions: {
-                modifyVars: BOOTSTRAPVARS,
-              },
-            },
-          },
-        ],
-      },
-      { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'], exclude: /bootstrap\.less$/ },
-    ],
+    rules: [bootstrapLessRule, lessRule],
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/graylog2-web-interface/webpack/bootstrap-less.js
+++ b/graylog2-web-interface/webpack/bootstrap-less.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+const path = require('path');
+const fs = require('fs');
+
+const ROOT_PATH = path.resolve(__dirname, '..');
+
+const BOOTSTRAPVARS = JSON.parse(
+  fs.readFileSync(path.resolve(ROOT_PATH, 'public/stylesheets/bootstrap-config.json'), 'utf-8'),
+).vars;
+
+function insertAtTop(element) {
+  const parent = document.querySelector('head');
+  // @ts-ignore
+  const lastInsertedElement = window._lastElementInsertedByStyleLoader;
+
+  if (!lastInsertedElement) {
+    parent.insertBefore(element, parent.firstChild);
+  } else if (lastInsertedElement.nextSibling) {
+    parent.insertBefore(element, lastInsertedElement.nextSibling);
+  } else {
+    parent.appendChild(element);
+  }
+
+  // @ts-ignore
+  window._lastElementInsertedByStyleLoader = element;
+}
+
+function createBootstrapLessRule(styleLoaderOptions = {}) {
+  return {
+    test: /bootstrap\.less$/,
+    use: [
+      { loader: 'style-loader', options: { insert: insertAtTop, ...styleLoaderOptions } },
+      'css-loader',
+      { loader: 'less-loader', options: { lessOptions: { modifyVars: BOOTSTRAPVARS } } },
+    ],
+  };
+}
+
+const bootstrapLessRule = createBootstrapLessRule();
+const lessRule = { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'], exclude: /bootstrap\.less$/ };
+
+module.exports = { createBootstrapLessRule, bootstrapLessRule, lessRule };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description

Introduces two reusable components `CreatePage` and `CreateModal`  that provide a consistent frame for entity creation flows across the product.
- `CreatePage` offers a dedicated full-page creation experience with navigation to the created entity on success
- `CreateModal` keeps users in their current workflow.

Both are documented in the Graylog Luma design system with an interactive Storybook pattern page covering when to use each surface and method.

Please note that this is a first version of the reusable component and the pattern documentation. We will likely change them further when we implement them.

Fixes https://github.com/Graylog2/graylog2-server/issues/25840

/nocl