### PR TITLE
Update Netty to 4.2.16

### DIFF
--- a/changelog/unreleased/pr-26603.toml
+++ b/changelog/unreleased/pr-26603.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update to Netty 4.2.16 to fix [several CVEs](https://netty.io/news/2026/07/06/4-2-16-Final.html)."
+
+pulls = ["26603"]

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <mongodb-driver.version>5.8.0</mongodb-driver.version>
         <mongojack.version>5.1.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.79.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>5.4.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
Release notes: https://netty.io/news/2026/07/06/4-2-16-Final.html