### PR TITLE
Add telemetry supplier for number of indices incompatible with the next major OS version

### DIFF
--- a/changelog/unreleased/pr-26764.toml
+++ b/changelog/unreleased/pr-26764.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add number of indices incompatible with the next major OpenSearch version to telemetry data."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14607"]
+pulls = ["26764"]

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/TelemetryModule.java
@@ -19,18 +19,19 @@ package org.graylog2.telemetry;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.PluginModule;
 import org.graylog2.telemetry.scheduler.TelemetrySubmissionPeriodical;
-import org.graylog2.telemetry.suppliers.UsersMetricsSupplier;
-import org.graylog2.telemetry.suppliers.InputsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.OutputsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.MongoDBMetricsSupplier;
-import org.graylog2.telemetry.suppliers.ShardsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.LookupTablesSupplier;
+import org.graylog2.telemetry.suppliers.DashboardsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.EventDefinitionsMetricsSupplier;
 import org.graylog2.telemetry.suppliers.EventNotificationsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.DashboardsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.StreamsMetricsSupplier;
-import org.graylog2.telemetry.suppliers.SidecarsVersionSupplier;
+import org.graylog2.telemetry.suppliers.InputsMetricsSupplier;
+import org.graylog2.telemetry.suppliers.LookupTablesSupplier;
+import org.graylog2.telemetry.suppliers.MongoDBMetricsSupplier;
 import org.graylog2.telemetry.suppliers.NodesSystemMetricsSupplier;
+import org.graylog2.telemetry.suppliers.OutdatedIndicesMetricsSupplier;
+import org.graylog2.telemetry.suppliers.OutputsMetricsSupplier;
+import org.graylog2.telemetry.suppliers.ShardsMetricsSupplier;
+import org.graylog2.telemetry.suppliers.SidecarsVersionSupplier;
+import org.graylog2.telemetry.suppliers.StreamsMetricsSupplier;
+import org.graylog2.telemetry.suppliers.UsersMetricsSupplier;
 
 public class TelemetryModule extends PluginModule {
     @Override
@@ -53,5 +54,6 @@ public class TelemetryModule extends PluginModule {
         addTelemetryMetricProvider("Streams Metrics", StreamsMetricsSupplier.class);
         addTelemetryMetricProvider("Sidecars Version", SidecarsVersionSupplier.class);
         addTelemetryMetricProvider("Nodes System Metrics", NodesSystemMetricsSupplier.class);
+        addTelemetryMetricProvider("Outdated Indices Metrics", OutdatedIndicesMetricsSupplier.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/OutdatedIndicesMetricsSupplier.java
+++ b/graylog2-server/src/main/java/org/graylog2/telemetry/suppliers/OutdatedIndicesMetricsSupplier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+package org.graylog2.telemetry.suppliers;
+
+import jakarta.inject.Inject;
+import org.graylog2.indexer.indices.OutdatedIndex;
+import org.graylog2.indexer.indices.OutdatedIndexService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.graylog2.telemetry.scheduler.TelemetryMetricSupplier;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+public class OutdatedIndicesMetricsSupplier implements TelemetryMetricSupplier {
+
+    private final OutdatedIndexService outdatedIndexService;
+
+    @Inject
+    public OutdatedIndicesMetricsSupplier(OutdatedIndexService outdatedIndexService) {
+        this.outdatedIndexService = outdatedIndexService;
+    }
+
+    @Override
+    public Optional<TelemetryEvent> get() {
+        final var indices = outdatedIndexService.getOutdatedIndices();
+
+        final var counts = new java.util.LinkedHashMap<String, Long>();
+        counts.put("managed", indices.stream().filter(OutdatedIndex::managedIndex).count());
+        counts.put("warm", indices.stream().filter(OutdatedIndex::warmIndex).count());
+        counts.put("active_write_index", indices.stream().filter(i -> i.activeWriteIndex() != null).count());
+        counts.put("system", indices.stream().filter(OutdatedIndex::isSystemIndex).count());
+        counts.put("foreign", indices.stream().filter(i -> !i.managedIndex() && !i.isSystemIndex()).count());
+
+        return Optional.of(TelemetryEvent.of(new HashMap<>(TypeFormatter.formatAll(counts))));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/OutdatedIndicesMetricsSupplierTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/telemetry/suppliers/OutdatedIndicesMetricsSupplierTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.telemetry.suppliers;
+
+import org.graylog2.indexer.indices.OutdatedIndex;
+import org.graylog2.indexer.indices.OutdatedIndexService;
+import org.graylog2.telemetry.scheduler.TelemetryEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OutdatedIndicesMetricsSupplierTest {
+    @Mock
+    private OutdatedIndexService outdatedIndexService;
+
+    @InjectMocks
+    private OutdatedIndicesMetricsSupplier supplier;
+
+    @Test
+    void shouldCountOutdatedIndicesByCategory() {
+        final OutdatedIndex managed = new OutdatedIndex("graylog_0", "7", false, true, null);
+        final OutdatedIndex managedActiveWrite = new OutdatedIndex("graylog_1", "7", false, true, "graylog_deflector");
+        final OutdatedIndex managedWarm = new OutdatedIndex("graylog_warm", "7", true, true, null);
+        final OutdatedIndex system = new OutdatedIndex(".kibana", "7", false);
+        final OutdatedIndex foreign = new OutdatedIndex("customer_data", "7", false);
+
+        when(outdatedIndexService.getOutdatedIndices())
+                .thenReturn(List.of(managed, managedActiveWrite, managedWarm, system, foreign));
+
+        final Optional<TelemetryEvent> event = supplier.get();
+
+        assertThat(event).isPresent();
+        assertThat(event.get().metrics()).isEqualTo(Map.<String, Object>of(
+                "managed", 3L,
+                "warm", 1L,
+                "active_write_index", 1L,
+                "system", 1L,
+                "foreign", 1L
+        ));
+    }
+
+    @Test
+    void shouldReturnZeroCountsWhenNoOutdatedIndices() {
+        when(outdatedIndexService.getOutdatedIndices()).thenReturn(List.of());
+
+        final Optional<TelemetryEvent> event = supplier.get();
+
+        assertThat(event).isPresent();
+        assertThat(event.get().metrics()).isEqualTo(Map.<String, Object>of(
+                "managed", 0L,
+                "warm", 0L,
+                "active_write_index", 0L,
+                "system", 0L,
+                "foreign", 0L
+        ));
+    }
+}


### PR DESCRIPTION
## Description
Adds a telemetry supplier that records the number of indices which will be incompatible with the next major version of OpenSearch.

## Motivation and Context
resolves https://github.com/Graylog2/graylog-plugin-enterprise/issues/14607

## How Has This Been Tested?
added test
set initial delay of `TelemetrySubmissionPeriodical` to 0 and observed values in telemetry

## Screenshots (if appropriate):
<img width="859" height="360" alt="image" src="https://github.com/user-attachments/assets/729f02f9-859a-4a6f-b071-1cabc2b29525" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

