### PR TITLE
Fix admin certificate regeneration/usage in data node system index reindex

### DIFF
--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/AdminOpensearchClientProvider.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/AdminOpensearchClientProvider.java
@@ -62,7 +62,7 @@ public class AdminOpensearchClientProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdminOpensearchClientProvider.class);
 
-    static final Duration CERT_LIFETIME = Duration.ofMinutes(1);
+    static final Duration CERT_LIFETIME = Duration.ofMinutes(15);
     static final Duration REFRESH_BEFORE_EXPIRY = Duration.ofMinutes(1);
 
     private final ClientCertSslContextFactory sslContextFactory;

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/AdminOpensearchClientProvider.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/AdminOpensearchClientProvider.java
@@ -21,7 +21,6 @@ import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.graylog.security.certutil.ClientCertSslContextFactory;
-import org.graylog.security.certutil.ClientCertSslContextFactoryImpl;
 import org.graylog.storage.opensearch3.client.CustomAsyncOpenSearchClient;
 import org.graylog.storage.opensearch3.client.CustomOpenSearchClient;
 import org.graylog2.configuration.IndexerHosts;
@@ -53,13 +52,17 @@ import static org.graylog.storage.opensearch3.OfficialOpensearchClientProvider.T
  * returned forever, while the underlying transport is hot-swapped through a
  * {@link DynamicTransport} when the cert nears expiry. This makes the returned client safe
  * to cache in adapter constructors.
