### PR TITLE
Check display field read permissions when resolving entity titles

### DIFF
--- a/changelog/unreleased/pr-26284.toml
+++ b/changelog/unreleased/pr-26284.toml
@@ -1,0 +1,3 @@
+type = "s"
+message = "Check display field read permissions when resolving entity titles."
+pulls = ["26284"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceImpl.java
@@ -32,6 +32,7 @@ import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityIdenti
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleRequest;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleResponse;
 import org.graylog2.search.SearchQueryField;
+import org.graylog2.shared.security.EntityPermissionsUtils;
 
 import jakarta.inject.Inject;
 
@@ -53,14 +54,17 @@ public class EntityTitleServiceImpl implements EntityTitleService {
 
     private final MongoConnection mongoConnection;
     private final DbEntitiesCatalog entitiesCatalog;
+    private final EntityPermissionsUtils entityPermissionsUtils;
 
     static final String TITLE_IF_NOT_PERMITTED = "";
 
     @Inject
     public EntityTitleServiceImpl(final MongoConnection mongoConnection,
-                                  final DbEntitiesCatalog entitiesCatalog) {
+                                  final DbEntitiesCatalog entitiesCatalog,
+                                  final EntityPermissionsUtils entityPermissionsUtils) {
         this.mongoConnection = mongoConnection;
         this.entitiesCatalog = entitiesCatalog;
+        this.entityPermissionsUtils = entityPermissionsUtils;
     }
 
     @Override
@@ -153,7 +157,8 @@ public class EntityTitleServiceImpl implements EntityTitleService {
                     return;
                 }
 
-                final boolean canReadTitle = checkCanReadTitle(permissions, dbEntityCatalogEntry.get().readPermission(), idAsString);
+                final boolean canReadTitle = checkCanReadTitle(permissions, dbEntityCatalogEntry.get().readPermission(), idAsString)
+                        && (!useCompositeDisplay || entityPermissionsUtils.areAllFieldsReadable(collection, displayFields));
                 final String title;
                 if (!canReadTitle) {
                     title = TITLE_IF_NOT_PERMITTED;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/TestSearchUser.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/TestSearchUser.java
@@ -58,6 +58,11 @@ public class TestSearchUser {
         return this;
     }
 
+    public TestSearchUser allowUserRead(String userId) {
+        this.permissions.put(RestPermissions.USERS_READ + ":" + userId, true);
+        return this;
+    }
+
     public TestSearchUser allowDashboard(String id) {
         this.permissions.put(DASHBOARDS_READ + ":" + id, true);
         return this;

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceMongoTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceMongoTest.java
@@ -28,7 +28,9 @@ import org.graylog2.rest.resources.system.contentpacks.titles.model.EntitiesTitl
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityIdentifier;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleRequest;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleResponse;
+import org.graylog2.shared.security.EntityPermissionsUtils;
 import org.graylog2.streams.StreamImpl;
+import org.graylog2.users.UserImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,14 +51,16 @@ public class EntityTitleServiceMongoTest {
         DbEntitiesCatalog entitiesCatalog = new DbEntitiesCatalog(
                 List.of(
                         new DbEntityCatalogEntry("streams", "title", StreamImpl.class, "streams:read", List.of()),
-                        new DbEntityCatalogEntry("nodes", "node_id", StreamImpl.class, "nodes:read", List.of())
+                        new DbEntityCatalogEntry("nodes", "node_id", StreamImpl.class, "nodes:read", List.of()),
+                        new DbEntityCatalogEntry("users", "full_name", UserImpl.class, "users:read",
+                                List.of("_id", "username", "email", "full_name"))
                 )
         );
         mongoDBTestService.importFixture("fixture_for_title_retrieval_testing.json", EntityTitleServiceImpl.class);
 
         final MongoConnection connection = mongoDBTestService.mongoConnection();
 
-        toTest = new EntityTitleServiceImpl(connection, entitiesCatalog);
+        toTest = new EntityTitleServiceImpl(connection, entitiesCatalog, new EntityPermissionsUtils(entitiesCatalog));
     }
 
     @Test
@@ -96,5 +100,59 @@ public class EntityTitleServiceMongoTest {
                 .hasSize(2)
                 .containsAll(List.of("01020302e16f9a1d1f6b074c", "01020302e16f9a1d1f6b0742"));
 
+    }
+
+    @Test
+    public void doesNotLeakNonReadableDisplayFields() {
+        //Request a user title built from the non-readable "password" field
+        final EntityTitleRequest request = new EntityTitleRequest(
+                List.of(
+                        new EntityIdentifier("01020302e16f9a1d1f6b0751", "users",
+                                null, null, List.of("password"), "{password}")
+                )
+        );
+
+        //user is even permitted to read the requested user
+        final SearchUser searchUser = TestSearchUser.builder()
+                .allowUserRead("01020302e16f9a1d1f6b0751")
+                .build();
+
+        final EntitiesTitleResponse response = toTest.getTitles(request, searchUser);
+
+        //the password hash must not leak into the title, despite the read permission
+        assertThat(response.entities())
+                .isNotNull()
+                .hasSize(1)
+                .contains(new EntityTitleResponse("01020302e16f9a1d1f6b0751", "users", TITLE_IF_NOT_PERMITTED));
+
+        assertThat(response.notPermitted())
+                .isNotNull()
+                .containsExactly("01020302e16f9a1d1f6b0751");
+    }
+
+    @Test
+    public void resolvesCompositeTitleFromReadableDisplayFields() {
+        //Request a user title built from the readable "full_name" field
+        final EntityTitleRequest request = new EntityTitleRequest(
+                List.of(
+                        new EntityIdentifier("01020302e16f9a1d1f6b0751", "users",
+                                null, null, List.of("full_name"), "{full_name}")
+                )
+        );
+
+        final SearchUser searchUser = TestSearchUser.builder()
+                .allowUserRead("01020302e16f9a1d1f6b0751")
+                .build();
+
+        final EntitiesTitleResponse response = toTest.getTitles(request, searchUser);
+
+        assertThat(response.entities())
+                .isNotNull()
+                .hasSize(1)
+                .contains(new EntityTitleResponse("01020302e16f9a1d1f6b0751", "users", "Jane Doe"));
+
+        assertThat(response.notPermitted())
+                .isNotNull()
+                .isEmpty();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/titles/EntityTitleServiceTest.java
@@ -26,6 +26,7 @@ import org.graylog2.rest.resources.system.contentpacks.titles.model.EntitiesTitl
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityIdentifier;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleRequest;
 import org.graylog2.rest.resources.system.contentpacks.titles.model.EntityTitleResponse;
+import org.graylog2.shared.security.EntityPermissionsUtils;
 import org.graylog2.streams.StreamImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +62,7 @@ class EntityTitleServiceTest {
 
     @BeforeEach
     void setUp() {
-        toTest = new EntityTitleServiceImpl(mongoConnection, entitiesCatalog);
+        toTest = new EntityTitleServiceImpl(mongoConnection, entitiesCatalog, new EntityPermissionsUtils(entitiesCatalog));
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/rest/resources/system/contentpacks/titles/fixture_for_title_retrieval_testing.json
+++ b/graylog2-server/src/test/resources/org/graylog2/rest/resources/system/contentpacks/titles/fixture_for_title_retrieval_testing.json
@@ -52,5 +52,14 @@
       "is_leader": true,
       "node_id": "Node Id 2"
     }
+  ],
+  "users" : [
+    {
+      "_id": {"$oid": "01020302e16f9a1d1f6b0751"},
+      "username": "jane",
+      "full_name": "Jane Doe",
+      "email": "jane@example.com",
+      "password": "deadbeefsecrethash"
+    }
   ]
 }


### PR DESCRIPTION
**Note:** This change needs to be backported to `7.1`.

## Description

`EntityTitleServiceImpl` now verifies — via `EntityPermissionsUtils#areAllFieldsReadable` — that all composite display fields of an entity are declared readable for the collection before using them to build the entity title. If any referenced field is not readable, the title is withheld (empty) and the entity is reported as not permitted, same as a failing entity read permission check.

Entities using a plain title field are unaffected, the check only applies when composite display fields are in use.

## Motivation and Context

Composite display titles are built from arbitrary collection fields. Without this check, a title could leak values from fields that are not declared readable for the collection.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)