### PR TITLE
Ban direct useNavigate import in favor of routing/useHistory

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -178,6 +178,11 @@ export default [
               message: 'Please use `routing/useLocation` instead.',
             },
             {
+              name: 'react-router-dom',
+              importNames: ['useNavigate'],
+              message: 'Please use `routing/useHistory` instead.',
+            },
+            {
               name: 'create-react-class',
               message: 'Please use an ES6 or functional component instead.',
             },

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { LinkContainer, IfPermitted, ShareButton, ConfirmDialog } from 'components/common';
 import { ButtonToolbar, MenuItem, DeleteMenuItem } from 'components/bootstrap';
@@ -89,7 +89,7 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
   const [showEntityShareModal, setShowEntityShareModal] = useState(false);
   const { pathname } = useLocation();
   const sendTelemetry = useSendTelemetry();
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const { actions: pluggableActions, actionModals: pluggableActionModals } =
     usePluggableEntitySharedActions<EventDefinition>(eventDefinition, 'event_definition');
   const moreActions = [pluggableActions.length ? pluggableActions : null].filter(Boolean);
@@ -243,7 +243,7 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
     }
   };
 
-  const onEditEventDefinition = () => navigate(Routes.ALERTS.DEFINITIONS.edit(eventDefinition.id));
+  const onEditEventDefinition = () => push(Routes.ALERTS.DEFINITIONS.edit(eventDefinition.id));
 
   const isEnabled = eventDefinition?.state === 'ENABLED';
 

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/CreateProfile.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -30,7 +29,6 @@ import useHistory from 'routing/useHistory';
 const CreateProfile = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
-  const navigate = useNavigate();
   const { createProfile } = useProfileMutations();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
   const location = useLocation<{ customFieldMappings: any }>();
@@ -57,10 +55,10 @@ const CreateProfile = () => {
           app_action_value: { mappingsQuantity: profile?.customFieldMappings?.length },
         });
 
-        navigate(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
+        history.push(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
       });
     },
-    [createProfile, navigate, sendTelemetry, telemetryPathName],
+    [createProfile, history, sendTelemetry, telemetryPathName],
   );
 
   useEffect(() => {

--- a/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetFieldTypeProfiles/EditProfile.tsx
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import omit from 'lodash/omit';
 
+import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -36,7 +36,7 @@ type Props = {
 
 const EditProfile = ({ profile }: Props) => {
   const sendTelemetry = useSendTelemetry();
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const { pathname } = useLocation();
   const { editProfile } = useProfileMutations();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
@@ -49,10 +49,10 @@ const EditProfile = ({ profile }: Props) => {
           app_action_value: { mappingsQuantity: newProfile?.customFieldMappings?.length },
         });
 
-        navigate(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
+        push(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
       });
     },
-    [editProfile, navigate, profile.id, sendTelemetry, telemetryPathName],
+    [editProfile, push, profile.id, sendTelemetry, telemetryPathName],
   );
 
   useEffect(() => {
@@ -67,8 +67,8 @@ const EditProfile = ({ profile }: Props) => {
       app_pathname: telemetryPathName,
       app_action_value: 'create-new-index-set-field-type-profile-canceled',
     });
-    navigate(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
-  }, [navigate, sendTelemetry, telemetryPathName]);
+    push(Routes.SYSTEM.INDICES.FIELD_TYPE_PROFILES.OVERVIEW);
+  }, [push, sendTelemetry, telemetryPathName]);
 
   const initialValues = useMemo(() => omit(profile, ['id', 'indexSetIds']), [profile]);
 

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateIndexSetTemplateButton.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateIndexSetTemplateButton.tsx
@@ -17,8 +17,8 @@
 
 import * as React from 'react';
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -30,7 +30,7 @@ const CreateIndexSetTemplateButton = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleClick = () => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.INDEX_SET_TEMPLATE.SELECT_OPENED, {
@@ -38,7 +38,7 @@ const CreateIndexSetTemplateButton = () => {
       app_action_value: 'select-index-set-template-opened',
     });
 
