### PR TITLE
Entity data table: Open actions menu when clicking anywhere in column header.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.test.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import Menu from 'components/bootstrap/Menu';
+import { MenuItem } from 'components/bootstrap';
+
+import useClickToOpenMenu, { MenuAnchor } from './useClickToOpenMenu';
+
+const TestTrigger = ({ onSelect = () => {} }: { onSelect?: () => void }) => {
+  const { triggerRef, opened, onOpenChange, anchorPosition, onClick, onKeyDown } =
+    useClickToOpenMenu<HTMLButtonElement>();
+
+  return (
+    <Menu opened={opened} onChange={onOpenChange} withinPortal position="bottom-start">
+      <Menu.Target>
+        <MenuAnchor style={{ left: anchorPosition?.x ?? 0, top: anchorPosition?.y ?? 0 }} />
+      </Menu.Target>
+      <button type="button" ref={triggerRef} onClick={onClick} onKeyDown={onKeyDown}>
+        Trigger
+      </button>
+      <Menu.Dropdown>
+        <MenuItem onClick={onSelect}>Item</MenuItem>
+      </Menu.Dropdown>
+    </Menu>
+  );
+};
+
+describe('useClickToOpenMenu', () => {
+  it('should open the menu when clicking the trigger', async () => {
+    render(<TestTrigger />);
+
+    await userEvent.click(await screen.findByRole('button', { name: /trigger/i }));
+
+    await screen.findByRole('menuitem', { name: /item/i });
+  });
+
+  it('should open the menu with the Enter key', async () => {
+    render(<TestTrigger />);
+
+    const trigger = await screen.findByRole('button', { name: /trigger/i });
+    trigger.focus();
+
+    await userEvent.keyboard('{Enter}');
+
+    await screen.findByRole('menuitem', { name: /item/i });
+  });
+
+  it('should return focus to the trigger once the menu closes', async () => {
+    const onSelect = jest.fn();
+    render(<TestTrigger onSelect={onSelect} />);
+
+    const trigger = await screen.findByRole('button', { name: /trigger/i });
+    await userEvent.click(trigger);
+    await userEvent.click(await screen.findByRole('menuitem', { name: /item/i }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.tsx
@@ -28,45 +28,23 @@ const StyledMenuAnchor = styled.div`
   pointer-events: none;
 `;
 
-// Zero-size and invisible: it only exists to be a Menu's positioning anchor, moved to the clicked
-// point (see useClickToOpenMenu below) so the dropdown opens exactly where its trigger element was
-// clicked, rather than anchored to the trigger's own position. Render it inside that Menu's
-// `Menu.Target`.
-//
-// Rendered through a portal straight into <body>: a CSS `transform` on any ancestor of this anchor
-// becomes the containing block for its `position: fixed`, which would resolve its coordinates
-// relative to that ancestor's own box instead of the viewport. Portaling past all of them avoids
-// having to know whether some particular ancestor happens to have one.
+// Invisible positioning anchor for a Menu's `Menu.Target`, moved to the click point; portaled into
+// <body> so a `transform` on some ancestor can't turn its `position: fixed` coordinates relative.
 export const MenuAnchor = forwardRef<HTMLDivElement, { style?: React.CSSProperties }>(
   ({ style = undefined, ...rest }, ref) =>
     createPortal(<StyledMenuAnchor ref={ref} style={style} {...rest} />, document.body),
 );
 
-/**
- * Wires up a "click anywhere on this element to open a Mantine `Menu` right where you clicked"
- * interaction, for making a whole element (not just a dedicated toggle button) act as a dropdown
- * trigger. A click or an Enter keypress on the returned `triggerRef` element opens the menu
- * anchored at that point (render `<MenuAnchor style={{ left: anchorPosition?.x ?? 0, top:
- * anchorPosition?.y ?? 0 }} />` inside the Menu's `Menu.Target`); a second click/Enter closes it
- * again; and closing it for any reason returns focus to the trigger element.
- *
- * Only handles the open/close/position state and the click/keydown wiring -- rendering the actual
- * `<Menu>`/`<Menu.Dropdown>` content, and deciding whether the trigger element has anything to
- * toggle in the first place, is left to the caller.
- */
+// Makes a whole element (not just a dedicated toggle button) act as a dropdown trigger: click or
+// Enter opens a Mantine `Menu` at that point, a second click/Enter closes it, and closing it for
+// any reason returns focus to the trigger; rendering the `<Menu>` itself is left to the caller.
 const useClickToOpenMenu = <Trigger extends HTMLElement = HTMLElement>() => {
   const triggerRef = useRef<Trigger>(null);
   const [opened, setOpened] = useState(false);
   const [anchorPosition, setAnchorPosition] = useState<Position | null>(null);
 
-  // Mantine's own dropdowns return focus to the element that opened them once they close; its
-  // built-in mechanism for that (Popover's `returnFocus`) just remembers `document.activeElement`
-  // at open time and refocuses it at close time -- but Menu's own FocusTrap moves focus into the
-  // dropdown (onto its first item) before that capture runs, so by then it's too late: it ends up
-  // "returning" focus to something inside the dropdown instead of the trigger. Doing it ourselves is
-  // simple and matches that same "usual dropdown" behavior: closing the menu, for any reason (an
-  // action, Escape, an outside click, or toggling it via the trigger again), always returns focus to
-  // the trigger element itself.
+  // Mantine's own focus-return fires too late here (its FocusTrap moves focus into the dropdown
+  // before that capture runs), so we return focus to the trigger on close ourselves.
   const onOpenChange = (nextOpened: boolean) => {
     setOpened(nextOpened);
 
@@ -87,9 +65,7 @@ const useClickToOpenMenu = <Trigger extends HTMLElement = HTMLElement>() => {
   };
 
   const onClick = (event: React.MouseEvent<Trigger>) => {
-    // A keyboard-triggered click (e.g. assistive tech activating a `role="button"` element)
-    // reports (0, 0) here, so fall back to anchoring at the trigger's own position instead of the
-    // top-left of the viewport.
+    // An assistive-tech-triggered click reports (0, 0) here, so fall back to the trigger's rect.
     const { clientX, clientY } = event;
     const hasPointerPosition = clientX !== 0 || clientY !== 0;
     const rect = event.currentTarget.getBoundingClientRect();
@@ -97,10 +73,7 @@ const useClickToOpenMenu = <Trigger extends HTMLElement = HTMLElement>() => {
     toggleAt(hasPointerPosition ? { x: clientX, y: clientY } : { x: rect.left, y: rect.bottom });
   };
 
-  // Only for a keydown on the trigger itself, not one that bubbled up from a focused descendant
-  // (e.g. a focused menu item -- since Menu.Dropdown is rendered through a portal into <body>,
-  // React's synthetic events still bubble along the *React* tree, not the DOM tree). Otherwise
-  // Enter on a descendant would toggle this menu instead of letting its own onClick run.
+  // Ignore keydowns bubbled up from a focused descendant (e.g. a menu item), only the trigger itself.
   const onKeyDown = (event: React.KeyboardEvent<Trigger>) => {
     if (event.target !== event.currentTarget || event.key !== 'Enter') {
       return;

--- a/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/useClickToOpenMenu.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { forwardRef, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+
+type Position = { x: number; y: number };
+
+const StyledMenuAnchor = styled.div`
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+`;
+
+// Zero-size and invisible: it only exists to be a Menu's positioning anchor, moved to the clicked
+// point (see useClickToOpenMenu below) so the dropdown opens exactly where its trigger element was
+// clicked, rather than anchored to the trigger's own position. Render it inside that Menu's
+// `Menu.Target`.
+//
+// Rendered through a portal straight into <body>: a CSS `transform` on any ancestor of this anchor
+// becomes the containing block for its `position: fixed`, which would resolve its coordinates
+// relative to that ancestor's own box instead of the viewport. Portaling past all of them avoids
+// having to know whether some particular ancestor happens to have one.
+export const MenuAnchor = forwardRef<HTMLDivElement, { style?: React.CSSProperties }>(
+  ({ style = undefined, ...rest }, ref) =>
+    createPortal(<StyledMenuAnchor ref={ref} style={style} {...rest} />, document.body),
+);
+
+/**
+ * Wires up a "click anywhere on this element to open a Mantine `Menu` right where you clicked"
+ * interaction, for making a whole element (not just a dedicated toggle button) act as a dropdown
+ * trigger. A click or an Enter keypress on the returned `triggerRef` element opens the menu
+ * anchored at that point (render `<MenuAnchor style={{ left: anchorPosition?.x ?? 0, top:
+ * anchorPosition?.y ?? 0 }} />` inside the Menu's `Menu.Target`); a second click/Enter closes it
+ * again; and closing it for any reason returns focus to the trigger element.
+ *
+ * Only handles the open/close/position state and the click/keydown wiring -- rendering the actual
+ * `<Menu>`/`<Menu.Dropdown>` content, and deciding whether the trigger element has anything to
+ * toggle in the first place, is left to the caller.
+ */
+const useClickToOpenMenu = <Trigger extends HTMLElement = HTMLElement>() => {
+  const triggerRef = useRef<Trigger>(null);
+  const [opened, setOpened] = useState(false);
+  const [anchorPosition, setAnchorPosition] = useState<Position | null>(null);
+
+  // Mantine's own dropdowns return focus to the element that opened them once they close; its
+  // built-in mechanism for that (Popover's `returnFocus`) just remembers `document.activeElement`
+  // at open time and refocuses it at close time -- but Menu's own FocusTrap moves focus into the
+  // dropdown (onto its first item) before that capture runs, so by then it's too late: it ends up
+  // "returning" focus to something inside the dropdown instead of the trigger. Doing it ourselves is
+  // simple and matches that same "usual dropdown" behavior: closing the menu, for any reason (an
+  // action, Escape, an outside click, or toggling it via the trigger again), always returns focus to
+  // the trigger element itself.
+  const onOpenChange = (nextOpened: boolean) => {
+    setOpened(nextOpened);
+
+    if (!nextOpened) {
+      triggerRef.current?.focus({ preventScroll: true });
+    }
+  };
+
+  const toggleAt = (position: Position) => {
+    if (opened) {
+      onOpenChange(false);
+
+      return;
+    }
+
+    setAnchorPosition(position);
+    setOpened(true);
+  };
+
+  const onClick = (event: React.MouseEvent<Trigger>) => {
+    // A keyboard-triggered click (e.g. assistive tech activating a `role="button"` element)
+    // reports (0, 0) here, so fall back to anchoring at the trigger's own position instead of the
+    // top-left of the viewport.
+    const { clientX, clientY } = event;
+    const hasPointerPosition = clientX !== 0 || clientY !== 0;
+    const rect = event.currentTarget.getBoundingClientRect();
+
+    toggleAt(hasPointerPosition ? { x: clientX, y: clientY } : { x: rect.left, y: rect.bottom });
+  };
+
+  // Only for a keydown on the trigger itself, not one that bubbled up from a focused descendant
+  // (e.g. a focused menu item -- since Menu.Dropdown is rendered through a portal into <body>,
+  // React's synthetic events still bubble along the *React* tree, not the DOM tree). Otherwise
+  // Enter on a descendant would toggle this menu instead of letting its own onClick run.
+  const onKeyDown = (event: React.KeyboardEvent<Trigger>) => {
+    if (event.target !== event.currentTarget || event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    const rect = event.currentTarget.getBoundingClientRect();
+    toggleAt({ x: rect.left, y: rect.bottom });
+  };
+
+  return { triggerRef, opened, onOpenChange, anchorPosition, onClick, onKeyDown };
+};
+
+export default useClickToOpenMenu;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -215,8 +215,6 @@ describe('<EntityDataTable />', () => {
 
     render(<EntityDataTable {...defaultProps} onSortChange={onSortChange} />);
 
-    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
-    // accessible name is still the drag-handle description, since dragging is the header's other role.
     await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /sort ascending/i }));
 
@@ -243,8 +241,6 @@ describe('<EntityDataTable />', () => {
 
     render(<EntityDataTable {...defaultProps} columnSchemas={columnSchemas} onChangeSlicing={onChangeSlicing} />);
 
-    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
-    // accessible name is still the drag-handle description, since dragging is the header's other role.
     await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /slice by values/i }));
 
@@ -263,8 +259,6 @@ describe('<EntityDataTable />', () => {
       />,
     );
 
-    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
-    // accessible name is still the drag-handle description, since dragging is the header's other role.
     await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /no slicing/i }));
 

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.test.tsx
@@ -215,7 +215,9 @@ describe('<EntityDataTable />', () => {
 
     render(<EntityDataTable {...defaultProps} onSortChange={onSortChange} />);
 
-    await userEvent.click(await screen.findByRole('button', { name: /toggle description actions/i }));
+    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
+    // accessible name is still the drag-handle description, since dragging is the header's other role.
+    await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /sort ascending/i }));
 
     await waitFor(() => expect(onSortChange).toHaveBeenCalledTimes(1));
@@ -223,12 +225,27 @@ describe('<EntityDataTable />', () => {
     expect(onSortChange).toHaveBeenCalledWith({ attributeId: 'description', direction: 'asc' });
   });
 
+  it('should open header actions menu with the Enter key, leaving Space free for column drag', async () => {
+    render(<EntityDataTable {...defaultProps} />);
+
+    const descriptionHeader = await screen.findByRole('button', {
+      name: /drag or press space to reorder description/i,
+    });
+    descriptionHeader.focus();
+
+    await userEvent.keyboard('{Enter}');
+
+    await screen.findByRole('menuitem', { name: /sort ascending/i });
+  });
+
   it('should slice by column using header action', async () => {
     const onChangeSlicing = jest.fn(() => {});
 
     render(<EntityDataTable {...defaultProps} columnSchemas={columnSchemas} onChangeSlicing={onChangeSlicing} />);
 
-    await userEvent.click(await screen.findByRole('button', { name: /toggle description actions/i }));
+    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
+    // accessible name is still the drag-handle description, since dragging is the header's other role.
+    await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /slice by values/i }));
 
     expect(onChangeSlicing).toHaveBeenCalledWith('description');
@@ -246,7 +263,9 @@ describe('<EntityDataTable />', () => {
       />,
     );
 
-    await userEvent.click(await screen.findByRole('button', { name: /toggle description actions/i }));
+    // The whole header cell opens the actions menu now (not a dedicated per-title button); its
+    // accessible name is still the drag-handle description, since dragging is the header's other role.
+    await userEvent.click(await screen.findByRole('button', { name: /drag or press space to reorder description/i }));
     await userEvent.click(await screen.findByRole('menuitem', { name: /no slicing/i }));
 
     expect(onChangeSlicing).toHaveBeenCalledWith(undefined, undefined);

--- a/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
@@ -134,9 +134,11 @@ const HeaderActionsDropdown = ({
       {/* Not the Menu.Target: opening/positioning is driven by the whole header's click handler
           (see AttributeHeader) so this only needs to render the label -- clicking it still opens
           the menu, since the click bubbles up to that handler. */}
-      {textAlign === 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
-      <DropdownTrigger title={`Toggle ${label} actions`}>{children}</DropdownTrigger>
-      {textAlign !== 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
+      <DropdownTrigger title={`Toggle ${label} actions`}>
+        {textAlign === 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
+        {children}
+        {textAlign !== 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
+      </DropdownTrigger>
 
       <Menu.Dropdown>
         {onSort && (

--- a/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
@@ -16,39 +16,45 @@
  */
 
 import * as React from 'react';
+import { forwardRef } from 'react';
+import { createPortal } from 'react-dom';
 import styled, { css } from 'styled-components';
 
 import Menu from 'components/bootstrap/Menu';
-import Icon from 'components/common/Icon';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { MenuItem } from 'components/bootstrap';
 
-export const DropdownCaret = styled(Icon)`
-  opacity: 0;
-  transition: opacity 0.15s ease-in-out;
-`;
-
-const DropdownTrigger = styled.button(
+// A plain (non-focusable) span: the header cell itself (ThInner, see AttributeHeader) is the one
+// focusable/clickable element for opening this menu, so this only renders the label -- it must
+// not be its own tab stop, or focusing the header would take two Tab presses instead of one.
+const DropdownTrigger = styled.span(
   ({ theme }) => css`
-    background: transparent;
-    border: 0;
-    padding: 0;
     display: inline-flex;
     align-items: center;
     gap: ${theme.spacings.xxs};
     line-height: inherit;
-
-    &:focus-visible {
-      outline-offset: 2px;
-    }
-
-    &:hover .header-action,
-    &:focus-within .header-action,
-    &[aria-expanded='true'] .header-action {
-      opacity: 1;
-    }
   `,
+);
+
+const StyledMenuAnchor = styled.div`
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+`;
+
+// Zero-size and invisible: it only exists to be the Menu's positioning anchor, moved to the
+// clicked point (see AttributeHeader) so the dropdown opens exactly where the header was clicked,
+// rather than anchored to the DropdownTrigger's own position.
+//
+// Rendered through a portal straight into <body>: the header (Th) always has a CSS `transform`
+// set (even when idle, it falls back to `translate3d(0, 0, 0)` -- see TableHead.tsx), and any
+// transformed ancestor becomes the containing block for a `position: fixed` descendant. Left in
+// place, this anchor's "fixed" coordinates would resolve relative to that header's own box
+// instead of the viewport, landing nowhere near the actual click.
+const MenuAnchor = forwardRef<HTMLDivElement, { style?: React.CSSProperties }>(({ style = undefined, ...rest }, ref) =>
+  createPortal(<StyledMenuAnchor ref={ref} style={style} {...rest} />, document.body),
 );
 
 const MenuItemLabel = styled.span<{ $active: boolean }>(
@@ -67,7 +73,9 @@ type Props = {
   appSection?: string;
   onSort?: (desc: boolean) => void;
   onHideColumn?: () => void;
-  textAlign?: string;
+  opened?: boolean;
+  onOpenChange?: (opened: boolean) => void;
+  anchorPosition?: { x: number; y: number } | null;
 };
 
 const HeaderActionsDropdown = ({
@@ -80,7 +88,9 @@ const HeaderActionsDropdown = ({
   appSection = undefined,
   onSort = undefined,
   onHideColumn = undefined,
-  textAlign = undefined,
+  opened = undefined,
+  onOpenChange = undefined,
+  anchorPosition = undefined,
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const hasActions = Boolean(onChangeSlicing || onSort || onHideColumn);
@@ -109,14 +119,14 @@ const HeaderActionsDropdown = ({
   }
 
   return (
-    <Menu shadow="md" withinPortal position="bottom-start">
+    <Menu shadow="md" withinPortal position="bottom-start" opened={opened} onChange={onOpenChange}>
       <Menu.Target>
-        <DropdownTrigger type="button" title={`Toggle ${label} actions`} aria-label={`Toggle ${label} actions`}>
-          {textAlign === 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
-          <span>{children}</span>
-          {textAlign !== 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
-        </DropdownTrigger>
+        <MenuAnchor style={{ left: anchorPosition?.x ?? 0, top: anchorPosition?.y ?? 0 }} />
       </Menu.Target>
+      {/* Not the Menu.Target: opening/positioning is driven by the whole header's click handler
+          (see AttributeHeader) so this only needs to render the label -- clicking it still opens
+          the menu, since the click bubbles up to that handler. */}
+      <DropdownTrigger title={`Toggle ${label} actions`}>{children}</DropdownTrigger>
       <Menu.Dropdown>
         {onSort && (
           <MenuItem onClick={() => onSort(false)} icon="arrow_upward">

--- a/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
@@ -16,11 +16,10 @@
  */
 
 import * as React from 'react';
-import { forwardRef } from 'react';
-import { createPortal } from 'react-dom';
 import styled, { css } from 'styled-components';
 
 import Menu from 'components/bootstrap/Menu';
+import { MenuAnchor } from 'components/bootstrap/useClickToOpenMenu';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { MenuItem } from 'components/bootstrap';
@@ -38,30 +37,10 @@ const DropdownTrigger = styled.span(
   `,
 );
 
-const StyledMenuAnchor = styled.div`
-  position: fixed;
-  width: 0;
-  height: 0;
-  pointer-events: none;
-`;
-
 export const DropdownCaret = styled(Icon)`
   opacity: 0;
   transition: opacity 0.15s ease-in-out;
 `;
-
-// Zero-size and invisible: it only exists to be the Menu's positioning anchor, moved to the
-// clicked point (see AttributeHeader) so the dropdown opens exactly where the header was clicked,
-// rather than anchored to the DropdownTrigger's own position.
-//
-// Rendered through a portal straight into <body>: the header (Th) always has a CSS `transform`
-// set (even when idle, it falls back to `translate3d(0, 0, 0)` -- see TableHead.tsx), and any
-// transformed ancestor becomes the containing block for a `position: fixed` descendant. Left in
-// place, this anchor's "fixed" coordinates would resolve relative to that header's own box
-// instead of the viewport, landing nowhere near the actual click.
-const MenuAnchor = forwardRef<HTMLDivElement, { style?: React.CSSProperties }>(({ style = undefined, ...rest }, ref) =>
-  createPortal(<StyledMenuAnchor ref={ref} style={style} {...rest} />, document.body),
-);
 
 const MenuItemLabel = styled.span<{ $active: boolean }>(
   ({ $active }) => css`

--- a/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/HeaderActionsDropdown.tsx
@@ -24,6 +24,7 @@ import Menu from 'components/bootstrap/Menu';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { MenuItem } from 'components/bootstrap';
+import Icon from 'components/common/Icon';
 
 // A plain (non-focusable) span: the header cell itself (ThInner, see AttributeHeader) is the one
 // focusable/clickable element for opening this menu, so this only renders the label -- it must
@@ -42,6 +43,11 @@ const StyledMenuAnchor = styled.div`
   width: 0;
   height: 0;
   pointer-events: none;
+`;
+
+export const DropdownCaret = styled(Icon)`
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
 `;
 
 // Zero-size and invisible: it only exists to be the Menu's positioning anchor, moved to the
@@ -76,6 +82,7 @@ type Props = {
   opened?: boolean;
   onOpenChange?: (opened: boolean) => void;
   anchorPosition?: { x: number; y: number } | null;
+  textAlign: 'right' | 'left';
 };
 
 const HeaderActionsDropdown = ({
@@ -91,6 +98,7 @@ const HeaderActionsDropdown = ({
   opened = undefined,
   onOpenChange = undefined,
   anchorPosition = undefined,
+  textAlign,
 }: Props) => {
   const sendTelemetry = useSendTelemetry();
   const hasActions = Boolean(onChangeSlicing || onSort || onHideColumn);
@@ -126,7 +134,10 @@ const HeaderActionsDropdown = ({
       {/* Not the Menu.Target: opening/positioning is driven by the whole header's click handler
           (see AttributeHeader) so this only needs to render the label -- clicking it still opens
           the menu, since the click bubbles up to that handler. */}
+      {textAlign === 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
       <DropdownTrigger title={`Toggle ${label} actions`}>{children}</DropdownTrigger>
+      {textAlign !== 'right' && <DropdownCaret name="arrow_drop_down" size="xs" className="header-action" />}
+
       <Menu.Dropdown>
         {onSort && (
           <MenuItem onClick={() => onSort(false)} icon="arrow_upward">

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ThDragOverlay.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ThDragOverlay.tsx
@@ -87,12 +87,13 @@ const ThGhostInner = <Entity extends EntityBase>(
   // Matches AttributeHeader: for right-aligned (numeric) columns, the indicator icons and title
   // are mirrored (indicators first, title last) instead of title-then-indicators, and the caret
   // inside the title button itself moves to the other side of the label too (see textAlign below).
-  const textAlign = columnMeta?.columnRenderer?.textAlign;
+  const textAlign = columnMeta?.columnRenderer?.textAlign as 'left' | 'right';
   const isRightAligned = textAlign === 'right';
 
   const titleGroup = (
     <LeftCol>
       <HeaderActionsDropdown
+        textAlign={textAlign}
         label={columnLabel}
         activeSort={sortDirection}
         isSliceActive={isSliceActive}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/ThDragOverlay.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ThDragOverlay.tsx
@@ -99,8 +99,7 @@ const ThGhostInner = <Entity extends EntityBase>(
         onChangeSlicing={canSlice ? () => {} : undefined}
         sliceColumnId={column.id}
         onSort={canSort ? () => {} : undefined}
-        onHideColumn={canHideColumn ? () => {} : undefined}
-        textAlign={textAlign}>
+        onHideColumn={canHideColumn ? () => {} : undefined}>
         {columnLabel}
       </HeaderActionsDropdown>
     </LeftCol>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useMemo, useContext, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useMemo, useContext, useLayoutEffect } from 'react';
 import type { createColumnHelper, Row, Column, HeaderContext, CellContext } from '@tanstack/react-table';
 import camelCase from 'lodash/camelCase';
 import { useSortable } from '@dnd-kit/sortable';
@@ -33,6 +33,7 @@ import { DRAG_HANDLE_DEFAULT_TITLE } from 'components/common/SortableList/DragHa
 import DndStylesContext from 'components/common/EntityDataTable/contexts/DndStylesContext';
 import useHeaderSectionObserver from 'components/common/EntityDataTable/hooks/useHeaderSectionObserver';
 import HeaderActionsDropdown from 'components/common/EntityDataTable/HeaderActionsDropdown';
+import useClickToOpenMenu from 'components/bootstrap/useClickToOpenMenu';
 import Icon from 'components/common/Icon';
 import ActiveSliceColContext from 'components/common/EntityDataTable/contexts/ActiveSliceColContext';
 import useMergedRef from 'util/hooks/useMergedRef';
@@ -153,8 +154,8 @@ const AttributeHeader = <Entity extends EntityBase>({
   const isDraggable = Boolean(columnMeta?.enableColumnOrdering);
   const isResizingAnyColumn = Boolean(ctx.table.getState().columnSizingInfo.isResizingColumn);
   const { attributes, isDragging, listeners, setNodeRef } = useSortableCol(colId, !isDraggable);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const mergedHeaderRef = useMergedRef(setNodeRef, headerRef);
+  const { triggerRef, opened, onOpenChange, anchorPosition, onClick, onKeyDown } = useClickToOpenMenu<HTMLDivElement>();
+  const mergedHeaderRef = useMergedRef(setNodeRef, triggerRef);
   const leftRef = useHeaderSectionObserver(colId, 'left', onHeaderSectionResize);
   const rightRef = useHeaderSectionObserver(colId, 'right', onHeaderSectionResize);
   const columnLabel = columnMeta?.label ?? colId;
@@ -170,45 +171,6 @@ const AttributeHeader = <Entity extends EntityBase>({
       ? `${DRAG_HANDLE_DEFAULT_TITLE} ${columnLabel.toLocaleLowerCase()}`
       : DRAG_HANDLE_DEFAULT_TITLE;
   const hasHeaderActions = Boolean(canSort || canSlice || canHideColumn);
-  const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
-  const [menuAnchorPosition, setMenuAnchorPosition] = useState<{ x: number; y: number } | null>(null);
-
-  // Mantine's own dropdowns return focus to the button that opened them once they close; its
-  // built-in mechanism for that (Popover's `returnFocus`) just remembers `document.activeElement`
-  // at open time and refocuses it at close time, independent of the target/anchor element -- but it
-  // isn't landing back on the header reliably for us here (likely something about the anchor being
-  // a portaled, non-focusable virtual point rather than the actual visible button Mantine expects).
-  // Doing it ourselves is simple and matches that same "usual dropdown" behavior: closing the menu,
-  // for any reason (an action, Escape, an outside click, or clicking the header again), always
-  // returns focus to the header cell itself.
-  const onActionsMenuOpenChange = (nextOpen: boolean) => {
-    setIsActionsMenuOpen(nextOpen);
-
-    if (!nextOpen) {
-      headerRef.current?.focus({ preventScroll: true });
-    }
-  };
-
-  const openActionsMenuAt = (position: { x: number; y: number }) => {
-    if (isActionsMenuOpen) {
-      onActionsMenuOpenChange(false);
-
-      return;
-    }
-
-    setMenuAnchorPosition(position);
-    setIsActionsMenuOpen(true);
-  };
-
-  const onHeaderClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    // A keyboard-triggered click (Enter/Space on a focused native button) reports (0, 0) here, so
-    // fall back to anchoring at the header's own position instead of the top-left of the viewport.
-    const { clientX, clientY } = event;
-    const hasPointerPosition = clientX !== 0 || clientY !== 0;
-    const rect = event.currentTarget.getBoundingClientRect();
-
-    openActionsMenuAt(hasPointerPosition ? { x: clientX, y: clientY } : { x: rect.left, y: rect.bottom });
-  };
 
   // Space is reserved for picking up the column drag (dnd-kit's keyboard sensor is configured to
   // only start on Space, see TableDndProvider), so Enter opens the actions menu instead -- matching
@@ -217,18 +179,11 @@ const AttributeHeader = <Entity extends EntityBase>({
   const onHeaderKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     listeners?.onKeyDown?.(event);
 
-    // Only for a keydown on the header itself, not one that bubbled up from a focused descendant
-    // (the sort icon, or -- since Menu.Dropdown is rendered through a portal into <body>, React's
-    // synthetic events still bubble along the *React* tree, not the DOM tree -- a focused menu
-    // item). Otherwise Enter on either of those would open/close this menu instead of letting the
-    // sort icon's or menu item's own onClick run.
-    if (event.target !== event.currentTarget || isDragging || !hasHeaderActions || event.key !== 'Enter') {
+    if (isDragging || !hasHeaderActions) {
       return;
     }
 
-    event.preventDefault();
-    const rect = event.currentTarget.getBoundingClientRect();
-    openActionsMenuAt({ x: rect.left, y: rect.bottom });
+    onKeyDown(event);
   };
 
   const sliceIndicator = isSliceActive && (
@@ -266,9 +221,9 @@ const AttributeHeader = <Entity extends EntityBase>({
         appSection={appSection}
         onSort={canSort ? (desc) => ctx.table.setSorting([{ id: colId, desc }]) : undefined}
         onHideColumn={canHideColumn ? () => ctx.header.column.toggleVisibility() : undefined}
-        opened={isActionsMenuOpen}
-        onOpenChange={onActionsMenuOpenChange}
-        anchorPosition={menuAnchorPosition}>
+        opened={opened}
+        onOpenChange={onOpenChange}
+        anchorPosition={anchorPosition}>
         {columnMeta?.columnRenderer?.renderHeader?.(columnLabel) ?? columnLabel}
       </HeaderActionsDropdown>
     </LeftCol>
@@ -293,7 +248,7 @@ const AttributeHeader = <Entity extends EntityBase>({
       // Opens the actions menu on a click anywhere in the header, not just on the title itself, and
       // toggles it closed on a second click. Elements with their own dedicated click behavior (the
       // sort icon) stop propagation so this doesn't also react to a click they already handled.
-      onClick={hasHeaderActions ? onHeaderClick : undefined}
+      onClick={hasHeaderActions ? onClick : undefined}
       // Overrides the onKeyDown that `listeners` above may have set, so dnd-kit's own Space/Enter
       // drag-pickup handling still runs (see onHeaderKeyDown, which calls it explicitly) alongside
       // our Enter-opens-the-menu behavior.

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
@@ -15,7 +15,7 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import { useCallback, useMemo, useContext, useLayoutEffect } from 'react';
+import { useCallback, useMemo, useContext, useLayoutEffect, useRef, useState } from 'react';
 import type { createColumnHelper, Row, Column, HeaderContext, CellContext } from '@tanstack/react-table';
 import camelCase from 'lodash/camelCase';
 import { useSortable } from '@dnd-kit/sortable';
@@ -35,6 +35,7 @@ import useHeaderSectionObserver from 'components/common/EntityDataTable/hooks/us
 import HeaderActionsDropdown from 'components/common/EntityDataTable/HeaderActionsDropdown';
 import Icon from 'components/common/Icon';
 import ActiveSliceColContext from 'components/common/EntityDataTable/contexts/ActiveSliceColContext';
+import useMergedRef from 'util/hooks/useMergedRef';
 
 import SortIcon from '../SortIcon';
 
@@ -73,9 +74,11 @@ export const ThInner = styled.div<{
       }
     `}
 
+    /* pointer, not grab, below: a plain click opens the actions menu, which is the more common
+       interaction, so the cursor hints at that instead of the (still available) drag-to-reorder. */
     ${$isDraggable &&
     css`
-      cursor: ${$isDragging ? 'grabbing' : 'grab'};
+      cursor: ${$isDragging ? 'grabbing' : 'pointer'};
 
       &:focus-visible .header-action {
         opacity: 1;
@@ -150,6 +153,8 @@ const AttributeHeader = <Entity extends EntityBase>({
   const isDraggable = Boolean(columnMeta?.enableColumnOrdering);
   const isResizingAnyColumn = Boolean(ctx.table.getState().columnSizingInfo.isResizingColumn);
   const { attributes, isDragging, listeners, setNodeRef } = useSortableCol(colId, !isDraggable);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const mergedHeaderRef = useMergedRef(setNodeRef, headerRef);
   const leftRef = useHeaderSectionObserver(colId, 'left', onHeaderSectionResize);
   const rightRef = useHeaderSectionObserver(colId, 'right', onHeaderSectionResize);
   const columnLabel = columnMeta?.label ?? colId;
@@ -164,6 +169,67 @@ const AttributeHeader = <Entity extends EntityBase>({
     typeof columnLabel === 'string'
       ? `${DRAG_HANDLE_DEFAULT_TITLE} ${columnLabel.toLocaleLowerCase()}`
       : DRAG_HANDLE_DEFAULT_TITLE;
+  const hasHeaderActions = Boolean(canSort || canSlice || canHideColumn);
+  const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
+  const [menuAnchorPosition, setMenuAnchorPosition] = useState<{ x: number; y: number } | null>(null);
+
+  // Mantine's own dropdowns return focus to the button that opened them once they close; its
+  // built-in mechanism for that (Popover's `returnFocus`) just remembers `document.activeElement`
+  // at open time and refocuses it at close time, independent of the target/anchor element -- but it
+  // isn't landing back on the header reliably for us here (likely something about the anchor being
+  // a portaled, non-focusable virtual point rather than the actual visible button Mantine expects).
+  // Doing it ourselves is simple and matches that same "usual dropdown" behavior: closing the menu,
+  // for any reason (an action, Escape, an outside click, or clicking the header again), always
+  // returns focus to the header cell itself.
+  const onActionsMenuOpenChange = (nextOpen: boolean) => {
+    setIsActionsMenuOpen(nextOpen);
+
+    if (!nextOpen) {
+      headerRef.current?.focus({ preventScroll: true });
+    }
+  };
+
+  const openActionsMenuAt = (position: { x: number; y: number }) => {
+    if (isActionsMenuOpen) {
+      onActionsMenuOpenChange(false);
+
+      return;
+    }
+
+    setMenuAnchorPosition(position);
+    setIsActionsMenuOpen(true);
+  };
+
+  const onHeaderClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    // A keyboard-triggered click (Enter/Space on a focused native button) reports (0, 0) here, so
+    // fall back to anchoring at the header's own position instead of the top-left of the viewport.
+    const { clientX, clientY } = event;
+    const hasPointerPosition = clientX !== 0 || clientY !== 0;
+    const rect = event.currentTarget.getBoundingClientRect();
+
+    openActionsMenuAt(hasPointerPosition ? { x: clientX, y: clientY } : { x: rect.left, y: rect.bottom });
+  };
+
+  // Space is reserved for picking up the column drag (dnd-kit's keyboard sensor is configured to
+  // only start on Space, see TableDndProvider), so Enter opens the actions menu instead -- matching
+  // every other Mantine dropdown button in the app (focus it, press Enter). Only relevant before a
+  // drag is picked up: once dragging, arrow keys move the column and Space/Tab drop it in place.
+  const onHeaderKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    listeners?.onKeyDown?.(event);
+
+    // Only for a keydown on the header itself, not one that bubbled up from a focused descendant
+    // (the sort icon, or -- since Menu.Dropdown is rendered through a portal into <body>, React's
+    // synthetic events still bubble along the *React* tree, not the DOM tree -- a focused menu
+    // item). Otherwise Enter on either of those would open/close this menu instead of letting the
+    // sort icon's or menu item's own onClick run.
+    if (event.target !== event.currentTarget || isDragging || !hasHeaderActions || event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    const rect = event.currentTarget.getBoundingClientRect();
+    openActionsMenuAt({ x: rect.left, y: rect.bottom });
+  };
 
   const sliceIndicator = isSliceActive && (
     <ActiveSliceIcon
@@ -176,7 +242,9 @@ const AttributeHeader = <Entity extends EntityBase>({
   const sortIndicator = sortDirection && <SortIcon<Entity> column={ctx.header.column} />;
 
   const indicatorIcons = (
-    <IndicatorCol ref={rightRef}>
+    // Stops the sort icon's own click from also bubbling up to the header's onClick (which would
+    // toggle the actions menu open/closed right after the sort click already did its own thing).
+    <IndicatorCol ref={rightRef} onClick={(event) => event.stopPropagation()}>
       {isRightAligned ? (
         <>
           {sortIndicator}
@@ -200,23 +268,40 @@ const AttributeHeader = <Entity extends EntityBase>({
         onChangeSlicing={canSlice ? onChangeSlicing : undefined}
         sliceColumnId={colId}
         appSection={appSection}
-        textAlign={textAlign}
         onSort={canSort ? (desc) => ctx.table.setSorting([{ id: colId, desc }]) : undefined}
-        onHideColumn={canHideColumn ? () => ctx.header.column.toggleVisibility() : undefined}>
+        onHideColumn={canHideColumn ? () => ctx.header.column.toggleVisibility() : undefined}
+        opened={isActionsMenuOpen}
+        onOpenChange={onActionsMenuOpenChange}
+        anchorPosition={menuAnchorPosition}>
         {columnMeta?.columnRenderer?.renderHeader?.(columnLabel) ?? columnLabel}
       </HeaderActionsDropdown>
     </LeftCol>
   );
 
+  // dnd-kit's own `attributes` already provide role="button"/tabIndex=0 when the column is
+  // draggable; when it isn't, supply the same thing ourselves whenever there's a menu to reach --
+  // this is the header's one focus stop (DropdownTrigger, in HeaderActionsDropdown, deliberately
+  // isn't focusable, so Tab doesn't land on the header twice).
+  const nonDraggableA11yProps = !isDraggable && hasHeaderActions ? { role: 'button' as const, tabIndex: 0 } : {};
+
   return (
     <ThInner
-      ref={setNodeRef}
+      ref={mergedHeaderRef}
       $isDraggable={isDraggable}
       $isDragging={isDragging}
       $isResizingAnyColumn={isResizingAnyColumn}
       title={isDraggable ? dragTitle : undefined}
       aria-label={isDraggable ? dragTitle : undefined}
-      {...(isDraggable ? { ...attributes, ...listeners } : {})}>
+      {...(isDraggable ? { ...attributes, ...listeners } : {})}
+      {...nonDraggableA11yProps}
+      // Opens the actions menu on a click anywhere in the header, not just on the title itself, and
+      // toggles it closed on a second click. Elements with their own dedicated click behavior (the
+      // sort icon) stop propagation so this doesn't also react to a click they already handled.
+      onClick={hasHeaderActions ? onHeaderClick : undefined}
+      // Overrides the onKeyDown that `listeners` above may have set, so dnd-kit's own Space/Enter
+      // drag-pickup handling still runs (see onHeaderKeyDown, which calls it explicitly) alongside
+      // our Enter-opens-the-menu behavior.
+      onKeyDown={isDraggable || hasHeaderActions ? onHeaderKeyDown : undefined}>
       {isDraggable && <DragIcon name="drag_indicator" size="xs" $isDragging={isDragging} className="header-action" />}
       {isRightAligned ? (
         <>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
@@ -172,10 +172,6 @@ const AttributeHeader = <Entity extends EntityBase>({
       : DRAG_HANDLE_DEFAULT_TITLE;
   const hasHeaderActions = Boolean(canSort || canSlice || canHideColumn);
 
-  // Space is reserved for picking up the column drag (dnd-kit's keyboard sensor is configured to
-  // only start on Space, see TableDndProvider), so Enter opens the actions menu instead -- matching
-  // every other Mantine dropdown button in the app (focus it, press Enter). Only relevant before a
-  // drag is picked up: once dragging, arrow keys move the column and Space/Tab drop it in place.
   const onHeaderKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     listeners?.onKeyDown?.(event);
 
@@ -229,10 +225,6 @@ const AttributeHeader = <Entity extends EntityBase>({
     </LeftCol>
   );
 
-  // dnd-kit's own `attributes` already provide role="button"/tabIndex=0 when the column is
-  // draggable; when it isn't, supply the same thing ourselves whenever there's a menu to reach --
-  // this is the header's one focus stop (DropdownTrigger, in HeaderActionsDropdown, deliberately
-  // isn't focusable, so Tab doesn't land on the header twice).
   const nonDraggableA11yProps = !isDraggable && hasHeaderActions ? { role: 'button' as const, tabIndex: 0 } : {};
 
   return (
@@ -245,13 +237,7 @@ const AttributeHeader = <Entity extends EntityBase>({
       aria-label={isDraggable ? dragTitle : undefined}
       {...(isDraggable ? { ...attributes, ...listeners } : {})}
       {...nonDraggableA11yProps}
-      // Opens the actions menu on a click anywhere in the header, not just on the title itself, and
-      // toggles it closed on a second click. Elements with their own dedicated click behavior (the
-      // sort icon) stop propagation so this doesn't also react to a click they already handled.
       onClick={hasHeaderActions ? onClick : undefined}
-      // Overrides the onKeyDown that `listeners` above may have set, so dnd-kit's own Space/Enter
-      // drag-pickup handling still runs (see onHeaderKeyDown, which calls it explicitly) alongside
-      // our Enter-opens-the-menu behavior.
       onKeyDown={isDraggable || hasHeaderActions ? onHeaderKeyDown : undefined}>
       {isDraggable && <DragIcon name="drag_indicator" size="xs" $isDragging={isDragging} className="header-action" />}
       {isRightAligned ? (

--- a/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/hooks/useAttributeColumnDefinitions.tsx
@@ -163,7 +163,7 @@ const AttributeHeader = <Entity extends EntityBase>({
   const canSort = ctx.header.column.getCanSort();
   const canHideColumn = ctx.header.column.getCanHide();
   const sortDirection = ctx.header.column.getIsSorted();
-  const textAlign = columnMeta?.columnRenderer?.textAlign;
+  const textAlign = columnMeta?.columnRenderer?.textAlign as 'left' | 'right';
   const isRightAligned = textAlign === 'right';
   const dragTitle =
     typeof columnLabel === 'string'
@@ -257,6 +257,7 @@ const AttributeHeader = <Entity extends EntityBase>({
   const titleGroup = (
     <LeftCol ref={leftRef}>
       <HeaderActionsDropdown
+        textAlign={textAlign}
         label={columnLabel}
         activeSort={sortDirection}
         isSliceActive={isSliceActive}

--- a/graylog2-web-interface/src/util/hooks/useMergedRef.ts
+++ b/graylog2-web-interface/src/util/hooks/useMergedRef.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+// eslint-disable-next-line no-restricted-imports
+import { useMergedRef } from '@mantine/hooks';
+
+export default useMergedRef;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this PR users can click anywhere in the entity data table headers to open the action menu.

<img width="923"  alt="Open dropdown" src="https://github.com/user-attachments/assets/5a873c1b-cc87-4f6b-97d9-21ae93a6f816" />



/nocl - small UI improvement