### PR TITLE
Fix KafkaContainer lifecycle management

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/kafka/KafkaContainer.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/kafka/KafkaContainer.java
@@ -34,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -245,8 +244,14 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     }
 
     @Override
-    public void close() {
-        super.close();
+    public void stop() {
+        // Close the admin client while the broker is still reachable. A leaked client outliving the container spins in
+        // the Kafka 4.x metadata rebootstrap loop forever, flooding the log until the JVM exits.
+        if (adminClient != null) {
+            adminClient.close(Duration.ofSeconds(10));
+            adminClient = null;
+        }
+        super.stop();
         network.close();
     }
 }


### PR DESCRIPTION
The testcontainers library calls #stop and not #close. We are now overriding #stop instead of #close in KafkaContainer to run a proper shutdown.

Also close the Kafka admin client when the test container shuts down A leaked admin client outliving its container spins in the Kafka 4.x metadata rebootstrap loop, flooding the test log until the JVM exits.

/nocl test infrastructure
