### PR TITLE
Resolve visualization chart labels via pluggable KeyMapperProvider

### DIFF
--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -117,6 +117,7 @@ import WarmTierQueryValidation from 'views/components/searchbar/queryvalidation/
 import ExportMessageWidgetAction from 'views/components/widgets/ExportWidgetAction/ExportMessageWidgetAction';
 import ExportWidgetAction from 'views/components/widgets/ExportWidgetAction/ExportWidgetAction';
 import FieldTypeValueRenderer from 'views/components/fieldtypes/FieldTypeValueRenderer';
+import CoreKeyMappers from 'views/components/visualizations/keyMappers/CoreKeyMappers';
 import AddTextWidget, { CreateTextWidget } from 'views/logic/creatoractions/AddTextWidget';
 import TextWidget from 'views/logic/widgets/TextWidget';
 import TextVisualization from 'views/components/widgets/text/TextVisualization';
@@ -411,6 +412,7 @@ const exports: PluginExports = {
     ['create-extractor'],
   ),
   fieldTypeValueRenderer: FieldTypeValueRenderer,
+  visualizationKeyMappers: CoreKeyMappers,
   visualizationTypes: visualizationBindings,
   widgetCreators: [
     {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.tsx
@@ -47,13 +47,16 @@ const mockDummyVisualization = ({
 
 jest.mock('graylog-web-plugin/plugin', () => ({
   PluginStore: {
-    exports: () => [
-      {
-        type: 'dummy',
-        displayName: 'Some Dummy Visualization',
-        component: mockDummyVisualization,
-      },
-    ],
+    exports: (key: string) =>
+      key === 'visualizationTypes'
+        ? [
+            {
+              type: 'dummy',
+              displayName: 'Some Dummy Visualization',
+              component: mockDummyVisualization,
+            },
+          ]
+        : [],
   },
 }));
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.tsx
@@ -26,6 +26,7 @@ import type { Events } from 'views/logic/searchtypes/events/EventHandler';
 import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import type { OnVisualizationConfigChange } from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
 import OnVisualizationConfigChangeContext from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
+import KeyMapperProvider from 'views/components/visualizations/KeyMapperProvider';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
 
@@ -117,18 +118,22 @@ const AggregationBuilder = ({
   ) as VisualizationResult;
 
   return (
-    <VisComponent
-      config={config}
-      data={rows}
-      setLoadingState={setLoadingState}
-      effectiveTimerange={effectiveTimerange}
-      editing={editing}
-      fields={fields}
-      height={height}
-      width={width}
-      toggleEdit={toggleEdit}
-      onChange={onVisualizationConfigChange}
-    />
+    <KeyMapperProvider data={rows} config={config} fields={fields}>
+      {/* VisComponent is resolved by visualization type at render time and cannot be hoisted. */}
+      {/* eslint-disable-next-line react-hooks/static-components */}
+      <VisComponent
+        config={config}
+        data={rows}
+        setLoadingState={setLoadingState}
+        effectiveTimerange={effectiveTimerange}
+        editing={editing}
+        fields={fields}
+        height={height}
+        width={width}
+        toggleEdit={toggleEdit}
+        onChange={onVisualizationConfigChange}
+      />
+    </KeyMapperProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import Plot from 'views/components/visualizations/plotly/AsyncPlot';
+
+import GenericPlot from './GenericPlot';
+
+jest.mock('views/components/visualizations/plotly/AsyncPlot', () => jest.fn(() => <div data-testid="plot" />));
+
+const lastLayout = () => {
+  const { calls } = asMock(Plot).mock;
+
+  return calls[calls.length - 1][0].layout;
+};
+
+describe('GenericPlot datarevision', () => {
+  beforeEach(() => {
+    asMock(Plot).mockClear();
+  });
+
+  it('bumps layout.datarevision when the chart data changes so Plotly repaints in-trace labels', () => {
+    const initial = [{ type: 'sankey', node: { label: ['id-1'] } }];
+    const { rerender } = render(<GenericPlot chartData={initial} />);
+
+    const firstRevision = lastLayout().datarevision;
+
+    // Same data reference on re-render: revision must stay stable (no needless replots).
+    rerender(<GenericPlot chartData={initial} />);
+
+    expect(lastLayout().datarevision).toBe(firstRevision);
+
+    // New data (e.g. an asset id resolved to a name): revision must change.
+    const resolved = [{ type: 'sankey', node: { label: ['Asset id-1'] } }];
+    rerender(<GenericPlot chartData={resolved} />);
+
+    expect(lastLayout().datarevision).not.toBe(firstRevision);
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useContext, useMemo, useCallback } from 'react';
+import { useContext, useMemo, useCallback, useState } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 import merge from 'lodash/merge';
 import type { Layout, PlotMouseEvent, PlotlyHTMLElement } from 'plotly.js';
@@ -229,6 +229,26 @@ const GenericPlot = ({
   const interactive = useContext(InteractiveContext);
   const plotLayout = usePlotLayout(layout);
   const plotChartData = usePlotChartData(chartData, setChartColor);
+
+  // Plotly.react does not always repaint in-trace labels (notably Sankey `node.label` and scatter
+  // `text`) when the data changes after the initial render — e.g. when entity/asset titles resolve
+  // asynchronously. Bumping `datarevision` whenever the chart data changes forces Plotly to
+  // re-evaluate the trace data. (Axis tick labels live in the layout and update without this.)
+  // Tracked with the "adjust state during render" pattern so the revision changes in the same
+  // render that the data changes — without an effect (extra commit) or a ref read during render.
+  const [dataRevision, setDataRevision] = useState(0);
+  const [revisionedChartData, setRevisionedChartData] = useState(plotChartData);
+
+  if (revisionedChartData !== plotChartData) {
+    setRevisionedChartData(plotChartData);
+    setDataRevision((revision) => revision + 1);
+  }
+
+  const plotLayoutWithRevision = useMemo(
+    () => ({ ...plotLayout, datarevision: dataRevision }),
+    [plotLayout, dataRevision],
+  );
+
   const plotConfig = useMemo(() => ({ ...defaultPlotConfig, ...config }), [config]);
   const onRenderComplete = useContext(RenderCompletionCallback);
 
@@ -283,7 +303,7 @@ const GenericPlot = ({
     <StyledPlot
       data={plotChartData}
       useResizeHandler
-      layout={plotLayout}
+      layout={plotLayoutWithRevision}
       style={style}
       onAfterPlot={_onAfterPlot}
       onClick={interactive ? _onMarkerClick : () => false}

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperContext.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperContext.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import type { KeyMapper } from 'views/components/visualizations/TransformKeys';
+
+const identityMapper: KeyMapper = (key) => key;
+
+const KeyMapperContext = React.createContext<KeyMapper>(identityMapper);
+
+export default KeyMapperContext;

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.reactivity.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.reactivity.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import * as Immutable from 'immutable';
+
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import { usePlugin } from 'views/test/testPlugins';
+
+import KeyMapperProvider from './KeyMapperProvider';
+import KeyMapperContext from './KeyMapperContext';
+
+// Asset-style binding that resolves titles ASYNCHRONOUSLY (after mount), mirroring the real
+// getTitles-backed resolver. This reproduces the live behaviour where ids render first and the
+// resolved names arrive on a later render.
+const testPlugin = {
+  exports: {
+    visualizationKeyMappers: [
+      {
+        type: 'associated-assets',
+        useKeyMapper: (keys: Array<string>) => {
+          const [titles, setTitles] = useState<Record<string, string>>({});
+          const key = useMemo(() => keys.join('|'), [keys]);
+
+          useEffect(() => {
+            setTitles(Object.fromEntries(keys.map((k) => [k, `Asset ${k}`])));
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+          }, [key]);
+
+          return useCallback((k: string) => titles[k] ?? k, [titles]);
+        },
+      },
+    ],
+  },
+};
+
+const fields = Immutable.List([new FieldTypeMapping('b', FieldType.create('associated-assets', []))]);
+
+const Consumer = ({ k, field }: { k: string; field: string }) => {
+  const mapKeys = useContext(KeyMapperContext);
+
+  return <span>{mapKeys(k, field)}</span>;
+};
+
+describe('KeyMapperProvider (async resolution)', () => {
+  usePlugin(testPlugin);
+
+  it('updates labels once asynchronously-loaded titles arrive', async () => {
+    const config = AggregationWidgetConfig.builder().rowPivots([Pivot.createValues(['b'])]).columnPivots([]).build();
+    const data = { chart: [{ source: 'leaf', key: ['b1'], values: [] }] } as any;
+
+    render(
+      <KeyMapperProvider data={data} config={config} fields={fields}>
+        <Consumer k="b1" field="b" />
+      </KeyMapperProvider>,
+    );
+
+    expect(await screen.findByText('Asset b1')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
@@ -17,12 +17,13 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import * as Immutable from 'immutable';
 
-import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import { usePlugin } from 'views/test/testPlugins';
 
 import KeyMapperProvider from './KeyMapperProvider';
 import KeyMapperContext from './KeyMapperContext';
@@ -38,10 +39,10 @@ const testPlugin = {
   },
 };
 
-const config = {
-  rowPivots: [{ fields: ['streams'] }],
-  columnPivots: [],
-} as unknown as AggregationWidgetConfig;
+const config = AggregationWidgetConfig.builder()
+  .rowPivots([Pivot.createValues(['streams'])])
+  .columnPivots([])
+  .build();
 
 const fields = Immutable.List([new FieldTypeMapping('streams', FieldType.create('streams', []))]);
 
@@ -56,8 +57,7 @@ const Consumer = ({ k }: { k: string }) => {
 };
 
 describe('KeyMapperProvider', () => {
-  beforeAll(() => PluginStore.register(testPlugin));
-  afterAll(() => PluginStore.unregister(testPlugin));
+  usePlugin(testPlugin);
 
   it('provides a mapper that resolves keys via the registered binding for the field type', () => {
     render(

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useContext } from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import * as Immutable from 'immutable';
+
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+
+import KeyMapperProvider from './KeyMapperProvider';
+import KeyMapperContext from './KeyMapperContext';
+
+const testPlugin = {
+  exports: {
+    visualizationKeyMappers: [
+      {
+        type: 'streams',
+        useKeyMapper: () => (key: string) => (key === 'stream-1' ? 'All messages' : key),
+      },
+    ],
+  },
+};
+
+const config = {
+  rowPivots: [{ fields: ['streams'] }],
+  columnPivots: [],
+} as unknown as AggregationWidgetConfig;
+
+const fields = Immutable.List([new FieldTypeMapping('streams', FieldType.create('streams', []))]);
+
+const data = {
+  chart: [{ source: 'leaf', key: ['stream-1'], values: [] }],
+} as any;
+
+const Consumer = ({ k }: { k: string }) => {
+  const mapKeys = useContext(KeyMapperContext);
+
+  return <span>{mapKeys(k, 'streams')}</span>;
+};
+
+describe('KeyMapperProvider', () => {
+  beforeAll(() => PluginStore.register(testPlugin));
+  afterAll(() => PluginStore.unregister(testPlugin));
+
+  it('provides a mapper that resolves keys via the registered binding for the field type', () => {
+    render(
+      <KeyMapperProvider data={data} config={config} fields={fields}>
+        <Consumer k="stream-1" />
+      </KeyMapperProvider>,
+    );
+
+    expect(screen.getByText('All messages')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw key for unknown values', () => {
+    render(
+      <KeyMapperProvider data={data} config={config} fields={fields}>
+        <Consumer k="stream-unknown" />
+      </KeyMapperProvider>,
+    );
+
+    expect(screen.getByText('stream-unknown')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.test.tsx
@@ -35,6 +35,12 @@ const testPlugin = {
         type: 'streams',
         useKeyMapper: () => (key: string) => (key === 'stream-1' ? 'All messages' : key),
       },
+      // Asset-style binding: only resolves keys it was actually handed by the provider, so a test
+      // fails if collectKeysByType does not prefetch the right ids for a given pivot layout.
+      {
+        type: 'associated-assets',
+        useKeyMapper: (keys: Array<string>) => (key: string) => (keys.includes(String(key)) ? `Asset ${key}` : key),
+      },
     ],
   },
 };
@@ -44,16 +50,20 @@ const config = AggregationWidgetConfig.builder()
   .columnPivots([])
   .build();
 
-const fields = Immutable.List([new FieldTypeMapping('streams', FieldType.create('streams', []))]);
+const fields = Immutable.List([
+  new FieldTypeMapping('streams', FieldType.create('streams', [])),
+  new FieldTypeMapping('a', FieldType.create('streams', [])),
+  new FieldTypeMapping('b', FieldType.create('associated-assets', [])),
+]);
 
 const data = {
   chart: [{ source: 'leaf', key: ['stream-1'], values: [] }],
 } as any;
 
-const Consumer = ({ k }: { k: string }) => {
+const Consumer = ({ k, field = 'streams' }: { k: string; field?: string }) => {
   const mapKeys = useContext(KeyMapperContext);
 
-  return <span>{mapKeys(k, 'streams')}</span>;
+  return <span>{mapKeys(k, field)}</span>;
 };
 
 describe('KeyMapperProvider', () => {
@@ -77,5 +87,50 @@ describe('KeyMapperProvider', () => {
     );
 
     expect(screen.getByText('stream-unknown')).toBeInTheDocument();
+  });
+
+  it('prefetches and resolves keys from the second of two row pivots (sankey/network layout)', () => {
+    const twoRowPivots = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.createValues(['a']), Pivot.createValues(['b'])])
+      .columnPivots([])
+      .build();
+    const twoRowPivotData = {
+      chart: [
+        { source: 'leaf', key: ['a1', 'b1'], values: [{ source: 'row-leaf', key: ['count()'], value: 5, rollup: true }] },
+        { source: 'leaf', key: ['a1', 'b2'], values: [{ source: 'row-leaf', key: ['count()'], value: 3, rollup: true }] },
+      ],
+    } as any;
+
+    render(
+      <KeyMapperProvider data={twoRowPivotData} config={twoRowPivots} fields={fields}>
+        <Consumer k="b1" field="b" />
+      </KeyMapperProvider>,
+    );
+
+    expect(screen.getByText('Asset b1')).toBeInTheDocument();
+  });
+
+  it('prefetches and resolves keys from a column pivot (one row + one column layout)', () => {
+    const rowAndColumn = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.createValues(['a'])])
+      .columnPivots([Pivot.createValues(['b'])])
+      .build();
+    const rowAndColumnData = {
+      chart: [
+        {
+          source: 'leaf',
+          key: ['a1'],
+          values: [{ source: 'col-leaf', key: ['b1', 'count()'], value: 5, rollup: false }],
+        },
+      ],
+    } as any;
+
+    render(
+      <KeyMapperProvider data={rowAndColumnData} config={rowAndColumn} fields={fields}>
+        <Consumer k="b1" field="b" />
+      </KeyMapperProvider>,
+    );
+
+    expect(screen.getByText('Asset b1')).toBeInTheDocument();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/KeyMapperProvider.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useCallback, useMemo } from 'react';
+
+import usePluginEntities from 'hooks/usePluginEntities';
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
+import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
+import type { Rows, Key } from 'views/logic/searchtypes/pivot/PivotHandler';
+import type { KeyMapper } from 'views/components/visualizations/TransformKeys';
+import collectKeysByType from 'views/components/visualizations/keyMappers/collectKeysByType';
+
+import KeyMapperContext from './KeyMapperContext';
+
+type Props = {
+  data: { [dataset: string]: Rows | unknown };
+  config: AggregationWidgetConfig;
+  fields: FieldTypeMappingsList;
+  children: React.ReactNode;
+};
+
+const KeyMapperProvider = ({ data, config, fields, children }: Props) => {
+  const bindings = usePluginEntities('visualizationKeyMappers');
+
+  const relevantTypes = useMemo(() => new Set((bindings ?? []).map((binding) => binding.type)), [bindings]);
+
+  const fieldTypeOf = useCallback((field: string) => fieldTypeFor(field, fields)?.type, [fields]);
+
+  const keysByType = useMemo(
+    () => collectKeysByType(data, config, fieldTypeOf, relevantTypes),
+    [data, config, fieldTypeOf, relevantTypes],
+  );
+
+  // Each binding contributes a resolver hook. Calling them while iterating is safe because plugin
+  // entries are registered once at module load, so this is a stable-length, stable-order list of
+  // hook calls on every render (the Rules of Hooks preconditions hold).
+  const mappers = (bindings ?? []).map((binding) => binding.useKeyMapper(keysByType[binding.type] ?? []));
+  const mapperByType = Object.fromEntries((bindings ?? []).map((binding, idx) => [binding.type, mappers[idx]] as const));
+
+  const fieldTypeByName = useMemo(() => {
+    const pivotFields = [
+      ...(config?.rowPivots ?? []).flatMap((pivot) => pivot.fields),
+      ...(config?.columnPivots ?? []).flatMap((pivot) => pivot.fields),
+    ];
+
+    return Object.fromEntries(pivotFields.map((name) => [name, fieldTypeOf(name)]));
+  }, [config, fieldTypeOf]);
+
+  // Not memoized on purpose: the mapper must change identity whenever a binding's resolution
+  // changes (e.g. async asset titles arrive) so downstream chart memos recompute. The chart data
+  // itself is already recomputed every render (the rows object is rebuilt upstream per render),
+  // so there is no extra cost to stabilize against.
+  const mapKeys: KeyMapper = (key: Key, field: string) => {
+    const type = fieldTypeByName[field];
+
+    return (type ? mapperByType[type]?.(key) : undefined) ?? key;
+  };
+
+  return <KeyMapperContext.Provider value={mapKeys}>{children}</KeyMapperContext.Provider>;
+};
+
+export default KeyMapperProvider;

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/CoreKeyMappers.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/CoreKeyMappers.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+
+import StreamsContext from 'contexts/StreamsContext';
+
+import CoreKeyMappers from './CoreKeyMappers';
+
+const mapperFor = (type: string) => CoreKeyMappers.find((m) => m.type === type)!.useKeyMapper;
+
+jest.mock('hooks/useInputs', () => ({
+  useInputs: () => ({ 'input-1': { id: 'input-1', title: 'Syslog UDP' } }),
+}));
+
+jest.mock('hooks/useNodeSummaries', () => () => ({
+  'node-1': { short_node_id: 'abc123', hostname: 'graylog-01' },
+}));
+
+describe('CoreKeyMappers', () => {
+  it('resolves stream ids to titles and falls back to the raw id', () => {
+    const wrapper = ({ children }: React.PropsWithChildren) => (
+      <StreamsContext.Provider value={[{ id: 'stream-1', title: 'All messages' } as any]}>
+        {children}
+      </StreamsContext.Provider>
+    );
+    const { result } = renderHook(() => mapperFor('streams')([]), { wrapper });
+
+    expect(result.current('stream-1')).toBe('All messages');
+    expect(result.current('unknown')).toBe('unknown');
+  });
+
+  it('resolves input ids to titles', () => {
+    const { result } = renderHook(() => mapperFor('input')([]));
+
+    expect(result.current('input-1')).toBe('Syslog UDP');
+    expect(result.current('missing')).toBe('missing');
+  });
+
+  it('formats node ids as "short_node_id / hostname"', () => {
+    const { result } = renderHook(() => mapperFor('node')([]));
+
+    expect(result.current('node-1')).toBe('abc123 / graylog-01');
+    expect(result.current('missing')).toBe('missing');
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/CoreKeyMappers.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/CoreKeyMappers.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useCallback, useContext, useMemo } from 'react';
+import type { PluginExports } from 'graylog-web-plugin/plugin';
+
+import StreamsContext from 'contexts/StreamsContext';
+import { useInputs } from 'hooks/useInputs';
+import useNodeSummaries from 'hooks/useNodeSummaries';
+import type { Key } from 'views/logic/searchtypes/pivot/PivotHandler';
+
+const formatNode = (node: { short_node_id: string; hostname: string }) => `${node.short_node_id} / ${node.hostname}`;
+
+const useStreamsKeyMapper = () => {
+  const streams = useContext(StreamsContext);
+  const streamsMap = useMemo(() => Object.fromEntries((streams ?? []).map((stream) => [stream.id, stream])), [streams]);
+
+  return useCallback((key: Key) => streamsMap[key]?.title ?? key, [streamsMap]);
+};
+
+const useInputKeyMapper = () => {
+  const inputs = useInputs();
+
+  return useCallback((key: Key) => inputs?.[key]?.title ?? key, [inputs]);
+};
+
+const useNodeKeyMapper = () => {
+  const nodes = useNodeSummaries();
+
+  return useCallback((key: Key) => (nodes?.[key] ? formatNode(nodes[key]) : key), [nodes]);
+};
+
+const CoreKeyMappers: PluginExports['visualizationKeyMappers'] = [
+  { type: 'streams', useKeyMapper: useStreamsKeyMapper },
+  { type: 'input', useKeyMapper: useInputKeyMapper },
+  { type: 'node', useKeyMapper: useNodeKeyMapper },
+];
+
+export default CoreKeyMappers;

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+
+import collectKeysByType from './collectKeysByType';
+
+const config = {
+  rowPivots: [{ fields: ['streams'] }],
+  columnPivots: [{ fields: ['gl2_source_input'] }],
+} as unknown as AggregationWidgetConfig;
+
+const fieldTypeOf = (field: string) => ({ streams: 'streams', gl2_source_input: 'input' })[field];
+
+const data = {
+  chart: [
+    {
+      source: 'leaf',
+      key: ['stream-a'],
+      values: [
+        { source: 'col-leaf', key: ['input-1'], rollup: false, value: 5 },
+        { source: 'col-leaf', key: ['input-2'], rollup: false, value: 7 },
+      ],
+    },
+    {
+      source: 'leaf',
+      key: ['stream-b'],
+      values: [{ source: 'col-leaf', key: ['input-1'], rollup: false, value: 3 }],
+    },
+  ],
+  events: [{ something: true }],
+} as any;
+
+describe('collectKeysByType', () => {
+  it('groups distinct pivot key values by relevant field type', () => {
+    const result = collectKeysByType(data, config, fieldTypeOf, new Set(['streams', 'input']));
+
+    expect(result.streams.sort()).toEqual(['stream-a', 'stream-b']);
+    expect(result.input.sort()).toEqual(['input-1', 'input-2']);
+  });
+
+  it('omits field types that are not relevant', () => {
+    const result = collectKeysByType(data, config, fieldTypeOf, new Set(['input']));
+
+    expect(result.streams).toBeUndefined();
+    expect(result.input.sort()).toEqual(['input-1', 'input-2']);
+  });
+
+  it('ignores the events dataset and missing/null keys', () => {
+    const withNulls = {
+      chart: [{ source: 'leaf', key: [null], values: [] }],
+      events: [{ x: 1 }],
+    } as any;
+
+    const result = collectKeysByType(withNulls, config, fieldTypeOf, new Set(['streams']));
+
+    expect(result.streams).toBeUndefined();
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
@@ -14,14 +14,15 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
 
 import collectKeysByType from './collectKeysByType';
 
-const config = {
-  rowPivots: [{ fields: ['streams'] }],
-  columnPivots: [{ fields: ['gl2_source_input'] }],
-} as unknown as AggregationWidgetConfig;
+const config = AggregationWidgetConfig.builder()
+  .rowPivots([Pivot.createValues(['streams'])])
+  .columnPivots([Pivot.createValues(['gl2_source_input'])])
+  .build();
 
 const fieldTypeOf = (field: string) => ({ streams: 'streams', gl2_source_input: 'input' })[field];
 

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
@@ -42,7 +42,7 @@ const data = {
     },
   ],
   events: [{ something: true }],
-} as any;
+};
 
 describe('collectKeysByType', () => {
   it('groups distinct pivot key values by relevant field type', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.test.ts
@@ -63,7 +63,7 @@ describe('collectKeysByType', () => {
     const withNulls = {
       chart: [{ source: 'leaf', key: [null], values: [] }],
       events: [{ x: 1 }],
-    } as any;
+    };
 
     const result = collectKeysByType(withNulls, config, fieldTypeOf, new Set(['streams']));
 

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.ts
@@ -70,7 +70,7 @@ const collectKeysByType = (
       return;
     }
 
-    (rows as Rows).forEach(visitRow);
+    rows.forEach(visitRow);
   });
 
   return Object.fromEntries(Object.entries(acc).map(([type, values]) => [type, Array.from(values)]));

--- a/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/keyMappers/collectKeysByType.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import type { Rows, Row, Key } from 'views/logic/searchtypes/pivot/PivotHandler';
+
+type VisualizationData = { [dataset: string]: Rows | unknown };
+
+const pivotFieldsOf = (pivots: AggregationWidgetConfig['rowPivots']): Array<string> =>
+  (pivots ?? []).flatMap((pivot) => pivot.fields);
+
+const collectKeysByType = (
+  data: VisualizationData,
+  config: AggregationWidgetConfig,
+  fieldTypeOf: (field: string) => string | undefined,
+  relevantTypes: Set<string>,
+): Record<string, Array<string>> => {
+  const rowFields = pivotFieldsOf(config?.rowPivots);
+  const columnFields = pivotFieldsOf(config?.columnPivots);
+  const acc: Record<string, Set<string>> = {};
+
+  const add = (field: string | undefined, value: Key) => {
+    if (!field || value === null || value === undefined) {
+      return;
+    }
+
+    const type = fieldTypeOf(field);
+
+    if (!type || !relevantTypes.has(type)) {
+      return;
+    }
+
+    (acc[type] ??= new Set<string>()).add(String(value));
+  };
+
+  const collectKey = (key: Array<Key> | undefined, fields: Array<string>) =>
+    (key ?? []).forEach((value, idx) => add(fields[idx], value));
+
+  const visitRow = (row: Row) => {
+    if ('key' in row && Array.isArray(row.key)) {
+      collectKey(row.key, rowFields);
+    }
+
+    if ('values' in row && Array.isArray(row.values)) {
+      row.values.forEach((value) => {
+        if (value.source === 'col-leaf') {
+          collectKey(value.key, columnFields);
+        } else if ('values' in value) {
+          visitRow(value);
+        }
+      });
+    }
+  };
+
+  Object.entries(data).forEach(([dataset, rows]) => {
+    if (dataset === 'events' || !Array.isArray(rows)) {
+      return;
+    }
+
+    (rows as Rows).forEach(visitRow);
+  });
+
+  return Object.fromEntries(Object.entries(acc).map(([type, values]) => [type, Array.from(values)]));
+};
+
+export default collectKeysByType;

--- a/graylog2-web-interface/src/views/components/visualizations/sankey/__tests__/SankeyVisualization.asyncLabels.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/sankey/__tests__/SankeyVisualization.asyncLabels.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { render, waitFor } from 'wrappedTestingLibrary';
+import * as Immutable from 'immutable';
+
+import mockComponent from 'helpers/mocking/MockComponent';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import Series from 'views/logic/aggregationbuilder/Series';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
+import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
+import TestStoreProvider from 'views/test/TestStoreProvider';
+import useViewsPlugin from 'views/test/testViewsPlugin';
+import { usePlugin } from 'views/test/testPlugins';
+import asMock from 'helpers/mocking/AsMock';
+import GenericPlot from 'views/components/visualizations/GenericPlot';
+import KeyMapperProvider from 'views/components/visualizations/KeyMapperProvider';
+
+import * as fixtures from './fixtures';
+
+import SankeyVisualization from '../SankeyVisualization';
+
+jest.mock('../../GenericPlot', () => jest.fn(mockComponent('GenericPlot')));
+
+// Async asset-style resolver: ids resolve to names AFTER mount, mirroring getTitles.
+const asyncAssetPlugin = {
+  exports: {
+    visualizationKeyMappers: [
+      {
+        type: 'associated-assets',
+        useKeyMapper: (keys: Array<string>) => {
+          const [titles, setTitles] = useState<Record<string, string>>({});
+          const joined = useMemo(() => keys.join('|'), [keys]);
+
+          useEffect(() => {
+            setTitles(Object.fromEntries(keys.map((k) => [k, `Asset ${k}`])));
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+          }, [joined]);
+
+          return useCallback((k: string) => titles[k] ?? k, [titles]);
+        },
+      },
+    ],
+  },
+};
+
+const effectiveTimerange: AbsoluteTimeRange = {
+  type: 'absolute',
+  from: '2022-04-27T12:15:59.633Z',
+  to: '2022-04-27T12:20:59.633Z',
+};
+
+const fields = Immutable.List([
+  new FieldTypeMapping('a', FieldType.create('streams', [])),
+  new FieldTypeMapping('b', FieldType.create('associated-assets', [])),
+]) as FieldTypeMappingsList;
+
+const config = AggregationWidgetConfig.builder()
+  .rowPivots([Pivot.createValues(['a']), Pivot.createValues(['b'])])
+  .series([Series.forFunction('count()')])
+  .visualization('sankey')
+  .build();
+
+const baseProps = {
+  effectiveTimerange,
+  fields,
+  height: 800,
+  width: 600,
+  setLoadingState: () => {},
+  onChange: () => {},
+  toggleEdit: () => {},
+  config,
+};
+
+const lastTrace = () => {
+  const { calls } = asMock(GenericPlot).mock;
+
+  return calls[calls.length - 1][0].chartData[0];
+};
+
+describe('SankeyVisualization async asset labels', () => {
+  useViewsPlugin();
+  usePlugin(asyncAssetPlugin);
+
+  beforeEach(() => {
+    asMock(GenericPlot).mockClear();
+  });
+
+  it('passes asset names (not raw ids) to the plot once titles resolve', async () => {
+    render(
+      <TestStoreProvider>
+        <KeyMapperProvider data={fixtures.twoRowPivots} config={config} fields={fields}>
+          <SankeyVisualization {...baseProps} data={fixtures.twoRowPivots} />
+        </KeyMapperProvider>
+      </TestStoreProvider>,
+    );
+
+    await waitFor(() => expect(lastTrace().node.label).toEqual(['a1', 'Asset b1', 'Asset b2', 'a2']));
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/useMapKeys.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/useMapKeys.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+
+import type { KeyMapper } from 'views/components/visualizations/TransformKeys';
+
+import useMapKeys from './useMapKeys';
+import KeyMapperContext from './KeyMapperContext';
+
+describe('useMapKeys', () => {
+  it('returns the identity mapper when no provider is present', () => {
+    const { result } = renderHook(() => useMapKeys());
+
+    expect(result.current('raw-id', 'streams')).toBe('raw-id');
+  });
+
+  it('returns the mapper supplied by KeyMapperContext', () => {
+    const mapper: KeyMapper = (key, field) => `${field}:${key}`;
+    const wrapper = ({ children }: React.PropsWithChildren) => (
+      <KeyMapperContext.Provider value={mapper}>{children}</KeyMapperContext.Provider>
+    );
+
+    const { result } = renderHook(() => useMapKeys(), { wrapper });
+
+    expect(result.current('stream-1', 'streams')).toBe('streams:stream-1');
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/useMapKeys.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/useMapKeys.ts
@@ -14,42 +14,11 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useCallback, useContext, useMemo } from 'react';
+import { useContext } from 'react';
 
 import type { KeyMapper } from 'views/components/visualizations/TransformKeys';
-import StreamsContext from 'contexts/StreamsContext';
-import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
-import type { Key } from 'views/logic/searchtypes/pivot/PivotHandler';
-import { useInputs } from 'hooks/useInputs';
-import useNodeSummaries from 'hooks/useNodeSummaries';
+import KeyMapperContext from 'views/components/visualizations/KeyMapperContext';
 
-const formatNode = (node: { short_node_id: string; hostname: string }) => `${node.short_node_id} / ${node.hostname}`;
-
-const useMapKeys = (): KeyMapper => {
-  const streams = useContext(StreamsContext);
-  const streamsMap = useMemo(() => Object.fromEntries(streams?.map((stream) => [stream.id, stream]) ?? []), [streams]);
-  const nodes = useNodeSummaries();
-  const inputs = useInputs();
-  const fieldTypes = useContext(FieldTypesContext);
-  const currentFields = useMemo(() => fieldTypes?.currentQuery, [fieldTypes?.currentQuery]);
-
-  return useCallback(
-    (key: Key, field: string) => {
-      const fieldType = currentFields?.find((type) => type.name === field);
-
-      switch (fieldType?.type?.type) {
-        case 'node':
-          return nodes?.[key] ? formatNode(nodes[key]) : key;
-        case 'input':
-          return inputs?.[key]?.title ?? key;
-        case 'streams':
-          return streamsMap?.[key]?.title ?? key;
-        default:
-          return key;
-      }
-    },
-    [currentFields, inputs, nodes, streamsMap],
-  );
-};
+const useMapKeys = (): KeyMapper => useContext(KeyMapperContext);
 
 export default useMapKeys;

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -68,6 +68,7 @@ import type { EntityPermissionsMapper } from 'logic/permissions/EntityPermission
 import type { WidgetsState } from 'views/logic/slices/widgetsSlice';
 import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import type { DEFAULT_AXIS_KEY } from 'views/components/visualizations/Constants';
+import type { Key } from 'views/logic/searchtypes/pivot/PivotHandler';
 
 export type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]
   ? ElementType
@@ -662,6 +663,10 @@ declare module 'graylog-web-plugin/plugin' {
     fieldTypeValueRenderer?: Array<{
       type: string;
       render: (value: unknown, field: string, render: React.ComponentType<ValueRendererProps>) => React.ReactNode;
+    }>;
+    visualizationKeyMappers?: Array<{
+      type: string;
+      useKeyMapper: (keys: Array<string>) => (key: Key) => Key;
     }>;
     messageAugmentations?: Array<MessageAugmentation>;
     searchTypes?: Array<SearchType<any, any>>;


### PR DESCRIPTION
## Description

Replaces the hardcoded `switch` that mapped visualization keys to chart labels with a pluggable `visualizationKeyMappers` plugin extension point. A new `KeyMapperProvider` reads the registered mappers and exposes the resolved mapper through `KeyMapperContext`, consumed via `useMapKeys`. The core mappers previously inlined in `useMapKeys` now live in `CoreKeyMappers` and are registered as the default binding. A `collectKeysByType` helper resolves which keys each mapper applies to.

## Motivation and Context

The label-resolution logic was a closed `switch` in `useMapKeys`, so plugins could not contribute their own visualization key mappers. Extracting it into a `visualizationKeyMappers` plugin key makes label resolution extensible while keeping the existing behavior intact for the core visualizations.

## How Has This Been Tested?

Added unit tests for `collectKeysByType`, `CoreKeyMappers`, `KeyMapperProvider`, and `useMapKeys`, plus updates to `AggregationBuilder` tests. Verified with `yarn tsgo`, `yarn lint:changes`, and `yarn test`.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Internal frontend refactor; introduces a plugin extension point for visualization key mappers with no end-user-visible behavior change.