### PR TITLE
Pin web-interface TypeScript to 6.0.3

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -167,6 +167,7 @@
     "stylelint-config-graylog": "file:packages/stylelint-config-graylog",
     "trace-unhandled": "^2.0.1",
     "ts-node": "^10.2.1",
+    "typescript": "6.0.3",
     "utility-types": "^3.10.0",
     "webpack-bundle-analyzer": "^5.2.0",
     "webpack-cli": "6.0.1",
@@ -175,6 +176,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "resolutions": {
-    "@types/plotly.js": "3.0.10"
+    "@types/plotly.js": "3.0.10",
+    "typescript": "6.0.3"
   }
 }

--- a/graylog2-web-interface/src/types.d.ts
+++ b/graylog2-web-interface/src/types.d.ts
@@ -22,6 +22,18 @@ declare module '*.css' {
   export default classes;
 }
 
+declare module '*.less' {
+  interface CSSClasses {
+    [key: string]: any;
+  }
+  const classes: CSSClasses;
+  export default classes;
+}
+
+// Imported only for its side effects (font-face injection). Its types live behind
+// an `exports` subpath that `moduleResolution: node10` cannot resolve.
+declare module '@graylog/sawmill/fonts';
+
 declare module '*.jpg' {
   export default string;
 }

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["node"],
     "allowJs": false,
     "downlevelIteration": true,
+    "ignoreDeprecations": "6.0",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1446,6 +1446,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
+"@babel/runtime@^7.23.8":
+  version "7.29.7"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
@@ -5634,11 +5639,6 @@ base64url@^3.0.1:
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
-baseline-browser-mapping@^2.10.34:
-  version "2.10.34"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz#dedb606362446777cfe328d30d4ee15056d06303"
-  integrity sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==
-
 baseline-browser-mapping@^2.9.0:
   version "2.9.11"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz#53724708c8db5f97206517ecfe362dbe5181deea"
@@ -6033,11 +6033,6 @@ camelize@^1.0.0:
 caniuse-lite@^1.0.30001663, caniuse-lite@^1.0.30001726, caniuse-lite@^1.0.30001759:
   version "1.0.30001797"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz"
-  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
-
-caniuse-lite@^1.0.30001797:
-  version "1.0.30001797"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
   integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
 
 canvas-fit@^1.5.0:
@@ -8135,7 +8130,7 @@ escodegen@^2.1.0:
     eslint "9.39.2"
     eslint-import-resolver-webpack "0.13.11"
     eslint-plugin-compat "7.0.2"
-    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-b4c3fd1b-0892-44f7-9774-a4e948197688-1780879366882/node_modules/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../../code/.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-6fb89363-feac-4483-9e23-52d6b314ce68-1780908581172/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.32.0"
     eslint-plugin-jest "29.15.2"
     eslint-plugin-jest-dom "5.5.0"
@@ -9747,12 +9742,12 @@ graphemer@^1.4.0:
     "@reduxjs/toolkit" "^2.5.1"
     "@tanstack/react-query" "5.100.14"
     "@types/react" "18.3.13"
-    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-65ebe45d-5754-439d-aa96-0dc5168ec071-1780879366442/node_modules/babel-preset-graylog"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-65ebe45d-5754-439d-aa96-0dc5168ec071-1780879366442/node_modules/eslint-config-graylog"
+    babel-preset-graylog "file:../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-ab9edc45-3a3b-4947-8ee6-0201f3041318-1780908580999/node_modules/babel-preset-graylog"
+    eslint-config-graylog "file:../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-ab9edc45-3a3b-4947-8ee6-0201f3041318-1780908580999/node_modules/eslint-config-graylog"
     formik "2.4.9"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-65ebe45d-5754-439d-aa96-0dc5168ec071-1780879366442/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-ab9edc45-3a3b-4947-8ee6-0201f3041318-1780908580999/node_modules/jest-preset-graylog"
     moment "2.30.1"
     moment-timezone "0.6.2"
     react "18.3.1"
@@ -12140,6 +12135,14 @@ marked@^4.0.16:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
+match-sorter@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.npmjs.org/match-sorter/-/match-sorter-8.3.0.tgz#85cb4c3b6b25df110b44d66ed6661625efb21834"
+  integrity sha512-8Py1GbZi5zsclYSFcPAH4H5xfTbeD0bOREA7qP/t8bW4MbOSlPl8sbqHOedEV7O+Bxyvxm6xs/v6BXJGe+JDNA==
+  dependencies:
+    "@babel/runtime" "^7.23.8"
+    remove-accents "0.5.0"
 
 material-colors@^1.2.1:
   version "1.2.6"
@@ -14625,6 +14628,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz#77991f37ba212afba162e375b627631315bed687"
+  integrity sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -16695,15 +16703,10 @@ typescript-eslint@^8.44.1:
     "@typescript-eslint/typescript-estree" "8.44.1"
     "@typescript-eslint/utils" "8.44.1"
 
-typescript@6.0.3:
+typescript@6.0.3, typescript@^5.7.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
-
-typescript@^5.7.3:
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
-  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

`typescript` was only a transitive dependency of the web interface, so `yarn tsc` resolved its bin non-deterministically and could run `5.8.2` (from `postcss-styled-syntax`'s nested copy) instead of the hoisted `6.0.3`.

- Add `typescript@6.0.3` as a direct `devDependency` and a `resolution` so the whole tree dedupes to a single `6.0.3` copy and the `tsc` bin is stable.
- `tsconfig`: set `ignoreDeprecations: "6.0"` for the now-deprecated `downlevelIteration` and `moduleResolution: node10` options.
- Add ambient declarations for `*.less` and `@graylog/sawmill/fonts` so TS 6.0's new requirement that side-effect imports resolve to type declarations is satisfied.

## Motivation and Context

Type-checking was non-deterministic depending on which `typescript` copy the `tsc` bin resolved to. Pinning a single direct version makes `yarn tsc` reproducible across machines and CI.

## How Has This Been Tested?

Ran `yarn tsc` locally and confirmed it now consistently uses `6.0.3` and completes without errors.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Build/dev-tooling only: pins the TypeScript version used for type-checking the web interface, no runtime impact.