### PR TITLE
Do not fetch messages in MessageResource when no index permissions (#…

### DIFF
--- a/changelog/unreleased/pr-26565.toml
+++ b/changelog/unreleased/pr-26565.toml
@@ -1,0 +1,3 @@
+type = "s"
+message = "Fix security issue in `MessageResource` that allowed fetching a message from an index the user has no read permission for. Prevent this kind of users to check index existence."
+pulls = ["26565"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -103,6 +103,7 @@ public class MessageResource extends RestResource {
                                 @PathParam("index") String index,
                                 @ApiParam(name = "messageId", required = true)
                                 @PathParam("messageId") String messageId) throws IOException {
+        checkPermission(RestPermissions.INDICES_READ, index);
         checkPermission(RestPermissions.MESSAGES_READ, messageId);
         try {
             final ResultMessage resultMessage = messages.get(messageId, index);


### PR DESCRIPTION
Note: This is a backport of #26565 to `7.0`.

## Description
Do not fetch messages in MessageResource when no index permissions.

## Motivation and Context
See https://github.com/Graylog2/graylog-plugin-enterprise/issues/13402

## How Has This Been Tested?
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

