### PR TITLE
Update sawmill to 4.0.7 and chroma-js to 3.2.0

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -60,7 +60,7 @@
     "bootstrap": "3.4.1",
     "bson-objectid": "^2.0.3",
     "buffer": "^6.0.3",
-    "chroma-js": "^2.0.3",
+    "chroma-js": "^3.2.0",
     "classnames": "^2.2.0",
     "core-js": "3.49.0",
     "cronstrue": "^3.14.0",
@@ -113,7 +113,7 @@
   "devDependencies": {
     "@cyclonedx/webpack-plugin": "^5.1.1",
     "@graylog/oxfmt-config": "^1.0.1",
-    "@types/chroma-js": "^2.1.3",
+    "@types/chroma-js": "^3.1.2",
     "@types/crossfilter": "0.0.38",
     "@types/express": "^5.0.6",
     "@types/express-formidable": "^1.2.4",

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -30,7 +30,7 @@
     "extends": "graylog"
   },
   "dependencies": {
-    "@graylog/sawmill": "4.0.6",
+    "@graylog/sawmill": "4.0.7",
     "@reduxjs/toolkit": "^2.5.1",
     "@tanstack/react-query": "5.101.0",
     "@types/react": "18.3.13",

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/Scale.ts
@@ -38,7 +38,7 @@ const scaleForGradient = (gradient: string): chroma.Scale => {
     case 'Rainbow':
       return plotlyScaleToChroma(scales[gradient]);
     default:
-      return chroma.scale(gradient);
+      return chroma.scale(gradient as chroma.BrewerPaletteName);
   }
 };
 

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2251,15 +2251,15 @@
   resolved "https://registry.yarnpkg.com/@graylog/oxfmt-config/-/oxfmt-config-1.0.1.tgz#badad4da2d6e28481cadadb666bf077b390efe36"
   integrity sha512-eugOB7/tjA4FOo0Z/8SoKRHtD10xJl7IDQR7NkE77n9yC1MLsdc0WMAv3EVXfgWUq5701r4PWIgm2HUE/grBrw==
 
-"@graylog/sawmill@4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@graylog/sawmill/-/sawmill-4.0.6.tgz#61cfbce29e68f9477756bbf30217c34d5e86860a"
-  integrity sha512-qjHHPrvXVdYw/F1a4fLgJpIG5i7BGF1J6TYKY9kK7GyiQbnQbBOpoBdxVrtp4/ICPXWBsqLQR7BEqYmt5jkJ4g==
+"@graylog/sawmill@4.0.7":
+  version "4.0.7"
+  resolved "https://registry.npmjs.org/@graylog/sawmill/-/sawmill-4.0.7.tgz#c7c48936ef6b520f513e0f0bbcea0069254dc9bd"
+  integrity sha512-cPnllgz9G5KPj0rJT4op1VbLo7U/RN3vUIaYBHItlrGcriHAEcnzhZx1tRBn5s9D+dZVpskqOWJBkvyWEz7z2w==
   dependencies:
     "@openfonts/dm-sans_latin" "^1.0.2"
     "@openfonts/source-sans-pro_latin" "^1.44.2"
     "@openfonts/ubuntu-mono_latin" "^1.44.1"
-    chroma-js "^2.1.2"
+    chroma-js "^3.2.0"
     lodash "^4.17.21"
 
 "@humanfs/core@^0.19.1":
@@ -3787,10 +3787,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/chroma-js@^2.1.3":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-2.4.4.tgz#254dddff54568ff8e5d0dcdb071871a458fdfd31"
-  integrity sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==
+"@types/chroma-js@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-3.1.2.tgz#29dd767ae46124c9d0cd3370bedad7364adcfd10"
+  integrity sha512-YBTQqArPN8A0niHXCwrO1z5x++a+6l0mLBykncUpr23oIPW7L4h39s6gokdK/bDrPmSh8+TjMmrhBPnyiaWPmQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -6092,10 +6092,10 @@ chownr@^3.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
   integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
-chroma-js@^2.0.3, chroma-js@^2.1.2:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
-  integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==
+chroma-js@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz#4e9e665290b9bbfece524fccf759d5120e351ff2"
+  integrity sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -8130,7 +8130,7 @@ escodegen@^2.1.0:
     eslint "9.39.2"
     eslint-import-resolver-webpack "0.13.11"
     eslint-plugin-compat "7.0.2"
-    eslint-plugin-graylog "file:packages/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../../../code/.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-ae43e943-fb44-4e44-946d-fc3f6c2e4b8e-1781247299598/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.32.0"
     eslint-plugin-jest "29.15.2"
     eslint-plugin-jest-dom "5.5.0"
@@ -9738,16 +9738,16 @@ graphemer@^1.4.0:
 "graylog-web-plugin@file:packages/graylog-web-plugin":
   version "7.2.0-SNAPSHOT"
   dependencies:
-    "@graylog/sawmill" "4.0.6"
+    "@graylog/sawmill" "4.0.7"
     "@reduxjs/toolkit" "^2.5.1"
     "@tanstack/react-query" "5.101.0"
     "@types/react" "18.3.13"
-    babel-preset-graylog "file:packages/babel-preset-graylog"
-    eslint-config-graylog "file:packages/eslint-config-graylog"
+    babel-preset-graylog "file:../../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-93630f31-2b54-464e-9155-5e275d5f633f-1781247299435/node_modules/babel-preset-graylog"
+    eslint-config-graylog "file:../../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-93630f31-2b54-464e-9155-5e275d5f633f-1781247299435/node_modules/eslint-config-graylog"
     formik "2.4.9"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:packages/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../../../code/.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-93630f31-2b54-464e-9155-5e275d5f633f-1781247299435/node_modules/jest-preset-graylog"
     moment "2.30.1"
     moment-timezone "0.6.2"
     react "18.3.1"


### PR DESCRIPTION
## Description

Bumps frontend dependencies:

- `@graylog/sawmill` `4.0.6` -> `4.0.7`
- `chroma-js` `^2.0.3` -> `^3.2.0` and `@types/chroma-js` `^2.1.3` -> `^3.1.2`

chroma 3's stricter `scale()` typing rejects a bare string, so the known brewer-palette gradient in `Scale.ts` is narrowed to `chroma.BrewerPaletteName`. No behavior change.

## Motivation and Context

Keep frontend dependencies current.

## How Has This Been Tested?

`yarn tsc` passes with the updated types; existing highlighting color-scale behavior is unchanged.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Dependency bump with no behavior change