### PR TITLE
Add function for merging multiple plugin bindings reliably.

### DIFF
--- a/graylog2-web-interface/AGENTS.md
+++ b/graylog2-web-interface/AGENTS.md
@@ -99,6 +99,7 @@ yarn tsc && yarn lint:changes && yarn test
 - Register: `PluginStore.register(new PluginManifest({}, { key: [data] }));`
 - Consume: `usePluginEntities('key')`
 - No central documentation of plugin store keys — search the codebase for usage.
+- **Merging bindings:** whenever you combine multiple plugin bindings (`PluginExports` objects) into one — e.g. assembling a `bindings.tsx` from sub-plugins, or aggregating bindings for `PluginStore.register` — you **must** use `mergePluginBindings` from `util/mergePluginBindings`. Do **not** use `lodash/merge`, `Immutable.Map().mergeWith`, object spreads (`{ ...a, ...b }`), or hand-written per-key array concatenation: those overwrite or index-merge array-valued keys (e.g. `pageNavigation`, `routes`) and silently drop entries. `mergePluginBindings` concatenates array-valued keys while deep-merging the rest.
 
 ## Finishing work
 

--- a/graylog2-web-interface/CONTRIBUTING.md
+++ b/graylog2-web-interface/CONTRIBUTING.md
@@ -189,6 +189,7 @@ To prevent session expiry during user interaction, every API request using `fetc
 - Register: `PluginStore.register(new PluginManifest({}, { key: [data] }));`
 - Consume: `usePluginEntities('key')`
 - No central docs for plugin store keys — search the codebase.
+- Merging bindings: always use `mergePluginBindings` from `util/mergePluginBindings` when combining multiple `PluginExports` objects (e.g. building a `bindings.tsx` from sub-plugins, or aggregating bindings for `PluginStore.register`). Never use `lodash/merge`, `Immutable.Map().mergeWith`, object spreads, or manual per-key array concatenation — they overwrite or index-merge array-valued keys (`pageNavigation`, `routes`, …) and drop entries. `mergePluginBindings` concatenates array-valued keys and deep-merges the rest.
 - Test without plugins: `disable_plugins=true yarn start`
 - Example plugin: [graylog-plugin-sample](https://github.com/Graylog2/graylog-plugin-sample)
 

--- a/graylog2-web-interface/src/util/mergePluginBindings.test.ts
+++ b/graylog2-web-interface/src/util/mergePluginBindings.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import mergePluginBindings from 'util/mergePluginBindings';
+
+describe('mergePluginBindings', () => {
+  it('concatenates array-valued keys from multiple bindings', () => {
+    const merged = mergePluginBindings({ routes: ['a'] }, { routes: ['b'] }, { routes: ['c'] });
+
+    expect(merged.routes).toEqual(['a', 'b', 'c']);
+  });
+
+  it('keeps array entries separate instead of merging them by index', () => {
+    const baseNav = { description: 'Base', children: [{ description: 'base-child' }] };
+    const injectedNav = { description: 'Injected', children: [{ description: 'injected-child' }] };
+
+    const merged = mergePluginBindings({ pageNavigation: [baseNav] }, { pageNavigation: [injectedNav] });
+
+    expect(merged.pageNavigation).toEqual([baseNav, injectedNav]);
+  });
+
+  it('preserves keys that only exist in one of the bindings', () => {
+    const merged = mergePluginBindings({ routes: ['a'] }, { navigation: ['b'] });
+
+    expect(merged).toEqual({ routes: ['a'], navigation: ['b'] });
+  });
+
+  it('deep-merges object-valued keys', () => {
+    const merged = mergePluginBindings(
+      { pages: { search: { component: 'SearchA' } } },
+      { pages: { other: { component: 'OtherB' } } },
+    );
+
+    expect(merged.pages).toEqual({ search: { component: 'SearchA' }, other: { component: 'OtherB' } });
+  });
+
+  it('does not mutate any of the source bindings', () => {
+    const first = { routes: ['a'] };
+    const second = { routes: ['b'] };
+
+    mergePluginBindings(first, second);
+
+    expect(first).toEqual({ routes: ['a'] });
+    expect(second).toEqual({ routes: ['b'] });
+  });
+
+  it('returns an empty object when called without bindings', () => {
+    expect(mergePluginBindings()).toEqual({});
+  });
+
+  it('returns an equivalent object when given a single binding', () => {
+    const merged = mergePluginBindings({ routes: ['a'], navigation: ['b'] });
+
+    expect(merged).toEqual({ routes: ['a'], navigation: ['b'] });
+  });
+});

--- a/graylog2-web-interface/src/util/mergePluginBindings.ts
+++ b/graylog2-web-interface/src/util/mergePluginBindings.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import mergeWith from 'lodash/mergeWith';
+import type { PluginExports } from 'graylog-web-plugin/plugin';
+
+type MergeablePluginBindings = PluginExports | Record<string, unknown>;
+
+// Concatenate array-valued keys instead of merging them by index, while letting lodash
+// deep-merge everything else. Returning `undefined` falls back to lodash's default behaviour.
+const concatArrays = (objValue: unknown, srcValue: unknown) =>
+  Array.isArray(objValue) ? objValue.concat(srcValue) : undefined;
+
+/**
+ * Merge multiple plugin binding objects (`PluginExports`) into a single one.
+ *
+ * Plugin bindings are keyed by extension point, and most values are arrays of entries
+ * (e.g. `pageNavigation`, `routes`, `eventDefinitionTypes`). When several (sub-)plugins
+ * contribute to the same extension point, their entries must be **concatenated** so each
+ * one is preserved as a separate entry.
+ *
+ * A naive `lodash/merge` merges arrays by index, which fuses unrelated entries together
+ * (e.g. a base `pageNavigation` entry with another plugin's nav injection). This helper
+ * uses `mergeWith` with a customizer that concatenates array-valued keys instead, and
+ * merges into a fresh `{}` target so none of the source bindings are mutated. Object-valued
+ * keys are still deep-merged, preserving keys that only exist in some of the bindings.
+ *
+ * @param bindings The plugin binding objects to merge, in order of precedence.
+ * @returns A new, merged `PluginExports` object.
+ */
+const mergePluginBindings = (...bindings: Array<MergeablePluginBindings>): PluginExports =>
+  mergeWith({}, ...bindings, concatArrays) as PluginExports;
+
+export default mergePluginBindings;


### PR DESCRIPTION
## Description

Adds `mergePluginBindings`, a small frontend helper that merges multiple `PluginExports` objects into a single one. Array-valued keys (e.g. `routes`, `pageNavigation`, `eventDefinitionTypes`) are **concatenated** so entries from different sub-plugins are preserved as separate entries, while object-valued keys are deep-merged. The merge writes into a fresh `{}` so none of the source bindings are mutated.

## Motivation and Context

A naive `lodash/merge` merges arrays by index, which fuses unrelated plugin entries together (e.g. a base `pageNavigation` entry with another plugin's nav injection). This logic was originally written inline for the security-app bindings fix (enterprise #14389); extracting it into a reusable helper lets other (sub-)plugin composition sites reuse the correct array-concatenating behavior.

## Usage

```ts
import mergePluginBindings from 'util/mergePluginBindings';

// Concatenates array-valued keys across bindings
const merged = mergePluginBindings(
  { routes: ['a'], pages: { search: { component: 'SearchA' } } },
  { routes: ['b'], pages: { other: { component: 'OtherB' } } },
);

// merged.routes === ['a', 'b']
// merged.pages === { search: { component: 'SearchA' }, other: { component: 'OtherB' } }
```

## How Has This Been Tested?

Added unit tests in `mergePluginBindings.test.ts` covering array concatenation, keeping array entries separate (no index merging), preserving single-binding keys, deep-merging objects, non-mutation of sources, and the empty/single-argument cases.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl new internal frontend utility, not yet wired up, no user-facing change