### PR TITLE
Check ownership before changing view sharing during update (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26344.toml
+++ b/changelog/unreleased/pr-26344.toml
@@ -1,0 +1,3 @@
+type = "s"
+message = "Validate ownership for share requests when updating view (search/dashboard)."
+pulls = ["26344"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -44,6 +44,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog.grn.GRNType;
 import org.graylog.grn.GRNTypes;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.search.Query;
@@ -63,6 +64,7 @@ import org.graylog.plugins.views.search.views.WidgetDTO;
 import org.graylog.plugins.views.startpage.StartPageService;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityService;
 import org.graylog.security.UserContext;
+import org.graylog.security.rest.RestResourceWithOwnerCheck;
 import org.graylog.security.shares.CreateEntityRequest;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
@@ -102,7 +104,7 @@ import static org.graylog2.shared.rest.documentation.generator.Generator.CLOUD_V
 @Path("/views")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
-public class ViewsResource extends RestResource implements PluginRestResource {
+public class ViewsResource extends RestResourceWithOwnerCheck implements PluginRestResource {
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create(ViewDTO.FIELD_ID))
             .put("title", SearchQueryField.create(ViewDTO.FIELD_TITLE))
@@ -269,7 +271,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
         final User user = userContext.getUser();
         var result = dbService.saveWithOwner(dto.toBuilder().owner(searchUser.username()).build(), user);
-        recentActivityService.create(result.id(), result.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH, searchUser);
+        recentActivityService.create(result.id(), toGRNType(dto), searchUser);
         updateViewSharing(createEntityRequest, searchUser, result);
 
         return result;
@@ -277,9 +279,12 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
     private void updateViewSharing(CreateEntityRequest<ViewDTO> createEntityRequest, SearchUser searchUser, ViewDTO dto) {
         createEntityRequest.shareRequest().ifPresent(shareRequest -> {
-            final var grnType = dto.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH;
-            entitySharesService.updateEntityShares(grnType, dto.id(), shareRequest, searchUser.getUser());
+            entitySharesService.updateEntityShares(toGRNType(dto), dto.id(), shareRequest, searchUser.getUser());
         });
+    }
+
+    private GRNType toGRNType(ViewDTO dto) {
+        return dto.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH;
     }
 
     private void validateIntegrity(ViewDTO dto, SearchUser searchUser, boolean newCreation) {
@@ -388,8 +393,11 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final ViewDTO updatedDTO = dto.toBuilder().id(id).build();
         validateDto(updatedDTO, searchUser);
 
+        final var grnType = toGRNType(dto);
+        createEntityRequest.shareRequest().ifPresent(request -> checkOwnership(grnType.toGRN(dto.id())));
+
         var result = dbService.update(updatedDTO);
-        recentActivityService.update(result.id(), result.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH, searchUser);
+        recentActivityService.update(result.id(), grnType, searchUser);
         updateViewSharing(createEntityRequest, searchUser, result);
 
         return result;
@@ -425,7 +433,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
         dbService.delete(id);
         triggerDeletedEvent(view);
-        recentActivityService.delete(view.id(), view.type().equals(ViewDTO.Type.DASHBOARD) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH, view.title(), searchUser);
+        recentActivityService.delete(view.id(), toGRNType(view), view.title(), searchUser);
         return view;
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.subject.Subject;
 import org.assertj.core.api.Assertions;
 import org.graylog.plugins.views.search.Query;
@@ -46,6 +47,7 @@ import org.graylog.plugins.views.startpage.StartPageService;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityService;
 import org.graylog.security.UserContext;
 import org.graylog.security.shares.CreateEntityRequest;
+import org.graylog.security.shares.EntityShareRequest;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.dashboards.events.DashboardDeletedEvent;
@@ -258,6 +260,57 @@ public class ViewsResourceTest {
     }
 
     @Test
+    public void throwsExceptionWhenUpdatingSharingOfViewUserDoesNotOwn() {
+        final ViewService viewService = mockViewService(TEST_DASHBOARD_VIEW);
+
+        // the default mock Subject is not permitted to own the entity
+        final ViewsResource viewsResource = createViewsResource(
+                viewService,
+                mock(StartPageService.class),
+                mock(RecentActivityService.class),
+                mock(ClusterEventBus.class),
+                new ReferencedSearchFiltersHelper(),
+                EMPTY_SEARCH_FILTER_VISIBILITY_CHECKER,
+                EMPTY_VIEW_RESOLVERS,
+                SEARCH
+        );
+
+        final CreateEntityRequest<ViewDTO> request = CreateEntityRequest.create(TEST_DASHBOARD_VIEW, EntityShareRequest.create(ImmutableMap.of()));
+
+        assertThatThrownBy(() -> viewsResource.update(VIEW_ID, request, SEARCH_USER))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("Not authorized to access entity");
+
+        verify(viewService, times(0)).update(any());
+    }
+
+    @Test
+    public void updatesSharingWhenUserOwnsView() {
+        final ViewService viewService = mockViewService(TEST_DASHBOARD_VIEW);
+        when(viewService.update(any())).thenReturn(TEST_DASHBOARD_VIEW);
+
+        final Subject owner = mock(Subject.class);
+        when(owner.isPermitted(any(Permission.class))).thenReturn(true);
+
+        final ViewsResource viewsResource = createViewsResource(
+                owner,
+                viewService,
+                mock(StartPageService.class),
+                mock(RecentActivityService.class),
+                mock(ClusterEventBus.class),
+                new ReferencedSearchFiltersHelper(),
+                EMPTY_SEARCH_FILTER_VISIBILITY_CHECKER,
+                EMPTY_VIEW_RESOLVERS,
+                SEARCH
+        );
+
+        final CreateEntityRequest<ViewDTO> request = CreateEntityRequest.create(TEST_DASHBOARD_VIEW, EntityShareRequest.create(ImmutableMap.of()));
+
+        viewsResource.update(VIEW_ID, request, SEARCH_USER);
+        verify(viewService).update(TEST_DASHBOARD_VIEW);
+    }
+
+    @Test
     void testVerifyIntegrity() {
         final ViewsResource viewsResource = createViewsResource(
                 mock(ViewService.class),
@@ -441,6 +494,10 @@ public class ViewsResourceTest {
     }
 
     private ViewsResource createViewsResource(final ViewService viewService, final StartPageService startPageService, final RecentActivityService recentActivityService, final ClusterEventBus clusterEventBus, ReferencedSearchFiltersHelper referencedSearchFiltersHelper, SearchFilterVisibilityChecker searchFilterVisibilityChecker, final Map<String, ViewResolver> viewResolvers, Search... existingSearches) {
+        return createViewsResource(mock(Subject.class), viewService, startPageService, recentActivityService, clusterEventBus, referencedSearchFiltersHelper, searchFilterVisibilityChecker, viewResolvers, existingSearches);
+    }
+
+    private ViewsResource createViewsResource(final Subject subject, final ViewService viewService, final StartPageService startPageService, final RecentActivityService recentActivityService, final ClusterEventBus clusterEventBus, ReferencedSearchFiltersHelper referencedSearchFiltersHelper, SearchFilterVisibilityChecker searchFilterVisibilityChecker, final Map<String, ViewResolver> viewResolvers, Search... existingSearches) {
 
         final SearchDomain searchDomain = mock(SearchDomain.class);
         for (Search search : existingSearches) {
@@ -452,7 +509,7 @@ public class ViewsResourceTest {
                 mock(AuditEventSender.class), mock(ObjectMapper.class), mock(EntitySharesService.class), mock(EntitySourceService.class)) {
             @Override
             protected Subject getSubject() {
-                return mock(Subject.class);
+                return subject;
             }
 
             @Override


### PR DESCRIPTION
**Note:** This is a backport of #26344 to `7.0`.

## Description

When updating a view (search or dashboard) with a share request, the resource now verifies that the current user owns the entity before applying the sharing change. 

## Motivation and Context

Previously, a user with update permission on a view but who was not its owner could submit an update request containing a `shareRequest` and thereby alter the view's sharing — effectively changing its ownership. The ownership check closes this gap: sharing can only be modified by the entity owner.

## How Has This Been Tested?

Added `ViewsResourceTest` cases covering both paths: a non-owner submitting an update with a share request now receives a `403 Forbidden`, while an owner can still update sharing. Existing `ViewsResource` tests continue to pass.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.