### PR TITLE
Render collectors settings inline instead of redirecting when unconfigured

### DIFF
--- a/graylog2-web-interface/src/pages/CollectorsOverviewPage.test.tsx
+++ b/graylog2-web-interface/src/pages/CollectorsOverviewPage.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { asMock } from 'helpers/mocking';
+import { useCollectorsConfig } from 'components/collectors/hooks';
+import type { CollectorsConfig } from 'components/collectors/types';
+
+import CollectorsOverviewPage from './CollectorsOverviewPage';
+
+jest.mock('components/collectors/hooks');
+jest.mock('./CollectorsSettingsPage', () => () => <div>collectors settings page</div>);
+jest.mock('components/collectors/overview', () => ({ CollectorsOverview: () => <div>collectors overview</div> }));
+jest.mock('components/collectors/common', () => ({ CollectorsPageNavigation: () => <div>collectors nav</div> }));
+
+describe('CollectorsOverviewPage', () => {
+  it('renders the settings page instead of the overview when the config is missing', () => {
+    asMock(useCollectorsConfig).mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<CollectorsOverviewPage />);
+
+    expect(screen.getByText('collectors settings page')).toBeInTheDocument();
+    expect(screen.queryByText('collectors overview')).not.toBeInTheDocument();
+  });
+
+  it('renders the overview once the config exists', () => {
+    asMock(useCollectorsConfig).mockReturnValue({
+      data: { signing_cert_id: 'signing-id' } as unknown as CollectorsConfig,
+      isLoading: false,
+    });
+
+    render(<CollectorsOverviewPage />);
+
+    expect(screen.getByText('collectors overview')).toBeInTheDocument();
+    expect(screen.queryByText('collectors settings page')).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/pages/CollectorsOverviewPage.tsx
+++ b/graylog2-web-interface/src/pages/CollectorsOverviewPage.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { Navigate } from 'react-router-dom';
 
 import { Row, Col } from 'components/bootstrap';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -24,7 +23,8 @@ import BetaBadge from 'components/common/BetaBadge';
 import { CollectorsOverview } from 'components/collectors/overview';
 import { CollectorsPageNavigation } from 'components/collectors/common';
 import { useCollectorsConfig } from 'components/collectors/hooks';
-import Routes from 'routing/Routes';
+
+import CollectorsSettingsPage from './CollectorsSettingsPage';
 
 const CollectorsOverviewPage = () => {
   const productName = useProductName();
@@ -39,7 +39,7 @@ const CollectorsOverviewPage = () => {
   }
 
   if (!config?.signing_cert_id) {
-    return <Navigate to={Routes.SYSTEM.COLLECTORS.SETTINGS} />;
+    return <CollectorsSettingsPage />;
   }
 
   return (


### PR DESCRIPTION
## Description
When the collectors configuration is missing (no `signing_cert_id`), `CollectorsOverviewPage` now renders `CollectorsSettingsPage` inline instead of redirecting to `/system/collectors/settings`. Once settings are saved, the `['collectors']` query cache is invalidated (a superset of `['collectors', 'config']`), so the overview appears automatically without a manual navigation.

## Motivation and Context
Redirecting to a separate settings route on first use was jarring and made the flow feel disjointed. Rendering the settings inline keeps the user on the overview page and lets it populate seamlessly once configured. This is WIP feature work being iterated on.

## How Has This Been Tested?
Added tests in `CollectorsOverviewPage.test.tsx` covering the unconfigured (renders settings inline) and configured (renders overview) states.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl WIP feature iteration, not yet user-facing