### PR TITLE
Remove focus outline on click for buttons rendered as links.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Button.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Button.tsx
@@ -183,6 +183,10 @@ const StyledButton = styled(MantineButton)<{
     &:focus {
       color: ${color};
       text-decoration: none;
+
+      &:not(:focus-visible) {
+        outline: none;
+      }
     }
 
     ${$active && activeStyles(theme.colors, $bsStyle)}


### PR DESCRIPTION
**Please note**, ideally we backport this fix to previous versions, similar to https://github.com/Graylog2/graylog2-server/pull/26504

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue with the the page navigation. After a click, these links showed an unwanted focus indicator:

<img width="254" height="142" alt="image" src="https://github.com/user-attachments/assets/4c44f225-88e9-4511-84da-a18432f0ccdd" />

In https://github.com/Graylog2/graylog2-server/pull/26504 we fixed a similar issue for the main navigation.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/13945
/nocl - imo the changelog in https://github.com/Graylog2/graylog2-server/pull/26504 already covers this fix.