### PR TITLE
Show indicator for active page in page navigation again.

### DIFF
--- a/graylog2-web-interface/src/components/common/NavTabs.tsx
+++ b/graylog2-web-interface/src/components/common/NavTabs.tsx
@@ -72,7 +72,7 @@ const NavTabs = ({ items }: Props) => (
   <Container>
     {items.map(({ path, description, exactPathMatch, BadgeComponent }) => (
       <LinkContainer to={path} relativeActive={!exactPathMatch} key={path}>
-        <StyledButton bsStyle="transparent">
+        <StyledButton bsStyle="transparent" showOverflow>
           <NavItemStateIndicator>
             {BadgeComponent ? <BadgeComponent text={description} /> : description}
           </NavItemStateIndicator>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a regression introduced with https://github.com/Graylog2/graylog2-server/pull/26424.

Before this fix the active tab indicator was not visible.
<img width="478" height="199" alt="image" src="https://github.com/user-attachments/assets/64ecf3a1-9636-4649-b660-6920f650e6db" />


After:
<img width="485" height="198" alt="image" src="https://github.com/user-attachments/assets/9be671d9-4923-46f2-8f6b-d913a2c41138" />

I tried adding a test for this regression, but it wasn’t possible to write a reasonable e2e or unit test that would actually be useful.

/nocl - unreleased regression
Fixes https://github.com/Graylog2/graylog2-server/issues/26656