### PR TITLE
Add `row` class name for `Row` component.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Row.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Row.tsx
@@ -57,8 +57,11 @@ const StyledRow = styled.div`
   }
 `;
 
-const Row = ({ children = undefined, as = undefined, ...rest }: Props, ref: React.ForwardedRef<HTMLDivElement>) => (
-  <StyledRow ref={ref} as={as} {...rest}>
+const Row = (
+  { children = undefined, as = undefined, className = undefined, ...rest }: Props,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) => (
+  <StyledRow ref={ref} as={as} className={`${className ?? ''} row`} {...rest}>
     {children}
   </StyledRow>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


This PR is a follow-up for https://github.com/Graylog2/graylog2-server/pull/26191. It simple adds a CSS class to the `Row` component which has been removed, but is still in use in some cases to style the `Row` component.

For example in the `MessageTableEntry` component.

```
.row {
  margin-right: 0;
}
```

Fixes https://github.com/Graylog2/graylog2-server/issues/26481

/nocl - Fixes a small unreleased UI regression