### PR TITLE
Refactor `OSPivot` into focused collaborators with test coverage

### DIFF
--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/OSPivot.java
@@ -16,157 +16,39 @@
  */
 package org.graylog.storage.opensearch2.views.searchtypes.pivot;
 
-import com.google.common.collect.ImmutableList;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
-import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
-import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
-import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
+/**
+ * Handles the {@link Pivot} search type for OpenSearch by delegating query generation to {@link PivotQueryGenerator}
+ * and result extraction to {@link PivotResultProcessor}.
+ */
 public class OSPivot implements OSSearchTypeHandler<Pivot> {
-    private static final Logger LOG = LoggerFactory.getLogger(OSPivot.class);
-    private static final String AGG_NAME = "agg";
-
-    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
-    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers;
-    private final EffectiveTimeRangeExtractor effectiveTimeRangeExtractor;
+    private final PivotQueryGenerator queryGenerator;
+    private final PivotResultProcessor resultProcessor;
 
     @Inject
     public OSPivot(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
                    Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers,
                    EffectiveTimeRangeExtractor effectiveTimeRangeExtractor) {
-        this.bucketHandlers = bucketHandlers;
-        this.seriesHandlers = seriesHandlers;
-        this.effectiveTimeRangeExtractor = effectiveTimeRangeExtractor;
+        this.queryGenerator = new PivotQueryGenerator(bucketHandlers, seriesHandlers);
+        this.resultProcessor = new PivotResultProcessor(bucketHandlers, seriesHandlers, effectiveTimeRangeExtractor);
     }
 
     @Override
     public void doGenerateQueryPart(Query query, Pivot pivot, OSGeneratedQueryContext queryContext) {
-        LOG.debug("Generating aggregation for {}", pivot);
-        final SearchSourceBuilder searchSourceBuilder = queryContext.searchSourceBuilder(pivot);
-
-        var generateRollups = pivot.rollup() || (pivot.rowGroups().isEmpty() && pivot.columnGroups().isEmpty());
-
-        // add global rollup series if those were requested
-        if (generateRollups) {
-            seriesStream(pivot, queryContext, "global rollup")
-                    .filter(result -> Placement.METRIC.equals(result.placement()))
-                    .map(SeriesAggregationBuilder::aggregationBuilder)
-                    .forEach(searchSourceBuilder::aggregation);
-        }
-
-        final BucketSpecHandler.CreatedAggregations<AggregationBuilder> createdAggregations = createPivots(BucketSpecHandler.Direction.Row, query, pivot, pivot.rowGroups(), queryContext);
-        final AggregationBuilder rootAggregation = createdAggregations.root();
-        final AggregationBuilder leafAggregation = createdAggregations.leaf();
-        final List<AggregationBuilder> metrics = createdAggregations.metrics();
-        seriesStream(pivot, queryContext, "metrics")
-                .forEach(result -> {
-                    switch (result.placement()) {
-                        case METRIC -> metrics.forEach(metric -> metric.subAggregation(result.aggregationBuilder()));
-                        case ROW -> rootAggregation.subAggregation(result.aggregationBuilder());
-                        case ROOT -> {
-                            if (!generateRollups) {
-                                searchSourceBuilder.aggregation(result.aggregationBuilder());
-                            }
-                        }
-                    }
-                });
-
-        if (!pivot.columnGroups().isEmpty()) {
-            final BucketSpecHandler.CreatedAggregations<AggregationBuilder> columnsAggregation = createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
-            final AggregationBuilder columnsRootAggregation = columnsAggregation.root();
-            final AggregationBuilder columnsLeafAggregation = columnsAggregation.leaf();
-            final List<AggregationBuilder> columnMetrics = columnsAggregation.metrics();
-            seriesStream(pivot, queryContext, "metrics")
-                    .forEach(result -> {
-                        var aggregationBuilder = result.aggregationBuilder();
-                        switch (result.placement()) {
-                            case COLUMN -> columnsLeafAggregation.subAggregation(aggregationBuilder);
-                            case METRIC -> columnMetrics.forEach(metric -> metric.subAggregation(aggregationBuilder));
-                        }
-                    });
-            if (leafAggregation != null) {
-                leafAggregation.subAggregation(columnsRootAggregation);
-            } else {
-                searchSourceBuilder.aggregation(columnsRootAggregation);
-            }
-        }
-
-        if (rootAggregation != null) {
-            searchSourceBuilder.aggregation(rootAggregation);
-        }
-
-        addTimeStampAggregations(searchSourceBuilder);
-    }
-
-    private void addTimeStampAggregations(SearchSourceBuilder searchSourceBuilder) {
-        final MinAggregationBuilder startTimestamp = AggregationBuilders.min("timestamp-min").field("timestamp");
-        final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
-        searchSourceBuilder.aggregation(startTimestamp);
-        searchSourceBuilder.aggregation(endTimestamp);
-    }
-
-    private BucketSpecHandler.CreatedAggregations<AggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, OSGeneratedQueryContext queryContext) {
-        AggregationBuilder leaf = null;
-        AggregationBuilder root = null;
-        final List<AggregationBuilder> metrics = new ArrayList<>();
-        for (BucketSpec bucketSpec : pivots) {
-            final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
-            final BucketSpecHandler.CreatedAggregations<AggregationBuilder> bucketAggregations = bucketHandler.createAggregation(direction, AGG_NAME, pivot, bucketSpec, queryContext, query);
-            final AggregationBuilder aggregationRoot = bucketAggregations.root();
-            final AggregationBuilder aggregationLeaf = bucketAggregations.leaf();
-            final List<AggregationBuilder> aggregationMetrics = bucketAggregations.metrics();
-
-            metrics.addAll(aggregationMetrics);
-            if (root == null && leaf == null) {
-                root = aggregationRoot;
-                leaf = aggregationLeaf;
-            } else {
-                leaf.subAggregation(aggregationRoot);
-                leaf = aggregationLeaf;
-            }
-        }
-
-        return BucketSpecHandler.CreatedAggregations.create(root, leaf, metrics);
-    }
-
-    private Stream<SeriesAggregationBuilder> seriesStream(Pivot pivot, OSGeneratedQueryContext queryContext, String reason) {
-        return pivot.series()
-                .stream()
-                .distinct()
-                .flatMap((seriesSpec) -> {
-                    final String seriesName = queryContext.seriesName(seriesSpec, pivot);
-                    LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
-                    final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());
-                    if (esPivotSeriesSpecHandler == null) {
-                        throw new IllegalArgumentException("No series handler registered for: " + seriesSpec.type());
-                    }
-                    return esPivotSeriesSpecHandler.createAggregation(seriesName, pivot, seriesSpec, queryContext).stream();
-                });
+        queryGenerator.generate(query, pivot, queryContext);
     }
 
     @WithSpan
