### PR TITLE
Declare lz4-java as dependency for core

### DIFF
--- a/changelog/unreleased/pr-26674.toml
+++ b/changelog/unreleased/pr-26674.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix Kafka inputs being unable to process LZ4-compressed record batches."
+
+pulls = ["26674"]

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -658,6 +658,7 @@
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
         </dependency>
+        <!-- Explicitly declare lz4 since kafka-clients depends on it and we exclude it from the declaration. -->
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -658,6 +658,10 @@
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
         </dependency>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>


### PR DESCRIPTION
## Description

  Kafka inputs crash with `NoClassDefFoundError: net/jpountz/lz4/LZ4Exception` when consuming any topic containing LZ4-compressed record batches. The input logs `Caught unrecoverable
  exception in poll. Stopping input` and stops:
```
  Caused by: java.lang.NoClassDefFoundError: net/jpountz/lz4/LZ4Exception
      at org.apache.kafka.common.compress.Lz4Compression.wrapForInput(Lz4Compression.java:58)
```
  ### Root cause

  PR #24687 banned `org.lz4:lz4-java` (CVE-2025-12183), excluded it transitively from `kafka-clients`, and switched to the community fork `at.yawk.lz4:lz4-java`. The fork was added to `dependencyManagement` and declared in the enterprise module, but it was never declared as a runtime dependency of the core `graylog2-server` module that owns `KafkaTransport`.

  Result: `kafka-clients` no longer supplies lz4, and nothing puts the fork on the server classpath. When Kafka decompresses an LZ4 batch, `net.jpountz.lz4.LZ4Exception` is missing. The enterprise declaration does not help, because plugins load in isolated classloaders, so the core input transport cannot see it.

  `zstd-jni` was re-added explicitly to the core module for exactly this reason; lz4 was missed.

  ### Why 7.1.x / master aren't affected

  The fix is masked by a transitive coincidence, not an intentional dependency:

  - 7.0.x ships Graylog's repackaged `kafka-clients:4.1.0`, which runtime-depends on `org.lz4:lz4-java` (banned/excluded here), so lz4 is stripped and nothing else supplies it.
  - 7.1.x/master ship `kafka-clients:4.3.1`, whose lz4 runtime dep was switched to the `at.yawk.lz4` fork (not excluded), so it lands on the classpath transitively. `amazon-kinesis-client` -> `software.amazon.glue:schema-registry-serde` pulls the same fork as a second incidental path.

  Both are accidents of a Kafka version bump. A future kafka-clients bump that drops or renames its lz4 dependency would silently reintroduce the crash on every edition. This change makes `at.yawk.lz4:lz4-java` an explicit core dependency so the classpath guarantee no longer rides on a transitive.

  ### Fix

  Declare the `at.yawk.lz4:lz4-java` fork as a dependency of the core `graylog2-server` module, next to `zstd-jni`. Version inherits from `graylog-parent` `dependencyManagement`.

  ### Affected versions / backport

  The 7.0.x line is broken, and the fork is not on the classpath in any 7.0.x build, including the latest patch. This same explicit declaration must be backported to 7.0.x, where it is the actual customer-facing fix (7.1.x/master already work via the transitive path).

  | Version | Behavior on LZ4 topic |
  | --- | --- |
  | `7.0.8`, `7.0.9` (latest 7.0.x) | Crashes (`NoClassDefFoundError`) |
  | `7.1.5`, master `7.2.0-SNAPSHOT` | Works (fork present transitively) |

  ### Affected inputs

  All Kafka inputs (`Raw`, `Syslog`, `GELF`, `Beats`, `CEF`), but only when the consumed topic contains LZ4-compressed batches. Other codecs (gzip, snappy, zstd, uncompressed) are unaffected.

  ## Testing

  Reproduced end-to-end against a Kafka topic with LZ4-compressed batches:

  - `graylog-enterprise:7.0.8` and `7.0.9` reproduced the crash.
  - `graylog-enterprise:7.1.5` and master `7.2.0-SNAPSHOT` (OSS + Enterprise) consume the same topic cleanly (fork present transitively).
  - Verified the fix by placing the fork on the 7.0.8 server classpath; the input then consumes the LZ4 topic and ingests all messages, 0 errors.