### PR TITLE
Fix false processing error for string timestamps in non-Graylog formats

### DIFF
--- a/changelog/unreleased/issue-26025.toml
+++ b/changelog/unreleased/issue-26025.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix false `Message failed to process` errors when a pipeline rule (e.g. `set_fields` with `key_value`) or an extractor assigns a string `timestamp` field in ISO-8601 format. Such timestamps are now parsed leniently instead of being recorded as a processing failure."
+
+issues = ["26025"]

--- a/changelog/unreleased/issue-26025.toml
+++ b/changelog/unreleased/issue-26025.toml
@@ -1,4 +1,5 @@
 type = "f"
-message = "Fix false `Message failed to process` errors when a pipeline rule (e.g. `set_fields` with `key_value`) or an extractor assigns a string `timestamp` field in ISO-8601 format. Such timestamps are now parsed leniently instead of being recorded as a processing failure."
+message = "Fix false `Message failed to process` errors when a pipeline rule or extractor assigns a string `timestamp` field in ISO-8601 format. Such timestamps are now parsed leniently instead of being recorded as a processing failure."
 
 issues = ["26025"]
+pulls = ["26269"]

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -47,6 +47,7 @@ import org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory;
 import org.graylog2.shared.messageq.Acknowledgeable;
 import org.graylog2.shared.utilities.ExceptionUtils;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -547,10 +549,30 @@ public class Message implements Messages, Indexable, Acknowledgeable {
         addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
     }
 
