### PR TITLE
Add kotlin-reflect to server classpath for Agent Workflow tool reflection

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -159,6 +159,17 @@
             <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
+        <!-- kotlin-stdlib is on the server classpath transitively (e.g. via okhttp). Kotlin's reflection
+             lookup runs on the classloader that loaded kotlin-stdlib, so kotlin-reflect must live on the
+             SAME (server) classpath. The enterprise Agent Workflow plugin bundles kotlin-reflect, but that
+             sits in the isolated plugin classloader where the server-loaded kotlin-stdlib can't see it,
+             causing KotlinReflectionNotSupportedError when Koog reflects over @Tool methods. Version is
+             managed by the kotlin-bom. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>


### PR DESCRIPTION
### What / why

Agent Workflow runs currently fail at runtime with:

```
kotlin.jvm.KotlinReflectionNotSupportedError: Kotlin reflection implementation is not found at runtime.
Make sure you have kotlin-reflect.jar in the classpath
    at ai.koog.agents.core.tools.reflect.ToolFromCallableExtensionsKt.asTools(...)
```

Koog reflects over the `@Tool`-annotated methods (via `kotlin-reflect`) when building its tool registry. `kotlin-stdlib` is on the **server** classpath (transitively, e.g. via okhttp), and Kotlin resolves its reflection implementation using the classloader that loaded `kotlin-stdlib`. `kotlin-reflect`, however, only lived in the **isolated enterprise plugin** classloader, which the server-loaded `kotlin-stdlib` cannot see. The transitive `kotlin-reflect` that previously came in via `software.amazon.glue:schema-registry-serde` was removed in #26684, which is what surfaced this.

Because of the classloader split, the model-provider **Test** button (which builds an agent with an *empty* tool registry, so no `@Tool` reflection) works, but an actual **workflow run** — which calls `asTools()` over the real tool set — throws.

### Fix

Declare `kotlin-reflect` on `graylog2-server` so it sits beside `kotlin-stdlib` on the same classpath. Version is managed by the `kotlin-bom` added in #26684.

/nocl behind the `agent_workflow` feature flag; not user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)