### PR TITLE
Fix issue with broken order after adding a new column

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -328,6 +328,45 @@ describe('<EntityDataTable />', () => {
         status: { status: ATTRIBUTE_STATUS.show },
         title: { status: 'hide' },
       },
+      order: ['description', 'status'],
+    });
+  });
+
+  it('should use current column order when showing a column without user order preferences', async () => {
+    const onLayoutPreferencesChange = jest.fn();
+
+    render(
+      <EntityDataTable
+        {...defaultProps}
+        layoutPreferences={{
+          attributes: {
+            description: { status: ATTRIBUTE_STATUS.show },
+            status: { status: ATTRIBUTE_STATUS.show },
+            title: { status: ATTRIBUTE_STATUS.show },
+          },
+          order: [],
+        }}
+        defaultDisplayedColumns={['description', 'status', 'title']}
+        defaultColumnOrder={['description', 'status', 'stream', 'title']}
+        onLayoutPreferencesChange={onLayoutPreferencesChange}
+      />,
+    );
+
+    await screen.findByRole('columnheader', { name: /title/i });
+    await screen.findByRole('columnheader', { name: /status/i });
+    await screen.findByRole('columnheader', { name: /description/i });
+
+    await userEvent.click(await screen.findByRole('button', { name: /configure visible columns/i }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: /show stream/i }));
+
+    expect(onLayoutPreferencesChange).toHaveBeenCalledWith({
+      attributes: {
+        description: { status: ATTRIBUTE_STATUS.show },
+        status: { status: ATTRIBUTE_STATUS.show },
+        stream: { status: ATTRIBUTE_STATUS.show },
+        title: { status: ATTRIBUTE_STATUS.show },
+      },
+      order: ['description', 'status', 'stream', 'title'],
     });
   });
 

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
@@ -62,6 +62,34 @@ const updateColumnPreferences = (
   return updatedPreferences;
 };
 
+const insertColumnAtDefaultPosition = (
+  currentOrder: Array<string>,
+  columnId: string,
+  defaultColumnOrder: Array<string>,
+) => {
+  if (currentOrder.includes(columnId)) {
+    return currentOrder;
+  }
+
+  const defaultIdx = defaultColumnOrder.indexOf(columnId);
+
+  if (defaultIdx === -1) {
+    return [...currentOrder, columnId];
+  }
+
+  const insertIdx = currentOrder.findIndex((currentColumnId) => {
+    const currentDefaultIdx = defaultColumnOrder.indexOf(currentColumnId);
+
+    return currentDefaultIdx !== -1 && currentDefaultIdx > defaultIdx;
+  });
+
+  if (insertIdx === -1) {
+    return [...currentOrder, columnId];
+  }
+
+  return [...currentOrder.slice(0, insertIdx), columnId, ...currentOrder.slice(insertIdx)];
+};
+
 type Props<Entity extends EntityBase> = {
   columnOrder: Array<string>;
   columnDefinitions: Array<ColumnDef<Entity>>;
@@ -141,26 +169,18 @@ const useTable = <Entity extends EntityBase>({
         attributes: updateColumnPreferences(visibleAttributeColumns, removedColumns, layoutPreferences.attributes),
       };
 
-      // if user has a custom order, we need to update it to reflect the visibility changes
-      if (layoutPreferences.order) {
-        const newOrder = layoutPreferences.order.filter((colId) => !removedColumns.has(colId));
-
-        // Insert added columns at their default positions or at the end
-        [...addedColumns].forEach((colId) => {
-          const defaultIdx = defaultColumnOrder.indexOf(colId);
-          if (defaultIdx !== -1 && defaultIdx < newOrder.length) {
-            newOrder.splice(defaultIdx, 0, colId);
-          } else {
-            newOrder.push(colId);
-          }
-        });
-
-        newLayoutPreferences.order = newOrder;
-      }
+      const currentAttributeColumnOrder = columnOrder.filter((colId) => !UTILITY_COLUMNS.has(colId));
+      const baseOrder = layoutPreferences.order?.length ? layoutPreferences.order : currentAttributeColumnOrder;
+      const newOrder = [...addedColumns].reduce(
+        (result, colId) => insertColumnAtDefaultPosition(result, colId, defaultColumnOrder),
+        baseOrder.filter((colId) => !removedColumns.has(colId)),
+      );
+      newLayoutPreferences.order = newOrder;
 
       return onLayoutPreferencesChange(newLayoutPreferences);
     },
     [
+      columnOrder,
       columnVisibility,
       defaultColumnOrder,
       layoutPreferences.order,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The issue happened only for initial layouts that are not defined for the users. 
Because we use layoutPreferences.order  which is [] we send to BE only 
As we merge the new column into layoutPreferences.order, we send only ['new-column']. 

To fix the issue, when layoutPreferences.order  is empty, we use visible column order and merge a new column inside 



## Motivation and Context
fix: #26538

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl