### PR TITLE
add event type to Badge onClick handler

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Badge.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.tsx
@@ -63,7 +63,7 @@ type Props = React.PropsWithChildren<{
   bsStyle?: ColorVariant;
   className?: string;
   'data-testid'?: string;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   onMouseEnter?: React.MouseEventHandler<HTMLElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLElement>;
   role?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In some cases, when we add an onClick handler to Badge, we need to add e.stopPropagation(). In the current onClick type implementation, we have nothing in the callback parameters. That causes a TS error. 
like here https://github.com/Graylog2/graylog-plugin-enterprise/pull/14636/changes#diff-fc06d32a631b7c264e25164ede49a403aeb159714639064b43d7943cb194be8e
To avoid this we have to add this type to onClick callback prameter

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl