### PR TITLE
Limit cert cname length

### DIFF
--- a/changelog/unreleased/pr-26786.toml
+++ b/changelog/unreleased/pr-26786.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Truncate certificate CN to RFC 5280's 64-character limit to prevent certificate generation from failing on hosts with long hostnames."
+
+pulls = ["26786"]

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertConstants.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertConstants.java
@@ -24,4 +24,8 @@ public interface CertConstants {
     String SIGNING_ALGORITHM = "SHA256withRSA";
     String PKCS12 = "PKCS12";
     String CA_KEY_ALIAS = "ca";
+    /**
+     * Maximum length of the CN (common name) attribute, per RFC 5280's ub-common-name upper bound.
+     */
+    int CN_MAX_LENGTH = 64;
 }

--- a/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog/security/certutil/CertificateGenerator.java
@@ -63,7 +63,7 @@ public class CertificateGenerator {
 
     public KeyPair generateKeyPair(CertRequest request) throws CertIOException, CertificateException, OperatorCreationException {
         java.security.KeyPair certKeyPair = keyGen.generateKeyPair();
-        final X500Name name = getX500Name(request.cnName());
+        final X500Name name = getX500Name(trim(request.cnName()));
 
         BigInteger serialNumber = new BigInteger(UUID.randomUUID().toString().replace("-", ""), 16);
         Instant validFrom = Instant.now();
@@ -104,6 +104,10 @@ public class CertificateGenerator {
         X509CertificateHolder certHolder = builder.build(signer);
         X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certHolder);
         return new KeyPair(certKeyPair.getPrivate(), certKeyPair.getPublic(), cert);
+    }
+
+    private String trim(String s) {
+        return s.length() > CertConstants.CN_MAX_LENGTH ? s.substring(0, CertConstants.CN_MAX_LENGTH) : s;
     }
 
     private static X500Name getX500Name(String cname) {

--- a/graylog2-server/src/test/java/org/graylog/security/certutil/CertificateGeneratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/certutil/CertificateGeneratorTest.java
@@ -46,4 +46,20 @@ class CertificateGeneratorTest {
         final CertRequest req = CertRequest.selfSigned(cname).validity(Duration.ofDays(1));
         return CERTIFICATE_GENERATOR.generateKeyPair(req);
     }
+
+    @Test
+    void testCnAtMaxLengthIsNotTruncated() throws Exception {
+        final String cname = "a".repeat(CertConstants.CN_MAX_LENGTH);
+        final KeyPair pair = selfSigned(cname);
+        final String cn = pair.certificate().getSubjectX500Principal().getName();
+        Assertions.assertThat(cn).isEqualTo("CN=" + cname);
+    }
+
+    @Test
+    void testCnExceedingMaxLengthIsTruncated() throws Exception {
+        final String cname = "a".repeat(CertConstants.CN_MAX_LENGTH + 1);
+        final KeyPair pair = selfSigned(cname);
+        final String cn = pair.certificate().getSubjectX500Principal().getName();
+        Assertions.assertThat(cn).isEqualTo("CN=" + "a".repeat(CertConstants.CN_MAX_LENGTH));
+    }
 }


### PR DESCRIPTION
## Description
CName is limited to 64 chars. Some hostnames may exceed this. Let's trim the hostname for CName and rely on SAN, where the full hostname is already present and doesn't cause any problems.

## How Has This Been Tested?
Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

