### PR TITLE
Show collections in Recent Activity with their type and title

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityEvent.java
@@ -19,8 +19,9 @@ package org.graylog.plugins.views.startpage.recentActivities;
 import org.graylog.grn.GRN;
 
 /*
- * Used with two constructors: activityType, itemId and userName for all Events except DELETE.
- * Because for DELETE, we can not lookup up title/type in the catalog later.
+ * Used with two constructors: the 3-arg form (no itemTitle) when the title can be resolved from the catalog at read
+ * time, the 4-arg form when it can not. That is the case for DELETE, because the entity is gone by then, and for
+ * entity types without a content pack facade, because those never appear in the catalog at all.
  * User is not part of the catalog so we use the userName instead of the id as we don't want to look up the user for every activity
  */
 public record RecentActivityEvent(ActivityType activityType, GRN grn, String itemTitle, String userName) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityService.java
@@ -119,12 +119,28 @@ public class RecentActivityService {
         postRecentActivity(new RecentActivityEvent(ActivityType.CREATE, grnRegistry.newGRN(grn, id), user.getFullName()));
     }
 
+    /**
+     * Records a creation and stores the given title with it. Use this for entity types that cannot be resolved
+     * through the {@link org.graylog2.lookup.Catalog} later on, i.e. those without a content pack facade.
+     */
+    public void create(String id, GRNType grn, String title, User user) {
+        postRecentActivity(new RecentActivityEvent(ActivityType.CREATE, grnRegistry.newGRN(grn, id), title, user.getFullName()));
+    }
+
     public void update(String id, GRNType grn, SearchUser user) {
         update(id, grn, user.getUser());
     }
 
     public void update(String id, GRNType grn, User user) {
         postRecentActivity(new RecentActivityEvent(ActivityType.UPDATE, grnRegistry.newGRN(grn, id), user.getFullName()));
+    }
+
+    /**
+     * Records an update and stores the given title with it. Use this for entity types that cannot be resolved
+     * through the {@link org.graylog2.lookup.Catalog} later on, i.e. those without a content pack facade.
+     */
+    public void update(String id, GRNType grn, String title, User user) {
+        postRecentActivity(new RecentActivityEvent(ActivityType.UPDATE, grnRegistry.newGRN(grn, id), title, user.getFullName()));
     }
 
     public void delete(String id, GRNType grn, String title, SearchUser user) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityServiceTest.java
