### PR TITLE
Show Edit/Duplicate Options for Sigma Rule Event Definitions

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -44,7 +44,6 @@ import type { EventDefinition } from '../event-definitions-types';
 import {
   isAggregationEventDefinition,
   isSystemEventDefinition,
-  isSigmaEventDefinition,
 } from '../event-definitions-types';
 
 type Props = {
@@ -263,7 +262,7 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
             </MenuItem>
           </IfPermitted>
           <IfPermitted permissions="eventdefinitions:create">
-            {!isSystemEventDefinition(eventDefinition) && !isSigmaEventDefinition(eventDefinition) && (
+            {!isSystemEventDefinition(eventDefinition) && (
               <MenuItem onClick={() => handleAction(DIALOG_TYPES.COPY, eventDefinition)}>Duplicate</MenuItem>
             )}
             <MenuItem divider />

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.test.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.test.tsx
@@ -29,7 +29,6 @@ import { adminUser } from 'fixtures/users';
 import { asMock } from 'helpers/mocking';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { useEventDefinitionWithContext } from 'components/event-definitions/hooks/useEventDefinitions';
-import useGetPermissionsByScope from 'hooks/useScopePermissions';
 import type { EventNotification } from 'components/event-notifications/hooks/useEventNotifications';
 
 import ViewEventDefinitionPage from './ViewEventDefinitionPage';
@@ -42,7 +41,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('hooks/useCurrentUser');
-jest.mock('hooks/useScopePermissions');
 
 jest.mock('components/event-definitions/hooks/useEventDefinitions', () => ({
   ...jest.requireActual('components/event-definitions/hooks/useEventDefinitions'),
@@ -70,11 +68,6 @@ describe('<ViewEventDefinitionPage />', () => {
         is_mutable: true,
       },
       isFetching: false,
-    });
-    asMock(useGetPermissionsByScope).mockReturnValue({
-      loadingScopePermissions: false,
-      scopePermissions: { is_mutable: true, is_deletable: true },
-      checkPermissions: () => true,
     });
     asMock(usePluginEntities).mockImplementation(
       (entityKey) =>

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
@@ -29,19 +29,14 @@ import { useEventNotifications } from 'components/event-notifications/hooks/useE
 import EventsPageNavigation from 'components/events/EventsPageNavigation';
 import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
-import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
 import { isSystemEventDefinition } from 'components/event-definitions/event-definitions-types';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
-import usePluginEntities from 'hooks/usePluginEntities';
 import {
   useEventDefinitionWithContext,
   copyEventDefinition,
   EVENT_DEFINITIONS_QUERY_KEY,
 } from 'components/event-definitions/hooks/useEventDefinitions';
 
-type SigmaEventDefinitionConfig = EventDefinition['config'] & {
-  sigma_rule_id: string;
-};
 
 const ViewEventDefinitionPage = () => {
   const params = useParams<{ definitionId?: string }>();
@@ -51,15 +46,6 @@ const ViewEventDefinitionPage = () => {
   const notifications = notificationsData?.notifications;
   const history = useHistory();
   const sendTelemetry = useSendTelemetry();
-  const [showSigmaModal, setShowSigmaModal] = useState(false);
-
-  const pluggableSigmaModal = usePluginEntities('eventDefinitions.components.editSigmaModal').find(
-    (entity: { key: string }) => entity.key === 'coreSigmaModal',
-  );
-
-  const CoreSigmaModal = pluggableSigmaModal
-    ? (pluggableSigmaModal.component as React.FC<{ ruleId: string; onCancel: () => void; onConfirm: () => void }>)
-    : null;
 
   const queryClient = useQueryClient();
   const { data, isFetching } = useEventDefinitionWithContext(params.definitionId);
@@ -100,11 +86,6 @@ const ViewEventDefinitionPage = () => {
 
   const onEditEventDefinition = () => history.push(Routes.ALERTS.DEFINITIONS.edit(params.definitionId));
 
-  const onSigmaModalClose = () => {
-    queryClient.invalidateQueries({ queryKey: [...EVENT_DEFINITIONS_QUERY_KEY, params.definitionId] });
-    setShowSigmaModal(false);
-  };
-
   if (isFetching || !eventDefinition || !notifications) {
     return (
       <DocumentTitle title="View Event Definition">
@@ -125,11 +106,11 @@ const ViewEventDefinitionPage = () => {
           title={`View "${eventDefinition.title}" Event Definition`}
           actions={
             <ButtonToolbar>
-                <IfPermitted permissions={`eventdefinitions:edit:${params.definitionId}`}>
-                  <Button bsStyle="primary" onClick={onEditEventDefinition}>
-                    Edit Event Definition
-                  </Button>
-                </IfPermitted>
+              <IfPermitted permissions={`eventdefinitions:edit:${params.definitionId}`}>
+                <Button bsStyle="primary" onClick={onEditEventDefinition}>
+                  Edit Event Definition
+                </Button>
+              </IfPermitted>
               {!isSystemEventDefinition(eventDefinition) && (
                 <IfPermitted permissions="eventdefinitions:create">
                   <Button onClick={() => setShowDialog(true)}>Duplicate Event Definition</Button>
@@ -162,13 +143,6 @@ const ViewEventDefinitionPage = () => {
           onCancel={() => setShowDialog(false)}>
           {`Are you sure you want to create a copy of "${eventDefinition.title}"?`}
         </ConfirmDialog>
-      )}
-      {showSigmaModal && CoreSigmaModal && (
-        <CoreSigmaModal
-          ruleId={(eventDefinition.config as SigmaEventDefinitionConfig).sigma_rule_id}
-          onCancel={onSigmaModalClose}
-          onConfirm={onSigmaModalClose}
-        />
       )}
     </>
   );

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.tsx
@@ -30,7 +30,7 @@ import EventsPageNavigation from 'components/events/EventsPageNavigation';
 import useHistory from 'routing/useHistory';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import type { EventDefinition } from 'components/event-definitions/event-definitions-types';
-import { isSystemEventDefinition, isSigmaEventDefinition } from 'components/event-definitions/event-definitions-types';
+import { isSystemEventDefinition } from 'components/event-definitions/event-definitions-types';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import usePluginEntities from 'hooks/usePluginEntities';
 import {
@@ -38,7 +38,6 @@ import {
   copyEventDefinition,
   EVENT_DEFINITIONS_QUERY_KEY,
 } from 'components/event-definitions/hooks/useEventDefinitions';
-import useGetPermissionsByScope from 'hooks/useScopePermissions';
 
 type SigmaEventDefinitionConfig = EventDefinition['config'] & {
   sigma_rule_id: string;
@@ -76,8 +75,6 @@ const ViewEventDefinitionPage = () => {
       },
     };
   }, [data]);
-
-  const { scopePermissions } = useGetPermissionsByScope(eventDefinition);
 
   useEffect(() => {
     if (!isFetching && !eventDefinition) {
@@ -128,14 +125,12 @@ const ViewEventDefinitionPage = () => {
           title={`View "${eventDefinition.title}" Event Definition`}
           actions={
             <ButtonToolbar>
-              {(!isSigmaEventDefinition(eventDefinition) || scopePermissions?.is_mutable) && (
                 <IfPermitted permissions={`eventdefinitions:edit:${params.definitionId}`}>
                   <Button bsStyle="primary" onClick={onEditEventDefinition}>
                     Edit Event Definition
                   </Button>
                 </IfPermitted>
-              )}
-              {!isSystemEventDefinition(eventDefinition) && !isSigmaEventDefinition(eventDefinition) && (
+              {!isSystemEventDefinition(eventDefinition) && (
                 <IfPermitted permissions="eventdefinitions:create">
                   <Button onClick={() => setShowDialog(true)}>Duplicate Event Definition</Button>
                 </IfPermitted>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Remove calls to `isSigmaEventDefinition` blocking Edit/Duplicate options
- Align `Edit Event Definition` button visibility on View Event Definition page with the Edit action menu option.
  - the `scope.isMutable` check is not used in the Actions menu item and breaks visibility of the button for Illuminate

/nocl 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes Graylog2/graylog-plugin-enterprise#14727

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

