### PR TITLE
Remove react-bootstrap Clearfix component and clearfix CSS class usage

### DIFF
--- a/graylog2-web-interface/src/components/common/ClearFloat.tsx
+++ b/graylog2-web-interface/src/components/common/ClearFloat.tsx
@@ -14,15 +14,14 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import styled from 'styled-components';
 
-// eslint-disable-next-line no-restricted-imports
-import {
-  /* 👇 no custom theme colors needed 👇 */
-  Collapse,
-  Dropdown,
-  Form,
-  PanelGroup,
-  /* 👆 no custom theme colors needed 👆 */
-} from 'react-bootstrap';
+/**
+ * An empty element that clears preceding floated siblings (e.g. Bootstrap `<Col>`
+ * elements not wrapped in a `<Row>`), so subsequent content starts on a new line.
+ */
+const ClearFloat = styled.div`
+  clear: both;
+`;
 
-export { Collapse, Dropdown, Form, PanelGroup };
+export default ClearFloat;

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -28,6 +28,7 @@ export { default as Box } from './Box';
 export { default as BrandIcon } from './BrandIcon';
 export { default as Card } from './Card';
 export { default as Center } from './Center';
+export { default as ClearFloat } from './ClearFloat';
 export { default as Carousel } from './Carousel';
 export { default as ClipboardButton } from './ClipboardButton';
 export { default as Collapsible } from './Collapsible';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -18,8 +18,8 @@ import * as React from 'react';
 import { useCallback, useMemo } from 'react';
 
 import { defaultCompare } from 'logic/DefaultCompare';
-import { Select } from 'components/common';
-import { Clearfix, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/bootstrap';
+import { ClearFloat, Select } from 'components/common';
+import { Col, ControlLabel, FormGroup, HelpBlock, Row } from 'components/bootstrap';
 import { HelpPanel } from 'components/event-definitions/common/HelpPanel';
 import type User from 'logic/users/User';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -204,7 +204,7 @@ const EventConditionForm = ({
           </HelpPanel>
         </Col>
       )}
-      <Clearfix />
+      <ClearFloat />
       {canEditCondition && eventDefinitionTypeComponent && (
         <>
           <hr className={styles.hr} />

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 
-import { Icon } from 'components/common';
-import { Button, ButtonToolbar, Clearfix, Col, FormGroup } from 'components/bootstrap';
+import { ClearFloat, Icon } from 'components/common';
+import { Button, ButtonToolbar, Col, FormGroup } from 'components/bootstrap';
 import {
   emptyBooleanExpressionConfig,
   emptyGroupExpressionConfig,
@@ -241,7 +241,7 @@ class AggregationConditionExpression extends React.Component<
             operator={this.getEffectiveGlobalGroupOperator()}
             onOperatorChange={this.handleOperatorChange}
           />
-          <Clearfix />
+          <ClearFloat />
           {expressionComponent}
         </>
       );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanExpression.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanExpression.tsx
@@ -16,7 +16,7 @@
  */
 import React from 'react';
 
-import { Clearfix } from 'components/bootstrap';
+import { ClearFloat } from 'components/common';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
 
 import AggregationConditionExpression from '../AggregationConditionExpression';
@@ -43,7 +43,7 @@ const BooleanExpression = ({ expression, level, onChildChange, validation = {}, 
       onChange={onChildChange('left')}
       level={level + 1}
     />
-    <Clearfix />
+    <ClearFloat />
     <AggregationConditionExpression
       {...props}
       expression={expression.right}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/GroupExpression.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/GroupExpression.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import styled from 'styled-components';
 
-import { Clearfix } from 'components/bootstrap';
+import { ClearFloat } from 'components/common';
 import { replaceBooleanExpressionOperatorInGroup } from 'logic/alerts/AggregationExpressionConfig';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
 
@@ -65,7 +65,7 @@ const GroupExpression = ({
         onOperatorChange={handleOperatorChange}
         placeholder={`Boolean operator group ${level + 1}`}
       />
-      <Clearfix />
+      <ClearFloat />
       <Group>
         <AggregationConditionExpression
           {...props}

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.tsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import Routes from 'routing/Routes';
-import { Spinner } from 'components/common';
+import { ClearFloat, Spinner } from 'components/common';
 import { Button, Alert, Table, Modal, BootstrapModalConfirm, BootstrapModalWrapper } from 'components/bootstrap';
 import {
   deleteConfigurationVariable,
@@ -186,7 +186,7 @@ class ConfigurationVariablesHelper extends React.Component<
     return (
       <div>
         <EditConfigurationVariableModal create saveConfigurationVariable={this._saveConfigurationVariable} />
-        <div className="clearfix" />
+        <ClearFloat />
         <div className={`table-responsive ${ConfigurationHelperStyle.tableMaxHeight}`}>
           <Table responsive>
             <thead>

--- a/graylog2-web-interface/src/components/users/TimeoutInput.tsx
+++ b/graylog2-web-interface/src/components/users/TimeoutInput.tsx
@@ -16,6 +16,7 @@
  */
 import * as React from 'react';
 import { useState } from 'react';
+import styled from 'styled-components';
 
 import { Row, Col, HelpBlock, Input, Alert } from 'components/bootstrap';
 import TimeoutUnitSelect from 'components/users/TimeoutUnitSelect';
@@ -26,6 +27,19 @@ type Props = {
   value?: number;
   onChange?: (value: number) => void;
 };
+
+// Contains its floated `<Col>` children, equivalent to Bootstrap 3's `.clearfix`.
+const ClearfixContainer = styled.div`
+  &::before,
+  &::after {
+    display: table;
+    content: ' ';
+  }
+
+  &::after {
+    clear: both;
+  }
+`;
 
 const _estimateUnit = (value: number): number => {
   if (value === 0) {
@@ -99,7 +113,7 @@ const TimeoutInput = ({ value: propsValue = MS_HOUR, onChange = () => {} }: Prop
           checked={sessionTimeoutNever}
         />
 
-        <div className="clearfix">
+        <ClearfixContainer>
           <Col xs={2}>
             <Input
               type="number"
@@ -121,7 +135,7 @@ const TimeoutInput = ({ value: propsValue = MS_HOUR, onChange = () => {} }: Prop
               <HelpBlock>Session automatically end after this amount of time, unless they are actively used.</HelpBlock>
             </Col>
           </Row>
-        </div>
+        </ClearfixContainer>
       </>
     </Input>
   );


### PR DESCRIPTION
## Description
Removes the deprecated react-bootstrap `Clearfix` component and the `clearfix` CSS class from the web interface. Float clearing is now handled by a small in-house `ClearFloat` styled component (`components/common`), which simply applies `clear: both`.

## Motivation and Context
`Clearfix` is one of the legacy react-bootstrap components we want to stop depending on. Replacing it with a tiny, explicit `ClearFloat` styled component removes the dependency surface while keeping rendered output identical.

## How Has This Been Tested?
Visual behavior is unchanged (both approaches clear preceding floats). Verified with `yarn tsgo`, `yarn lint:changes`, and the existing test suite on the touched components.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Internal frontend refactor, rendered output unchanged