### PR TITLE
Make Sidecar default collector paths and host variable configurable (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26199.toml
+++ b/changelog/unreleased/pr-26199.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Make Sidecar default collector paths and host variable configurable."
+
+pulls = ["26199"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/common/SidecarPluginConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/common/SidecarPluginConfiguration.java
@@ -17,17 +17,36 @@
 package org.graylog.plugins.sidecar.common;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.StringNotEmptyValidator;
 import org.graylog2.plugin.PluginConfigBean;
 
+import java.util.regex.Pattern;
+
 public class SidecarPluginConfiguration implements PluginConfigBean {
     private static final String PREFIX = "sidecar_";
 
     @Parameter(value = PREFIX + "user", validator = StringNotEmptyValidator.class)
     private String user = "graylog-sidecar";
+
+    @Parameter(value = PREFIX + "collector_binary_dir", validator = StringNotEmptyValidator.class)
+    private String collectorBinaryDir = "/usr/lib/graylog-sidecar";
+
+    @Parameter(value = PREFIX + "spool_dir", validator = StringNotEmptyValidator.class)
+    private String spoolDir = "/var/lib/graylog-sidecar";
+
+    @Parameter(value = PREFIX + "windows_install_dir", validator = StringNotEmptyValidator.class)
+    private String windowsInstallDir = "C:\\Program Files\\Graylog\\sidecar";
+
+    @Parameter(value = PREFIX + "server_config_dir", validator = StringNotEmptyValidator.class)
+    private String serverConfigDir = "/etc/graylog/server";
+
+    @Parameter(value = PREFIX + "host_variable", validator = ConfigurationVariableNameValidator.class)
+    private String hostVariable = "graylog_host";
 
     @Parameter(value = PREFIX + "cache_time", validator = PositiveDurationValidator.class)
     private Duration cacheTime = Duration.hours(1L);
@@ -45,5 +64,41 @@ public class SidecarPluginConfiguration implements PluginConfigBean {
 
     public int getCacheMaxSize() {
         return cacheMaxSize;
+    }
+
+    public String getCollectorBinaryDir() {
+        return collectorBinaryDir;
+    }
+
+    public String getSpoolDir() {
+        return spoolDir;
+    }
+
+    public String getWindowsInstallDir() {
+        return windowsInstallDir;
+    }
+
+    public String getServerConfigDir() {
+        return serverConfigDir;
+    }
+
+    public String getHostVariable() {
+        return hostVariable;
+    }
+
+    /**
+     * Rejects values that aren't valid configuration variable names (same rule as {@code ConfigurationVariableResource}),
+     * since the value is embedded into collector templates as {@code ${user.<name>}}.
+     */
+    public static class ConfigurationVariableNameValidator implements Validator<String> {
+        private static final Pattern VALID_NAME = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
+
+        @Override
+        public void validate(String name, String value) throws ValidationException {
+            if (value == null || !VALID_NAME.matcher(value).matches()) {
+                throw new ValidationException("Parameter " + name + " (\"" + value + "\") may only contain the " +
+                        "characters A-Z, a-z, 0-9, _ and must not start with a digit.");
+            }
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -27,6 +27,7 @@ import com.mongodb.client.result.UpdateResult;
 import jakarta.inject.Inject;
 import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.graylog.plugins.sidecar.common.SidecarPluginConfiguration;
 import org.graylog.plugins.sidecar.rest.models.Collector;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
 import org.graylog.plugins.sidecar.rest.models.ConfigurationVariable;
@@ -67,6 +68,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
     public static final String OS_DARWIN = "darwin";
     public static final String OS_WINDOWS = "windows";
     private static final Logger LOG = LoggerFactory.getLogger(V20180212165000_AddDefaultCollectors.class);
+    // Default host variable referenced by the templates below; sidecar_host_variable can override it.
+    private static final String DEFAULT_HOST_VARIABLE = "graylog_host";
     private final CollectorService collectorService;
     private final ConfigurationVariableService configurationVariableService;
     private final MongoCollection<Document> collection;
@@ -74,6 +77,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
     private final ConfigurationService configurationService;
 
     private final ClusterConfigService clusterConfigService;
+    private final SidecarPluginConfiguration pluginConfiguration;
     private MigrationState migrationState;
     private MigrationState updatedMigrationState;
 
@@ -83,13 +87,15 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                                 ConfigurationVariableService configurationVariableService,
                                                 ConfigurationService configurationService,
                                                 MongoConnection mongoConnection,
-                                                ClusterConfigService clusterConfigService) {
+                                                ClusterConfigService clusterConfigService,
+                                                SidecarPluginConfiguration pluginConfiguration) {
         this.httpExternalUri = httpConfiguration.getHttpExternalUri();
         this.collectorService = collectorService;
         this.configurationVariableService = configurationVariableService;
         this.configurationService = configurationService;
         this.collection = mongoConnection.getMongoDatabase().getCollection(CollectorService.COLLECTION_NAME);
         this.clusterConfigService = clusterConfigService;
+        this.pluginConfiguration = pluginConfiguration;
     }
 
     @Override
@@ -103,7 +109,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
         updatedMigrationState = migrationState;
 
         removeConfigPath();
-        ensureConfigurationVariable("graylog_host", "Graylog Host.", httpExternalUri.getHost());
+        ensureConfigurationVariable(pluginConfiguration.getHostVariable(), "Server Host", httpExternalUri.getHost());
 
         ensureFilebeatCollectorsAndConfig();
         ensureAuditbeatCollectorsAndConfig();
@@ -115,15 +121,22 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
         }
     }
 
+    // Double backslashes so a Windows path is a valid FreeMarker string literal (e.g. ${sidecar.spoolDir!"<path>"}).
+    private static String freemarkerEscape(String path) {
+        return path.replace("\\", "\\\\");
+    }
+
     private void ensureFilebeatCollectorsAndConfig() {
+        final var linuxSpoolDir = pluginConfiguration.getSpoolDir() + "/collectors/filebeat";
+        final var winInstallDir = freemarkerEscape(pluginConfiguration.getWindowsInstallDir());
 
         final var commonConfig = f("""
                 %s
                 output.logstash:
                    hosts: ["${user.graylog_host}:5044"]
                 path:
-                   data: ${sidecar.spoolDir!\"/var/lib/graylog-sidecar/collectors/filebeat\"}/data
-                   logs: ${sidecar.spoolDir!\"/var/lib/graylog-sidecar/collectors/filebeat\"}/log
+                   data: ${sidecar.spoolDir!\"%s\"}/data
+                   logs: ${sidecar.spoolDir!\"%s\"}/log
 
                 filebeat.inputs:
 
@@ -153,7 +166,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                         overwrite_keys: true
                   fields:
                     event_source_product: zeek
-                """, BEATS_PREAMBEL);
+                """, BEATS_PREAMBEL, linuxSpoolDir, linuxSpoolDir);
 
         String apacheConfigType = """
 
@@ -170,7 +183,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "filebeat",
                 "exec",
                 OS_LINUX,
-                "/usr/lib/graylog-sidecar/filebeat",
+                pluginConfiguration.getCollectorBinaryDir() + "/filebeat",
                 "-c  %s",
                 "test config -c %s",
                 commonConfig + f(apacheConfigType, """
@@ -212,7 +225,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "filebeat",
                 "svc",
                 OS_WINDOWS,
-                "C:\\Program Files\\Graylog\\sidecar\\filebeat.exe",
+                pluginConfiguration.getWindowsInstallDir() + "\\filebeat.exe",
                 "-c \"%s\"",
                 "test config -c \"%s\"",
                 f("""
@@ -220,8 +233,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                 output.logstash:
                                    hosts: ["${user.graylog_host}:5044"]
                                 path:
-                                   data: ${sidecar.spoolDir!\"C:\\\\Program Files\\\\Graylog\\\\sidecar\\\\cache\\\\filebeat\"}\\data
-                                   logs: ${sidecar.spoolDir!\"C:\\\\Program Files\\\\Graylog\\\\sidecar\"}\\logs
+                                   data: ${sidecar.spoolDir!\"%s\"}\\data
+                                   logs: ${sidecar.spoolDir!\"%s\"}\\logs
                                 tags:
                                 - windows
                                 filebeat.inputs:
@@ -230,15 +243,16 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                   paths:
                                   - C:\\logs\\log.log
                                 """,
-                        BEATS_PREAMBEL));
+                        BEATS_PREAMBEL, winInstallDir + "\\\\cache\\\\filebeat", winInstallDir));
     }
 
     private void ensureAuditbeatCollectorsAndConfig() {
+        final var auditbeatSpoolDir = pluginConfiguration.getSpoolDir() + "/collectors/auditbeat";
         ensureCollector(
                 "auditbeat",
                 "exec",
                 OS_LINUX,
-                "/usr/lib/graylog-sidecar/auditbeat",
+                pluginConfiguration.getCollectorBinaryDir() + "/auditbeat",
                 "-c  %s",
                 "test config -c %s",
                 f("""
@@ -246,8 +260,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                 output.logstash:
                                    hosts: ["${user.graylog_host}:5044"]
                                 path:
-                                   data: ${sidecar.spoolDir!\"/var/lib/graylog-sidecar/collectors/auditbeat\"}/data
-                                   logs: ${sidecar.spoolDir!\"/var/lib/graylog-sidecar/collectors/auditbeat\"}/log
+                                   data: ${sidecar.spoolDir!\"%s\"}/data
+                                   logs: ${sidecar.spoolDir!\"%s\"}/log
                                 fields:
                                   event_source_product: linux_auditbeat
 
@@ -304,7 +318,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                   - /sbin
                                   - /usr/sbin
                                   - /etc
-                                  - /etc/graylog/server
+                                  - %s
                                   exclude_files:
                                   - '(?i)\\.sw[nop]$'
                                   - '~$'
@@ -315,16 +329,17 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                   max_file_size: 100 MiB
                                   hash_types: [sha256]
                                   recursive: false""",
-                        BEATS_PREAMBEL)
+                        BEATS_PREAMBEL, auditbeatSpoolDir, auditbeatSpoolDir, pluginConfiguration.getServerConfigDir())
         ).ifPresent(collector -> ensureDefaultConfiguration("auditbeat-linux-default", collector));
     }
 
     private void ensureWinlogbeatCollectorsAndConfig() {
+        final var winInstallDir = freemarkerEscape(pluginConfiguration.getWindowsInstallDir());
         ensureCollector(
                 "winlogbeat",
                 "svc",
                 OS_WINDOWS,
-                "C:\\Program Files\\Graylog\\sidecar\\winlogbeat.exe",
+                pluginConfiguration.getWindowsInstallDir() + "\\winlogbeat.exe",
                 "-c \"%s\"",
                 "test config -c \"%s\"",
                 f("""
@@ -332,8 +347,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                 output.logstash:
                                    hosts: ["${user.graylog_host}:5044"]
                                 path:
-                                  data: ${sidecar.spoolDir!\"C:\\\\Program Files\\\\Graylog\\\\sidecar\\\\cache\\\\winlogbeat\"}\\data
-                                  logs: ${sidecar.spoolDir!\"C:\\\\Program Files\\\\Graylog\\\\sidecar\"}\\logs
+                                  data: ${sidecar.spoolDir!\"%s\"}\\data
+                                  logs: ${sidecar.spoolDir!\"%s\"}\\logs
                                 tags:
                                  - windows
                                 winlogbeat:
@@ -359,7 +374,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                      ignore_older: 96h
                                    - name: windows PowerShell
                                      ignore_older: 96h""",
-                        BEATS_PREAMBEL
+                        BEATS_PREAMBEL, winInstallDir + "\\\\cache\\\\winlogbeat", winInstallDir
                 )
         ).ifPresent(collector -> ensureDefaultConfiguration("winlogbeat-default", collector));
     }
@@ -543,7 +558,13 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                                 String validationCommand,
                                                 String defaultTemplate) {
 
-        this.updatedMigrationState = updatedMigrationState.withNewDefaultTemplate(collectorName, nodeOperatingSystem, defaultTemplate);
+        // Resolve the host variable (no-op for the default) before withNewDefaultTemplate() records the template's checksum.
+        final String resolvedTemplate = defaultTemplate.replace(
+                ConfigurationVariable.reference(DEFAULT_HOST_VARIABLE),
+                ConfigurationVariable.reference(pluginConfiguration.getHostVariable())
+        );
+
+        this.updatedMigrationState = updatedMigrationState.withNewDefaultTemplate(collectorName, nodeOperatingSystem, resolvedTemplate);
 
         Collector collector = null;
         try {
@@ -553,13 +574,13 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 LOG.debug(msg, collectorName, nodeOperatingSystem);
                 throw new IllegalArgumentException();
             }
-            if (!defaultTemplate.equals(collector.defaultTemplate()) &&
+            if (!resolvedTemplate.equals(collector.defaultTemplate()) &&
                     migrationState.isKnownDefaultTemplate(collectorName, nodeOperatingSystem, collector.defaultTemplate())) {
                 LOG.info("{} collector default template on {} is unchanged, updating it.", collectorName, nodeOperatingSystem);
                 try {
                     return Optional.of(collectorService.save(
                             collector.toBuilder()
-                                    .defaultTemplate(defaultTemplate)
+                                    .defaultTemplate(resolvedTemplate)
                                     .build()));
                 } catch (Exception e) {
                     LOG.error("Can't save collector '{}'!", collectorName, e);
@@ -576,7 +597,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                         executablePath,
                         executeParameters,
                         validationCommand,
-                        defaultTemplate
+                        resolvedTemplate
                 )));
             } catch (Exception e) {
                 LOG.error("Can't save collector '{}'!", collectorName, e);

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/ConfigurationVariable.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/ConfigurationVariable.java
@@ -62,6 +62,11 @@ public abstract class ConfigurationVariable implements MongoEntity {
 
     @JsonIgnore
     public String fullName() {
-        return String.format(Locale.ENGLISH, "${%s.%s}", VARIABLE_PREFIX, name());
+        return reference(name());
+    }
+
+    /** Template reference for a variable {@code name}, e.g. {@code ${user.graylog_host}}. */
+    public static String reference(String name) {
+        return String.format(Locale.ENGLISH, "${%s.%s}", VARIABLE_PREFIX, name);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/common/SidecarPluginConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/common/SidecarPluginConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.sidecar.common;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.RepositoryException;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class SidecarPluginConfigurationTest {
+
+    private SidecarPluginConfiguration configFrom(Map<String, String> properties)
+            throws RepositoryException, ValidationException {
+        final SidecarPluginConfiguration config = new SidecarPluginConfiguration();
+        new JadConfig(new InMemoryRepository(properties), config).process();
+        return config;
+    }
+
+    @Test
+    void defaultsMatchTheGraylogSidecarPackages() throws Exception {
+        final SidecarPluginConfiguration config = configFrom(Map.of());
+
+        assertThat(config.getUser()).isEqualTo("graylog-sidecar");
+        assertThat(config.getCollectorBinaryDir()).isEqualTo("/usr/lib/graylog-sidecar");
+        assertThat(config.getSpoolDir()).isEqualTo("/var/lib/graylog-sidecar");
+        assertThat(config.getWindowsInstallDir()).isEqualTo("C:\\Program Files\\Graylog\\sidecar");
+        assertThat(config.getServerConfigDir()).isEqualTo("/etc/graylog/server");
+        assertThat(config.getHostVariable()).isEqualTo("graylog_host");
+    }
+
+    @Test
+    void pathsAndUserAreConfigurable() throws Exception {
+        final Map<String, String> rawConfig = Map.of(
+                "sidecar_user", "custom-sidecar",
+                "sidecar_collector_binary_dir", "/usr/lib/custom-sidecar",
+                "sidecar_spool_dir", "/var/lib/custom-sidecar",
+                "sidecar_windows_install_dir", "C:\\Program Files\\custom\\sidecar",
+                "sidecar_server_config_dir", "/etc/custom/server"
+        );
+
+        final SidecarPluginConfiguration config = configFrom(rawConfig);
+
+        assertThat(config.getUser()).isEqualTo(rawConfig.get("sidecar_user"));
+        assertThat(config.getCollectorBinaryDir()).isEqualTo(rawConfig.get("sidecar_collector_binary_dir"));
+        assertThat(config.getSpoolDir()).isEqualTo(rawConfig.get("sidecar_spool_dir"));
+        assertThat(config.getWindowsInstallDir()).isEqualTo(rawConfig.get("sidecar_windows_install_dir"));
+        assertThat(config.getServerConfigDir()).isEqualTo(rawConfig.get("sidecar_server_config_dir"));
+    }
+
+    @Test
+    void hostVariableIsConfigurable() throws Exception {
+        final SidecarPluginConfiguration config = configFrom(Map.of("sidecar_host_variable", "custom_host"));
+
+        assertThat(config.getHostVariable()).isEqualTo("custom_host");
+    }
+
+    @Test
+    void rejectsInvalidHostVariableNames() {
+        assertThat(catchThrowable(() -> configFrom(Map.of("sidecar_host_variable", "my host"))))
+                .isInstanceOf(ValidationException.class);
+        assertThat(catchThrowable(() -> configFrom(Map.of("sidecar_host_variable", "1host"))))
+                .isInstanceOf(ValidationException.class);
+        assertThat(catchThrowable(() -> configFrom(Map.of("sidecar_host_variable", "my-host"))))
+                .isInstanceOf(ValidationException.class);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectorsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectorsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.sidecar.migrations;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.graylog.plugins.sidecar.common.SidecarPluginConfiguration;
+import org.graylog.plugins.sidecar.migrations.V20180212165000_AddDefaultCollectors.MigrationState;
+import org.graylog.plugins.sidecar.rest.models.Collector;
+import org.graylog.plugins.sidecar.rest.models.ConfigurationVariable;
+import org.graylog.plugins.sidecar.services.CollectorService;
+import org.graylog.plugins.sidecar.services.ConfigurationService;
+import org.graylog.plugins.sidecar.services.ConfigurationVariableService;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class V20180212165000_AddDefaultCollectorsTest {
+
+    // Deep stubs make removeConfigPath()'s mongo chain a no-op without explicit stubbing.
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MongoConnection mongoConnection;
+    @Mock
+    private HttpConfiguration httpConfiguration;
+    @Mock
+    private CollectorService collectorService;
+    @Mock
+    private ConfigurationService configurationService;
+    @Mock
+    private ConfigurationVariableService configurationVariableService;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+    @Captor
+    private ArgumentCaptor<Collector> collectorCaptor;
+    @Captor
+    private ArgumentCaptor<ConfigurationVariable> variableCaptor;
+
+    // Custom package layout shared by the configured-path tests.
+    private static final Map<String, String> CUSTOM_PATHS = Map.of(
+            "sidecar_collector_binary_dir", "/usr/lib/custom-sidecar",
+            "sidecar_spool_dir", "/var/lib/custom-sidecar",
+            "sidecar_windows_install_dir", "C:\\Program Files\\custom\\sidecar"
+    );
+
+    @BeforeEach
+    void setUp() {
+        when(httpConfiguration.getHttpExternalUri()).thenReturn(URI.create("http://graylog.example.com:9000/"));
+        when(clusterConfigService.getOrDefault(eq(MigrationState.class), any())).thenReturn(MigrationState.createEmpty());
+        // save() echoes the entity back with an id so the migration completes.
+        when(collectorService.save(any())).thenAnswer(
+                inv -> ((Collector) inv.getArgument(0)).toBuilder().id("000000000000000000000001").build()
+        );
+        when(configurationService.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(configurationVariableService.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void seedsDefaultPathsMatchingTheGraylogSidecarPackages() {
+        final var collectors = migrate(new SidecarPluginConfiguration());
+
+        assertThat(exec(collectors, "filebeat|linux")).isEqualTo("/usr/lib/graylog-sidecar/filebeat");
+        assertThat(exec(collectors, "auditbeat|linux")).isEqualTo("/usr/lib/graylog-sidecar/auditbeat");
+        assertThat(exec(collectors, "filebeat|windows")).isEqualTo("C:\\Program Files\\Graylog\\sidecar\\filebeat.exe");
+        assertThat(exec(collectors, "winlogbeat|windows")).isEqualTo("C:\\Program Files\\Graylog\\sidecar\\winlogbeat.exe");
+
+        // spoolDir fallbacks must stay byte-identical, or the migration's CRC check breaks on upgrades.
+        assertThat(template(collectors, "filebeat|linux")).contains("/var/lib/graylog-sidecar/collectors/filebeat");
+        assertThat(template(collectors, "filebeat|windows")).contains("C:\\\\Program Files\\\\Graylog\\\\sidecar\\\\cache\\\\filebeat");
+
+        // Default install keeps the graylog_host reference (backwards compatible).
+        assertThat(template(collectors, "filebeat|linux")).contains("${user.graylog_host}");
+    }
+
+    @Test
+    void appliesConfiguredPathsToEveryCollector() throws Exception {
+        final var collectors = migrate(configWith(CUSTOM_PATHS));
+
+        assertThat(exec(collectors, "filebeat|linux")).isEqualTo("/usr/lib/custom-sidecar/filebeat");
+        assertThat(exec(collectors, "winlogbeat|windows")).isEqualTo("C:\\Program Files\\custom\\sidecar\\winlogbeat.exe");
+        assertThat(template(collectors, "filebeat|linux")).contains("/var/lib/custom-sidecar/collectors/filebeat");
+        assertThat(template(collectors, "filebeat|windows")).contains("C:\\\\Program Files\\\\custom\\\\sidecar\\\\cache\\\\filebeat");
+
+        assertThat(collectors.values()).allSatisfy(c ->
+                assertThat(c.executablePath() + " " + c.defaultTemplate()).doesNotContain("graylog-sidecar"));
+        assertThat(template(collectors, "auditbeat|linux")).contains("/etc/graylog/server");
+    }
+
+    @Test
+    void usesConfiguredHostVariable() throws Exception {
+        final var collectors = migrate(configWith(Map.of("sidecar_host_variable", "custom_host")));
+
+        assertThat(collectors.values()).allSatisfy(c ->
+                assertThat(c.defaultTemplate())
+                        .contains("${user.custom_host}")
+                        .doesNotContain("${user.graylog_host}")
+        );
+
+        verify(configurationVariableService).save(variableCaptor.capture());
+        assertThat(variableCaptor.getValue().name()).isEqualTo("custom_host");
+        assertThat(variableCaptor.getValue().description()).doesNotContain("Graylog");
+    }
+
+    @Test
+    void usesConfiguredServerConfigDirInAuditbeatFileIntegrity() throws Exception {
+        final var collectors = migrate(configWith(Map.of("sidecar_server_config_dir", "/etc/acme/server")));
+
+        assertThat(template(collectors, "auditbeat|linux"))
+                .contains("/etc/acme/server")
+                .doesNotContain("/etc/graylog/server");
+    }
+
+    private Map<String, Collector> migrate(SidecarPluginConfiguration config) {
+        new V20180212165000_AddDefaultCollectors(httpConfiguration, collectorService, configurationVariableService,
+                configurationService, mongoConnection, clusterConfigService, config).upgrade();
+
+        verify(collectorService, atLeastOnce()).save(collectorCaptor.capture());
+        return collectorCaptor.getAllValues().stream()
+                .collect(Collectors.toMap(c -> c.name() + "|" + c.nodeOperatingSystem(), c -> c));
+    }
+
+    private static SidecarPluginConfiguration configWith(Map<String, String> properties) throws Exception {
+        final var config = new SidecarPluginConfiguration();
+        new JadConfig(new InMemoryRepository(properties), config).process();
+        return config;
+    }
+
+    private static String exec(Map<String, Collector> collectors, String key) {
+        return collectors.get(key).executablePath();
+    }
+
+    private static String template(Map<String, Collector> collectors, String key) {
+        return collectors.get(key).defaultTemplate();
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -803,3 +803,42 @@ mongodb_max_connections = 1000
 #          instability. Proceed with caution.
 # Default: 0
 #search_query_engine_data_lake_jobs_queue_size = 0
+
+##################
+# Sidecar settings
+##################
+
+# Name of the built-in Graylog service account a Sidecar authenticates as.
+#sidecar_user = graylog-sidecar
+
+# Expiration time for entries in the Sidecar ETag caches.
+#sidecar_cache_time = 1h
+
+# Maximum number of entries held by each of the Sidecar ETag caches.
+#sidecar_cache_max_size = 5000
+
+# The options below seed the default collectors and configurations. To update ones that already exist, edit
+# them in the Graylog web interface, or drop the sidecar_collectors, sidecar_configurations and
+# sidecar_configuration_variables collections to re-create them.
+
+# Directory holding the Linux collector binaries from the Sidecar package; used for the default collector
+# executable paths. Applied only when the default collectors are first created; existing collectors keep
+# their executable paths.
+#sidecar_collector_binary_dir = /usr/lib/graylog-sidecar
+
+# Default Linux collector spool directory; used as the spoolDir fallback in the default collector configurations.
+# Applied when the default configurations are first created.
+#sidecar_spool_dir = /var/lib/graylog-sidecar
+
+# Windows Sidecar installation directory; used for the default Windows executable paths and spoolDir fallbacks.
+# Remember to escape backslashes as a double backslash (see the note at the top of this file). Applied when the
+# default collectors are first created; existing collectors keep their executable paths.
+#sidecar_windows_install_dir = C:\\Program Files\\Graylog\\sidecar
+
+# Server configuration directory monitored by the default auditbeat file integrity configuration. Applied when
+# the default configuration is first created.
+#sidecar_server_config_dir = /etc/graylog/server
+
+# Name of the configuration variable (referenced as ${user.<name>}) that holds the server host. Allowed
+# characters: A-Z, a-z, 0-9, and underscore; it must not start with a digit.
+#sidecar_host_variable = graylog_host


### PR DESCRIPTION
Note: This is a backport of #26199 to `7.0` (manually created due to conflicts in `SidecarPluginConfiguration`)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Make the hardcoded paths and host-variable name in the default Sidecar collectors (seeded by the `V20180212165000_AddDefaultCollectors` migration) configurable via `graylog.conf`, for deployments with a custom Sidecar/server layout.

New server options, all defaulting to the current values:

- `sidecar_collector_binary_dir` (default: `/usr/lib/graylog-sidecar`)
- `sidecar_spool_dir` (default: `/var/lib/graylog-sidecar`)
- `sidecar_windows_install_dir` (default: `C:\Program Files\Graylog\sidecar`)
- `sidecar_server_config_dir` (default: `/etc/graylog/server`)
- `sidecar_host_variable` (default: `graylog_host`)

**Note:** these settings only supply the values used when the bundled collectors and configurations are first seeded into MongoDB. On existing installs, collector executable paths are not changed, and template values are refreshed only for collectors whose default template hasn't been customized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Add to `graylog.conf`:
```
sidecar_collector_binary_dir = /usr/lib/custom-sidecar
sidecar_spool_dir            = /var/lib/custom-sidecar
sidecar_windows_install_dir  = C:\\Program Files\\Custom\\sidecar
sidecar_server_config_dir    = /etc/custom/server
sidecar_host_variable        = custom_host
```

2. Drop the already seeded data so it's re-created on server startup. In the MongoDB console (assuming there are no assigned sidecars):
```
db.sidecar_collectors.drop()
db.sidecar_configurations.drop()
db.sidecar_configuration_variables.drop()
```

3. Restart Graylog server, then in the UI under **System -> Sidecars -> Configuration** confirm:
   - opening a default configuration (e.g. `filebeat-linux-default`) shows `/var/lib/custom-sidecar/...` and `${user.custom_host}`. `auditbeat-linux-default` shows `/etc/custom/server`
   - the collectors' executable paths use `/usr/lib/custom-sidecar/...`
   - **Configuration Variables** lists `custom_host`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

