### PR TITLE
Expose the search-cluster node name on NodeInfo

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -284,6 +284,7 @@ public class ClusterAdapterES7 implements ClusterAdapter {
 
     private NodeInfo createNodeInfo(JsonNode nodesJson) {
         return NodeInfo.builder()
+                .name(nodesJson.at("/name").asText())
                 .version(nodesJson.at("/version").asText())
                 .os(nodesJson.at("/os"))
                 .roles(toStream(nodesJson.at("/roles").elements()).map(JsonNode::asText).toList())

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
@@ -293,6 +293,7 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
 
     private NodeInfo createNodeInfo(JsonNode nodesJson) {
         return NodeInfo.builder()
+                .name(nodesJson.at("/name").asText())
                 .version(nodesJson.at("/version").asText())
                 .os(nodesJson.at("/os"))
                 .roles(toStream(nodesJson.at("/roles").elements()).map(JsonNode::asText).toList())

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ClusterAdapterOS.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ClusterAdapterOS.java
@@ -315,6 +315,7 @@ public class ClusterAdapterOS implements ClusterAdapter {
 
     private org.graylog2.system.stats.elasticsearch.NodeInfo createNodeInfo(JsonNode nodesJson) {
         return org.graylog2.system.stats.elasticsearch.NodeInfo.builder()
+                .name(nodesJson.at("/name").asText())
                 .version(nodesJson.at("/version").asText())
                 .os(nodesJson.at("/os"))
                 .roles(toStream(nodesJson.at("/roles").elements()).map(JsonNode::asText).toList())

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodeInfo.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodeInfo.java
@@ -31,6 +31,9 @@ public abstract class NodeInfo {
     }
 
     @JsonProperty
+    public abstract String name();
+
+    @JsonProperty
     public abstract String version();
 
     @JsonProperty
@@ -44,6 +47,8 @@ public abstract class NodeInfo {
 
     @AutoValue.Builder
     public abstract static class Builder {
+        public abstract Builder name(String name);
+
         public abstract Builder version(String version);
 
         public abstract Builder os(Object os);


### PR DESCRIPTION
/nocl
/prd Graylog2/graylog-plugin-enterprise#14917

## Description

The node stats adapter already fetches each search-cluster node's name from the `_nodes` response but dropped it: `NodeInfo` carried only version, OS, roles, and heap, keyed by node id.

The System Overview health panel's `shard_count` check (Graylog2/graylog-plugin-enterprise#14658) needs to join per-node shard counts (keyed by node **name**, from `_cat/allocation`) with per-node heap (keyed by node **id**, from `_nodes`). The only existing id-to-name bridge, `ClusterAdapter.nodeIdToName()`, is a per-node round-trip. This change exposes the node `name` on `NodeInfo` so a single `_nodes` read carries it, populated in the OpenSearch 2/3 and Elasticsearch 7 adapters.

Additive field on a serialize-only DTO, no behavior change on its own. Independent of other health-panel work and can merge standalone.

## How Tested

- Exercised end to end by the enterprise `ShardCountHealthReporter` unit tests in Graylog2/graylog-plugin-enterprise#14658, which join shard allocation to heap on this field.
