### PR TITLE
Properly mock `usePermissions` in test of  `EditInputButton` component

### DIFF
--- a/graylog2-web-interface/src/components/inputs/EditInputButton.test.tsx
+++ b/graylog2-web-interface/src/components/inputs/EditInputButton.test.tsx
@@ -90,7 +90,7 @@ describe('EditInputButton', () => {
     asMock(useInputMutations).mockReturnValue({
       updateInput: updateInputMock,
     } as any);
-    asMock(usePermissions).mockReturnValue({ isPermitted: () => true });
+    asMock(usePermissions).mockReturnValue({ isPermitted: () => true, isAnyPermitted: () => true });
     asMock(useSendTelemetry).mockReturnValue(jest.fn());
     asMock(useLocation).mockReturnValue({
       pathname: '/system/input/diagnosis/input3',
@@ -135,7 +135,7 @@ describe('EditInputButton', () => {
   });
 
   it('does not render the button without edit permissions', () => {
-    asMock(usePermissions).mockReturnValue({ isPermitted: () => false });
+    asMock(usePermissions).mockReturnValue({ isPermitted: () => false, isAnyPermitted: () => true });
 
     renderSUT();
 


### PR DESCRIPTION
## Description
Adds `isAnyPermitted: () => true` to the `usePermissions` mock in `EditInputButton.test.tsx`. The component started calling `isAnyPermitted` after #26455, but the test mock introduced in #26491 only stubbed `isPermitted`, leaving `isAnyPermitted` undefined at runtime.

## Motivation and Context
The overlapping merges of #26491 and #26455 introduced a build/test failure: `EditInputButton` now invokes `isAnyPermitted`, which the test's `usePermissions` mock did not provide. This fixes the resulting failure.

## How Has This Been Tested?
Ran the `EditInputButton` test suite locally.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Test-only fix for a build error introduced by overlapping merges of #26491 and #26455.