### PR TITLE
Hide create dashboard button for users without create permission

### DIFF
--- a/changelog/unreleased/pr-26448.toml
+++ b/changelog/unreleased/pr-26448.toml
@@ -1,0 +1,3 @@
+type = "f"
+message = "Hide the create dashboard button for users without the `dashboards:create` permission."
+pulls = ["26448"]

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.tsx
@@ -21,12 +21,17 @@ import { DocumentTitle, PageHeader } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import DashboardsOverview from 'views/components/dashboard/DashboardsOverview';
 import CreateButton from 'components/common/CreateButton';
+import IfPermitted from 'components/common/IfPermitted';
 
 const DashboardsPage = () => (
   <DocumentTitle title="Dashboards">
     <PageHeader
       title="Dashboards"
-      actions={<CreateButton entityKey="Dashboard" />}
+      actions={
+        <IfPermitted permissions={['dashboards:create']}>
+          <CreateButton entityKey="Dashboard" />
+        </IfPermitted>
+      }
       documentationLink={{
         title: 'Dashboard documentation',
         path: DocsHelper.PAGES.DASHBOARDS,


### PR DESCRIPTION
**Note:** This needs a backport to previous versions.

## Description
Wraps the dashboard `CreateButton` on the Dashboards page in `IfPermitted` so it is only rendered for users with the `dashboards:create` permission.

## Motivation and Context
Users without the `dashboards:create` permission were still shown the "Create" button, which would fail if clicked. The button is now hidden for those users.

## How Has This Been Tested?
Verified locally that the button is shown for users with the `dashboards:create` permission and hidden for users without it.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.