### PR TITLE
Degrade gracefully when OSHI/JNA native load fails on noexec data dir (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-26471.toml
+++ b/changelog/unreleased/issue-26471.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed a startup failure on hosts where the Graylog data directory is on a `noexec` filesystem, caused by the node CPU-load metric eagerly loading the OSHI/JNA native library during boot. The metric now initializes lazily and degrades gracefully instead of preventing the server from starting."
+
+issues = ["26471"]

--- a/graylog2-server/src/main/java/org/graylog2/periodical/CpuLoadGauge.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/CpuLoadGauge.java
@@ -17,13 +17,18 @@
 package org.graylog2.periodical;
 
 import com.codahale.metrics.Gauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import oshi.SystemInfo;
 import oshi.hardware.CentralProcessor;
 
 public class CpuLoadGauge implements Gauge<Double> {
 
-    private long[] lastTicks = processor().getSystemCpuLoadTicks();
-    private Double cpuLoad;
+    private static final Logger LOG = LoggerFactory.getLogger(CpuLoadGauge.class);
+
+    private long[] lastTicks;
+    private volatile Double cpuLoad;
+    private boolean disabled = false;
 
     @Override
     public Double getValue() {
@@ -31,14 +36,35 @@ public class CpuLoadGauge implements Gauge<Double> {
     }
 
     public void update() {
-        final CentralProcessor processor = processor();
-        final long[] newTicks = processor.getSystemCpuLoadTicks();
-        cpuLoad = processor.getSystemCpuLoadBetweenTicks(lastTicks, newTicks) * 100.0d;
-        lastTicks = newTicks;
+        if (disabled) {
+            return;
+        }
+        try {
+            final CentralProcessor processor = processor();
+            final long[] newTicks = processor.getSystemCpuLoadTicks();
+            if (lastTicks == null) {
+                // First run: there is no previous sample to compare against yet, so just seed the baseline.
+                lastTicks = newTicks;
+                return;
+            }
+            cpuLoad = processor.getSystemCpuLoadBetweenTicks(lastTicks, newTicks) * 100.0d;
+            lastTicks = newTicks;
+        } catch (LinkageError | RuntimeException e) {
+            // The CPU-load metric is a nice-to-have and must never crash the node. Native OSHI/JNA load
+            // failures surface as LinkageErrors (typically a 'noexec' data dir), and OSHI can also throw
+            // RuntimeExceptions reading CPU stats - catch both, but not Throwable (keep OutOfMemoryError etc.
+            // propagating). Disable the metric and carry on. Remedy: point 'jna.tmpdir' at an exec-capable dir.
+            disabled = true;
+            cpuLoad = null;
+            LOG.warn("Disabling the system CPU-load metric: unable to read CPU statistics via the OSHI native library. " +
+                    "This usually means the Graylog data directory (which holds the unpacked JNA native library) is on " +
+                    "a 'noexec' mounted filesystem. To enable the metric, point 'jna.tmpdir' at a writable, " +
+                    "exec-capable directory via the JVM options.", e);
+        }
     }
 
-    private static CentralProcessor processor() {
-        SystemInfo si = new SystemInfo();
+    protected CentralProcessor processor() {
+        final SystemInfo si = new SystemInfo();
         return si.getHardware().getProcessor();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/periodical/CpuLoadGaugeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/CpuLoadGaugeTest.java
@@ -16,17 +16,64 @@
  */
 package org.graylog2.periodical;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import oshi.hardware.CentralProcessor;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class CpuLoadGaugeTest {
     @Test
-    void testGauge() {
-        final CpuLoadGauge gauge = new CpuLoadGauge();
-        Assertions.assertThat(gauge.getValue()).isNull();
+    void reportsCpuLoadAfterTwoSamples() {
+        // Stub the processor so the test exercises the gauge's own seed-then-compute logic and stays
+        // deterministic and independent of native OSHI/JNA availability (which is absent on 'noexec' hosts).
+        final CentralProcessor processor = mock(CentralProcessor.class);
+        when(processor.getSystemCpuLoadTicks()).thenReturn(new long[]{1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L});
+        when(processor.getSystemCpuLoadBetweenTicks(any(), any())).thenReturn(0.42d);
+
+        final CpuLoadGauge gauge = new CpuLoadGauge() {
+            @Override
+            protected CentralProcessor processor() {
+                return processor;
+            }
+        };
+
+        // No sample taken yet.
+        assertThat(gauge.getValue()).isNull();
+
+        // The first run only seeds the baseline ticks, so there is nothing to compare against yet.
         gauge.update();
-        Assertions.assertThat(gauge.getValue())
-                .isNotNull()
-                .isGreaterThanOrEqualTo(0.0d);
+        assertThat(gauge.getValue()).isNull();
+
+        // The second run has a previous sample to compute the load between: 0.42 * 100.
+        gauge.update();
+        assertThat(gauge.getValue()).isEqualTo(42.0d);
+    }
+
+    @Test
+    void degradesGracefullyWhenNativeAccessFails() {
+        // Simulate a host where OSHI/JNA cannot load its native library (e.g. a 'noexec' data dir),
+        // which surfaces as a LinkageError (NoClassDefFoundError / UnsatisfiedLinkError), not an Exception.
+        final AtomicInteger nativeCalls = new AtomicInteger();
+        final CpuLoadGauge gauge = new CpuLoadGauge() {
+            @Override
+            protected CentralProcessor processor() {
+                nativeCalls.incrementAndGet();
+                throw new NoClassDefFoundError("Could not initialize class oshi.software.os.linux.LinuxOperatingSystemJNA");
+            }
+        };
+
+        // update() must swallow the error rather than propagate it.
+        gauge.update();
+        assertThat(gauge.getValue()).isNull();
+
+        // Once disabled, subsequent runs stay quiet: the native path is never touched again.
+        gauge.update();
+        assertThat(gauge.getValue()).isNull();
+        assertThat(nativeCalls.get()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
Note: This is a backport of #26608 to `7.1`.

Closes #26471

## Description

On 7.1+, the server fails to start on hosts where the Graylog data directory is on a `noexec`-mounted filesystem (common on hardened systems). Startup dies while the periodicals are being constructed with `NoClassDefFoundError: Could not initialize class oshi.software.os.linux.LinuxOperatingSystemJNA` /  `UnsatisfiedLinkError: ... failed to map segment from shared object`.


The regression is due to `NodeMetricPeriodical` (new in 7.1.0), that builds a `CpuLoadGauge` in a field initializer. `CpuLoadGauge` in turn touches OSHI native code in its own field initializer, so constructing the periodical forces OSHI/JNA to unpack and `dlopen()` its native library at boot. On a `noexec` mount the kernel refuses to map the library and startup dies.

The fix:
- `CpuLoadGauge` no longer touches native code at construction. It seeds its baseline lazily on the first `update()` and computes load from the second run onward.
- Native access is guarded with `try/catch`. Catching `LinkageError` rather than `Throwable` keeps JVM-fatal errors such as `OutOfMemoryError` propagating. On failure it disables the metric and logs a single warning naming the likely `noexec` cause and the `jna.tmpdir` remedy.

`OshiService` is intentionally left unchanged. Its construction is already wrapped in a `catch` in `SystemStatsModule`, which falls back to the JMX probes if the native library cannot load, so it is not on this boot-failure path. `CpuLoadGauge` was the only eager OSHI consumer without such a guard.

## How Tested

Automation: `CpuLoadGaugeTest` updated
Manual test instructions: on a host with the data dir on a `noexec` mount (or by pointing `-Djna.tmpdir` at a `noexec` directory), 7.1 fails to boot before this change; with the change the server starts, logs the single CPU-load warning, and the `org.graylog2.system.cpu.percent` metric is absent rather than crashing the node.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