@@ -175,96 +57,6 @@ public class OSPivot implements OSSearchTypeHandler<Pivot> {
                                              Pivot pivot,
                                              SearchResponse queryResult,
                                              OSGeneratedQueryContext queryContext) {
-        final AbsoluteRange effectiveTimerange = this.effectiveTimeRangeExtractor.extract(queryResult, query, pivot);
-
-        final var fieldsNames = pivot.rowGroups().stream().flatMap(bs -> bs.fields().stream());
-        final var seriesNames = pivot.series().stream().map(SeriesSpec::id).toList();
-
-        final List<String> colGroupNames = pivot.columnGroups().isEmpty() ? seriesNames : new ArrayList<>();
-
-        final PivotResult.Builder resultBuilder = PivotResult.builder()
-                .id(pivot.id())
-                .effectiveTimerange(effectiveTimerange)
-                .total(extractDocumentCount(queryResult));
-
-        pivot.name().ifPresent(resultBuilder::name);
-
-        final MultiBucketsAggregation.Bucket initialBucket = createInitialBucket(queryResult);
-
-        retrieveBuckets(pivot, pivot.rowGroups(), initialBucket)
-                .forEach(tuple -> {
-                    final ImmutableList<String> rowKeys = tuple.keys();
-                    final MultiBucketsAggregation.Bucket rowBucket = tuple.bucket();
-                    final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder()
-                            .key(rowKeys)
-                            .source("leaf");
-                    if (pivot.columnGroups().isEmpty() || pivot.rollup()) {
-                        processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
-                    }
-                    if (!pivot.columnGroups().isEmpty()) {
-                        var contextWithRowBucket = queryContext.withRowBucket(rowBucket);
-                        retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
-                                .forEach(columnBucketTuple -> {
-                                    final ImmutableList<String> columnKeys = columnBucketTuple.keys();
-                                    colGroupNames.add(String.join(", ", Stream.concat(columnKeys.stream(), seriesNames.stream()).toList()));
-
-                                    final MultiBucketsAggregation.Bucket columnBucket = columnBucketTuple.bucket();
-
-                                    processSeries(rowBuilder, queryResult, contextWithRowBucket, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
-                                });
-                    }
-                    resultBuilder.addRow(rowBuilder.build());
-                });
-
-        if (!pivot.rowGroups().isEmpty() && pivot.rollup()) {
-            final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.of());
-            processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), initialBucket, true, "row-inner");
-            resultBuilder.addRow(rowBuilder.source("non-leaf").build());
-        }
-
-        return resultBuilder.columnNames(Stream.concat(fieldsNames, colGroupNames.stream().distinct().sorted()).toList()).build();
-    }
-
-    private Stream<PivotBucket> retrieveBuckets(Pivot pivot, List<BucketSpec> pivots, MultiBucketsAggregation.Bucket initialBucket) {
-        Stream<PivotBucket> result = Stream.of(PivotBucket.create(ImmutableList.of(), initialBucket));
-
-        for (BucketSpec bucketSpec : pivots) {
-            result = result.flatMap((tuple) -> {
-                final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
-                return bucketHandler.extractBuckets(pivot, bucketSpec, tuple);
-            });
-        }
-
-        return result;
-    }
-
-    private MultiBucketsAggregation.Bucket createInitialBucket(SearchResponse queryResult) {
-        return InitialBucket.create(queryResult);
-    }
-
-    private void processSeries(PivotResult.Row.Builder rowBuilder,
-                               SearchResponse searchResult,
-                               OSGeneratedQueryContext queryContext,
-                               Pivot pivot,
-                               ArrayDeque<String> columnKeys,
-                               HasAggregations aggregation,
-                               boolean rollup,
-                               String source) {
-        pivot.series().forEach(seriesSpec -> {
-            final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> seriesHandler = seriesHandlers.get(seriesSpec.type());
-            final Aggregation series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
-            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, queryContext)
-                    .map(value -> {
-                        columnKeys.addLast(value.id());
-                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
-                        columnKeys.removeLast();
-                        return v;
-                    })
-                    .forEach(rowBuilder::addValue);
-        });
-    }
-
-    private long extractDocumentCount(SearchResponse queryResult) {
-        return queryResult.getHits().getTotalHits().value;
+        return resultProcessor.extract(query, pivot, queryResult, queryContext);
     }
 }

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/PivotQueryGenerator.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/PivotQueryGenerator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.views.searchtypes.pivot;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Builds the OpenSearch aggregation tree for a {@link Pivot}: global rollup series, row and column bucket groups,
+ * the metric/row/column/root series placed within them, and the timestamp range aggregations.
+ */
+class PivotQueryGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(PivotQueryGenerator.class);
+    private static final String AGG_NAME = "agg";
+
+    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
+    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers;
+
+    PivotQueryGenerator(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                        Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers) {
+        this.bucketHandlers = bucketHandlers;
+        this.seriesHandlers = seriesHandlers;
+    }
+
+    void generate(Query query, Pivot pivot, OSGeneratedQueryContext queryContext) {
+        LOG.debug("Generating aggregation for {}", pivot);
+        final SearchSourceBuilder searchSourceBuilder = queryContext.searchSourceBuilder(pivot);
+
+        final boolean generateRollups = pivot.rollup() || (pivot.rowGroups().isEmpty() && pivot.columnGroups().isEmpty());
+
+        if (generateRollups) {
+            addGlobalRollupSeries(pivot, queryContext, searchSourceBuilder);
+        }
+
+        final BucketSpecHandler.CreatedAggregations<AggregationBuilder> rowAggregations =
+                createPivots(BucketSpecHandler.Direction.Row, query, pivot, pivot.rowGroups(), queryContext);
+        addRowSeries(pivot, queryContext, searchSourceBuilder, rowAggregations, generateRollups);
+
+        if (!pivot.columnGroups().isEmpty()) {
+            addColumnGroups(query, pivot, queryContext, searchSourceBuilder, rowAggregations.leaf());
+        }
+
+        if (rowAggregations.root() != null) {
+            searchSourceBuilder.aggregation(rowAggregations.root());
+        }
+
+        addTimestampAggregations(searchSourceBuilder);
+    }
+
+    private void addGlobalRollupSeries(Pivot pivot, OSGeneratedQueryContext queryContext, SearchSourceBuilder searchSourceBuilder) {
+        seriesStream(pivot, queryContext, "global rollup")
+                .filter(result -> Placement.METRIC.equals(result.placement()))
+                .map(SeriesAggregationBuilder::aggregationBuilder)
+                .forEach(searchSourceBuilder::aggregation);
+    }
+
+    private void addRowSeries(Pivot pivot,
+                              OSGeneratedQueryContext queryContext,
+                              SearchSourceBuilder searchSourceBuilder,
+                              BucketSpecHandler.CreatedAggregations<AggregationBuilder> rowAggregations,
+                              boolean generateRollups) {
+        final AggregationBuilder rootAggregation = rowAggregations.root();
+        final List<AggregationBuilder> metrics = rowAggregations.metrics();
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(result -> {
+                    switch (result.placement()) {
+                        case METRIC -> metrics.forEach(metric -> metric.subAggregation(result.aggregationBuilder()));
+                        case ROW -> rootAggregation.subAggregation(result.aggregationBuilder());
+                        case ROOT -> {
+                            if (!generateRollups) {
+                                searchSourceBuilder.aggregation(result.aggregationBuilder());
+                            }
+                        }
+                    }
+                });
+    }
+
+    private void addColumnGroups(Query query,
+                                 Pivot pivot,
+                                 OSGeneratedQueryContext queryContext,
+                                 SearchSourceBuilder searchSourceBuilder,
+                                 AggregationBuilder rowLeafAggregation) {
+        final BucketSpecHandler.CreatedAggregations<AggregationBuilder> columnsAggregation =
+                createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
+        final List<AggregationBuilder> columnMetrics = columnsAggregation.metrics();
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(result -> {
+                    final var aggregationBuilder = result.aggregationBuilder();
+                    switch (result.placement()) {
+                        case COLUMN -> columnsAggregation.leaf().subAggregation(aggregationBuilder);
+                        case METRIC -> columnMetrics.forEach(metric -> metric.subAggregation(aggregationBuilder));
+                    }
+                });
+        if (rowLeafAggregation != null) {
+            rowLeafAggregation.subAggregation(columnsAggregation.root());
+        } else {
+            searchSourceBuilder.aggregation(columnsAggregation.root());
+        }
+    }
+
+    private void addTimestampAggregations(SearchSourceBuilder searchSourceBuilder) {
+        final MinAggregationBuilder startTimestamp = AggregationBuilders.min("timestamp-min").field("timestamp");
+        final MaxAggregationBuilder endTimestamp = AggregationBuilders.max("timestamp-max").field("timestamp");
+        searchSourceBuilder.aggregation(startTimestamp);
+        searchSourceBuilder.aggregation(endTimestamp);
+    }
+
+    private BucketSpecHandler.CreatedAggregations<AggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, OSGeneratedQueryContext queryContext) {
+        AggregationBuilder leaf = null;
+        AggregationBuilder root = null;
+        final List<AggregationBuilder> metrics = new ArrayList<>();
+        for (BucketSpec bucketSpec : pivots) {
+            final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
+            final BucketSpecHandler.CreatedAggregations<AggregationBuilder> bucketAggregations = bucketHandler.createAggregation(direction, AGG_NAME, pivot, bucketSpec, queryContext, query);
+            final AggregationBuilder aggregationRoot = bucketAggregations.root();
+            final AggregationBuilder aggregationLeaf = bucketAggregations.leaf();
+            final List<AggregationBuilder> aggregationMetrics = bucketAggregations.metrics();
+
+            metrics.addAll(aggregationMetrics);
+            if (root == null && leaf == null) {
+                root = aggregationRoot;
+                leaf = aggregationLeaf;
+            } else {
+                leaf.subAggregation(aggregationRoot);
+                leaf = aggregationLeaf;
+            }
+        }
+
+        return BucketSpecHandler.CreatedAggregations.create(root, leaf, metrics);
+    }
+
+    private Stream<SeriesAggregationBuilder> seriesStream(Pivot pivot, OSGeneratedQueryContext queryContext, String reason) {
+        return pivot.series()
+                .stream()
+                .distinct()
+                .flatMap((seriesSpec) -> {
+                    final String seriesName = queryContext.seriesName(seriesSpec, pivot);
+                    LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
+                    final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());
+                    if (esPivotSeriesSpecHandler == null) {
+                        throw new IllegalArgumentException("No series handler registered for: " + seriesSpec.type());
+                    }
+                    return esPivotSeriesSpecHandler.createAggregation(seriesName, pivot, seriesSpec, queryContext).stream();
+                });
+    }
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/PivotResultProcessor.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/PivotResultProcessor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.views.searchtypes.pivot;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Turns an OpenSearch {@link SearchResponse} into a {@link PivotResult} by walking the row and column bucket
+ * aggregations, extracting series values for each leaf, and adding the optional rollup row.
+ */
+class PivotResultProcessor {
+    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
+    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers;
+    private final EffectiveTimeRangeExtractor effectiveTimeRangeExtractor;
+
+    PivotResultProcessor(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                         Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers,
+                         EffectiveTimeRangeExtractor effectiveTimeRangeExtractor) {
+        this.bucketHandlers = bucketHandlers;
+        this.seriesHandlers = seriesHandlers;
+        this.effectiveTimeRangeExtractor = effectiveTimeRangeExtractor;
+    }
+
+    SearchType.Result extract(Query query, Pivot pivot, SearchResponse queryResult, OSGeneratedQueryContext queryContext) {
+        final AbsoluteRange effectiveTimerange = this.effectiveTimeRangeExtractor.extract(queryResult, query, pivot);
+
+        final var fieldsNames = pivot.rowGroups().stream().flatMap(bs -> bs.fields().stream());
+        final var seriesNames = pivot.series().stream().map(SeriesSpec::id).toList();
+
+        final List<String> colGroupNames = pivot.columnGroups().isEmpty() ? seriesNames : new ArrayList<>();
+
+        final PivotResult.Builder resultBuilder = PivotResult.builder()
+                .id(pivot.id())
+                .effectiveTimerange(effectiveTimerange)
+                .total(extractDocumentCount(queryResult));
+
+        pivot.name().ifPresent(resultBuilder::name);
+
+        final MultiBucketsAggregation.Bucket initialBucket = InitialBucket.create(queryResult);
+
+        retrieveBuckets(pivot, pivot.rowGroups(), initialBucket)
+                .forEach(tuple -> resultBuilder.addRow(buildRow(pivot, queryResult, queryContext, seriesNames, colGroupNames, tuple)));
+
+        if (!pivot.rowGroups().isEmpty() && pivot.rollup()) {
+            resultBuilder.addRow(buildRollupRow(pivot, queryResult, queryContext, initialBucket));
+        }
+
+        return resultBuilder.columnNames(Stream.concat(fieldsNames, colGroupNames.stream().distinct().sorted()).toList()).build();
+    }
+
+    private PivotResult.Row buildRow(Pivot pivot,
+                                     SearchResponse queryResult,
+                                     OSGeneratedQueryContext queryContext,
+                                     List<String> seriesNames,
+                                     List<String> colGroupNames,
+                                     PivotBucket tuple) {
+        final ImmutableList<String> rowKeys = tuple.keys();
+        final MultiBucketsAggregation.Bucket rowBucket = tuple.bucket();
+        final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder()
+                .key(rowKeys)
+                .source("leaf");
+        if (pivot.columnGroups().isEmpty() || pivot.rollup()) {
+            processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
+        }
+        if (!pivot.columnGroups().isEmpty()) {
+            final var contextWithRowBucket = queryContext.withRowBucket(rowBucket);
+            retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
+                    .forEach(columnBucketTuple -> {
+                        final ImmutableList<String> columnKeys = columnBucketTuple.keys();
+                        colGroupNames.add(String.join(", ", Stream.concat(columnKeys.stream(), seriesNames.stream()).toList()));
+
+                        final MultiBucketsAggregation.Bucket columnBucket = columnBucketTuple.bucket();
+
+                        processSeries(rowBuilder, queryResult, contextWithRowBucket, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
+                    });
+        }
+        return rowBuilder.build();
+    }
+
+    private PivotResult.Row buildRollupRow(Pivot pivot,
+                                           SearchResponse queryResult,
+                                           OSGeneratedQueryContext queryContext,
+                                           MultiBucketsAggregation.Bucket initialBucket) {
+        final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.of());
+        processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), initialBucket, true, "row-inner");
+        return rowBuilder.source("non-leaf").build();
+    }
+
+    private Stream<PivotBucket> retrieveBuckets(Pivot pivot, List<BucketSpec> pivots, MultiBucketsAggregation.Bucket initialBucket) {
+        Stream<PivotBucket> result = Stream.of(PivotBucket.create(ImmutableList.of(), initialBucket));
+
+        for (BucketSpec bucketSpec : pivots) {
+            result = result.flatMap((tuple) -> {
+                final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
+                return bucketHandler.extractBuckets(pivot, bucketSpec, tuple);
+            });
+        }
+
+        return result;
+    }
+
+    private void processSeries(PivotResult.Row.Builder rowBuilder,
+                               SearchResponse searchResult,
+                               OSGeneratedQueryContext queryContext,
+                               Pivot pivot,
+                               ArrayDeque<String> columnKeys,
+                               HasAggregations aggregation,
+                               boolean rollup,
+                               String source) {
+        pivot.series().forEach(seriesSpec -> {
+            final OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation> seriesHandler = seriesHandlers.get(seriesSpec.type());
+            final Aggregation series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
+            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, queryContext)
+                    .map(value -> {
+                        columnKeys.addLast(value.id());
+                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
+                        columnKeys.removeLast();
+                        return v;
+                    })
+                    .forEach(rowBuilder::addValue);
+        });
+    }
+
+    private long extractDocumentCount(SearchResponse queryResult) {
+        return queryResult.getHits().getTotalHits().value;
+    }
+}

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/searchtypes/pivots/OSPivotTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/searchtypes/pivots/OSPivotTest.java
@@ -17,21 +17,42 @@
 package org.graylog.storage.opensearch2.views.searchtypes.pivots;
 
 import com.google.common.collect.ImmutableList;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
 import org.graylog.shaded.opensearch2.org.apache.lucene.search.TotalHits;
 import org.graylog.shaded.opensearch2.org.opensearch.action.search.SearchResponse;
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHit;
 import org.graylog.shaded.opensearch2.org.opensearch.search.SearchHits;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregations;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.HasAggregations;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Max;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.metrics.Min;
