### PR TITLE
Fix startup issue of MongoDBContainer 8.x on Linux kernel >= 6.19

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
@@ -17,13 +17,17 @@
 package org.graylog.testing.mongodb;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -52,6 +56,30 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         withNetwork(requireNonNull(network, "network cannot be null"));
         withNetworkAliases(NETWORK_ALIAS);
         waitingFor(Wait.forListeningPort());
+
+
+        // Workaround for running MongoDB 8.x on Linux kernel version >= 6.19
+        // See: https://jira.mongodb.org/browse/SERVER-121912
+        try {
+            if (DockerImageName.parse(dockerImageName).getVersionPart().startsWith("8.")) {
+                final var osName = System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT);
+
+                if (osName.contains("linux")) {
+                    final var kernelVersion = System.getProperty("os.version", "0.0").split("\\.");
+                    if (kernelVersion.length < 2) {
+                        throw new IllegalStateException("Unexpected Linux kernel version: " + Arrays.toString(kernelVersion));
+                    }
+                    final int kernelMajorVersion = Objects.requireNonNullElse(Ints.tryParse(kernelVersion[0]), 0);
+                    final int kernelMinorVersion = Objects.requireNonNullElse(Ints.tryParse(kernelVersion[1]), 0);
+
+                    if (kernelMajorVersion >= 7 || (kernelMajorVersion == 6 && kernelMinorVersion >= 19)) {
+                        withEnv("GLIBC_TUNABLES", "glibc.pthread.rseq=1");
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error applying Linux kernel version workaround for MongoDB 8.x", e);
+        }
     }
 
     public String infoString() {

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBContainer.java
@@ -73,6 +73,7 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
                     final int kernelMinorVersion = Objects.requireNonNullElse(Ints.tryParse(kernelVersion[1]), 0);
 
                     if (kernelMajorVersion >= 7 || (kernelMajorVersion == 6 && kernelMinorVersion >= 19)) {
+                        LOG.info("Applying MongoDB 8.x workaround (running on Linux {})", System.getProperty("os.version"));
                         withEnv("GLIBC_TUNABLES", "glibc.pthread.rseq=1");
                     }
                 }


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/SERVER-121912

/nocl test fix

