### PR TITLE
Fix "Fleet" filter on the Collector Instances page

### DIFF
--- a/changelog/unreleased/pr-26485.toml
+++ b/changelog/unreleased/pr-26485.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Fix fleet filter on the Collector instances table."
+
+pulls = ["26485"]

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/FleetDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/FleetDTO.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
-import org.graylog.collectors.FleetService;
 import org.graylog.collectors.CollectorsPermissions;
+import org.graylog.collectors.FleetService;
 import org.graylog2.database.BuildableMongoEntity;
 import org.graylog2.database.DbEntity;
 
@@ -30,7 +30,12 @@ import java.time.Instant;
 
 @AutoValue
 @JsonDeserialize(builder = FleetDTO.Builder.class)
-@DbEntity(collection = FleetService.COLLECTION_NAME, titleField = FleetDTO.FIELD_NAME, readPermission = CollectorsPermissions.FLEET_READ)
+@DbEntity(
+        collection = FleetService.COLLECTION_NAME,
+        titleField = FleetDTO.FIELD_NAME,
+        readPermission = CollectorsPermissions.FLEET_READ,
+        readableFields = {"_id", FleetDTO.FIELD_NAME}
+)
 public abstract class FleetDTO implements BuildableMongoEntity<FleetDTO, FleetDTO.Builder> {
     public static final String FIELD_NAME = "name";
     public static final String FIELD_DESCRIPTION = "description";

--- a/graylog2-server/src/main/java/org/graylog/collectors/rest/CollectorInstancesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/rest/CollectorInstancesResource.java
@@ -128,6 +128,7 @@ public class CollectorInstancesResource extends RestResource {
                     .title("Fleet")
                     .relatedCollection(FleetService.COLLECTION_NAME)
                     .relatedIdentifier("_id")
+                    .relatedProperty(FleetDTO.FIELD_NAME)
                     .relatedDisplayFields(List.of(FleetDTO.FIELD_NAME))
                     .relatedDisplayTemplate("{name}")
                     .type(SearchQueryField.Type.OBJECT_ID)


### PR DESCRIPTION
The "readableFields" setting was missing on the DbEntities annotation in the FleetDTO class.

Also set "name" as relatedProperty for fleets, so it doesn't default to "title". (which doesn't exist on fleets)