### PR TITLE
Apply Forwarder input static fields to forwarded messages (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-13676.toml
+++ b/changelog/unreleased/issue-13676.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Apply static fields configured on a Forwarder input to forwarded messages."
+
+issues = ["Graylog2/graylog-plugin-enterprise#13676"]

--- a/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
@@ -65,19 +65,31 @@ public class StaticFieldFilter implements MessageFilter {
 
     @Override
     public boolean filter(Message msg) {
-        if (msg.getSourceInputId() == null) {
-            return false;
+        applyStaticFields(msg, msg.getSourceInputId());
+
+        // Forwarded messages arrive on the local Forwarder input but carry the remote input's ID in
+        // sourceInputId/gl2_source_input. Static fields configured on the local Forwarder input are keyed by
+        // its own ID, which is available in gl2_forwarder_input, so apply those as well.
+        final Object forwarderInputId = msg.getField(Message.FIELD_GL2_FORWARDER_INPUT);
+        if (forwarderInputId != null) {
+            applyStaticFields(msg, forwarderInputId.toString());
         }
 
-        for (final Map.Entry<String, String> field : staticFields.getOrDefault(msg.getSourceInputId(), Collections.emptyList())) {
+        return false;
+    }
+
+    private void applyStaticFields(Message msg, String inputId) {
+        if (inputId == null) {
+            return;
+        }
+
+        for (final Map.Entry<String, String> field : staticFields.getOrDefault(inputId, Collections.emptyList())) {
             if (!msg.hasField(field.getKey())) {
                 msg.addField(field.getKey(), field.getValue());
             } else {
                 LOG.debug("Message already contains field [{}]. Not overwriting.", field.getKey());
             }
         }
-
-        return false;
     }
 
     @Subscribe

--- a/graylog2-server/src/test/java/org/graylog2/filters/StaticFieldFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/filters/StaticFieldFilterTest.java
@@ -90,6 +90,28 @@ public class StaticFieldFilterTest {
     }
 
     @Test
+    public void appliesStaticFieldsForForwarderInput() throws Exception {
+        final String forwarderInputId = "forwarder-input-id";
+
+        // A forwarded message carries the remote input's ID in sourceInputId, but the local
+        // Forwarder input's ID is available in the gl2_forwarder_input field.
+        Message msg = messageFactory.createMessage("hello", "junit", Tools.nowUTC());
+        msg.setSourceInputId("remote-input-id");
+        msg.addField(Message.FIELD_GL2_FORWARDER_INPUT, forwarderInputId);
+
+        when(input.getId()).thenReturn(forwarderInputId);
+        when(inputService.all()).thenReturn(Collections.singletonList(input));
+        when(inputService.getStaticFields(eq(forwarderInputId)))
+                .thenReturn(Collections.singletonList(Maps.immutableEntry("foo", "bar")));
+
+        final StaticFieldFilter filter = new StaticFieldFilter(inputService, new EventBus(), scheduler);
+        filter.lifecycleChanged(Lifecycle.STARTING);
+        filter.filter(msg);
+
+        assertEquals("bar", msg.getField("foo"));
+    }
+
+    @Test
     public void testFilterIsNotOverwritingExistingKeys() {
         Message msg = messageFactory.createMessage("hello", "junit", Tools.nowUTC());
         msg.addField("foo", "IWILLSURVIVE");


### PR DESCRIPTION
Note: This is a backport of #26315 to `7.1`.

Refs Graylog2/graylog-plugin-enterprise#13676

Static fields configured on a Forwarder input are now applied to forwarded messages. Previously they were silently dropped.

### Why it was broken
A forwarded message effectively arrives on two inputs, living in two distinct ID spaces:

  | | ID source | Field | Used by |
  |---|---|---|---|
  | Remote collecting input (on the forwarder) | `forwarder_inputs` collection | `gl2_source_input` / transient `sourceInputId` | `from_input`, `from_forwarder_input` |
  | Local ForwarderServiceInput (receives the gRPC stream) | `inputs` collection | `gl2_forwarder_input` | — |

`StaticFieldFilter` looked up static fields only by `sourceInputId`, which for forwarded messages holds the remote input's ID. That ID has no entry in the local static-fields cache, so static fields configured on the local Forwarder input were never matched.

### The fix
`StaticFieldFilter` now also applies static fields keyed by `gl2_forwarder_input` (the local Forwarder input's ID). The transient `sourceInputId` is deliberately left untouched.

The obvious one-line alternative — having `CloudForwarderCodec` set `sourceInputId` to the local Forwarder input — would regress two existing pipeline functions that depend on `sourceInputId` holding the remote forwarder-input ID:
  - `from_forwarder_input` — compares `getSourceInputId()` against the forwarder-input registry; would always return `false`.
  - `from_input` — would stop matching the remote input.

### Safety
- No-op for non-forwarded messages (`gl2_forwarder_input` is absent).
- Both IDs are MongoDB ObjectIds from separate collections, so collision is negligible; even if the two keys coincided, the existing no-overwrite guard makes the second application idempotent.

### `ExtractorFilter`
`ExtractorFilter` has the identical lookup pattern, so extractors on a Forwarder input are likewise not applied. Left unchanged intentionally: forwarded messages are already decoded (the remote input ran its extractors), extractors run arbitrary parsing that can throw/reshape messages.

### How tested
- Added unit test `StaticFieldFilterTest#appliesStaticFieldsForForwarderInput`

Manual:
  1. Set up a forwarder sending to a local Forwarder input.
  2. On the Forwarder input, configure a static field (e.g. `asset = zusi`).
  3. Send messages through the forwarder and confirm the static field appears on the received messages.
  4. Confirm non-forwarded inputs still apply their static fields, and that a `from_forwarder_input` / `from_input` pipeline rule still matches forwarded messages 