-    navigate(Routes.SYSTEM.INDICES.TEMPLATES.CREATE);
+    push(Routes.SYSTEM.INDICES.TEMPLATES.CREATE);
   };
 
   return (

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateTemplate.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/CreateTemplate.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
@@ -30,7 +29,6 @@ import useHistory from 'routing/useHistory';
 const CreateTemplate = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
-  const navigate = useNavigate();
   const { createTemplate } = useTemplateMutation();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
   const history = useHistory();
@@ -43,10 +41,10 @@ const CreateTemplate = () => {
       });
 
       createTemplate(template).then(() => {
-        navigate(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
+        history.push(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
       });
     },
-    [createTemplate, navigate, sendTelemetry, telemetryPathName],
+    [createTemplate, history, sendTelemetry, telemetryPathName],
   );
 
   useEffect(() => {

--- a/graylog2-web-interface/src/components/indices/IndexSetTemplates/EditTemplate.tsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetTemplates/EditTemplate.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import { getPathnameWithoutId } from 'util/URLUtils';
@@ -32,7 +32,7 @@ type Props = {
 
 const EditTemplate = ({ template }: Props) => {
   const sendTelemetry = useSendTelemetry();
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const { pathname } = useLocation();
   const { updateTemplate } = useTemplateMutation();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
@@ -45,10 +45,10 @@ const EditTemplate = ({ template }: Props) => {
           app_action_value: 'edit-index-set-template-edited',
         });
 
-        navigate(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
+        push(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
       });
     },
-    [updateTemplate, navigate, template.id, sendTelemetry, telemetryPathName],
+    [updateTemplate, push, template.id, sendTelemetry, telemetryPathName],
   );
 
   useEffect(() => {
@@ -63,8 +63,8 @@ const EditTemplate = ({ template }: Props) => {
       app_pathname: telemetryPathName,
       app_action_value: 'edit-index-set-template-cancelled',
     });
-    navigate(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
-  }, [navigate, sendTelemetry, telemetryPathName]);
+    push(Routes.SYSTEM.INDICES.TEMPLATES.OVERVIEW);
+  }, [push, sendTelemetry, telemetryPathName]);
 
   return (
     <TemplateForm

--- a/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/StartInputStep.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputSetupWizard/steps/StartInputStep.tsx
@@ -17,10 +17,10 @@
 import * as React from 'react';
 import { useState, useMemo } from 'react';
 import type { UseMutationResult } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { ClusterInputState } from '@graylog/server-api';
 
+import useHistory from 'routing/useHistory';
 import usePluginEntities from 'hooks/usePluginEntities';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import useLocation from 'routing/useLocation';
@@ -62,7 +62,7 @@ const StartInputStep = () => {
   const sendTelemetry = useSendTelemetry();
   const { pathname } = useLocation();
   const telemetryPathName = useMemo(() => getPathnameWithoutId(pathname), [pathname]);
-  const navigateTo = useNavigate();
+  const { push } = useHistory();
   const { goToPreviousStep, orderedSteps, activeStep, wizardData } = useInputSetupWizard();
   const isIlluminateFlow = wizardData.flow === INPUT_WIZARD_FLOWS.ILLUMINATE;
 
@@ -274,7 +274,7 @@ const StartInputStep = () => {
 
     if (!input) return;
 
-    navigateTo(Routes.SYSTEM.INPUT_DIAGNOSIS(input.id));
+    push(Routes.SYSTEM.INPUT_DIAGNOSIS(input.id));
   };
 
   const handleBackClick = () => {

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import usePluginEntities from 'hooks/usePluginEntities';
 import { Row, Col, Button, Label } from 'components/bootstrap';
@@ -34,7 +34,7 @@ type Props = {
 const Cache = ({ cache, noEdit = false }: Props) => {
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(cache);
   const plugin = usePluginEntities('lookupTableCaches').find((p: CachePluginType) => p.type === cache.config?.type);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const canEdit = !noEdit && !loadingScopePermissions && scopePermissions?.is_mutable;
 
@@ -43,7 +43,7 @@ const Cache = ({ cache, noEdit = false }: Props) => {
   }
 
   const handleEdit = () => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(cache.name));
+    push(Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(cache.name));
   };
 
   return (

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import * as JSON from 'util/json';
 import Routes from 'routing/Routes';
 import usePluginEntities from 'hooks/usePluginEntities';
@@ -39,7 +39,7 @@ const DataAdapter = ({ dataAdapter, noEdit = false }: Props) => {
   const [lookupKey, setLookupKey] = useState('');
   const [lookupResult, setLookupResult] = useState(null);
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(dataAdapter);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const canEdit = !noEdit && !loadingScopePermissions && scopePermissions?.is_mutable;
 
@@ -56,7 +56,7 @@ const DataAdapter = ({ dataAdapter, noEdit = false }: Props) => {
   };
 
   const handleEdit = () => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(dataAdapter.name));
+    push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(dataAdapter.name));
   };
 
   const plugin = usePluginEntities('lookupTableAdapters').find(

--- a/graylog2-web-interface/src/components/lookup-tables/adapter-list/column-renderers.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapter-list/column-renderers.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { MetricContainer, CounterRate } from 'components/metrics';
 import type { ColumnRenderers } from 'components/common/EntityDataTable';
@@ -48,11 +48,11 @@ const Title = styled.div`
 const TitleCol = ({ adapter, children }: { adapter: DataAdapterEntity; children: string }) => {
   const { errors } = useErrorsContext();
   const adapterErrorText = errors?.adapterErrors[adapter.name];
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const onClick = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(adapter?.name));
-  }, [navigate, adapter?.name]);
+    push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(adapter?.name));
+  }, [push, adapter?.name]);
 
   return (
     <TitleRow>

--- a/graylog2-web-interface/src/components/lookup-tables/adapter-list/use-actions.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapter-list/use-actions.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { MenuItem, DeleteMenuItem, BootstrapModalConfirm } from 'components/bootstrap';
 import { Spinner } from 'components/common';
@@ -37,11 +37,11 @@ function Actions({ adapter }: ActionsProps) {
   const sendTelemetry = useSendTelemetry();
   const { deleteDataAdapter, deletingDataAdapter } = useDeleteDataAdapter();
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(adapter);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleEdit = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(adapter.name));
-  }, [adapter, navigate]);
+    push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(adapter.name));
+  }, [adapter, push]);
 
   const handleDelete = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.LUT.DATA_ADAPTER_DELETED, {

--- a/graylog2-web-interface/src/components/lookup-tables/cache-list/column-renderers.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/cache-list/column-renderers.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import NumberUtils from 'util/NumberUtils';
 import { MetricsMapper, MetricContainer, CounterRate } from 'components/metrics';
@@ -45,11 +45,11 @@ const Title = styled.div`
 `;
 
 const TitleCol = ({ cache, children }: { cache: CacheEntity; children: string }) => {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const onClick = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.show(cache.name));
-  }, [navigate, cache.name]);
+    push(Routes.SYSTEM.LOOKUPTABLES.CACHES.show(cache.name));
+  }, [push, cache.name]);
 
   return (
     <TitleRow>

--- a/graylog2-web-interface/src/components/lookup-tables/cache-list/use-actions.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/cache-list/use-actions.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { MenuItem, DeleteMenuItem, BootstrapModalConfirm } from 'components/bootstrap';
 import { Spinner } from 'components/common';
@@ -37,11 +37,11 @@ function Actions({ cache }: ActionsProps) {
   const sendTelemetry = useSendTelemetry();
   const { deleteCache, deletingCache } = useDeleteCache();
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(cache);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleEdit = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(cache.name));
-  }, [navigate, cache.name]);
+    push(Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(cache.name));
+  }, [push, cache.name]);
 
   const handleDelete = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.LUT.CACHE_DELETED, {

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-form/index.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-form/index.tsx
@@ -18,8 +18,9 @@ import * as React from 'react';
 import { useMemo } from 'react';
 import { Formik } from 'formik';
 import type { FormikErrors } from 'formik';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Wizard, Spinner } from 'components/common';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
@@ -71,7 +72,7 @@ function LookupTableWizard() {
   const { lookupTable, loadingLookupTable } = useFetchLookupTable(lutIdOrName);
   const initialValues = useMemo(() => lookupTable || INIT_TABLE_VALUES, [lookupTable]);
   const [steps, { activeStep, setActiveStep }] = useSteps();
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const sendTelemetry = useSendTelemetry();
   const { createLookupTable, creatingLookupTable } = useCreateLookupTable();
   const { updateLookupTable, updatingLookupTable } = useUpdateLookupTable();
@@ -99,7 +100,7 @@ function LookupTableWizard() {
         },
       });
 
-      navigate(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW);
+      push(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW);
     });
   };
 

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-form/wizard-buttons.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-form/wizard-buttons.tsx
@@ -17,9 +17,9 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 import { useFormikContext } from 'formik';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import useScopePermissions from 'hooks/useScopePermissions';
 import { Button } from 'components/bootstrap';
@@ -42,7 +42,7 @@ type Props = {
 function WizardButtons({ isCreate, stepIds, activeStepId, onStepChange, isLoading }: Props) {
   const { values, submitForm, resetForm, isValid } = useFormikContext<LookupTableType>();
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(values);
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const onFirstStep = useMemo(() => stepIds.indexOf(activeStepId) === 0, [stepIds, activeStepId]);
   const onLastStep = useMemo(() => stepIds.indexOf(activeStepId) === stepIds.length - 1, [stepIds, activeStepId]);
 
@@ -64,7 +64,7 @@ function WizardButtons({ isCreate, stepIds, activeStepId, onStepChange, isLoadin
 
   const onCancel = () => {
     resetForm();
-    navigate(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW);
+    push(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW);
   };
 
   const canModify = useMemo(

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-list/column-renderers.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-list/column-renderers.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { useErrorsContext } from 'components/lookup-tables/contexts/ErrorsContext';
 import type { ColumnRenderers } from 'components/common/EntityDataTable';
@@ -47,11 +47,11 @@ const Title = styled.div`
 const TitleCol = ({ lut, children }: { lut: LookupTableEntity; children: string }) => {
   const { errors } = useErrorsContext();
   const tableErrorText = errors?.lutErrors[lut.name];
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const onClick = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.show(lut.name));
-  }, [navigate, lut.name]);
+    push(Routes.SYSTEM.LOOKUPTABLES.show(lut.name));
+  }, [push, lut.name]);
 
   return (
     <TitleRow>
@@ -63,11 +63,11 @@ const TitleCol = ({ lut, children }: { lut: LookupTableEntity; children: string 
 
 const CacheCol = ({ cacheId, caches }: { cacheId: string; caches: CachesMap }) => {
   const { errors } = useErrorsContext();
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const onClick = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.show(caches?.[cacheId]?.name));
-  }, [cacheId, caches, navigate]);
+    push(Routes.SYSTEM.LOOKUPTABLES.CACHES.show(caches?.[cacheId]?.name));
+  }, [cacheId, caches, push]);
 
   if (!caches || !cacheId || !caches[cacheId]) return <i>No cache</i>;
 
