### PR TITLE
Introduce VerifiedCsr to type-enforce CSR proof-of-possession

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/collectors/opamp/OpAmpService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/opamp/OpAmpService.java
@@ -256,7 +256,7 @@ public class OpAmpService {
             if (existingInstance.isPresent()) {
                 final var publicKeyFromExistingCollector = PemUtils.parseCertificate(
                         existingInstance.get().activeCertificatePem()).getPublicKey();
-                final var publicKeyFromCSR = PemUtils.extractPublicKeyFromCsr(csr);
+                final var publicKeyFromCSR = csr.publicKey();
                 if (!Arrays.equals(publicKeyFromExistingCollector.getEncoded(), publicKeyFromCSR.getEncoded())) {
                     LOG.warn("Rejecting re-enrollment for collector {}: CSR public key does not match public key in " +
                             "stored certificate", instanceUid);

--- a/graylog2-server/src/main/java/org/graylog/security/pki/CertificateBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/CertificateBuilder.java
@@ -524,8 +524,9 @@ public class CertificateBuilder {
     /**
      * Signs a Certificate Signing Request (CSR) and produces an X.509 certificate.
      * <p>
-     * The caller must supply a CSR that has already been parsed and signature-verified — typically
-     * via {@link PemUtils#parseCsr(String)}. This method does not re-verify the self-signature.
+     * Accepting only {@link VerifiedCsr} guarantees the CSR's self-signature has already been
+     * verified (see {@link PemUtils#parseCsr(String)}), so the requester has proven possession of
+     * the private key.
      * <p>
      * This method:
      * <ul>
@@ -536,7 +537,7 @@ public class CertificateBuilder {
      *   <li>Caps the cert's {@code NotAfter} at the issuer's {@code NotAfter}</li>
      * </ul>
      *
-     * @param csr       the parsed and verified CSR
+     * @param csr       the signature-verified CSR
      * @param issuer    the issuing CA's certificate entry (must contain the private key)
      * @param subjectCn the common name for the certificate subject (CSR subject is ignored)
      * @param validity  the validity period of the certificate
@@ -544,10 +545,10 @@ public class CertificateBuilder {
      * @throws Exception                if signing fails
      * @throws IllegalArgumentException if the CSR public key is not Ed25519
      */
-    public X509Certificate signCsr(PKCS10CertificationRequest csr, CertificateEntry issuer, String subjectCn, Duration validity)
+    public X509Certificate signCsr(VerifiedCsr csr, CertificateEntry issuer, String subjectCn, Duration validity)
             throws Exception {
 
-        final PublicKey publicKey = PemUtils.extractPublicKeyFromCsr(csr);
+        final PublicKey publicKey = csr.publicKey();
 
         if (!Set.of("Ed25519", "EdDSA").contains(publicKey.getAlgorithm())) {
             throw new IllegalArgumentException(

--- a/graylog2-server/src/main/java/org/graylog/security/pki/PemUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/PemUtils.java
@@ -24,13 +24,10 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.operator.ContentVerifierProvider;
-import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
@@ -135,9 +132,8 @@ public final class PemUtils {
      * Parses a PEM-encoded PKCS#10 Certificate Signing Request and verifies its self-signature.
      * <p>
      * A valid CSR self-signature proves that the requester holds the private key corresponding to
-     * the public key carried in the CSR. Any {@link PKCS10CertificationRequest} returned by this
-     * method has therefore already been cryptographically verified; callers do not need to verify
-     * it again.
+     * the public key carried in the CSR. The returned {@link VerifiedCsr} can only exist if that
+     * verification succeeded; callers do not need to (and cannot forget to) verify it again.
      * <p>
      * This method is algorithm-agnostic — policy such as "CSRs must use Ed25519" is enforced by
      * higher-level callers (e.g., {@link CertificateBuilder#signCsr}), not here.
@@ -148,47 +144,15 @@ public final class PemUtils {
      *                              cannot be verified
      * @throws IOException          if the PEM cannot be read
      */
-    public static PKCS10CertificationRequest parseCsr(String pem) throws IOException, CertificateException {
+    public static VerifiedCsr parseCsr(String pem) throws IOException, CertificateException {
         try (PEMParser pemParser = new PEMParser(new StringReader(pem))) {
             final Object object = pemParser.readObject();
             if (!(object instanceof PKCS10CertificationRequest csr)) {
                 throw new CertificateException("PEM does not contain a valid CSR");
             }
 
-            final boolean signatureValid;
-            try {
-                final ContentVerifierProvider verifier = new JcaContentVerifierProviderBuilder()
-                        .setProvider("BC")
-                        .build(csr.getSubjectPublicKeyInfo());
-                signatureValid = csr.isSignatureValid(verifier);
-            } catch (Exception e) {
-                throw new CertificateException("CSR signature verification failed", e);
-            }
-
-            if (!signatureValid) {
-                throw new CertificateException("CSR signature is invalid");
-            }
-
-            return csr;
+            return VerifiedCsr.verify(csr);
         }
-    }
-
-    /**
-     * Extracts the public key from a parsed PKCS#10 CSR.
-     * <p>
-     * This is a pure extractor: it performs no signature verification (use {@link #parseCsr} for
-     * that) and enforces no algorithm policy. Callers that require a specific key algorithm must
-     * check {@link PublicKey#getAlgorithm()} on the returned key themselves.
-     *
-     * @param csr the parsed CSR
-     * @return the public key contained in the CSR
-     * @throws PEMException if the CSR's {@code SubjectPublicKeyInfo} cannot be converted to a
-     *                      {@link PublicKey} (e.g., unsupported key algorithm)
-     */
-    public static PublicKey extractPublicKeyFromCsr(PKCS10CertificationRequest csr) throws PEMException {
-        return new org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter()
-                .setProvider("BC")
-                .getPublicKey(csr.getSubjectPublicKeyInfo());
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/security/pki/VerifiedCsr.java
+++ b/graylog2-server/src/main/java/org/graylog/security/pki/VerifiedCsr.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.pki;
+
+import org.bouncycastle.openssl.PEMException;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.operator.ContentVerifierProvider;
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.cert.CertificateException;
+
+/**
+ * A PKCS#10 Certificate Signing Request whose self-signature has been verified.
+ * <p>
+ * A valid self-signature proves that the requester holds the private key corresponding to the
+ * public key carried in the CSR (proof-of-possession). Instances can only be obtained through
+ * {@link PemUtils#parseCsr(String)} or the package-private {@link #verify} factory, both of which
+ * perform that verification — so holding a {@code VerifiedCsr} is a compile-time guarantee that
+ * the check happened. APIs that must not operate on unverified CSRs, such as
+ * {@link CertificateBuilder#signCsr}, accept this type instead of a raw
+ * {@link PKCS10CertificationRequest} to make the verification requirement impossible to skip.
+ */
+public final class VerifiedCsr {
+
+    static {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    private final PKCS10CertificationRequest csr;
+
+    private VerifiedCsr(PKCS10CertificationRequest csr) {
+        this.csr = csr;
+    }
+
+    /**
+     * Verifies the CSR's self-signature and wraps it.
+     * <p>
+     * This factory is algorithm-agnostic — policy such as "CSRs must use Ed25519" is enforced by
+     * higher-level callers (e.g., {@link CertificateBuilder#signCsr}), not here.
+     *
+     * @param csr the parsed CSR
+     * @return the signature-verified CSR
+     * @throws CertificateException if the CSR's self-signature cannot be verified
+     */
+    static VerifiedCsr verify(PKCS10CertificationRequest csr) throws CertificateException {
+        final boolean signatureValid;
+        try {
+            final ContentVerifierProvider verifier = new JcaContentVerifierProviderBuilder()
+                    .setProvider("BC")
+                    .build(csr.getSubjectPublicKeyInfo());
+            signatureValid = csr.isSignatureValid(verifier);
+        } catch (Exception e) {
+            throw new CertificateException("CSR signature verification failed", e);
+        }
+
+        if (!signatureValid) {
+            throw new CertificateException("CSR signature is invalid");
+        }
+
+        return new VerifiedCsr(csr);
+    }
+
+    /**
+     * @return the underlying PKCS#10 CSR
+     */
+    public PKCS10CertificationRequest csr() {
+        return csr;
+    }
+
+    /**
+     * Extracts the public key from the CSR. No algorithm policy is enforced; callers that require
+     * a specific key algorithm must check {@link PublicKey#getAlgorithm()} on the returned key
+     * themselves.
+     *
+     * @return the public key contained in the CSR
+     * @throws PEMException if the CSR's {@code SubjectPublicKeyInfo} cannot be converted to a
+     *                      {@link PublicKey} (e.g., unsupported key algorithm)
+     */
+    public PublicKey publicKey() throws PEMException {
+        return new JcaPEMKeyConverter()
+                .setProvider("BC")
+                .getPublicKey(csr.getSubjectPublicKeyInfo());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/collectors/opamp/auth/AgentTokenServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/opamp/auth/AgentTokenServiceTest.java
@@ -36,6 +36,7 @@ import org.graylog.grn.GRNRegistry;
 import org.graylog.security.pki.CertificateEntry;
 import org.graylog.security.pki.CertificateService;
 import org.graylog.security.pki.PemUtils;
+import org.graylog.security.pki.VerifiedCsr;
 import org.graylog.testing.TestClocks;
 import org.graylog.testing.cluster.ClusterConfigServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
@@ -132,7 +133,7 @@ class AgentTokenServiceTest {
         final byte[] csrPem = createCsrPem("CN=test-agent", agentKeyPair, "Ed25519");
 
         // Sign CSR with enrollment CA - need to create a CertificateEntry from the signed X509Certificate
-        final PKCS10CertificationRequest parsedCsr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
+        final VerifiedCsr parsedCsr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
         final X509Certificate signedCert = certificateService.builder().signCsr(parsedCsr, enrollmentCa, "test-agent", Duration.ofDays(365));
         final String certFingerprint = PemUtils.computeFingerprint(signedCert);
         final String certPem = PemUtils.toPem(signedCert);
@@ -229,7 +230,7 @@ class AgentTokenServiceTest {
         final byte[] csrPem = createCsrPem("CN=test-agent", agentKeyPair, "Ed25519");
 
         // Sign CSR with enrollment CA
-        final PKCS10CertificationRequest parsedCsr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
+        final VerifiedCsr parsedCsr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
         final X509Certificate signedCert = certificateService.builder().signCsr(parsedCsr, enrollmentCa, "test-agent", Duration.ofDays(365));
         final String certFingerprint = PemUtils.computeFingerprint(signedCert);
         final String certPem = PemUtils.toPem(signedCert);

--- a/graylog2-server/src/test/java/org/graylog/security/pki/PemUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/pki/PemUtilsTest.java
@@ -121,10 +121,10 @@ class PemUtilsTest {
         final KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
         final byte[] csrPem = builder.createCsr(keyPair, "test-agent");
 
-        final PKCS10CertificationRequest csr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
+        final VerifiedCsr csr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
 
         assertThat(csr).isNotNull();
-        assertThat(csr.getSubject().toString()).contains("CN=test-agent");
+        assertThat(csr.csr().getSubject().toString()).contains("CN=test-agent");
     }
 
     @Test
@@ -167,15 +167,15 @@ class PemUtilsTest {
                 .hasMessageContaining("signature is invalid");
     }
 
-    // extractPublicKeyFromCsr tests
+    // VerifiedCsr.publicKey tests
 
     @Test
-    void extractPublicKeyFromCsrReturnsCsrPublicKey() throws Exception {
+    void verifiedCsrPublicKeyReturnsCsrPublicKey() throws Exception {
         final KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
         final byte[] csrPem = builder.createCsr(keyPair, "test-agent");
-        final PKCS10CertificationRequest csr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
+        final VerifiedCsr csr = PemUtils.parseCsr(new String(csrPem, StandardCharsets.UTF_8));
 
-        final PublicKey extracted = PemUtils.extractPublicKeyFromCsr(csr);
+        final PublicKey extracted = csr.publicKey();
 
         assertThat(Arrays.equals(keyPair.getPublic().getEncoded(), extracted.getEncoded())).isTrue();
     }


### PR DESCRIPTION
`CertificateBuilder#signCsr` documented that callers must pass an already-verified CSR, but accepted any `PKCS10CertificationRequest` — nothing stopped a future caller from signing an unverified CSR and silently dropping the proof-of-possession guarantee.

`PemUtils.parseCsr` now returns a `VerifiedCsr`, a wrapper whose only producer is the self-signature verification, and `#signCsr` only accepts that type, making the verification requirement impossible to skip. Public key extraction moves onto the wrapper (`VerifiedCsr#publicKey`), replacing `PemUtils.extractPublicKeyFromCsr`.

/nocl internal refactoring

