### PR TITLE
Add network-graph edge query actions

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/OnClickPopoverValueGroups.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/OnClickPopoverValueGroups.tsx
@@ -77,6 +77,7 @@ type GroupingActionsProps = {
   rowPivotValues: Array<ValueGroupItem>;
   setFieldData: Props['setFieldData'];
   metricValue?: ValueGroupItem;
+  combineOperator?: 'AND' | 'OR' | 'EDGE';
 };
 
 const GroupingActions = ({
@@ -84,6 +85,7 @@ const GroupingActions = ({
   rowPivotValues,
   setFieldData,
   metricValue = undefined,
+  combineOperator = undefined,
 }: GroupingActionsProps) => {
   const groupings = [...columnPivotValues, ...rowPivotValues];
   const valuePath = groupings.map(({ value, field }) => ({ [field]: value }));
@@ -96,7 +98,7 @@ const GroupingActions = ({
         setFieldData({
           value: metricValue?.value ?? '',
           field: metricValue?.field ?? '',
-          contexts: { valuePath },
+          contexts: { valuePath, valuePathOperator: combineOperator },
         })
       }>
       <ValueRenderer field="" value={displayValue} traceColor={metricValue?.traceColor ?? null} />
@@ -124,6 +126,7 @@ const OnClickPopoverValueGroups = ({ metricValue, rowPivotValues, columnPivotVal
           rowPivotValues={rowPivotValues}
           setFieldData={setFieldData}
           metricValue={metricValue}
+          combineOperator={config.visualization === 'network' ? 'EDGE' : undefined}
         />
       )}
       <GroupingsContainer $withMargin={showMultipleAction}>

--- a/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/SankeyOnClickPopover.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/SankeyOnClickPopover.test.tsx
@@ -129,6 +129,16 @@ describe('SankeyOnClickPopover', () => {
       expect(screen.queryByText('408')).not.toBeInTheDocument();
     });
 
+    it('does not tag the sankey combined groupings option with the EDGE operator', async () => {
+      renderPopover(linkClickPoint);
+
+      await userEvent.click(await screen.findByText('index.html-GET'));
+
+      const dropdown = await screen.findByTestId('action-dropdown');
+
+      expect(dropdown).toHaveAttribute('data-value-path-operator', '');
+    });
+
     it('shows resolved node labels rather than raw ids in the groupings dialog', async () => {
       renderPopover(linkClickPointWithResolvedIds);
 
@@ -197,6 +207,38 @@ describe('SankeyOnClickPopover', () => {
 
       expect(dropdown).toHaveAttribute('data-value-path-operator', 'OR');
       expect(JSON.parse(dropdown.getAttribute('data-value-path'))).toEqual([{ source: 'a' }, { target: 'a' }]);
+    });
+  });
+
+  describe('for a network graph edge', () => {
+    const networkConfig = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.createValues(['source'])])
+      .columnPivots([Pivot.createValues(['target'])])
+      .series([new Series('count()')])
+      .visualization('network')
+      .build();
+    const networkActionContext = { widget: { config: { visualization: 'network' } } } as unknown as ActionContexts;
+
+    it('tags the combined groupings option with the EDGE operator', async () => {
+      render(
+        <FieldTypesContext.Provider value={fieldTypes}>
+          <ActionContext.Provider value={networkActionContext}>
+            <Popover opened withinPortal={false}>
+              <Popover.Target>
+                <button type="button">target</button>
+              </Popover.Target>
+              <SankeyOnClickPopover clickPoint={linkClickPoint} config={networkConfig} onPopoverClose={jest.fn()} />
+            </Popover>
+          </ActionContext.Provider>
+        </FieldTypesContext.Provider>,
+      );
+
+      await userEvent.click(await screen.findByText('index.html-GET'));
+
+      const dropdown = await screen.findByTestId('action-dropdown');
+
+      expect(dropdown).toHaveAttribute('data-value-path-operator', 'EDGE');
+      expect(JSON.parse(dropdown.getAttribute('data-value-path'))).toEqual([{ page: 'index.html' }, { action: 'GET' }]);
     });
   });
 

--- a/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/Types.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/OnClickPopover/Types.ts
@@ -41,7 +41,7 @@ export type Rel = { x: number; y: number };
 export type FieldData = {
   field: string;
   value: Datum;
-  contexts: { valuePath: ValuePath; valuePathOperator?: 'AND' | 'OR' } | null;
+  contexts: { valuePath: ValuePath; valuePathOperator?: 'AND' | 'OR' | 'EDGE' } | null;
 };
 
 export type OnClickPopoverDropdownProps = {

--- a/graylog2-web-interface/src/views/components/visualizations/network/NetworkGraphVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/network/NetworkGraphVisualization.tsx
@@ -57,6 +57,10 @@ type SimLink = { source: number | SimNode; target: number | SimNode };
 
 const LAYOUT_ITERATIONS = 500;
 const NODE_RADIUS = 75;
+// Number of invisible hit-target markers sampled along each edge so the whole edge is clickable.
+// Plotly click detection is point-based, and an edge's only real data points are its endpoints
+// (which coincide with node markers), so without these an edge line is not clickable.
+const EDGE_HIT_SAMPLES = 9;
 
 const runLayout = (nodeCount: number, links: ReadonlyArray<{ source: number; target: number }>): Array<SimNode> => {
   const simNodes: Array<SimNode> = Array.from({ length: nodeCount }, (_, i) => ({ id: i }));
@@ -130,6 +134,17 @@ type EdgeTrace = {
   // Per-point customdata so plotly attaches the edge metadata to whichever point the
   // user lands on when clicking the line segment.
   customdata: Array<EdgeCustomData | null>;
+  hoverinfo: 'none';
+  showlegend: false;
+};
+
+type HitTrace = {
+  type: 'scatter';
+  mode: 'markers';
+  x: Array<number>;
+  y: Array<number>;
+  marker: { size: number; opacity: number; color: string };
+  customdata: Array<EdgeCustomData>;
   hoverinfo: 'none';
   showlegend: false;
 };
@@ -225,7 +240,7 @@ const NetworkGraphVisualization = makeVisualization(({ config, data, height, wid
   const visualizationConfig =
     (config.visualizationConfig as NetworkVisualizationConfig) ?? NetworkVisualizationConfig.empty();
 
-  const plot = useMemo<{ traces: [EdgeTrace, NodeTrace]; xs: Array<number>; ys: Array<number> } | null>(() => {
+  const plot = useMemo<{ traces: [EdgeTrace, HitTrace, NodeTrace]; xs: Array<number>; ys: Array<number> } | null>(() => {
     const rowFields = config.rowPivots.flatMap((pivot) => pivot.fields);
     const columnFields = config.columnPivots.flatMap((pivot) => pivot.fields);
     const allFields = [...rowFields, ...columnFields];
@@ -246,6 +261,9 @@ const NetworkGraphVisualization = makeVisualization(({ config, data, height, wid
     const edgeX: Array<number | null> = [];
     const edgeY: Array<number | null> = [];
     const edgeCustomData: Array<EdgeCustomData | null> = [];
+    const hitX: Array<number> = [];
+    const hitY: Array<number> = [];
+    const hitCustomData: Array<EdgeCustomData> = [];
     edges.forEach((edge) => {
       const s = positions[edge.source];
       const t = positions[edge.target];
@@ -271,6 +289,15 @@ const NetworkGraphVisualization = makeVisualization(({ config, data, height, wid
       // Both points carry the same edge metadata; the separator slot is `null` so
       // plotly won't surface a click between segments.
       edgeCustomData.push(cd, cd, null);
+
+      // Sample interior points along the edge (excluding endpoints, which sit on the nodes) so a
+      // click anywhere along the edge lands on a hit-detectable marker carrying the edge metadata.
+      for (let i = 1; i <= EDGE_HIT_SAMPLES; i += 1) {
+        const f = i / (EDGE_HIT_SAMPLES + 1);
+        hitX.push(s.x + f * (t.x - s.x));
+        hitY.push(s.y + f * (t.y - s.y));
+        hitCustomData.push(cd);
+      }
     });
 
     const textColor = theme.colors.text.primary;
@@ -282,6 +309,18 @@ const NetworkGraphVisualization = makeVisualization(({ config, data, height, wid
       y: edgeY,
       line: { width: 1, color: theme.colors.text.secondary },
       customdata: edgeCustomData,
+      hoverinfo: 'none',
+      showlegend: false,
+    };
+
+    const hitTrace: HitTrace = {
+      type: 'scatter',
+      mode: 'markers',
+      x: hitX,
+      y: hitY,
+      // Invisible (opacity 0) but still rendered as points, so they remain hit-detectable.
+      marker: { size: 10, opacity: 0, color: theme.colors.text.secondary },
+      customdata: hitCustomData,
       hoverinfo: 'none',
       showlegend: false,
     };
@@ -324,7 +363,7 @@ const NetworkGraphVisualization = makeVisualization(({ config, data, height, wid
       showlegend: false,
     };
 
-    return { traces: [edgeTrace, nodeTrace], xs, ys };
+    return { traces: [edgeTrace, hitTrace, nodeTrace], xs, ys };
   }, [config, mapKeys, rows, theme, visualizationConfig]);
 
   const layout = useMemo(() => buildLayout(width, height, plot), [width, height, plot]);

--- a/graylog2-web-interface/src/views/components/visualizations/network/__tests__/NetworkGraphVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/network/__tests__/NetworkGraphVisualization.test.tsx
@@ -60,11 +60,19 @@ const baseProps = {
   toggleEdit: () => {},
 };
 
-const lastTraces = () => {
+const chartData = (): Array<Record<string, any>> => {
   const { calls } = asMock(GenericPlot).mock;
   const lastCall = calls[calls.length - 1];
 
-  return lastCall[0].chartData as [Record<string, any>, Record<string, any>];
+  return lastCall[0].chartData as Array<Record<string, any>>;
+};
+
+const edgeLineTrace = () => chartData()[0];
+const hitTrace = () => chartData()[1];
+const nodeTrace = () => {
+  const data = chartData();
+
+  return data[data.length - 1];
 };
 
 describe('NetworkGraphVisualization', () => {
@@ -83,7 +91,8 @@ describe('NetworkGraphVisualization', () => {
 
     render(<WrappedNetwork {...baseProps} config={config} data={fixtures.twoRowPivots} />);
 
-    const [edgeTrace, nodeTrace] = lastTraces();
+    const edgeTrace = edgeLineTrace();
+    const node = nodeTrace();
 
     expect(edgeTrace.type).toBe('scatter');
     expect(edgeTrace.mode).toBe('lines');
@@ -93,16 +102,41 @@ describe('NetworkGraphVisualization', () => {
     expect(edgeTrace.x[5]).toBeNull();
     expect(edgeTrace.x[8]).toBeNull();
 
-    expect(nodeTrace.type).toBe('scatter');
-    expect(nodeTrace.mode).toBe('markers+text');
-    expect(nodeTrace.text).toEqual(['a1', 'b1', 'b2', 'a2']);
-    expect(nodeTrace.customdata).toEqual([
+    expect(node.type).toBe('scatter');
+    expect(node.mode).toBe('markers+text');
+    expect(node.text).toEqual(['a1', 'b1', 'b2', 'a2']);
+    expect(node.customdata).toEqual([
       { field: 'source', value: 'a1' },
       { field: 'target', value: 'b1' },
       { field: 'target', value: 'b2' },
       { field: 'source', value: 'a2' },
     ]);
-    expect(nodeTrace.marker.color).toEqual([2, 2, 1, 1]);
+    expect(node.marker.color).toEqual([2, 2, 1, 1]);
+  });
+
+  it('renders an invisible hit-target trace with sampled points along each edge', () => {
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([Pivot.createValues(['source']), Pivot.createValues(['target'])])
+      .series([Series.forFunction('count()')])
+      .visualization('network')
+      .build();
+
+    render(<WrappedNetwork {...baseProps} config={config} data={fixtures.twoRowPivots} />);
+
+    const hits = hitTrace();
+
+    // 3 edges × 9 samples each.
+    expect(hits.type).toBe('scatter');
+    expect(hits.mode).toBe('markers');
+    expect(hits.marker.opacity).toBe(0);
+    expect(hits.x).toHaveLength(27);
+    expect(hits.y).toHaveLength(27);
+    // Each sample carries the edge (link) metadata so the popover treats it as an edge.
+    expect(hits.customdata[0].source).toBeDefined();
+    expect(hits.customdata[0].target).toBeDefined();
+
+    // The node trace stays last so it wins hit-detection near endpoints.
+    expect(nodeTrace().mode).toBe('markers+text');
   });
 
   it('makes the graph zoomable and pannable', () => {
@@ -134,16 +168,16 @@ describe('NetworkGraphVisualization', () => {
 
     const { calls } = asMock(GenericPlot).mock;
     const props = calls[calls.length - 1][0];
-    const nodeTrace = props.chartData[1];
+    const node = props.chartData[props.chartData.length - 1];
     const [xLo, xHi] = props.layout.xaxis.range;
     const [yLo, yHi] = props.layout.yaxis.range;
 
     // The initial range is an explicit padded range (so double-click reset restores it) that fully
     // contains every node with room to spare for the labels.
-    expect(xLo).toBeLessThan(Math.min(...nodeTrace.x));
-    expect(xHi).toBeGreaterThan(Math.max(...nodeTrace.x));
-    expect(yLo).toBeLessThan(Math.min(...nodeTrace.y));
-    expect(yHi).toBeGreaterThan(Math.max(...nodeTrace.y));
+    expect(xLo).toBeLessThan(Math.min(...node.x));
+    expect(xHi).toBeGreaterThan(Math.max(...node.x));
+    expect(yLo).toBeLessThan(Math.min(...node.y));
+    expect(yHi).toBeGreaterThan(Math.max(...node.y));
   });
 
   it('unifies same value across stages into a single node', () => {
@@ -155,10 +189,10 @@ describe('NetworkGraphVisualization', () => {
 
     render(<WrappedNetwork {...baseProps} config={config} data={fixtures.sharedValue} />);
 
-    const [, nodeTrace] = lastTraces();
+    const node = nodeTrace();
 
-    expect(nodeTrace.text).toEqual(['x', 'y']);
-    expect(nodeTrace.marker.color).toEqual([2, 2]);
+    expect(node.text).toEqual(['x', 'y']);
+    expect(node.marker.color).toEqual([2, 2]);
   });
 
   it('uses static weight of 1 per edge when no metric is configured', () => {
@@ -170,10 +204,10 @@ describe('NetworkGraphVisualization', () => {
 
     render(<WrappedNetwork {...baseProps} config={config} data={fixtures.twoRowPivotsNoMetric} />);
 
-    const [, nodeTrace] = lastTraces();
+    const node = nodeTrace();
 
-    expect(nodeTrace.text).toEqual(['a1', 'b1', 'a2', 'b2']);
-    expect(nodeTrace.marker.color).toEqual([1, 1, 1, 1]);
+    expect(node.text).toEqual(['a1', 'b1', 'a2', 'b2']);
+    expect(node.marker.color).toEqual([1, 1, 1, 1]);
   });
 
   it('chains edges across 3 groupings', () => {
@@ -186,12 +220,13 @@ describe('NetworkGraphVisualization', () => {
 
     render(<WrappedNetwork {...baseProps} config={config} data={fixtures.threeGroupings} />);
 
-    const [edgeTrace, nodeTrace] = lastTraces();
+    const edgeTrace = edgeLineTrace();
+    const node = nodeTrace();
 
-    expect(nodeTrace.text).toEqual(['a1', 'b1', 'c1', 'c2', 'b2']);
+    expect(node.text).toEqual(['a1', 'b1', 'c1', 'c2', 'b2']);
     // 5 edges × 3 entries (src, tgt, null) = 15
     expect(edgeTrace.x).toHaveLength(15);
-    expect(nodeTrace.customdata).toEqual([
+    expect(node.customdata).toEqual([
       { field: 'a', value: 'a1' },
       { field: 'b', value: 'b1' },
       { field: 'c', value: 'c1' },

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.test.ts
@@ -16,11 +16,25 @@
  */
 import { MISSING_BUCKET_NAME } from 'views/Constants';
 
-import { concatQueryStrings, escape, predicate } from './QueryHelper';
+import { concatQueryStrings, edgeClause, escape, predicate } from './QueryHelper';
 
 describe('QueryHelper', () => {
   it('quotes $ in values', () => {
     expect(escape('foo$bar$')).toEqual('foo\\$bar\\$');
+  });
+
+  describe('edgeClause', () => {
+    it('builds a symmetric compound clause over both fields, bracketed as one group', () => {
+      expect(edgeClause({ field: 'source', value: 'a1' }, { field: 'target', value: 'b1' })).toBe(
+        '((source:a1 AND target:b1) OR (source:b1 AND target:a1))',
+      );
+    });
+
+    it('escapes values', () => {
+      expect(edgeClause({ field: 'source', value: 'a b' }, { field: 'target', value: 'c:d' })).toBe(
+        '((source:"a b" AND target:c\\:d) OR (source:c\\:d AND target:"a b"))',
+      );
+    });
   });
 
   describe('concatQueryStrings', () => {

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.ts
@@ -75,3 +75,13 @@ export const predicate = (field: string, value: string | number) =>
     : `${field}:${value}`;
 
 export const not = (query: string) => `NOT ${query}`.replace(/^NOT NOT /, '');
+
+export const edgeClause = (
+  a: { field: string; value: string | number },
+  b: { field: string; value: string | number },
+) => {
+  const pair = (v1: string | number, v2: string | number) =>
+    `${predicate(a.field, escape(v1))} AND ${predicate(b.field, escape(v2))}`;
+
+  return `((${pair(a.value, b.value)}) OR (${pair(b.value, a.value)}))`;
+};

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
@@ -157,6 +157,37 @@ describe('AddToQueryHandler', () => {
     expect(updateQueryString).toHaveBeenCalledWith('anotherQueryId', 'foo:23 AND (source:a OR target:a)');
   });
 
+  it('combines an edge value path into a symmetric compound clause when the operator is EDGE', async () => {
+    const query = createQuery('anotherQueryId', 'foo:23');
+    const view = createViewWithQuery(query);
+    const state = { ...mockRootState, view: { view } } as RootState;
+    const dispatch = mockDispatch(state);
+
+    const widget = AggregationWidget.builder()
+      .id('widget1')
+      .config(AggregationWidgetConfig.builder().visualization('network').build())
+      .build();
+
+    await dispatch(
+      AddToQueryHandler({
+        queryId: 'anotherQueryId',
+        field: 'source',
+        value: 'a',
+        type: new FieldType('keyword', [], []),
+        contexts: {
+          widget,
+          valuePath: [{ source: 'a' }, { target: 'b' }],
+          valuePathOperator: 'EDGE',
+        },
+      }),
+    );
+
+    expect(updateQueryString).toHaveBeenCalledWith(
+      'anotherQueryId',
+      'foo:23 AND ((source:a AND target:b) OR (source:b AND target:a))',
+    );
+  });
+
   it('resolves the field type per value path entry for mixed field types', async () => {
     const query = createQuery('anotherQueryId', 'foo:23');
     const view = createViewWithQuery(query);

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -18,7 +18,14 @@ import uniq from 'lodash/uniq';
 
 import type FieldType from 'views/logic/fieldtypes/FieldType';
 import recordQueryStringUsage from 'views/logic/queries/recordQueryStringUsage';
-import { escape, addToQuery, formatTimestamp, predicate, concatQueryStrings } from 'views/logic/queries/QueryHelper';
+import {
+  escape,
+  addToQuery,
+  formatTimestamp,
+  predicate,
+  concatQueryStrings,
+  edgeClause,
+} from 'views/logic/queries/QueryHelper';
 import { updateQueryString } from 'views/logic/slices/viewSlice';
 import { selectQueryString } from 'views/logic/slices/viewSelectors';
 import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
@@ -64,13 +71,24 @@ const AddToQueryHandler =
         : [{ field, value, type }],
     );
 
-    const newQuery =
-      multipleValues && contexts?.valuePathOperator === 'OR'
-        ? addToQuery(oldQuery, orClause(valuesToAdd))
-        : valuesToAdd.reduce(
-            (prev, valueToAdd) => formatNewQuery(prev, valueToAdd.field, valueToAdd.value, valueToAdd.type),
-            oldQuery,
-          );
+    let newQuery: string;
+
+    if (multipleValues && contexts?.valuePathOperator === 'EDGE') {
+      newQuery = addToQuery(
+        oldQuery,
+        edgeClause(
+          { field: valuesToAdd[0].field, value: valuesToAdd[0].value },
+          { field: valuesToAdd[1].field, value: valuesToAdd[1].value },
+        ),
+      );
+    } else if (multipleValues && contexts?.valuePathOperator === 'OR') {
+      newQuery = addToQuery(oldQuery, orClause(valuesToAdd));
+    } else {
+      newQuery = valuesToAdd.reduce(
+        (prev, valueToAdd) => formatNewQuery(prev, valueToAdd.field, valueToAdd.value, valueToAdd.type),
+        oldQuery,
+      );
+    }
 
     await recordQueryStringUsage(newQuery, oldQuery);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.ts
@@ -150,6 +150,31 @@ describe('ExcludeFromQueryHandler', () => {
     expect(updateQueryString).toHaveBeenCalledWith('queryId', 'answer:42 AND NOT (source:a OR target:a)');
   });
 
+  it('negates the symmetric edge clause when the operator is EDGE', async () => {
+    const query = createQuery('answer:42');
+    const view = createViewWithQuery(query);
+    const state = { ...mockRootState, view: { view } } as RootState;
+    const dispatch = mockDispatch(state);
+
+    await dispatch(
+      ExcludeFromQueryHandler({
+        queryId: 'queryId',
+        field: 'source',
+        value: 'a',
+        contexts: {
+          widget: { config: { visualization: 'network' } } as unknown as Widget,
+          valuePath: [{ source: 'a' }, { target: 'b' }],
+          valuePathOperator: 'EDGE',
+        },
+      }),
+    );
+
+    expect(updateQueryString).toHaveBeenCalledWith(
+      'queryId',
+      'answer:42 AND NOT ((source:a AND target:b) OR (source:b AND target:a))',
+    );
+  });
+
   it('escapes special characters in field value', async () => {
     const query = createQuery('*');
     const view = createViewWithQuery(query);

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -16,7 +16,7 @@
  */
 import uniq from 'lodash/uniq';
 
-import { escape, addToQuery, predicate, not, concatQueryStrings } from 'views/logic/queries/QueryHelper';
+import { escape, addToQuery, predicate, not, concatQueryStrings, edgeClause } from 'views/logic/queries/QueryHelper';
 import recordQueryStringUsage from 'views/logic/queries/recordQueryStringUsage';
 import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
 import type { RootState } from 'views/types';
@@ -44,6 +44,15 @@ const excludeOrClause = (oldQuery: string, valuePath: ValuePath) => {
   return addToQuery(oldQuery, not(`(${orGroup})`));
 };
 
+// Negates the symmetric edge clause, e.g. `NOT ((source:a AND target:b) OR (source:b AND target:a))`.
+const excludeEdgeClause = (oldQuery: string, valuePath: ValuePath) => {
+  const [e0, e1] = valuePath;
+  const [f0, v0] = Object.entries(e0)[0];
+  const [f1, v1] = Object.entries(e1)[0];
+
+  return addToQuery(oldQuery, not(edgeClause({ field: f0, value: v0 }, { field: f1, value: v1 })));
+};
+
 type Args = {
   queryId: string;
   field: string;
@@ -59,10 +68,18 @@ const ExcludeFromQueryHandler =
 
     const valuesToAdd = uniq(multipleValues ? contexts.valuePath.map(() => ({ field, value })) : [{ field, value }]);
 
-    const newQuery =
-      multipleValues && contexts?.valuePathOperator === 'OR'
-        ? excludeOrClause(oldQuery, contexts.valuePath)
-        : valuesToAdd.reduce((prev, valueToAdd) => formatNewQuery(prev, valueToAdd.field, valueToAdd.value), oldQuery);
+    let newQuery: string;
+
+    if (multipleValues && contexts?.valuePathOperator === 'EDGE') {
+      newQuery = excludeEdgeClause(oldQuery, contexts.valuePath);
+    } else if (multipleValues && contexts?.valuePathOperator === 'OR') {
+      newQuery = excludeOrClause(oldQuery, contexts.valuePath);
+    } else {
+      newQuery = valuesToAdd.reduce(
+        (prev, valueToAdd) => formatNewQuery(prev, valueToAdd.field, valueToAdd.value),
+        oldQuery,
+      );
+    }
 
     await recordQueryStringUsage(newQuery, oldQuery);
 

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.ts
@@ -48,7 +48,7 @@ type Args = {
   queryId: string;
   field: string;
   value?: string;
-  contexts?: { valuePath?: ValuePath; valuePathOperator?: 'AND' | 'OR'; widget?: Widget } | null;
+  contexts?: { valuePath?: ValuePath; valuePathOperator?: 'AND' | 'OR' | 'EDGE'; widget?: Widget } | null;
 };
 
 const ExcludeFromQueryHandler =

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -281,8 +281,9 @@ export interface ActionContexts {
   message: Message;
   valuePath: ValuePath;
   // How to combine the entries of `valuePath` when generating a query clause. Defaults to 'AND'
-  // (combined groupings); 'OR' is used e.g. for a network-graph node queried across all groupings.
-  valuePathOperator?: 'AND' | 'OR';
+  // (combined groupings); 'OR' is used e.g. for a network-graph node queried across all groupings;
+  // 'EDGE' builds the symmetric two-field clause for a network-graph edge.
+  valuePathOperator?: 'AND' | 'OR' | 'EDGE';
   isLocalNode: boolean;
   parameters?: Immutable.Set<Parameter>;
   parameterBindings?: ParameterBindings;


### PR DESCRIPTION
## Description

Makes edges in the network graph visualization clickable and wires them up to the existing add-to-query / exclude-from-query value actions. Clicking an edge now filters the search down to the messages connecting the two nodes.

Key pieces:

- `NetworkGraphVisualization` renders invisible (`opacity: 0`) hit-target markers sampled along each edge. Plotly click detection is point-based and an edge's only real data points are its endpoints (which coincide with node markers), so without these the edge line was not clickable.
- New `EDGE` value-path operator threaded through `ActionContexts`, the `OnClickPopover` types/components, `AddToQueryHandler`, and `ExcludeFromQueryHandler`.
- New `edgeClause` helper in `QueryHelper` builds a symmetric two-field clause, e.g. `((source:a AND target:b) OR (source:b AND target:a))`, so edge direction doesn't matter. `ExcludeFromQueryHandler` negates it.

## Motivation and Context

The network graph already supported querying by node, but edges — which represent the relationship between two nodes — were not interactive. This lets users drill into the messages behind a specific connection directly from the graph.

## How Has This Been Tested?

Added/updated unit tests for `QueryHelper.edgeClause`, `AddToQueryHandler`, `ExcludeFromQueryHandler`, `NetworkGraphVisualization`, and `SankeyOnClickPopover`. Also verified edge clicking and the resulting query manually in the search view.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/nocl Builds on the still-unreleased network graph visualization; no user-facing changelog entry needed.