### PR TITLE
Add read permission check on Event definition for duplicate

### DIFF
--- a/changelog/unreleased/issue-26590.toml
+++ b/changelog/unreleased/issue-26590.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Enforce per-entity read permission on the event definition duplicate endpoint, preventing users from cloning event definitions they have not been granted access to."
+
+pulls = ["26706"]
+issues = ["26590"]

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -567,6 +567,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_CREATE)
     @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
     public EventDefinitionDto duplicate(@Parameter(name = "definitionId") @PathParam("definitionId") @NotBlank String definitionId, @Context UserContext userContext) {
+        checkPermission(RestPermissions.EVENT_DEFINITIONS_READ, definitionId);
         final EventDefinitionDto eventDefinitionDto = dbService.get(definitionId).orElseThrow(() ->
                 new BadRequestException(f("Unable to find event definition '%s' to duplicate", definitionId)));
         checkEventDefinitionPermissions(eventDefinitionDto, "create");

--- a/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
@@ -32,8 +32,10 @@ import org.graylog.events.processor.EventDefinitionHandler;
 import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.events.processor.EventProcessorEngine;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityService;
+import org.graylog.security.UserContext;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -152,6 +155,33 @@ public class EventDefinitionsResourceTest {
         resource.suggestTags("", 99999);
 
         verify(dbService).suggestTags(eq(""), eq(100));
+    }
+
+    @Test
+    public void duplicateWithoutReadPermissionOnDefinitionIsForbidden() {
+        final String definitionId = "54e3deadbeefdeadbeefaffe";
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ + ":" + definitionId)).thenReturn(false);
+
+        assertThrows(ForbiddenException.class, () -> resource.duplicate(definitionId, mock(UserContext.class)));
+
+        // The definition must not even be loaded when the caller lacks read access to it.
+        verify(dbService, never()).get(any());
+        verify(eventDefinitionHandler, never()).duplicate(any(), any());
+    }
+
+    @Test
+    public void duplicateWithReadPermissionOnDefinitionSucceeds() {
+        final String definitionId = "54e3deadbeefdeadbeefaffe";
+        final EventDefinitionDto dto = eventDefinitionDto(config1);
+        final User user = mock(User.class);
+        final UserContext userContext = mock(UserContext.class);
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ + ":" + definitionId)).thenReturn(true);
+        when(dbService.get(definitionId)).thenReturn(Optional.of(dto));
+        when(userContext.getUser()).thenReturn(user);
+
+        resource.duplicate(definitionId, userContext);
+
+        verify(eventDefinitionHandler).duplicate(dto, user);
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check that user had read permission on an Event defintion before allowing it to be duplicated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/Graylog2/graylog2-server/issues/26590

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.

