### PR TITLE
Preload Material Symbols icon font to avoid font-display fallback

### DIFF
--- a/graylog2-web-interface/src/preload.ts
+++ b/graylog2-web-interface/src/preload.ts
@@ -15,3 +15,23 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import '@material-symbols/font-700/rounded.css';
+import materialSymbolsFont from '@material-symbols/font-700/material-symbols-rounded.woff2';
+
+// The icon `@font-face` uses `font-display: block`, so the browser only fetches the font
+// lazily when the first icon paints. In slow/cold environments (e.g. headless e2e) that
+// fetch can miss the block window, causing icons to fall back to their ligature source
+// text ("search", ...). Emitting a real `<link rel="preload">` from this early-loading
+// entry (it runs before `app.js`) starts the fetch up front, so the font is ready by the
+// time icons first render. `crossorigin` is required for the preload to be reused by the
+// CORS fetch that `@font-face` performs.
+const preloadIconFont = () => {
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.as = 'font';
+  link.type = 'font/woff2';
+  link.href = materialSymbolsFont;
+  link.crossOrigin = 'anonymous';
+  document.head.appendChild(link);
+};
+
+preloadIconFont();

--- a/graylog2-web-interface/src/types.d.ts
+++ b/graylog2-web-interface/src/types.d.ts
@@ -44,6 +44,10 @@ declare module '*.png' {
   export default string;
 }
 
+declare module '*.woff2' {
+  export default string;
+}
+
 declare module 'jest-preset-graylog/lib/timeouts' {
   export const timeoutMultiplier: () => number;
   export const applyTimeoutMultiplier: (x: number) => number;


### PR DESCRIPTION
## Description

The Material Symbols icon `@font-face` uses `font-display: block`, and the font is only fetched lazily when the first icon paints. In slow/cold environments (e.g. headless e2e), that fetch can miss the block window and icons fall back to their ligature source text (`search`, ...) instead of the glyph.

This emits a real `<link rel="preload" as="font" crossorigin>` from the early-loading `preload` entry (which runs before `app.js`), so the font fetch starts up front and is ready by the time icons render. The webpack-resolved URL matches the `@font-face` `src`, so the preload is reused rather than double-fetched.

## Motivation and Context

Icons intermittently render as their raw ligature text in slow/cold environments (notably headless e2e runs) because the lazy font fetch misses the `font-display: block` window. Preloading the font up front avoids the fallback.

## How Has This Been Tested?

Verified locally that the preload `<link>` is emitted with a URL matching the `@font-face` `src` and that the font is served from a single fetch (no double-download).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl Internal change to asset loading; no user-facing behavior change.