### PR TITLE
Fix possible race condition in `NodeService`

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/AbstractNodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/AbstractNodeService.java
@@ -30,6 +30,7 @@ import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.plugin.system.NodeId;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,14 +49,23 @@ public abstract class AbstractNodeService<DTO extends NodeDto> implements NodeSe
     public static final String LAST_SEEN_FIELD = "$last_seen";
     private final long pingTimeout;
     private final static Map<String, Object> lastSeenFieldDefinition = Map.of("last_seen", Map.of("$type", "timestamp"));
-    private final static BasicDBObject addLastSeenFieldAsDate = new BasicDBObject("$addFields",
-            Map.of("last_seen_date", Map.of("$cond",
-            Map.of(
+    private final static Map<String, Object> dateExpression = Map.of(
+            "$cond", Map.of(
                     "if", Map.of("$isNumber", LAST_SEEN_FIELD),
                     "then", Map.of("$toDate", Map.of("$toLong", LAST_SEEN_FIELD)),
                     "else", Map.of("$toDate", Map.of("$dateToString", Map.of("date", LAST_SEEN_FIELD)))
             )
-    )));
+    );
+    private final static BasicDBObject addLastSeenFieldAsDate = new BasicDBObject(
+            "$addFields",
+            Map.of(
+                    "last_seen_date",
+                    Map.of("$ifNull", List.of(dateExpression, "$$NOW"))
+                    // we need to set this field to now if the value is null. This happens only during the brief time
+                    // when the node information is updated (or first registered), followed immediately by a db call
+                    // to update the time.
+            )
+    );
 
     private final MongoCollection<DTO> db;
 
@@ -139,7 +149,14 @@ public abstract class AbstractNodeService<DTO extends NodeDto> implements NodeSe
                 addLastSeenFieldAsDate,
                 new BasicDBObject("$match", Map.of("$expr", Map.of("$lt", List.of("$last_seen_date", Map.of("$subtract", List.of("$$NOW", this.pingTimeout))))))
         ))) {
-            var outdatedIds = stream.map(NodeDto::id).toList();
+            var outdatedIds = stream
+                    .peek(dto -> {
+                        String lastSeen = Optional.ofNullable(dto.getLastSeen())
+                                .map(DateTime::toString)
+                                .orElse("unknown");
+                        LOG.warn("Removing stale node {} (last seen {})", dto.getNodeId(), lastSeen);
+                    })
+                    .map(NodeDto::id).toList();
 
             if (!outdatedIds.isEmpty()) {
                 db.deleteMany(MongoUtils.stringIdsIn(outdatedIds));
@@ -178,10 +195,13 @@ public abstract class AbstractNodeService<DTO extends NodeDto> implements NodeSe
             registerServer(dto);
         }
         // set timestamp using db
-        db.updateOne(
+        UpdateResult updateResult = db.updateOne(
                 new BasicDBObject("node_id", dto.getNodeId()),
                 new BasicDBObject("$currentDate", lastSeenFieldDefinition)
         );
+        if (updateResult.getMatchedCount() != 1) {
+            LOG.warn("Could not mark node {} as alive", dto.getNodeId());
+        }
         try {
             // Remove old nodes that are no longer running. (Just some housekeeping)
             dropOutdated();


### PR DESCRIPTION
## Description
In #25932 we refactored the `NodeService` to use `MongoCollections` with typed entities.
This required to set the `last_seen` field in a subsequent call in order to have this field managed by the database.

If two servers are started at almost the same time, this can cause the `dropOutdated` method to drop nodes which have this field not yet set. 

To circumvent that, we use a null check and set `last_seen` to now in this special case.

/nocl

## Motivation and Context
fixes a regression introduced during development

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