+    /**
+     * Additional formatters used to leniently parse a timestamp that was assigned as a string during processing
+     * (e.g. by the {@code set_fields} pipeline function or an extractor). {@link DateTimeConverter} only accepts the
+     * internal Graylog format ({@code yyyy-MM-dd HH:mm:ss.SSS}) for strings, so we fall back to these before treating
+     * the value as a genuine error. All of these require a complete date and time, so partial values (e.g. a bare
+     * year like "1234") are still rejected. See https://github.com/Graylog2/graylog2-server/issues/26025
+     */
+    private static final List<DateTimeFormatter> LENIENT_TIMESTAMP_FORMATTERS = List.of(
+            Tools.ES_DATE_FORMAT_NO_MS_FORMATTER,   // yyyy-MM-dd HH:mm:ss
+            Tools.ISO_DATE_FORMAT_FORMATTER,        // ISO-8601 with milliseconds and offset, e.g. ...T08:57:55.123Z
+            Tools.ISO_DATE_FORMAT_NO_MS_FORMATTER); // ISO-8601 without milliseconds, e.g. ...T08:57:55+0200
+
     private DateTime convertToDateTime(@Nonnull Object value) {
         try {
             return DateTimeConverter.convertToDateTime(value);
         } catch (IllegalArgumentException e) {
+            // A string timestamp in a valid but non-Graylog format (e.g. ISO-8601 from a firewall) is not a
+            // processing failure - try to parse it leniently before recording an error and forcing the current time.
+            if (value instanceof String) {
+                final Optional<DateTime> leniently = parseTimestampLeniently((String) value);
+                if (leniently.isPresent()) {
+                    return leniently.get();
+                }
+            }
             final String error = "Invalid value for field timestamp in message <" + getId() + ">, forcing to current time.";
             LOG.trace("{}: {}", error, e);
             addProcessingError(new ProcessingError(ProcessingFailureCause.InvalidTimestampException,
@@ -558,6 +580,17 @@ public class Message implements Messages, Indexable, Acknowledgeable {
                     , "Value <" + value + "> caused exception: " + ExceptionUtils.getRootCauseMessage(e)));
             return Tools.nowUTC();
         }
+    }
+
+    private static Optional<DateTime> parseTimestampLeniently(String value) {
+        for (final DateTimeFormatter formatter : LENIENT_TIMESTAMP_FORMATTERS) {
+            try {
+                return Optional.of(formatter.parseDateTime(value));
+            } catch (IllegalArgumentException ignored) {
+                // try the next formatter
+            }
+        }
+        return Optional.empty();
     }
 
     private DateTime fallbackForNullTimestamp() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -555,6 +555,9 @@ public class Message implements Messages, Indexable, Acknowledgeable {
      * internal Graylog format ({@code yyyy-MM-dd HH:mm:ss.SSS}) for strings, so we fall back to these before treating
      * the value as a genuine error. All of these require a complete date and time, so partial values (e.g. a bare
      * year like "1234") are still rejected. See https://github.com/Graylog2/graylog2-server/issues/26025
+     *
+     * Ordering is significant: from cheap to expensive
+     * All formatters must use withZoneUTC() for correct zoning
      */
     private static final List<DateTimeFormatter> LENIENT_TIMESTAMP_FORMATTERS = List.of(
             Tools.ES_DATE_FORMAT_NO_MS_FORMATTER,   // yyyy-MM-dd HH:mm:ss

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -47,7 +47,6 @@ import org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory;
 import org.graylog2.shared.messageq.Acknowledgeable;
 import org.graylog2.shared.utilities.ExceptionUtils;
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +66,6 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -549,33 +547,10 @@ public class Message implements Messages, Indexable, Acknowledgeable {
         addTimestampField(FIELD_GL2_ORIGINAL_TIMESTAMP, oldTimeStamp);
     }
 
-    /**
-     * Additional formatters used to leniently parse a timestamp that was assigned as a string during processing
-     * (e.g. by the {@code set_fields} pipeline function or an extractor). {@link DateTimeConverter} only accepts the
-     * internal Graylog format ({@code yyyy-MM-dd HH:mm:ss.SSS}) for strings, so we fall back to these before treating
-     * the value as a genuine error. All of these require a complete date and time, so partial values (e.g. a bare
-     * year like "1234") are still rejected. See https://github.com/Graylog2/graylog2-server/issues/26025
-     *
-     * Ordering is significant: from cheap to expensive
-     * All formatters must use withZoneUTC() for correct zoning
-     */
-    private static final List<DateTimeFormatter> LENIENT_TIMESTAMP_FORMATTERS = List.of(
-            Tools.ES_DATE_FORMAT_NO_MS_FORMATTER,   // yyyy-MM-dd HH:mm:ss
-            Tools.ISO_DATE_FORMAT_FORMATTER,        // ISO-8601 with milliseconds and offset, e.g. ...T08:57:55.123Z
-            Tools.ISO_DATE_FORMAT_NO_MS_FORMATTER); // ISO-8601 without milliseconds, e.g. ...T08:57:55+0200
-
     private DateTime convertToDateTime(@Nonnull Object value) {
         try {
             return DateTimeConverter.convertToDateTime(value);
         } catch (IllegalArgumentException e) {
-            // A string timestamp in a valid but non-Graylog format (e.g. ISO-8601 from a firewall) is not a
-            // processing failure - try to parse it leniently before recording an error and forcing the current time.
-            if (value instanceof String) {
-                final Optional<DateTime> leniently = parseTimestampLeniently((String) value);
-                if (leniently.isPresent()) {
-                    return leniently.get();
-                }
-            }
             final String error = "Invalid value for field timestamp in message <" + getId() + ">, forcing to current time.";
             LOG.trace("{}: {}", error, e);
             addProcessingError(new ProcessingError(ProcessingFailureCause.InvalidTimestampException,
@@ -583,17 +558,6 @@ public class Message implements Messages, Indexable, Acknowledgeable {
                     , "Value <" + value + "> caused exception: " + ExceptionUtils.getRootCauseMessage(e)));
             return Tools.nowUTC();
         }
-    }
-
-    private static Optional<DateTime> parseTimestampLeniently(String value) {
-        for (final DateTimeFormatter formatter : LENIENT_TIMESTAMP_FORMATTERS) {
-            try {
-                return Optional.of(formatter.parseDateTime(value));
-            } catch (IllegalArgumentException ignored) {
-                // try the next formatter
-            }
-        }
-        return Optional.empty();
     }
 
     private DateTime fallbackForNullTimestamp() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/DateTimeConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/DateTimeConverter.java
@@ -18,6 +18,7 @@ package org.graylog2.plugin.utilities.date;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
 
 import javax.annotation.Nonnull;
 import java.time.Instant;
@@ -31,8 +32,15 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_FORMATTER;
+import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_NO_MS_FORMATTER;
+import static org.graylog2.plugin.Tools.ISO_DATE_FORMAT_FORMATTER;
+import static org.graylog2.plugin.Tools.ISO_DATE_FORMAT_NO_MS_FORMATTER;
 
 public class DateTimeConverter {
+    // The date part "yyyy-MM-dd" is always 10 characters, so index 10 holds the separator
+    // between the date and the time component.
+    private static final int DATE_TIME_SEPARATOR_INDEX = 10;
+
     public static DateTime convertToDateTime(@Nonnull Object value) {
         if (value instanceof DateTime) {
             return (DateTime) value;
@@ -59,9 +67,38 @@ public class DateTimeConverter {
         } else if (value instanceof Instant) {
             return new DateTime(Date.from((Instant) value), DateTimeZone.UTC);
         } else if (value instanceof String) {
-            return ES_DATE_FORMAT_FORMATTER.parseDateTime((String) value);
+            return parseStringToDateTime((String) value);
         } else {
             throw new IllegalArgumentException("Value of invalid type <" + value.getClass().getSimpleName() + "> provided");
         }
+    }
+
+    /**
+     * Parses the supported timestamp string formats with a single formatter, selected up front from telltale
+     * characters rather than by trying each pattern in turn. All supported strings share the layout
+     * {@code yyyy-MM-dd<sep>HH:mm:ss[.SSS][offset]}, where {@code <sep>} is a space (Graylog's internal format) or
+     * {@code 'T'} (ISO-8601). The presence of a {@code '.'} selects the millisecond variant.
+     *
+     * <p>Supported patterns:
+     * <ul>
+     *     <li>{@code yyyy-MM-dd HH:mm:ss.SSS}</li>
+     *     <li>{@code yyyy-MM-dd HH:mm:ss}</li>
+     *     <li>{@code yyyy-MM-dd'T'HH:mm:ss.SSSZZ}</li>
+     *     <li>{@code yyyy-MM-dd'T'HH:mm:ssZZ}</li>
+     * </ul>
+     *
+     * <p>Anything else (including ISO values without a zone/offset, which are ambiguous) fails fast with an
+     * {@link IllegalArgumentException}. See https://github.com/Graylog2/graylog2-server/issues/26025
+     */
+    private static DateTime parseStringToDateTime(String value) {
+        final char separator = value.length() > DATE_TIME_SEPARATOR_INDEX ? value.charAt(DATE_TIME_SEPARATOR_INDEX) : 0;
+        final boolean hasMillis = value.indexOf('.') > 0;
+
+        final DateTimeFormatter formatter = switch (separator) {
+            case ' ' -> hasMillis ? ES_DATE_FORMAT_FORMATTER : ES_DATE_FORMAT_NO_MS_FORMATTER;
+            case 'T' -> hasMillis ? ISO_DATE_FORMAT_FORMATTER : ISO_DATE_FORMAT_NO_MS_FORMATTER;
+            default -> throw new IllegalArgumentException("Unsupported timestamp string format: <" + value + ">");
+        };
+        return formatter.parseDateTime(value);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -1950,6 +1950,24 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    void setFieldsWithTimestamp() {
+        // Reproduces https://github.com/Graylog2/graylog2-server/issues/26025: key_value decodes a log line that
+        // contains a "timestamp" key in ISO-8601 format, and set_fields assigns it. This must not be counted as a
+        // processing failure, and the parsed timestamp must be used.
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = messageFactory.createMessage(
+                "device_name=\"SFW\" timestamp=\"2026-05-18T08:57:55+0200\" src_ip=\"192.168.0.222\"",
+                "test", Tools.nowUTC());
+        evaluateRule(rule, message);
+
+        assertThat(message.getField("device_name")).isEqualTo("SFW");
+        assertThat(message.getField("src_ip")).isEqualTo("192.168.0.222");
+        // +0200 means the instant is 06:57:55 UTC; getTimestamp() triggers the lenient conversion
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2026, 5, 18, 6, 57, 55, DateTimeZone.UTC));
+        assertThat(message.processingErrors()).isEmpty();
+    }
+
+    @Test
     void arrayContains() throws IOException {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         final Message message = messageFactory.createMessage("message", "source", DateTime.now(DateTimeZone.UTC));

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -845,6 +845,55 @@ public class MessageTest {
         assertThat(message.processingErrors()).isEmpty();
     }
 
+    @Test
+    public void assignIsoStringWithOffsetAsTimestamp() {
+        // Reproduces https://github.com/Graylog2/graylog2-server/issues/26025: a pipeline rule (set_fields with
+        // key_value) assigns a string timestamp in ISO-8601 format with a numeric offset. This must be parsed
+        // leniently and must not record a processing error.
+        final Message message = new Message("message", "source", Tools.nowUTC());
+        message.addField(Message.FIELD_TIMESTAMP, "2026-05-18T08:57:55+0200");
+
+        // +0200 means the instant is 06:57:55 UTC
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2026, 5, 18, 6, 57, 55, DateTimeZone.UTC));
+        assertThat(message.processingErrors()).isEmpty();
+    }
+
+    @Test
+    public void assignIsoStringInUtcAsTimestamp() {
+        final Message message = new Message("message", "source", Tools.nowUTC());
+        message.addField(Message.FIELD_TIMESTAMP, "2026-05-18T08:57:55.123Z");
+
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2026, 5, 18, 8, 57, 55, 123, DateTimeZone.UTC));
+        assertThat(message.processingErrors()).isEmpty();
+    }
+
+    @Test
+    public void assignEsFormatStringWithoutMillisAsTimestamp() {
+        final Message message = new Message("message", "source", Tools.nowUTC());
+        message.addField(Message.FIELD_TIMESTAMP, "2026-05-18 08:57:55");
+
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2026, 5, 18, 8, 57, 55, DateTimeZone.UTC));
+        assertThat(message.processingErrors()).isEmpty();
+    }
+
+    @Test
+    public void assignUnparseableStringStillRecordsProcessingError() {
+        // Do not use fixed time from setUp() in this test
+        DateTimeUtils.setCurrentMillisSystem();
+
+        final Message message = new Message("message", "source", Tools.nowUTC().minusMinutes(2));
+        final DateTime previousTimestamp = message.getTimestamp();
+
+        message.addField(Message.FIELD_TIMESTAMP, "not-a-timestamp");
+
+        // genuinely invalid value still falls back to the current time and records an error
+        assertThat(message.getTimestamp()).isNotEqualTo(previousTimestamp);
+        assertThat(message.processingErrors()).satisfies(e -> {
+            assertThat(e).hasSize(1);
+            assertThat(e.get(0).getCause()).isEqualTo(ProcessingFailureCause.InvalidTimestampException);
+        });
+    }
+
     // Arguably, a message should not allow null values for basic fields, but it is what it is. Here we are checking
     // that at least basic operations can deal with null values in the 'message' field without failing with e.g. an
     // NPE.

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -802,7 +802,7 @@ public class MessageTest {
             assertThat(e).hasSize(1);
             assertThat(e.get(0).getCause()).isEqualTo(ProcessingFailureCause.InvalidTimestampException);
             assertThat(e.get(0).getMessage()).startsWith("Replaced invalid timestamp value in message <");
-            assertThat(e.get(0).getDetails()).startsWith("Value <1234> caused exception: Invalid format: \"1234\" is too short");
+            assertThat(e.get(0).getDetails()).startsWith("Value <1234> caused exception: Unsupported timestamp string format: <1234>");
         });
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/DateTimeConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/DateTimeConverterTest.java
@@ -179,6 +179,14 @@ class DateTimeConverterTest {
     }
 
     @Test
