### PR TITLE
Use `usePlugin` helper in tests instead of manual `beforeAll`/`afterAll`

### DIFF
--- a/graylog2-web-interface/src/routing/hooks/getShowRouteForEntity.test.ts
+++ b/graylog2-web-interface/src/routing/hooks/getShowRouteForEntity.test.ts
@@ -16,11 +16,12 @@
  */
 
 import { renderHook } from 'wrappedTestingLibrary/hooks';
-import { PluginStore, PluginManifest } from 'graylog-web-plugin/plugin';
+import { PluginManifest } from 'graylog-web-plugin/plugin';
 
 import useShowRouteForEntity from 'routing/hooks/useShowRouteForEntity';
 import type { QualifiedUrl } from 'routing/Routes';
 import Routes from 'routing/Routes';
+import { usePlugin } from 'views/test/testPlugins';
 
 describe('getShowRouteFromGRN', () => {
   describe('should return correct route', () => {
@@ -46,9 +47,7 @@ describe('getShowRouteFromGRN', () => {
       },
     );
 
-    beforeAll(() => PluginStore.register(plugin));
-
-    afterAll(() => PluginStore.unregister(plugin));
+    usePlugin(plugin);
 
     it('should return entity routes defined by plugins', () => {
       const { result } = renderHook(() => useShowRouteForEntity('special-id', 'dashboard'));

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.groupBy.test.tsx
@@ -19,7 +19,6 @@ import * as Immutable from 'immutable';
 import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
 import selectEvent from 'helpers/selectEvent';
@@ -34,6 +33,7 @@ import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visuali
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
 import type { FieldTypeMappingsList } from 'views/logic/fieldtypes/types';
 import useSortableItemRectsMock from 'components/common/SortableList/tests/useSortableItemRectsMock';
+import { usePlugin } from 'views/test/testPlugins';
 
 import AggregationWizard from '../AggregationWizard';
 
@@ -98,9 +98,7 @@ describe('AggregationWizard', () => {
       </FieldTypesContext.Provider>,
     );
 
-  beforeAll(() => PluginStore.register(plugin));
-
-  afterAll(() => PluginStore.unregister(plugin));
+  usePlugin(plugin);
 
   beforeEach(() => {
     asMock(useActiveQueryId).mockReturnValue('queryId');

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.metric.test.tsx
@@ -19,7 +19,6 @@ import * as Immutable from 'immutable';
 import { render, screen, waitFor, within } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import { applyTimeoutMultiplier } from 'jest-preset-graylog/lib/timeouts';
 
 import selectEvent from 'helpers/selectEvent';
@@ -33,6 +32,7 @@ import FieldTypesContext from 'views/components/contexts/FieldTypesContext';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
 import useActiveQueryId from 'views/hooks/useActiveQueryId';
+import { usePlugin } from 'views/test/testPlugins';
 
 import AggregationWizard from '../AggregationWizard';
 
@@ -91,9 +91,7 @@ describe('AggregationWizard', () => {
       </FieldTypesContext.Provider>,
     );
 
-  beforeAll(() => PluginStore.register(plugin));
-
-  afterAll(() => PluginStore.unregister(plugin));
+  usePlugin(plugin);
 
   beforeEach(() => {
     asMock(useActiveQueryId).mockReturnValue('queryId');

--- a/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/__tests__/AggregationWizard.visualization.test.tsx
@@ -20,7 +20,6 @@ import { useContext } from 'react';
 import { render, screen, waitFor } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import type { PluginRegistration } from 'graylog-web-plugin/plugin';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import selectEvent from 'helpers/selectEvent';
 import AggregationWizard from 'views/components/aggregationwizard/AggregationWizard';
@@ -28,6 +27,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import OnVisualizationConfigChangeContext from 'views/components/aggregationwizard/OnVisualizationConfigChangeContext';
+import { usePlugin } from 'views/test/testPlugins';
 
 const widgetConfig = AggregationWidgetConfig.builder().visualization('table').build();
 
@@ -135,9 +135,7 @@ const expectSubmitButtonToBeDisabled = async () => {
 };
 
 describe('AggregationWizard/Visualizations', () => {
-  beforeAll(() => PluginStore.register(visualizationPlugin));
-
-  afterAll(() => PluginStore.unregister(visualizationPlugin));
+  usePlugin(visualizationPlugin);
 
   it('shows visualization section if it is present', async () => {
     render(<SimpleAggregationWizard />);


### PR DESCRIPTION
## Description

Replaces the manual `beforeAll(() => PluginStore.register(plugin))` / `afterAll(() => PluginStore.unregister(plugin))` pattern with the `usePlugin` helper from `views/test/testPlugins` in a handful of test files.

## Motivation and Context

The `usePlugin` helper encapsulates plugin registration/unregistration for the duration of a test suite, removing boilerplate and reducing the risk of leaking plugin state between tests.

## How Has This Been Tested?

Ran the affected test suites locally; no behavior change, only test setup was refactored.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Test-only refactor; no user-facing impact.