### PR TITLE
Allow entering arbitrary field names in the aggregation wizard

### DIFF
--- a/changelog/unreleased/pr-26422.toml
+++ b/changelog/unreleased/pr-26422.toml
@@ -1,0 +1,3 @@
+type = "a"
+message = "Allow entering arbitrary field names for groupings and metrics in the aggregation wizard."
+pulls = ["26422"]

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -141,6 +141,31 @@ describe('AggregationWizard', () => {
   );
 
   it(
+    'should allow entering an arbitrary field that is not in the field list',
+    async () => {
+      const onChange = jest.fn();
+      renderSUT({ onChange });
+
+      await addGrouping();
+
+      const groupingContainer = await screen.findByTestId('grouping-0');
+      const fieldInput = await selectEvent.findSelectInput('Add a field', { container: groupingContainer });
+      await selectEvent.create(fieldInput, 'my_custom_field');
+
+      await within(groupingContainer).findByText('my_custom_field');
+      await submitWidgetConfigForm();
+
+      const pivot = Pivot.createValues(['my_custom_field'], expectedPivotConfig);
+      const updatedConfig = widgetConfig.toBuilder().rowPivots([pivot]).build();
+
+      await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+      expect(onChange).toHaveBeenCalledWith(updatedConfig);
+    },
+    extendedTimeout,
+  );
+
+  it(
     'should update config, even when field only exists for current query',
     async () => {
       const onChange = jest.fn();

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 import * as Immutable from 'immutable';
-import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
 import { PluginStore } from 'graylog-web-plugin/plugin';
@@ -121,6 +121,24 @@ describe('AggregationWizard', () => {
       await selectEvent.chooseOption('Select a function', 'Minimum');
 
       await screen.findByText('Field is required for function min.');
+    },
+    extendedTimeout,
+  );
+
+  it(
+    'should allow entering an arbitrary field for a metric',
+    async () => {
+      renderSUT();
+
+      await addMetric();
+
+      const metricContainer = await screen.findByTestId('metric-0');
+      await selectEvent.chooseOption('Select a function', 'Minimum', { container: metricContainer });
+
+      const fieldInput = await selectEvent.findSelectInput('Select a field', { container: metricContainer });
+      await selectEvent.create(fieldInput, 'my_custom_field');
+
+      await within(metricContainer).findByText('my_custom_field');
     },
     extendedTimeout,
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.test.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.test.ts
@@ -14,12 +14,18 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as Immutable from 'immutable';
+
 import type {
   WidgetConfigFormValues,
   GroupingValidationErrors,
 } from 'views/components/aggregationwizard/WidgetConfigForm';
+import FieldType, { FieldTypes } from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import { ValuesType, DateType } from 'views/logic/aggregationbuilder/Pivot';
+import { DEFAULT_PIVOT_LIMIT } from 'views/Constants';
 
-import GroupingElement from './GroupingElement';
+import GroupingElement, { onGroupingFieldsChange } from './GroupingElement';
 
 describe('GroupByElement', () => {
   describe('Validation', () => {
@@ -213,6 +219,76 @@ describe('GroupByElement', () => {
       const result = onRemove(4, { groupBy: { ...groupBy, groupings: [grouping1, grouping2] } });
 
       expect(result.groupBy.groupings).toStrictEqual([grouping1, grouping2]);
+    });
+  });
+
+  describe('onGroupingFieldsChange', () => {
+    const knownFields = Immutable.List([
+      new FieldTypeMapping('http_method', new FieldType('string', [], [])),
+      new FieldTypeMapping('timestamp', FieldTypes.DATE()),
+    ]);
+    const fieldTypes = { all: knownFields, currentQuery: knownFields, queryFields: Immutable.Map() };
+
+    const timeGrouping = {
+      id: 'grouping-id',
+      direction: 'row' as const,
+      type: 'time' as const,
+      fields: [] as Array<string>,
+      interval: { type: 'auto', scaling: 1 } as const,
+    };
+
+    it('treats an unknown field as a values grouping', () => {
+      const setFieldValue = jest.fn();
+
+      onGroupingFieldsChange({
+        fieldTypes,
+        activeQueryId: 'queryId',
+        groupingIndex: 0,
+        grouping: timeGrouping,
+        newFields: ['arbitrary_field'],
+        setFieldValue,
+      });
+
+      expect(setFieldValue).toHaveBeenCalledWith(
+        'groupBy.groupings.0',
+        expect.objectContaining({ type: ValuesType, fields: ['arbitrary_field'], limit: DEFAULT_PIVOT_LIMIT }),
+      );
+    });
+
+    it('treats a known non-date field as a values grouping', () => {
+      const setFieldValue = jest.fn();
+
+      onGroupingFieldsChange({
+        fieldTypes,
+        activeQueryId: 'queryId',
+        groupingIndex: 0,
+        grouping: timeGrouping,
+        newFields: ['http_method'],
+        setFieldValue,
+      });
+
+      expect(setFieldValue).toHaveBeenCalledWith(
+        'groupBy.groupings.0',
+        expect.objectContaining({ type: ValuesType, fields: ['http_method'] }),
+      );
+    });
+
+    it('keeps a known date field as a date grouping', () => {
+      const setFieldValue = jest.fn();
+
+      onGroupingFieldsChange({
+        fieldTypes,
+        activeQueryId: 'queryId',
+        groupingIndex: 0,
+        grouping: timeGrouping,
+        newFields: ['timestamp'],
+        setFieldValue,
+      });
+
+      expect(setFieldValue).toHaveBeenCalledWith(
+        'groupBy.groupings.0',
+        expect.objectContaining({ type: DateType, fields: ['timestamp'] }),
+      );
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/GroupingElement.ts
@@ -96,9 +96,11 @@ export const onGroupingFieldsChange = ({
     return;
   }
 
-  const groupingHasValuesField = fieldTypes.currentQuery.some(
-    ({ name, type }) => newFields.includes(name) && type.type !== 'date',
-  );
+  const isKnownDateField = (fieldName: string) =>
+    fieldTypes.currentQuery.some(({ name, type }) => name === fieldName && type.type === 'date');
+  // A field counts as a "values" field unless it is a known date field. Unknown
+  // (arbitrary) fields are therefore treated as values fields rather than date fields.
+  const groupingHasValuesField = newFields.some((fieldName) => !isKnownDateField(fieldName));
   const newGroupingType = groupingHasValuesField ? ValuesType : DateType;
 
   if (grouping.type === newGroupingType) {

--- a/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/grouping/configuration/FieldComponent.tsx
@@ -92,6 +92,7 @@ const FieldComponent = ({ groupingIndex }: Props) => {
         createSelectPlaceholder={createSelectPlaceholder}
         isFieldQualified={isFieldQualified}
         showUnit={showFieldUnit}
+        allowCreate
       />
     </Input>
   );

--- a/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/metric/MetricConfiguration.tsx
@@ -197,6 +197,7 @@ const Metric = ({ index }: Props) => {
                   <FieldSelect
                     id="metric-field-select"
                     selectRef={metricFieldSelectRef}
+                    allowCreate
                     onChange={(fieldName) => {
                       onChange({ target: { name, value: fieldName } });
                     }}

--- a/graylog2-web-interface/src/views/components/widgets/FieldsConfiguration.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldsConfiguration.tsx
@@ -49,6 +49,7 @@ type Props = {
   showListCollapseButton?: boolean;
   showUnit?: boolean;
   fieldSelect?: React.ComponentType<React.ComponentProps<typeof FieldSelect>>;
+  allowCreate?: boolean;
 };
 
 const FieldsConfiguration = ({
@@ -63,6 +64,7 @@ const FieldsConfiguration = ({
   showListCollapseButton = false,
   showUnit = false,
   fieldSelect: FieldSelectComponent = FieldSelect,
+  allowCreate = false,
 }: Props) => {
   const [showSelectedList, setShowSelectedList] = useState(true);
   const onAddField = useCallback(
@@ -109,6 +111,7 @@ const FieldsConfiguration = ({
           onChange={onChange}
           fieldSelect={FieldSelectComponent}
           showUnit={showUnit}
+          allowCreate={allowCreate}
         />
       )}
       <FieldSelectComponent
@@ -127,6 +130,7 @@ const FieldsConfiguration = ({
         showSelectAllRest={showSelectAllRest}
         onDeSelectAll={onDeselectAll}
         showDeSelectAll={showDeSelectAll && !!selectedFields.length}
+        allowCreate={allowCreate}
       />
     </>
   );

--- a/graylog2-web-interface/src/views/components/widgets/SelectedFieldsList.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/SelectedFieldsList.tsx
@@ -48,6 +48,7 @@ type ListItemProps = {
   selectSize: 'normal' | 'small';
   selectedFields: Array<string>;
   showUnit: boolean;
+  allowCreate: boolean;
 };
 
 const Actions = styled.div`
@@ -66,6 +67,7 @@ const ListItem = forwardRef<HTMLDivElement, ListItemProps>(
       selectSize,
       selectedFields,
       showUnit,
+      allowCreate,
     }: ListItemProps,
     ref,
   ) => {
@@ -82,6 +84,7 @@ const ListItem = forwardRef<HTMLDivElement, ListItemProps>(
           <EditFieldSelect
             id="add-field-select"
             as={fieldSelect}
+            allowCreate={allowCreate}
             onChange={_onChange}
             onMenuClose={() => setIsEditing(false)}
             autoFocus
@@ -119,6 +122,7 @@ type Props = {
   selectSize?: 'normal' | 'small';
   selectedFields: Array<string>;
   showUnit?: boolean;
+  allowCreate?: boolean;
 };
 
 const SelectedFieldsList = ({
@@ -128,6 +132,7 @@ const SelectedFieldsList = ({
   displayOverlayInPortal = false,
   showUnit = false,
   fieldSelect = undefined,
+  allowCreate = false,
 }: Props) => {
   const fieldsForList = useMemo(() => selectedFields?.map((field) => ({ id: field, title: field })), [selectedFields]);
 
@@ -171,10 +176,11 @@ const SelectedFieldsList = ({
           className={className}
           ref={ref}
           showUnit={showUnit}
+          allowCreate={allowCreate}
         />
       );
     },
-    [selectSize, selectedFields, fieldSelect, showUnit, onChangeField, onRemoveField],
+    [selectSize, selectedFields, fieldSelect, showUnit, allowCreate, onChangeField, onRemoveField],
   );
 
   const onSortChange = useCallback(


### PR DESCRIPTION
## Description

Allows entering arbitrary field names — ones that are not present in the current field list — when configuring groupings and metrics in the aggregation wizard. The field selects now accept created values, and an unknown grouping field defaults to a `values` grouping rather than being treated as a date field.

## Motivation and Context

Users sometimes need to aggregate on fields that are not (yet) part of the indexed field list, e.g. fields that only appear in some messages or are produced by pipelines. Previously the wizard only permitted selecting from the known field list, which blocked these cases.

## How Has This Been Tested?

Added unit tests covering:
- entering an arbitrary field for a grouping and for a metric (`AggregationWizard.groupBy.test.tsx`, `AggregationWizard.metric.test.tsx`)
- `onGroupingFieldsChange` classifying unknown and known non-date fields as `values` groupings while keeping known date fields as `date` groupings (`GroupingElement.test.ts`)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.