### PR TITLE
Fit the MCP server to mcp-sdk 2.0.0 (`7.1`)

### DIFF
--- a/changelog/unreleased/pr-26526.toml
+++ b/changelog/unreleased/pr-26526.toml
@@ -1,0 +1,5 @@
+type = "added" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Add support for validating MCP tool call arguments. Upgrade io.modelcontextprotocol.sdk dependency to version 2.0.0"
+
+issues = [""]
+pulls = ["26526"]

--- a/graylog2-server/src/main/java/org/graylog/mcp/config/McpConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/config/McpConfiguration.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 public abstract class McpConfiguration {
     public static final McpConfiguration DEFAULT_VALUES = create(
             false,
+            false,
             false
     );
 
@@ -35,11 +36,15 @@ public abstract class McpConfiguration {
     @JsonProperty("enable_output_schema")
     public abstract boolean enableOutputSchema();
 
+    @JsonProperty("enable_input_validation")
+    public abstract boolean enableInputValidation();
+
     @JsonCreator
     public static McpConfiguration create(
             @JsonProperty("enable_remote_access") boolean enableRemoteAccess,
-            @JsonProperty("enable_output_schema") boolean enableOutputSchema
+            @JsonProperty("enable_output_schema") boolean enableOutputSchema,
+            @JsonProperty("enable_input_validation") boolean enableInputValidation
     ) {
-        return new AutoValue_McpConfiguration(enableRemoteAccess, enableOutputSchema);
+        return new AutoValue_McpConfiguration(enableRemoteAccess, enableOutputSchema, enableInputValidation);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/mcp/resources/DashboardResourceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/resources/DashboardResourceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.mcp.resources;
 
+import com.google.common.base.Strings;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -81,10 +82,10 @@ public class DashboardResourceProvider extends ResourceProvider {
         if (!permissionHelper.getSearchUser().canReadView(dashboard)) {
             return Optional.empty();
         }
-        return Optional.of(McpSchema.Resource.builder()
-                .name(dashboard.title())
+        // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+        final String name = Strings.isNullOrEmpty(dashboard.title()) ? dashboard.id() : dashboard.title();
+        return Optional.of(McpSchema.Resource.builder(grn.toString(), name)
                 .description(dashboard.description())
-                .uri(grn.toString())
                 .build());
     }
 
@@ -98,15 +99,13 @@ public class DashboardResourceProvider extends ResourceProvider {
 
         try (resultStream) {
             return resultStream
-                    .map(dashboard -> new McpSchema.Resource(
-                            GRN_TYPE.toGRN(dashboard.id()).toString(),
-                            dashboard.title(),
-                            dashboard.title(),
-                            dashboard.description(),
-                            null,
-                            null,
-                            null,
-                            null))
+                    .map(dashboard -> McpSchema.Resource.builder(
+                                    GRN_TYPE.toGRN(dashboard.id()).toString(),
+                                    // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+                                    Strings.isNullOrEmpty(dashboard.title()) ? dashboard.id() : dashboard.title())
+                            .title(dashboard.title())
+                            .description(dashboard.description())
+                            .build())
                     .toList();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/mcp/resources/DashboardResourceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/resources/DashboardResourceProvider.java
@@ -99,7 +99,6 @@ public class DashboardResourceProvider extends ResourceProvider {
 
         try (resultStream) {
             return resultStream
-<<<<<<< backport-7.1/refactor/mcp-sdk
                     .map(dashboard -> McpSchema.Resource.builder(
                                     GRN_TYPE.toGRN(dashboard.id()).toString(),
                                     // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
@@ -107,18 +106,6 @@ public class DashboardResourceProvider extends ResourceProvider {
                             .title(dashboard.title())
                             .description(dashboard.description())
                             .build())
-=======
-                    .map(dashboard -> new McpSchema.Resource(
-                            GRN_TYPE.toGRN(dashboard.id()).toString(),
-                            // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
-                            Strings.isNullOrEmpty(dashboard.title()) ? dashboard.id() : dashboard.title(),
-                            dashboard.title(),
-                            dashboard.description(),
-                            null,
-                            null,
-                            null,
-                            null))
->>>>>>> 7.1
                     .toList();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/mcp/resources/EventDefinitionResourceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/resources/EventDefinitionResourceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.mcp.resources;
 
+import com.google.common.base.Strings;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -79,10 +80,10 @@ public class EventDefinitionResourceProvider extends ResourceProvider {
             return Optional.empty();
         }
         final var eventDefinition = definitionDto.get();
-        return Optional.of(McpSchema.Resource.builder()
-                .name(eventDefinition.title())
+        // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+        final String name = Strings.isNullOrEmpty(eventDefinition.title()) ? eventDefinition.id() : eventDefinition.title();
+        return Optional.of(McpSchema.Resource.builder(grn.toString(), name)
                 .description(eventDefinition.description())
-                .uri(grn.toString())
                 .build());
     }
 
@@ -92,15 +93,13 @@ public class EventDefinitionResourceProvider extends ResourceProvider {
             return dtos
                     .filter(eventDefinition -> permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ,
                             eventDefinition.id()))
-                    .map(eventDefinition -> new McpSchema.Resource(
-                            GRN_TYPE.toGRN(eventDefinition.id()).toString(),
-                            eventDefinition.title(),
-                            eventDefinition.title(),
-                            eventDefinition.description(),
-                            null,
-                            null,
-                            null,
-                            null))
+                    .map(eventDefinition -> McpSchema.Resource.builder(
+                                    GRN_TYPE.toGRN(eventDefinition.id()).toString(),
+                                    // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+                                    Strings.isNullOrEmpty(eventDefinition.title()) ? eventDefinition.id() : eventDefinition.title())
+                            .title(eventDefinition.title())
+                            .description(eventDefinition.description())
+                            .build())
                     .toList();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/mcp/resources/EventDefinitionResourceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/resources/EventDefinitionResourceProvider.java
@@ -93,7 +93,6 @@ public class EventDefinitionResourceProvider extends ResourceProvider {
             return dtos
                     .filter(eventDefinition -> permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ,
                             eventDefinition.id()))
-<<<<<<< backport-7.1/refactor/mcp-sdk
                     .map(eventDefinition -> McpSchema.Resource.builder(
                                     GRN_TYPE.toGRN(eventDefinition.id()).toString(),
                                     // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
@@ -101,18 +100,6 @@ public class EventDefinitionResourceProvider extends ResourceProvider {
                             .title(eventDefinition.title())
                             .description(eventDefinition.description())
                             .build())
-=======
-                    .map(eventDefinition -> new McpSchema.Resource(
-                            GRN_TYPE.toGRN(eventDefinition.id()).toString(),
-                            // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
-                            Strings.isNullOrEmpty(eventDefinition.title()) ? eventDefinition.id() : eventDefinition.title(),
-                            eventDefinition.title(),
-                            eventDefinition.description(),
-                            null,
-                            null,
-                            null,
-                            null))
->>>>>>> 7.1
                     .toList();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/mcp/resources/StreamResourceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/resources/StreamResourceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.mcp.resources;
 
+import com.google.common.base.Strings;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -77,10 +78,10 @@ public class StreamResourceProvider extends ResourceProvider {
         }
         try {
             final Stream stream = streamService.load(grn.entity());
-            return Optional.of(McpSchema.Resource.builder()
-                    .name(stream.getTitle())
+            // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+            final String name = Strings.isNullOrEmpty(stream.getTitle()) ? stream.getId() : stream.getTitle();
+            return Optional.of(McpSchema.Resource.builder(grn.toString(), name)
                     .description(stream.getDescription())
-                    .uri(grn.toString())
                     .build());
         } catch (NotFoundException e) {
             return Optional.empty();
@@ -93,15 +94,13 @@ public class StreamResourceProvider extends ResourceProvider {
         try (var dtos = streamService.streamAllDTOs()) {
             return dtos
                     .filter(stream -> permissionHelper.isPermitted(RestPermissions.STREAMS_READ, stream.getId()))
-                    .map(stream -> new McpSchema.Resource(
-                            GRN_TYPE.toGRN(stream.getId()).toString(),
-                            stream.getTitle(),
-                            stream.getTitle(),
-                            stream.getDescription(),
-                            null,
-                            null,
-                            null,
-                            null))
+                    .map(stream -> McpSchema.Resource.builder(
+                                    GRN_TYPE.toGRN(stream.getId()).toString(),
+                                    // MCP SDK 2.0.0 rejects a null/empty Resource name; fall back to the id.
+                                    Strings.isNullOrEmpty(stream.getTitle()) ? stream.getId() : stream.getTitle())
+                            .title(stream.getTitle())
+                            .description(stream.getDescription())
+                            .build())
                     .toList();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/McpRestResource.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/McpRestResource.java
@@ -17,7 +17,6 @@
 package org.graylog.mcp.server;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,7 +48,6 @@ import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -64,8 +62,6 @@ public class McpRestResource extends RestResource {
     private static final String HEADER_MCP_SESSION_ID = "Mcp-Session-Id";
     private static final String HEADER_MCP_PROTOCOL_VERSION = "MCP-Protocol-Version";
 
-    private final ObjectMapper objectMapper;
-
     private final McpService mcpService;
 
     private final SecurityContext securityContext;
@@ -73,10 +69,9 @@ public class McpRestResource extends RestResource {
     private final ClusterConfigService clusterConfig;
 
     @Inject
-    public McpRestResource(final ClusterConfigService clusterConfig, final McpService mcpService, final ObjectMapper objectMapper, final SecurityContext securityContext) {
+    public McpRestResource(final ClusterConfigService clusterConfig, final McpService mcpService, final SecurityContext securityContext) {
         this.clusterConfig = clusterConfig;
         this.mcpService = mcpService;
-        this.objectMapper = objectMapper;
         this.securityContext = securityContext;
     }
 
@@ -91,16 +86,15 @@ public class McpRestResource extends RestResource {
                          @HeaderParam(HEADER_MCP_PROTOCOL_VERSION) String protocolVersionHeader,
                          @HeaderParam(HEADER_MCP_SESSION_ID) String mcpSessionIdHeader,
                          @Context SearchUser searchUser,
-                         @Parameter(name = "jsonrpc_message", required = true) JsonNode payload) throws IOException {
+                         @Parameter(name = "jsonrpc_message", required = true) JsonNode payload) {
         final McpConfiguration mcpConfig = clusterConfig.getOrDefault(McpConfiguration.class,
                 McpConfiguration.DEFAULT_VALUES);
         if (!mcpConfig.enableRemoteAccess()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
 
-        if (!containsAnyRequests(payload)) {
-            // no requests, simply respond, responses or notifications
-            // must not create new responses (https://modelcontextprotocol.io/specification/2025-06-18/basic#notifications)
+        if (payload == null || payload.isMissingNode() || payload.isNull()) {
+            // nothing to handle
             return Response.accepted().build();
         }
 
@@ -112,62 +106,75 @@ public class McpRestResource extends RestResource {
         // We only implement non-streaming for now if the client is willing to go one-shot. we might support SSE later.
         final String accept = Optional.ofNullable(acceptHeader).orElse("");
         final boolean stream = accept.contains(MediaType.SERVER_SENT_EVENTS) && !accept.contains(MediaType.APPLICATION_JSON);
-        if (!stream) {
-            // Simple one-shot JSON reply
-            Object id = null;
-            try {
-                final McpSchema.JSONRPCRequest request = objectMapper.convertValue(payload, McpSchema.JSONRPCRequest.class);
-                LOG.trace("Received JSON-RPC request {}", request);
-                id = request.id();
 
-                if (protocolVersionHeader != null) {
-                    // According to: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
-                    // The protocol version sent by the client SHOULD be the one negotiated during initialization.
-                    // The server is NOT responsible for ensuring that the negotiated version remains the same over multiple requests.
-                    if (!McpService.ALL_SUPPORTED_MCP_VERSIONS.contains(protocolVersionHeader)) {
-                        LOG.warn("Invalid protocol version for request header {}", protocolVersionHeader);
-                        // Example: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#error-handling
-                        throw McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
-                                .message("Invalid protocol version header " + protocolVersionHeader)
-                                .data(Map.of("supported", McpService.ALL_SUPPORTED_MCP_VERSIONS, "requested", protocolVersionHeader))
-                                .build();
-                    }
-                } else {
-                    // TODO: manage session ids -> retrieve negotiated version as fallback, use "2025-03-26" as default
-                    protocolVersionHeader = McpService.FALLBACK_MCP_VERSION;
-                }
-                final PermissionHelper permissionHelper = new PermissionHelper(getCurrentUser(), securityContext, searchUser);
-                final Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, sessionId, protocolVersionHeader);
-
-                if (result.isPresent() && LOG.isTraceEnabled()) {
-                    LOG.trace("Successfully handled JSON-RPC request: {}", objectMapper.writeValueAsString(result));
-                }
-                return Response.ok(new McpSchema.JSONRPCResponse("2.0", id, result.orElse(null), null))
-                        .header(HEADER_MCP_SESSION_ID, sessionId)
-                        .build();
-            } catch (McpError e) {
-                return Response.status(Response.Status.BAD_REQUEST)
-                        .entity(new McpSchema.JSONRPCResponse("2.0", id, null, e.getJsonRpcError()))
-                        .header(HEADER_MCP_SESSION_ID, sessionId)
-                        .build();
-            } catch (Exception e) {
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                        .entity(new McpSchema.JSONRPCResponse("2.0",
-                                id,
-                                null,
-                                new McpSchema.JSONRPCResponse.JSONRPCError(
-                                        McpSchema.ErrorCodes.INTERNAL_ERROR,
-                                        e.getMessage(),
-                                        null
-                                )
-                        ))
-                        .header(HEADER_MCP_SESSION_ID, sessionId)
-                        .build();
-            }
+        final McpSchema.JSONRPCMessage message;
+        try {
+            message = mcpService.parseMessage(payload);
+        } catch (Exception e) {
+            // Not a recognisable JSON-RPC message; we have no id to respond against, so reject the request.
+            LOG.warn("Received an unparseable JSON-RPC message", e);
+            return Response.status(Response.Status.BAD_REQUEST).build();
         }
 
-        LOG.warn("SSE is not supported at the moment, returning 405 Method Not Allowed");
-        return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        if (!(message instanceof McpSchema.JSONRPCRequest request)) {
+            // responses and notifications must not create new responses
+            // (https://modelcontextprotocol.io/specification/2025-06-18/basic#notifications)
+            return Response.accepted().build();
+        }
+        LOG.trace("Received JSON-RPC request {}", request);
+
+        if (stream) {
+            // Simple one-shot JSON reply only; SSE streaming is not implemented yet.
+            LOG.warn("SSE is not supported at the moment, returning 405 Method Not Allowed");
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+
+        final Object id = request.id();
+        try {
+            if (protocolVersionHeader != null) {
+                // According to: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
+                // The protocol version sent by the client SHOULD be the one negotiated during initialization.
+                // The server is NOT responsible for ensuring that the negotiated version remains the same over multiple requests.
+                if (!McpService.ALL_SUPPORTED_MCP_VERSIONS.contains(protocolVersionHeader)) {
+                    LOG.warn("Invalid protocol version for request header {}", protocolVersionHeader);
+                    // Example: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#error-handling
+                    throw McpError.builder(McpSchema.ErrorCodes.INVALID_PARAMS)
+                            .message("Invalid protocol version header " + protocolVersionHeader)
+                            .data(Map.of("supported", McpService.ALL_SUPPORTED_MCP_VERSIONS, "requested", protocolVersionHeader))
+                            .build();
+                }
+            } else {
+                // TODO: manage session ids -> retrieve negotiated version as fallback, use "2025-03-26" as default
+                protocolVersionHeader = McpService.FALLBACK_MCP_VERSION;
+            }
+            final PermissionHelper permissionHelper = new PermissionHelper(getCurrentUser(), securityContext, searchUser);
+            final Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, sessionId, protocolVersionHeader, mcpConfig);
+
+            if (result.isPresent() && LOG.isTraceEnabled()) {
+                LOG.trace("Successfully handled JSON-RPC request: {}", result.get());
+            }
+            return Response.ok(new McpSchema.JSONRPCResponse("2.0", id, result.orElse(null), null))
+                    .header(HEADER_MCP_SESSION_ID, sessionId)
+                    .build();
+        } catch (McpError e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(new McpSchema.JSONRPCResponse("2.0", id, null, e.getJsonRpcError()))
+                    .header(HEADER_MCP_SESSION_ID, sessionId)
+                    .build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new McpSchema.JSONRPCResponse("2.0",
+                            id,
+                            null,
+                            new McpSchema.JSONRPCResponse.JSONRPCError(
+                                    McpSchema.ErrorCodes.INTERNAL_ERROR,
+                                    e.getMessage(),
+                                    null
+                            )
+                    ))
+                    .header(HEADER_MCP_SESSION_ID, sessionId)
+                    .build();
+        }
     }
 
     @GET
@@ -186,18 +193,5 @@ public class McpRestResource extends RestResource {
     }
 
     // TODO: manage session ids -> DELETE session ids and return NO_CONTENT
-
-    private boolean containsAnyRequests(JsonNode node) {
-        if (node == null || node.isMissingNode() || node.isNull()) return false;
-        if (node.isObject()) {
-            return node.hasNonNull("method") && node.has("id");
-        }
-        if (node.isArray()) {
-            for (JsonNode n : node) {
-                if (containsAnyRequests(n)) return true;
-            }
-        }
-        return false;
-    }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/McpService.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/McpService.java
@@ -18,8 +18,13 @@ package org.graylog.mcp.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapperSupplier;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import io.modelcontextprotocol.json.schema.jackson2.JacksonJsonSchemaValidatorSupplier;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.ProtocolVersions;
@@ -27,6 +32,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNType;
+import org.graylog.mcp.config.McpConfiguration;
 import org.graylog.mcp.tools.PermissionHelper;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
@@ -36,9 +42,11 @@ import org.graylog2.web.customization.CustomizationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.graylog2.audit.AuditEventTypes.MCP_PROMPT_GET;
@@ -59,6 +67,13 @@ public class McpService {
     static final List<String> ALL_SUPPORTED_MCP_VERSIONS = List.of(LATEST_SUPPORTED_MCP_VERSION);
 
     private final ObjectMapper objectMapper;
+    // The MCP SDK's own JSON mapper -- NOT the global Graylog ObjectMapper, whose SnakeCaseStrategy and
+    // custom modules interfere with the SDK's camelCase @JsonProperty mappings. The McpSchema records carry
+    // their own Jackson annotations (incl. @JsonIgnoreProperties(ignoreUnknown=true) as of SDK 2.0.0), so
+    // this tolerates forward-compatible fields from newer clients without extra configuration (java-sdk#766).
+    private final McpJsonMapper protocolMapper = new JacksonMcpJsonMapperSupplier().get();
+    // Validates tool-call arguments against each tool's input schema; caches compiled schemas internally.
+    private final JsonSchemaValidator schemaValidator = new JacksonJsonSchemaValidatorSupplier().get();
     private final AuditEventSender auditEventSender;
     private final CustomizationConfig customizationConfig;
     private final GRNRegistry grnRegistry;
@@ -80,11 +95,15 @@ public class McpService {
         this.resourceProviders = resourceProviders;
     }
 
-    public Optional<McpSchema.Result> handle(PermissionHelper permissionHelper, McpSchema.JSONRPCRequest request, String sessionId) throws McpError {
-        return handle(permissionHelper, request, sessionId, null);
+    /**
+     * Parses a raw JSON-RPC payload into a typed message (request, notification, or response) using
+     * the MCP protocol mapper. McpService owns that mapper, so HTTP callers don't need one of their own.
+     */
+    public McpSchema.JSONRPCMessage parseMessage(JsonNode payload) throws IOException {
+        return McpSchema.deserializeJsonRpcMessage(protocolMapper, payload.toString());
     }
 
-    public Optional<McpSchema.Result> handle(PermissionHelper permissionHelper, McpSchema.JSONRPCRequest request, String sessionId, String protocolVersion) throws McpError {
+    public Optional<McpSchema.Result> handle(PermissionHelper permissionHelper, McpSchema.JSONRPCRequest request, String sessionId, String protocolVersion, McpConfiguration config) throws McpError {
         final AuditActor auditActor = AuditActor.user(permissionHelper.getCurrentUser().getName());
         final Map<String, Object> auditContext = Maps.newHashMap();
         auditContext.put("sessionId", sessionId);
@@ -93,7 +112,7 @@ public class McpService {
 
         switch (request.method()) {
             case McpSchema.METHOD_INITIALIZE -> {
-                final McpSchema.InitializeRequest initializeRequest = objectMapper.convertValue(request.params(), new TypeReference<>() {});
+                final McpSchema.InitializeRequest initializeRequest = protocolMapper.convertValue(request.params(), McpSchema.InitializeRequest.class);
                 auditContext.put("request", initializeRequest);
                 final McpSchema.InitializeResult result = new McpSchema.InitializeResult(
                         // Version negotiation: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#version-negotiation
@@ -106,7 +125,7 @@ public class McpService {
                                 new McpSchema.ServerCapabilities.ResourceCapabilities(false, false),
                                 new McpSchema.ServerCapabilities.ToolCapabilities(false)
                         ),
-                        new McpSchema.Implementation(customizationConfig.productName(), ServerVersion.VERSION.toString()),
+                        McpSchema.Implementation.builder(customizationConfig.productName(), ServerVersion.VERSION.toString()).build(),
                         null,
                         null);
                 auditEventSender.success(auditActor, AuditEventType.create(MCP_PROTOCOL_INITIALIZE), auditContext);
@@ -124,13 +143,13 @@ public class McpService {
                         .map(resourceProvider -> resourceProvider.list(permissionHelper))
                         .flatMap(List::stream)
                         .toList();
-                final McpSchema.ListResourcesResult result = new McpSchema.ListResourcesResult(resourceList, null);
+                final McpSchema.ListResourcesResult result = McpSchema.ListResourcesResult.builder(resourceList).build();
                 LOG.debug("Returning available resources {}", result);
                 auditEventSender.success(auditActor, AuditEventType.create(MCP_RESOURCE_LIST), auditContext);
                 return Optional.of(result);
             }
             case McpSchema.METHOD_RESOURCES_READ -> {
-                final McpSchema.ReadResourceRequest readResourceRequest = objectMapper.convertValue(request.params(), new TypeReference<>() {});
+                final McpSchema.ReadResourceRequest readResourceRequest = protocolMapper.convertValue(request.params(), McpSchema.ReadResourceRequest.class);
                 auditContext.put("request", readResourceRequest);
                 LOG.debug("Reading resource: {}", readResourceRequest);
                 try {
@@ -139,8 +158,11 @@ public class McpService {
                             .read(permissionHelper, new URI(readResourceRequest.uri()))
                             .orElseThrow();
                     auditEventSender.success(auditActor, AuditEventType.create(MCP_RESOURCE_READ), auditContext);
-                    final var contents = new McpSchema.TextResourceContents(resource.uri(), null, resource.description());
-                    return Optional.of(new McpSchema.ReadResourceResult(List.of(contents)));
+                    final var contents = McpSchema.TextResourceContents.builder(
+                            resource.uri(),
+                            Objects.requireNonNullElse(resource.description(), "")
+                    ).build();
+                    return Optional.of(McpSchema.ReadResourceResult.builder(List.of(contents)).build());
                 } catch (Exception e) {
                     throw McpError.builder(McpSchema.ErrorCodes.RESOURCE_NOT_FOUND)
                             .message("Failed to read resource")
@@ -152,41 +174,50 @@ public class McpService {
                 LOG.debug("Listing available resource templates");
                 final List<McpSchema.ResourceTemplate> templates = resourceProviders.values().stream()
                         .map(ResourceProvider::resourceTemplate)
-                        .map(template -> new McpSchema.ResourceTemplate(
-                                template.uriTemplate().getTemplate(),
-                                template.name(),
-                                template.title(),
-                                template.description(),
-                                template.contentType(),
-                                null
-                        ))
+                        .map(template -> McpSchema.ResourceTemplate.builder(
+                                        template.uriTemplate().getTemplate(),
+                                        template.name())
+                                .title(template.title())
+                                .description(template.description())
+                                .mimeType(template.contentType())
+                                .build())
                         .toList();
                 auditEventSender.success(auditActor, AuditEventType.create(MCP_RESOURCE_READTEMPLATES), auditContext);
-                return Optional.of(new McpSchema.ListResourceTemplatesResult(templates, null));
+                return Optional.of(McpSchema.ListResourceTemplatesResult.builder(templates).build());
             }
             case McpSchema.METHOD_TOOLS_LIST -> {
                 LOG.debug("Listing available tools");
                 final List<McpSchema.Tool> toolList = this.tools.values().stream().map(tool -> {
-                    var builder = McpSchema.Tool.builder()
-                            .name(tool.name())
+                    var builder = McpSchema.Tool.builder(tool.name(), tool.inputSchema())
                             .title(tool.title())
                             .description(tool.description());
-                    tool.inputSchema().ifPresent(builder::inputSchema);
                     if (tool.isOutputSchemaEnabled()) {
                         tool.outputSchema().ifPresent(builder::outputSchema);
                     }
                     return builder.build();
                 }).toList();
                 auditEventSender.success(auditActor, AuditEventType.create(MCP_TOOL_LIST), auditContext);
-                return Optional.of(new McpSchema.ListToolsResult(toolList, null));
+                return Optional.of(McpSchema.ListToolsResult.builder(toolList).build());
             }
             case McpSchema.METHOD_TOOLS_CALL -> {
-                final McpSchema.CallToolRequest callToolRequest = objectMapper.convertValue(request.params(), new TypeReference<>() {});
+                final McpSchema.CallToolRequest callToolRequest = protocolMapper.convertValue(request.params(), McpSchema.CallToolRequest.class);
                 auditContext.put("request", callToolRequest);
 
                 LOG.debug("Calling MCP tool: {}", callToolRequest);
                 if (tools.containsKey(callToolRequest.name())) {
                     final Tool<?, ?> tool = tools.get(callToolRequest.name());
+                    if (config.enableInputValidation()) {
+                        final var validation = schemaValidator.validate(tool.inputSchema(),
+                                Objects.requireNonNullElse(callToolRequest.arguments(), Map.of()));
+                        if (!validation.valid()) {
+                            auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
+                            return Optional.of(McpSchema.CallToolResult.builder()
+                                    .content(List.of(McpSchema.TextContent.builder(
+                                            "Invalid tool arguments: " + validation.errorMessage()).build()))
+                                    .isError(true)
+                                    .build());
+                        }
+                    }
                     try {
                         final Object result = tool.apply(permissionHelper, callToolRequest.arguments());
                         if (tool.outputSchema().isPresent()) {
@@ -198,7 +229,7 @@ public class McpService {
                                 auditEventSender.success(auditActor, AuditEventType.create(MCP_TOOL_CALL),
                                         auditContext);
                                 return Optional.of(McpSchema.CallToolResult.builder()
-                                        .content(List.of(new McpSchema.TextContent(objectMapper.writeValueAsString(result))))
+                                        .content(List.of(McpSchema.TextContent.builder(objectMapper.writeValueAsString(result)).build()))
                                         .isError(false)
                                         .structuredContent(structuredContent)
                                         .build());
@@ -211,21 +242,21 @@ public class McpService {
                             // no schema, just return the string representation directly
                             auditEventSender.success(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
                             return Optional.of(McpSchema.CallToolResult.builder()
-                                    .content(List.of(new McpSchema.TextContent(result.toString())))
+                                    .content(List.of(McpSchema.TextContent.builder(result.toString()).build()))
                                     .isError(false)
                                     .build());
                         }
                     } catch (Exception e) {
                         auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
                         return Optional.of(McpSchema.CallToolResult.builder()
-                                .content(List.of(new McpSchema.TextContent(f("Tool call failed: %s", e.getMessage()))))
+                                .content(List.of(McpSchema.TextContent.builder(f("Tool call failed: %s", e.getMessage())).build()))
                                 .isError(true)
                                 .build());
                     }
                 } else {
                     auditEventSender.failure(auditActor, AuditEventType.create(MCP_TOOL_CALL), auditContext);
                     return Optional.of(McpSchema.CallToolResult.builder()
-                            .content(List.of(new McpSchema.TextContent("Unknown tool named: " + callToolRequest.name())))
+                            .content(List.of(McpSchema.TextContent.builder("Unknown tool named: " + callToolRequest.name()).build()))
                             .isError(true)
                             .build());
                 }
@@ -233,11 +264,11 @@ public class McpService {
             case McpSchema.METHOD_PROMPT_LIST -> {
                 LOG.debug("Listing available prompts");
                 auditEventSender.success(auditActor, AuditEventType.create(MCP_PROMPT_LIST), auditContext);
-                return Optional.of(new McpSchema.ListPromptsResult(List.of(), null));
+                return Optional.of(McpSchema.ListPromptsResult.builder(List.of()).build());
             }
             case McpSchema.METHOD_PROMPT_GET -> {
                 // disabled for now
-                final McpSchema.GetPromptRequest promptRequest = objectMapper.convertValue(request.params(), new TypeReference<>() {});
+                final McpSchema.GetPromptRequest promptRequest = protocolMapper.convertValue(request.params(), McpSchema.GetPromptRequest.class);
                 auditContext.put("request", promptRequest);
                 LOG.debug("Getting prompt {}", promptRequest.name());
                 auditEventSender.failure(auditActor, AuditEventType.create(MCP_PROMPT_GET), auditContext);

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
@@ -20,12 +20,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
-import io.modelcontextprotocol.spec.McpSchema;
-import jakarta.inject.Inject;
 import org.graylog.mcp.config.McpConfiguration;
 import org.graylog.mcp.tools.PermissionHelper;
 import org.graylog2.plugin.cluster.ClusterConfigService;
-import org.graylog2.web.customization.CustomizationConfig;
 
 import java.util.Map;
 import java.util.Optional;
@@ -44,7 +41,7 @@ public abstract class Tool<P, O> {
     private final String name;
     private final String title;
     private final String description;
-    private final McpSchema.JsonSchema inputSchema;
+    private final Map<String, Object> inputSchema;
     private final Map<String, Object> outputSchema;
 
     @Deprecated
@@ -92,11 +89,10 @@ public abstract class Tool<P, O> {
 
         // we can precompute the schema for our parameters, it's statically known
         final var inputSchemaNode = generator.generateSchema(parameterType.getType());
-        if (inputSchemaNode.isEmpty()) {
-            this.inputSchema = null;
-        } else {
-            this.inputSchema = objectMapper.convertValue(inputSchemaNode, McpSchema.JsonSchema.class);
-        }
+        // MCP requires every tool to declare an input schema; a parameterless tool gets an empty object schema.
+        this.inputSchema = inputSchemaNode.isEmpty()
+                ? Map.of("type", "object")
+                : objectMapper.convertValue(inputSchemaNode, new TypeReference<Map<String, Object>>() {});
         // if our tool produces anything other than a String, we want to create a JSON schema for it
         if (String.class.equals(outputType.getType())) {
             this.outputSchema = null;
@@ -130,8 +126,8 @@ public abstract class Tool<P, O> {
     }
 
     @JsonProperty
-    public Optional<McpSchema.JsonSchema> inputSchema() {
-        return Optional.ofNullable(inputSchema);
+    public Map<String, Object> inputSchema() {
+        return inputSchema;
     }
 
     @JsonProperty

--- a/graylog2-server/src/test/java/org/graylog/mcp/resources/DashboardResourceProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/resources/DashboardResourceProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.mcp.resources;
+
+import org.graylog.grn.GRNRegistry;
+import org.graylog.mcp.tools.PermissionHelper;
+import org.graylog.plugins.views.search.permissions.SearchUser;
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.ViewService;
+import org.graylog2.web.customization.CustomizationConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardResourceProviderTest {
+    private static final String ID = "5f4dcc3b5aa765d61d8327de";
+
+    @Mock
+    private ViewService viewService;
+    @Mock
+    private PermissionHelper permissionHelper;
+    @Mock
+    private SearchUser searchUser;
+    @Mock
+    private ViewDTO dashboard;
+
+    private DashboardResourceProvider provider;
+    private URI uri;
+
+    @BeforeEach
+    void setUp() {
+        provider = new DashboardResourceProvider(viewService, new CustomizationConfig(null), GRNRegistry.createWithBuiltinTypes());
+        uri = URI.create(DashboardResourceProvider.GRN_TYPE.toGRN(ID).toString());
+    }
+
+    @Test
+    void readFallsBackToIdWhenTitleIsBlank() {
+        // Regression guard: a blank-titled dashboard must stay readable (SDK 2.0.0 rejects a blank
+        // Resource name), so read() falls back to the id like list() does.
+        when(viewService.get(ID)).thenReturn(Optional.of(dashboard));
+        when(permissionHelper.getSearchUser()).thenReturn(searchUser);
+        when(searchUser.canReadView(dashboard)).thenReturn(true);
+        when(dashboard.title()).thenReturn("");
+        when(dashboard.id()).thenReturn(ID);
+        when(dashboard.description()).thenReturn("a dashboard");
+
+        assertThat(provider.read(permissionHelper, uri)).hasValueSatisfying(r -> {
+            assertThat(r.name()).isEqualTo(ID);
+            assertThat(r.uri()).isEqualTo(uri.toString());
+            assertThat(r.description()).isEqualTo("a dashboard");
+        });
+    }
+
+    @Test
+    void readUsesTitleWhenPresent() {
+        when(viewService.get(ID)).thenReturn(Optional.of(dashboard));
+        when(permissionHelper.getSearchUser()).thenReturn(searchUser);
+        when(searchUser.canReadView(dashboard)).thenReturn(true);
+        when(dashboard.title()).thenReturn("My Dashboard");
+        when(dashboard.description()).thenReturn("a dashboard");
+
+        assertThat(provider.read(permissionHelper, uri))
+                .hasValueSatisfying(r -> assertThat(r.name()).isEqualTo("My Dashboard"));
+    }
+
+    @Test
+    void readReturnsEmptyWhenNotFound() {
+        when(viewService.get(ID)).thenReturn(Optional.empty());
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+
+    @Test
+    void readReturnsEmptyWhenNotPermitted() {
+        when(viewService.get(ID)).thenReturn(Optional.of(dashboard));
+        when(permissionHelper.getSearchUser()).thenReturn(searchUser);
+        when(searchUser.canReadView(dashboard)).thenReturn(false);
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/mcp/resources/EventDefinitionResourceProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/resources/EventDefinitionResourceProviderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.mcp.resources;
+
+import org.graylog.events.processor.DBEventDefinitionService;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.mcp.tools.PermissionHelper;
+import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.web.customization.CustomizationConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventDefinitionResourceProviderTest {
+    private static final String ID = "5f4dcc3b5aa765d61d8327de";
+
+    @Mock
+    private DBEventDefinitionService eventDefinitionService;
+    @Mock
+    private PermissionHelper permissionHelper;
+    @Mock
+    private EventDefinitionDto eventDefinition;
+
+    private EventDefinitionResourceProvider provider;
+    private URI uri;
+
+    @BeforeEach
+    void setUp() {
+        provider = new EventDefinitionResourceProvider(eventDefinitionService, new CustomizationConfig(null), GRNRegistry.createWithBuiltinTypes());
+        uri = URI.create(EventDefinitionResourceProvider.GRN_TYPE.toGRN(ID).toString());
+    }
+
+    @Test
+    void readFallsBackToIdWhenTitleIsBlank() {
+        // Regression guard: a blank-titled event definition must stay readable (SDK 2.0.0 rejects a
+        // blank Resource name), so read() falls back to the id like list() does.
+        when(permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, ID)).thenReturn(true);
+        when(eventDefinitionService.get(ID)).thenReturn(Optional.of(eventDefinition));
+        when(eventDefinition.title()).thenReturn("");
+        when(eventDefinition.id()).thenReturn(ID);
+        when(eventDefinition.description()).thenReturn("an event definition");
+
+        assertThat(provider.read(permissionHelper, uri)).hasValueSatisfying(r -> {
+            assertThat(r.name()).isEqualTo(ID);
+            assertThat(r.uri()).isEqualTo(uri.toString());
+            assertThat(r.description()).isEqualTo("an event definition");
+        });
+    }
+
+    @Test
+    void readUsesTitleWhenPresent() {
+        when(permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, ID)).thenReturn(true);
+        when(eventDefinitionService.get(ID)).thenReturn(Optional.of(eventDefinition));
+        when(eventDefinition.title()).thenReturn("My Event Definition");
+        when(eventDefinition.description()).thenReturn("an event definition");
+
+        assertThat(provider.read(permissionHelper, uri))
+                .hasValueSatisfying(r -> assertThat(r.name()).isEqualTo("My Event Definition"));
+    }
+
+    @Test
+    void readReturnsEmptyWhenNotPermitted() {
+        when(permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, ID)).thenReturn(false);
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+
+    @Test
+    void readReturnsEmptyWhenNotFound() {
+        when(permissionHelper.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ, ID)).thenReturn(true);
+        when(eventDefinitionService.get(ID)).thenReturn(Optional.empty());
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/mcp/resources/StreamResourceProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/resources/StreamResourceProviderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.mcp.resources;
+
+import org.graylog.grn.GRNRegistry;
+import org.graylog.mcp.tools.PermissionHelper;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.streams.StreamService;
+import org.graylog2.web.customization.CustomizationConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreamResourceProviderTest {
+    private static final String ID = "5f4dcc3b5aa765d61d8327de";
+
+    @Mock
+    private StreamService streamService;
+    @Mock
+    private PermissionHelper permissionHelper;
+    @Mock
+    private Stream stream;
+
+    private StreamResourceProvider provider;
+    private URI uri;
+
+    @BeforeEach
+    void setUp() {
+        provider = new StreamResourceProvider(streamService, new CustomizationConfig(null), GRNRegistry.createWithBuiltinTypes());
+        uri = URI.create(StreamResourceProvider.GRN_TYPE.toGRN(ID).toString());
+    }
+
+    @Test
+    void readFallsBackToIdWhenTitleIsBlank() throws Exception {
+        // Regression guard: the REST API allows a blank stream title, but SDK 2.0.0 rejects a blank
+        // Resource name. read() must fall back to the id like list() does, so the entity stays readable.
+        when(permissionHelper.isPermitted(RestPermissions.STREAMS_READ, ID)).thenReturn(true);
+        when(streamService.load(ID)).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("");
+        when(stream.getId()).thenReturn(ID);
+        when(stream.getDescription()).thenReturn("a stream");
+
+        assertThat(provider.read(permissionHelper, uri)).hasValueSatisfying(r -> {
+            assertThat(r.name()).isEqualTo(ID);
+            assertThat(r.uri()).isEqualTo(uri.toString());
+            assertThat(r.description()).isEqualTo("a stream");
+        });
+    }
+
+    @Test
+    void readUsesTitleWhenPresent() throws Exception {
+        when(permissionHelper.isPermitted(RestPermissions.STREAMS_READ, ID)).thenReturn(true);
+        when(streamService.load(ID)).thenReturn(stream);
+        when(stream.getTitle()).thenReturn("My Stream");
+        when(stream.getDescription()).thenReturn("a stream");
+
+        assertThat(provider.read(permissionHelper, uri))
+                .hasValueSatisfying(r -> assertThat(r.name()).isEqualTo("My Stream"));
+    }
+
+    @Test
+    void readReturnsEmptyWhenNotPermitted() {
+        when(permissionHelper.isPermitted(RestPermissions.STREAMS_READ, ID)).thenReturn(false);
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+
+    @Test
+    void readReturnsEmptyWhenStreamNotFound() throws Exception {
+        when(permissionHelper.isPermitted(RestPermissions.STREAMS_READ, ID)).thenReturn(true);
+        when(streamService.load(ID)).thenThrow(new NotFoundException("not found"));
+        assertThat(provider.read(permissionHelper, uri)).isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/mcp/server/McpRestResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/server/McpRestResourceTest.java
@@ -34,9 +34,8 @@ public class McpRestResourceTest {
         // we have to create mocks for the rest, too
         resource = new McpRestResource(clusterConfigService,
                                        null,
-                                       null,
                                        null);
-        clusterConfigService.write(McpConfiguration.create(false, false));
+        clusterConfigService.write(McpConfiguration.create(false, false, false));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/mcp/server/McpServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/server/McpServiceTest.java
@@ -24,6 +24,7 @@ import org.glassfish.jersey.uri.UriTemplate;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNType;
 import org.graylog.grn.GRNTypes;
+import org.graylog.mcp.config.McpConfiguration;
 import org.graylog.mcp.tools.PermissionHelper;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
@@ -50,6 +51,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,6 +91,10 @@ class McpServiceTest {
         );
     }
 
+    private Optional<McpSchema.Result> handle(McpSchema.JSONRPCRequest request) {
+        return mcpService.handle(permissionHelper, request, "session123", null, McpConfiguration.DEFAULT_VALUES);
+    }
+
     @Test
     void testInitializeWithValidProtocolVersion() throws Exception {
         // Given
@@ -105,7 +111,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -120,6 +126,31 @@ class McpServiceTest {
         assertThat(initResult.capabilities().tools()).isNotNull();
 
         verify(auditEventSender).success(any(AuditActor.class), any(AuditEventType.class), anyMap());
+    }
+
+    @Test
+    void testInitializeToleratesUnknownCapabilityFields() throws Exception {
+        // Regression test for https://github.com/Graylog2/graylog2-server/issues/25956
+        // Newer MCP clients may send forward-compatible fields (e.g. capabilities.sampling.tools)
+        // that the SDK's Sampling record doesn't declare.
+        var params = Map.of(
+                "protocolVersion", ProtocolVersions.MCP_2025_06_18,
+                "capabilities", Map.of("sampling", Map.of("tools", Map.of())),
+                "clientInfo", Map.of("name", "TestClient", "version", "1.0.0")
+        );
+        var request = new McpSchema.JSONRPCRequest(
+                "2.0",
+                McpSchema.METHOD_INITIALIZE,
+                "1",
+                params
+        );
+
+        Optional<McpSchema.Result> result = handle(request);
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).isInstanceOf(McpSchema.InitializeResult.class);
+        McpSchema.InitializeResult initResult = (McpSchema.InitializeResult) result.get();
+        assertThat(initResult.protocolVersion()).isEqualTo(ProtocolVersions.MCP_2025_06_18);
     }
 
     @Test
@@ -138,7 +169,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -166,7 +197,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isEmpty();
@@ -194,7 +225,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -230,7 +261,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -259,9 +290,48 @@ class McpServiceTest {
         );
 
         // When/Then
-        assertThatThrownBy(() -> mcpService.handle(permissionHelper, request, "session123"))
+        assertThatThrownBy(() -> handle(request))
                 .isInstanceOf(McpError.class)
                 .hasMessageContaining("Failed to read resource");
+    }
+
+    @Test
+    void testReadResourceWithNullDescriptionStillReturnsResource() throws Exception {
+        // Regression guard for the MCP SDK 2.0.0 upgrade: the SDK now enforces required fields in its
+        // record constructors. McpService builds McpSchema.TextResourceContents(uri, null, description),
+        // where the resource description is the (nullable) "text" argument. SDK 2.0.0 rejects a null
+        // text with IllegalArgumentException("text must not be null"), which McpService's catch-all maps
+        // to RESOURCE_NOT_FOUND. A readable entity with no description (common in Graylog) must not be
+        // reported as missing.
+        ResourceProvider mockProvider = mock(ResourceProvider.class);
+        McpSchema.Resource resource = McpSchema.Resource.builder()
+                .uri("grn::dashboard:test123")
+                .name("Test Dashboard")
+                // intentionally no description -> null
+                .build();
+        when(mockProvider.read(eq(permissionHelper), any(URI.class))).thenReturn(Optional.of(resource));
+
+        resourceProviders.put(GRNTypes.DASHBOARD, mockProvider);
+
+        var readParams = new McpSchema.ReadResourceRequest("grn:local:0:internal:dashboard:test123");
+        var request = new McpSchema.JSONRPCRequest(
+                "2.0",
+                McpSchema.METHOD_RESOURCES_READ,
+                "1",
+                objectMapper.convertValue(readParams, Map.class)
+        );
+
+        // When
+        Optional<McpSchema.Result> result = handle(request);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isInstanceOf(McpSchema.ReadResourceResult.class);
+
+        McpSchema.ReadResourceResult readResult = (McpSchema.ReadResourceResult) result.get();
+        assertThat(readResult.contents()).hasSize(1);
+
+        verify(auditEventSender).success(any(AuditActor.class), any(AuditEventType.class), anyMap());
     }
 
     @Test
@@ -287,7 +357,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -307,7 +377,7 @@ class McpServiceTest {
         when(mockTool.name()).thenReturn("test_tool");
         when(mockTool.title()).thenReturn("Test Tool");
         when(mockTool.description()).thenReturn("A test tool");
-        when(mockTool.inputSchema()).thenReturn(Optional.empty());
+        when(mockTool.inputSchema()).thenReturn(Map.of("type", "object"));
 
         tools.put("test_tool", mockTool);
 
@@ -319,7 +389,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -351,7 +421,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -376,7 +446,7 @@ class McpServiceTest {
         );
 
         // When
-        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+        Optional<McpSchema.Result> result = handle(request);
 
         // Then
         assertThat(result).isPresent();
@@ -405,7 +475,7 @@ class McpServiceTest {
         );
 
         // When/Then
-        assertThat(mcpService.handle(permissionHelper, request, "session123")).get().satisfies(result -> {
+        assertThat(handle(request)).get().satisfies(result -> {
             assertThat(result).isInstanceOf(McpSchema.CallToolResult.class);
             final McpSchema.CallToolResult callResult = (McpSchema.CallToolResult) result;
             assertThat(callResult.isError()).isTrue();
@@ -426,7 +496,7 @@ class McpServiceTest {
 
         // When/Then
         assertThatNoException().isThrownBy(() -> {
-            Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+            Optional<McpSchema.Result> result = handle(request);
 
             assertThat(result).isPresent();
             assertThat(result.get()).isInstanceOf(McpSchema.ListPromptsResult.class);
@@ -452,7 +522,7 @@ class McpServiceTest {
 
         // When/Then
         assertThatNoException().isThrownBy(() -> {
-            Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123");
+            Optional<McpSchema.Result> result = handle(request);
 
             assertThat(result).isPresent();
             assertThat(result.get()).isInstanceOf(McpSchema.GetPromptResult.class);
@@ -477,7 +547,7 @@ class McpServiceTest {
         );
 
         // When/Then
-        assertThatThrownBy(() -> mcpService.handle(permissionHelper, request, "session123"))
+        assertThatThrownBy(() -> handle(request))
                 .isInstanceOf(McpError.class)
                 .hasMessageContaining("Unsupported method");
     }
@@ -493,8 +563,61 @@ class McpServiceTest {
         );
 
         // When/Then
-        assertThatThrownBy(() -> mcpService.handle(permissionHelper, request, "session123"))
+        assertThatThrownBy(() -> handle(request))
                 .isInstanceOf(McpError.class)
                 .hasMessageContaining("Unsupported method");
+    }
+
+    @Test
+    void testCallToolRejectsInvalidArgumentsWhenValidationEnabled() throws Exception {
+        final McpConfiguration config = McpConfiguration.create(false, false, true);
+
+        Tool<Map<String, Object>, String> mockTool = mock(Tool.class);
+        when(mockTool.inputSchema()).thenReturn(Map.of(
+                "type", "object",
+                "properties", Map.of("limit", Map.of("type", "integer")),
+                "required", List.of("limit")));
+        tools.put("test_tool", mockTool);
+
+        // missing the required "limit" property
+        var callParams = new McpSchema.CallToolRequest("test_tool", Map.of());
+        var request = new McpSchema.JSONRPCRequest("2.0", McpSchema.METHOD_TOOLS_CALL, "1",
+                objectMapper.convertValue(callParams, Map.class));
+
+        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123", null, config);
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).isInstanceOf(McpSchema.CallToolResult.class);
+        final McpSchema.CallToolResult callResult = (McpSchema.CallToolResult) result.get();
+        assertThat(callResult.isError()).isTrue();
+        verify(mockTool, never()).apply(any(), any());
+        verify(auditEventSender).failure(any(AuditActor.class), any(AuditEventType.class), anyMap());
+    }
+
+    @Test
+    void testCallToolAcceptsValidArgumentsWhenValidationEnabled() throws Exception {
+        final McpConfiguration config = McpConfiguration.create(false, false, true);
+
+        Tool<Map<String, Object>, String> mockTool = mock(Tool.class);
+        when(mockTool.inputSchema()).thenReturn(Map.of(
+                "type", "object",
+                "properties", Map.of("limit", Map.of("type", "integer")),
+                "required", List.of("limit")));
+        when(mockTool.outputSchema()).thenReturn(Optional.empty());
+        when(mockTool.apply(eq(permissionHelper), any())).thenReturn("Tool result");
+        tools.put("test_tool", mockTool);
+
+        var callParams = new McpSchema.CallToolRequest("test_tool", Map.of("limit", 5));
+        var request = new McpSchema.JSONRPCRequest("2.0", McpSchema.METHOD_TOOLS_CALL, "1",
+                objectMapper.convertValue(callParams, Map.class));
+
+        Optional<McpSchema.Result> result = mcpService.handle(permissionHelper, request, "session123", null, config);
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).isInstanceOf(McpSchema.CallToolResult.class);
+        final McpSchema.CallToolResult callResult = (McpSchema.CallToolResult) result.get();
+        assertThat(callResult.isError()).isFalse();
+        verify(mockTool).apply(eq(permissionHelper), any());
+        verify(auditEventSender).success(any(AuditActor.class), any(AuditEventType.class), anyMap());
     }
 }

--- a/graylog2-web-interface/src/components/configurations/McpConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/McpConfig.tsx
@@ -32,6 +32,7 @@ import DocsHelper from 'util/DocsHelper';
 type McpConfigState = {
   enable_remote_access: boolean;
   enable_output_schema: boolean;
+  enable_input_validation: boolean;
 };
 
 const McpConfig = () => {
@@ -58,6 +59,10 @@ const McpConfig = () => {
 
   const onModalClickEnableOutputSchema = () => {
     setModalConfig({ ...modalConfig, enable_output_schema: !modalConfig.enable_output_schema });
+  };
+
+  const onModalClickEnableInputValidation = () => {
+    setModalConfig({ ...modalConfig, enable_input_validation: !modalConfig.enable_input_validation });
   };
 
   const onModalCancel = () => {
@@ -92,6 +97,9 @@ const McpConfig = () => {
         <br />
         <dt>Output schema</dt>
         <dd>{viewConfig.enable_output_schema ? 'Enabled' : 'Disabled'}</dd>
+        <br />
+        <dt>Input validation</dt>
+        <dd>{viewConfig.enable_input_validation ? 'Enabled' : 'Disabled'}</dd>
       </dl>
 
       <IfPermitted permissions="clusterconfigentry:edit">
@@ -125,6 +133,15 @@ const McpConfig = () => {
               name="output-schema-enabled"
               checked={modalConfig.enable_output_schema}
               onChange={onModalClickEnableOutputSchema}
+            />
+            <Input
+              id="enable-input-validation-checkbox"
+              disabled={!modalConfig.enable_remote_access}
+              type="checkbox"
+              label="Enable Tool Input Validation"
+              name="input-validation-enabled"
+              checked={modalConfig.enable_input_validation}
+              onChange={onModalClickEnableInputValidation}
             />
           </fieldset>
         </BootstrapModalForm>


### PR DESCRIPTION
Note: This is a backport of #26526 to `7.1`.

## Description

Adapts the MCP server (`org.graylog.mcp.*`, server-only) to mcp-sdk 2.0.0, which deprecated much of the `McpSchema` API and changed several wire behaviours:

- **Protocol mapper**: use the SDK's own `McpJsonMapper` for protocol (de)serialization instead of the bespoke `@McpProtocolObjectMapper` workaround (now deleted). 2.0.0 adds `@JsonIgnoreProperties(ignoreUnknown=true)` to every wire record, so unknown forward-compatible fields are tolerated without it.
- **Builders**: migrate deprecated `McpSchema` constructors to the required-first builder factories in `McpService` and the resource providers.
- **Input schema as `Map`**: model `Tool.inputSchema` as `Map<String, Object>` instead of the deprecated `JsonSchema` record. Side effect: emitted input schemas now carry the `$schema` 2020-12 dialect declaration (additive; output schemas already did).
- **Tool-input validation**: validate `tools/call` arguments against each tool's input schema using the SDK's `JsonSchemaValidator`, returning a `CallToolResult(isError=true)` on failure. Gated by a new `McpConfiguration.enableInputValidation` flag, default `false`.
- **Envelope parsing**: parse the JSON-RPC envelope in `McpService` via `McpSchema.deserializeJsonRpcMessage` (typed request/notification/response dispatch). `McpRestResource` no longer holds the mapper, reads `McpConfiguration` once per request, and returns `400` for unparseable bodies.
- **Resource read fix**: `read()` now falls back to the entity id for blank-titled resources, matching `list()`, so a blank-titled stream/dashboard/event definition stays readable instead of surfacing as `RESOURCE_NOT_FOUND`.

## Motivation and Context

Follows the `io.modelcontextprotocol.sdk:mcp-bom` 2.0.0 bump in #26415, which was merged with only minimal regression patches while the larger refactor was postponed. This is that refactor: it clears all SDK deprecation warnings in the MCP production code and aligns the server with 2.0.0's required-field enforcement, lenient wire deserialization, Map-based schemas, and optional input validation.

Relates to `modelcontextprotocol/java-sdk#766`, `modelcontextprotocol/java-sdk#749`, and `modelcontextprotocol/java-sdk#873`.

## How Has This Been Tested?

- **Unit:** `McpServiceTest` (incl. new tool-input-validation tests), `McpRestResourceTest`, and new `StreamResourceProviderTest`, `DashboardResourceProviderTest`, `EventDefinitionResourceProviderTest` (read() name fallback + permission/not-found paths). 33 MCP tests pass.
- **Manual (live, raw `curl` to `/api/mcp`):** `initialize` with `capabilities.sampling.tools` → `200`; `tools/list` (inputSchema carries `$schema`); tool calls; envelope dispatch (notification → `202`, unparseable → `400`); input validation on/off (bad args → `isError`, good args pass); and a blank-titled stream `resources/read` succeeding with `name` = id.

## Screenshots (if appropriate):

N/A — backend only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.