+import org.graylog.shaded.opensearch2.org.opensearch.search.builder.SearchSourceBuilder;
 import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch2.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.EffectiveTimeRangeExtractor;
 import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivot;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotBucketSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.PivotBucket;
+import org.graylog.storage.opensearch2.views.searchtypes.pivot.SeriesAggregationBuilder;
+import org.graylog.testing.jsonpath.JsonPathAssert;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -50,8 +71,14 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -187,4 +214,304 @@ public class OSPivotTest {
         ));
     }
 
+    // ----------------------------------------------------------------------------------------------------------------
+    // Query generation (doGenerateQueryPart)
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void alwaysAddsTimestampMinMaxAggregations() {
+        final Pivot pivot = Pivot.builder().id("p").series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations['timestamp-min'].min.field").isEqualTo("timestamp");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations['timestamp-max'].max.field").isEqualTo("timestamp");
+    }
+
+    @Test
+    public void generatesAggregationForRowGroup() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("field1");
+    }
+
+    @Test
+    public void nestsMultipleRowGroups() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1"), values("field2")).series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("field1");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.agg.terms.field").isEqualTo("field2");
+    }
+
+    @Test
+    public void attachesMetricSeriesAsSubAggregationOfRowLeaf() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(Values.NAME, new FakeBucketHandler()),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::metric, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void attachesGlobalRollupMetricSeriesAtRootWhenNoGroupsPresent() {
+        final Pivot pivot = Pivot.builder().id("p").series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::metric, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void attachesColumnGroupUnderRowLeaf() {
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series()
+                .rollup(false)
+                .build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("row1");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.agg.terms.field").isEqualTo("col1");
+    }
+
+    @Test
+    public void attachesColumnGroupAtRootWhenNoRowGroupsPresent() {
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .columnGroups(values("col1"))
+                .series()
+                .rollup(false)
+                .build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("col1");
+    }
+
+    @Test
+    public void attachesRootPlacedSeriesAtRootWhenNotGeneratingRollups() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("row1")).series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(Values.NAME, new FakeBucketHandler()),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::root, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void throwsWhenNoSeriesHandlerIsRegistered() {
+        final Pivot pivot = Pivot.builder().id("p").series(count()).rollup(false).build();
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        final OSGeneratedQueryContext context = mock(OSGeneratedQueryContext.class);
+        when(context.searchSourceBuilder(any())).thenReturn(searchSourceBuilder);
+        final OSPivot sut = new OSPivot(Map.of(), Map.of(), new EffectiveTimeRangeExtractor());
+
+        assertThatThrownBy(() -> sut.doGenerateQueryPart(query, pivot, context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No series handler registered for: " + Count.NAME);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Result extraction (doExtractResult) with row/column/series handling
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void extractsOneLeafRowPerRowGroupBucket() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(false).build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of("field1", List.of(
+                PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketsAggregation.Bucket.class)),
+                PivotBucket.create(ImmutableList.of("b"), mock(MultiBucketsAggregation.Bucket.class))
+        )));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 42L)));
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(2);
+        assertThat(result.rows().get(0).key()).containsExactly("a");
+        assertThat(result.rows().get(0).source()).isEqualTo("leaf");
+        assertThat(result.rows().get(0).values()).hasSize(1);
+        final PivotResult.Value value = result.rows().get(0).values().get(0);
+        assertThat(value.key()).containsExactly("count()");
+        assertThat(value.value()).isEqualTo(42L);
+        assertThat(value.rollup()).isTrue();
+        assertThat(value.source()).isEqualTo("row-leaf");
+        assertThat(result.rows().get(1).key()).containsExactly("b");
+    }
+
+    @Test
+    public void addsRollupRowWhenRowGroupsPresentAndRollupEnabled() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(true).build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of("field1", List.of(
+                PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketsAggregation.Bucket.class))
+        )));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 7L)));
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(2);
+        final PivotResult.Row rollupRow = result.rows().get(1);
+        assertThat(rollupRow.key()).isEmpty();
+        assertThat(rollupRow.source()).isEqualTo("non-leaf");
+        assertThat(rollupRow.values()).hasSize(1);
+        assertThat(rollupRow.values().get(0).source()).isEqualTo("row-inner");
+    }
+
+    @Test
+    public void extractsNestedColumnValues() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series(count())
+                .rollup(false)
+                .build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of(
+                "row1", List.of(PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketsAggregation.Bucket.class))),
+                "col1", List.of(PivotBucket.create(ImmutableList.of("x"), mock(MultiBucketsAggregation.Bucket.class)))
+        ));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 5L)));
+        when(queryContext.withRowBucket(any())).thenReturn(queryContext);
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(1);
+        final PivotResult.Row row = result.rows().get(0);
+        assertThat(row.key()).containsExactly("a");
+        assertThat(row.values()).hasSize(1);
+        final PivotResult.Value value = row.values().get(0);
+        assertThat(value.key()).containsExactly("x", "count()");
+        assertThat(value.value()).isEqualTo(5L);
+        assertThat(value.source()).isEqualTo("col-leaf");
+    }
+
+    @Test
+    public void buildsColumnNamesFromRowFieldsAndColumnKeys() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series(count())
+                .rollup(false)
+                .build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of(
+                "row1", List.of(PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketsAggregation.Bucket.class))),
+                "col1", List.of(PivotBucket.create(ImmutableList.of("x"), mock(MultiBucketsAggregation.Bucket.class)))
+        ));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 5L)));
+        when(queryContext.withRowBucket(any())).thenReturn(queryContext);
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.columnNames()).containsExactly("row1", "x, count()");
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------------------------------------------------
+
+    private DocumentContext generateQueryPart(Pivot pivot,
+                                              Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                                              Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers) {
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        final OSGeneratedQueryContext context = mock(OSGeneratedQueryContext.class);
+        when(context.searchSourceBuilder(any())).thenReturn(searchSourceBuilder);
+        when(context.seriesName(any(), any())).thenReturn("metricseries");
+
+        final OSPivot sut = new OSPivot(bucketHandlers, seriesHandlers, new EffectiveTimeRangeExtractor());
+        sut.doGenerateQueryPart(query, pivot, context);
+
+        return JsonPath.parse(searchSourceBuilder.toString());
+    }
+
+    private void stubResultMetadata() {
+        returnDocumentCount(queryResult, 10);
+        final Aggregations timestampAggregations = createTimestampRangeAggregations(
+                (double) new Date().getTime(), (double) new Date().getTime());
+        when(queryResult.getAggregations()).thenReturn(timestampAggregations);
+        when(query.effectiveTimeRange(any())).thenReturn(RelativeRange.create(300));
+    }
+
+    private static Values values(String field) {
+        return Values.builder().field(field).build();
+    }
+
+    private static Count count() {
+        return Count.builder().id("count()").build();
+    }
+
+    private static class FakeBucketHandler extends OSPivotBucketSpecHandler<Values> {
+        private final Map<String, List<PivotBucket>> bucketsByField;
+
+        private FakeBucketHandler() {
+            this(Map.of());
+        }
+
+        private FakeBucketHandler(Map<String, List<PivotBucket>> bucketsByField) {
+            this.bucketsByField = bucketsByField;
+        }
+
+        @Override
+        public CreatedAggregations<AggregationBuilder> doCreateAggregation(Direction direction, String name, Pivot pivot, Values bucketSpec, OSGeneratedQueryContext queryContext, Query query) {
+            return CreatedAggregations.create(AggregationBuilders.terms(name).field(bucketSpec.fields().get(0)));
+        }
+
+        @Override
+        public Stream<PivotBucket> extractBuckets(Pivot pivot, BucketSpec bucketSpecs, PivotBucket previousBucket) {
+            return bucketsByField.getOrDefault(bucketSpecs.fields().get(0), List.of()).stream();
+        }
+    }
+
+    private static class FakeSeriesHandler extends OSPivotSeriesSpecHandler<Count, Aggregation> {
+        private final Function<AggregationBuilder, SeriesAggregationBuilder> placement;
+        private final List<SeriesSpecHandler.Value> resultValues;
+
+        private FakeSeriesHandler(Function<AggregationBuilder, SeriesAggregationBuilder> placement, List<SeriesSpecHandler.Value> resultValues) {
+            this.placement = placement;
+            this.resultValues = resultValues;
+        }
+
+        @Override
+        public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count seriesSpec, OSGeneratedQueryContext queryContext) {
+            return List.of(placement.apply(AggregationBuilders.max(name).field("value")));
+        }
+
+        @Override
+        public Aggregation extractAggregationFromResult(Pivot pivot, PivotSpec spec, HasAggregations currentAggregationOrBucket, IndexerGeneratedQueryContext<?> queryContext) {
+            return null;
+        }
+
+        @Override
+        public Stream<SeriesSpecHandler.Value> doHandleResult(Pivot pivot, Count seriesSpec, SearchResponse searchResult, Aggregation aggregationResult, OSGeneratedQueryContext queryContext) {
+            return resultValues.stream();
+        }
+    }
 }

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivot.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/OSPivot.java
@@ -16,249 +16,44 @@
  */
 package org.graylog.storage.opensearch3.views.searchtypes.pivot;
 
