### PR TITLE
Replay dashboard widget search in a new tab

### DIFF
--- a/changelog/unreleased/pr-26268.toml
+++ b/changelog/unreleased/pr-26268.toml
@@ -1,2 +1,3 @@
 type = "f"
 message = "Replaying a dashboard widget again opens the replayed search in a new browser tab, keeping the dashboard open."
+pulls = ["26268"]

--- a/changelog/unreleased/pr-replay-search-new-tab.toml
+++ b/changelog/unreleased/pr-replay-search-new-tab.toml
@@ -1,0 +1,2 @@
+type = "f"
+message = "Replaying a dashboard widget again opens the replayed search in a new browser tab, keeping the dashboard open."

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
@@ -111,6 +111,23 @@ describe('ReplaySearchButton', () => {
     });
   });
 
+  describe('new tab behaviour', () => {
+    it('opens the replayed search in the same tab by default', async () => {
+      render(<ReplaySearchButton />);
+      const button = await findReplayButton();
+
+      expect(button.target).not.toBe('_blank');
+    });
+
+    it('opens the replayed search in a new tab when newTab is set', async () => {
+      render(<ReplaySearchButton newTab />);
+      const button = await findReplayButton();
+
+      expect(button.target).toBe('_blank');
+      expect(button.rel).toBe('noopener noreferrer');
+    });
+  });
+
   describe('on click', () => {
     it('persists search filters to local storage so the replayed search can consume them', async () => {
       const filters = Immutable.List([filter('source:my-host'), filter('level:ERROR')]);

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -90,24 +90,36 @@ export const ReplaySearchButtonComponent = ({
   children = undefined,
   onClick = undefined,
   component: Component = NeutralLink,
+  newTab = false,
 }: {
   children?: React.ReactNode;
   searchLink: string;
   onClick?: () => void;
   component?: React.ComponentType<CustomComponentProps>;
+  newTab?: boolean;
 }) => {
   const title = 'Replay search';
+
+  const content = children ? (
+    <>
+      {children} <StyledIcon name={iconName} />
+    </>
+  ) : (
+    <IconButton name={iconName} focusable={false} title={title} />
+  );
+
+  if (newTab) {
+    return (
+      <Component href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
+        {content}
+      </Component>
+    );
+  }
 
   return (
     <LinkContainer to={searchLink}>
       <Component title={title} onClick={onClick}>
-        {children ? (
-          <>
-            {children} <StyledIcon name={iconName} />
-          </>
-        ) : (
-          <IconButton name={iconName} focusable={false} title={title} />
-        )}
+        {content}
       </Component>
     </LinkContainer>
   );
@@ -122,6 +134,7 @@ type Props = {
   filters?: FiltersType;
   children?: React.ReactNode;
   parameterBindings?: ParameterBindings;
+  newTab?: boolean;
 };
 
 const ReplaySearchButton = ({
@@ -133,6 +146,7 @@ const ReplaySearchButton = ({
   filters = undefined,
   children = undefined,
   parameterBindings = undefined,
+  newTab = false,
 }: Props) => {
   const sessionId = useMemo(() => `replay-search-${generateId()}`, []);
   const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, streamCategories, parameters, filters);
@@ -151,7 +165,7 @@ const ReplaySearchButton = ({
   }, [sessionId, parameters, parameterBindings, filters]);
 
   return (
-    <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch}>
+    <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch} newTab={newTab}>
       {children}
     </ReplaySearchButtonComponent>
   );

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -108,15 +108,11 @@ export const ReplaySearchButtonComponent = ({
     <IconButton name={iconName} focusable={false} title={title} />
   );
 
-  if (newTab) {
-    return (
-      <Component href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
-        {content}
-      </Component>
-    );
-  }
-
-  return (
+  return newTab ? (
+    <Component href={searchLink} target="_blank" rel="noopener noreferrer" title={title} onClick={onClick}>
+      {content}
+    </Component>
+  ) : (
     <LinkContainer to={searchLink}>
       <Component title={title} onClick={onClick}>
         {content}
@@ -132,7 +128,6 @@ type Props = {
   streamCategories?: string[] | undefined;
   parameters?: Immutable.Set<Parameter>;
   filters?: FiltersType;
-  children?: React.ReactNode;
   parameterBindings?: ParameterBindings;
   newTab?: boolean;
 };
@@ -144,7 +139,6 @@ const ReplaySearchButton = ({
   streamCategories = undefined,
   parameters = undefined,
   filters = undefined,
-  children = undefined,
   parameterBindings = undefined,
   newTab = false,
 }: Props) => {
@@ -164,11 +158,7 @@ const ReplaySearchButton = ({
     }
   }, [sessionId, parameters, parameterBindings, filters]);
 
-  return (
-    <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch} newTab={newTab}>
-      {children}
-    </ReplaySearchButtonComponent>
-  );
+  return <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch} newTab={newTab} />;
 };
 
 export default ReplaySearchButton;

--- a/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetActionsMenu.tsx
@@ -240,6 +240,7 @@ const WidgetActionsMenu = ({ isFocused, onPositionsChange, position, title, togg
             parameterBindings={parameterBindings}
             parameters={parameters}
             filters={widget.filters}
+            newTab
           />
         </IfDashboard>
         <ExtraMenuWidgetActions widget={widget} />


### PR DESCRIPTION
## Description
A recent refactoring switched `ReplaySearchButton` from a plain anchor with `target="_blank"` to a `LinkContainer`, which navigates within the SPA in the same tab. That is fine for replaying events from the Alerts page, but a dashboard widget replay should open in a new tab so the dashboard stays open.

This adds a `newTab` prop (defaulting to `false`); when set, the button renders the plain anchor with `target="_blank" rel="noopener noreferrer"` instead of the `LinkContainer`. `WidgetActionsMenu` now passes `newTab` for dashboard widgets. The render path is also simplified to a single ternary and the unused `children` prop on the outer `ReplaySearchButton` is removed.

## Motivation and Context
Replaying a dashboard widget navigated away from the dashboard in the same tab, forcing the user to navigate back. Opening the replayed search in a new tab keeps the dashboard open.

## How Has This Been Tested?
Added unit tests covering the `newTab` rendering path. Ran `yarn tsc` and the `ReplaySearchButton` test suite (10 tests passing).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.