### PR TITLE
Gate sidecar user endpoint on sidecars:read instead of users:read

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -35,7 +35,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotFoundException;
@@ -91,8 +90,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import static org.graylog2.shared.security.RestPermissions.USERS_READ;
 
 @PublicCloudAPI
 @Tag(name = "Sidecar", description = "Manage Sidecar fleet")
@@ -309,17 +306,13 @@ public class SidecarResource extends RestResource implements PluginRestResource 
 
     @GET
     @Path("/user")
+    @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     @Operation(summary = "Get basic sidecar user")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Success", useReturnTypeSchema = true),
             @ApiResponse(responseCode = "404", description = "The sidecar user could not be found.")
     })
     public BasicUserResponse getBasicSidecarUser() {
-
-        if (!isPermitted(USERS_READ, sidecarUserName)) {
-            throw new ForbiddenException("Not allowed to view user " + sidecarUserName);
-        }
-
         final User user = userManagementService.load(sidecarUserName);
         if (user == null) {
             throw new NotFoundException("Couldn't find user " + sidecarUserName);

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/rest/SidecarResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/rest/SidecarResourceTest.java
@@ -31,6 +31,8 @@ import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog.plugins.sidecar.system.SidecarConfiguration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.rest.models.users.responses.BasicUserResponse;
 import org.graylog2.shared.users.UserManagementService;
 import org.joda.time.Period;
 import org.junit.jupiter.api.BeforeEach;
@@ -240,5 +242,29 @@ public class SidecarResourceTest extends RestResourceBaseTest {
 
         assertThat(response).isError();
         assertThat(response).isStatus(Response.Status.BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetBasicSidecarUser() throws Exception {
+        final User sidecarUser = mock(User.class);
+        when(sidecarUser.getId()).thenReturn("sidecar-user-id");
+        when(sidecarUser.getName()).thenReturn("graylog-sidecar");
+        when(sidecarUser.getFullName()).thenReturn("Sidecar System User");
+        when(sidecarUser.isReadOnly()).thenReturn(true);
+        when(sidecarUser.isServiceAccount()).thenReturn(true);
+        when(userManagementService.load("graylog-sidecar")).thenReturn(sidecarUser);
+
+        final BasicUserResponse response = this.resource.getBasicSidecarUser();
+
+        assertNotNull(response);
+        assertEquals("sidecar-user-id", response.id());
+        assertEquals("graylog-sidecar", response.username());
+    }
+
+    @Test
+    public void testGetBasicSidecarUserNotFound() throws Exception {
+        when(userManagementService.load("graylog-sidecar")).thenReturn(null);
+
+        assertThrows(NotFoundException.class, () -> this.resource.getBasicSidecarUser());
     }
 }


### PR DESCRIPTION
GET /sidecars/user previously required users:read on the configured sidecar
user and returned 403 otherwise. Since the frontend turns any 403 into a
full-page unauthorized error, this broke the Sidecars page for users who can
view it but can't read the sidecar user.

Gate the endpoint on sidecars:read — the permission the page already requires
— so the configured username can be surfaced to anyone allowed on the page.
The API token hint remains gated client-side on users:tokencreate for that
user.

/nocl
fix #26349 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

