### PR TITLE
Onboarding experience main resource, with methods to retrieve and store state

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.onboarding;
+
+import org.graylog.plugins.onboarding.audit.OnboardingAuditEventTypes;
+import org.graylog.plugins.onboarding.rest.OnboardingResource;
+import org.graylog2.plugin.PluginModule;
+
+public class OnboardingModule extends PluginModule {
+    @Override
+    protected void configure() {
+        addSystemRestResource(OnboardingResource.class);
+        addAuditEventTypes(OnboardingAuditEventTypes.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingState.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.onboarding;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+//TODO: wrapping status for (near) future extendability
+public record OnboardingState(@JsonProperty("status") OnboardingStatus status) {
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingStatus.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/onboarding/OnboardingStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.onboarding;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum OnboardingStatus {
+    @JsonProperty("finished") FINISHED,
+    @JsonProperty("dismissed") DISMISSED,
+    @JsonProperty("unknown") UNKNOWN,
+    //TODO: more values expected
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/onboarding/audit/OnboardingAuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/onboarding/audit/OnboardingAuditEventTypes.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.onboarding.audit;
+
+import org.graylog2.audit.PluginAuditEventTypes;
+
+import java.util.Set;
+
+public class OnboardingAuditEventTypes implements PluginAuditEventTypes {
+    private static final String NAMESPACE = "onboarding";
+
+    public static final String ONBOARDING_STATUS_UPDATE = NAMESPACE + ":status:update";
+
+    @Override
+    public Set<String> auditEventTypes() {
+        return Set.of(ONBOARDING_STATUS_UPDATE);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/onboarding/rest/OnboardingResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/onboarding/rest/OnboardingResource.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.onboarding.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog.plugins.onboarding.OnboardingState;
+import org.graylog.plugins.onboarding.OnboardingStatus;
+import org.graylog.plugins.onboarding.audit.OnboardingAuditEventTypes;
+import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
+
+import java.util.Locale;
+
+@Tag(name = "Onboarding", description = "Manages the onboarding process state")
+@Path("/onboarding")
+@Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
+public class OnboardingResource extends RestResource {
+
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public OnboardingResource(final ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @GET
+    @NoAuditEvent("Read-only operation")
+    @Operation(summary = "Get current onboarding status")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current onboarding status")
+    })
+    public OnboardingState get() {
+        if (isPermitted(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)) {
+            final OnboardingState status = clusterConfigService.get(OnboardingState.class);
+            if (status != null) {
+                return status;
+            }
+        }
+        return new OnboardingState(OnboardingStatus.UNKNOWN);
+    }
+
+    @PUT
+    @Path("/{status}")
+    @AuditEvent(type = OnboardingAuditEventTypes.ONBOARDING_STATUS_UPDATE)
+    @Operation(summary = "Update onboarding status")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated onboarding status"),
+            @ApiResponse(responseCode = "400", description = "Bad request, illegal status value")
+    })
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_EDIT)
+    public Response update(@Parameter(name = "status", required = true) @PathParam("status") final String status) {
+        try {
+            clusterConfigService.write(
+                    new OnboardingState(
+                            OnboardingStatus.valueOf(status.toUpperCase(Locale.ROOT))
+                    )
+            );
+            return Response.ok().build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -43,6 +43,7 @@ import org.graylog.plugins.formatting.units.UnitsModule;
 import org.graylog.plugins.map.MapWidgetModule;
 import org.graylog.plugins.map.config.GeoIpProcessorConfig;
 import org.graylog.plugins.netflow.NetFlowPluginModule;
+import org.graylog.plugins.onboarding.OnboardingModule;
 import org.graylog.plugins.pipelineprocessor.PipelineConfig;
 import org.graylog.plugins.sidecar.SidecarModule;
 import org.graylog.plugins.sidecar.common.SidecarPluginConfiguration;
@@ -211,6 +212,7 @@ public class Server extends ServerBootstrap implements DocumentedBeansService {
                 new NetFlowPluginModule(),
                 new CEFInputModule(),
                 new SidecarModule(),
+                new OnboardingModule(),
                 new ContentPacksModule(),
                 new ViewsBindings(),
                 new JobSchedulerModule(),

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -212,7 +212,6 @@ public class Server extends ServerBootstrap implements DocumentedBeansService {
                 new NetFlowPluginModule(),
                 new CEFInputModule(),
                 new SidecarModule(),
-                new OnboardingModule(),
                 new ContentPacksModule(),
                 new ViewsBindings(),
                 new JobSchedulerModule(),
@@ -243,6 +242,9 @@ public class Server extends ServerBootstrap implements DocumentedBeansService {
         );
 
         modules.add(new FieldTypeManagementModule());
+        if (featureFlags.isOn("onboarding_experience")) {
+            modules.add(new OnboardingModule());
+        }
 
         return modules.build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/audit/AuditCoverageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/audit/AuditCoverageTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.events.audit.EventsAuditEventTypes;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
+import org.graylog.plugins.onboarding.audit.OnboardingAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.sidecar.audit.SidecarAuditEventTypes;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
@@ -61,6 +62,7 @@ public class AuditCoverageTest {
                 .addAll(new SecurityAuditEventTypes().auditEventTypes())
                 .addAll(new IntegrationsAuditEventTypes().auditEventTypes())
                 .addAll(new CaAuditEventTypes().auditEventTypes())
+                .addAll(new OnboardingAuditEventTypes().auditEventTypes())
                 .build();
         final Reflections reflections = new Reflections(configurationBuilder);
 


### PR DESCRIPTION
## Description
Adds backend support for persisting the onboarding wizard state in cluster config, exposing it via a new REST endpoint and registering it in the enterprise plugin.
/nocl
Fixes #26457

## How Has This Been Tested?
Manually.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

