### PR TITLE
Fixing issue where adding a new column resets custom column width in entity data table.

### DIFF
--- a/changelog/unreleased/pr-26741.toml
+++ b/changelog/unreleased/pr-26741.toml
@@ -1,4 +1,0 @@
-type = "f"
-message = "Fix entity data table resetting manually resized column widths when a column's visibility was toggled."
-
-pulls = ["26741"]

--- a/changelog/unreleased/pr-26741.toml
+++ b/changelog/unreleased/pr-26741.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix entity data table resetting manually resized column widths when a column's visibility was toggled."
+
+pulls = ["26741"]

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -370,6 +370,44 @@ describe('<EntityDataTable />', () => {
     });
   });
 
+  it('should preserve custom column widths when toggling column visibility', async () => {
+    const onLayoutPreferencesChange = jest.fn();
+
+    render(
+      <EntityDataTable
+        {...defaultProps}
+        layoutPreferences={{
+          attributes: {
+            description: { status: ATTRIBUTE_STATUS.show, width: 350 },
+            status: { status: ATTRIBUTE_STATUS.show },
+            title: { status: ATTRIBUTE_STATUS.show },
+          },
+          order: [],
+        }}
+        defaultDisplayedColumns={['description', 'status', 'title']}
+        defaultColumnOrder={['description', 'status', 'stream', 'title']}
+        onLayoutPreferencesChange={onLayoutPreferencesChange}
+      />,
+    );
+
+    await screen.findByRole('columnheader', { name: /title/i });
+    await screen.findByRole('columnheader', { name: /status/i });
+    await screen.findByRole('columnheader', { name: /description/i });
+
+    await userEvent.click(await screen.findByRole('button', { name: /configure visible columns/i }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: /show stream/i }));
+
+    expect(onLayoutPreferencesChange).toHaveBeenCalledWith({
+      attributes: {
+        description: { status: ATTRIBUTE_STATUS.show, width: 350 },
+        status: { status: ATTRIBUTE_STATUS.show },
+        stream: { status: ATTRIBUTE_STATUS.show },
+        title: { status: ATTRIBUTE_STATUS.show },
+      },
+      order: ['description', 'status', 'stream', 'title'],
+    });
+  });
+
   it('if there are user preferences, only selected columns should be displayed', async () => {
     const onLayoutPreferencesChange = jest.fn();
 

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useTable.ts
@@ -51,12 +51,12 @@ const updateColumnPreferences = (
 
   // All currently visible columns will be marked as 'show'
   visibleAttributeColumns.forEach((col) => {
-    updatedPreferences[col] = { status: ATTRIBUTE_STATUS.show };
+    updatedPreferences[col] = { ...updatedPreferences[col], status: ATTRIBUTE_STATUS.show };
   });
 
   // Only explicitly hidden columns will be marked as 'hide'
   removedColumns.forEach((col) => {
-    updatedPreferences[col] = { status: ATTRIBUTE_STATUS.hide };
+    updatedPreferences[col] = { ...updatedPreferences[col], status: ATTRIBUTE_STATUS.hide };
   });
 
   return updatedPreferences;


### PR DESCRIPTION
This PR fixes an unreleased bug.

## Description
<!--- Describe your changes in detail -->

Fixes a bug in the entity data table where manually resizing a column's width would get discarded as soon as any column's visibility was toggled (e.g. showing a new column via the column visibility select). The `onColumnVisibilityChange` handler rebuilt the stored preference object for every currently visible column using `{ status: ... }`, overwriting rather than merging into the existing preference and dropping its `width` field. That change was persisted immediately, causing the resized width to be lost on the next refetch.

The fix merges into the existing per-column preference instead of replacing it, so `width` (and any other stored preference) survives visibility changes. Added a regression test that resizes toggles a column's visibility and asserts an existing column's `width` preference is preserved.

/nocl - fixes unreleased bug.