### PR TITLE
Remove not needed license header.

### DIFF
--- a/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Patterns/CreatingAnEntity.mdx
@@ -1,21 +1,3 @@
-{/\*
-
-- Copyright (C) 2020 Graylog, Inc.
--
-- This program is free software: you can redistribute it and/or modify
-- it under the terms of the Server Side Public License, version 1,
-- as published by MongoDB, Inc.
--
-- This program is distributed in the hope that it will be useful,
-- but WITHOUT ANY WARRANTY; without even the implied warranty of
-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-- Server Side Public License for more details.
--
-- You should have received a copy of the Server Side Public License
-- along with this program. If not, see
-- <http://www.mongodb.com/licensing/server-side-public-license>.
-  \*/}
-
 import { Canvas, Meta, Unstyled } from '@storybook/addon-docs/blocks';
 import { Alert } from 'components/bootstrap';
 import * as CreatingAnEntityStories from './CreatingAnEntity.stories';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR removes a not needed license header for a `.mdx` file. On format the license header is transformed into a comment that results in a storybook build error. Similar to the styleguidist `.md` files, these storybook files do not require a license header.

```
🚨 Unable to index ./stories/Patterns/CreatingAnEntity.mdx:
│  Error: Could not parse expression with acorn
```

/nocl