+    void convertFromIsoStringWithMillisWithoutOffsetIsRejected() {
+        // The millis variant routes through a different formatter than the no-ms case above, but a value
+        // without zone/offset is equally ambiguous and must be rejected.
+        assertThatThrownBy(() -> DateTimeConverter.convertToDateTime("2026-05-18T08:57:55.123"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void convertFromUnsupportedStringFormat() {
         assertThatThrownBy(() -> DateTimeConverter.convertToDateTime("not-a-timestamp"))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/DateTimeConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/date/DateTimeConverterTest.java
@@ -142,6 +142,50 @@ class DateTimeConverterTest {
     }
 
     @Test
+    void convertFromESDateStringWithoutMillis() {
+        //ES_DATE_FORMAT_NO_MS = "yyyy-MM-dd HH:mm:ss";
+        final String input = "2026-05-18 08:57:55";
+
+        final DateTime output = DateTimeConverter.convertToDateTime(input);
+        final DateTime expectedOutput = new DateTime(2026, 5, 18, 8, 57, 55, DateTimeZone.UTC);
+        assertThat(output).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    void convertFromIsoStringWithOffset() {
+        // yyyy-MM-dd'T'HH:mm:ssZZ - +0200 means the instant is 06:57:55 UTC
+        final String input = "2026-05-18T08:57:55+0200";
+
+        final DateTime output = DateTimeConverter.convertToDateTime(input);
+        final DateTime expectedOutput = new DateTime(2026, 5, 18, 6, 57, 55, DateTimeZone.UTC);
+        assertThat(output).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    void convertFromIsoStringInUtcWithMillis() {
+        // yyyy-MM-dd'T'HH:mm:ss.SSSZZ
+        final String input = "2026-05-18T08:57:55.123Z";
+
+        final DateTime output = DateTimeConverter.convertToDateTime(input);
+        final DateTime expectedOutput = new DateTime(2026, 5, 18, 8, 57, 55, 123, DateTimeZone.UTC);
+        assertThat(output).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    void convertFromIsoStringWithoutOffsetIsRejected() {
+        // A value without zone/offset is ambiguous and must be rejected.
+        assertThatThrownBy(() -> DateTimeConverter.convertToDateTime("2026-05-18T08:57:55"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void convertFromUnsupportedStringFormat() {
+        assertThatThrownBy(() -> DateTimeConverter.convertToDateTime("not-a-timestamp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported timestamp string format");
+    }
+
+    @Test
     void convertFromInvalidType() {
         assertThatThrownBy(() -> DateTimeConverter.convertToDateTime(1234))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFieldsWithTimestamp.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/setFieldsWithTimestamp.txt
@@ -1,0 +1,6 @@
+rule "set_fields_with_timestamp"
+when true
+then
+  let kv = key_value(value: to_string($message.message), trim_value_chars: "\"");
+  set_fields(fields: kv);
+end


### PR DESCRIPTION
Fixes #26025: a false `Message failed to process` error when a pipeline rule (`set_fields` with `key_value`) or an extractor assigns a string `timestamp` field in ISO-8601 format (e.g. `2026-05-18T08:57:55+0200` from a Sophos firewall).

## Why

`set_fields` writes the decoded `timestamp` value into the reserved `timestamp` field as a raw string. At end-of-processing, `Message.convertToDateTime` only accepted Graylog's internal `yyyy-MM-dd HH:mm:ss.SSS` format for strings, so a valid ISO-8601 value threw, recorded an InvalidTimestampException`, forced the timestamp to the current time, and incremented the processing-failure counter, even though the message was indexed correctly.

## How

The fix replaces the single hard-coded `ES_DATE_FORMAT_FORMATTER.parseDateTime` call in `DateTimeConverter.convertToDateTime(String)` with a small dispatcher that supports four formats: ES with/without millis, and ISO-8601 with/without millis.

Caveats:
- A value without zone or offset like 2026-05-18T08:57:55 is still rejected as ambiguous.
- Non-padded dates like 2026-5-8 08:57:55.123 are also intentionally out of scope.

## How tested

Added unit tests in `MessageTest` (ISO+offset, ISO UTC with millis, space/no-ms, and unparseable-still-errors) and an end-to-end `key_value` → `set_fields` test in `FunctionsSnippetsTest`.

Manual test (from the issue):
    1. Create the `decode-key-value-message` pipeline rule and connect it to the
       default stream.
    2. Create a Syslog UDP input on port `1514`.
    3. Send the sample Sophos message: `nc -u 127.0.0.1 1514` then paste the log line.
    4. Confirm the message is indexed with timestamp `2026-05-18T06:57:55Z` and the
       input's `Message errors` counter does **not** increase.
