### PR TITLE
Add read permission check on Event definition for duplicate (`7.0`)

### DIFF
--- a/changelog/unreleased/issue-26590.toml
+++ b/changelog/unreleased/issue-26590.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Enforce per-entity read permission on the event definition duplicate endpoint, preventing users from cloning event definitions they have not been granted access to."
+
+pulls = ["26706"]
+issues = ["26590"]

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -487,6 +487,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_CREATE)
     @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
     public EventDefinitionDto duplicate(@ApiParam(name = "definitionId") @PathParam("definitionId") @NotBlank String definitionId, @Context UserContext userContext) {
+        checkPermission(RestPermissions.EVENT_DEFINITIONS_READ, definitionId);
         final EventDefinitionDto eventDefinitionDto = dbService.get(definitionId).orElseThrow(() ->
                 new BadRequestException(f("Unable to find event definition '%s' to duplicate", definitionId)));
         checkEventDefinitionPermissions(eventDefinitionDto, "create");

--- a/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
@@ -19,6 +19,7 @@ package org.graylog.events.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import jakarta.ws.rs.ForbiddenException;
+import org.apache.shiro.subject.Subject;
 import org.graylog.events.context.EventDefinitionContextService;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.DBEventDefinitionService;
@@ -29,16 +30,26 @@ import org.graylog.events.processor.EventDefinitionHandler;
 import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.events.processor.EventProcessorEngine;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityService;
+import org.graylog.security.UserContext;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.RestPermissions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -68,14 +79,14 @@ public class EventDefinitionsResourceTest {
     EntitySharesService entitySharesService;
 
     EventDefinitionsResource resource;
+    Subject subject;
 
     @Before
     public void setup() {
-        resource = new EventDefinitionsResource(
-                dbService, eventDefinitionHandler, contextService, engine, recentActivityService,
-                auditEventSender, objectMapper, new DefaultEventResolver(), new EventDefinitionConfiguration(), entitySharesService);
-        when(config1.type()).thenReturn(CONFIG_TYPE_1);
-        when(config2.type()).thenReturn(CONFIG_TYPE_2);
+        subject = mock(Subject.class);
+        resource = new TestEventDefinitionsResource(subject);
+        lenient().when(config1.type()).thenReturn(CONFIG_TYPE_1);
+        lenient().when(config2.type()).thenReturn(CONFIG_TYPE_2);
     }
 
     @Test
@@ -92,6 +103,33 @@ public class EventDefinitionsResourceTest {
                 resource.checkProcessorConfig(eventDefinitionDto(config1), eventDefinitionDto(config2)));
     }
 
+    @Test
+    public void duplicateWithoutReadPermissionOnDefinitionIsForbidden() {
+        final String definitionId = "54e3deadbeefdeadbeefaffe";
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ + ":" + definitionId)).thenReturn(false);
+
+        assertThrows(ForbiddenException.class, () -> resource.duplicate(definitionId, mock(UserContext.class)));
+
+        // The definition must not even be loaded when the caller lacks read access to it.
+        verify(dbService, never()).get(any());
+        verify(eventDefinitionHandler, never()).duplicate(any(), any());
+    }
+
+    @Test
+    public void duplicateWithReadPermissionOnDefinitionSucceeds() {
+        final String definitionId = "54e3deadbeefdeadbeefaffe";
+        final EventDefinitionDto dto = eventDefinitionDto(config1);
+        final User user = mock(User.class);
+        final UserContext userContext = mock(UserContext.class);
+        when(subject.isPermitted(RestPermissions.EVENT_DEFINITIONS_READ + ":" + definitionId)).thenReturn(true);
+        when(dbService.get(definitionId)).thenReturn(Optional.of(dto));
+        when(userContext.getUser()).thenReturn(user);
+
+        resource.duplicate(definitionId, userContext);
+
+        verify(eventDefinitionHandler).duplicate(dto, user);
+    }
+
     static EventDefinitionDto eventDefinitionDto(EventProcessorConfig config) {
         return EventDefinitionDto.builder()
                 .title("Test")
@@ -105,5 +143,26 @@ public class EventDefinitionsResourceTest {
                         .backlogSize(0)
                         .build())
                 .build();
+    }
+
+    /**
+     * Subclass of {@link EventDefinitionsResource} that returns a configurable Shiro {@link Subject}
+     * so tests can stub permission checks. Mirrors the override pattern used in
+     * {@code RestResourceBaseTest}.
+     */
+    private class TestEventDefinitionsResource extends EventDefinitionsResource {
+        private final Subject subject;
+
+        TestEventDefinitionsResource(Subject subject) {
+            super(dbService, eventDefinitionHandler, contextService, engine, recentActivityService,
+                    auditEventSender, objectMapper, new DefaultEventResolver(), new EventDefinitionConfiguration(),
+                    entitySharesService);
+            this.subject = subject;
+        }
+
+        @Override
+        protected Subject getSubject() {
+            return subject;
+        }
     }
 }


### PR DESCRIPTION
Note: This is a backport of #26706 to `7.0`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check that user had read permission on an Event defintion before allowing it to be duplicated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/Graylog2/graylog2-server/issues/26590

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
