### PR TITLE
Hide `Button` overflow to fix table scroll issue.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -169,7 +169,6 @@ const StyledButton = styled(MantineButton)<{
   return css`
     color: ${color};
     font-weight: 400;
-    overflow: visible;
 
     ${disabledStyles(theme.colors, $bsStyle)}
     ${stylesForSize($bsSize, $bsStyle)}
@@ -190,7 +189,6 @@ const StyledButton = styled(MantineButton)<{
 
     .mantine-Button-label {
       gap: 0.25em;
-      overflow: visible;
     }
 
     .mantine-Button-loader {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an issue where we display a horizontal scroll bar in cases where a scroll bar is not required.
I was able to reproduce it on the stream overview by zooming out via the chrome controls (e.g. to 90%) on my laptop screen.

<img alt="scroll issue" src="https://github.com/user-attachments/assets/199989b0-59db-49eb-bbe2-1dfacef257ab" />

The root cause seems to be: 
1. The paginated entity table container has a `overflow-x: auto;` styling.
2. Buttons (in this case the column visibility select button) have a `::before` element. When you remove it (or just its `inset` styling) it fixes the scroll issue. We can't remove it, but we can remove `overflow: visible;` from the button component. The default mantine button styling seems to be `overflow: hidden`.

I could not find a use case for `overflow: visible`.

Fixes https://github.com/Graylog2/graylog2-server/issues/25371
/nocl - small visual fix
