### PR TITLE
Merge user preferences into default or existing layout

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -17,6 +17,9 @@
 package org.graylog2.rest.resources.entities.preferences;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -66,12 +69,15 @@ public class EntityListPreferencesResource {
 
     private final EntityListPreferencesService entityListPreferencesService;
     private final Map<String, EntityListMetricProvider> metricProviders;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public EntityListPreferencesResource(final EntityListPreferencesService entityListPreferencesService,
-                                         final Map<String, EntityListMetricProvider> metricProviders) {
+                                         final Map<String, EntityListMetricProvider> metricProviders,
+                                         final ObjectMapper objectMapper) {
         this.entityListPreferencesService = entityListPreferencesService;
         this.metricProviders = metricProviders;
+        this.objectMapper = objectMapper;
     }
 
     @POST
@@ -80,21 +86,36 @@ public class EntityListPreferencesResource {
     @Operation(summary = "Create or update user preferences for certain entity list")
     @Consumes(MediaType.APPLICATION_JSON)
     @NoAuditEvent("Audit logs are not stored for entity list preferences")
-    public Response create(@RequestBody(required = true) EntityListPreferences entityListPreferences,
+    public Response create(@RequestBody(required = true, content = @Content(schema = @Schema(implementation = EntityListPreferences.class))) JsonNode entityListPreferences,
                            @Parameter(name = "entity_list_id", required = true) @PathParam("entity_list_id") @NotEmpty String entityListId,
                            @QueryParam("layout_variant") String layoutVariant,
                            @Context UserContext userContext) throws ValidationException {
 
         final String currentUserId = userContext.getUserId();
+        final String resolvedLayoutVariant = obtainLayoutVariant(layoutVariant);
         final StoredEntityListPreferencesId complexId = StoredEntityListPreferencesId.builder()
                 .userId(currentUserId)
                 .entityListId(entityListId)
-                .layoutVariant(obtainLayoutVariant(layoutVariant))
+                .layoutVariant(resolvedLayoutVariant)
                 .build();
+        final StoredEntityListPreferencesId complexFallBackId = StoredEntityListPreferencesId.builder()
+                .userId(null)
+                .entityListId(entityListId)
+                .layoutVariant(resolvedLayoutVariant)
+                .build();
+
+        final StoredEntityListPreferences existingUserPreferences = entityListPreferencesService.get(complexId);
+        final StoredEntityListPreferences fallBackPreferences = entityListPreferencesService.get(complexFallBackId);
+
+        final EntityListPreferences basePreferences =
+                resolveBasePreferences(existingUserPreferences, fallBackPreferences);
+
+        final EntityListPreferences mergedPreferences = mergePreferences(basePreferences, entityListPreferences);
         final StoredEntityListPreferences storedPreferences = StoredEntityListPreferences.builder()
                 .preferencesId(complexId)
-                .preferences(entityListPreferences)
+                .preferences(mergedPreferences)
                 .build();
+
         final boolean successful = entityListPreferencesService.save(storedPreferences);
         if (successful) {
             return Response.ok().build();
@@ -176,5 +197,31 @@ public class EntityListPreferencesResource {
 
     private String obtainLayoutVariant(final String layoutVariant) {
         return layoutVariant == null || layoutVariant.isBlank() ? StoredEntityListPreferencesId.GENERAL_LAYOUT_VARIANT : layoutVariant;
+    }
+
+    private EntityListPreferences mergePreferences(final EntityListPreferences basePreferences,
+                                                   final JsonNode preferencesPatch) {
+        final ObjectNode merged = basePreferences == null
+                ? objectMapper.createObjectNode()
+                : objectMapper.valueToTree(basePreferences);
+
+        preferencesPatch.properties().forEach(entry -> merged.set(entry.getKey(), entry.getValue()));
+
+        return objectMapper.convertValue(merged, EntityListPreferences.class);
+    }
+
+    private EntityListPreferences resolveBasePreferences(
+            StoredEntityListPreferences existingUserPreferences,
+            StoredEntityListPreferences fallBackPreferences
+    ) {
+        if (existingUserPreferences != null) {
+            return existingUserPreferences.preferences();
+        }
+
+        if (fallBackPreferences != null) {
+            return fallBackPreferences.preferences();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
On the new alert and events page, we have a fallback for predefined layouts. They include filters. The filters are not part of the table layout on FE. That means that on change layout events are not sending the prop filter to BE. In this case, BE just deletes the filter, which means that later, BE wouldn't send default filters to FE anymore. 

To fix this issue, this PR, instead of saving exactly what the user sends, merges the user data into the existing (or fallback) layout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl