### PR TITLE
Use `display: flex;` by default for `Label` component.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Label.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Label.tsx
@@ -25,6 +25,13 @@ const Label = styled(Badge)(
     padding-left: ${theme.spacings.xs};
     padding-right: ${theme.spacings.xs};
     text-align: center;
+
+    .mantine-Badge-label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: ${theme.spacings.xxs};
+    }
   `,
 );
 

--- a/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { Label } from 'components/bootstrap';
 import type { ColumnRenderers, ColumnSchema } from 'components/common/EntityDataTable';
 import { Icon, Link } from 'components/common';
 import DataNodeStatusCell from 'components/datanode/DataNodeList/DataNodeStatusCell';
@@ -27,7 +28,7 @@ import type { ClusterDataNode } from './fetchClusterDataNodes';
 import IndexingMetricsCell from './cells/IndexingMetricsCell';
 
 import CpuMetricsCell from '../shared-components/CpuMetricsCell';
-import { RoleLabel, SecondaryText } from '../shared-components/NodeMetricsLayout';
+import { SecondaryText } from '../shared-components/NodeMetricsLayout';
 import SizeAndRatioMetric from '../shared-components/SizeAndRatioMetric';
 
 export const DEFAULT_VISIBLE_COLUMNS = [
@@ -62,10 +63,10 @@ export const createColumnDefinitions = (): Array<ColumnSchema> => [
   { id: 'storage', title: 'Storage', sortable: false, isDerived: true },
 ];
 
-const getRoleLabels = (roles: Array<string>) =>
+const getLabels = (roles: Array<string>) =>
   roles.map((role) => (
     <span key={role}>
-      <RoleLabel bsSize="xs">{role}</RoleLabel>&nbsp;
+      <Label bsSize="xs">{role}</Label>&nbsp;
     </span>
   ));
 
@@ -162,7 +163,7 @@ export const createColumnRenderers = (productName: string): ColumnRenderers<Clus
       minWidth: 200,
     },
     opensearch_roles: {
-      renderCell: (_value, entity) => getRoleLabels(getDataNodeRoles(entity)),
+      renderCell: (_value, entity) => getLabels(getDataNodeRoles(entity)),
       minWidth: 220,
     },
   },

--- a/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
@@ -63,7 +63,7 @@ export const createColumnDefinitions = (): Array<ColumnSchema> => [
   { id: 'storage', title: 'Storage', sortable: false, isDerived: true },
 ];
 
-const getLabels = (roles: Array<string>) =>
+const getRoleLabels = (roles: Array<string>) =>
   roles.map((role) => (
     <span key={role}>
       <Label bsSize="xs">{role}</Label>&nbsp;
@@ -163,7 +163,7 @@ export const createColumnRenderers = (productName: string): ColumnRenderers<Clus
       minWidth: 200,
     },
     opensearch_roles: {
-      renderCell: (_value, entity) => getLabels(getDataNodeRoles(entity)),
+      renderCell: (_value, entity) => getRoleLabels(getDataNodeRoles(entity)),
       minWidth: 220,
     },
   },

--- a/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/GraylogNodesColumnConfiguration.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/GraylogNodesColumnConfiguration.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
 import type { ColumnRenderers, ColumnSchema } from 'components/common/EntityDataTable';
 
 import type { ClusterGraylogNode as GraylogNode } from './fetchClusterGraylogNodes';
@@ -27,7 +28,7 @@ import ProcessingStateCell from './cells/ProcessingStateCell';
 import ThroughputMetricsCell from './cells/ThroughputMetricsCell';
 
 import CpuMetricsCell from '../shared-components/CpuMetricsCell';
-import { SecondaryText, StyledLabel } from '../shared-components/NodeMetricsLayout';
+import { SecondaryText } from '../shared-components/NodeMetricsLayout';
 import SizeAndRatioMetric from '../shared-components/SizeAndRatioMetric';
 
 const JOURNAL_WARNING_THRESHOLD = 0.1;
@@ -68,7 +69,7 @@ export const createColumnRenderers = (): ColumnRenderers<GraylogNode> => ({
     },
     is_leader: {
       renderCell: (isLeader: boolean) => (
-        <SecondaryText>{isLeader ? <StyledLabel bsSize="xs">Leader</StyledLabel> : <span>-</span>}</SecondaryText>
+        <SecondaryText>{isLeader ? <Label bsSize="xs">Leader</Label> : <span>-</span>}</SecondaryText>
       ),
       staticWidth: 'matchHeader',
     },

--- a/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/HostnameCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/HostnameCell.tsx
@@ -16,11 +16,12 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
 import { Link } from 'components/common';
 import Routes from 'routing/Routes';
 
 import type { ClusterGraylogNode } from '../fetchClusterGraylogNodes';
-import { NodePrimary, SecondaryText, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { NodePrimary, SecondaryText } from '../../shared-components/NodeMetricsLayout';
 
 type Props = {
   node: ClusterGraylogNode;
@@ -45,7 +46,7 @@ const HostnameCell = ({ node }: Props) => {
       {nodeId ? <Link to={Routes.SYSTEM.CLUSTER.NODE_SHOW(nodeId)}>{nodeName}</Link> : nodeName}
       {node.is_leader && (
         <SecondaryText>
-          <StyledLabel bsSize="xs">Leader</StyledLabel>
+          <Label bsSize="xs">Leader</Label>
         </SecondaryText>
       )}
     </NodePrimary>

--- a/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/LifecycleCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/LifecycleCell.tsx
@@ -16,8 +16,10 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
+
 import type { ClusterGraylogNode } from '../fetchClusterGraylogNodes';
-import { MetricsColumn, MetricsRow, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { MetricsColumn, MetricsRow } from '../../shared-components/NodeMetricsLayout';
 
 type Props = {
   node: ClusterGraylogNode;
@@ -33,13 +35,13 @@ const LifecycleCell = ({ node }: Props) => {
   return (
     <MetricsColumn>
       <MetricsRow>
-        <StyledLabel
+        <Label
           bsStyle={lifecycleStatus === 'RUNNING' ? 'success' : 'warning'}
           bsSize="xs"
           title={lifecycleStatus}
           aria-label={lifecycleStatus}>
           {lifecycleStatus}
-        </StyledLabel>
+        </Label>
       </MetricsRow>
     </MetricsColumn>
   );

--- a/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/LoadBalancerStatusCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/LoadBalancerStatusCell.tsx
@@ -16,8 +16,10 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
+
 import type { ClusterGraylogNode } from '../fetchClusterGraylogNodes';
-import { MetricsColumn, MetricsRow, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { MetricsColumn, MetricsRow } from '../../shared-components/NodeMetricsLayout';
 
 type Props = {
   node: ClusterGraylogNode;
@@ -33,12 +35,9 @@ const LoadBalancerStatusCell = ({ node }: Props) => {
   return (
     <MetricsColumn>
       <MetricsRow>
-        <StyledLabel
-          bsStyle={status === 'ALIVE' ? 'success' : 'warning'}
-          bsSize="xs"
-          aria-label={`Load balancer ${status}`}>
+        <Label bsStyle={status === 'ALIVE' ? 'success' : 'warning'} bsSize="xs" aria-label={`Load balancer ${status}`}>
           {status}
-        </StyledLabel>
+        </Label>
       </MetricsRow>
     </MetricsColumn>
   );

--- a/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/ProcessingStateCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/graylog-nodes/cells/ProcessingStateCell.tsx
@@ -16,8 +16,10 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
+
 import type { ClusterGraylogNode } from '../fetchClusterGraylogNodes';
-import { MetricsColumn, MetricsRow, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { MetricsColumn, MetricsRow } from '../../shared-components/NodeMetricsLayout';
 
 type Props = {
   node: ClusterGraylogNode;
@@ -33,12 +35,12 @@ const ProcessingStateCell = ({ node }: Props) => {
   return (
     <MetricsColumn>
       <MetricsRow>
-        <StyledLabel
+        <Label
           bsStyle={node.is_processing ? 'success' : 'warning'}
           bsSize="xs"
           aria-label={`Message processing ${status}`}>
           {status}
-        </StyledLabel>
+        </Label>
       </MetricsRow>
     </MetricsColumn>
   );

--- a/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/MongodbNodesColumnConfiguration.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/MongodbNodesColumnConfiguration.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 
+import { Label } from 'components/bootstrap';
 import type { ColumnRenderers } from 'components/common/EntityDataTable';
 
 import type { MongodbNode } from './fetchClusterMongodbNodes';
@@ -24,7 +25,7 @@ import PercentRatioCell from './cells/PercentRatioCell';
 import ProfilingLevelCell from './cells/ProfilingLevelCell';
 import ReplicationLagCell from './cells/ReplicationLagCell';
 
-import { RoleLabel, SecondaryText } from '../shared-components/NodeMetricsLayout';
+import { SecondaryText } from '../shared-components/NodeMetricsLayout';
 
 const REPLICATION_LAG_WARNING_THRESHOLD_MS = 1000;
 const REPLICATION_LAG_DANGER_THRESHOLD_MS = 30000;
@@ -62,7 +63,7 @@ export const createColumnRenderers = (): ColumnRenderers<MongodbNode> => ({
           );
         }
 
-        return <RoleLabel bsSize="xs">{role}</RoleLabel>;
+        return <Label bsSize="xs">{role}</Label>;
       },
       minWidth: 130,
     },

--- a/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/cells/ProfilingLevelCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/cells/ProfilingLevelCell.tsx
@@ -17,7 +17,9 @@
 import React from 'react';
 import type { ColorVariant } from '@graylog/sawmill';
 
-import { MetricsColumn, MetricsRow, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { Label } from 'components/bootstrap';
+
+import { MetricsColumn, MetricsRow } from '../../shared-components/NodeMetricsLayout';
 import { MongodbProfilingLevel, type MongodbProfilingLevelType } from '../fetchClusterMongodbNodes';
 
 const LEVEL_LABELS: Record<MongodbProfilingLevelType, { label: string; style: ColorVariant }> = {
@@ -44,9 +46,9 @@ const ProfilingLevelCell = ({ profilingLevel }: Props) => {
   return (
     <MetricsColumn>
       <MetricsRow>
-        <StyledLabel bsStyle={resolvedLevelInfo.style} bsSize="xs">
+        <Label bsStyle={resolvedLevelInfo.style} bsSize="xs">
           {resolvedLevelInfo.label}
-        </StyledLabel>
+        </Label>
       </MetricsRow>
     </MetricsColumn>
   );

--- a/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/cells/ReplicationLagCell.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/mongodb-nodes/cells/ReplicationLagCell.tsx
@@ -18,7 +18,9 @@ import React from 'react';
 
 import NumberUtils from 'util/NumberUtils';
 
-import { MetricPlaceholder, MetricsColumn, MetricsRow, StyledLabel } from '../../shared-components/NodeMetricsLayout';
+import { Label } from 'components/bootstrap';
+
+import { MetricPlaceholder, MetricsColumn, MetricsRow } from '../../shared-components/NodeMetricsLayout';
 import { MongodbRole, type MongodbRoleType } from '../fetchClusterMongodbNodes';
 
 type Props = {
@@ -91,9 +93,9 @@ const ReplicationLagCell = ({ replicationLag, role, warningThreshold, dangerThre
   return (
     <MetricsColumn>
       <MetricsRow>
-        <StyledLabel bsStyle={exceedsDanger ? 'danger' : 'warning'} bsSize="xs" title={exactValueTitle}>
+        <Label bsStyle={exceedsDanger ? 'danger' : 'warning'} bsSize="xs" title={exactValueTitle}>
           {formatted}
-        </StyledLabel>
+        </Label>
       </MetricsRow>
     </MetricsColumn>
   );

--- a/graylog2-web-interface/src/components/cluster-configuration/shared-components/NodeMetricsLayout.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/shared-components/NodeMetricsLayout.tsx
@@ -17,8 +17,6 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Label } from 'components/bootstrap';
-
 export const MetricsColumn = styled.div`
   display: flex;
   flex-direction: column;
