### PR TITLE
Make hovered sankey edges stand out more

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/sankey/SankeyVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/sankey/SankeyVisualization.tsx
@@ -59,7 +59,14 @@ export type SankeyTrace = {
   orientation: 'h';
   arrangement: 'fixed';
   node: { label: Array<string>; customdata: Array<NodeCustomData>; pad: number; thickness: number };
-  link: { source: Array<number>; target: Array<number>; value: Array<number>; label: Array<string>; color: string };
+  link: {
+    source: Array<number>;
+    target: Array<number>;
+    value: Array<number>;
+    label: Array<string>;
+    color: string;
+    hovercolor: string;
+  };
 };
 
 const STAGE_SEPARATOR = ' ';
@@ -119,6 +126,7 @@ const buildSankeyTrace = (
   displayKeys: Array<Array<string>>,
   allFields: Array<string>,
   linkColor: string,
+  linkHoverColor: string,
 ): SankeyTrace => {
   const nodeIndex = new Map<string, number>();
   const labels: Array<string> = [];
@@ -176,7 +184,7 @@ const buildSankeyTrace = (
     orientation: 'h',
     arrangement: 'fixed',
     node: { label: labels, customdata, pad: 15, thickness: 18 },
-    link: { source, target, value, label, color: linkColor },
+    link: { source, target, value, label, color: linkColor, hovercolor: linkHoverColor },
   };
 };
 
@@ -192,6 +200,10 @@ const SankeyVisualization = makeVisualization(({ config, data }: VisualizationCo
   // contrast (lower index = more contrast), so a value toward the background end keeps the
   // links subtle in both themes — a lighter gray in light mode, a darker gray in dark mode.
   const linkColor = chroma(theme.colors.gray[70]).alpha(0.3).css();
+
+  // On hover, jump to a higher-contrast gray that is nearly opaque so the hovered flow clearly
+  // stands out from the faint resting links (plotly's default only nudges the opacity slightly).
+  const linkHoverColor = chroma(theme.colors.gray[40]).alpha(0.85).css();
 
   const trace = useMemo<SankeyTrace | null>(() => {
     const rowFields = config.rowPivots.flatMap((pivot) => pivot.fields);
@@ -211,8 +223,8 @@ const SankeyVisualization = makeVisualization(({ config, data }: VisualizationCo
 
     const displayKeys = paths.map((path) => path.keys.map((k, i) => String(mapKeys(k, allFields[i]) ?? k)));
 
-    return buildSankeyTrace(paths, displayKeys, allFields, linkColor);
-  }, [config, mapKeys, rows, linkColor]);
+    return buildSankeyTrace(paths, displayKeys, allFields, linkColor, linkHoverColor);
+  }, [config, mapKeys, rows, linkColor, linkHoverColor]);
 
   return (
     <Container>

--- a/graylog2-web-interface/src/views/components/visualizations/sankey/__tests__/SankeyVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/sankey/__tests__/SankeyVisualization.test.tsx
@@ -239,6 +239,23 @@ describe('SankeyVisualization', () => {
     expect(trace.node.color).toBeUndefined();
   });
 
+  it('uses a distinct, more prominent hover color so hovered links stand out', () => {
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.createValues(['a']), Pivot.createValues(['b'])])
+      .series([Series.forFunction('count()')])
+      .visualization('sankey')
+      .build();
+
+    render(<WrappedSankey {...baseProps} config={config} data={fixtures.twoRowPivots} />);
+
+    const trace = lastTrace();
+
+    expect(typeof trace.link.hovercolor).toBe('string');
+    expect(trace.link.hovercolor).not.toHaveLength(0);
+    // The hover color differs from the resting color, so hovering changes the appearance.
+    expect(trace.link.hovercolor).not.toEqual(trace.link.color);
+  });
+
   it('renders an empty-state message when there are no rows', () => {
     const config = AggregationWidgetConfig.builder()
       .rowPivots([Pivot.createValues(['a']), Pivot.createValues(['b'])])


### PR DESCRIPTION
## Description
Sankey link edges are intentionally faint at rest. On hover, Plotly only nudges the link opacity slightly by default, so the hovered flow barely changes and is hard to follow. This sets an explicit `link.hovercolor` — a higher-contrast, nearly opaque gray — so the hovered edge clearly stands out from the resting links.

## Motivation and Context
The default hover behavior made it hard to trace a specific flow through the Sankey diagram. A distinct hover color makes the highlighted edge obvious.

## How Has This Been Tested?
Added a unit test asserting the trace exposes a non-empty `link.hovercolor` that differs from the resting `link.color`. Verified the existing Sankey test suite still passes.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Minor visual tweak to Sankey hover styling