### PR TITLE
Allow Edit of Sigma Event Definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -257,13 +257,11 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
           bsSize="xsmall"
         />
         <MoreActions>
-          {(!isSigmaEventDefinition(eventDefinition) || showActions()) && (
             <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
               <MenuItem onClick={onEditEventDefinition} data-testid="edit-button">
                 Edit
               </MenuItem>
             </IfPermitted>
-          )}
           <IfPermitted permissions="eventdefinitions:create">
             {!isSystemEventDefinition(eventDefinition) && !isSigmaEventDefinition(eventDefinition) && (
               <MenuItem onClick={() => handleAction(DIALOG_TYPES.COPY, eventDefinition)}>Duplicate</MenuItem>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Revert previous change that completely blocked edits of non-DEFAULT-scoped Sigma event definitions in the UI.
/nocl reverting unreleased change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