+ *
+ * <p>Refresh is lazy and driven by actual use: the cert is only rotated when a request is
+ * about to be sent and the current cert is close to expiry (see {@link #refreshIfNeeded()},
+ * wired as the transport's pre-request hook).
  */
 @Singleton
 public class AdminOpensearchClientProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdminOpensearchClientProvider.class);
 
-    static final Duration CERT_LIFETIME = Duration.ofMinutes(15);
+    static final Duration CERT_LIFETIME = Duration.ofMinutes(1);
     static final Duration REFRESH_BEFORE_EXPIRY = Duration.ofMinutes(1);
 
     private final ClientCertSslContextFactory sslContextFactory;
@@ -70,7 +73,6 @@ public class AdminOpensearchClientProvider {
 
     private volatile OfficialOpensearchClient cachedClient;
     private volatile DynamicTransport dynamicTransport;
-    private volatile ScheduledExecutorService drainScheduler;
     private volatile Instant currentCertExpiresAt;
 
     @Inject
@@ -89,14 +91,22 @@ public class AdminOpensearchClientProvider {
     /**
      * Returns the admin client. The same {@link OfficialOpensearchClient} instance is returned
      * across the lifetime of this provider; only the internal transport (and underlying cert)
-     * is rotated when the cert nears expiry.
+     * is rotated, lazily, when a request is sent through a client whose cert nears expiry.
      */
     @Nonnull
     public OfficialOpensearchClient getAdminClient() {
-        if (cachedClient != null && !needsRefresh(clock.instant())) {
-            return cachedClient;
-        }
         return initOrRefresh();
+    }
+
+    /**
+     * Rotates the cert if it is close to expiry. Wired as the {@link DynamicTransport}
+     * pre-request hook so the cached (and therefore never re-fetched) client picks up a fresh
+     * cert on its next actual use rather than relying on a background timer.
+     */
+    void refreshIfNeeded() {
+        if (cachedClient != null && needsRefresh(clock.instant())) {
+            initOrRefresh();
+        }
     }
 
     private synchronized OfficialOpensearchClient initOrRefresh() {
@@ -105,32 +115,36 @@ public class AdminOpensearchClientProvider {
             return cachedClient;
         }
 
+        if (cachedClient == null) {
+            this.dynamicTransport = new DynamicTransport(buildTransport(), createDrainScheduler(), this::refreshIfNeeded);
+            this.cachedClient = new OfficialOpensearchClient(
+                    new CustomOpenSearchClient(dynamicTransport),
+                    new CustomAsyncOpenSearchClient(dynamicTransport),
+                    objectMapper);
+            this.currentCertExpiresAt = now.plus(CERT_LIFETIME);
+            LOG.info("Built admin OpenSearch client with a {} min cert lifetime.", CERT_LIFETIME.toMinutes());
+        } else {
+            dynamicTransport.swap(buildTransport());
+            this.currentCertExpiresAt = now.plus(CERT_LIFETIME);
+            LOG.debug("Rotated admin OpenSearch client certificate.");
+        }
+        return cachedClient;
+    }
+
+    /**
+     * Builds a fresh transport authenticated with a newly minted, short-lived admin cert.
+     */
+    private OpenSearchTransport buildTransport() {
         try {
-            final OpenSearchTransport newTransport = sslContextFactory.buildClientCertSslContext(IndexerAdminCertConstants.ADMIN_CN, CERT_LIFETIME)
+            return sslContextFactory.buildClientCertSslContext(IndexerAdminCertConstants.ADMIN_CN, CERT_LIFETIME)
                     .map(TransportConfig::clientCertAuth)
                     .map(certAuth -> transportProvider.buildTransport(hosts, certAuth))
-                    .orElse(transportProvider.buildTransport(hosts));
-
-            if (cachedClient == null) {
-                this.drainScheduler = createDrainScheduler();
-                this.dynamicTransport = new DynamicTransport(newTransport, drainScheduler);
-                this.cachedClient = new OfficialOpensearchClient(
-                        new CustomOpenSearchClient(dynamicTransport),
-                        new CustomAsyncOpenSearchClient(dynamicTransport),
-                        objectMapper);
-                LOG.info("Built admin OpenSearch client with a {} min cert lifetime.", CERT_LIFETIME.toMinutes());
-            } else {
-                dynamicTransport.swap(newTransport);
-                LOG.debug("Rotated admin OpenSearch client certificate.");
-            }
-            this.currentCertExpiresAt = now.plus(CERT_LIFETIME);
+                    .orElseGet(() -> transportProvider.buildTransport(hosts));
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new IllegalStateException("Failed to build admin OpenSearch client", e);
         }
-
-        return cachedClient;
     }
 
     private boolean needsRefresh(Instant now) {

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/DynamicTransport.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/DynamicTransport.java
@@ -39,18 +39,29 @@ public class DynamicTransport implements OpenSearchTransport {
 
     private final AtomicReference<OpenSearchTransport> current;
     private final ScheduledExecutorService scheduler;
+    private final Runnable beforeRequest;
     private final AtomicLong swapGeneration = new AtomicLong(0);
     private volatile long drainedGeneration = 0;
 
     public DynamicTransport(OpenSearchTransport initial, ScheduledExecutorService scheduler) {
+        this(initial, scheduler, () -> {});
+    }
+
+    /**
+     * @param beforeRequest hook run before every request is dispatched. Lets an owner lazily
+     *                      rotate the underlying transport (e.g. to refresh an expiring client
+     *                      certificate). Must be cheap and idempotent, as it runs on the request path.
+     */
+    public DynamicTransport(OpenSearchTransport initial, ScheduledExecutorService scheduler, Runnable beforeRequest) {
         this.current = new AtomicReference<>(initial);
         this.scheduler = scheduler;
+        this.beforeRequest = beforeRequest;
     }
 
     public void swap(OpenSearchTransport newTransport) {
         final OpenSearchTransport old = current.getAndSet(newTransport);
         final long generation = swapGeneration.incrementAndGet();
-        LOG.info("OpenSearch transport swapped due to node list update (generation {}). Draining old transport.", generation);
+        LOG.info("OpenSearch transport swapped (generation {}). Draining old transport.", generation);
         try {
             scheduler.schedule(() -> {
                 drainedGeneration = generation;
@@ -80,6 +91,7 @@ public class DynamicTransport implements OpenSearchTransport {
             RequestT request,
             Endpoint<RequestT, ResponseT, ErrorT> endpoint,
             TransportOptions options) throws IOException {
+        beforeRequest.run();
         try {
             return current.get().performRequest(request, endpoint, options);
         } catch (IOException e) {
@@ -92,6 +104,11 @@ public class DynamicTransport implements OpenSearchTransport {
             RequestT request,
             Endpoint<RequestT, ResponseT, ErrorT> endpoint,
             TransportOptions options) {
+        try {
+            beforeRequest.run();
+        } catch (RuntimeException e) {
+            return CompletableFuture.failedFuture(e);
+        }
         return current.get().performRequestAsync(request, endpoint, options)
                 .exceptionally(t -> {
                     final Throwable cause = unwrapCompletionException(t);

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/AdminOpensearchClientProviderTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/AdminOpensearchClientProviderTest.java
@@ -115,6 +115,29 @@ class AdminOpensearchClientProviderTest {
     }
 
     @Test
+    void refreshIfNeededRotatesTransportOnUseOnlyWhenCertNearsExpiry() {
+        final Instant start = Instant.parse("2026-01-01T00:00:00Z");
+        final MutableClock clock = new MutableClock(start);
+        final AdminOpensearchClientProvider provider = newProvider(clock, initializedSslContextFactory());
+
+        final OfficialOpensearchClient client = provider.getAdminClient();
+        verify(transportProvider, times(1)).buildTransport(any(), any());
+
+        // A "use" while the cert is still fresh must not mint a new cert.
+        provider.refreshIfNeeded();
+        verify(transportProvider, times(1)).buildTransport(any(), any());
+
+        // Once the cert nears expiry, the next "use" rotates the transport in place.
+        clock.advance(AdminOpensearchClientProvider.CERT_LIFETIME);
+        provider.refreshIfNeeded();
+
+        verify(transportProvider, times(2)).buildTransport(any(), any());
+        assertThat(provider.getAdminClient())
+                .as("client reference must remain stable across the on-use rotation")
+                .isSameAs(client);
+    }
+
+    @Test
     void requestsCertWithAdminCommonNameAndConfiguredLifetime() {
         final ClientCertSslContextFactory sslContextFactory = (commonName, certificateLifetime) -> {
             if(!commonName.equals("graylog-admin") || !certificateLifetime.equals(AdminOpensearchClientProvider.CERT_LIFETIME)) {

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/DynamicTransportTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/DynamicTransportTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -171,6 +172,42 @@ class DynamicTransportTest {
                 .isInstanceOf(ExecutionException.class)
                 .cause()
                 .isSameAs(originalException);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void runsBeforeRequestHookAheadOfEachRequest() throws IOException {
+        final var delegate = mock(OpenSearchTransport.class);
+        final var endpoint = mock(Endpoint.class);
+        final var options = mock(TransportOptions.class);
+        when(delegate.performRequest(any(), any(), any())).thenReturn("result");
+        when(delegate.performRequestAsync(any(), any(), any())).thenReturn(CompletableFuture.completedFuture("result"));
+
+        final var hookCalls = new AtomicInteger();
+        final var transport = new DynamicTransport(delegate, scheduler, hookCalls::incrementAndGet);
+
+        transport.performRequest("req", endpoint, options);
+        transport.performRequestAsync("req", endpoint, options);
+
+        assertThat(hookCalls).hasValue(2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void asyncReturnsFailedFutureWhenBeforeRequestHookThrows() {
+        final var delegate = mock(OpenSearchTransport.class);
+        final var endpoint = mock(Endpoint.class);
+        final var options = mock(TransportOptions.class);
+        final var hookFailure = new IllegalStateException("cert refresh failed");
+
+        final var transport = new DynamicTransport(delegate, scheduler, () -> {
+            throw hookFailure;
+        });
+
+        final CompletableFuture<?> future = transport.performRequestAsync("req", endpoint, options);
+        assertThat(future).isCompletedExceptionally();
+        assertThatThrownBy(future::get).isInstanceOf(ExecutionException.class).cause().isSameAs(hookFailure);
+        verify(delegate, never()).performRequestAsync(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Description
The admin certificate was used after its expiry because the refresh of the transport was not triggered correctly.
This PR fixes this and swaps the transport with a new one with a fresh certificate on demand if the certificate would be expired.

## Motivation and Context
/nocl fixes error introduced during development

## How Has This Been Tested?
reduced lifetime of certificate, made two calls to AdminIndicesAdapter so the second call would have used an expired certificate, made sure that a new one was minted

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

