### PR TITLE
MessageResouce permission check fixed (6.3) (#26657)

### DIFF
--- a/changelog/unreleased/pr-26657.toml
+++ b/changelog/unreleased/pr-26657.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix problem in `GET /messages/{index}/{messageId}`. Permission requirements introduced by previous security fix have been too strong, they have been relaxed."
+
+pulls = ["26657"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -96,14 +96,13 @@ public class MessageResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get a single message.")
     @ApiResponses(value = {
-            @ApiResponse(code = 404, message = "Specified index does not exist."),
-            @ApiResponse(code = 404, message = "Message does not exist.")
+            @ApiResponse(code = 200, message = "Returns the message."),
+            @ApiResponse(code = 404, message = "Specified message does not exist or the user does not have the required permissions.")
     })
     public ResultMessage search(@ApiParam(name = "index", value = "The index this message is stored in.", required = true)
                                 @PathParam("index") String index,
                                 @ApiParam(name = "messageId", required = true)
                                 @PathParam("messageId") String messageId) throws IOException {
-        checkPermission(RestPermissions.INDICES_READ, index);
         checkPermission(RestPermissions.MESSAGES_READ, messageId);
         try {
             final ResultMessage resultMessage = messages.get(messageId, index);
@@ -111,10 +110,8 @@ public class MessageResource extends RestResource {
             checkMessageReadPermission(message);
 
             return resultMessage;
-        } catch (DocumentNotFoundException e) {
-            throw new NotFoundException("Message " + messageId + " does not exist in index " + index, e);
-        } catch (IndexNotFoundException e) {
-            throw new NotFoundException("Index " + index + " does not exist.", e);
+        } catch (DocumentNotFoundException | IndexNotFoundException | ForbiddenException e) {
+            throw new NotFoundException("Specified message does not exist or the user does not have the required permissions");
         }
     }
 


### PR DESCRIPTION
Note: This is a backport of #26657 to `6.3`.

## Description
Fix problem in `GET /messages/{index}/{messageId}`. 
Permission requirements introduced by previous security fix have been too strong. The original permissions were correct, so this fix rolls back the permissions.
The exception handling has been modified to not disclose any information that a user without the correct permissions can use to deduct additional information about the system state. This change addresses the security concerns raised in the security advisory.
Fixes https://github.com/Graylog2/graylog2-server/issues/26652
/nocl

## Motivation and Context
See https://github.com/Graylog2/graylog2-server/issues/26652

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

