### PR TITLE
Manage Kotlin dependencies

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -768,6 +768,13 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <!-- Glue schema support pulls in outdated Kotlin dependencies. ATM we don't support integrating
+                 Amazon Kinesis Data Streams with the AWS Glue Schema Registry, so we can skip the dependency.
+                 Once we add support, this exclusion has to be revisited. -->
+                <exclusion>
+                    <groupId>software.amazon.glue</groupId>
+                    <artifactId>schema-registry-serde</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- end of additional integrations dependencies -->

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
@@ -18,6 +18,7 @@ package org.graylog.integrations.aws.transports;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.graylog.integrations.aws.AWSClientBuilderUtil;
@@ -36,15 +37,22 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClientBuilder;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClientBuilder;
+import software.amazon.kinesis.checkpoint.CheckpointConfig;
 import software.amazon.kinesis.common.ConfigsBuilder;
+import software.amazon.kinesis.coordinator.CoordinatorConfig;
 import software.amazon.kinesis.coordinator.NoOpWorkerStateChangeListener;
 import software.amazon.kinesis.coordinator.Scheduler;
 import software.amazon.kinesis.coordinator.WorkerStateChangeListener;
+import software.amazon.kinesis.leases.LeaseManagementConfig;
+import software.amazon.kinesis.lifecycle.LifecycleConfig;
 import software.amazon.kinesis.lifecycle.NoOpTaskExecutionListener;
 import software.amazon.kinesis.lifecycle.TaskExecutionListener;
 import software.amazon.kinesis.lifecycle.TaskOutcome;
 import software.amazon.kinesis.lifecycle.TaskType;
 import software.amazon.kinesis.lifecycle.events.TaskExecutionListenerInput;
+import software.amazon.kinesis.metrics.MetricsConfig;
+import software.amazon.kinesis.processor.ProcessorConfig;
+import software.amazon.kinesis.retrieval.RetrievalConfig;
 import software.amazon.kinesis.retrieval.polling.PollingConfig;
 
 import java.util.Locale;
@@ -135,7 +143,7 @@ public class KinesisConsumer implements Runnable {
             LOG.debug("Using workerId [{}].", workerId);
 
             // The application name needs to be unique per input/consumer.
-            final String applicationName = String.format(Locale.ENGLISH, "graylog-aws-plugin-%s", kinesisStreamName);
+            final String applicationName = applicationName(kinesisStreamName);
             LOG.debug("Using Kinesis applicationName [{}].", applicationName);
 
             // The KinesisShardProcessorFactory contains the message processing logic.
@@ -174,19 +182,52 @@ public class KinesisConsumer implements Runnable {
                 }
             };
 
-            this.kinesisScheduler = new Scheduler(
-                    configsBuilder.checkpointConfig(),
-                    configsBuilder.coordinatorConfig().workerStateChangeListener(workerStateChangeListener),
-                    configsBuilder.leaseManagementConfig(),
-                    configsBuilder.lifecycleConfig().taskExecutionListener(taskExecutionListener),
-                    configsBuilder.metricsConfig(),
-                    configsBuilder.processorConfig(),
-                    configsBuilder.retrievalConfig().retrievalSpecificConfig(pollingConfig));
+            // ConfigsBuilder accessors create a new config object on every call, so each config must be
+            // materialized exactly once and the same instances passed to the Scheduler — otherwise the
+            // customizeSchedulerConfigs() customizations would be silently discarded.
+            final CheckpointConfig checkpointConfig = configsBuilder.checkpointConfig();
+            final CoordinatorConfig coordinatorConfig = configsBuilder.coordinatorConfig()
+                    .workerStateChangeListener(workerStateChangeListener);
+            final LeaseManagementConfig leaseManagementConfig = configsBuilder.leaseManagementConfig();
+            final LifecycleConfig lifecycleConfig = configsBuilder.lifecycleConfig()
+                    .taskExecutionListener(taskExecutionListener);
+            final MetricsConfig metricsConfig = configsBuilder.metricsConfig();
+            final ProcessorConfig processorConfig = configsBuilder.processorConfig();
+            final RetrievalConfig retrievalConfig = configsBuilder.retrievalConfig()
+                    .retrievalSpecificConfig(pollingConfig);
+
+            customizeSchedulerConfigs(coordinatorConfig, leaseManagementConfig, metricsConfig, retrievalConfig, pollingConfig);
+
+            this.kinesisScheduler = new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig,
+                    lifecycleConfig, metricsConfig, processorConfig, retrievalConfig);
 
             LOG.debug("Starting Kinesis scheduler.");
             kinesisScheduler.run();
             LOG.debug("After Kinesis scheduler stopped.");
         }
