### PR TITLE
Fix hiding the <CreateButton /> on overview pages if the user lags permissions

### DIFF
--- a/graylog2-web-interface/src/components/common/CreateButton.test.tsx
+++ b/graylog2-web-interface/src/components/common/CreateButton.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { adminUser } from 'fixtures/users';
+import { asMock } from 'helpers/mocking';
+import useCurrentUser from 'hooks/useCurrentUser';
+import usePluginEntities from 'hooks/usePluginEntities';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import type { QualifiedUrl } from 'routing/Routes';
+
+import CreateButton from './CreateButton';
+
+jest.mock('hooks/useCurrentUser');
+jest.mock('hooks/usePluginEntities');
+jest.mock('logic/telemetry/useSendTelemetry');
+jest.mock('routing/useLocation', () => jest.fn(() => ({ pathname: '/test' })));
+
+const entityCreatorWithPermissions = {
+  id: 'Stream',
+  title: 'Create stream',
+  path: '/streams/new' as QualifiedUrl<string>,
+  permissions: 'streams:create',
+};
+
+const entityCreatorWithoutPermissions = {
+  id: 'Content Pack',
+  title: 'Create content pack',
+  path: '/system/contentpacks/create' as QualifiedUrl<string>,
+};
+
+describe('CreateButton', () => {
+  beforeEach(() => {
+    asMock(usePluginEntities).mockReturnValue([entityCreatorWithPermissions, entityCreatorWithoutPermissions]);
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+    asMock(useSendTelemetry).mockReturnValue(jest.fn());
+  });
+
+  it('renders button for user with the required permission', () => {
+    const user = adminUser.toBuilder().permissions(Immutable.List(['streams:create'])).build();
+    asMock(useCurrentUser).mockReturnValue(user);
+
+    render(<CreateButton entityKey="Stream" />);
+
+    expect(screen.getByText(/Create stream/)).toBeInTheDocument();
+  });
+
+  it('does not render button for user without the required permission', () => {
+    const user = adminUser.toBuilder().permissions(Immutable.List([])).build();
+    asMock(useCurrentUser).mockReturnValue(user);
+
+    render(<CreateButton entityKey="Stream" />);
+
+    expect(screen.queryByText(/Create stream/)).not.toBeInTheDocument();
+  });
+
+  it('renders button when no permissions are required on the entity creator', () => {
+    const user = adminUser.toBuilder().permissions(Immutable.List([])).build();
+    asMock(useCurrentUser).mockReturnValue(user);
+
+    render(<CreateButton entityKey="Content Pack" />);
+
+    expect(screen.getByText(/Create content pack/)).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/CreateButton.tsx
+++ b/graylog2-web-interface/src/components/common/CreateButton.tsx
@@ -67,7 +67,7 @@ const CreateButton = ({ disabled = false, entityKey }: Props) => {
   }, [entityCreator, pathname, sendTelemetry]);
 
   return (
-    <PermissionWrapper>
+    <PermissionWrapper permissions={entityCreator?.permissions}>
       <LinkContainer to={entityCreator.path}>
         <Button bsSize="md" bsStyle="primary" onClick={_onClick} disabled={disabled}>
           {entityCreator.title}


### PR DESCRIPTION
## Why
'Feat/14047 sigma rules to event definition wizard UI' moved the code to handle permissions out side of the component to treat it seperatly.

With that the code no longer had access to the entityCreator.permissions and the component was renderded without permissions. That way the <CreateButton /> component was always rendered nevertheless the user did not have the right permissions.

## What
We introduced a simple test which ensures that the button is hided if a user does not have the right permissions.

We pass the entityCreator.permissions to the new <PermissionsWrapper />

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/14849

/nocl

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

