### PR TITLE
Introduces new API getIndexStats (`7.1`)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -155,6 +155,14 @@ public class Indices {
         return indicesAdapter.getIndexStats(Collections.singleton(indexSet.getIndexWildcard()));
     }
 
+    /**
+     * Returns lightweight index statistics (docs + store only) for the given index wildcards.
+     * This is significantly faster than {@link #getIndicesStats(Collection)} which fetches full shard-level stats.
+     */
+    public JsonNode getIndexStats(final Collection<String> indexWildcards) {
+        return indicesAdapter.getIndexStats(indexWildcards);
+    }
+
     public boolean exists(String indexName) {
         try {
             return indicesAdapter.exists(indexName);


### PR DESCRIPTION
Note: This is a backport of #25890 to `7.1`.

/nocl see related enterprise issue

<!--- Provide a general summary of your changes in the Title above -->
Added getIndexStats(Collection<String>) overload to Indices.java that delegates to the existing lightweight adapter method.

See enterprise PR for details.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Refer to Graylog2/graylog-plugin-enterprise#9993
/prd Graylog2/graylog-plugin-enterprise#14499