+    }
+
+    /**
+     * Hook that allows tests to tune KCL coordination timings (e.g. lease failover, polling intervals)
+     * before the {@link Scheduler} is built. KCL's defaults are appropriate for production but make
+     * integration tests needlessly slow. Production code must not override this.
+     */
+    @VisibleForTesting
+    void customizeSchedulerConfigs(CoordinatorConfig coordinatorConfig,
+                                   LeaseManagementConfig leaseManagementConfig,
+                                   MetricsConfig metricsConfig,
+                                   RetrievalConfig retrievalConfig,
+                                   PollingConfig pollingConfig) {
+        // Intentionally empty: production uses KCL defaults.
+    }
+
+    /**
+     * The KCL application name used for a stream. KCL derives the DynamoDB lease table name from it,
+     * which integration tests rely on when pre-seeding leases.
+     */
+    @VisibleForTesting
+    static String applicationName(String kinesisStreamName) {
+        return String.format(Locale.ENGLISH, "graylog-aws-plugin-%s", kinesisStreamName);
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerIT.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerIT.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.aws.transports;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.graylog.aws.AWSAsyncProxyConfigurationProvider;
+import org.graylog.aws.AWSProxyConfigurationProvider;
+import org.graylog.integrations.aws.AWSAuthFactory;
+import org.graylog.integrations.aws.AWSClientBuilderUtil;
+import org.graylog.integrations.aws.AWSMessageType;
+import org.graylog.integrations.aws.resources.requests.AWSRequest;
+import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
+import org.graylog2.Configuration;
+import org.graylog2.plugin.InputFailureRecorder;
+import org.graylog2.plugin.journal.RawMessage;
+import org.graylog2.plugin.system.SimpleNodeId;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.kinesis.coordinator.CoordinatorConfig;
+import software.amazon.kinesis.leases.LeaseManagementConfig;
+import software.amazon.kinesis.metrics.MetricsConfig;
+import software.amazon.kinesis.metrics.MetricsLevel;
+import software.amazon.kinesis.retrieval.RetrievalConfig;
+import software.amazon.kinesis.retrieval.polling.PollingConfig;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Boots the KCL-based Kinesis consumer against a local AWS emulator and verifies a record
+ * round-trip. Also proves the consumer starts without the (excluded) Glue schema-registry-serde
+ * dependency on the classpath and guards future amazon-kinesis-client upgrades.
+ */
+class KinesisConsumerIT {
+
+    private static final String STREAM = "kinesis-consumer-it-stream";
+    private static final String TEST_MESSAGE = "kinesis-consumer-it test message";
+    private static final String PASSWORD_SECRET = "0123456789abcdef";
+    // KCL derives the lease table name from the application name; sourcing it from production code
+    // makes it impossible for the pre-seeded table (below) to drift out of sync with the consumer.
+    private static final String LEASE_TABLE = KinesisConsumer.applicationName(STREAM);
+
+    private static final KinesisEmulatorContainer EMULATOR = new KinesisEmulatorContainer();
+    private static final String KCL_LOGGER = "software.amazon.kinesis";
+
+    private static Level previousKclLogLevel;
+
+    @BeforeAll
+    static void setUp() {
+        // KCL logs its lease lifecycle milestones (lease taking, shard consumer creation, worker
+        // state) at INFO; without them a hanging consumer is nearly undiagnosable from the test
+        // output. Bump to DEBUG locally when investigating — but beware, DEBUG is extremely chatty
+        // (sub-second renewer/prefetcher/metrics loops). Restored in tearDown() because failsafe
+        // runs all ITs in one JVM fork.
+        previousKclLogLevel = LogManager.getLogger(KCL_LOGGER).getLevel();
+        Configurator.setLevel(KCL_LOGGER, Level.INFO);
+
+        EMULATOR.start();
+        final String shardId;
+        try (KinesisClient kinesis = KinesisClient.builder()
+                .endpointOverride(EMULATOR.endpoint())
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                .build()) {
+            kinesis.createStream(r -> r.streamName(STREAM).shardCount(1));
+            kinesis.waiter().waitUntilStreamExists(r -> r.streamName(STREAM));
+            // Put the record before the consumer starts. The consumer reads from TRIM_HORIZON
+            // (via the pre-seeded lease checkpoint below), so it sees the record.
+            kinesis.putRecord(r -> r.streamName(STREAM)
+                    .partitionKey("test-partition-key")
+                    .data(SdkBytes.fromUtf8String(TEST_MESSAGE)));
+            shardId = kinesis.listShards(r -> r.streamName(STREAM)).shards().get(0).shardId();
+        }
+
+        // Pre-seed the lease table with an unowned lease for the single shard. Without this, KCL's
+        // Scheduler.shouldInitiateLeaseSync() waits a hardcoded random 1-30s jitter (thundering-herd
+        // protection for real fleets) before the initial shard sync creates the lease. With the
+        // lease present, initialization proceeds immediately and the lease taker can acquire it on
+        // its first pass. The attributes are the lenient minimal set read by KCL's
+        // DynamoDBLeaseSerializer; no leaseOwner attribute means "available". KCL adds its
+        // LeaseOwnerToLeaseKeyIndex GSI to the existing table by itself.
+        // Deliberately no fallback: if a future KCL stops honoring the pre-seeded lease, its own
+        // shard sync would create leases at the default LATEST position, the pre-put record would
+        // never arrive, and the test FAILS by timeout — loud, instead of silently passing slower.
+        try (DynamoDbClient dynamo = DynamoDbClient.builder()
+                .endpointOverride(EMULATOR.endpoint())
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                .build()) {
+            dynamo.createTable(r -> r.tableName(LEASE_TABLE)
+                    .attributeDefinitions(a -> a.attributeName("leaseKey").attributeType(ScalarAttributeType.S))
+                    .keySchema(k -> k.attributeName("leaseKey").keyType(KeyType.HASH))
+                    .billingMode(BillingMode.PAY_PER_REQUEST));
+            dynamo.waiter().waitUntilTableExists(r -> r.tableName(LEASE_TABLE));
+            dynamo.putItem(r -> r.tableName(LEASE_TABLE).item(Map.of(
+                    "leaseKey", AttributeValue.fromS(shardId),
+                    "leaseCounter", AttributeValue.fromN("0"),
+                    "checkpoint", AttributeValue.fromS("TRIM_HORIZON"),
+                    "checkpointSubSequenceNumber", AttributeValue.fromN("0"),
+                    "ownerSwitchesSinceCheckpoint", AttributeValue.fromN("0"))));
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        Configurator.setLevel(KCL_LOGGER, previousKclLogLevel);
+        EMULATOR.stop();
+    }
+
+    @Test
+    void consumesRecordFromKinesisStream() throws Exception {
+        final BlockingQueue<RawMessage> received = new LinkedBlockingQueue<>();
+        // Captures the first failure signal, whether the consumer thread dies with an uncaught
+        // exception or KCL reports a failure through the InputFailureRecorder. Lets the test
+        // abort immediately with the root cause instead of blocking for the full timeout.
+        final AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
+
+        final EncryptedValueService encryptedValueService = new EncryptedValueService(PASSWORD_SECRET);
+        final String endpoint = EMULATOR.endpoint().toString();
+        final AWSRequest request = AWSRequestImpl.builder()
+                .region(Region.US_EAST_1.id())
+                .awsAccessKeyId("test")
+                .awsSecretAccessKey(encryptedValueService.encrypt("test"))
+                .kinesisEndpoint(endpoint)
+                .dynamodbEndpoint(endpoint)
+                .cloudwatchEndpoint(endpoint)
+                .build();
+
+        final AWSClientBuilderUtil clientBuilderUtil = new AWSClientBuilderUtil(
+                AWSAuthFactory::new,
+                encryptedValueService,
+                new Configuration(),
+                new AWSProxyConfigurationProvider(null),
+                new AWSAsyncProxyConfigurationProvider(null));
+
+        final KinesisTransport transport = mock(KinesisTransport.class);
+        when(transport.isThrottled()).thenReturn(false);
+
+        // The consumer reports KCL failures through the InputFailureRecorder instead of throwing, so
+        // capture those signals as well. Transient vs. terminal matters here: the 2-arg setFailing()
+        // comes from the TaskExecutionListener on any failed KCL task, which KCL retries — record it
+        // only as diagnostic context. The 3-arg setFailing() comes from
+        // onAllInitializationAttemptsFailed, which is terminal — abort on it.
+        final AtomicReference<String> lastTaskFailure = new AtomicReference<>();
+        final InputFailureRecorder failureRecorder = mock(InputFailureRecorder.class);
+        doAnswer(invocation -> {
+            lastTaskFailure.set(invocation.getArgument(1, String.class));
+            return null;
+        }).when(failureRecorder).setFailing(any(), anyString());
+        doAnswer(invocation -> {
+            final Throwable cause = invocation.getArgument(2, Throwable.class);
+            consumerFailure.compareAndSet(null,
+                    cause != null ? cause : new RuntimeException(invocation.getArgument(1, String.class)));
+            return null;
+        }).when(failureRecorder).setFailing(any(), anyString(), any());
+
+        // Anonymous subclass tunes KCL's coordination timings, which default to production
+        // values (10s failover, 10s shard polling, LATEST initial position) that would make
+        // this test take over a minute.
+        final KinesisConsumer consumer = new KinesisConsumer(
+                new SimpleNodeId("00000000-0000-0000-0000-000000000000"),
+                transport,
+                new ObjectMapperProvider().get(),
+                received::add,
+                STREAM,
+                AWSMessageType.KINESIS_RAW,
+                10_000,
+                request,
+                clientBuilderUtil,
+                failureRecorder) {
+            @Override
+            void customizeSchedulerConfigs(CoordinatorConfig coordinatorConfig,
+                                           LeaseManagementConfig leaseManagementConfig,
+                                           MetricsConfig metricsConfig,
+                                           RetrievalConfig retrievalConfig,
+                                           PollingConfig pollingConfig) {
+                coordinatorConfig.parentShardPollIntervalMillis(1000);
+                // The ShardConsumer state machine advances one state per worker-loop tick
+                // (create -> initialize -> process), so the default 1s interval costs ~3s
+                // before the first record is delivered.
+                coordinatorConfig.shardConsumerDispatchPollIntervalMillis(100);
+                leaseManagementConfig.failoverTimeMillis(500);
+                metricsConfig.metricsLevel(MetricsLevel.NONE);
+                // KCL 3.x assigns leases through a leader-driven LeaseAssignmentManager built around
+                // worker-utilization metrics and EC2/ECS/EKS platform detection. Neither exists on a
+                // dev machine or a local emulator: the IMDS probe burns ~15s in connect timeouts at
+                // Scheduler construction, and leases never get assigned, so no GetRecords call is ever
+                // made and the consumer hangs. Run the official 2.x-compatible assignment path
+                // (workers take unowned leases directly) and skip the platform probe
+                // (disableWorkerMetrics has no effect beyond skipping the probe).
+                coordinatorConfig.clientVersionConfig(
+                        CoordinatorConfig.ClientVersionConfig.CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2X);
+                leaseManagementConfig.workerUtilizationAwareAssignmentConfig().disableWorkerMetrics(true);
+                // Graceful lease handoff waits a default 30s for the previous owner to checkpoint and
+                // release. There are no previous owners in this test — don't wait for them.
+                leaseManagementConfig.gracefulLeaseHandoffConfig().isGracefulLeaseHandoffEnabled(false);
+                pollingConfig.idleTimeBetweenReadsInMillis(200);
+            }
+        };
+
+        final Thread consumerThread = new Thread(consumer, "kinesis-consumer-it");
+        consumerThread.setDaemon(true);
+        consumerThread.setUncaughtExceptionHandler((t, e) -> consumerFailure.compareAndSet(null, e));
+        consumerThread.start();
+        try {
+            // Poll in short intervals up to the deadline so the test fails fast — with the root
+            // cause — when the consumer dies instead of blocking for the full timeout. The healthy
+            // path delivers in well under 10s; the deadline is headroom for slow CI runners.
+            final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+            RawMessage message = null;
+            while (message == null && System.nanoTime() < deadlineNanos) {
+                message = received.poll(1, TimeUnit.SECONDS);
+                if (message == null && (consumerFailure.get() != null || !consumerThread.isAlive())) {
+                    fail("Kinesis consumer died before delivering a record", consumerFailure.get());
+                }
+            }
+            // A terminal failure may have landed in the final poll window after the deadline check.
+            if (message == null && consumerFailure.get() != null) {
+                fail("Kinesis consumer died before delivering a record", consumerFailure.get());
+            }
+            final String taskFailure = lastTaskFailure.get();
+            assertThat(message)
+                    .as("KCL consumer should deliver the pre-put record within the timeout"
+                            + (taskFailure == null ? "" : "; last transient KCL task failure: " + taskFailure))
+                    .isNotNull();
+            assertThat(new String(message.getPayload(), StandardCharsets.UTF_8)).contains(TEST_MESSAGE);
+        } finally {
+            // Expect a few benign "LeaderDecider uninitialized" ERROR logs here: KCL's graceful
+            // shutdown tears down its migration components before the worker loop exits, and each
+            // loop tick in that window throws, gets caught and logged by KCL, and is retried. The
+            // 100ms dispatch interval makes this pre-existing KCL race visible; shutdown still
+            // completes cleanly (verified by the bounded join below).
+            consumer.stop();
+            consumerThread.join(TimeUnit.SECONDS.toMillis(30));
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisEmulatorContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisEmulatorContainer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.aws.transports;
+
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * Minimal AWS emulator container providing Kinesis and DynamoDB for KCL integration tests.
+ * Runs Floci (MIT-licensed, LocalStack-API-compatible). LocalStack itself is not an option:
+ * its free tier prohibits commercial use since March 2026 and the image requires an auth token.
+ * Uses a plain GenericContainer (like {@code S3MinioContainer}) to avoid extra test dependencies.
+ * Since {@code SERVICES} does not include {@code cloudwatch}, KCL consumers under test must disable
+ * metrics ({@code MetricsLevel.NONE}), which the seam-based tests do.
+ */
+class KinesisEmulatorContainer extends GenericContainer<KinesisEmulatorContainer> {
+    private static final String IMAGE = "floci/floci:1.5.33";
+    private static final int PORT = 4566;
+
+    KinesisEmulatorContainer() {
+        super(IMAGE);
+        withExposedPorts(PORT);
+        withEnv("SERVICES", "kinesis,dynamodb");
+        // Forward container output to the test log so CI failures are diagnosable.
+        withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(KinesisEmulatorContainer.class)));
+        waitingFor(new HttpWaitStrategy()
+                .forPath("/_localstack/health")
+                .forPort(PORT)
+                .withStartupTimeout(Duration.ofSeconds(60)));
+    }
+
+    URI endpoint() {
+        return URI.create("http://" + getHost() + ":" + getMappedPort(PORT));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,9 @@
         <jsoup.version>1.22.2</jsoup.version>
         <kafka.version>4.3.1</kafka.version>
         <kafka09.version>0.9.0.1-7</kafka09.version>
+        <kotlin.version>2.3.21</kotlin.version>
+        <kotlinx-serialization.version>1.11.0</kotlinx-serialization.version>
+        <kotlinx-coroutines.version>1.11.0</kotlinx-coroutines.version>
         <log4j.version>2.26.1</log4j.version>
         <lucene.version>10.5.0</lucene.version>
         <lz4.version>1.11.1</lz4.version>
@@ -620,6 +623,27 @@
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-module-jakarta-validation</artifactId>
                 <version>${json-schema-generator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-serialization-bom</artifactId>
+                <version>${kotlinx-serialization.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-coroutines-bom</artifactId>
+                <version>${kotlinx-coroutines.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Adds dependency management for Kotlin, which is used transitively by the graylog2-server module but also required by the enterprise plugin.

By managing the Kotlin dependencies, we can ensure a consistent version.

Also excludes the dependencies required for Glue schema serde support from the Kinesis client. We are not using that functionality and it and rather relying on upwards compatibility, we exclude it. To make sure that the Kinesis consumer is still functional, I've added a very basic integration test.

 ### Dependency tree:

before:
```
./mvnw -pl org.graylog2:graylog2-server dependency:tree -Dverbose -Dincludes='org.jetbrains.kotlin:*,org.jetbrains.kotlinx:*'
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 26.5
[INFO] os.detected.version.major: 26
[INFO] os.detected.version.minor: 5
[INFO] os.detected.classifier: osx-aarch_64
[INFO]
[INFO] --------------------< org.graylog2:graylog2-server >--------------------
[INFO] Building Graylog 7.2.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.7.0:tree (default-cli) @ graylog2-server ---
[INFO] org.graylog2:graylog2-server:jar:7.2.0-SNAPSHOT
[INFO] +- com.squareup.okhttp3:okhttp-jvm:jar:5.4.0:compile
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:compile (scope not updated to compile)
[INFO] |  \- com.squareup.okio:okio-jvm:jar:3.17.0:compile (scope not updated to compile)
[INFO] |     \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:compile - omitted for duplicate)
[INFO] +- com.squareup.retrofit2:retrofit:jar:3.0.0:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:5.4.0:compile (version managed from 4.12.0; scope not updated to compile)
[INFO] |  |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:runtime - omitted for duplicate)
[INFO] |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:compile - omitted for duplicate)
[INFO] +- com.squareup.okhttp3:okhttp-tls:jar:5.4.0:test
[INFO] |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:test - omitted for duplicate)
[INFO] +- software.amazon.kinesis:amazon-kinesis-client:jar:3.5.0:compile
[INFO] |  \- software.amazon.glue:schema-registry-serde:jar:1.1.27:compile
[INFO] |     +- com.kjetland:mbknor-jackson-jsonschema_2.12:jar:1.0.39:compile
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar:1.3.50:compile - omitted for conflict with 1.9.25)
[INFO] |     +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile - omitted for conflict with 2.1.21)
[INFO] |     +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.25:compile
[INFO] |     |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile - omitted for conflict with 2.1.21)
[INFO] |     |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.9.25:compile
[INFO] |     |     \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile - omitted for conflict with 2.1.21)
[INFO] |     +- org.jetbrains.kotlin:kotlin-reflect:jar:1.9.25:compile
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:compile - omitted for conflict with 2.1.21)
[INFO] |     +- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:jar:1.9.25:compile
[INFO] |     |  +- org.jetbrains.kotlin:kotlin-scripting-common:jar:1.9.25:runtime
[INFO] |     |  |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:runtime - omitted for conflict with 2.1.21)
[INFO] |     |  +- org.jetbrains.kotlin:kotlin-scripting-jvm:jar:1.9.25:runtime
[INFO] |     |  |  +- org.jetbrains.kotlin:kotlin-script-runtime:jar:1.9.25:runtime
[INFO] |     |  |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:runtime - omitted for conflict with 2.1.21)
[INFO] |     |  |  \- (org.jetbrains.kotlin:kotlin-scripting-common:jar:1.9.25:runtime - omitted for duplicate)
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:runtime - omitted for conflict with 2.1.21)
[INFO] |     +- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar:1.9.25:compile
[INFO] |     |  +- (org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:jar:1.9.25:runtime - omitted for duplicate)
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.25:runtime - omitted for conflict with 2.1.21)
[INFO] |     +- com.squareup.okio:okio-fakefilesystem:jar:3.2.0:compile
[INFO] |     |  \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.2.0:compile (scope not updated to compile)
[INFO] |     |     +- (org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.6.20:compile - omitted for conflict with 1.9.25)
[INFO] |     |     +- org.jetbrains.kotlinx:kotlinx-datetime-jvm:jar:0.3.2:compile
[INFO] |     |     |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.0:compile - omitted for conflict with 2.1.21)
[INFO] |     |     |  \- (org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.6.0:compile - omitted for conflict with 1.7.10)
[INFO] |     |     \- (org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.6.20:compile - omitted for conflict with 1.7.10)
[INFO] |     +- org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:jar:1.4.0:compile
[INFO] |     |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.7.10:compile - omitted for conflict with 2.1.21)
[INFO] |     |  +- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.7.10:compile
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.7.10:compile - omitted for conflict with 1.9.25)
[INFO] |     +- com.squareup.wire:wire-schema:jar:5.2.0:compile
[INFO] |     |  +- com.squareup.wire:wire-runtime:jar:5.2.0:runtime
[INFO] |     |  |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |     |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |     \- com.squareup.wire:wire-compiler:jar:5.2.0:compile
[INFO] |        +- com.squareup.wire:wire-schema-jvm:jar:5.2.0:compile (scope not updated to compile)
[INFO] |        |  +- com.squareup:kotlinpoet-jvm:jar:2.0.0:compile (scope not updated to compile)
[INFO] |        |  |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.10:compile - omitted for conflict with 2.1.21)
[INFO] |        |  |  \- (org.jetbrains.kotlin:kotlin-reflect:jar:2.0.10:runtime - omitted for conflict with 1.9.25)
[INFO] |        |  +- com.squareup.wire:wire-runtime-jvm:jar:5.2.0:compile (scope not updated to compile)
[INFO] |        |  |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:compile - omitted for conflict with 2.1.21)
[INFO] |        |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:compile - omitted for conflict with 2.1.21)
[INFO] |        +- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:compile - omitted for conflict with 2.1.21)
[INFO] |        +- com.squareup.wire:wire-kotlin-generator:jar:5.2.0:runtime
[INFO] |        |  +- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |        |  \- com.squareup.wire:wire-grpc-client-jvm:jar:5.2.0:runtime
[INFO] |        |     +- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:jar:1.9.0:runtime
[INFO] |        |     |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.0:runtime - omitted for conflict with 2.1.21)
[INFO] |        |     \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |        +- com.squareup.wire:wire-java-generator:jar:5.2.0:runtime
[INFO] |        |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |        +- com.squareup.wire:wire-swift-generator:jar:5.2.0:runtime
[INFO] |        |  +- io.outfoxx:swiftpoet:jar:1.6.5:runtime
[INFO] |        |  |  +- (org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.7.21:runtime - omitted for conflict with 1.9.25)
[INFO] |        |  |  \- (org.jetbrains.kotlin:kotlin-reflect:jar:1.7.21:runtime - omitted for conflict with 1.9.25)
[INFO] |        |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |        +- (org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:jar:1.7.3:runtime - omitted for conflict with 1.4.0)
[INFO] |        \- com.charleskorn.kaml:kaml-jvm:jar:0.67.0:runtime
[INFO] |           +- (org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:jar:1.7.3:runtime - omitted for conflict with 1.4.0)
[INFO] |           +- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.21:runtime - omitted for conflict with 2.1.21)
[INFO] |           \- it.krzeminski:snakeyaml-engine-kmp-jvm:jar:3.0.3:runtime
[INFO] |              +- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.0.10:runtime - omitted for conflict with 2.1.21)
[INFO] |              \- net.thauvin.erik.urlencoder:urlencoder-lib-jvm:jar:1.6.0:runtime
[INFO] |                 \- (org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.24:runtime - omitted for conflict with 2.1.21)
[INFO] \- com.squareup.okhttp3:mockwebserver3:jar:5.4.0:test
[INFO]    \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.1.21:test - omitted for duplicate)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.062 s
[INFO] Finished at: 2026-07-17T13:14:14+02:00
[INFO] ------------------------------------------------------------------------
```


after:
```
./mvnw -pl org.graylog2:graylog2-server dependency:tree -Dverbose -Dincludes='org.jetbrains.kotlin:*,org.jetbrains.kotlinx:*'
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 26.5
[INFO] os.detected.version.major: 26
[INFO] os.detected.version.minor: 5
[INFO] os.detected.classifier: osx-aarch_64
[INFO]
[INFO] --------------------< org.graylog2:graylog2-server >--------------------
[INFO] Building Graylog 7.2.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.7.0:tree (default-cli) @ graylog2-server ---
[INFO] org.graylog2:graylog2-server:jar:7.2.0-SNAPSHOT
[INFO] +- com.squareup.okhttp3:okhttp-jvm:jar:5.4.0:compile
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:compile (version managed from 2.1.21; scope not updated to compile)
[INFO] |  \- com.squareup.okio:okio-jvm:jar:3.17.0:compile (scope not updated to compile)
[INFO] |     \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:compile - version managed from 2.1.21; omitted for duplicate)
[INFO] +- com.squareup.retrofit2:retrofit:jar:3.0.0:compile
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:5.4.0:compile (version managed from 4.12.0)
[INFO] |  |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:runtime - version managed from 2.1.21; omitted for duplicate)
[INFO] |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:compile - version managed from 2.1.21; omitted for duplicate)
[INFO] +- com.squareup.okhttp3:okhttp-tls:jar:5.4.0:test
[INFO] |  \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:test - version managed from 2.1.21; omitted for duplicate)
[INFO] \- com.squareup.okhttp3:mockwebserver3:jar:5.4.0:test
[INFO]    \- (org.jetbrains.kotlin:kotlin-stdlib:jar:2.3.21:test - version managed from 2.1.21; omitted for duplicate)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.342 s
[INFO] Finished at: 2026-07-17T13:15:28+02:00
[INFO] ------------------------------------------------------------------------
```

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/14880
/nocl not user-facing