-import com.google.common.collect.ImmutableList;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
-import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
-import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
-import org.graylog.storage.opensearch3.views.MutableSearchRequestBuilder;
 import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch3.views.searchtypes.OSSearchTypeHandler;
-import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.opensearch.client.json.JsonData;
-import org.opensearch.client.opensearch._types.aggregations.Aggregate;
-import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
 import org.opensearch.client.opensearch.core.msearch.MultiSearchItem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
+/**
+ * Handles the {@link Pivot} search type for OpenSearch by delegating query generation to {@link PivotQueryGenerator}
+ * and result extraction to {@link PivotResultProcessor}.
+ */
 public class OSPivot implements OSSearchTypeHandler<Pivot> {
-    private static final Logger LOG = LoggerFactory.getLogger(OSPivot.class);
-    private static final String AGG_NAME = "agg";
-
-    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
-    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers;
-    private final EffectiveTimeRangeExtractor effectiveTimeRangeExtractor;
+    private final PivotQueryGenerator queryGenerator;
+    private final PivotResultProcessor resultProcessor;
 
     @Inject
     public OSPivot(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
                    Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers,
                    EffectiveTimeRangeExtractor effectiveTimeRangeExtractor) {
-        this.bucketHandlers = bucketHandlers;
-        this.seriesHandlers = seriesHandlers;
-        this.effectiveTimeRangeExtractor = effectiveTimeRangeExtractor;
+        this.queryGenerator = new PivotQueryGenerator(bucketHandlers, seriesHandlers);
+        this.resultProcessor = new PivotResultProcessor(bucketHandlers, seriesHandlers, effectiveTimeRangeExtractor);
     }
 
     @Override
     public void doGenerateQueryPart(Query query, Pivot pivot, OSGeneratedQueryContext queryContext) {
-        LOG.debug("Generating aggregation for {}", pivot);
-        var searchSourceBuilder = queryContext.searchSourceBuilder(pivot);
-
-        var generateRollups = pivot.rollup() || (pivot.rowGroups().isEmpty() && pivot.columnGroups().isEmpty());
-
-        // add global rollup series if those were requested
-        if (generateRollups) {
-            seriesStream(pivot, queryContext, "global rollup")
-                    .filter(result -> Placement.METRIC.equals(result.placement()))
-                    .map(SeriesAggregationBuilder::aggregationBuilder)
-                    .forEach(searchSourceBuilder::aggregation);
-        }
-
-        final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> createdAggregations = createPivots(BucketSpecHandler.Direction.Row, query, pivot, pivot.rowGroups(), queryContext);
-        final MutableNamedAggregationBuilder rootAggregation = createdAggregations.root();
-        final MutableNamedAggregationBuilder leafAggregation = createdAggregations.leaf();
-        final List<MutableNamedAggregationBuilder> metrics = createdAggregations.metrics();
-        seriesStream(pivot, queryContext, "metrics")
-                .forEach(result -> {
-                    switch (result.placement()) {
-                        case METRIC -> metrics.forEach(metric -> metric.subAggregation(result.aggregationBuilder()));
-                        case ROW -> rootAggregation.subAggregation(result.aggregationBuilder());
-                        case ROOT -> {
-                            if (!generateRollups) {
-                                searchSourceBuilder.aggregation(result.aggregationBuilder());
-                            }
-                        }
-                    }
-                });
-
-        if (!pivot.columnGroups().isEmpty()) {
-            final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> columnsAggregation = createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
-            final MutableNamedAggregationBuilder columnsRootAggregation = columnsAggregation.root();
-            final MutableNamedAggregationBuilder columnsLeafAggregation = columnsAggregation.leaf();
-            final List<MutableNamedAggregationBuilder> columnMetrics = columnsAggregation.metrics();
-            seriesStream(pivot, queryContext, "metrics")
-                    .forEach(result -> {
-                        final var aggregationBuilder = result.aggregationBuilder();
-                        switch (result.placement()) {
-                            case COLUMN -> columnsLeafAggregation.subAggregation(aggregationBuilder);
-                            case METRIC -> columnMetrics.forEach(metric -> metric.subAggregation(aggregationBuilder));
-                        }
-                    });
-            if (leafAggregation != null) {
-                leafAggregation.subAggregation(columnsRootAggregation);
-            } else {
-                searchSourceBuilder.aggregation(columnsRootAggregation);
-            }
-        }
-
-        if (rootAggregation != null) {
-            searchSourceBuilder.aggregation(rootAggregation);
-        }
-
-        addTimeStampAggregations(searchSourceBuilder);
-    }
-
-    private void addTimeStampAggregations(MutableSearchRequestBuilder searchSourceBuilder) {
-        final MutableNamedAggregationBuilder startTimestamp = new MutableNamedAggregationBuilder(
-                "timestamp-min",
-                Aggregation.builder().min(f -> f.field("timestamp")));
-        final MutableNamedAggregationBuilder endTimestamp = new MutableNamedAggregationBuilder(
-                "timestamp-max",
-                Aggregation.builder().max(f -> f.field("timestamp")));
-        searchSourceBuilder.aggregation(startTimestamp);
-        searchSourceBuilder.aggregation(endTimestamp);
-    }
-
-    private BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, OSGeneratedQueryContext queryContext) {
-        MutableNamedAggregationBuilder leaf = null;
-        MutableNamedAggregationBuilder root = null;
-        final List<MutableNamedAggregationBuilder> metrics = new ArrayList<>();
-        for (BucketSpec bucketSpec : pivots) {
-            final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
-            final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> bucketAggregations = bucketHandler.createAggregation(direction, AGG_NAME, pivot, bucketSpec, queryContext, query);
-            final MutableNamedAggregationBuilder aggregationRoot = bucketAggregations.root();
-            final MutableNamedAggregationBuilder aggregationLeaf = bucketAggregations.leaf();
-            final List<MutableNamedAggregationBuilder> aggregationMetrics = bucketAggregations.metrics();
-
-            metrics.addAll(aggregationMetrics);
-            if (root == null && leaf == null) {
-                root = aggregationRoot;
-                leaf = aggregationLeaf;
-            } else {
-                leaf.subAggregation(aggregationRoot);
-                leaf = aggregationLeaf;
-            }
-        }
-
-        return BucketSpecHandler.CreatedAggregations.create(root, leaf, metrics);
-    }
-
-    private Stream<SeriesAggregationBuilder> seriesStream(Pivot pivot, OSGeneratedQueryContext queryContext, String reason) {
-        return pivot.series()
-                .stream()
-                .distinct()
-                .flatMap((seriesSpec) -> {
-                    final String seriesName = queryContext.seriesName(seriesSpec, pivot);
-                    LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
-                    final OSPivotSeriesSpecHandler<? extends SeriesSpec> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());
-                    if (esPivotSeriesSpecHandler == null) {
-                        throw new IllegalArgumentException("No series handler registered for: " + seriesSpec.type());
-                    }
-                    return esPivotSeriesSpecHandler.createAggregation(seriesName, pivot, seriesSpec, queryContext).stream();
-                });
+        queryGenerator.generate(query, pivot, queryContext);
     }
 
     @WithSpan
     @Override
     public SearchType.Result doExtractResult(Query query, Pivot pivot, MultiSearchItem<JsonData> queryResult, OSGeneratedQueryContext queryContext) {
-        final AbsoluteRange effectiveTimerange = this.effectiveTimeRangeExtractor.extract(queryResult, query, pivot);
-
-        final var fieldsNames = pivot.rowGroups().stream().flatMap(bs -> bs.fields().stream());
-        final var seriesNames = pivot.series().stream().map(SeriesSpec::id).toList();
-
-        final List<String> colGroupNames = pivot.columnGroups().isEmpty() ? seriesNames : new ArrayList<>();
-
-        final PivotResult.Builder resultBuilder = PivotResult.builder()
-                .id(pivot.id())
-                .effectiveTimerange(effectiveTimerange)
-                .total(extractDocumentCount(queryResult));
-
-        pivot.name().ifPresent(resultBuilder::name);
-
-        final InitialBucket initialBucket = InitialBucket.create(queryResult);
-
-        retrieveBuckets(pivot, pivot.rowGroups(), initialBucket)
-                .forEach(tuple -> {
-                    final ImmutableList<String> rowKeys = tuple.keys();
-                    final MultiBucketBase rowBucket = tuple.bucket();
-                    final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder()
-                            .key(rowKeys)
-                            .source("leaf");
-                    if (pivot.columnGroups().isEmpty() || pivot.rollup()) {
-                        processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
-                    }
-                    if (!pivot.columnGroups().isEmpty()) {
-                        var contextWithRowBucket = queryContext.withRowBucket(rowBucket);
-                        retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
-                                .forEach(columnBucketTuple -> {
-                                    final ImmutableList<String> columnKeys = columnBucketTuple.keys();
-                                    colGroupNames.add(String.join(", ", Stream.concat(columnKeys.stream(), seriesNames.stream()).toList()));
-
-                                    final MultiBucketBase columnBucket = columnBucketTuple.bucket();
-
-                                    processSeries(rowBuilder, queryResult, contextWithRowBucket, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
-                                });
-                    }
-                    resultBuilder.addRow(rowBuilder.build());
-                });
-
-        if (!pivot.rowGroups().isEmpty() && pivot.rollup()) {
-            final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.of());
-            processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), initialBucket, true, "row-inner");
-            resultBuilder.addRow(rowBuilder.source("non-leaf").build());
-        }
-
-        return resultBuilder.columnNames(Stream.concat(fieldsNames, colGroupNames.stream().distinct().sorted()).toList()).build();
-    }
-
-    private Stream<PivotBucket> retrieveBuckets(Pivot pivot, List<BucketSpec> pivots, MultiBucketBase aggregations) {
-        Stream<PivotBucket> result = Stream.of(PivotBucket.create(ImmutableList.of(), aggregations));
-
-        for (BucketSpec bucketSpec : pivots) {
-            result = result.flatMap((tuple) -> {
-                final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
-                return bucketHandler.extractBuckets(pivot, bucketSpec, tuple);
-            });
-        }
-
-        return result;
-    }
-
-    private void processSeries(PivotResult.Row.Builder rowBuilder,
-                               MultiSearchItem<JsonData> searchResult,
-                               OSGeneratedQueryContext queryContext,
-                               Pivot pivot,
-                               ArrayDeque<String> columnKeys,
-                               MultiBucketBase aggregation,
-                               boolean rollup,
-                               String source) {
-        pivot.series().forEach(seriesSpec -> {
-            final OSPivotSeriesSpecHandler<? extends SeriesSpec> seriesHandler = seriesHandlers.get(seriesSpec.type());
-            final Aggregate series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
-            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, queryContext)
-                    .map(value -> {
-                        columnKeys.addLast(value.id());
-                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
-                        columnKeys.removeLast();
-                        return v;
-                    })
-                    .forEach(rowBuilder::addValue);
-        });
-    }
-
-    private long extractDocumentCount(MultiSearchItem<JsonData> queryResult) {
-        return queryResult.hits().total().value();
+        return resultProcessor.extract(query, pivot, queryResult, queryContext);
     }
 }

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/PivotQueryGenerator.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/PivotQueryGenerator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch3.views.searchtypes.pivot;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.storage.opensearch3.views.MutableSearchRequestBuilder;
+import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Builds the OpenSearch aggregation tree for a {@link Pivot}: global rollup series, row and column bucket groups,
+ * the metric/row/column/root series placed within them, and the timestamp range aggregations.
+ */
+class PivotQueryGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(PivotQueryGenerator.class);
+    private static final String AGG_NAME = "agg";
+
+    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
+    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers;
+
+    PivotQueryGenerator(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                        Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers) {
+        this.bucketHandlers = bucketHandlers;
+        this.seriesHandlers = seriesHandlers;
+    }
+
+    void generate(Query query, Pivot pivot, OSGeneratedQueryContext queryContext) {
+        LOG.debug("Generating aggregation for {}", pivot);
+        final MutableSearchRequestBuilder searchSourceBuilder = queryContext.searchSourceBuilder(pivot);
+
+        final boolean generateRollups = pivot.rollup() || (pivot.rowGroups().isEmpty() && pivot.columnGroups().isEmpty());
+
+        if (generateRollups) {
+            addGlobalRollupSeries(pivot, queryContext, searchSourceBuilder);
+        }
+
+        final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> rowAggregations =
+                createPivots(BucketSpecHandler.Direction.Row, query, pivot, pivot.rowGroups(), queryContext);
+        addRowSeries(pivot, queryContext, searchSourceBuilder, rowAggregations, generateRollups);
+
+        if (!pivot.columnGroups().isEmpty()) {
+            addColumnGroups(query, pivot, queryContext, searchSourceBuilder, rowAggregations.leaf());
+        }
+
+        if (rowAggregations.root() != null) {
+            searchSourceBuilder.aggregation(rowAggregations.root());
+        }
+
+        addTimestampAggregations(searchSourceBuilder);
+    }
+
+    private void addGlobalRollupSeries(Pivot pivot, OSGeneratedQueryContext queryContext, MutableSearchRequestBuilder searchSourceBuilder) {
+        seriesStream(pivot, queryContext, "global rollup")
+                .filter(result -> Placement.METRIC.equals(result.placement()))
+                .map(SeriesAggregationBuilder::aggregationBuilder)
+                .forEach(searchSourceBuilder::aggregation);
+    }
+
+    private void addRowSeries(Pivot pivot,
+                              OSGeneratedQueryContext queryContext,
+                              MutableSearchRequestBuilder searchSourceBuilder,
+                              BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> rowAggregations,
+                              boolean generateRollups) {
+        final MutableNamedAggregationBuilder rootAggregation = rowAggregations.root();
+        final List<MutableNamedAggregationBuilder> metrics = rowAggregations.metrics();
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(result -> {
+                    switch (result.placement()) {
+                        case METRIC -> metrics.forEach(metric -> metric.subAggregation(result.aggregationBuilder()));
+                        case ROW -> rootAggregation.subAggregation(result.aggregationBuilder());
+                        case ROOT -> {
+                            if (!generateRollups) {
+                                searchSourceBuilder.aggregation(result.aggregationBuilder());
+                            }
+                        }
+                    }
+                });
+    }
+
+    private void addColumnGroups(Query query,
+                                 Pivot pivot,
+                                 OSGeneratedQueryContext queryContext,
+                                 MutableSearchRequestBuilder searchSourceBuilder,
+                                 MutableNamedAggregationBuilder rowLeafAggregation) {
+        final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> columnsAggregation =
+                createPivots(BucketSpecHandler.Direction.Column, query, pivot, pivot.columnGroups(), queryContext);
+        final List<MutableNamedAggregationBuilder> columnMetrics = columnsAggregation.metrics();
+        seriesStream(pivot, queryContext, "metrics")
+                .forEach(result -> {
+                    final var aggregationBuilder = result.aggregationBuilder();
+                    switch (result.placement()) {
+                        case COLUMN -> columnsAggregation.leaf().subAggregation(aggregationBuilder);
+                        case METRIC -> columnMetrics.forEach(metric -> metric.subAggregation(aggregationBuilder));
+                    }
+                });
+        if (rowLeafAggregation != null) {
+            rowLeafAggregation.subAggregation(columnsAggregation.root());
+        } else {
+            searchSourceBuilder.aggregation(columnsAggregation.root());
+        }
+    }
+
+    private void addTimestampAggregations(MutableSearchRequestBuilder searchSourceBuilder) {
+        final MutableNamedAggregationBuilder startTimestamp = new MutableNamedAggregationBuilder(
+                "timestamp-min",
+                Aggregation.builder().min(f -> f.field("timestamp")));
+        final MutableNamedAggregationBuilder endTimestamp = new MutableNamedAggregationBuilder(
+                "timestamp-max",
+                Aggregation.builder().max(f -> f.field("timestamp")));
+        searchSourceBuilder.aggregation(startTimestamp);
+        searchSourceBuilder.aggregation(endTimestamp);
+    }
+
+    private BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> createPivots(BucketSpecHandler.Direction direction, Query query, Pivot pivot, List<BucketSpec> pivots, OSGeneratedQueryContext queryContext) {
+        MutableNamedAggregationBuilder leaf = null;
+        MutableNamedAggregationBuilder root = null;
+        final List<MutableNamedAggregationBuilder> metrics = new ArrayList<>();
+        for (BucketSpec bucketSpec : pivots) {
+            final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
+            final BucketSpecHandler.CreatedAggregations<MutableNamedAggregationBuilder> bucketAggregations = bucketHandler.createAggregation(direction, AGG_NAME, pivot, bucketSpec, queryContext, query);
+            final MutableNamedAggregationBuilder aggregationRoot = bucketAggregations.root();
+            final MutableNamedAggregationBuilder aggregationLeaf = bucketAggregations.leaf();
+            final List<MutableNamedAggregationBuilder> aggregationMetrics = bucketAggregations.metrics();
+
+            metrics.addAll(aggregationMetrics);
+            if (root == null && leaf == null) {
+                root = aggregationRoot;
+                leaf = aggregationLeaf;
+            } else {
+                leaf.subAggregation(aggregationRoot);
+                leaf = aggregationLeaf;
+            }
+        }
+
+        return BucketSpecHandler.CreatedAggregations.create(root, leaf, metrics);
+    }
+
+    private Stream<SeriesAggregationBuilder> seriesStream(Pivot pivot, OSGeneratedQueryContext queryContext, String reason) {
+        return pivot.series()
+                .stream()
+                .distinct()
+                .flatMap((seriesSpec) -> {
+                    final String seriesName = queryContext.seriesName(seriesSpec, pivot);
+                    LOG.debug("Adding {} series '{}' with name '{}'", reason, seriesSpec.type(), seriesName);
+                    final OSPivotSeriesSpecHandler<? extends SeriesSpec> esPivotSeriesSpecHandler = seriesHandlers.get(seriesSpec.type());
+                    if (esPivotSeriesSpecHandler == null) {
+                        throw new IllegalArgumentException("No series handler registered for: " + seriesSpec.type());
+                    }
+                    return esPivotSeriesSpecHandler.createAggregation(seriesName, pivot, seriesSpec, queryContext).stream();
+                });
+    }
+}

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/PivotResultProcessor.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/views/searchtypes/pivot/PivotResultProcessor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch3.views.searchtypes.pivot;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
+import org.opensearch.client.opensearch.core.msearch.MultiSearchItem;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Turns an OpenSearch {@link MultiSearchItem} response into a {@link PivotResult} by walking the row and column bucket
+ * aggregations, extracting series values for each leaf, and adding the optional rollup row.
+ */
+class PivotResultProcessor {
+    private final Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers;
+    private final Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers;
+    private final EffectiveTimeRangeExtractor effectiveTimeRangeExtractor;
+
+    PivotResultProcessor(Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                         Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers,
+                         EffectiveTimeRangeExtractor effectiveTimeRangeExtractor) {
+        this.bucketHandlers = bucketHandlers;
+        this.seriesHandlers = seriesHandlers;
+        this.effectiveTimeRangeExtractor = effectiveTimeRangeExtractor;
+    }
+
+    SearchType.Result extract(Query query, Pivot pivot, MultiSearchItem<JsonData> queryResult, OSGeneratedQueryContext queryContext) {
+        final AbsoluteRange effectiveTimerange = this.effectiveTimeRangeExtractor.extract(queryResult, query, pivot);
+
+        final var fieldsNames = pivot.rowGroups().stream().flatMap(bs -> bs.fields().stream());
+        final var seriesNames = pivot.series().stream().map(SeriesSpec::id).toList();
+
+        final List<String> colGroupNames = pivot.columnGroups().isEmpty() ? seriesNames : new ArrayList<>();
+
+        final PivotResult.Builder resultBuilder = PivotResult.builder()
+                .id(pivot.id())
+                .effectiveTimerange(effectiveTimerange)
+                .total(extractDocumentCount(queryResult));
+
+        pivot.name().ifPresent(resultBuilder::name);
+
+        final InitialBucket initialBucket = InitialBucket.create(queryResult);
+
+        retrieveBuckets(pivot, pivot.rowGroups(), initialBucket)
+                .forEach(tuple -> resultBuilder.addRow(buildRow(pivot, queryResult, queryContext, seriesNames, colGroupNames, tuple)));
+
+        if (!pivot.rowGroups().isEmpty() && pivot.rollup()) {
+            resultBuilder.addRow(buildRollupRow(pivot, queryResult, queryContext, initialBucket));
+        }
+
+        return resultBuilder.columnNames(Stream.concat(fieldsNames, colGroupNames.stream().distinct().sorted()).toList()).build();
+    }
+
+    private PivotResult.Row buildRow(Pivot pivot,
+                                     MultiSearchItem<JsonData> queryResult,
+                                     OSGeneratedQueryContext queryContext,
+                                     List<String> seriesNames,
+                                     List<String> colGroupNames,
+                                     PivotBucket tuple) {
+        final ImmutableList<String> rowKeys = tuple.keys();
+        final MultiBucketBase rowBucket = tuple.bucket();
+        final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder()
+                .key(rowKeys)
+                .source("leaf");
+        if (pivot.columnGroups().isEmpty() || pivot.rollup()) {
+            processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), rowBucket, true, "row-leaf");
+        }
+        if (!pivot.columnGroups().isEmpty()) {
+            final var contextWithRowBucket = queryContext.withRowBucket(rowBucket);
+            retrieveBuckets(pivot, pivot.columnGroups(), rowBucket)
+                    .forEach(columnBucketTuple -> {
+                        final ImmutableList<String> columnKeys = columnBucketTuple.keys();
+                        colGroupNames.add(String.join(", ", Stream.concat(columnKeys.stream(), seriesNames.stream()).toList()));
+
+                        final MultiBucketBase columnBucket = columnBucketTuple.bucket();
+
+                        processSeries(rowBuilder, queryResult, contextWithRowBucket, pivot, new ArrayDeque<>(columnKeys), columnBucket, false, "col-leaf");
+                    });
+        }
+        return rowBuilder.build();
+    }
+
+    private PivotResult.Row buildRollupRow(Pivot pivot,
+                                           MultiSearchItem<JsonData> queryResult,
+                                           OSGeneratedQueryContext queryContext,
+                                           InitialBucket initialBucket) {
+        final PivotResult.Row.Builder rowBuilder = PivotResult.Row.builder().key(ImmutableList.of());
+        processSeries(rowBuilder, queryResult, queryContext, pivot, new ArrayDeque<>(), initialBucket, true, "row-inner");
+        return rowBuilder.source("non-leaf").build();
+    }
+
+    private Stream<PivotBucket> retrieveBuckets(Pivot pivot, List<BucketSpec> pivots, MultiBucketBase aggregations) {
+        Stream<PivotBucket> result = Stream.of(PivotBucket.create(ImmutableList.of(), aggregations));
+
+        for (BucketSpec bucketSpec : pivots) {
+            result = result.flatMap((tuple) -> {
+                final OSPivotBucketSpecHandler<? extends BucketSpec> bucketHandler = bucketHandlers.get(bucketSpec.type());
+                return bucketHandler.extractBuckets(pivot, bucketSpec, tuple);
+            });
+        }
+
+        return result;
+    }
+
+    private void processSeries(PivotResult.Row.Builder rowBuilder,
+                               MultiSearchItem<JsonData> searchResult,
+                               OSGeneratedQueryContext queryContext,
+                               Pivot pivot,
+                               ArrayDeque<String> columnKeys,
+                               MultiBucketBase aggregation,
+                               boolean rollup,
+                               String source) {
+        pivot.series().forEach(seriesSpec -> {
+            final OSPivotSeriesSpecHandler<? extends SeriesSpec> seriesHandler = seriesHandlers.get(seriesSpec.type());
+            final Aggregate series = seriesHandler.extractAggregationFromResult(pivot, seriesSpec, aggregation, queryContext);
+            seriesHandler.handleResult(pivot, seriesSpec, searchResult, series, queryContext)
+                    .map(value -> {
+                        columnKeys.addLast(value.id());
+                        final PivotResult.Value v = PivotResult.Value.create(columnKeys, value.value(), rollup, source);
+                        columnKeys.removeLast();
+                        return v;
+                    })
+                    .forEach(rowBuilder::addValue);
+        });
+    }
+
+    private long extractDocumentCount(MultiSearchItem<JsonData> queryResult) {
+        return queryResult.hits().total().value();
+    }
+}

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/views/searchtypes/pivots/OSPivotTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/views/searchtypes/pivots/OSPivotTest.java
@@ -16,14 +16,31 @@
  */
 package org.graylog.storage.opensearch3.views.searchtypes.pivots;
 
