### PR TITLE
Catch possible ID mismatch when trying to update a view

### DIFF
--- a/changelog/unreleased/pr-26715.toml
+++ b/changelog/unreleased/pr-26715.toml
@@ -1,4 +1,4 @@
-type = "f"
+type = "s"
 message = "Fix bug in updating a view where the check for permissions could test on a wrong view ID."
 
 pulls = ["26715"]

--- a/changelog/unreleased/pr-26715.toml
+++ b/changelog/unreleased/pr-26715.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix bug in updating a view where the check for permissions could test on a wrong view ID."
+
+pulls = ["26715"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -399,7 +399,6 @@ public class ViewsResource extends RestResourceWithOwnerCheck implements PluginR
                           @Context SearchUser searchUser) {
         // the ID from the path always has to match the id from the request body for an update.
         // currently, the FE always uses it like that, so mismatches should only occur when using the API directly
-        // possible improvement could be removing the ID from the path and only have it in the body
         if (!id.equals(createEntityRequest.entity().id())) {
            throw new BadRequestException("Invalid update request");
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -397,12 +397,19 @@ public class ViewsResource extends RestResourceWithOwnerCheck implements PluginR
     public ViewDTO update(@Parameter(name = "id") @PathParam("id") @NotEmpty String id,
                           @RequestBody(required = true) @Valid CreateEntityRequest<ViewDTO> createEntityRequest,
                           @Context SearchUser searchUser) {
+        // the ID from the path always has to match the id from the request body for an update.
+        // currently, the FE always uses it like that, so mismatches should only occur when using the API directly
+        // possible improvement could be removing the ID from the path and only have it in the body
+        if (!id.equals(createEntityRequest.entity().id())) {
+           throw new BadRequestException("Invalid update request");
+        }
+
         final ViewDTO dto = createEntityRequest.entity();
         final ViewDTO updatedDTO = dto.toBuilder().id(id).build();
         validateDto(updatedDTO, searchUser);
 
         final var grnType = toGRNType(dto);
-        createEntityRequest.shareRequest().ifPresent(request -> checkOwnership(grnType.toGRN(dto.id())));
+        createEntityRequest.shareRequest().ifPresent(request -> checkOwnership(grnType.toGRN(updatedDTO.id())));
 
         var result = dbService.update(updatedDTO);
         recentActivityService.update(result.id(), grnType, searchUser);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -284,6 +284,37 @@ public class ViewsResourceTest {
         verify(viewService, times(0)).update(any());
     }
 
+    /**
+     * Test for security fix in #26715, where we now additionally make sure that the ID from the path and in the body with the entity have to match.
+     * We only use the path ID in the end for the update operation but a mismatch can signify a possible malicious request.
+     */
+    @Test
+    public void throwsExceptionWhenUpdatingViewWithPathAndIDMismatch() {
+        final ViewService viewService = mockViewService(TEST_DASHBOARD_VIEW);
+
+        // making sure that the invalid view id is different from the view id used in all tests by adding a prefix
+        final String INVALID_VIEW_ID = "invalid_" + VIEW_ID;
+        final CreateEntityRequest<ViewDTO> request = CreateEntityRequest.create(TEST_DASHBOARD_VIEW.toBuilder().id(INVALID_VIEW_ID).build(), EntityShareRequest.create(ImmutableMap.of()));
+
+        final ViewsResource viewsResource = createViewsResource(
+                viewService,
+                mock(StartPageService.class),
+                mock(RecentActivityService.class),
+                mock(ClusterEventBus.class),
+                new ReferencedSearchFiltersHelper(),
+                EMPTY_SEARCH_FILTER_VISIBILITY_CHECKER,
+                EMPTY_VIEW_RESOLVERS,
+                SEARCH
+        );
+
+        assertThatThrownBy(() -> viewsResource.update(VIEW_ID, request, SEARCH_USER))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Invalid update request");
+
+        verify(viewService, times(0)).update(any());
+    }
+
+
     @Test
     public void updatesSharingWhenUserOwnsView() {
         final ViewService viewService = mockViewService(TEST_DASHBOARD_VIEW);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes an oversight in https://github.com/Graylog2/graylog2-server/pull/26344

which we got notified by https://github.com/Graylog2/graylog2-server/security/advisories/GHSA-w997-cmqr-xrx6 

We are now also making sure that for update, the ID from the entity matches the ID from the path. The ID is not enforced by the `@Valid` on the view entity as it's not necessary for creation. But for an update on an existing view, it is always present and our FE always puts it in the request.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manual testing, added a unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

