### PR TITLE
Close MongoDB client in MongoDBTestService before container shutdown

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBTestService.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBTestService.java
@@ -17,6 +17,7 @@
 package org.graylog.testing.mongodb;
 
 import com.google.common.io.Resources;
+import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
@@ -46,6 +47,7 @@ public class MongoDBTestService implements AutoCloseable {
     private final MongoDBContainer container;
     private final MongoDBVersion version;
     private MongoConnectionImpl mongoConnection;
+    private MongoClient mongoClient;
 
     /**
      * Create service instance with the default version and network and start it immediately.
@@ -89,7 +91,7 @@ public class MongoDBTestService implements AutoCloseable {
         mongoConfiguration.setUri(uri());
 
         this.mongoConnection = new MongoConnectionImpl(mongoConfiguration);
-        this.mongoConnection.connect();
+        this.mongoClient = this.mongoConnection.connect();
         this.mongoConnection.getMongoDatabase().drop();
     }
 
@@ -98,6 +100,11 @@ public class MongoDBTestService implements AutoCloseable {
      */
     @Override
     public void close() {
+        // Explicitly close the client so we don't have a running client when we shut down the container.
+        if (mongoClient != null) {
+            mongoClient.close();
+            mongoClient = null;
+        }
         container.close();
     }
 


### PR DESCRIPTION
Without this, we see a lot of MongoSocketReadException errors in the build logs because of dangling MongoDB clients trying to connect to a stopped container.

The errors are harmless because the clients are stopped on JVM shutdown, but they spammed the build logs with lots of messages.

Example message:

```
2026-07-29T06:51:11.1747413Z 2026-07-29 06:51:11,070 INFO : org.mongodb.driver.cluster - Exception in monitor thread while connecting to server localhost:32769
2026-07-29T06:51:11.1777106Z com.mongodb.MongoSocketReadException: Prematurely reached end of stream
2026-07-29T06:51:11.1781815Z 	at com.mongodb.internal.connection.SocketStream.read(SocketStream.java:184)
2026-07-29T06:51:11.1783035Z 	at com.mongodb.internal.connection.InternalStreamConnection.receiveResponseBuffers(InternalStreamConnection.java:942)
2026-07-29T06:51:11.1784492Z 	at com.mongodb.internal.connection.InternalStreamConnection.receiveCommandMessageResponse(InternalStreamConnection.java:567)
2026-07-29T06:51:11.1785965Z 	at com.mongodb.internal.connection.InternalStreamConnection.receive(InternalStreamConnection.java:519)
2026-07-29T06:51:11.1814079Z 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.doHeartbeat(DefaultServerMonitor.java:311)
2026-07-29T06:51:11.1822370Z 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.lookupServerDescription(DefaultServerMonitor.java:262)
2026-07-29T06:51:11.1823974Z 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitor.run(DefaultServerMonitor.java:203)
```

I checked the logs of a `master` build, and it contained around 900 of those messages.

/nocl test infrastructure