### PR TITLE
Fix security demo pages not rendering when using a path prefix

### DIFF
--- a/changelog/unreleased/pr-26645.toml
+++ b/changelog/unreleased/pr-26645.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix security demo pages not rendering when Graylog is deployed with a path prefix."
+
+pulls = ["26645"]

--- a/graylog2-web-interface/src/components/security/teaser/SecurityPage.tsx
+++ b/graylog2-web-interface/src/components/security/teaser/SecurityPage.tsx
@@ -23,11 +23,11 @@ import AppRoutes, { SECURITY_PATH } from 'routing/Routes';
 import { Overview, UserActivity, HostActivity, NetworkActivity, Anomalies } from 'components/security/pages';
 
 const subRoutes = [
-  { path: AppRoutes.SECURITY.OVERVIEW, element: <Overview /> },
-  { path: AppRoutes.SECURITY.USER_ACTIVITY, element: <UserActivity /> },
-  { path: AppRoutes.SECURITY.HOST_ACTIVITY, element: <HostActivity /> },
-  { path: AppRoutes.SECURITY.NETWORK_ACTIVITY, element: <NetworkActivity /> },
-  { path: AppRoutes.SECURITY.ANOMALIES, element: <Anomalies /> },
+  { path: AppRoutes.unqualified.SECURITY.OVERVIEW, element: <Overview /> },
+  { path: AppRoutes.unqualified.SECURITY.USER_ACTIVITY, element: <UserActivity /> },
+  { path: AppRoutes.unqualified.SECURITY.HOST_ACTIVITY, element: <HostActivity /> },
+  { path: AppRoutes.unqualified.SECURITY.NETWORK_ACTIVITY, element: <NetworkActivity /> },
+  { path: AppRoutes.unqualified.SECURITY.ANOMALIES, element: <Anomalies /> },
 ].map((route) => ({ ...route, path: route.path.slice(SECURITY_PATH.length) }));
 
 const SecurityPage = () => (


### PR DESCRIPTION
## Description

Security demo pages failed to render when Graylog was deployed with a path prefix
(e.g. `http://example.org/graylog`). The nested sub-routes in `SecurityPage.tsx`
were constructed from the qualified (prefix-aware) route paths and then had the
bare `/security` segment stripped — corrupting the paths whenever an app prefix
was present. Switching to the unqualified route paths ensures the strip always
removes exactly `/security`, producing correct relative paths for the nested router
regardless of deployment configuration.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/12181