### PR TITLE
Add per entity permission checks to Notification Test endpoint

### DIFF
--- a/changelog/unreleased/issue-14753.toml
+++ b/changelog/unreleased/issue-14753.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Add entity-level permission check to event notification test endpoint."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14753"]
+pulls = ["26614"]

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -306,6 +306,9 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @NoAuditEvent("only used to test event notifications")
     public Response test(@Parameter(name = "JSON Body") NotificationDto dto) {
         checkPermission(RestPermissions.EVENT_NOTIFICATIONS_CREATE);
+        if (!isNullOrEmpty(dto.id())) {
+            checkPermission(RestPermissions.EVENT_NOTIFICATIONS_EDIT, dto.id());
+        }
         final ValidationResult validationResult = dto.validate();
         if (validationResult.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds entity-level permission check to event notification test endpoint which is the same checks that the `/events/notifications/{notificationId}/test` uses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/14753

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify that a user cannot test a notification they do not have edit permission for.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