+import com.google.common.collect.ImmutableList;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.engine.IndexerGeneratedQueryContext;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
+import org.graylog.plugins.views.search.searchtypes.pivot.PivotSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog.plugins.views.search.searchtypes.pivot.series.Count;
+import org.graylog.storage.opensearch3.views.MutableSearchRequestBuilder;
 import org.graylog.storage.opensearch3.views.OSGeneratedQueryContext;
 import org.graylog.storage.opensearch3.views.searchtypes.OSSearchTypeHandler;
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.EffectiveTimeRangeExtractor;
+import org.graylog.storage.opensearch3.views.searchtypes.pivot.MutableNamedAggregationBuilder;
 import org.graylog.storage.opensearch3.views.searchtypes.pivot.OSPivot;
+import org.graylog.storage.opensearch3.views.searchtypes.pivot.OSPivotBucketSpecHandler;
+import org.graylog.storage.opensearch3.views.searchtypes.pivot.OSPivotSeriesSpecHandler;
+import org.graylog.storage.opensearch3.views.searchtypes.pivot.PivotBucket;
+import org.graylog.storage.opensearch3.views.searchtypes.pivot.SeriesAggregationBuilder;
+import org.graylog.testing.jsonpath.JsonPathAssert;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -41,6 +58,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.MultiBucketBase;
 import org.opensearch.client.opensearch.core.msearch.MultiSearchItem;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.client.opensearch.core.search.TotalHits;
