### PR TITLE
Fixing entity data table drag and drop issue by properly sanitizing all column ids.

### DIFF
--- a/changelog/unreleased/pr-26762.toml
+++ b/changelog/unreleased/pr-26762.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed a visual glitch when dragging a column with a dot in its id in the entity data table; the column order still changed correctly, but the drag animation was broken."
+
+pulls = ["26762"]

--- a/graylog2-web-interface/src/components/common/EntityDataTable/CSSVariables.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/CSSVariables.ts
@@ -15,9 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 
-export const columnTransformVar = (colId: string) => `--col-${colId}-transform`;
-export const columnWidthVar = (colId: string) => `--col-${colId.replace(/\./g, '_')}-width`;
-export const columnOpacityVar = (colId: string) => `--col-${colId}-opacity`;
+const sanitizeColId = (colId: string) => colId.replace(/\./g, '_');
+
+export const columnTransformVar = (colId: string) => `--col-${sanitizeColId(colId)}-transform`;
+export const columnWidthVar = (colId: string) => `--col-${sanitizeColId(colId)}-width`;
+export const columnOpacityVar = (colId: string) => `--col-${sanitizeColId(colId)}-opacity`;
 export const columnTransition = () => `--col-transition`;
 export const actionsHeaderWidthVar = `--actions-header-width`;
 export const displayScrollRightIndicatorVar = `--display-scroll-right-indicator`;


### PR DESCRIPTION
Please note, this PR needs a backport to `7.1`.

## Description

This PR fixes the following visual bug, which occurred on drag and drop for columns. It occurred for example for the sources column on the event definitions page. We are fixing the issue by properly sanitizing the column id (`_entity_source.source`). 

<img width="785" height="579" alt="drag and drop" src="https://github.com/user-attachments/assets/4638395f-fbaa-4664-b660-740ed8c7e874" />
