### PR TITLE
fix(cluster): cache cluster traffic query to stop refetch flood

### DIFF
--- a/graylog2-web-interface/src/components/cluster/hooks/useClusterTraffic.ts
+++ b/graylog2-web-interface/src/components/cluster/hooks/useClusterTraffic.ts
@@ -32,6 +32,7 @@ const useClusterTraffic = (days: number) => {
       ),
     enabled: !!days,
     placeholderData: keepPreviousData,
+    staleTime: 30_000,
   });
 
   return { traffic, isLoading };


### PR DESCRIPTION
### Problem

On Enterprise pages that render the traffic graph (System > Overview, Licenses),
the `TrafficGraph` subtree is remounted repeatedly. `/api/system/cluster/traffic`
returns `200`, but with react-query's default `staleTime: 0` + `refetchOnMount` it
refetches on every fresh mount, flooding the backend at a high rate.

### Fix

`useClusterTraffic` — add `staleTime: 30_000`. Traffic is a multi-day aggregate, so a
30s window is more than fresh enough and collapses remount-driven refetches into cache
hits.
/nocl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

