### PR TITLE
Mock `@graylog/server-api` in storybook to avoid dependency on generated api stubs.

### DIFF
--- a/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/main.ts
@@ -54,7 +54,7 @@ const config: StorybookConfig = {
       ],
       alias: {
         ...(sbConfig.resolve?.alias ?? {}),
-        '@graylog/server-api': path.resolve(webInterfaceRoot, 'target/api'),
+        '@graylog/server-api': path.resolve(__dirname, 'server-api-mock.js'),
       },
     },
   }),

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/server-api-mock.js
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/server-api-mock.js
@@ -21,4 +21,5 @@
 const asyncFn = () => Promise.resolve({});
 const namespace = new Proxy({}, { get: () => asyncFn });
 
+// eslint-disable-next-line no-undef
 module.exports = new Proxy({}, { get: () => namespace });

--- a/graylog2-web-interface/docs/graylog-luma/.storybook/server-api-mock.js
+++ b/graylog2-web-interface/docs/graylog-luma/.storybook/server-api-mock.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+// Stub for @graylog/server-api used during storybook builds.
+// The real module is generated from the OpenAPI spec and requires the Java backend build.
+// Each exported namespace (e.g. SystemFields, FavoriteFields) is an object of async functions.
+const asyncFn = () => Promise.resolve({});
+const namespace = new Proxy({}, { get: () => asyncFn });
+
+module.exports = new Proxy({}, { get: () => namespace });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The storybook build for `graylog-luma` failed in CI because the webpack alias for `@graylog/server-api` pointed to `target/api`, a directory generated from the Java backend's API spec that never exists in a fresh checkout. This adds a Proxy-based stub module and updates the storybook webpack config to always use it, so the build works both locally and in CI without requiring the API codegen step.

/nocl