### PR TITLE
Add design system link to help menu and README

### DIFF
--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -35,6 +35,8 @@ There's an online version of the frontend documentation and component gallery at
 
 The online version is automatically deployed and reflects the current state of the `master` branch in this repository.
 
+Note: We are migrating to a new design system. Please refer to the new design system at [https://graylog2.github.io/design-system](https://graylog2.github.io/design-system) for up-to-date component documentation and guidelines.
+
 ### Run documentation locally
 You may also run the documentation locally to contribute to it or see a different version than the current master:
 

--- a/graylog2-web-interface/src/components/navigation/bindings.ts
+++ b/graylog2-web-interface/src/components/navigation/bindings.ts
@@ -112,6 +112,9 @@ const navigationBindings: PluginExports = {
   ],
   helpMenu: [
     { description: 'Documentation', externalLink: DocsHelper.versionedDocsHomePage() },
+    ...(AppConfig.gl2DevMode()
+      ? [{ description: 'Design System', externalLink: 'https://graylog2.github.io/design-system' }]
+      : []),
     { description: 'Keyboard Shortcuts', action: ({ showHotkeysModal }) => showHotkeysModal() },
     {
       description: 'API browser',

--- a/graylog2-web-interface/src/views/bindings.routes.test.tsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.tsx
@@ -19,10 +19,10 @@ import { StreamSearchPage } from 'views/pages';
 import bindings from './bindings';
 
 jest.mock('util/AppConfig', () => ({
+  ...jest.requireActual('util/AppConfig'),
   gl2ServerUrl: () => 'http://localhost:9000/api/',
   gl2AppPathPrefix: jest.fn(() => '/gl2/'),
-  isFeatureEnabled: () => false,
-  isCloud: jest.fn(() => false),
+  __esModule: true,
 }));
 
 describe('bindings.routes', () => {

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.tsx
@@ -33,11 +33,9 @@ import GlobalOverride from 'views/logic/search/GlobalOverride';
 import Sidebar from './Sidebar';
 
 jest.mock('util/AppConfig', () => ({
-  gl2AppPathPrefix: jest.fn(() => ''),
+  ...jest.requireActual('util/AppConfig'),
   rootTimeZone: jest.fn(() => 'America/Chicago'),
-  gl2ServerUrl: jest.fn(() => undefined),
-  isCloud: jest.fn(() => false),
-  isFeatureEnabled: jest.fn(() => false),
+  __esModule: true,
 }));
 
 jest.mock('hooks/useHotkey', () => jest.fn());

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.tsx
@@ -36,11 +36,9 @@ import OriginalAreaVisualization from '../AreaVisualization';
 jest.mock('../../GenericPlot', () => jest.fn(mockComponent('GenericPlot')));
 
 jest.mock('util/AppConfig', () => ({
-  gl2AppPathPrefix: jest.fn(() => ''),
+  ...jest.requireActual('util/AppConfig'),
   rootTimeZone: jest.fn(() => 'America/Chicago'),
-  gl2ServerUrl: jest.fn(() => undefined),
-  isCloud: jest.fn(() => false),
-  isFeatureEnabled: () => true,
+  __esModule: true,
 }));
 
 const AreaVisualization = ({ ...props }: React.ComponentProps<typeof OriginalAreaVisualization>) => (


### PR DESCRIPTION
## Description

Adds a link to the new [Graylog Design System](https://graylog2.github.io/design-system) in two places: the help menu in the navigation (only visible in dev mode), and the web interface README alongside the existing styleguide link, noting the ongoing migration.

/nocl