### PR TITLE
Remove dead server-side sort control from paginated LDAP search

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,6 +36,22 @@ message's accounted size, regardless of whether the restore counted against the 
 This field is informational and is not used to compute license usage, so your license consumption is
 unaffected by the change.
 
+### LDAP/AD Team Sync No Longer Runs a Full Reconciliation on Every Login
+
+Previously, every LDAP or Active Directory login triggered a full, org-wide team synchronization that
+reconciled all synced teams and their members. On large directories this made logins slow.
+
+Logins now synchronize only the logging-in user's own team memberships. The full reconciliation, which
+creates, renames, and deletes teams for remote groups and updates membership for users who have not
+logged in, now runs as a background job (approximately hourly) on the leader node instead.
+
+After upgrading, directory-side changes that affect users who do not log in (for example removing a user
+from a group, or renaming or deleting a group) may take up to an hour to be reflected, rather than
+propagating at the next login of any user. To apply such changes immediately, open the active
+authentication service backend and click **Trigger Synchronization** in its group synchronization section
+(equivalently, `POST /api/plugins/org.graylog.plugins.security/team-sync/trigger/{authServiceId}`).
+Re-activating the authentication service backend also runs a full synchronization.
+
 ## Web Interface Changes
 
 ### Event Definition "Fields" step renamed to "Additional Details"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,8 +46,10 @@ creates, renames, and deletes teams for remote groups and updates membership for
 logged in, now runs as a background job (approximately hourly) on the leader node instead.
 
 After upgrading, directory-side changes that affect users who do not log in (for example removing a user
-from a group, or renaming or deleting a group) may take up to an hour to be reflected, rather than
-propagating at the next login of any user. To apply such changes immediately, open the active
+from a group, or renaming or deleting a group) may take up to the configured full sync interval (1 hour by
+default) to be reflected, rather than propagating at the next login of any user. The interval is tunable via
+the `full_sync_interval` value of the `TeamSyncConfig` cluster configuration (not surfaced in the UI); a zero
+or negative value disables the periodic sync. To apply such changes immediately, open the active
 authentication service backend and click **Trigger Synchronization** in its group synchronization section
 (equivalently, `POST /api/plugins/org.graylog.plugins.security/team-sync/trigger/{authServiceId}`).
 Re-activating the authentication service backend also runs a full synchronization.

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -37,9 +37,7 @@ import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchResultEntry;
 import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.ldap.sdk.SimpleBindRequest;
-import com.unboundid.ldap.sdk.controls.ServerSideSortRequestControl;
 import com.unboundid.ldap.sdk.controls.SimplePagedResultsControl;
-import com.unboundid.ldap.sdk.controls.SortKey;
 import com.unboundid.ldap.sdk.extensions.StartTLSExtendedRequest;
 import com.unboundid.util.Base64;
 import com.unboundid.util.LDAPTestUtils;
@@ -195,8 +193,6 @@ public class UnboundLDAPConnector {
             searchRequest.setTimeLimitSeconds(requestTimeoutSeconds);
             searchRequest.addControl(new SimplePagedResultsControl(pageSize, cookie));
             final SearchResult searchResult = connection.search(searchRequest);
-            SortKey sortKey = new SortKey("cn");
-            searchRequest.addControl(new ServerSideSortRequestControl(sortKey));
             SimplePagedResultsControl responseControl = SimplePagedResultsControl.get(searchResult);
             final List<SearchResultEntry> results = searchResult.getSearchEntries();
             LOG.debug("Received page of [{}] records.", results.size());


### PR DESCRIPTION
/nocl see related enterprise PR Graylog2/graylog-plugin-enterprise#14835

`UnboundLDAPConnector.searchPaginated()` added a `ServerSideSortRequestControl` to the `SearchRequest` *after* `connection.search()` had already executed, so the control was never sent to the server. This removes the dead control and the now-unused `SortKey`.

Sorting is not needed here: the only caller (the enterprise team-sync member resolver) feeds the paginated results into hash maps, and Simple Paged Results does not require a sort for correct paging. Relocating the control to before the search would be actively harmful on Active Directory, which caps server-side sorts (`MaxTempTableSize`) and can fail a sorted large result set with `unavailableCriticalExtension` or a size-limit error, reintroducing the failure that paging was added to avoid.

No functional change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
