### PR TITLE
Add unit tests for SyslogUtils

### DIFF
--- a/changelog/unreleased/issue-26488.toml
+++ b/changelog/unreleased/issue-26488.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Add unit tests for `SyslogUtils` covering the RFC 5424 severity/facility lookups and the priority decomposition helpers."
+
+pulls = ["Graylog2/graylog2-server#26488"]

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/syslog/SyslogUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.syslog;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyslogUtilsTest {
+
+    @ParameterizedTest(name = "level {0} -> \"{1}\"")
+    @CsvSource({
+            "0, Emergency",
+            "1, Alert",
+            "2, Critical",
+            "3, Error",
+            "4, Warning",
+            "5, Notice",
+            "6, Informational",
+            "7, Debug",
+    })
+    void levelToString_mapsRfc5424Severities(int level, String expected) {
+        assertThat(SyslogUtils.levelToString(level)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "out-of-range level {0} -> \"Unknown\"")
+    @ValueSource(ints = {-1, 8, 9, 100, Integer.MAX_VALUE, Integer.MIN_VALUE})
+    void levelToString_returnsUnknownForOutOfRange(int level) {
+        assertThat(SyslogUtils.levelToString(level)).isEqualTo("Unknown");
+    }
+
+    @ParameterizedTest(name = "facility {0} -> \"{1}\"")
+    @CsvSource({
+            "0, kern",
+            "1, user",
+            "2, mail",
+            "3, daemon",
+            "4, auth",
+            "5, syslog",
+            "6, lpr",
+            "7, news",
+            "8, uucp",
+            "9, clock",
+            "10, authpriv",
+            "11, ftp",
+            "12, ntp",
+            "13, log audit",
+            "14, log alert",
+            "15, cron",
+            "16, local0",
+            "17, local1",
+            "18, local2",
+            "19, local3",
+            "20, local4",
+            "21, local5",
+            "22, local6",
+            "23, local7",
+    })
+    void facilityToString_mapsRfc5424Facilities(int facility, String expected) {
+        assertThat(SyslogUtils.facilityToString(facility)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "out-of-range facility {0} -> \"Unknown\"")
+    @ValueSource(ints = {-1, 24, 25, 100, Integer.MAX_VALUE, Integer.MIN_VALUE})
+    void facilityToString_returnsUnknownForOutOfRange(int facility) {
+        assertThat(SyslogUtils.facilityToString(facility)).isEqualTo("Unknown");
+    }
+
+    @ParameterizedTest(name = "priority {0} -> facility {1}, level {2}")
+    @CsvSource({
+            // priority, expectedFacility, expectedLevel  (RFC 5424: PRI = facility * 8 + severity)
+            "0,   0,  0",   // kern / Emergency
+            "7,   0,  7",   // kern / Debug
+            "8,   1,  0",   // user / Emergency
+            "34,  4,  2",   // auth / Critical   (RFC 5424 worked example)
+            "165, 20, 5",   // local4 / Notice   (RFC 5424 worked example)
+            "191, 23, 7",   // local7 / Debug    (maximum standard PRI)
+    })
+    void facilityAndLevelFromPriority_decomposePri(int priority, int expectedFacility, int expectedLevel) {
+        assertThat(SyslogUtils.facilityFromPriority(priority)).isEqualTo(expectedFacility);
+        assertThat(SyslogUtils.levelFromPriority(priority)).isEqualTo(expectedLevel);
+    }
+
+    @Test
+    void facilityAndLevelFromPriority_recomposeToOriginalPriority() {
+        // For every valid PRI value, facility * 8 + level must reconstruct the original priority.
+        for (int priority = 0; priority <= 191; priority++) {
+            final int facility = SyslogUtils.facilityFromPriority(priority);
+            final int level = SyslogUtils.levelFromPriority(priority);
+            assertThat((facility << 3) + level)
+                    .as("priority %d should round-trip through facility/level", priority)
+                    .isEqualTo(priority);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds unit test coverage for `SyslogUtils`, which previously had no tests. This is a test-only change — no production code is modified.

## Motivation and Context

`SyslogUtils` provides the RFC 5424 syslog severity/facility name lookups (`levelToString`, `facilityToString`) and the priority decomposition helpers (`levelFromPriority`, `facilityFromPriority`) used by the pipeline processor's syslog functions. It had no test coverage, so a future change could silently break the RFC 5424 mappings without any test failing. These characterization tests pin the documented behavior.

## How Has This Been Tested?

Added `SyslogUtilsTest` (JUnit 5 + AssertJ, matching the module's house style). 51 parameterized cases:

- all severities `0`–`7` map to the RFC 5424 names, and out-of-range values (incl. `Integer.MIN/MAX_VALUE`) return `"Unknown"`;
- all facilities `0`–`23` map to their names, and out-of-range values return `"Unknown"`;
- priority decomposition, including the two RFC 5424 worked examples (PRI `34` → `auth`/`Critical`, PRI `165` → `local4`/`Notice`);
- a round-trip property check confirming `facility * 8 + level == priority` for every valid PRI value `0`–`191`.

All 51 cases pass locally.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Test-only change: adds coverage for existing behavior, no functional change.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation. (n/a — test-only)