@@ -83,11 +83,11 @@ const CacheCol = ({ cacheId, caches }: { cacheId: string; caches: CachesMap }) =
 
 const DataAdapterCol = ({ dataAdapterId, dataAdapters }: { dataAdapterId: string; dataAdapters: AdaptersMap }) => {
   const { errors } = useErrorsContext();
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const onClick = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(dataAdapters?.[dataAdapterId]?.name));
-  }, [dataAdapterId, dataAdapters, navigate]);
+    push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(dataAdapters?.[dataAdapterId]?.name));
+  }, [dataAdapterId, dataAdapters, push]);
 
   if (!dataAdapters || !dataAdapterId || !dataAdapters[dataAdapterId]) return <i>No data adapters</i>;
 

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-list/use-actions.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-list/use-actions.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { MenuItem, DeleteMenuItem, BootstrapModalConfirm } from 'components/bootstrap';
 import { Spinner } from 'components/common';
@@ -37,11 +37,11 @@ function Actions({ lut }: ActionsProps) {
   const sendTelemetry = useSendTelemetry();
   const { deleteLookupTable, deletingLookupTable } = useDeleteLookupTable();
   const { loadingScopePermissions, scopePermissions } = useScopePermissions(lut);
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleEdit = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.edit(lut.name));
-  }, [lut, navigate]);
+    push(Routes.SYSTEM.LOOKUPTABLES.edit(lut.name));
+  }, [lut, push]);
 
   const handleDelete = useCallback(() => {
     sendTelemetry(TELEMETRY_EVENT_TYPE.LUT.DELETED, {

--- a/graylog2-web-interface/src/components/lookup-tables/lookup-table-view/basic-details.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/lookup-table-view/basic-details.tsx
@@ -17,8 +17,8 @@
 import * as React from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Button } from 'components/bootstrap';
 import { Col, Row, DataWell } from 'components/lookup-tables/layout-componets';
@@ -37,11 +37,11 @@ type Props = {
 };
 
 function LookupTableDetails({ table, canEdit = false }: Props) {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleEdit = useCallback(() => {
-    navigate(Routes.SYSTEM.LOOKUPTABLES.edit(table.name));
-  }, [table, navigate]);
+    push(Routes.SYSTEM.LOOKUPTABLES.edit(table.name));
+  }, [table, push]);
 
   return (
     <>

--- a/graylog2-web-interface/src/components/streams/StreamDetails/StreamDetails.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/StreamDetails.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import URI from 'urijs';
@@ -156,7 +155,6 @@ const getPageDescription = (segment: DetailsSegment) => (
 );
 
 const StreamDetails = ({ stream }: Props) => {
-  const navigate = useNavigate();
   const { segment } = useQuery();
   const [currentSegment, setCurrentSegment] = useState<DetailsSegment>((segment as DetailsSegment) || INTAKE_SEGMENT);
   const DataLakeJobComponent = PluginStore.exports('dataLake')?.[0]?.DataLakeJobs;
@@ -204,7 +202,7 @@ const StreamDetails = ({ stream }: Props) => {
       <Container>
         <Header>
           <LeftCol>
-            <Button onClick={() => navigate(Routes.STREAMS)}>
+            <Button onClick={() => history.push(Routes.STREAMS)}>
               <Icon name="arrow_left_alt" size="sm" /> Back
             </Button>
 

--- a/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
+++ b/graylog2-web-interface/src/hooks/useLocationSearchPagination.test.ts
@@ -65,7 +65,7 @@ describe('useLocationSearchPagination custom hook', () => {
 
     act(() => setPagination(nextPage));
 
-    expect(mockNavigate).toHaveBeenCalledWith({ pathname: '/', search: stringify(nextPage) });
+    expect(mockNavigate).toHaveBeenCalledWith(`/?${stringify(nextPage)}`);
   });
 
   it.each`

--- a/graylog2-web-interface/src/hooks/useLocationSearchPagination.ts
+++ b/graylog2-web-interface/src/hooks/useLocationSearchPagination.ts
@@ -15,9 +15,9 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { parse, stringify } from 'qs';
 
+import useHistory from 'routing/useHistory';
 import useLocation from 'routing/useLocation';
 import type { Pagination } from 'stores/PaginationTypes';
 
@@ -28,7 +28,7 @@ type UseLocationSearchPaginationType = {
 };
 
 const useLocationSearchPagination = (defaultPagination: Pagination): UseLocationSearchPaginationType => {
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const location = useLocation();
   const [parsedPagination, setParsedPagination] = useState<Pagination>(defaultPagination);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
@@ -51,15 +51,13 @@ const useLocationSearchPagination = (defaultPagination: Pagination): UseLocation
       };
     };
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setParsedPagination(parsePaginationFromSearch(location.search));
     setIsInitialized(true);
   }, [location.search, defaultPagination]);
 
   const setLocationSearchPagination = (nextPagination: Pagination) => {
-    navigate({
-      pathname: location.pathname,
-      search: stringify(nextPagination),
-    });
+    push(`${location.pathname}${stringify(nextPagination, { addQueryPrefix: true })}`);
   };
 
   return {

--- a/graylog2-web-interface/src/integrations/aws/AWSInputConfiguration.tsx
+++ b/graylog2-web-interface/src/integrations/aws/AWSInputConfiguration.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'integrations/aws/common/Routes';
 
 type AWSInputConfigurationProps = {
@@ -24,11 +24,11 @@ type AWSInputConfigurationProps = {
 };
 
 const AWSInputConfiguration = ({ url = Routes.INTEGRATIONS.AWS.CLOUDWATCH.index }: AWSInputConfigurationProps) => {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   useEffect(() => {
-    navigate(url);
-  }, [url, navigate]);
+    push(url);
+  }, [url, push]);
 
   return null;
 };

--- a/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.tsx
+++ b/graylog2-web-interface/src/integrations/aws/cloudwatch/CloudWatch.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useContext, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Wizard from 'components/common/Wizard';
 import { getValueFromInput } from 'util/FormsUtils';
 import Routes from 'routing/Routes';
@@ -43,7 +43,7 @@ const CloudWatch = ({ externalInputSubmit = false, onSubmit = undefined }: Cloud
   const { availableStreams } = useContext(ApiContext);
   const { sidebar, clearSidebar } = useContext(SidebarContext);
   // const history = useHistory();
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const handleStepChange = (nextStep) => {
     setCurrentStep(nextStep);
@@ -79,7 +79,7 @@ const CloudWatch = ({ externalInputSubmit = false, onSubmit = undefined }: Cloud
         onSubmit(maybeFormData);
       } else {
         // history.push(Routes.SYSTEM.INPUTS);
-        navigate(Routes.SYSTEM.INPUTS);
+        push(Routes.SYSTEM.INPUTS);
       }
     };
 
@@ -130,7 +130,7 @@ const CloudWatch = ({ externalInputSubmit = false, onSubmit = undefined }: Cloud
     currentStep,
     setEnabledStep,
     onSubmit,
-    navigate,
+    push,
   ]);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
+++ b/graylog2-web-interface/src/pages/ClusterConfigurationPage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { DocumentTitle, PageHeader } from 'components/common';
 import ClusterConfigurationPageNavigation from 'components/cluster-configuration/ClusterConfigurationPageNavigation';
 import HideOnCloud from 'util/conditional/HideOnCloud';
@@ -28,13 +28,13 @@ import Routes from 'routing/Routes';
 
 const ClusterConfigurationPage = () => {
   const currentUser = useCurrentUser();
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   useEffect(() => {
     if (!isPermitted(currentUser.permissions, 'clusterconfiguration:read')) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [currentUser.permissions, navigate]);
+  }, [currentUser.permissions, push]);
 
   return (
     <DocumentTitle title="Cluster Configuration">

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { Col, Row } from 'components/bootstrap';
 import { DocumentTitle, PageHeader } from 'components/common';
 import EventDefinitionFormContainer from 'components/event-definitions/event-definition-form/EventDefinitionFormContainer';
@@ -30,7 +30,7 @@ import useQuery from 'routing/useQuery';
 
 const CreateEventDefinitionPage = () => {
   const currentUser = useCurrentUser();
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   const [eventDefinitionTitle, setEventDefinitionTitle] = useState();
   const { step } = useQuery();
@@ -50,14 +50,14 @@ const CreateEventDefinitionPage = () => {
   );
 
   const goToOverview = useCallback(() => {
-    navigate(Routes.ALERTS.DEFINITIONS.LIST);
-  }, [navigate]);
+    push(Routes.ALERTS.DEFINITIONS.LIST);
+  }, [push]);
 
   useEffect(() => {
     if (!isPermitted(currentUser.permissions, 'eventdefinitions:create')) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [currentUser.permissions, navigate]);
+  }, [currentUser.permissions, push]);
 
   return (
     <DocumentTitle title={pageTitle}>

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import URI from 'urijs';
 
 import EventsPageNavigation from 'components/events/EventsPageNavigation';
@@ -40,11 +40,10 @@ const EditEventDefinitionPage = () => {
   const currentUser = useCurrentUser();
   const [eventDefinition, setEventDefinition] = useState<EventDefinition>(undefined);
   const history = useHistory();
-  const navigate = useNavigate();
 
   const goToOverview = useCallback(() => {
-    navigate(Routes.ALERTS.DEFINITIONS.LIST);
-  }, [navigate]);
+    history.push(Routes.ALERTS.DEFINITIONS.LIST);
+  }, [history]);
 
   useEffect(() => {
     if (isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`)) {

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypeProfileCreatePage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypeProfileCreatePage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { DocumentTitle, PageHeader } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
@@ -26,14 +26,14 @@ import useHasTypeMappingPermission from 'hooks/useHasTypeMappingPermission';
 import { IndicesPageNavigation } from 'components/indices';
 
 const IndexSetFieldTypeProfileCreatePage = () => {
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const hasMappingPermission = useHasTypeMappingPermission();
 
   useEffect(() => {
     if (!hasMappingPermission) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [hasMappingPermission, navigate]);
+  }, [hasMappingPermission, push]);
 
   return (
     <DocumentTitle title="Create Index Set Field Type Profile">

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypeProfileEditPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypeProfileEditPage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
@@ -30,14 +30,14 @@ import { IndicesPageNavigation } from 'components/indices';
 const IndexSetFieldTypeProfileEditPage = () => {
   const { profileId } = useParams();
   const { data, isFetching } = useProfile(profileId);
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const hasMappingPermission = useHasTypeMappingPermission();
 
   useEffect(() => {
     if (!hasMappingPermission) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [hasMappingPermission, navigate]);
+  }, [hasMappingPermission, push]);
 
   return (
     <DocumentTitle title="Edit Index Set Field Type Profile">

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypeProfilesPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypeProfilesPage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { DocumentTitle, PageHeader } from 'components/common';
 import { Row, Col } from 'components/bootstrap';
 import DocsHelper from 'util/DocsHelper';
@@ -27,14 +27,14 @@ import { IndicesPageNavigation } from 'components/indices';
 import useHasTypeMappingPermission from 'hooks/useHasTypeMappingPermission';
 
 const IndexSetFieldTypeProfilesPage = () => {
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const hasMappingPermission = useHasTypeMappingPermission();
 
   useEffect(() => {
     if (!hasMappingPermission) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [hasMappingPermission, navigate]);
+  }, [hasMappingPermission, push]);
 
   return (
     <DocumentTitle title="Index Set Field Type Profiles">

--- a/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.tsx
+++ b/graylog2-web-interface/src/pages/IndexSetFieldTypesPage.tsx
@@ -15,8 +15,8 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { Row, Col } from 'components/bootstrap';
 import useSingleIndexSet from 'components/indices/hooks/useSingleIndexSet';
@@ -31,15 +31,15 @@ import isIndexFieldTypeChangeAllowed from 'components/indices/helpers/isIndexFie
 
 const IndexSetFieldTypesPage = () => {
   const { indexSetId } = useParams();
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const { data: indexSet, isInitialLoading } = useSingleIndexSet(indexSetId);
   const hasMappingPermission = useHasTypeMappingPermission();
 
   useEffect(() => {
     if (!hasMappingPermission) {
-      navigate(Routes.NOTFOUND);
+      push(Routes.NOTFOUND);
     }
-  }, [hasMappingPermission, navigate]);
+  }, [hasMappingPermission, push]);
 
   const indexFieldTypeChangeAllowed = useMemo(() => isIndexFieldTypeChangeAllowed(indexSet), [indexSet]);
 

--- a/graylog2-web-interface/src/pages/InputDiagnosisPage.tsx
+++ b/graylog2-web-interface/src/pages/InputDiagnosisPage.tsx
@@ -16,8 +16,8 @@
  */
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { Icon } from 'components/common';
 import useParams from 'routing/useParams';
 import { Button, SegmentedControl } from 'components/bootstrap';
@@ -101,7 +101,7 @@ const getListeningProtocol = (input?: Input) => {
 const InputDiagnosisPage = () => {
   const { inputId } = useParams();
   const { input, inputNodeStates, inputMetrics } = useInputDiagnosis(inputId);
-  const navigate = useNavigate();
+  const { push } = useHistory();
   const productName = useProductName();
   const listeningProtocol = getListeningProtocol(input);
   const [currentTab, setCurrentTab] = useState<DiagnosisTab>('overview');
@@ -115,7 +115,7 @@ const InputDiagnosisPage = () => {
   return (
     <>
       <Header>
-        <Button onClick={() => navigate(Routes.SYSTEM.INPUTS)}>
+        <Button onClick={() => push(Routes.SYSTEM.INPUTS)}>
           <Icon name="arrow_left_alt" size="sm" /> Back
         </Button>
         <LeftCol>

--- a/graylog2-web-interface/src/pages/LUTCacheDetailsPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTCacheDetailsPage.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { Button, Row, Col } from 'components/bootstrap';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 import { CacheView } from 'components/lookup-tables';
@@ -43,7 +43,7 @@ const FlexCol = styled(Col)`
 `;
 
 function LUTCacheDetailsPage() {
-  const navigate = useNavigate();
+  const { goBack } = useHistory();
 
   return (
     <FlexContainer>
@@ -52,7 +52,7 @@ function LUTCacheDetailsPage() {
         pageTitle="Caches Details for Lookup Tables"
         pageDescription="Caches store values for lookup tables to improve performance."
         actions={
-          <Button bsStyle="primary" onClick={() => navigate(-1)}>
+          <Button bsStyle="primary" onClick={() => goBack()}>
             Back to list
           </Button>
         }>

--- a/graylog2-web-interface/src/pages/LUTCachesFormPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTCachesFormPage.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Spinner } from 'components/common';
 import { Button, Row, Col } from 'components/bootstrap';
@@ -40,8 +41,8 @@ const FlexCol = styled(Col)`
 function LUTDataAdaptersFormPage() {
   const { cacheIdOrName } = useParams<{ cacheIdOrName: string }>();
   const { cache, loadingCache } = useFetchCache(cacheIdOrName);
-  const navigate = useNavigate();
-  const navigateBack = () => navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW);
+  const { push } = useHistory();
+  const navigateBack = () => push(Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW);
 
   return (
     <FlexContainer>

--- a/graylog2-web-interface/src/pages/LUTCachesPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.tsx
@@ -15,15 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Button } from 'components/bootstrap';
 import { CachesOverview } from 'components/lookup-tables';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 
 function LUTCachesPage() {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   return (
     <LUTPageLayout
@@ -31,7 +31,7 @@ function LUTCachesPage() {
       pageTitle="Caches for Lookup Tables"
       pageDescription="Caches provide the actual values for lookup tables."
       actions={
-        <Button bsStyle="primary" onClick={() => navigate(Routes.SYSTEM.LOOKUPTABLES.CACHES.CREATE)}>
+        <Button bsStyle="primary" onClick={() => push(Routes.SYSTEM.LOOKUPTABLES.CACHES.CREATE)}>
           Create cache
         </Button>
       }>

--- a/graylog2-web-interface/src/pages/LUTDataAdapterDetailsPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdapterDetailsPage.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { Button, Row, Col } from 'components/bootstrap';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 import { DataAdapterView } from 'components/lookup-tables';
@@ -43,7 +43,7 @@ const FlexCol = styled(Col)`
 `;
 
 function LUTDataAdapterDetailsPage() {
-  const navigate = useNavigate();
+  const { goBack } = useHistory();
 
   return (
     <FlexContainer>
@@ -52,7 +52,7 @@ function LUTDataAdapterDetailsPage() {
         pageTitle="Data Adapter Details for Lookup Tables"
         pageDescription="Data adapters provide the actual values for lookup tables."
         actions={
-          <Button bsStyle="primary" onClick={() => navigate(-1)}>
+          <Button bsStyle="primary" onClick={() => goBack()}>
             Back to list
           </Button>
         }>

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersFormPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersFormPage.tsx
@@ -16,8 +16,9 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Spinner } from 'components/common';
 import { Button, Row, Col } from 'components/bootstrap';
@@ -40,8 +41,8 @@ const FlexCol = styled(Col)`
 function LUTDataAdaptersFormPage() {
   const { adapterIdOrName } = useParams<{ adapterIdOrName: string }>();
   const { dataAdapter, loadingDataAdapter } = useFetchDataAdapter(adapterIdOrName);
-  const navigate = useNavigate();
-  const navigateBack = () => navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW);
+  const { push } = useHistory();
+  const navigateBack = () => push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW);
 
   return (
     <FlexContainer>

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.tsx
@@ -15,15 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Button } from 'components/bootstrap';
 import { DataAdaptersOverview } from 'components/lookup-tables';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 
 function LUTDataAdaptersPage() {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   return (
     <LUTPageLayout
@@ -31,7 +31,7 @@ function LUTDataAdaptersPage() {
       pageTitle="Data Adapters for Lookup Tables"
       pageDescription="Data adapters provide the actual values for lookup tables."
       actions={
-        <Button bsStyle="primary" onClick={() => navigate(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE)}>
+        <Button bsStyle="primary" onClick={() => push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE)}>
           Create data adapter
         </Button>
       }>

--- a/graylog2-web-interface/src/pages/LUTDetailsPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTDetailsPage.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import { Button, Row, Col } from 'components/bootstrap';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 import { LookupTableView } from 'components/lookup-tables';
@@ -43,7 +43,7 @@ const FlexCol = styled(Col)`
 `;
 
 function LUTDetailsPage() {
-  const navigate = useNavigate();
+  const { goBack } = useHistory();
 
   return (
     <FlexContainer>
@@ -52,7 +52,7 @@ function LUTDetailsPage() {
         pageTitle="Lookup Tables Details"
         pageDescription="Lookup tables can be used in extractors, converters and processing pipelines to translate message fields or to enrich messages."
         actions={
-          <Button bsStyle="primary" onClick={() => navigate(-1)}>
+          <Button bsStyle="primary" onClick={() => goBack()}>
             Back to list
           </Button>
         }>

--- a/graylog2-web-interface/src/pages/LUTFormPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTFormPage.tsx
@@ -16,8 +16,8 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Button, Row, Col } from 'components/bootstrap';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
@@ -44,7 +44,7 @@ const FlexCol = styled(Col)`
 `;
 
 function LUTFormPage() {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   return (
     <FlexContainer>
@@ -53,7 +53,7 @@ function LUTFormPage() {
         pageTitle="Lookup Tables Create"
         pageDescription="Lookup tables can be used in extractors, converters and processing pipelines to translate message fields or to enrich messages."
         actions={
-          <Button bsStyle="primary" onClick={() => navigate(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW)}>
+          <Button bsStyle="primary" onClick={() => push(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW)}>
             Back to list
           </Button>
         }>

--- a/graylog2-web-interface/src/pages/LUTTablesPage.tsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.tsx
@@ -15,15 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
 
+import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
 import { Button } from 'components/bootstrap';
 import { LookupTablesOverview } from 'components/lookup-tables';
 import { LUTPageLayout } from 'components/lookup-tables/layout-componets';
 
 function LUTTablesPage() {
-  const navigate = useNavigate();
+  const { push } = useHistory();
 
   return (
     <LUTPageLayout
@@ -31,7 +31,7 @@ function LUTTablesPage() {
       pageTitle="Lookup Tables"
       pageDescription="Lookup tables can be used in extractors, converters and processing pipelines to translate message fields or to enrich messages."
       actions={
-        <Button bsStyle="primary" onClick={() => navigate(Routes.SYSTEM.LOOKUPTABLES.CREATE)}>
+        <Button bsStyle="primary" onClick={() => push(Routes.SYSTEM.LOOKUPTABLES.CREATE)}>
           Create lookup table
         </Button>
       }>

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
@@ -16,7 +16,7 @@
  */
 import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/bootstrap';
@@ -52,7 +52,6 @@ const ViewEventDefinitionPage = () => {
   const notifications = notificationsData?.notifications;
   const history = useHistory();
   const sendTelemetry = useSendTelemetry();
-  const navigate = useNavigate();
   const [showSigmaModal, setShowSigmaModal] = useState(false);
 
   const pluggableSigmaModal = usePluginEntities('eventDefinitions.components.editSigmaModal').find(
@@ -94,7 +93,7 @@ const ViewEventDefinitionPage = () => {
     copyEventDefinition(eventDefinition).then(
       (duplicatedEvent) => {
         queryClient.invalidateQueries({ queryKey: EVENT_DEFINITIONS_QUERY_KEY });
-        navigate(Routes.ALERTS.DEFINITIONS.edit(duplicatedEvent.id));
+        history.push(Routes.ALERTS.DEFINITIONS.edit(duplicatedEvent.id));
       },
       () => {
         // Error feedback is handled by `copyEventDefinition` itself.
@@ -102,7 +101,7 @@ const ViewEventDefinitionPage = () => {
     );
   };
 
-  const onEditEventDefinition = () => navigate(Routes.ALERTS.DEFINITIONS.edit(params.definitionId));
+  const onEditEventDefinition = () => history.push(Routes.ALERTS.DEFINITIONS.edit(params.definitionId));
 
   const onSigmaModalClose = () => {
     queryClient.invalidateQueries({ queryKey: [...EVENT_DEFINITIONS_QUERY_KEY, params.definitionId] });

--- a/graylog2-web-interface/src/routing/useHistory.ts
+++ b/graylog2-web-interface/src/routing/useHistory.ts
@@ -15,6 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useNavigate } from 'react-router-dom';
 
 const useHistory = () => {

--- a/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DashboardPageContextProvider.tsx
@@ -16,9 +16,9 @@
  */
 import * as React from 'react';
 import { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import URI from 'urijs';
 
+import useHistory from 'routing/useHistory';
 import useLocation from 'routing/useLocation';
 import useQuery from 'routing/useQuery';
 import DashboardPageContext from 'views/components/contexts/DashboardPageContext';
@@ -55,40 +55,41 @@ const useSyncStateWithQueryParams = ({ dashboardPage, uriParams, setDashboardPag
   }, [uriParams.page, dashboardPage, setDashboardPage, states, dispatch]);
 };
 
-const useCleanupQueryParams = ({ uriParams, query, navigate }) => {
+const useCleanupQueryParams = ({ uriParams, query, replace }) => {
   useEffect(() => {
     if (uriParams?.page === undefined) {
       const baseURI = _clearURI(query);
       const newQuery = baseURI.toString();
 
       if (query !== newQuery) {
-        navigate(newQuery, { replace: true });
+        replace(newQuery);
       }
     }
-  }, [query, navigate, uriParams?.page]);
+  }, [query, replace, uriParams?.page]);
 };
 
 const DashboardPageContextProvider = ({ children }: { children: React.ReactNode }): React.ReactElement => {
   const { search, pathname } = useLocation();
   const query = pathname + search;
-  const navigate = useNavigate();
+  const { replace } = useHistory();
   const [dashboardPage, setDashboardPage] = useState<string | undefined>();
   const params = useQuery();
   const uriParams = useMemo(
     () => ({
       page: params.page,
     }),
+    // eslint-disable-next-line @tanstack/query/no-unstable-deps
     [params],
   );
 
   useSyncStateWithQueryParams({ dashboardPage, uriParams, setDashboardPage });
-  useCleanupQueryParams({ uriParams, query, navigate });
+  useCleanupQueryParams({ uriParams, query, replace });
 
   const dashboardPageContextValue = useMemo(() => {
     const updatePageParams = (newPage: string | undefined) => {
       const newUri = _updateQueryParams(newPage, query);
 
-      navigate(newUri, { replace: true });
+      replace(newUri);
     };
 
     const setDashboardPageParam = (nextPage: string) => updatePageParams(nextPage);
@@ -99,7 +100,7 @@ const DashboardPageContextProvider = ({ children }: { children: React.ReactNode 
       unsetDashboardPage: unSetDashboardPageParam,
       dashboardPage: dashboardPage,
     };
-  }, [dashboardPage, navigate, query]);
+  }, [dashboardPage, replace, query]);
 
   return <DashboardPageContext.Provider value={dashboardPageContextValue}>{children}</DashboardPageContext.Provider>;
 };


### PR DESCRIPTION
## Description

Adds an ESLint `no-restricted-imports` rule banning direct `useNavigate` imports from `react-router-dom`, and migrates all existing direct usages to the `routing/useHistory` wrapper. The wrapper's own import is exempted with an inline `eslint-disable`.

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/14707

## Motivation and Context

We already funnel `useLocation` through a `routing/` wrapper for consistency and to keep a single seam over `react-router-dom`. Navigation was the odd one out — components imported `useNavigate` directly. This change enforces the same imperative-navigation convention across the codebase so there's one consistent way to navigate programmatically.

## How Has This Been Tested?

Purely a refactor with no runtime behavior change (`history.push`/`history.replace` map to the same navigation as `navigate(...)`). Verified via type-checking and the existing test suite; the new ESLint rule flags any future direct `useNavigate` import.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Internal refactor plus dev-only ESLint rule; no user-facing behavior change.