### PR TITLE
Use `Table` props to apply table styling instead of bootstrap CSS classes.

### DIFF
--- a/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/SyncedUsersSection/SyncedUsersSection.tsx
@@ -85,7 +85,7 @@ const SyncedUsersSection = ({ roles, authenticationBackend }: Props) => {
         onChange={(newPage, newPerPage) => setPagination({ ...pagination, page: newPage, perPage: newPerPage })}
         useQueryParameter={false}>
         <DataTable
-          className="table-hover"
+          hover
           customFilter={
             <SyncedUsersFilter
               onSearch={(newQuery) => setPagination({ ...pagination, query: newQuery, page: DEFAULT_PAGINATION.page })}

--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.tsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.tsx
@@ -136,7 +136,7 @@ const BackendsOverview = () => {
         </p>
         <PaginatedList totalItems={paginatedBackends.pagination.total}>
           <DataTable
-            className="table-hover"
+            hover
             customFilter={<BackendsFilter onSearch={onSearch} />}
             dataRowFormatter={(authBackend) => _backendsOverviewItem(authBackend, context, paginatedRoles)}
             filterKeys={[]}

--- a/graylog2-web-interface/src/components/bootstrap/Label.md
+++ b/graylog2-web-interface/src/components/bootstrap/Label.md
@@ -1,7 +1,7 @@
 ```js { "props": { "className": "container" } }
 const styles = ['Primary', 'Danger', 'Warning', 'Success', 'Info', 'Default'];
 
-<table className="table table-sm table-striped">
+<table>
   <tbody>
     {styles.map((style, i) => (
       <tr key={`button-${style}-${i}`}>

--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.md
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.md
@@ -34,7 +34,7 @@ const rowFormatter = (entity, idx) => {
 
 <DataTable
   id="entity-list"
-  className="table-hover"
+  hover
   headers={headers}
   headerCellFormatter={(header) => <th>{header}</th>}
   sortByKey={'title'}
@@ -84,7 +84,7 @@ const rowFormatter = (entity, idx) => {
 
 <DataTable
   id="entity-list"
-  className="table-hover"
+  hover
   headers={headers}
   headerCellFormatter={(header) => <th>{header}</th>}
   sortBy={(entity) => entity.roles[0]}

--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.tsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.tsx
@@ -37,6 +37,12 @@ type DataTableProps = {
   children?: React.ReactNode;
   /** Adds a custom class to the table element. */
   className?: string;
+  /** Enables striped row styling. */
+  striped?: boolean;
+  /** Enables hover row highlighting. */
+  hover?: boolean;
+  /** Enables condensed cell padding. */
+  condensed?: boolean;
   /** Overrides the default filter. */
   customFilter?: React.ReactNode;
   /** Adds a custom class to the row element. */
@@ -94,6 +100,9 @@ class DataTable extends React.Component<
     customFilter: undefined,
     children: undefined,
     className: '',
+    striped: undefined,
+    hover: undefined,
+    condensed: undefined,
     filterKeys: [],
     filterLabel: 'Filter',
     noDataText: 'No data available.',
@@ -175,6 +184,9 @@ class DataTable extends React.Component<
       children,
       noDataText,
       className,
+      striped,
+      hover,
+      condensed,
       rowClassName,
       useResponsiveTable,
       rows,
@@ -189,7 +201,7 @@ class DataTable extends React.Component<
       data = <p>Filter does not match any data.</p>;
     } else {
       data = (
-        <Table className={className}>
+        <Table className={className} striped={striped} hover={hover} condensed={condensed}>
           <thead>{this.getFormattedHeaders()}</thead>
           <tbody>{this.getFormattedDataRows()}</tbody>
         </Table>

--- a/graylog2-web-interface/src/components/common/KeyValueTable.tsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.tsx
@@ -206,7 +206,7 @@ class KeyValueTable extends React.Component<
     return (
       <div className="key-value-table-component">
         <div className={`table-responsive ${this.props.containerClassName}`}>
-          <Table className={`table table-striped ${this.props.className}`}>
+          <Table striped className={this.props.className}>
             <thead>{this._formattedHeaders(this.props.headers)}</thead>
             <tbody>
               {this._formattedRows(this.props.pairs)}

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.tsx
@@ -54,6 +54,7 @@ type Props = {
   headerCellFormatter?: (header: string) => React.ReactElement;
   /** Array of values to be use as headers. The render is controlled by `headerCellFormatter`. */
   headers: Array<string>;
+  hover?: boolean;
   /** Element id to use in the table container */
   id: string;
   /** Text or element to show when there is no data. */
@@ -88,6 +89,7 @@ const PaginatedDataTable = ({
   filterKeys = undefined,
   id,
   useResponsiveTable = false,
+  hover = undefined,
   ...rest
 }: Props) => {
   const rows = useMemo(() => rowsProp ?? [], [rowsProp]);

--- a/graylog2-web-interface/src/components/common/message/messagetable/MessageTable.tsx
+++ b/graylog2-web-interface/src/components/common/message/messagetable/MessageTable.tsx
@@ -160,8 +160,8 @@ const MessageTable = ({
 
   return (
     <MessageTableProviders>
-      <TableWrapper className="table-responsive" id="sticky-augmentations-container" ref={scrollContainerRef}>
-        <Table className="table table-condensed">
+      <TableWrapper id="sticky-augmentations-container" ref={scrollContainerRef}>
+        <Table responsive>
           <TableHead>
             <tr>
               {displayBulkSelectCol && (

--- a/graylog2-web-interface/src/components/common/message/messagetable/MessageTable.tsx
+++ b/graylog2-web-interface/src/components/common/message/messagetable/MessageTable.tsx
@@ -160,8 +160,8 @@ const MessageTable = ({
 
   return (
     <MessageTableProviders>
-      <TableWrapper id="sticky-augmentations-container" ref={scrollContainerRef}>
-        <Table responsive>
+      <TableWrapper className="table-responsive" id="sticky-augmentations-container" ref={scrollContainerRef}>
+        <Table className="table table-condensed">
           <TableHead>
             <tr>
               {displayBulkSelectCol && (

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsList.tsx
@@ -144,7 +144,8 @@ class FieldsList extends React.Component<
       <>
         <DataTable
           id="event-definition-fields"
-          className="table-striped table-hover"
+          striped
+          hover
           headers={HEADERS}
           rows={fieldNames}
           dataRowFormatter={this.fieldFormatter}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.tsx
@@ -108,7 +108,8 @@ class NotificationList extends React.Component<
       <>
         <DataTable
           id="event-definition-notifications"
-          className="table-striped table-hover"
+          striped
+          hover
           headers={['Notification', 'Type', 'Actions']}
           sortByKey="title"
           rows={definitionNotifications}

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.tsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.tsx
@@ -260,7 +260,8 @@ class GrokPatterns extends React.Component<
                   <PaginatedList onChange={this._onPageChange} totalItems={pagination.total}>
                     <GrokPatternsList
                       id="grok-pattern-list"
-                      className="table-striped table-hover"
+                      striped
+                      hover
                       headers={headers}
                       headerCellFormatter={_headerCellFormatter}
                       sortByKey="name"

--- a/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.tsx
+++ b/graylog2-web-interface/src/components/loggers/ClusterSupportBundleOverview.tsx
@@ -84,7 +84,7 @@ const ClusterSupportBundleOverview = () => {
           </Header>
           <ClusterSupportBundleInfo />
           {list.length > 0 ? (
-            <Table className="table-striped table-condensed table-hover">
+            <Table striped condensed hover>
               <colgroup>
                 <FilenameCol />
               </colgroup>

--- a/graylog2-web-interface/src/components/nodes/InputTypesDataTable.tsx
+++ b/graylog2-web-interface/src/components/nodes/InputTypesDataTable.tsx
@@ -51,7 +51,9 @@ const InputTypesDataTable = ({ inputDescriptions = undefined }: Props) => {
     <DataTable
       id="input-types-list"
       rowClassName="row-sm"
-      className="table-hover table-condensed table-striped"
+      striped
+      condensed
+      hover
       headers={headers}
       headerCellFormatter={headerCellFormatter}
       sortByKey="name"

--- a/graylog2-web-interface/src/components/nodes/PluginsDataTable.tsx
+++ b/graylog2-web-interface/src/components/nodes/PluginsDataTable.tsx
@@ -58,7 +58,9 @@ const PluginsDataTable = ({ plugins = undefined }: Props) => {
     <DataTable
       id="plugin-list"
       rowClassName="row-sm"
-      className="table-hover table-condensed table-striped"
+      striped
+      condensed
+      hover
       headers={headers}
       headerCellFormatter={headerCellFormatter}
       sortByKey="name"

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverview.tsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverview.tsx
@@ -96,7 +96,7 @@ const SharedEntitiesOverview = ({ entityType, searchPaginated, setLoading }: Pro
         onChange={(newPage, newPerPage) => setPagination({ ...pagination, page: newPage, perPage: newPerPage })}
         useQueryParameter={false}>
         <DataTable
-          className="table-hover"
+          hover
           customFilter={<SharedEntitiesFilter onSearch={_handleSearch} onFilter={_handleFilter} />}
           dataRowFormatter={(sharedEntity) => _sharedEntityOverviewItem(sharedEntity, context)}
           filterKeys={[]}

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.tsx
@@ -140,7 +140,7 @@ const ProcessingTimelineComponent = () => {
       <StyledPaginatedList totalItems={total}>
         <DataTable
           id="processing-timeline"
-          className="table-hover"
+          hover
           headers={headers}
           headerCellFormatter={_headerCellFormatter}
           rows={pipelines}

--- a/graylog2-web-interface/src/components/pipelines/StageRules.tsx
+++ b/graylog2-web-interface/src/components/pipelines/StageRules.tsx
@@ -192,7 +192,7 @@ const StageRules = ({
   return (
     <DataTable
       id={`stage-rules-${pipeline.id}-${stage.stage}`}
-      className="table-hover"
+      hover
       headers={headers}
       headerCellFormatter={headerCellFormatter}
       rows={rules}

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.tsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.tsx
@@ -137,7 +137,7 @@ const RolesOverview = () => {
           <StyledPaginatedList totalItems={paginatedRoles.pagination.total}>
             <DataTable
               id="roles-overview"
-              className="table-hover"
+              hover
               rowClassName="no-bm"
               headers={TABLE_HEADERS}
               headerCellFormatter={_headerCellFormatter}

--- a/graylog2-web-interface/src/components/rules/RuleList.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.tsx
@@ -78,7 +78,7 @@ const RuleList = ({
   return (
     <DataTable
       id="rule-list"
-      className="table-hover"
+      hover
       headers={headers}
       headerCellFormatter={headerCellFormatter}
       sortByKey="title"

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorConfigurationModal.tsx
@@ -259,7 +259,7 @@ const CollectorConfigurationModal = ({
           </InfoContainer>
         )}
         <ConfigurationContainer>
-          <ConfigurationTable className="table-condensed table-hover">
+          <ConfigurationTable condensed hover>
             <tbody>
               {rows.length === 0 ? (
                 <TableRow>

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.tsx
@@ -102,7 +102,7 @@ class CollectorList extends React.Component<CollectorListProps> {
               <div className={style.collectorTable}>
                 <DataTable
                   id="collector-list"
-                  className="table-hover"
+                  hover
                   headers={headers}
                   headerCellFormatter={headerCellFormatter}
                   rows={collectors}

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.tsx
@@ -110,7 +110,7 @@ class ConfigurationList extends React.Component<Props> {
               <div className={style.configurationTable}>
                 <DataTable
                   id="collector-configurations-list"
-                  className="table-hover"
+                  hover
                   headers={headers}
                   headerCellFormatter={_headerCellFormatter}
                   rows={configurations}

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.tsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.tsx
@@ -71,7 +71,7 @@ const SidecarStatusFileList = ({ files }: Props) => {
     <div>
       <DataTable
         id="log-file-list"
-        className="table-hover"
+        hover
         headers={headers}
         headerCellFormatter={_headerCellFormatter}
         rows={files}

--- a/graylog2-web-interface/src/components/users/UsersOverview/SystemAdministratorOverview.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/SystemAdministratorOverview.tsx
@@ -40,7 +40,7 @@ const SystemAdministratorOverview = ({ adminUser, dataRowFormatter, headers, hea
         </p>
         <DataTable
           id="users-overview"
-          className="table-hover"
+          hover
           headers={headers}
           headerCellFormatter={headerCellFormatter}
           sortByKey="fullName"

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.tsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.tsx
@@ -141,7 +141,7 @@ const UsersOverview = () => {
           <StyledPaginatedList totalItems={total}>
             <DataTable
               id="users-overview"
-              className="table-hover"
+              hover
               rowClassName="no-bm"
               headers={TABLE_HEADERS}
               headerCellFormatter={_headerCellFormatter}

--- a/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/events/EventsList/EventsTable.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { useCallback } from 'react';
 
+import { Table } from 'components/bootstrap';
 import { TableHead, TableHeaderCell } from 'views/components/datatable';
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 import type EventsWidgetConfig from 'views/logic/widgets/events/EventsWidgetConfig';
@@ -57,7 +58,7 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
 
   return (
     <TableWrapper>
-      <table className="table table-condensed">
+      <Table condensed>
         <TableHead>
           <tr>
             {config.fields.toArray().map((field) => {
@@ -89,7 +90,7 @@ const EventsTable = ({ events, config, onSortChange, setLoadingState }: Props) =
             <EventsTableRow key={event.id} event={event} fields={config.fields} />
           ))}
         </tbody>
-      </table>
+      </Table>
     </TableWrapper>
   );
 };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

This PR fixes a styling issue with table rows in dark mode.
<img width="515" height="253" alt="image" src="https://github.com/user-attachments/assets/f70a2076-d3a6-405d-8094-b49177cb3532" />

The regression was introduced in https://github.com/Graylog2/graylog2-server/pull/26186.
Before this refactoring, there were two ways to apply Bootstrap table styles such as striped or condensed:
- via Table props, e.g. `<Table condensed>`
- via Bootstrap CSS classes, e.g. `<Table className="table table-condensed">`

After the refactoring, only the prop-based approach is supported.
This PR migrates the CSS classes to the proper props.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/14402
Fixes https://github.com/Graylog2/graylog2-server/issues/26246
/nocl - fixes unreleased regression