### PR TITLE
Fix role label padding regression in RolesCell

### DIFF
--- a/graylog2-web-interface/src/components/permissions/RolesCell.tsx
+++ b/graylog2-web-interface/src/components/permissions/RolesCell.tsx
@@ -28,7 +28,6 @@ const Role = styled(Label)`
   margin-right: 5px;
   margin-bottom: 5px;
   display: inline-block;
-  padding: 4px 6px;
 `;
 
 type Props = {


### PR DESCRIPTION
## Description
## Motivation and Context

Cleanup for a visual regression introduced by #26351, where the explicit padding made role labels render inconsistently with the rest of the UI.

## How Has This Been Tested?

## Screenshots (if appropriate):

Before:
<img width="3811" height="1534" alt="image" src="https://github.com/user-attachments/assets/cfba6293-d5ff-4b77-93d7-2f17da660658" />

After:
<img width="3835" height="1565" alt="image" src="https://github.com/user-attachments/assets/c78a8c5a-c7ea-4413-9a2b-955ff5889d52" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Fix unreleased change