### PR TITLE
Fix hover background color on pinned actions column in `EntityDataTable`.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Table.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.tsx
@@ -17,7 +17,12 @@
 import React from 'react';
 import { Table as MantineTable } from '@mantine/core';
 import styled, { css } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
 
+export const TABLE_ROW_HOVER_TRANSITION = 'background-color 150ms ease-in-out';
+export const TABLE_ROW_PINNED_HOVER_BG_VAR = '--table-row-pinned-hover-bg';
+export const flattenTableBackground = (theme: DefaultTheme, color: string) =>
+  theme.utils.flattenColorStack([theme.colors.global.contentBackground, color]);
 export const PINNED_CELL_CLASS_NAME = 'table-pinned-cell';
 export const PINNED_CELL_STRIPED_CLASS_NAME = 'table-pinned-cell-striped';
 
@@ -78,7 +83,7 @@ const StyledTable = styled(MantineTable)<StyledProps>(
 
     & tbody > tr {
       background-color: ${theme.colors.global.contentBackground};
-      transition: background-color 150ms ease-in-out;
+      transition: ${TABLE_ROW_HOVER_TRANSITION};
     }
 
     ${$striped &&
@@ -100,6 +105,7 @@ const StyledTable = styled(MantineTable)<StyledProps>(
     css`
       & tbody > tr:hover {
         background-color: ${theme.colors.table.row.backgroundHover};
+        ${TABLE_ROW_PINNED_HOVER_BG_VAR}: ${flattenTableBackground(theme, theme.colors.table.row.backgroundHover)};
       }
     `}
 
@@ -109,28 +115,20 @@ const StyledTable = styled(MantineTable)<StyledProps>(
       & tbody:only-of-type > tr:hover,
       & tbody:not(:only-of-type) > tr:hover {
         background-color: ${theme.colors.table.row.backgroundHover};
+        ${TABLE_ROW_PINNED_HOVER_BG_VAR}: ${flattenTableBackground(theme, theme.colors.table.row.backgroundHover)};
       }
     `}
 
     & thead > tr > th.${PINNED_CELL_CLASS_NAME} {
-      background-color: ${theme.utils.flattenColorStack([
-        theme.colors.global.contentBackground,
-        theme.colors.table.head.background,
-      ])};
+      background-color: ${flattenTableBackground(theme, theme.colors.table.head.background)};
     }
 
     & tbody > tr > .${PINNED_CELL_CLASS_NAME}, & tfoot > tr > .${PINNED_CELL_CLASS_NAME} {
-      background-color: ${theme.utils.flattenColorStack([
-        theme.colors.global.contentBackground,
-        theme.colors.table.row.background,
-      ])};
+      background-color: ${flattenTableBackground(theme, theme.colors.table.row.background)};
     }
 
     & tbody > tr > .${PINNED_CELL_STRIPED_CLASS_NAME} {
-      background-color: ${theme.utils.flattenColorStack([
-        theme.colors.global.contentBackground,
-        theme.colors.table.row.backgroundStriped,
-      ])};
+      background-color: ${flattenTableBackground(theme, theme.colors.table.row.backgroundStriped)};
     }
 
     @media print {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useActionsColumnDefinition.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useActionsColumnDefinition.tsx
@@ -23,6 +23,7 @@ import styled, { css } from 'styled-components';
 import useResizeObserver from '@react-hook/resize-observer';
 
 import { ButtonToolbar } from 'components/bootstrap';
+import { TABLE_ROW_HOVER_TRANSITION, TABLE_ROW_PINNED_HOVER_BG_VAR, flattenTableBackground } from 'components/bootstrap/Table';
 import type { EntityBase } from 'components/common/EntityDataTable/types';
 import { ACTIONS_COL_ID, CELL_PADDING } from 'components/common/EntityDataTable/Constants';
 import { actionsHeaderWidthVar } from 'components/common/EntityDataTable/CSSVariables';
@@ -40,10 +41,7 @@ const BackgroundFoundation = styled.div`
 
 const HeaderBackground = styled(BackgroundFoundation)(
   ({ theme }) => css`
-    background-color: ${theme.utils.flattenColorStack([
-      theme.colors.global.contentBackground,
-      theme.colors.table.head.background,
-    ])};
+    background-color: ${flattenTableBackground(theme, theme.colors.table.head.background)};
   `,
 );
 
@@ -52,12 +50,14 @@ const Actions = styled.div<{ $isEvenRow: boolean }>(
     display: flex;
     justify-content: flex-end;
     padding: ${CELL_PADDING}px;
-    background-color: ${theme.utils.flattenColorStack([
-      theme.colors.global.contentBackground,
-      $isEvenRow ? theme.colors.table.row.background : theme.colors.table.row.backgroundStriped,
-    ])};
+    background-color: ${flattenTableBackground(theme, $isEvenRow ? theme.colors.table.row.background : theme.colors.table.row.backgroundStriped)};
     height: 100%;
     align-items: flex-start;
+    transition: ${TABLE_ROW_HOVER_TRANSITION};
+
+    tr:hover & {
+      background-color: var(${TABLE_ROW_PINNED_HOVER_BG_VAR});
+    }
   `,
 );
 


### PR DESCRIPTION
## Description

The pinned actions column in `EntityDataTable` did not change background color on row hover, because its background is applied to an inner `div` rather than the `td`, so the table's `tr:hover` rule had no effect.

This fixes the issue by adding a `tr:hover &` selector to the `Actions` styled component, using a CSS custom property (`--table-row-pinned-hover-bg`) set on the hovered `tr` in `Table.tsx`. This keeps the hover color as a single source of truth, defined once alongside the row hover rule.

/nocl - fixes unreleased bug