### PR TITLE
fix(rest): return 400 for invalid query parameter values

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -72,6 +72,7 @@ import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JsonMappingExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JsonProcessingExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.MissingStreamPermissionExceptionMapper;
+import org.graylog2.shared.rest.exceptionmappers.ParamExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.WebApplicationExceptionMapper;
 import org.graylog2.shared.security.ShiroRequestHeadersBinder;
 import org.graylog2.shared.security.ShiroSecurityContextFilter;
@@ -280,6 +281,7 @@ public class JerseyService extends AbstractIdleService {
                         JsonMappingExceptionMapper.class,
                         AnyExceptionClassMapper.class,
                         MissingStreamPermissionExceptionMapper.class,
+                        ParamExceptionMapper.class,
                         WebApplicationExceptionMapper.class,
                         BadRequestExceptionMapper.class,
                         RestAccessLogFilter.class,

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptionmappers/ParamExceptionMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptionmappers/ParamExceptionMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.exceptionmappers;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.glassfish.jersey.server.ParamException;
+import org.graylog2.plugin.rest.ApiError;
+
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+/**
+ * Maps Jersey {@link ParamException} (including invalid query parameters) to HTTP 400.
+ * <p>
+ * Jersey defaults URI parameter conversion failures to 404; for request parameters that
+ * is misleading. See Graylog issue #4721.
+ */
+@Provider
+public class ParamExceptionMapper implements ExceptionMapper<ParamException> {
+    @Override
+    public Response toResponse(ParamException exception) {
+        final String message = f("Invalid value for %s parameter %s",
+                exception.getParameterType().getSimpleName(),
+                exception.getParameterName());
+        final ApiError apiError = ApiError.create(message);
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .entity(apiError)
+                .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/exceptionmappers/ParamExceptionMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/exceptionmappers/ParamExceptionMapperTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.shared.rest.exceptionmappers;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.glassfish.jersey.server.ParamException;
+import org.graylog2.plugin.rest.ApiError;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParamExceptionMapperTest {
+    private final ExceptionMapper<ParamException> mapper = new ParamExceptionMapper();
+
+    @Test
+    void mapsQueryParamExceptionToBadRequest() {
+        final ParamException exception = new ParamException.QueryParamException(
+                new NumberFormatException("For input string: \"hoge\""), "skip", "0");
+        final Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.BAD_REQUEST);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+        assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+        assertThat(((ApiError) response.getEntity()).message())
+                .isEqualTo("Invalid value for QueryParam parameter skip");
+    }
+
+    @Test
+    void mapsLimitQueryParamExceptionToBadRequest() {
+        final ParamException exception = new ParamException.QueryParamException(
+                new NumberFormatException("For input string: \"hoge\""), "limit", "0");
+        final Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(((ApiError) response.getEntity()).message())
+                .isEqualTo("Invalid value for QueryParam parameter limit");
+    }
+}


### PR DESCRIPTION
## Description
Register a Jersey `ParamExceptionMapper` so invalid request parameters (query/path conversion failures) return **HTTP 400** with an `ApiError` body instead of Jersey’s default **404**.

Example affected call from #4721:
```
GET /api/system/indices/index_sets?skip=hoge&limit=0&stats=false
```
Previously returned `404` / `HTTP 404 Not Found`. Now returns `400` with a message like `Invalid value for QueryParam parameter skip`.

## Motivation and Context
Fixes #4721. Jersey still maps URI parameter conversion failures to 404 (`ParamException.UriParamException`). That is incorrect for query parameters such as `skip`/`limit` on the index sets API.

## How Has This Been Tested?
```
./mvnw test -pl :graylog2-server \
  -Dtest=ParamExceptionMapperTest \
  -Dskip.web.build=true -Dmaven.javadoc.skip=true
```
- Confirmed on current `master` that Jersey 4.0.2 still uses `Response.Status.NOT_FOUND` for `QueryParamException`
- Unit tests cover `skip` and `limit` style `QueryParamException` → 400 + `ApiError`

Platform: macOS (aarch64), JDK 21

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.