@@ -49,6 +49,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(MongoJackExtension.class)
@@ -77,6 +78,8 @@ public class RecentActivityServiceTest {
                TestUserService testUserService) {
         admin = TestUser.builder().withId("637748db06e1d74da0a54331").withUsername("local:admin").isLocalAdmin(true).build();
         user = TestUser.builder().withId("637748db06e1d74da0a54330").withUsername("test").isLocalAdmin(false).build();
+        // TestUser only stubs getName(). Activity rows carry getFullName(), so stub it here to tell the two apart.
+        when(user.getFullName()).thenReturn("Test User");
         searchUser = TestSearchUser.builder().withUser(user).build();
         searchAdmin = TestSearchUser.builder().withUser(admin).build();
 
@@ -203,7 +206,9 @@ public class RecentActivityServiceTest {
 
         assertThat(collector.events).singleElement().satisfies(event -> {
             assertThat(event.activityType()).isEqualTo(ActivityType.CREATE);
+            assertThat(event.grn()).isEqualTo(grnRegistry.newGRN(GRNTypes.DASHBOARD, "1"));
             assertThat(event.itemTitle()).isEqualTo("My Dashboard");
+            assertThat(event.userName()).isEqualTo("Test User");
         });
     }
 
@@ -216,7 +221,9 @@ public class RecentActivityServiceTest {
 
         assertThat(collector.events).singleElement().satisfies(event -> {
             assertThat(event.activityType()).isEqualTo(ActivityType.UPDATE);
+            assertThat(event.grn()).isEqualTo(grnRegistry.newGRN(GRNTypes.DASHBOARD, "1"));
             assertThat(event.itemTitle()).isEqualTo("My Dashboard");
+            assertThat(event.userName()).isEqualTo("Test User");
         });
     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/startpage/recentActivities/RecentActivityServiceTest.java
@@ -16,6 +16,8 @@
  */
 package org.graylog.plugins.views.startpage.recentActivities;
 
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import org.apache.shiro.authz.Permission;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
@@ -40,6 +42,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -57,6 +61,7 @@ public class RecentActivityServiceTest {
     RecentActivityService recentActivityService;
     TestUserService testUserService;
     GRNRegistry grnRegistry;
+    EventBus eventBus;
 
     PermissionAndRoleResolver permissionAndRoleResolver;
 
@@ -94,10 +99,11 @@ public class RecentActivityServiceTest {
 
         this.testUserService = testUserService;
         this.grnRegistry = grnRegistry;
+        this.eventBus = new EventBus();
         this.recentActivityService = new RecentActivityService(
                 mongoCollections,
                 mongodb.mongoConnection(),
-               null,
+                eventBus,
                 grnRegistry,
                 permissionAndRoleResolver,
                 MAXIMUM,
@@ -186,5 +192,40 @@ public class RecentActivityServiceTest {
 
         assertThat(activities.delegate().stream().filter(a -> Objects.equals(a.itemGrn().entity(), "2")).toList().size()).isEqualTo(1);
         assertThat(activities.delegate().stream().filter(a -> Objects.equals(a.itemGrn().entity(), "3")).toList().size()).isEqualTo(1);
+    }
+
+    @Test
+    public void testCreateWithTitleStoresTheGivenTitle() {
+        final var collector = new RecentActivityEventCollector();
+        eventBus.register(collector);
+
+        recentActivityService.create("1", GRNTypes.DASHBOARD, "My Dashboard", user);
+
+        assertThat(collector.events).singleElement().satisfies(event -> {
+            assertThat(event.activityType()).isEqualTo(ActivityType.CREATE);
+            assertThat(event.itemTitle()).isEqualTo("My Dashboard");
+        });
+    }
+
+    @Test
+    public void testUpdateWithTitleStoresTheGivenTitle() {
+        final var collector = new RecentActivityEventCollector();
+        eventBus.register(collector);
+
+        recentActivityService.update("1", GRNTypes.DASHBOARD, "My Dashboard", user);
+
+        assertThat(collector.events).singleElement().satisfies(event -> {
+            assertThat(event.activityType()).isEqualTo(ActivityType.UPDATE);
+            assertThat(event.itemTitle()).isEqualTo("My Dashboard");
+        });
+    }
+
+    static class RecentActivityEventCollector {
+        final List<RecentActivityEvent> events = new ArrayList<>();
+
+        @Subscribe
+        public void handle(RecentActivityEvent event) {
+            events.add(event);
+        }
     }
 }

--- a/graylog2-web-interface/src/util/getTitleForEntityType.test.ts
+++ b/graylog2-web-interface/src/util/getTitleForEntityType.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import getTitleForEntityType from 'util/getTitleForEntityType';
+
+describe('getTitleForEntityType', () => {
+  it('returns a readable title for a collection', () => {
+    expect(getTitleForEntityType('collection')).toBe('collection');
+  });
+});

--- a/graylog2-web-interface/src/util/getTitleForEntityType.test.ts
+++ b/graylog2-web-interface/src/util/getTitleForEntityType.test.ts
@@ -20,4 +20,8 @@ describe('getTitleForEntityType', () => {
   it('returns a readable title for a collection', () => {
     expect(getTitleForEntityType('collection')).toBe('collection');
   });
+
+  it('returns a readable title for collection entities, which is what sharing a collection records', () => {
+    expect(getTitleForEntityType('collection_entities')).toBe('collection entities');
+  });
 });

--- a/graylog2-web-interface/src/util/getTitleForEntityType.ts
+++ b/graylog2-web-interface/src/util/getTitleForEntityType.ts
@@ -36,6 +36,7 @@ const supportedTypes = new Set([
   'event_procedure',
   'event_procedure_step',
   'collection',
+  'collection_entities',
 ]);
 
 const getTitleForEntityType = (type: string, throwErrorOnUnknown = true) => {

--- a/graylog2-web-interface/src/util/getTitleForEntityType.ts
+++ b/graylog2-web-interface/src/util/getTitleForEntityType.ts
@@ -35,6 +35,7 @@ const supportedTypes = new Set([
   'sigma_rule',
   'event_procedure',
   'event_procedure_step',
+  'collection',
 ]);
 
 const getTitleForEntityType = (type: string, throwErrorOnUnknown = true) => {


### PR DESCRIPTION
Related to Graylog2/graylog-plugin-enterprise#14932

/nocl Changelog lives in the enterprise PR, since the user visible fix is a collections one.

## Description

Creating a collection produced a Recent Activity entry reading `The (unsupported type collection) 689abc… was created by X`. Two separate causes, both in this repo.

`getTitleForEntityType` resolves labels from a hardcoded allowlist that omits `collection`, so the label fell through to the unsupported-type placeholder. The route and the permission prefix already resolve for collections, only the label had no path.

Collections also have no content pack facade. `StartPageItemTitleRetriever` resolves titles exclusively through `Catalog`, which is built from content pack entity excerpts, so the lookup misses and the list falls back to the stored title. That is `null` for `CREATE`, so the UI rendered the raw ObjectId. This PR adds `create`/`update` overloads that store the title alongside the activity, which is what `delete` already does and for the same reason.

## How Tested

- unit tests
- New `getTitleForEntityType.test.ts`.
- Manual: Verified on a test instance:
  - creating a collection, then `GET /api/startpage/recentActivity`, returns `item_title` set to the collection title. It was previously `null`, which is why the UI fell back to the raw ObjectId.
  - the Welcome page renders `The collection <title> was created by <user>` instead of `The (unsupported type collection) <hex id> was created`.
  - renaming gives HTTP 200 and an `update` row carrying the new title; deleting gives HTTP 204, a `delete` row carrying the title, and the earlier rows for that collection purged.
  - note the create row keeps the pre-rename title while the update row shows the new one, which is the expected consequence of storing the title at write time.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
