### PR TITLE
Fix issue when disabled slicing became enabled after sorting change

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/SlicesOverview.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedEntityTable/slicing/SlicesOverview.tsx
@@ -176,7 +176,12 @@ const SlicesOverview = ({
     setEmptyPage(1);
 
     if (sliceCol) {
-      onSlicingPreferencesChange({ sliceColumn: sliceCol, sortBy: mode, order: direction });
+      onSlicingPreferencesChange({
+        sliceColumn: sliceCol,
+        sortBy: mode,
+        order: direction,
+        readOnly: slicingPreferences?.readOnly,
+      });
     }
   };
   const onSortDirectionUpdate = (direction: SortDirection) => {
@@ -184,7 +189,12 @@ const SlicesOverview = ({
     setEmptyPage(1);
 
     if (sliceCol) {
-      onSlicingPreferencesChange({ sliceColumn: sliceCol, sortBy: sortMode, order: direction });
+      onSlicingPreferencesChange({
+        sliceColumn: sliceCol,
+        sortBy: sortMode,
+        order: direction,
+        readOnly: slicingPreferences?.readOnly,
+      });
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The bug happens because onc changing  sorting settings (sorting by or order) we create a new object without including the current readOnly flag 

## Motivation and Context
Open variant with disabled sorting (Assets or Investigation), then change any slicing sort settings, and you will  see that removing slicing is now available 


https://github.com/user-attachments/assets/344115a0-fdfb-4f87-b89b-46129a58e091



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
/nocl
