### PR TITLE
Add uppercase prop to badge component

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Badge.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.tsx
@@ -34,7 +34,8 @@ const mapFontSize: Record<SupportedMantineSize, 'tiny' | 'small' | 'body'> = {
   lg: 'body',
 };
 
-const StyledBadge = styled(MantineBadge)<{ color: ColorVariant; size: SupportedMantineSize }>(
+const StyledBadge = styled(MantineBadge)<{ color: ColorVariant; size: SupportedMantineSize;}
+>(
   ({ theme, color, size }) => css`
     text-transform: none;
     background-color: ${color};
@@ -54,6 +55,9 @@ const StyledBadge = styled(MantineBadge)<{ color: ColorVariant; size: SupportedM
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    &.uppercase {
+      text-transform: uppercase;
+    }
   `,
 );
 
@@ -69,6 +73,7 @@ type Props = React.PropsWithChildren<{
   role?: string;
   style?: React.CSSProperties;
   title?: string;
+  uppercase?: boolean;
 }>;
 
 const Badge = (
@@ -85,6 +90,7 @@ const Badge = (
     style = undefined,
     title = undefined,
     bsSize = 'md',
+    uppercase = false,
   }: Props,
   ref: React.ForwardedRef<HTMLElement>,
 ) => {
@@ -95,7 +101,7 @@ const Badge = (
   const sharedProps = {
     'aria-label': ariaLabel,
     color,
-    className,
+    className: uppercase ? `${className ?? ''} uppercase` : className,
     title,
     'data-testid': dataTestid,
     role,
@@ -120,7 +126,10 @@ const Badge = (
   }
 
   return (
-    <StyledBadge {...sharedProps} component="span" ref={ref as React.Ref<HTMLSpanElement>}>
+    <StyledBadge
+      {...sharedProps}
+      component="span"
+      ref={ref as React.Ref<HTMLSpanElement>}>
       {children}
     </StyledBadge>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In some cases, to get an uppercase badge, we have to restyle the Badge component. Now instead, we can just add `uppercase` prop

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl