### PR TITLE
Add running OpenSearch version to data nodes in cluster configuration entity table

### DIFF
--- a/changelog/unreleased/issue-26809.toml
+++ b/changelog/unreleased/issue-26809.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Add the version of OpenSearch running in data nodes to the cluster configuration page table."
+
+pulls = ["26821"]
+issues = ["26809"]

--- a/data-node/src/test/java/org/graylog/datanode/opensearch/statemachine/tracer/InMemoryDataNodeMetadataService.java
+++ b/data-node/src/test/java/org/graylog/datanode/opensearch/statemachine/tracer/InMemoryDataNodeMetadataService.java
@@ -22,9 +22,11 @@ import org.graylog2.cluster.nodes.DataNodeMetadataService;
 import org.graylog2.cluster.nodes.OpensearchVersionsOverview;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 class InMemoryDataNodeMetadataService implements DataNodeMetadataService {
 
@@ -41,6 +43,13 @@ class InMemoryDataNodeMetadataService implements DataNodeMetadataService {
     @Override
     public Optional<DataNodeMetadata> findByNodeId(String nodeId) {
         return Optional.ofNullable(store.get(nodeId));
+    }
+
+    @Override
+    public Map<String, DataNodeMetadata> findByNodeIds(Collection<String> nodeIds) {
+        return store.entrySet().stream()
+                .filter(entry -> nodeIds.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeMetadataService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeMetadataService.java
@@ -18,6 +18,8 @@ package org.graylog2.cluster.nodes;
 
 import jakarta.annotation.Nullable;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 public interface DataNodeMetadataService {
@@ -25,6 +27,8 @@ public interface DataNodeMetadataService {
     void setOpensearchVersions(String nodeId, String currentVersion, @Nullable String latestAvailableVersion);
 
     Optional<DataNodeMetadata> findByNodeId(String nodeId);
+    
+    Map<String, DataNodeMetadata> findByNodeIds(Collection<String> nodeIds);
 
     OpensearchVersionsOverview getVersionsOverview();
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeMetadataServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/nodes/DataNodeMetadataServiceImpl.java
@@ -26,8 +26,12 @@ import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class DataNodeMetadataServiceImpl implements DataNodeMetadataService {
 
@@ -60,6 +64,17 @@ public class DataNodeMetadataServiceImpl implements DataNodeMetadataService {
         return Optional.ofNullable(
                 collection.find(Filters.eq(DataNodeMetadata.FIELD_NODE_ID, nodeId)).first()
         );
+    }
+
+    @Override
+    public Map<String, DataNodeMetadata> findByNodeIds(Collection<String> nodeIds) {
+        if (nodeIds.isEmpty()) {
+            return Map.of();
+        }
+        return collection.find(Filters.in(DataNodeMetadata.FIELD_NODE_ID, nodeIds))
+                .into(new ArrayList<>())
+                .stream()
+                .collect(Collectors.toMap(DataNodeMetadata::nodeId, Function.identity(), (first, ignored) -> first));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeWithOpensearchVersion.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeWithOpensearchVersion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import jakarta.annotation.Nullable;
+import org.graylog2.cluster.nodes.DataNodeDto;
+
+/**
+ * A data node, enriched with the OpenSearch version it is currently running. That version is not part of the
+ * {@code datanodes} collection, it lives in {@code datanode_metadata} and is written by the data node itself once
+ * OpenSearch has come up.
+ * <p>
+ * The data node is unwrapped, so the JSON representation is flat and remains backwards compatible with the plain
+ * {@link DataNodeDto} representation.
+ */
+public record DataNodeWithOpensearchVersion(
+        @JsonUnwrapped DataNodeDto dataNode,
+        @JsonProperty(FIELD_OPENSEARCH_VERSION) @Nullable String opensearchVersion
+) {
+    public static final String FIELD_OPENSEARCH_VERSION = "opensearch_version";
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
@@ -31,8 +31,11 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodeMetadata;
+import org.graylog2.cluster.nodes.DataNodeMetadataService;
 import org.graylog2.cluster.nodes.DataNodePaginatedService;
 import org.graylog2.cluster.nodes.DataNodeStatus;
+import org.graylog2.cluster.nodes.NodeDto;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.rest.models.SortOrder;
 import org.graylog2.rest.models.tools.responses.PageListResponse;
@@ -48,6 +51,8 @@ import org.graylog2.shared.rest.resources.RestResource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,6 +63,7 @@ import java.util.stream.Collectors;
 public class DatanodeResource extends RestResource {
 
     private final DataNodePaginatedService dataNodePaginatedService;
+    private final DataNodeMetadataService dataNodeMetadataService;
     private final SearchQueryParser searchQueryParser;
 
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
@@ -74,6 +80,8 @@ public class DatanodeResource extends RestResource {
             EntityAttribute.builder().id(DataNodeDto.FIELD_CLUSTER_ADDRESS).title("Transport address").type(SearchQueryField.Type.STRING).searchable(true).sortable(true).build(),
             EntityAttribute.builder().id(DataNodeDto.FIELD_CERT_VALID_UNTIL).title("Certificate valid until").type(SearchQueryField.Type.DATE).sortable(true).build(),
             EntityAttribute.builder().id(DataNodeDto.FIELD_DATANODE_VERSION).title("Version").type(SearchQueryField.Type.STRING).sortable(true).build(),
+            // Not sortable: the OpenSearch version is stored in a separate collection and joined in after paging.
+            EntityAttribute.builder().id(DataNodeWithOpensearchVersion.FIELD_OPENSEARCH_VERSION).title("OpenSearch version").type(SearchQueryField.Type.STRING).sortable(false).build(),
             EntityAttribute.builder().id(DataNodeDto.FIELD_OPENSEARCH_ROLES).title("Roles").type(SearchQueryField.Type.STRING).sortable(true).build()
     );
 
@@ -86,32 +94,45 @@ public class DatanodeResource extends RestResource {
             .build();
 
     @Inject
-    public DatanodeResource(DataNodePaginatedService dataNodePaginatedService) {
+    public DatanodeResource(DataNodePaginatedService dataNodePaginatedService,
+                            DataNodeMetadataService dataNodeMetadataService) {
         this.dataNodePaginatedService = dataNodePaginatedService;
+        this.dataNodeMetadataService = dataNodeMetadataService;
         this.searchQueryParser = new SearchQueryParser("hostname", SEARCH_FIELD_MAPPING);
     }
 
     @GET
     @Timed
     @Operation(summary = "Get a paginated list of all datanodes in this cluster")
-    public PageListResponse<DataNodeDto> dataNodes(@Parameter(name = "page") @QueryParam("page") @DefaultValue("1") int page,
-                                                   @Parameter(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
-                                                   @Parameter(name = "query") @QueryParam("query") @DefaultValue("") String query,
-                                                   @Parameter(name = "sort",
-                                                             description = "The field to sort the result on",
-                                                             required = true,
-                                                             schema = @Schema(allowableValues = {"hostname", "data_node_status", "transport_address", "cert_valid_until", "datanode_version"}))
-                                                   @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sort,
-                                                   @Parameter(name = "order", description = "The sort direction",
-                                                             schema = @Schema(allowableValues = {"asc", "desc"}))
-                                                   @DefaultValue(DEFAULT_SORT_DIRECTION) @QueryParam("order") SortOrder order
+    public PageListResponse<DataNodeWithOpensearchVersion> dataNodes(@Parameter(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+                                                                     @Parameter(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+                                                                     @Parameter(name = "query") @QueryParam("query") @DefaultValue("") String query,
+                                                                     @Parameter(name = "sort",
+                                                                               description = "The field to sort the result on",
+                                                                               required = true,
+                                                                               schema = @Schema(allowableValues = {"hostname", "data_node_status", "transport_address", "cert_valid_until", "datanode_version"}))
+                                                                     @DefaultValue(DEFAULT_SORT_FIELD) @QueryParam("sort") String sort,
+                                                                     @Parameter(name = "order", description = "The sort direction",
+                                                                               schema = @Schema(allowableValues = {"asc", "desc"}))
+                                                                     @DefaultValue(DEFAULT_SORT_DIRECTION) @QueryParam("order") SortOrder order
 
     ) {
         final SearchQuery searchQuery = searchQueryParser.parse(query);
         final PaginatedList<DataNodeDto> result = dataNodePaginatedService.searchPaginated(searchQuery, order.toBsonSort(sort), page, perPage);
 
-
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+                result.grandTotal().orElse(0L), sort, order, withOpensearchVersions(result), attributes, settings);
+    }
+
+    private List<DataNodeWithOpensearchVersion> withOpensearchVersions(List<DataNodeDto> dataNodes) {
+        final Map<String, DataNodeMetadata> metadata = dataNodeMetadataService.findByNodeIds(
+                dataNodes.stream().map(NodeDto::getNodeId).toList());
+
+        return dataNodes.stream()
+                .map(dataNode -> new DataNodeWithOpensearchVersion(dataNode,
+                        Optional.ofNullable(metadata.get(dataNode.getNodeId()))
+                                .map(DataNodeMetadata::currentOpensearchVersion)
+                                .orElse(null)))
+                .toList();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/nodes/DataNodeMetadataServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/nodes/DataNodeMetadataServiceImplTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MongoDBExtension.class)
@@ -75,6 +77,27 @@ class DataNodeMetadataServiceImplTest {
             assertThat(metadata.nodeId()).isEqualTo(NODE_ID);
             assertThat(metadata.currentOpensearchVersion()).isEqualTo("2.19.5");
         });
+    }
+
+    @Test
+    void findByNodeIdsReturnsEmptyMapForEmptyInput() {
+        service.setOpensearchVersions(NODE_ID, "2.19.5", null);
+
+        assertThat(service.findByNodeIds(List.of())).isEmpty();
+    }
+
+    @Test
+    void findByNodeIdsOnlyReturnsRequestedNodesThatHaveMetadata() {
+        final String otherNodeId = "other-node-0000-0000-0000-000000000000";
+        final String unknownNodeId = "unknown-node-0000-0000-0000-000000000000";
+
+        service.setOpensearchVersions(NODE_ID, "2.19.5", null);
+        service.setOpensearchVersions(otherNodeId, "2.18.0", null);
+
+        assertThat(service.findByNodeIds(List.of(NODE_ID, unknownNodeId)))
+                .hasSize(1)
+                .extractingByKey(NODE_ID)
+                .satisfies(metadata -> assertThat(metadata.currentOpensearchVersion()).isEqualTo("2.19.5"));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeWithOpensearchVersionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeWithOpensearchVersionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.cluster.nodes.DataNodeDto;
+import org.graylog2.cluster.nodes.DataNodeStatus;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataNodeWithOpensearchVersionTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    private static DataNodeDto dataNode() {
+        return DataNodeDto.builder()
+                .setId("node-id")
+                .setHostname("datanode1.example.com")
+                .setDataNodeStatus(DataNodeStatus.AVAILABLE)
+                .setDatanodeVersion("7.2.0")
+                .build();
+    }
+
+    @Test
+    void serializesOpensearchVersionAlongsideUnwrappedDataNodeFields() {
+        final JsonNode json = objectMapper.valueToTree(new DataNodeWithOpensearchVersion(dataNode(), "2.19.5"));
+
+        assertThat(json.path("opensearch_version").asText()).isEqualTo("2.19.5");
+        // the data node itself must stay flat, no nesting introduced by the wrapper
+        assertThat(json.path("hostname").asText()).isEqualTo("datanode1.example.com");
+        assertThat(json.path("node_id").asText()).isEqualTo("node-id");
+        assertThat(json.path("datanode_version").asText()).isEqualTo("7.2.0");
+        assertThat(json.path("datanode_status").asText()).isEqualTo("AVAILABLE");
+        assertThat(json.has("data_node")).isFalse();
+    }
+
+    @Test
+    void serializesNullOpensearchVersionForNodesWithoutMetadata() {
+        final JsonNode json = objectMapper.valueToTree(new DataNodeWithOpensearchVersion(dataNode(), null));
+
+        assertThat(json.path("opensearch_version").isNull()).isTrue();
+        assertThat(json.path("hostname").asText()).isEqualTo("datanode1.example.com");
+    }
+}

--- a/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.test.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.test.tsx
@@ -51,4 +51,27 @@ describe('DataNodesColumnConfiguration', () => {
     expect(screen.getByText('8.0.0')).toBeInTheDocument();
     expect(screen.queryByTitle(warningMessage)).not.toBeInTheDocument();
   });
+
+  const renderOpensearchVersionCell = (opensearchVersion: string | undefined) => {
+    const { attributes } = createColumnRenderers(productName);
+    const cell = attributes.opensearch_version.renderCell(
+      undefined,
+      { opensearch_version: opensearchVersion } as ClusterDataNode,
+      undefined,
+    );
+
+    render(<>{cell}</>);
+  };
+
+  it('shows the OpenSearch version the data node is running', () => {
+    renderOpensearchVersionCell('2.19.5');
+
+    expect(screen.getByText('2.19.5')).toBeInTheDocument();
+  });
+
+  it('shows a placeholder when the OpenSearch version is unknown', () => {
+    renderOpensearchVersionCell(undefined);
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
 });

--- a/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
+++ b/graylog2-web-interface/src/components/cluster-configuration/data-nodes/DataNodesColumnConfiguration.tsx
@@ -35,6 +35,7 @@ export const DEFAULT_VISIBLE_COLUMNS = [
   'hostname',
   'opensearch_roles',
   'datanode_version',
+  'opensearch_version',
   'datanode_status',
   'cpu',
   'memory',
@@ -166,6 +167,14 @@ export const createColumnRenderers = (productName: string): ColumnRenderers<Clus
         );
       },
       minWidth: 200,
+    },
+    opensearch_version: {
+      renderCell: (_value, entity) => (
+        <SecondaryText>
+          <span>{entity.opensearch_version ?? 'N/A'}</span>
+        </SecondaryText>
+      ),
+      minWidth: 180,
     },
     opensearch_roles: {
       renderCell: (_value, entity) => getRoleLabels(getDataNodeRoles(entity)),

--- a/graylog2-web-interface/src/components/datanode/Types.ts
+++ b/graylog2-web-interface/src/components/datanode/Types.ts
@@ -61,6 +61,7 @@ export type DataNode = {
   cert_valid_until: string | null;
   error_msg?: string;
   datanode_version: string;
+  opensearch_version?: string;
   version_compatible: boolean;
   object_id?: string;
   cluster_address: string;


### PR DESCRIPTION
## Description
Adds the currently running OpenSearch version in the data nodes on the cluster configuration page.

## Motivation and Context
resolves #26809 

## How Has This Been Tested?
Added tests, locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

