### PR TITLE
Fix collectors fleet creation flow and default instance filters

### DIFF
--- a/graylog2-web-interface/src/components/collectors/fleets/CollectorsFleets.tsx
+++ b/graylog2-web-interface/src/components/collectors/fleets/CollectorsFleets.tsx
@@ -59,7 +59,7 @@ const CollectorsFleets = () => {
   );
 
   const closeCreateModal = useCallback(() => {
-    history.push(Routes.SYSTEM.COLLECTORS.FLEETS);
+    history.goBack();
   }, [history]);
 
   const handleSaveFleet = async (fleet: Omit<Fleet, 'id' | 'created_at' | 'updated_at'>) => {

--- a/graylog2-web-interface/src/components/collectors/hooks/useDefaultInstanceFilters.test.ts
+++ b/graylog2-web-interface/src/components/collectors/hooks/useDefaultInstanceFilters.test.ts
@@ -65,6 +65,6 @@ describe('useDefaultInstanceFilters', () => {
     const lastSeenFilter = result.current.get('last_seen');
 
     expect(lastSeenFilter).toHaveLength(1);
-    expect(lastSeenFilter[0]).toMatch(/^\d{4}-\d{2}-\d{2}T.*><$/);
+    expect(lastSeenFilter[0]).toMatch(/^relative@86400$/);
   });
 });

--- a/graylog2-web-interface/src/components/collectors/hooks/useDefaultInstanceFilters.ts
+++ b/graylog2-web-interface/src/components/collectors/hooks/useDefaultInstanceFilters.ts
@@ -14,7 +14,6 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useMemo } from 'react';
 import { OrderedMap } from 'immutable';
 import moment from 'moment';
 
@@ -25,16 +24,13 @@ import { useCollectorsConfig } from './useCollectorsConfig';
 const useDefaultInstanceFilters = (): UrlQueryFilters | undefined => {
   const { data: config } = useCollectorsConfig();
 
-  return useMemo(() => {
-    if (!config?.collector_default_visibility_threshold) {
-      return undefined;
-    }
+  if (!config?.collector_default_visibility_threshold) {
+    return undefined;
+  }
 
-    const threshold = moment.duration(config.collector_default_visibility_threshold);
-    const cutoff = moment().subtract(threshold).utc().toISOString();
+  const threshold = moment.duration(config.collector_default_visibility_threshold).asSeconds();
 
-    return OrderedMap({ last_seen: [`${cutoff}><`] });
-  }, [config?.collector_default_visibility_threshold]);
+  return OrderedMap({ last_seen: [`relative@${threshold}`] });
 };
 
 export default useDefaultInstanceFilters;

--- a/graylog2-web-interface/src/components/collectors/overview/FleetCardsGrid.tsx
+++ b/graylog2-web-interface/src/components/collectors/overview/FleetCardsGrid.tsx
@@ -69,7 +69,7 @@ const FleetCardsGrid = ({ fleets, filter }: Props) => {
           sources to define what data its Collectors should collect. Once configured,{' '}
           <Link to={Routes.SYSTEM.COLLECTORS.DEPLOYMENT}>deploy Collectors</Link> using an enrollment token.
         </p>
-        <Button bsStyle="success" onClick={() => history.push(Routes.SYSTEM.COLLECTORS.FLEETS)}>
+        <Button bsStyle="success" onClick={() => history.push(Routes.SYSTEM.COLLECTORS.FLEETS_NEW)}>
           Create Fleet
         </Button>
       </EmptyEntity>


### PR DESCRIPTION
## Description
## Motivation and Context

Some minor improvements to the collectors UI:

  - When no Fleets exist on the Collectors Overview page, there is a "Create fleet" button which navigates to the Fleets overview, but does not open the create modal. This is fixed by changing the route.
  - When clicking the "Cancel" button in that modal, we are now going back to the last page, so we go back to the "Collectors Overview" page if we opened it from there.
  - On the Instances Overview, the default filter for the `last_seen` field is now a relative time range instead of an absolute one calculated on current time - 24h.

## How Has This Been Tested?

## Screenshots (if appropriate):

Before (create fleet flow):
<img width="1272" height="619" alt="create-fleet-old" src="https://github.com/user-attachments/assets/11e54364-3ad2-4620-a638-96fe72bac697" />

After (create fleet flow);
<img width="1272" height="619" alt="create-fleet-new" src="https://github.com/user-attachments/assets/1d038268-e761-4dd1-9d55-b5ff1bd81cbc" />

Before (instance filters):
<img width="2176" height="876" alt="image" src="https://github.com/user-attachments/assets/ba0e3bf6-606d-41fd-88c4-49f5084ddd30" />

After (instance filters):
<img width="2132" height="839" alt="image" src="https://github.com/user-attachments/assets/be6bffb9-9f82-4999-b9a3-476b0ed689a2" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Minor change in the user flows