### PR TITLE
Fix missing rate metrics in data node

### DIFF
--- a/changelog/unreleased/pr-26456.toml
+++ b/changelog/unreleased/pr-26456.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed missing rate metrics in Data Node Dashboard."
+issues = ["Graylog2/graylog-plugin-enterprise#14568"]
+pulls = ["26456"]

--- a/data-node/src/main/java/org/graylog/datanode/periodicals/MetricsCollector.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/MetricsCollector.java
@@ -216,7 +216,7 @@ public class MetricsCollector extends Periodical {
 
         if (Objects.nonNull(searchResponse) && searchResponse.hits().total().value() > 0) {
             // Retrieve the first hit (latest document) from the search response
-            return OSSerializationUtils.toMap(searchResponse.hits().hits().getFirst());
+            return OSSerializationUtils.toMap(searchResponse.hits().hits().getFirst().source());
         } else {
             LOG.info("No previous metrics for cluster");
         }


### PR DESCRIPTION
## Description
Fixes parsing of previous metrics for calculating rate metrics.

needs backport to 7.1

## Motivation and Context
With the migration to the new OS adapter rate metrics in the Data Node Dashboard were not shown.
This is due to rate metrics not being calculated correctly because previous metrics were retrieved/parsed incorrect.

fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/14568

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

