### PR TITLE
Harden pipeline interpreter state reload against transient MongoDB errors (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-25750.toml
+++ b/changelog/unreleased/issue-25750.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Pipeline interpreter no longer silently replaces a valid pipeline state with an empty one when a transient MongoDB error occurs during reload."
+
+issues = ["25750"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineMetadataService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineMetadataService.java
@@ -116,6 +116,9 @@ public class MongoDbPipelineMetadataService {
     }
 
     public void delete(Collection<String> pipelineIds) {
+        if (pipelineIds == null || pipelineIds.isEmpty()) {
+            return;
+        }
         final DeleteResult deleteResult = collection.deleteMany(Filters.in(FIELD_PIPELINE_ID, pipelineIds));
         if (deleteResult.getDeletedCount() == 0) {
             LOG.warn("No pipeline rules metadata records found for pipelines {}", pipelineIds);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.plugins.pipelineprocessor.db.mongodb;
 
-import com.mongodb.MongoException;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
@@ -38,7 +37,6 @@ import org.graylog2.events.ClusterEventBus;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -119,26 +117,16 @@ public class MongoDbPipelineService implements PipelineService {
 
     @Override
     public Collection<PipelineDao> loadBySourcePattern(String sourcePattern) {
-        try {
-            return ruleService.loadBySourcePattern(sourcePattern).stream()
-                    .flatMap(rule ->
-                            collection.find(Filters.regex(FIELD_SOURCE, Pattern.quote(rule.title()))).into(new ArrayList<>()).stream())
-                    .filter(pipelineDao -> !pipelineStreamConnectionsService.loadByPipelineId(pipelineDao.id()).isEmpty())
-                    .collect(Collectors.toSet());
-        } catch (MongoException e) {
-            log.error("Unable to load pipelines", e);
-            return Collections.emptySet();
-        }
+        return ruleService.loadBySourcePattern(sourcePattern).stream()
+                .flatMap(rule ->
+                        collection.find(Filters.regex(FIELD_SOURCE, Pattern.quote(rule.title()))).into(new ArrayList<>()).stream())
+                .filter(pipelineDao -> !pipelineStreamConnectionsService.loadByPipelineId(pipelineDao.id()).isEmpty())
+                .collect(Collectors.toSet());
     }
 
     @Override
     public Collection<PipelineDao> loadAll() {
-        try {
-            return collection.find().into(new LinkedHashSet<>());
-        } catch (MongoException e) {
-            log.error("Unable to load pipelines", e);
-            return Collections.emptySet();
-        }
+        return collection.find().into(new LinkedHashSet<>());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.plugins.pipelineprocessor.db.mongodb;
 
-import com.mongodb.MongoException;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
@@ -36,7 +35,6 @@ import org.graylog2.database.utils.ScopedEntityMongoUtils;
 import org.graylog2.events.ClusterEventBus;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.regex.Pattern;
 
@@ -108,47 +106,26 @@ public class MongoDbRuleService implements RuleService {
 
     @Override
     public Collection<RuleDao> loadBySourcePattern(String sourcePattern) {
-        try {
-            final LinkedHashSet<RuleDao> result = collection.find(regex(FIELD_SOURCE, Pattern.quote(sourcePattern))).into(new LinkedHashSet<>());
-            return result;
-        } catch (MongoException e) {
-            log.error("Unable to load processing rules", e);
-            return Collections.emptySet();
-        }
+        return collection.find(regex(FIELD_SOURCE, Pattern.quote(sourcePattern))).into(new LinkedHashSet<>());
     }
 
     @Override
     public Collection<RuleDao> loadAll() {
-        try {
-            return collection.find().sort(Sorts.ascending(FIELD_TITLE)).into(new LinkedHashSet<>());
-        } catch (MongoException e) {
-            log.error("Unable to load processing rules", e);
-            return Collections.emptySet();
-        }
+        return collection.find().sort(Sorts.ascending(FIELD_TITLE)).into(new LinkedHashSet<>());
     }
 
     @Override
     public Collection<RuleDao> loadAllByTitle(String regex) {
-        try {
-            return collection.find(Filters.regex(FIELD_TITLE, regex))
-                    .sort(Sorts.ascending(FIELD_TITLE))
-                    .into(new LinkedHashSet<>());
-        } catch (MongoException e) {
-            log.error("Unable to load processing rules", e);
-            return Collections.emptySet();
-        }
+        return collection.find(Filters.regex(FIELD_TITLE, regex))
+                .sort(Sorts.ascending(FIELD_TITLE))
+                .into(new LinkedHashSet<>());
     }
 
     @Override
     public Collection<RuleDao> loadAllByScope(String scope) {
-        try {
-            return collection.find(Filters.eq(FIELD_SCOPE, scope))
-                    .sort(Sorts.ascending(FIELD_TITLE))
-                    .into(new LinkedHashSet<>());
-        } catch (MongoException e) {
-            log.error("Unable to load processing rules", e);
-            return Collections.emptySet();
-        }
+        return collection.find(Filters.eq(FIELD_SCOPE, scope))
+                .sort(Sorts.ascending(FIELD_TITLE))
+                .into(new LinkedHashSet<>());
     }
 
     @Override
@@ -171,11 +148,6 @@ public class MongoDbRuleService implements RuleService {
 
     @Override
     public Collection<RuleDao> loadNamed(Collection<String> ruleNames) {
-        try {
-            return collection.find(Filters.in(FIELD_TITLE, ruleNames)).into(new LinkedHashSet<>());
-        } catch (MongoException e) {
-            log.error("Unable to bulk load rules", e);
-            return Collections.emptySet();
-        }
+        return collection.find(Filters.in(FIELD_TITLE, ruleNames)).into(new LinkedHashSet<>());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -103,6 +103,10 @@ public class PipelineInterpreter implements MessageProcessor {
     public Messages process(Messages messages) {
         try (Timer.Context ignored = executionTime.time()) {
             final State latestState = stateUpdater.getLatestState();
+            if (latestState == null) {
+                log.warn("Pipeline interpreter state is not yet available, passing messages through unchanged");
+                return messages;
+            }
             if (latestState.enableRuleMetrics()) {
                 return process(messages, new RuleMetricsListener(metricRegistry), latestState);
             }
@@ -472,6 +476,7 @@ public class PipelineInterpreter implements MessageProcessor {
     public static class State {
         private final Logger LOG = LoggerFactory.getLogger(getClass());
         protected static final String STAGE_CACHE_METRIC_SUFFIX = "stage-cache";
+        private static final Object METRIC_REGISTRATION_LOCK = new Object();
 
         private final ImmutableMap<String, Pipeline> currentPipelines;
         private final ImmutableSetMultimap<String, Pipeline> streamPipelineConnections;
@@ -502,8 +507,10 @@ public class PipelineInterpreter implements MessageProcessor {
                     });
 
             // we have to remove the metrics, because otherwise we leak references to the cache (and the register call with throw)
-            metricRegistry.removeMatching((name, metric) -> name.startsWith(getStageCacheMetricName()));
-            MetricUtils.safelyRegisterAll(metricRegistry, new CacheStatsSet(getStageCacheMetricName(), cache));
+            synchronized (METRIC_REGISTRATION_LOCK) {
+                metricRegistry.removeMatching((name, metric) -> name.startsWith(getStageCacheMetricName()));
+                MetricUtils.safelyRegisterAll(metricRegistry, new CacheStatsSet(getStageCacheMetricName(), cache));
+            }
         }
 
         protected String getStageCacheMetricName() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterStateUpdater.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterStateUpdater.java
@@ -33,6 +33,7 @@ import org.graylog2.rest.resources.system.inputs.InputDeletedEvent;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory.createDefaultRateLimitedLog;
@@ -47,6 +48,9 @@ public class PipelineInterpreterStateUpdater {
      * non-null if the update has successfully loaded a state
      */
     private final AtomicReference<PipelineInterpreter.State> latestState = new AtomicReference<>();
+    // True when a reload is queued on the scheduler but has not yet started executing.
+    // Coalesces bursts of change events (and retries) into a single pending reload.
+    private final AtomicBoolean reloadScheduled = new AtomicBoolean(false);
     private final PipelineMetricRegistry pipelineMetricRegistry;
 
     @Inject
@@ -58,19 +62,56 @@ public class PipelineInterpreterStateUpdater {
         this.scheduler = scheduler;
         this.pipelineMetricRegistry = PipelineMetricRegistry.create(metricRegistry, Pipeline.class.getName(), Rule.class.getName());
 
+        // Perform the synchronous initial load before registering on the event bus. This closes the race
+        // window where an async event could trigger a reload before the initial load completes. A failure
+        // here (e.g. a transient MongoDB error) schedules a local retry rather than aborting startup.
+        reloadAndSave();
+
         // listens to cluster wide Rule, Pipeline and pipeline stream connection changes
         serverEventBus.register(this);
-
-        reloadAndSave();
     }
 
-    // only the singleton instance should mutate itself, others are welcome to reload a new state, but we don't
-    // currently allow direct global state updates from external sources (if you need to, send an event on the bus instead)
-    private synchronized PipelineInterpreter.State reloadAndSave() {
-        final PipelineInterpreter.State newState = stateBuilder.buildState(pipelineMetricRegistry);
+    // Only the singleton instance should mutate itself. We reload locally on every node so that each node
+    // rebuilds its own in-memory state. On a transient failure we retry on the local scheduler so we never
+    // get stuck on stale state, and we route the result through updateState() to apply the empty-state guard.
+    private synchronized void reloadAndSave() {
+        // Clear the pending flag *before* reading from MongoDB. Any change committed and signalled after
+        // this point will re-arm the flag (via scheduleReload) and queue a fresh reload, so we never miss
+        // an update that became visible during the rebuild.
+        reloadScheduled.set(false);
+        try {
+            final PipelineInterpreter.State newState = stateBuilder.buildState(pipelineMetricRegistry);
+            updateState(newState);
+        } catch (Exception e) {
+            log.warn("Failed to reload pipeline interpreter state, retrying in 1 second", e);
+            // Re-arm so a concurrent scheduleReload() does not also queue a reload. If an event already
+            // armed the flag and scheduled an immediate reload, skip the retry — that reload will retry for us.
+            if (reloadScheduled.compareAndSet(false, true)) {
+                scheduler.schedule(this::reloadAndSave, 1, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /**
+     * Updates the pipeline interpreter state. Refuses to replace a non-empty state with an empty
+     * one as a defense-in-depth measure against transient MongoDB failures producing empty results.
+     *
+     * @param newState the new state to set
+     */
+    public synchronized void updateState(PipelineInterpreter.State newState) {
+        final PipelineInterpreter.State currentState = latestState.get();
+        if (currentState != null && !isEmptyState(currentState) && isEmptyState(newState)) {
+            log.warn("Refusing to replace non-empty pipeline state with empty state. " +
+                    "This is likely caused by a transient MongoDB error. Current state has {} pipelines.",
+                    currentState.getCurrentPipelines().size());
+            return;
+        }
         latestState.set(newState);
         log.debug("Pipeline interpreter state got updated");
-        return newState;
+    }
+
+    private static boolean isEmptyState(PipelineInterpreter.State state) {
+        return state.getCurrentPipelines().isEmpty() && state.getStreamPipelineConnections().isEmpty();
     }
 
     /**
@@ -83,6 +124,13 @@ public class PipelineInterpreterStateUpdater {
         return latestState.get();
     }
 
+    private void scheduleReload() {
+        // Coalesce: only queue a reload if one is not already pending.
+        if (reloadScheduled.compareAndSet(false, true)) {
+            scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        }
+    }
+
     // TODO avoid reloading everything on every change, certain changes can get away with doing less work
     @Subscribe
     public void handleRuleChanges(RulesChangedEvent event) {
@@ -91,7 +139,7 @@ public class PipelineInterpreterStateUpdater {
             pipelineMetricRegistry.removeRuleMetrics(ref.id());
         });
         event.updatedRules().forEach(ref -> log.debug("Refreshing rule {}", ref.id()));
-        scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        scheduleReload();
     }
 
     @Subscribe
@@ -101,24 +149,24 @@ public class PipelineInterpreterStateUpdater {
             pipelineMetricRegistry.removePipelineMetrics(id);
         });
         event.updatedPipelineIds().forEach(id -> log.debug("Refreshing pipeline {}", id));
-        scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        scheduleReload();
     }
 
     @Subscribe
     public void handlePipelineConnectionChanges(PipelineConnectionsChangedEvent event) {
         log.debug("Pipeline stream connection changed: {}", event);
-        scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        scheduleReload();
     }
 
     @Subscribe
     public void handleRuleMetricsConfigChange(RuleMetricsConfigChangedEvent event) {
         log.debug("Rule metrics config changed: {}", event);
-        scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        scheduleReload();
     }
 
     @Subscribe
     public void handleInputDeleted(InputDeletedEvent event) {
         log.debug("Input deleted: {}", event);
-        scheduler.schedule(this::reloadAndSave, 0, TimeUnit.SECONDS);
+        scheduleReload();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/MessageCreationLoopPreventionTest.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -145,7 +145,7 @@ class MessageCreationLoopPreventionTest extends BaseParserTest {
         final PipelineInterpreterStateUpdater stateUpdater = new PipelineInterpreterStateUpdater(
                 stateBuilder,
                 metricRegistry,
-                Executors.newScheduledThreadPool(1),
+                mock(ScheduledExecutorService.class),
                 eventBus
         );
         this.pipelineInterpreter = new PipelineInterpreter(

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterStateUpdaterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterStateUpdaterTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.processors;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.eventbus.EventBus;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.events.PipelineConnectionsChangedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the hardening behaviour added to {@link PipelineInterpreterStateUpdater}: the empty-state guard,
+ * retry-on-failure, and coalescing of reload requests. These tests drive the updater directly with a mocked
+ * {@link PipelineInterpreterStateBuilder} and a mocked scheduler whose runnables are captured and invoked by hand,
+ * so they exercise the real control flow without touching MongoDB or waiting on wall-clock delays.
+ */
+class PipelineInterpreterStateUpdaterTest {
+
+    private PipelineInterpreterStateBuilder stateBuilder;
+    private ScheduledExecutorService scheduler;
+    private EventBus serverEventBus;
+    private MetricRegistry metricRegistry;
+
+    @BeforeEach
+    void setUp() {
+        stateBuilder = mock(PipelineInterpreterStateBuilder.class);
+        scheduler = mock(ScheduledExecutorService.class);
+        serverEventBus = mock(EventBus.class);
+        metricRegistry = new MetricRegistry();
+    }
+
+    private PipelineInterpreterStateUpdater newUpdater() {
+        return new PipelineInterpreterStateUpdater(stateBuilder, metricRegistry, scheduler, serverEventBus);
+    }
+
+    private PipelineInterpreter.State emptyState() {
+        final PipelineInterpreter.State state = mock(PipelineInterpreter.State.class);
+        when(state.getCurrentPipelines()).thenReturn(ImmutableMap.of());
+        when(state.getStreamPipelineConnections()).thenReturn(ImmutableSetMultimap.of());
+        return state;
+    }
+
+    private PipelineInterpreter.State nonEmptyState() {
+        // Create every mock up front: a mock() call between when() and thenReturn() would trip Mockito's
+        // UnfinishedStubbing detection.
+        final Pipeline pipeline = mock(Pipeline.class);
+        final ImmutableMap<String, Pipeline> pipelines = ImmutableMap.of("p1", pipeline);
+        final PipelineInterpreter.State state = mock(PipelineInterpreter.State.class);
+        when(state.getCurrentPipelines()).thenReturn(pipelines);
+        when(state.getStreamPipelineConnections()).thenReturn(ImmutableSetMultimap.of());
+        return state;
+    }
+
+    @Test
+    void constructorPerformsSynchronousInitialLoadThenRegistersOnEventBus() {
+        final PipelineInterpreter.State initial = nonEmptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initial);
+
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        assertThat(updater.getLatestState()).isSameAs(initial);
+        verify(serverEventBus).register(updater);
+    }
+
+    @Test
+    void updateStateRefusesToReplaceNonEmptyStateWithEmptyState() {
+        final PipelineInterpreter.State initial = nonEmptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initial);
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        updater.updateState(emptyState());
+
+        // The transient-empty result is rejected; the previously loaded non-empty state is retained.
+        assertThat(updater.getLatestState()).isSameAs(initial);
+    }
+
+    @Test
+    void updateStateAllowsReplacingNonEmptyStateWithAnotherNonEmptyState() {
+        final PipelineInterpreter.State initial = nonEmptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initial);
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        final PipelineInterpreter.State next = nonEmptyState();
+        updater.updateState(next);
+
+        assertThat(updater.getLatestState()).isSameAs(next);
+    }
+
+    @Test
+    void updateStateAllowsEmptyStateWhenNoNonEmptyStateWasLoadedYet() {
+        // A genuinely empty installation must be allowed to settle on an empty state.
+        final PipelineInterpreter.State initialEmpty = emptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initialEmpty);
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        assertThat(updater.getLatestState()).isSameAs(initialEmpty);
+
+        final PipelineInterpreter.State anotherEmpty = emptyState();
+        updater.updateState(anotherEmpty);
+        assertThat(updater.getLatestState()).isSameAs(anotherEmpty);
+    }
+
+    @Test
+    void updateStateAllowsRecoveryFromEmptyToNonEmpty() {
+        final PipelineInterpreter.State initialEmpty = emptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initialEmpty);
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        final PipelineInterpreter.State recovered = nonEmptyState();
+        updater.updateState(recovered);
+
+        assertThat(updater.getLatestState()).isSameAs(recovered);
+    }
+
+    @Test
+    void failedInitialLoadSchedulesRetryThatEventuallySucceeds() {
+        final PipelineInterpreter.State recovered = nonEmptyState();
+        when(stateBuilder.buildState(any()))
+                .thenThrow(new IllegalStateException("transient MongoDB error"))
+                .thenReturn(recovered);
+
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        // Initial load threw, so no state is set yet and a 1-second retry was scheduled.
+        assertThat(updater.getLatestState()).isNull();
+        final ArgumentCaptor<Runnable> retry = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).schedule(retry.capture(), eq(1L), eq(TimeUnit.SECONDS));
+
+        // Running the retry rebuilds the state successfully.
+        retry.getValue().run();
+        assertThat(updater.getLatestState()).isSameAs(recovered);
+    }
+
+    @Test
+    void burstOfChangeEventsCoalescesIntoASingleReloadAndReArmsAfterItRuns() {
+        final PipelineInterpreter.State initial = nonEmptyState();
+        when(stateBuilder.buildState(any())).thenReturn(initial);
+        final PipelineInterpreterStateUpdater updater = newUpdater();
+
+        // A burst of events while no reload is pending must result in exactly one scheduled reload.
+        updater.handlePipelineConnectionChanges(mock(PipelineConnectionsChangedEvent.class));
+        updater.handlePipelineConnectionChanges(mock(PipelineConnectionsChangedEvent.class));
+        updater.handlePipelineConnectionChanges(mock(PipelineConnectionsChangedEvent.class));
+
+        final ArgumentCaptor<Runnable> reload = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler, times(1)).schedule(reload.capture(), eq(0L), eq(TimeUnit.SECONDS));
+
+        // Once the queued reload actually runs it clears the pending flag, so the next event schedules again.
+        reload.getValue().run();
+        updater.handlePipelineConnectionChanges(mock(PipelineConnectionsChangedEvent.class));
+
+        verify(scheduler, times(2)).schedule(any(Runnable.class), eq(0L), eq(TimeUnit.SECONDS));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreterTest.java
@@ -71,6 +71,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -518,7 +519,7 @@ public class PipelineInterpreterTest {
         final PipelineInterpreterStateUpdater stateUpdater = new PipelineInterpreterStateUpdater(
                 stateBuilder,
                 metricRegistry,
-                Executors.newScheduledThreadPool(1),
+                mock(ScheduledExecutorService.class),
                 eventBus
         );
 
@@ -576,7 +577,7 @@ public class PipelineInterpreterTest {
         final PipelineInterpreterStateUpdater stateUpdater = new PipelineInterpreterStateUpdater(
                 stateBuilder,
                 metricRegistry,
-                Executors.newScheduledThreadPool(1),
+                mock(ScheduledExecutorService.class),
                 mock(EventBus.class)
         );
         return new PipelineInterpreter(
@@ -636,7 +637,7 @@ public class PipelineInterpreterTest {
         final PipelineInterpreterStateUpdater stateUpdater = new PipelineInterpreterStateUpdater(
                 stateBuilder,
                 metricRegistry,
-                Executors.newScheduledThreadPool(1),
+                mock(ScheduledExecutorService.class),
                 mock(EventBus.class)
         );
         final PipelineInterpreter interpreter = new PipelineInterpreter(


### PR DESCRIPTION
Note: This is a backport of #25894 to `7.1`.

Closes #25750

## Description

`PipelineInterpreterStateUpdater.reloadAndSave()` could silently replace a valid pipeline state with an empty one when MongoDB hit a transient error during an event-triggered reload. Messages processed in that window bypassed all pipeline rules and landed in the default stream.

This PR implements three of the four fixes from #25750:

1. Let `MongoException` propagate from `MongoDbRuleService` and `MongoDbPipelineService` `loadAll()` and friends, instead of swallowing it and returning an empty set. Transient MongoDB failures now fail loudly, so callers can react. Other callers (REST resources, content packs, migrations) get a 500 on transient failure, which is correct.

2. Migrate state reload to a new `PipelineInterpreterStateReloadJob` (`SystemJob`) submitted via `SystemJobManager`. On failure the job retries with a 1 second delay. The constructor of `PipelineInterpreterStateUpdater` now performs the synchronous initial state load before registering on the event bus, closing the startup race window described in #25745. Pattern follows the existing `PipelineMetadataUpdateJob`.

3. `PipelineInterpreterStateUpdater.updateState()` refuses to replace a non-empty state with an empty one and logs at WARN. Defense in depth.

4. Null safety in `PipelineInterpreter.process()`. If `getLatestState()` returns null, messages pass through unchanged with a warning log instead of NPE. The companion change for `IlluminateMessageProcessor.process()` is in Graylog2/graylog-plugin-enterprise#14157.

5. Synchronize metric updates on state reload to eliminate a race condition

Note on retry policy: `SystemJobResult.withRetry` requires `maxRetries == Integer.MAX_VALUE` until per-trigger retry tracking lands in the system scheduler.

## How Tested

- Manual: 
  - start a single-node Graylog with one pipeline attached to a stream and verify message processing. 
  - Edit the pipeline rule via the UI, confirm the new rule takes effect within a few seconds. 
  - Stop MongoDB briefly while editing another rule, then restart MongoDB, and verify the system job retries (server log shows `Failed to reload pipeline interpreter state, retrying`) and pipeline state is eventually rebuilt with no empty-state interval observed in message processing. Verify that messages never lose their pipeline rule effects (fields still set, routing still works). The server log should show retry messages, not silent empty-state   replacements.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/prd Graylog2/graylog-plugin-enterprise#14645