@@ -53,16 +51,6 @@ export const NodePrimary = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2px;
-`;
-
-export const StyledLabel = styled(Label)`
-  display: inline-flex;
-`;
-
-export const RoleLabel = styled(Label)`
-  display: inline-flex;
-  justify-content: center;
-  gap: 4px;
 `;
 
 export const MetricPlaceholder = () => (

--- a/graylog2-web-interface/src/components/cluster-configuration/shared-components/RatioIndicator.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/shared-components/RatioIndicator.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components';
 
 import NumberUtils from 'util/NumberUtils';
 
-import { StyledLabel } from './NodeMetricsLayout';
+import { Label } from 'components/bootstrap';
 
 const SecondaryText = styled.div`
   font-size: small;
@@ -62,9 +62,9 @@ const RatioIndicator = ({ ratio, warningThreshold = Number.NaN, dangerThreshold 
 
   return (
     <SecondaryText>
-      <StyledLabel bsStyle={exceedsDanger ? 'danger' : 'warning'} bsSize="xs">
+      <Label bsStyle={exceedsDanger ? 'danger' : 'warning'} bsSize="xs">
         {formattedRatio}
-      </StyledLabel>
+      </Label>
     </SecondaryText>
   );
 };

--- a/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeStatusCell.tsx
+++ b/graylog2-web-interface/src/components/datanode/DataNodeList/DataNodeStatusCell.tsx
@@ -15,16 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 
 import { Label } from 'components/bootstrap';
 import type { DataNode } from 'components/datanode/Types';
-
-const StatusLabel = styled(Label)`
-  display: inline-flex;
-  justify-content: center;
-  gap: 4px;
-`;
 
 type Props = {
   dataNode: DataNode;
@@ -35,17 +28,17 @@ const DataNodeStatusCell = ({ dataNode }: Props) => {
 
   return (
     <>
-      <StatusLabel
+      <Label
         bsStyle={datanodeDisabled ? 'warning' : 'success'}
         title={dataNode.datanode_status}
         aria-label={dataNode.datanode_status}>
         {dataNode.datanode_status}
-      </StatusLabel>
+      </Label>
       &nbsp;
       {dataNode.action_queue && (
-        <StatusLabel bsStyle="warning" title={dataNode.datanode_status} aria-label={dataNode.datanode_status}>
+        <Label bsStyle="warning" title={dataNode.datanode_status} aria-label={dataNode.datanode_status}>
           queued for {dataNode.action_queue}
-        </StatusLabel>
+        </Label>
       )}
     </>
   );

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/StatusCell.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/StatusCell.tsx
@@ -35,9 +35,6 @@ import { isSystemEventDefinition } from '../event-definitions-types';
 const StatusLabel = styled(Label)<{ $clickable: boolean }>(
   ({ $clickable }) => css`
     cursor: ${$clickable ? 'pointer' : 'default'};
-    display: inline-flex;
-    justify-content: center;
-    gap: 4px;
   `,
 );
 

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
@@ -79,7 +79,6 @@ const PipelineStage = styled.div<{ $idle?: boolean }>(
 );
 const DefaultLabel = styled(Label)(
   ({ theme }) => css`
-    display: inline-flex;
     margin-left: ${theme.spacings.xs};
     vertical-align: inherit;
   `,

--- a/graylog2-web-interface/src/components/rules/RuleDeprecationInfo.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleDeprecationInfo.tsx
@@ -30,10 +30,8 @@ type Props = {
 
 const DeprecatedLabel = styled(Label)(
   ({ theme }) => css`
-    display: inline-flex;
     margin-left: ${theme.spacings.xs};
     vertical-align: inherit;
-    gap: ${theme.spacings.xxs};
   `,
 );
 

--- a/graylog2-web-interface/src/components/rules/RuleListEntry.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleListEntry.tsx
@@ -54,7 +54,6 @@ const LimitedTd = styled.td(
 );
 const DefaultLabel = styled(Label)(
   ({ theme }) => css`
-    display: inline-flex;
     margin-left: ${theme.spacings.xxs};
     vertical-align: inherit;
   `,

--- a/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterStatusCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/output-filter/FilterStatusCell.tsx
@@ -24,9 +24,6 @@ import type { StreamOutputFilterRule } from './Types';
 const StatusLabel = styled(Label)<{ $clickable: boolean }>(
   ({ $clickable }) => css`
     cursor: ${$clickable ? 'pointer' : 'default'};
-    display: inline-flex;
-    justify-content: center;
-    gap: 4px;
   `,
 );
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ColumnRenderers.tsx
@@ -64,7 +64,7 @@ const customColumnRenderers = (
     },
     disabled: {
       renderCell: (_disabled: string, stream) => <StatusCell stream={stream} />,
-      staticWidth: 'matchHeader' as const,
+      staticWidth: 100,
     },
     rules: {
       renderCell: (_rules: StreamRule[], stream) => <StreamRulesCell stream={stream} />,

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/StatusCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/StatusCell.tsx
@@ -27,8 +27,6 @@ import type { Stream } from 'logic/streams/types';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 
-const StatusLabel = styled(Label)``;
-
 const InnerContainer = styled.span`
   display: inline-flex;
   justify-content: center;
@@ -86,7 +84,7 @@ const StatusCell = ({ stream }: Props) => {
   }, [sendTelemetry, stream.disabled, stream.id, stream.title, resumeStream, pauseStream]);
 
   return (
-    <StatusLabel
+    <Label
       bsStyle={stream.disabled ? 'warning' : 'success'}
       onClick={disableChange ? undefined : toggleStreamStatus}
       title={title}
@@ -100,7 +98,7 @@ const StatusCell = ({ stream }: Props) => {
           </>
         )}
       </InnerContainer>
-    </StatusLabel>
+    </Label>
   );
 };
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/TitleCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/TitleCell.tsx
@@ -26,7 +26,6 @@ type Props = {
   stream: Stream;
 };
 const DefaultLabel = styled(Label)`
-  display: inline-flex;
   margin-left: 5px;
   vertical-align: inherit;
 `;

--- a/graylog2-web-interface/src/pages/DataNodePage.tsx
+++ b/graylog2-web-interface/src/pages/DataNodePage.tsx
@@ -47,12 +47,6 @@ const StyledHorizontalDl = styled.dl(
     }
   `,
 );
-const StatusLabel = styled(Label)`
-  display: inline-flex;
-  justify-content: center;
-  gap: 4px;
-`;
-
 const ActionsCol = styled(Col)`
   text-align: right;
 `;
@@ -93,13 +87,13 @@ const DataNodePage = () => {
               <dd>{datanode.transport_address || '-'}</dd>
               <dt>Status:</dt>
               <dd>
-                <StatusLabel
+                <Label
                   bsStyle={datanodeDisabled ? 'warning' : 'success'}
                   title={datanode.datanode_status}
                   aria-label={datanode.datanode_status}
                   role="button">
                   {datanode.datanode_status || 'N/A'}
-                </StatusLabel>
+                </Label>
               </dd>
               <dt>Certificate valid until:</dt>
               <dd>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a regression with the `Label` component which has been introduced with https://github.com/Graylog2/graylog2-server/pull/26351.

Before:
<img width="101" height="206" alt="image" src="https://github.com/user-attachments/assets/049ab1ec-0555-4d5c-8c7d-674fd8ee3c9f" />

After:
<img width="118" height="253" alt="image" src="https://github.com/user-attachments/assets/39dcfb9d-6b75-4517-8e0d-2e68a0b799e9" />


It fixes it by using `display: flex;` by default for the element which wraps the `Label` children.

This change needs to be tested together with https://github.com/Graylog2/graylog-plugin-enterprise/pull/14530

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/14529
/nocl - unreleased regression