@@ -48,9 +67,14 @@ import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -183,4 +207,305 @@ public class OSPivotTest {
         ));
     }
 
+    // ----------------------------------------------------------------------------------------------------------------
+    // Query generation (doGenerateQueryPart)
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void alwaysAddsTimestampMinMaxAggregations() {
+        final Pivot pivot = Pivot.builder().id("p").series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations['timestamp-min'].min.field").isEqualTo("timestamp");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations['timestamp-max'].max.field").isEqualTo("timestamp");
+    }
+
+    @Test
+    public void generatesAggregationForRowGroup() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("field1");
+    }
+
+    @Test
+    public void nestsMultipleRowGroups() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1"), values("field2")).series().rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("field1");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.agg.terms.field").isEqualTo("field2");
+    }
+
+    @Test
+    public void attachesMetricSeriesAsSubAggregationOfRowLeaf() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(Values.NAME, new FakeBucketHandler()),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::metric, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void attachesGlobalRollupMetricSeriesAtRootWhenNoGroupsPresent() {
+        final Pivot pivot = Pivot.builder().id("p").series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::metric, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void attachesColumnGroupUnderRowLeaf() {
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series()
+                .rollup(false)
+                .build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("row1");
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.aggregations.agg.terms.field").isEqualTo("col1");
+    }
+
+    @Test
+    public void attachesColumnGroupAtRootWhenNoRowGroupsPresent() {
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .columnGroups(values("col1"))
+                .series()
+                .rollup(false)
+                .build();
+
+        final DocumentContext doc = generateQueryPart(pivot, Map.of(Values.NAME, new FakeBucketHandler()), Map.of());
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.agg.terms.field").isEqualTo("col1");
+    }
+
+    @Test
+    public void attachesRootPlacedSeriesAtRootWhenNotGeneratingRollups() {
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("row1")).series(count()).rollup(false).build();
+
+        final DocumentContext doc = generateQueryPart(pivot,
+                Map.of(Values.NAME, new FakeBucketHandler()),
+                Map.of(Count.NAME, new FakeSeriesHandler(SeriesAggregationBuilder::root, List.of())));
+
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.aggregations.metricseries.max.field").isEqualTo("value");
+    }
+
+    @Test
+    public void throwsWhenNoSeriesHandlerIsRegistered() {
+        final Pivot pivot = Pivot.builder().id("p").series(count()).rollup(false).build();
+
+        final MutableSearchRequestBuilder searchSourceBuilder = new MutableSearchRequestBuilder();
+        final OSGeneratedQueryContext context = mock(OSGeneratedQueryContext.class);
+        when(context.searchSourceBuilder(any())).thenReturn(searchSourceBuilder);
+        final OSPivot sut = new OSPivot(Map.of(), Map.of(), new EffectiveTimeRangeExtractor());
+
+        assertThatThrownBy(() -> sut.doGenerateQueryPart(query, pivot, context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No series handler registered for: " + Count.NAME);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Result extraction (doExtractResult) with row/column/series handling
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void extractsOneLeafRowPerRowGroupBucket() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(false).build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of("field1", List.of(
+                PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketBase.class)),
+                PivotBucket.create(ImmutableList.of("b"), mock(MultiBucketBase.class))
+        )));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 42L)));
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(2);
+        assertThat(result.rows().get(0).key()).containsExactly("a");
+        assertThat(result.rows().get(0).source()).isEqualTo("leaf");
+        assertThat(result.rows().get(0).values()).hasSize(1);
+        final PivotResult.Value value = result.rows().get(0).values().get(0);
+        assertThat(value.key()).containsExactly("count()");
+        assertThat(value.value()).isEqualTo(42L);
+        assertThat(value.rollup()).isTrue();
+        assertThat(value.source()).isEqualTo("row-leaf");
+        assertThat(result.rows().get(1).key()).containsExactly("b");
+    }
+
+    @Test
+    public void addsRollupRowWhenRowGroupsPresentAndRollupEnabled() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder().id("p").rowGroups(values("field1")).series(count()).rollup(true).build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of("field1", List.of(
+                PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketBase.class))
+        )));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 7L)));
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(2);
+        final PivotResult.Row rollupRow = result.rows().get(1);
+        assertThat(rollupRow.key()).isEmpty();
+        assertThat(rollupRow.source()).isEqualTo("non-leaf");
+        assertThat(rollupRow.values()).hasSize(1);
+        assertThat(rollupRow.values().get(0).source()).isEqualTo("row-inner");
+    }
+
+    @Test
+    public void extractsNestedColumnValues() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series(count())
+                .rollup(false)
+                .build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of(
+                "row1", List.of(PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketBase.class))),
+                "col1", List.of(PivotBucket.create(ImmutableList.of("x"), mock(MultiBucketBase.class)))
+        ));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 5L)));
+        when(queryContext.withRowBucket(any())).thenReturn(queryContext);
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.rows()).hasSize(1);
+        final PivotResult.Row row = result.rows().get(0);
+        assertThat(row.key()).containsExactly("a");
+        assertThat(row.values()).hasSize(1);
+        final PivotResult.Value value = row.values().get(0);
+        assertThat(value.key()).containsExactly("x", "count()");
+        assertThat(value.value()).isEqualTo(5L);
+        assertThat(value.source()).isEqualTo("col-leaf");
+    }
+
+    @Test
+    public void buildsColumnNamesFromRowFieldsAndColumnKeys() {
+        stubResultMetadata();
+        final Pivot pivot = Pivot.builder()
+                .id("p")
+                .rowGroups(values("row1"))
+                .columnGroups(values("col1"))
+                .series(count())
+                .rollup(false)
+                .build();
+
+        final FakeBucketHandler bucketHandler = new FakeBucketHandler(Map.of(
+                "row1", List.of(PivotBucket.create(ImmutableList.of("a"), mock(MultiBucketBase.class))),
+                "col1", List.of(PivotBucket.create(ImmutableList.of("x"), mock(MultiBucketBase.class)))
+        ));
+        final FakeSeriesHandler seriesHandler = new FakeSeriesHandler(SeriesAggregationBuilder::metric,
+                List.of(SeriesSpecHandler.Value.create("count()", Count.NAME, 5L)));
+        when(queryContext.withRowBucket(any())).thenReturn(queryContext);
+        final OSPivot sut = new OSPivot(Map.of(Values.NAME, bucketHandler), Map.of(Count.NAME, seriesHandler), new EffectiveTimeRangeExtractor());
+
+        final PivotResult result = (PivotResult) sut.doExtractResult(query, pivot, queryResult, queryContext);
+
+        assertThat(result.columnNames()).containsExactly("row1", "x, count()");
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------------------------------------------------
+
+    private DocumentContext generateQueryPart(Pivot pivot,
+                                              Map<String, OSPivotBucketSpecHandler<? extends BucketSpec>> bucketHandlers,
+                                              Map<String, OSPivotSeriesSpecHandler<? extends SeriesSpec>> seriesHandlers) {
+        final MutableSearchRequestBuilder searchSourceBuilder = new MutableSearchRequestBuilder();
+        final OSGeneratedQueryContext context = mock(OSGeneratedQueryContext.class);
+        when(context.searchSourceBuilder(any())).thenReturn(searchSourceBuilder);
+        when(context.seriesName(any(), any())).thenReturn("metricseries");
+
+        final OSPivot sut = new OSPivot(bucketHandlers, seriesHandlers, new EffectiveTimeRangeExtractor());
+        sut.doGenerateQueryPart(query, pivot, context);
+
+        return JsonPath.parse(searchSourceBuilder.toString());
+    }
+
+    private void stubResultMetadata() {
+        returnDocumentCount(queryResult, 10);
+        when(queryResult.aggregations()).thenReturn(createTimestampRangeAggregations(
+                (double) new Date().getTime(), (double) new Date().getTime()));
+        when(query.effectiveTimeRange(any())).thenReturn(RelativeRange.create(300));
+    }
+
+    private static Values values(String field) {
+        return Values.builder().field(field).build();
+    }
+
+    private static Count count() {
+        return Count.builder().id("count()").build();
+    }
+
+    private static class FakeBucketHandler extends OSPivotBucketSpecHandler<Values> {
+        private final Map<String, List<PivotBucket>> bucketsByField;
+
+        private FakeBucketHandler() {
+            this(Map.of());
+        }
+
+        private FakeBucketHandler(Map<String, List<PivotBucket>> bucketsByField) {
+            this.bucketsByField = bucketsByField;
+        }
+
+        @Override
+        public CreatedAggregations<MutableNamedAggregationBuilder> doCreateAggregation(Direction direction, String name, Pivot pivot, Values bucketSpec, OSGeneratedQueryContext queryContext, Query query) {
+            return CreatedAggregations.create(new MutableNamedAggregationBuilder(name,
+                    Aggregation.builder().terms(t -> t.field(bucketSpec.fields().get(0)))));
+        }
+
+        @Override
+        public Stream<PivotBucket> extractBuckets(Pivot pivot, BucketSpec bucketSpecs, PivotBucket previousBucket) {
+            return bucketsByField.getOrDefault(bucketSpecs.fields().get(0), List.of()).stream();
+        }
+    }
+
+    private static class FakeSeriesHandler extends OSPivotSeriesSpecHandler<Count> {
+        private final Function<MutableNamedAggregationBuilder, SeriesAggregationBuilder> placement;
+        private final List<SeriesSpecHandler.Value> resultValues;
+
+        private FakeSeriesHandler(Function<MutableNamedAggregationBuilder, SeriesAggregationBuilder> placement, List<SeriesSpecHandler.Value> resultValues) {
+            this.placement = placement;
+            this.resultValues = resultValues;
+        }
+
+        @Override
+        public List<SeriesAggregationBuilder> doCreateAggregation(String name, Pivot pivot, Count seriesSpec, OSGeneratedQueryContext queryContext) {
+            return List.of(placement.apply(new MutableNamedAggregationBuilder(name,
+                    Aggregation.builder().max(m -> m.field("value")))));
+        }
+
+        @Override
+        public Aggregate extractAggregationFromResult(Pivot pivot, PivotSpec spec, MultiBucketBase currentAggregationOrBucket, IndexerGeneratedQueryContext<?> queryContext) {
+            return null;
+        }
+
+        @Override
+        public Stream<SeriesSpecHandler.Value> doHandleResult(Pivot pivot, Count seriesSpec, MultiSearchItem<JsonData> searchResult, Aggregate aggregationResult, OSGeneratedQueryContext queryContext) {
+            return resultValues.stream();
+        }
+    }
 }


### PR DESCRIPTION
## Description

The goal of this PR is to simplify the logic of the `OSPivot` search type. Therefore, it splits `OSPivot` into two focused collaborators:

  - `PivotQueryGenerator` (builds the search query: rollups, row/column groups, series placement, timestamp aggregations) 
  - `PivotResultProcessor` (extracts results: leaf rows, rollup row, nested column values, column names)

leaving `OSPivot` a thin delegator. Behavior is preserved.

Before splitting, `OSPivotTest` was expanded for both `opensearch2` and `opensearch3` with characterization tests covering query generation and result extraction, using lightweight fake handlers to isolate orchestration. That net of tests guards the refactor.

## Motivation and Context

`OSPivot` had grown into a single class mixing query construction and result extraction, making it hard to read and test. Separating the two responsibilities improves readability and testability without changing runtime behavior.

## How Has This Been Tested?

Added `OSPivotTest` characterization tests for both `graylog-storage-opensearch2` and `graylog-storage-opensearch3` covering query generation (rollups, row/column groups, series placement, timestamp aggregations, missing-handler error) and result extraction (leaf rows, rollup row, nested column values, column names). All pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Internal refactor with preserved behavior plus added test coverage; no user-facing impact.