### PR TITLE
Do not fetch messages in MessageResource when no index permissions

### DIFF
--- a/changelog/unreleased/pr-26565.toml
+++ b/changelog/unreleased/pr-26565.toml
@@ -1,0 +1,3 @@
+type = "s"
+message = "Fix security issue in `MessageResource` that allowed fetching a message from an index the user has no read permission for. Prevent this kind of users to check index existence."
+pulls = ["26565"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -96,8 +96,8 @@ public class MessageResource extends RestResource {
     @Operation(summary = "Get a single message.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Returns the message", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "Specified index does not exist"),
-            @ApiResponse(responseCode = "404", description = "Message does not exist")
+            @ApiResponse(responseCode = "404", description = "Specified index does not exist."),
+            @ApiResponse(responseCode = "404", description = "Message does not exist.")
     })
     public ResultMessage search(@Parameter(name = "index", description = "The index this message is stored in.", required = true)
                                 @PathParam("index") String index,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -76,9 +76,6 @@ import static java.util.Objects.requireNonNull;
 @Path("/messages")
 public class MessageResource extends RestResource {
 
-    private static final String INDEX_NOT_PERMITTED_OR_MISSING = "The requested index cannot be found, or the user does not have the required permissions";
-    private static final String MESSAGE_NOT_PERMITTED_OR_MISSING = "The requested message cannot be found, or the user does not have the required permissions";
-
     private final Messages messages;
     private final CodecFactory codecFactory;
     private final IndexSetRegistry indexSetRegistry;
@@ -99,25 +96,15 @@ public class MessageResource extends RestResource {
     @Operation(summary = "Get a single message.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Returns the message", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "Specified index does not exist or user is not privileged to see it."),
-            @ApiResponse(responseCode = "404", description = "Message does not exist or user is not privileged to see it.")
+            @ApiResponse(responseCode = "404", description = "Specified index does not exist"),
+            @ApiResponse(responseCode = "404", description = "Message does not exist")
     })
     public ResultMessage search(@Parameter(name = "index", description = "The index this message is stored in.", required = true)
                                 @PathParam("index") String index,
                                 @Parameter(name = "messageId", required = true)
                                 @PathParam("messageId") String messageId) throws IOException {
-        try {
-            checkPermission(RestPermissions.INDICES_READ, index);
-        } catch (ForbiddenException e) {
-            //intentionally using the same error for missing permissions and index not found, as decided in graylog-plugin-enterprise/issues/13402
-            throw new NotFoundException(INDEX_NOT_PERMITTED_OR_MISSING, e);
-        }
-        try {
-            checkPermission(RestPermissions.MESSAGES_READ, messageId);
-        } catch (ForbiddenException e) {
-            //intentionally using the same error for missing permissions and message not found, as decided in graylog-plugin-enterprise/issues/13402
-            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
-        }
+        checkPermission(RestPermissions.INDICES_READ, index);
+        checkPermission(RestPermissions.MESSAGES_READ, messageId);
         try {
             final ResultMessage resultMessage = messages.get(messageId, index);
             final Message message = resultMessage.getMessage();
@@ -125,14 +112,10 @@ public class MessageResource extends RestResource {
 
             return resultMessage;
         } catch (DocumentNotFoundException e) {
-            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
+            throw new NotFoundException("Message " + messageId + " does not exist in index " + index, e);
         } catch (IndexNotFoundException e) {
-            throw new NotFoundException(INDEX_NOT_PERMITTED_OR_MISSING, e);
-        } catch (ForbiddenException e) {
-            //intentionally using the same error for missing permissions and message not found, as decided in graylog-plugin-enterprise/issues/13402
-            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
+            throw new NotFoundException("Index " + index + " does not exist.", e);
         }
-
     }
 
     private void checkMessageReadPermission(Message message) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -75,6 +75,10 @@ import static java.util.Objects.requireNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/messages")
 public class MessageResource extends RestResource {
+
+    private static final String INDEX_NOT_PERMITTED_OR_MISSING = "The requested index cannot be found, or the user does not have the required permissions";
+    private static final String MESSAGE_NOT_PERMITTED_OR_MISSING = "The requested message cannot be found, or the user does not have the required permissions";
+
     private final Messages messages;
     private final CodecFactory codecFactory;
     private final IndexSetRegistry indexSetRegistry;
@@ -95,14 +99,25 @@ public class MessageResource extends RestResource {
     @Operation(summary = "Get a single message.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Returns the message", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "404", description = "Specified index does not exist."),
-            @ApiResponse(responseCode = "404", description = "Message does not exist.")
+            @ApiResponse(responseCode = "404", description = "Specified index does not exist or user is not privileged to see it."),
+            @ApiResponse(responseCode = "404", description = "Message does not exist or user is not privileged to see it.")
     })
     public ResultMessage search(@Parameter(name = "index", description = "The index this message is stored in.", required = true)
                                 @PathParam("index") String index,
                                 @Parameter(name = "messageId", required = true)
                                 @PathParam("messageId") String messageId) throws IOException {
-        checkPermission(RestPermissions.MESSAGES_READ, messageId);
+        try {
+            checkPermission(RestPermissions.INDICES_READ, index);
+        } catch (ForbiddenException e) {
+            //intentionally using the same error for missing permissions and index not found, as decided in graylog-plugin-enterprise/issues/13402
+            throw new NotFoundException(INDEX_NOT_PERMITTED_OR_MISSING, e);
+        }
+        try {
+            checkPermission(RestPermissions.MESSAGES_READ, messageId);
+        } catch (ForbiddenException e) {
+            //intentionally using the same error for missing permissions and message not found, as decided in graylog-plugin-enterprise/issues/13402
+            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
+        }
         try {
             final ResultMessage resultMessage = messages.get(messageId, index);
             final Message message = resultMessage.getMessage();
@@ -110,10 +125,14 @@ public class MessageResource extends RestResource {
 
             return resultMessage;
         } catch (DocumentNotFoundException e) {
-            throw new NotFoundException("Message " + messageId + " does not exist in index " + index, e);
+            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
         } catch (IndexNotFoundException e) {
-            throw new NotFoundException("Index " + index + " does not exist.", e);
+            throw new NotFoundException(INDEX_NOT_PERMITTED_OR_MISSING, e);
+        } catch (ForbiddenException e) {
+            //intentionally using the same error for missing permissions and message not found, as decided in graylog-plugin-enterprise/issues/13402
+            throw new NotFoundException(MESSAGE_NOT_PERMITTED_OR_MISSING, e);
         }
+
     }
 
     private void checkMessageReadPermission(Message message) {
@@ -191,7 +210,7 @@ public class MessageResource extends RestResource {
     @Path("/{index}/analyze")
     @Timed
     @Operation(summary = "Analyze a message string",
-                  description = "Returns what tokens/terms a message string (message or full_message) is split to.")
+               description = "Returns what tokens/terms a message string (message or full_message) is split to.")
     @RequiresPermissions(RestPermissions.MESSAGES_ANALYZE)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Returns tokens", useReturnTypeSchema = true),


### PR DESCRIPTION
## Description
Do not fetch messages in MessageResource when no index permissions.

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/13402

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

