### PR TITLE
fix(pipelines): remove stream connections when deleting a pipeline

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/PipelineStreamConnectionsService.java
@@ -34,5 +34,14 @@ public interface PipelineStreamConnectionsService {
 
     void delete(String streamId);
 
+    /**
+     * Removes the given pipeline ID from all stream connection documents.
+     * Deletes a connection document when its {@code pipeline_ids} list becomes empty.
+     * <p>
+     * Note: the default routing pipeline ("Default Routing") is not deletable, so its
+     * connection to the default stream is never removed via this method.
+     */
+    void deleteConnectionsForPipeline(String pipelineId);
+
     Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds);
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/memory/InMemoryPipelineStreamConnectionsService.java
@@ -89,6 +89,25 @@ public class InMemoryPipelineStreamConnectionsService implements PipelineStreamC
     }
 
     @Override
+    public void deleteConnectionsForPipeline(String pipelineId) {
+        for (PipelineConnections connections : loadByPipelineId(pipelineId)) {
+            final Set<String> remainingPipelineIds = connections.pipelineIds().stream()
+                    .filter(id -> !id.equals(pipelineId))
+                    .collect(Collectors.toSet());
+
+            if (remainingPipelineIds.isEmpty()) {
+                store.remove(connections.id());
+                clusterBus.post(PipelineConnectionsChangedEvent.create(connections.streamId(), connections.pipelineIds()));
+            } else {
+                final PipelineConnections updated = connections.toBuilder()
+                        .pipelineIds(remainingPipelineIds)
+                        .build();
+                save(updated);
+            }
+        }
+    }
+
+    @Override
     public Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds) {
         return streamIds.stream()
                 .collect(Collectors.toMap(streamId -> streamId, store::get));

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -131,7 +131,10 @@ public class MongoDbPipelineService implements PipelineService {
 
     @Override
     public void delete(String id) {
+        // Delete the pipeline first so non-deletable system pipelines (e.g. Default Routing)
+        // fail before any stream connections are modified. See #21008.
         scopedEntityMongoUtils.deleteById(id);
+        pipelineStreamConnectionsService.deleteConnectionsForPipeline(id);
         clusterBus.post(PipelinesChangedEvent.deletedPipelineId(id));
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
@@ -108,6 +108,25 @@ public class MongoDbPipelineStreamConnectionsService implements PipelineStreamCo
     }
 
     @Override
+    public void deleteConnectionsForPipeline(String pipelineId) {
+        for (PipelineConnections connections : loadByPipelineId(pipelineId)) {
+            final Set<String> remainingPipelineIds = connections.pipelineIds().stream()
+                    .filter(id -> !id.equals(pipelineId))
+                    .collect(Collectors.toSet());
+
+            if (remainingPipelineIds.isEmpty()) {
+                log.debug("Removing pipeline connections for stream {}", connections.streamId());
+                delete(connections.streamId());
+            } else {
+                final PipelineConnections updated = connections.toBuilder()
+                        .pipelineIds(remainingPipelineIds)
+                        .build();
+                save(updated);
+            }
+        }
+    }
+
+    @Override
     public Map<String, PipelineConnections> loadByStreamIds(Collection<String> streamIds) {
         try (final var stream = MongoUtils.stream(collection.find(in("stream_id", streamIds)))) {
             return stream.collect(Collectors.toMap(PipelineConnections::streamId, conn -> conn));

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -218,24 +218,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
 
     @Override
     public void delete(PipelineDao nativeEntity) {
-        final Set<PipelineConnections> pipelineConnections = connectionsService.loadByPipelineId(nativeEntity.id());
-        for (PipelineConnections connections : pipelineConnections) {
-            final Set<String> pipelineIds = connections.pipelineIds().stream()
-                    .filter(pipelineId -> !pipelineId.equals(nativeEntity.id()))
-                    .collect(Collectors.toSet());
-
-            if (pipelineIds.isEmpty()) {
-                LOG.trace("Removing pipeline connections for stream {}", connections.streamId());
-                connectionsService.delete(connections.streamId());
-            } else {
-                final PipelineConnections newConnections = connections.toBuilder()
-                        .pipelineIds(pipelineIds)
-                        .build();
-                LOG.trace("Saving updated pipeline connections: {}", newConnections);
-                connectionsService.save(newConnections);
-            }
-        }
-
+        // Stream connection cleanup runs inside PipelineService.delete (see #21008).
         pipelineService.delete(nativeEntity.id());
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineServiceDeleteTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineServiceDeleteTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.pipelineprocessor.db.mongodb;
+
+import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog2.database.MongoCollections;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.database.entities.DefaultEntityScope;
+import org.graylog2.database.entities.EntityScopeService;
+import org.graylog2.database.entities.ImmutableSystemScope;
+import org.graylog2.events.ClusterEventBus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MongoDBExtension.class)
+@ExtendWith(MockitoExtension.class)
+class MongoDbPipelineServiceDeleteTest {
+
+    @Mock
+    ClusterEventBus clusterEventBus;
+
+    private MongoDbPipelineService pipelineService;
+    private MongoDbPipelineStreamConnectionsService connectionsService;
+
+    @BeforeEach
+    void setUp(MongoCollections mongoCollections) {
+        final EntityScopeService entityScopeService = new EntityScopeService(
+                Set.of(new DefaultEntityScope(), new ImmutableSystemScope()));
+        connectionsService = new MongoDbPipelineStreamConnectionsService(mongoCollections, clusterEventBus);
+        pipelineService = new MongoDbPipelineService(
+                mongoCollections, entityScopeService, clusterEventBus, null, connectionsService);
+    }
+
+    @Test
+    void deleteRemovesPipelineIdFromConnections() throws NotFoundException {
+        final PipelineDao pipelineA = pipelineService.save(PipelineDao.builder()
+                .title("pipeline-a")
+                .description("a")
+                .source("pipeline \"pipeline-a\"\nstage 0 match either\nend")
+                .build());
+        final PipelineDao pipelineB = pipelineService.save(PipelineDao.builder()
+                .title("pipeline-b")
+                .description("b")
+                .source("pipeline \"pipeline-b\"\nstage 0 match either\nend")
+                .build());
+
+        connectionsService.save(PipelineConnections.create(null, "stream-1", Set.of(pipelineA.id(), pipelineB.id())));
+
+        pipelineService.delete(pipelineA.id());
+
+        final PipelineConnections remaining = connectionsService.load("stream-1");
+        assertThat(remaining.pipelineIds()).containsExactly(pipelineB.id());
+    }
+
+    @Test
+    void deleteRemovesConnectionDocumentWhenLastPipeline() {
+        final PipelineDao pipeline = pipelineService.save(PipelineDao.builder()
+                .title("lonely-pipeline")
+                .description("alone")
+                .source("pipeline \"lonely-pipeline\"\nstage 0 match either\nend")
+                .build());
+
+        connectionsService.save(PipelineConnections.create(null, "stream-2", Set.of(pipeline.id())));
+
+        pipelineService.delete(pipeline.id());
+
+        assertThatThrownBy(() -> connectionsService.load("stream-2"))
+                .isInstanceOf(NotFoundException.class);
+        assertThat(connectionsService.loadByPipelineId(pipeline.id())).isEmpty();
+    }
+
+    @Test
+    void deleteDoesNotRemoveConnectionsForNonDeletableSystemPipeline() throws NotFoundException {
+        final PipelineDao systemPipeline = pipelineService.save(PipelineDao.create(
+                null,
+                ImmutableSystemScope.NAME,
+                "Default Routing",
+                "System generated pipeline",
+                "pipeline \"Default Routing\"\nstage 0 match either\nend",
+                null,
+                null));
+
+        connectionsService.save(PipelineConnections.create(null, "000000000000000000000001", Set.of(systemPipeline.id())));
+
+        assertThatThrownBy(() -> pipelineService.delete(systemPipeline.id()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final PipelineConnections stillConnected = connectionsService.load("000000000000000000000001");
+        assertThat(stillConnected.pipelineIds()).containsExactly(systemPipeline.id());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -105,9 +105,9 @@ public class PipelineFacadeTest {
         entityScopeService = new EntityScopeService(Set.of(new DefaultEntityScope(), new ImmutableSystemScope()));
 
         final ClusterEventBus clusterEventBus = new ClusterEventBus("cluster-event-bus", Executors.newSingleThreadExecutor());
-        pipelineService = new MongoDbPipelineService(
-                mongoCollections, entityScopeService, clusterEventBus, mock(MongoDbRuleService.class), mock(PipelineStreamConnectionsService.class));
         connectionsService = new MongoDbPipelineStreamConnectionsService(mongoCollections, clusterEventBus);
+        pipelineService = new MongoDbPipelineService(
+                mongoCollections, entityScopeService, clusterEventBus, mock(MongoDbRuleService.class), connectionsService);
 
         facade = new PipelineFacade(objectMapper, pipelineService, connectionsService, pipelineRuleParser, ruleService, streamService);
     }
@@ -265,11 +265,13 @@ public class PipelineFacadeTest {
         final PipelineDao pipelineDao = pipelineService.load("5a85c4854b900afd5d662be3");
 
         assertThat(pipelineService.loadAll()).hasSize(2);
+        assertThat(connectionsService.loadByPipelineId("5a85c4854b900afd5d662be3")).isNotEmpty();
         facade.delete(pipelineDao);
         assertThat(pipelineService.loadAll()).hasSize(1);
 
         assertThatThrownBy(() -> pipelineService.load("5a85c4854b900afd5d662be3"))
                 .isInstanceOf(NotFoundException.class);
+        assertThat(connectionsService.loadByPipelineId("5a85c4854b900afd5d662be3")).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Description
When a pipeline is deleted, cascade cleanup of `pipeline_processor_pipelines_streams`:
- remove the pipeline ID from every connection document's `pipeline_ids` list
- delete the connection document when the list becomes empty

Cleanup runs only after the pipeline document is successfully deleted, so non-deletable system pipelines (e.g. **Default Routing**) still fail first and their default-stream connection is left intact.

Connection cleanup previously lived only in `PipelineFacade.delete` (content packs). It is now part of `PipelineService.delete` so REST deletes get the same behavior. `PipelineFacade` delegates to that path.

## Motivation and Context
Fixes #21008 — obsolete connection documents remained after pipeline deletion.

## How Has This Been Tested?
```
./mvnw test -pl :graylog2-server \
  -Dtest=MongoDbPipelineServiceDeleteTest,PipelineFacadeTest \
  -Dskip.web.build=true -Dmaven.javadoc.skip=true
```
- `MongoDbPipelineServiceDeleteTest` (3 tests): multi-pipeline connection update, empty-doc removal, non-deletable Default Routing left alone
- `PipelineFacadeTest` (14 tests): including delete asserting connections are cleared

Platform: macOS (aarch64), JDK 21, MongoDB 7 via Testcontainers/Colima

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.