### PR TITLE
Add missing CSS class for `ControlLabel`.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/ControlLabel.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/ControlLabel.tsx
@@ -41,7 +41,7 @@ const ControlLabel = ({ children, className = undefined, htmlFor = undefined, st
   const controlId = useContext(FormGroupControlIdContext);
 
   return (
-    <StyledLabel htmlFor={htmlFor ?? controlId} className={className} style={style}>
+    <StyledLabel htmlFor={htmlFor ?? controlId} className={`${className} control-label`} style={style}>
       {children}
     </StyledLabel>
   );

--- a/graylog2-web-interface/src/components/bootstrap/ControlLabel.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/ControlLabel.tsx
@@ -41,7 +41,7 @@ const ControlLabel = ({ children, className = undefined, htmlFor = undefined, st
   const controlId = useContext(FormGroupControlIdContext);
 
   return (
-    <StyledLabel htmlFor={htmlFor ?? controlId} className={`${className} control-label`} style={style}>
+    <StyledLabel htmlFor={htmlFor ?? controlId} className={`${className ?? ''} control-label`} style={style}>
       {children}
     </StyledLabel>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a small follow-up for https://github.com/Graylog2/graylog2-server/pull/26348. 

This PR adds a CSS class which is still used as a selector in some cases.

Before:
<img width="378" height="244" alt="image" src="https://github.com/user-attachments/assets/18634f58-6257-4ae7-9e21-d66822a269ec" />


After:
<img width="372" height="259" alt="image" src="https://github.com/user-attachments/assets/4ace2bb1-1750-42d3-9ec7-025620ea2594" />


/nocl
