### PR TITLE
Add AWSAuthFactory.createCloseable to release the assume-role STS client

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -173,30 +173,35 @@ public class AWSAuthFactory {
             stsClientBuilder.httpClientBuilder(stsHttpClientBuilder);
         }
         final StsClient stsClient = stsClientBuilder.build();
+        // getCallerIdentity() can throw before the handle owns the client; close it here or it leaks.
+        try {
+            // The custom roleSessionName is extra metadata, which will be logged in AWS CloudTrail with each request
+            // to help with auditing and debugging.
+            final String roleSessionName;
+            if (accessKey != null) {
+                roleSessionName = String.format(Locale.ROOT, "ACCESS_KEY_%s@ACCOUNT_%s", accessKey,
+                        stsClient.getCallerIdentity(GetCallerIdentityRequest.builder().build()).account());
+            } else {
+                roleSessionName = String.format(Locale.ROOT, "ACCOUNT_%s",
+                        stsClient.getCallerIdentity(GetCallerIdentityRequest.builder().build()).account());
+            }
 
-        // The custom roleSessionName is extra metadata, which will be logged in AWS CloudTrail with each request
-        // to help with auditing and debugging.
-        final String roleSessionName;
-        if (accessKey != null) {
-            roleSessionName = String.format(Locale.ROOT, "ACCESS_KEY_%s@ACCOUNT_%s", accessKey,
-                    stsClient.getCallerIdentity(GetCallerIdentityRequest.builder().build()).account());
-        } else {
-            roleSessionName = String.format(Locale.ROOT, "ACCOUNT_%s",
-                    stsClient.getCallerIdentity(GetCallerIdentityRequest.builder().build()).account());
+            LOG.debug("Cross account role session name: " + roleSessionName);
+            final AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
+                    .roleSessionName(roleSessionName)
+                    .roleArn(assumeRoleArn);
+            if (!isNullOrEmpty(externalId)) {
+                assumeRoleRequestBuilder.externalId(externalId);
+            }
+            final StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider.builder()
+                    .refreshRequest(assumeRoleRequestBuilder.build())
+                    .stsClient(stsClient)
+                    .build();
+            return new CredentialsProviderHandle(provider, stsClient);
+        } catch (RuntimeException e) {
+            IoUtils.closeQuietly(stsClient, LOG);
+            throw e;
         }
-
-        LOG.debug("Cross account role session name: " + roleSessionName);
-        final AssumeRoleRequest.Builder assumeRoleRequestBuilder = AssumeRoleRequest.builder()
-                .roleSessionName(roleSessionName)
-                .roleArn(assumeRoleArn);
-        if (!isNullOrEmpty(externalId)) {
-            assumeRoleRequestBuilder.externalId(externalId);
-        }
-        final StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider.builder()
-                .refreshRequest(assumeRoleRequestBuilder.build())
-                .stsClient(stsClient)
-                .build();
-        return new CredentialsProviderHandle(provider, stsClient);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -30,8 +30,11 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
@@ -96,6 +99,29 @@ public class AWSAuthFactory {
                                          @Nullable String assumeRoleArn,
                                          @Nullable String externalId,
                                          @Nullable ApacheHttpClient.Builder stsHttpClientBuilder) {
+        // Discards the STS client handle. Callers on this overload cannot close the STS client backing an
+        // assume-role provider, so its connection pool leaks for the process lifetime; see createCloseable.
+        return createCloseable(requireKeySecret, stsRegion, accessKey, secretKey, assumeRoleArn, externalId, stsHttpClientBuilder)
+                .provider();
+    }
+
+    /**
+     * Same resolution as {@link #create(boolean, String, String, String, String, String, ApacheHttpClient.Builder)},
+     * but returns a {@link CredentialsProviderHandle} so the caller can close the STS client backing an assume-role
+     * provider.
+     *
+     * <p>For an assume-role configuration the STS client is created here and handed to
+     * {@link StsAssumeRoleCredentialsProvider}, which never closes it: {@link StsCredentialsProvider#close()} only
+     * clears the session cache. Callers that build a fresh provider per operation must therefore close the handle,
+     * or the STS client's Apache connection pool leaks on every call.
+     */
+    public CredentialsProviderHandle createCloseable(boolean requireKeySecret,
+                                                     @Nullable String stsRegion,
+                                                     @Nullable String accessKey,
+                                                     @Nullable String secretKey,
+                                                     @Nullable String assumeRoleArn,
+                                                     @Nullable String externalId,
+                                                     @Nullable ApacheHttpClient.Builder stsHttpClientBuilder) {
         AwsCredentialsProvider awsCredentials = requireKeySecret ? getKeySecretCredentialsProvider(accessKey, secretKey) :
                 getAwsCredentialsProvider(accessKey, secretKey);
 
@@ -109,7 +135,7 @@ public class AWSAuthFactory {
             return buildStsCredentialsProvider(awsCredentials, stsRegion, assumeRoleArn, accessKey, externalId, stsHttpClientBuilder);
         }
 
-        return awsCredentials;
+        return new CredentialsProviderHandle(awsCredentials, null);
     }
 
     private static AwsCredentialsProvider getAwsCredentialsProvider(String accessKey, String secretKey) {
@@ -135,10 +161,10 @@ public class AWSAuthFactory {
      * Note: In order to assume a role, a role must be provided to the AWS STS client a role that has the "sts:AssumeRole"
      * permission, which provides authorization for a role to be assumed.
      */
-    private static AwsCredentialsProvider buildStsCredentialsProvider(AwsCredentialsProvider awsCredentials, String stsRegion,
-                                                                       String assumeRoleArn, @Nullable String accessKey,
-                                                                       @Nullable String externalId,
-                                                                       @Nullable ApacheHttpClient.Builder stsHttpClientBuilder) {
+    private static CredentialsProviderHandle buildStsCredentialsProvider(AwsCredentialsProvider awsCredentials, String stsRegion,
+                                                                         String assumeRoleArn, @Nullable String accessKey,
+                                                                         @Nullable String externalId,
+                                                                         @Nullable ApacheHttpClient.Builder stsHttpClientBuilder) {
 
         final StsClientBuilder stsClientBuilder = StsClient.builder()
                 .region(Region.of(stsRegion))
@@ -166,9 +192,41 @@ public class AWSAuthFactory {
         if (!isNullOrEmpty(externalId)) {
             assumeRoleRequestBuilder.externalId(externalId);
         }
-        return StsAssumeRoleCredentialsProvider.builder()
+        final StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider.builder()
                 .refreshRequest(assumeRoleRequestBuilder.build())
                 .stsClient(stsClient)
                 .build();
+        return new CredentialsProviderHandle(provider, stsClient);
+    }
+
+    /**
+     * A resolved {@link AwsCredentialsProvider} paired with the STS client backing an assume-role provider, if any.
+     *
+     * <p>{@link StsCredentialsProvider#close()} only clears the provider's session cache; the {@link StsClient} it
+     * was handed is caller-supplied and {@code final}, so it is never closed and its Apache connection pool leaks.
+     * This handle owns both resources so a caller can release them together. {@link #close()} closes the credentials
+     * provider first -- stopping its background session refresh -- and then the STS client.
+     */
+    public static final class CredentialsProviderHandle implements AutoCloseable {
+        private final AwsCredentialsProvider provider;
+        @Nullable
+        private final SdkAutoCloseable stsClient;
+
+        CredentialsProviderHandle(AwsCredentialsProvider provider, @Nullable SdkAutoCloseable stsClient) {
+            this.provider = provider;
+            this.stsClient = stsClient;
+        }
+
+        public AwsCredentialsProvider provider() {
+            return provider;
+        }
+
+        @Override
+        public void close() {
+            if (provider instanceof SdkAutoCloseable closeableProvider) {
+                IoUtils.closeQuietly(closeableProvider, LOG);
+            }
+            IoUtils.closeQuietly(stsClient, LOG);
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -259,5 +260,28 @@ public class AWSAuthFactoryTest {
 
         assertThat(handle.provider()).isExactlyInstanceOf(StaticCredentialsProvider.class);
         assertThatCode(handle::close).doesNotThrowAnyException();
+    }
+
+    // getCallerIdentity() throws before the handle exists, so the client must be closed directly or it leaks.
+    @Test
+    public void createCloseable_assumeRole_closesStsClientWhenGetCallerIdentityThrows() {
+        final StsClient mockStsClient = mock(StsClient.class);
+        final RuntimeException failure = new RuntimeException("STS unavailable");
+        when(mockStsClient.getCallerIdentity(any(GetCallerIdentityRequest.class))).thenThrow(failure);
+
+        final StsClientBuilder mockStsClientBuilder = mock(StsClientBuilder.class);
+        when(mockStsClientBuilder.region(any())).thenReturn(mockStsClientBuilder);
+        when(mockStsClientBuilder.credentialsProvider(any())).thenReturn(mockStsClientBuilder);
+        when(mockStsClientBuilder.build()).thenReturn(mockStsClient);
+
+        try (MockedStatic<StsClient> mockedStsClient = mockStatic(StsClient.class)) {
+            mockedStsClient.when(StsClient::builder).thenReturn(mockStsClientBuilder);
+
+            assertThatThrownBy(() -> awsAuthFactory.createCloseable(
+                    false, "us-east-1", "key", "secret", "arn:aws:iam::123456789012:role/TestRole", null, (ApacheHttpClient.Builder) null))
+                    .isSameAs(failure);
+
+            verify(mockStsClient).close();
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -34,9 +34,11 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class AWSAuthFactoryTest {
@@ -213,5 +215,49 @@ public class AWSAuthFactoryTest {
         final AwsCredentialsProvider withExternalId = awsAuthFactory.create(false, null, "key", "secret", "some-external-id", (String) null);
         assertThat(withoutExternalId).isExactlyInstanceOf(StaticCredentialsProvider.class);
         assertThat(withExternalId).isExactlyInstanceOf(StaticCredentialsProvider.class);
+    }
+
+    // --- createCloseable: the returned handle must close the STS client that the credentials provider never owns.
+    // StsCredentialsProvider.close() only clears the session cache, leaving the StsClient's Apache connection pool
+    // to leak on every call; the handle is what lets a caller release it. ---
+
+    @Test
+    public void createCloseable_assumeRole_closeClosesStsClientAndProvider() {
+        final StsClient mockStsClient = buildMockStsClient();
+        final StsClientBuilder mockStsClientBuilder = mock(StsClientBuilder.class);
+        when(mockStsClientBuilder.region(any())).thenReturn(mockStsClientBuilder);
+        when(mockStsClientBuilder.credentialsProvider(any())).thenReturn(mockStsClientBuilder);
+        when(mockStsClientBuilder.build()).thenReturn(mockStsClient);
+
+        final StsAssumeRoleCredentialsProvider mockProvider = mock(StsAssumeRoleCredentialsProvider.class);
+        final StsAssumeRoleCredentialsProvider.Builder mockProviderBuilder = mock(StsAssumeRoleCredentialsProvider.Builder.class);
+        when(mockProviderBuilder.refreshRequest(any(AssumeRoleRequest.class))).thenReturn(mockProviderBuilder);
+        when(mockProviderBuilder.stsClient(any())).thenReturn(mockProviderBuilder);
+        when(mockProviderBuilder.build()).thenReturn(mockProvider);
+
+        try (MockedStatic<StsClient> mockedStsClient = mockStatic(StsClient.class);
+             MockedStatic<StsAssumeRoleCredentialsProvider> mockedProvider = mockStatic(StsAssumeRoleCredentialsProvider.class)) {
+            mockedStsClient.when(StsClient::builder).thenReturn(mockStsClientBuilder);
+            mockedProvider.when(StsAssumeRoleCredentialsProvider::builder).thenReturn(mockProviderBuilder);
+
+            final AWSAuthFactory.CredentialsProviderHandle handle = awsAuthFactory.createCloseable(
+                    false, "us-east-1", "key", "secret", "arn:aws:iam::123456789012:role/TestRole", null, (ApacheHttpClient.Builder) null);
+
+            assertThat(handle.provider()).isSameAs(mockProvider);
+
+            handle.close();
+
+            verify(mockStsClient).close();
+            verify(mockProvider).close();
+        }
+    }
+
+    @Test
+    public void createCloseable_staticCredentials_hasNoStsClientAndCloseIsSafe() {
+        final AWSAuthFactory.CredentialsProviderHandle handle = awsAuthFactory.createCloseable(
+                false, null, "key", "secret", null, null, (ApacheHttpClient.Builder) null);
+
+        assertThat(handle.provider()).isExactlyInstanceOf(StaticCredentialsProvider.class);
+        assertThatCode(handle::close).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
/nocl

## Description

`AWSAuthFactory.buildStsCredentialsProvider` creates an `StsClient` and hands it to `StsAssumeRoleCredentialsProvider`, which never closes it: `StsCredentialsProvider.close()` only clears the session cache. A caller that builds a credentials provider per operation therefore leaks the STS client's Apache connection pool on every call.

This adds `AWSAuthFactory.createCloseable(...)`, which returns a `CredentialsProviderHandle` bundling the provider with its STS client so a caller can close both. The existing `create(...)` overloads delegate to it and discard the handle, so their behaviour is unchanged.

First consumer is the Data Lake backend validator fix in `Graylog2/graylog-plugin-enterprise#15011`.

## How Tested
- `AWSAuthFactoryTest`: two new cases (assume-role handle closes the STS client and provider; static-credentials handle has no STS client and closes safely). 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have added tests to cover my changes.

