### PR TITLE
Adds absolute time range filter to MCP tools

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/mcp/tools/AbsoluteTimeRange.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/tools/AbsoluteTimeRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.mcp.tools;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import jakarta.validation.constraints.NotBlank;
+
+public record AbsoluteTimeRange(
+        @JsonProperty("from")
+        @JsonPropertyDescription("Start of the time range in ISO 8601 format (e.g. 2024-01-01T00:00:00.000Z)")
+        @NotBlank
+        String from,
+
+        @JsonProperty("to")
+        @JsonPropertyDescription("End of the time range in ISO 8601 format (e.g. 2024-01-01T01:00:00.000Z)")
+        @NotBlank
+        String to
+) {}

--- a/graylog2-server/src/main/java/org/graylog/mcp/tools/AggregateMessagesTool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/tools/AggregateMessagesTool.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
@@ -36,7 +37,10 @@ import org.graylog.plugins.views.search.rest.scriptingapi.request.Grouping;
 import org.graylog.plugins.views.search.rest.scriptingapi.request.Metric;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.web.customization.CustomizationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +91,7 @@ public class AggregateMessagesTool extends Tool<AggregateMessagesTool.Parameters
                     parameters.query(),
                     parameters.streams(),
                     parameters.streamCategories(),
-                    RelativeRange.create(parameters.rangeSeconds()),
+                    resolveTimeRange(parameters),
                     parameters.groupings(),
                     parameters.metrics()
             );
@@ -100,6 +104,17 @@ public class AggregateMessagesTool extends Tool<AggregateMessagesTool.Parameters
         } catch (NoSuchElementException | QueryFailedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static TimeRange resolveTimeRange(Parameters parameters) {
+        if (parameters.absoluteRange() != null) {
+            try {
+                return AbsoluteRange.create(parameters.absoluteRange().from(), parameters.absoluteRange().to());
+            } catch (InvalidRangeParametersException e) {
+                throw new IllegalArgumentException("Invalid absolute time range: " + e.getMessage(), e);
+            }
+        }
+        return RelativeRange.create(parameters.rangeSeconds());
     }
 
     @AutoValue
@@ -117,8 +132,13 @@ public class AggregateMessagesTool extends Tool<AggregateMessagesTool.Parameters
         @JsonPropertyDescription("A set of stream categories to search in")
         public abstract Set<String> streamCategories();
 
+        @JsonProperty("absolute_range")
+        @JsonPropertyDescription("An absolute time range with required 'from' and 'to' fields in ISO 8601 format. Takes precedence over range_seconds when provided.")
+        @Nullable
+        public abstract AbsoluteTimeRange absoluteRange();
+
         @JsonProperty("range_seconds")
-        @JsonPropertyDescription("The number of seconds to look back, the search window is always up to now, with this many seconds into the past.")
+        @JsonPropertyDescription("The number of seconds to look back, the search window is always up to now, with this many seconds into the past. Ignored when absolute_range is provided.")
         @DefaultValue("3600")
         @Positive
         public abstract int rangeSeconds();
@@ -148,7 +168,8 @@ public class AggregateMessagesTool extends Tool<AggregateMessagesTool.Parameters
                         .query("")
                         .streams(Set.of())
                         .streamCategories(Set.of())
-                        .rangeSeconds(3600);
+                        .rangeSeconds(3600)
+                        .absoluteRange(null);
             }
 
             @JsonProperty("query")
@@ -157,6 +178,9 @@ public class AggregateMessagesTool extends Tool<AggregateMessagesTool.Parameters
             @JsonProperty("range_seconds")
             public abstract Builder rangeSeconds(
                     @Positive final int rangeSeconds);
+
+            @JsonProperty("absolute_range")
+            public abstract Builder absoluteRange(@Nullable final AbsoluteTimeRange absoluteRange);
 
             @JsonProperty("streams")
             public abstract Builder streams(final Set<String> streams);

--- a/graylog2-server/src/main/java/org/graylog/mcp/tools/SearchMessagesTool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/tools/SearchMessagesTool.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -34,7 +35,10 @@ import org.graylog.plugins.views.search.rest.scriptingapi.mapping.QueryFailedExc
 import org.graylog.plugins.views.search.rest.scriptingapi.request.MessagesRequestSpec;
 import org.graylog.plugins.views.search.rest.scriptingapi.response.TabularResponse;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.web.customization.CustomizationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +88,7 @@ public class SearchMessagesTool extends Tool<SearchMessagesTool.Parameters, Tabu
                     parameters.query(),
                     parameters.streams(),
                     parameters.streamCategories(),
-                    RelativeRange.create(parameters.rangeSeconds()),
+                    resolveTimeRange(parameters),
                     null,
                     null,
                     parameters.offset(),
@@ -99,6 +103,17 @@ public class SearchMessagesTool extends Tool<SearchMessagesTool.Parameters, Tabu
         } catch (NoSuchElementException | QueryFailedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static TimeRange resolveTimeRange(Parameters parameters) {
+        if (parameters.absoluteRange() != null) {
+            try {
+                return AbsoluteRange.create(parameters.absoluteRange().from(), parameters.absoluteRange().to());
+            } catch (InvalidRangeParametersException e) {
+                throw new IllegalArgumentException("Invalid absolute time range: " + e.getMessage(), e);
+            }
+        }
+        return RelativeRange.create(parameters.rangeSeconds());
     }
 
     @AutoValue
@@ -132,8 +147,13 @@ public class SearchMessagesTool extends Tool<SearchMessagesTool.Parameters, Tabu
         @PositiveOrZero
         public abstract int offset();
 
+        @JsonProperty("absolute_range")
+        @JsonPropertyDescription("An absolute time range with required 'from' and 'to' fields in ISO 8601 format. Takes precedence over range_seconds when provided.")
+        @Nullable
+        public abstract AbsoluteTimeRange absoluteRange();
+
         @JsonProperty("range_seconds")
-        @JsonPropertyDescription("The number of seconds to look back, the search window is always up to now, with this many seconds into the past.")
+        @JsonPropertyDescription("The number of seconds to look back, the search window is always up to now, with this many seconds into the past. Ignored when absolute_range is provided.")
         @DefaultValue("3600")
         @Positive
         public abstract int rangeSeconds();
@@ -154,7 +174,8 @@ public class SearchMessagesTool extends Tool<SearchMessagesTool.Parameters, Tabu
                         .fields(List.of("source", "timestamp"))
                         .limit(50)
                         .offset(0)
-                        .rangeSeconds(3600);
+                        .rangeSeconds(3600)
+                        .absoluteRange(null);
             }
 
             @JsonProperty("query")
@@ -170,6 +191,9 @@ public class SearchMessagesTool extends Tool<SearchMessagesTool.Parameters, Tabu
             @JsonProperty("range_seconds")
             public abstract Builder rangeSeconds(
                     @Positive final int rangeSeconds);
+
+            @JsonProperty("absolute_range")
+            public abstract Builder absoluteRange(@Nullable final AbsoluteTimeRange absoluteRange);
 
             @JsonProperty("streams")
             public abstract Builder streams(final Set<String> streams);


### PR DESCRIPTION
Adds absolute time range filter to aggregate messages and search messages MCP tools
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new absolute_range filter with from / to dates to filter.

If present, absolute_range takes precedence over the already existing range_seconds, if missing it fallbacks to range_seconds. 100% backward compatible

## Motivation and Context
Implements #26421 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

