### PR TITLE
Fix path traversal in datanode proxy resources

### DIFF
--- a/changelog/unreleased/pr-26825.toml
+++ b/changelog/unreleased/pr-26825.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Fix path traversal in datanode proxy resources."
+
+pulls = ["26825"]
+issues = ["Graylog2/graylog-plugin-enterprise#15029"]

--- a/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeOpensearchProxyIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeOpensearchProxyIT.java
@@ -75,6 +75,20 @@ public class DatanodeOpensearchProxyIT {
         Assertions.assertThat(message).contains("This request is not allowed");
     }
 
+    @FullBackendTest
+    void testPathTraversalAboveRootIsRejected() {
+        final String message = apis.get("/datanodes/any/opensearch/_cluster/../../_search", 400).extract().body().asString();
+        Assertions.assertThat(message).contains("This request is not allowed");
+    }
+
+    @FullBackendTest
+    void testPathTraversalOutOfAllowedPrefixIsRejected() {
+        // "_cat/../_search" textually starts with the allowed "_cat" prefix, but resolves to the
+        // disallowed "_search" endpoint once the ".." segment is applied - the allowlist must reject it.
+        final String message = apis.get("/datanodes/any/opensearch/_cat/../_search", 400).extract().body().asString();
+        Assertions.assertThat(message).contains("This request is not allowed");
+    }
+
 
     @FullBackendTest
     void testNonAdminUser() {

--- a/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeRestProxyIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/searchbackend/datanode/DatanodeRestProxyIT.java
@@ -72,4 +72,12 @@ public class DatanodeRestProxyIT {
                 .assertThat().body("opensearch.node.node_name", Matchers.equalTo("indexer"));
 
     }
+
+    @FullBackendTest
+    void testPathTraversalAboveRootIsRejectedEvenWithAllowlistDisabled() {
+        // The allowlist is disabled for this test class, but a path that traverses above its own root
+        // must still be rejected - normalization isn't part of the allowlist rules, it's a baseline check.
+        final String message = apis.get("/datanodes/any/rest/../secret", 400).extract().body().asString();
+        Assertions.assertThat(message).contains("This request is not allowed");
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
@@ -48,7 +48,7 @@ import java.util.List;
 import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 
 @RequiresAuthentication
-@Tag(name = "DataNodes/API", description = "Proxy direct access to Data Node's API")
+@Tag(name = "DataNodes/API", description = "Proxy direct access to Data Node's Opensearch API")
 @Produces(MediaType.APPLICATION_JSON)
 @Timed
 @Path("/datanodes/{hostname}/opensearch/{path: .*}")
@@ -71,7 +71,7 @@ public class DataNodeApiProxyResource extends RestResource {
     }
 
     @GET
-    @Operation(summary = "GET request to Data Node's API")
+    @Operation(summary = "GET request to Data Node's Opensearch API")
     @AuditEvent(type = DATANODE_API_REQUEST)
     public Response requestGet(@Parameter(name = "path", required = true)
                                @PathParam("path") String path,
@@ -82,7 +82,7 @@ public class DataNodeApiProxyResource extends RestResource {
     }
 
     @POST
-    @Operation(summary = "POST request to Data Node's API")
+    @Operation(summary = "POST request to Data Node's Opensearch API")
     @AuditEvent(type = DATANODE_API_REQUEST)
     public Response requestPost(@Parameter(name = "path", required = true)
                                 @PathParam("path") String path,
@@ -93,7 +93,7 @@ public class DataNodeApiProxyResource extends RestResource {
     }
 
     @PUT
-    @Operation(summary = "PUT request to Data Node's API")
+    @Operation(summary = "PUT request to Data Node's Opensearch API")
     @AuditEvent(type = DATANODE_API_REQUEST)
     public Response requestPut(@Parameter(name = "path", required = true)
                                @PathParam("path") String path,
@@ -104,7 +104,7 @@ public class DataNodeApiProxyResource extends RestResource {
     }
 
     @DELETE
-    @Operation(summary = "DELETE request to Data Node's API")
+    @Operation(summary = "DELETE request to Data Node's Opensearch API")
     @AuditEvent(type = DATANODE_API_REQUEST)
     public Response requestDelete(@Parameter(name = "path", required = true)
                                   @PathParam("path") String path,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResource.java
@@ -44,7 +44,6 @@ import org.graylog2.shared.security.RestPermissions;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Predicate;
 
 import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 
@@ -55,20 +54,20 @@ import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 @Path("/datanodes/{hostname}/opensearch/{path: .*}")
 @RequiresPermissions(RestPermissions.DATANODE_OPENSEARCH_PROXY)
 public class DataNodeApiProxyResource extends RestResource {
-    private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
+    private static final DataNodeProxyAllowlist RESTRICTED_ALLOWLIST = new DataNodeProxyAllowlist(List.of(
             request -> request.path().startsWith("_cluster"),
             request -> request.path().startsWith("_cat"),
             request -> request.path().startsWith("_mapping") && request.method().equals("GET")
-    );
+    ));
 
     private final ProxyRequestAdapter proxyRequestAdapter;
-    private final boolean enableAllowlist;
+    private final DataNodeProxyAllowlist allowlist;
 
     @Inject
     public DataNodeApiProxyResource(ProxyRequestAdapter proxyRequestAdapter,
                                     @Named("datanode_proxy_api_allowlist") boolean enableAllowlist) {
         this.proxyRequestAdapter = proxyRequestAdapter;
-        this.enableAllowlist = enableAllowlist;
+        this.allowlist = enableAllowlist ? RESTRICTED_ALLOWLIST : DataNodeProxyAllowlist.allowAll();
     }
 
     @GET
@@ -118,14 +117,14 @@ public class DataNodeApiProxyResource extends RestResource {
     private Response request(ContainerRequestContext context, String path, String hostname) throws IOException {
         final var request = new ProxyRequestAdapter.ProxyRequest(context.getMethod(), path, context.getEntityStream(), hostname, context.getUriInfo().getQueryParameters());
 
-        if (enableAllowlist && allowList.stream().noneMatch(condition -> condition.test(request))) {
+        try {
+            final var response = proxyRequestAdapter.request(allowlist.authorize(request));
+            return Response.status(response.status()).type(response.contentType()).entity(response.response()).build();
+        } catch (RequestNotAllowedException e) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("This request is not allowed.")
                     .type(MediaType.TEXT_PLAIN_TYPE)
                     .build();
         }
-
-        final var response = proxyRequestAdapter.request(request);
-        return Response.status(response.status()).type(response.contentType()).entity(response.response()).build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeProxyAllowlist.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeProxyAllowlist.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+import org.apache.commons.io.FilenameUtils;
+import org.graylog2.indexer.datanode.ProxyRequestAdapter;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+/**
+ * Shared allowlist evaluation for the data node proxy resources. A request is allowed if, after its path has
+ * been normalized to a canonical form (resolving "." and ".." segments), at least one of the configured rules
+ * matches it. Paths that attempt to traverse above their own root are rejected outright.
+ */
+public class DataNodeProxyAllowlist {
+    private final List<Predicate<ProxyRequestAdapter.ProxyRequest>> rules;
+
+    public DataNodeProxyAllowlist(List<Predicate<ProxyRequestAdapter.ProxyRequest>> rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * An allowlist that permits any path, for use when the allowlist feature is disabled. Requests still go
+     * through {@link #authorize(ProxyRequestAdapter.ProxyRequest)}, so a path can never traverse above its own
+     * root even with the allowlist "off" — only the rule matching itself is bypassed.
+     */
+    public static DataNodeProxyAllowlist allowAll() {
+        return new DataNodeProxyAllowlist(List.of(request -> true));
+    }
+
+    /**
+     * Normalizes the request's path and checks the result against the allowlist rules. Rule matching and any
+     * downstream forwarding must both use the returned, normalized request rather than the original one, so
+     * that a path segment like "_cluster/../secrets" can't pass the rules on its raw, pre-normalization text
+     * while actually resolving to a different, disallowed endpoint.
+     *
+     * @return the request with its path replaced by the normalized form
+     * @throws RequestNotAllowedException if the path traverses above its root, or no rule matches it
+     */
+    public ProxyRequestAdapter.ProxyRequest authorize(ProxyRequestAdapter.ProxyRequest request) throws RequestNotAllowedException {
+        final String normalizedPath = normalize(request.path())
+                .orElseThrow(() -> new RequestNotAllowedException(f("Path traverses above its root: %s", request.path())));
+        final ProxyRequestAdapter.ProxyRequest normalizedRequest = withPath(request, normalizedPath);
+        if (!isAllowed(normalizedRequest)) {
+            throw new RequestNotAllowedException(f("Path is not allowlisted: %s", normalizedPath));
+        }
+        return normalizedRequest;
+    }
+
+    private boolean isAllowed(ProxyRequestAdapter.ProxyRequest request) {
+        return rules.stream().anyMatch(rule -> rule.test(request));
+    }
+
+    private static ProxyRequestAdapter.ProxyRequest withPath(ProxyRequestAdapter.ProxyRequest request, String path) {
+        return new ProxyRequestAdapter.ProxyRequest(request.method(), path, request.body(), request.hostname(),
+                request.queryParameters(), request.subject());
+    }
+
+    /**
+     * Resolves "." and ".." segments in the given path. {@code unixSeparator} is forced to {@code true} so
+     * behavior doesn't depend on the platform the server runs on.
+     *
+     * @return the canonical path, or empty if it attempts to traverse above its own root
+     *         (e.g. "_cluster/../../_nodes").
+     */
+    static Optional<String> normalize(String path) {
+        return Optional.ofNullable(FilenameUtils.normalize(path, true));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DataNodeRestApiProxyResource.java
@@ -42,7 +42,6 @@ import org.graylog2.shared.security.RestPermissions;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Predicate;
 
 import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 
@@ -53,25 +52,25 @@ import static org.graylog2.audit.AuditEventTypes.DATANODE_API_REQUEST;
 @Timed
 @RequiresPermissions(RestPermissions.DATANODE_REST_PROXY)
 public class DataNodeRestApiProxyResource extends RestResource {
-    private static final List<Predicate<ProxyRequestAdapter.ProxyRequest>> allowList = List.of(
+    private static final DataNodeProxyAllowlist RESTRICTED_ALLOWLIST = new DataNodeProxyAllowlist(List.of(
             request -> isAllowed(request, "indices-directory", "GET", RestPermissions.DATANODE_MIGRATION),
             request -> isAllowed(request, "logs", "GET", RestPermissions.CLUSTER_CONFIGURATION_READ),
             request -> isAllowed(request, "metrics", "GET", RestPermissions.CLUSTER_CONFIGURATION_READ),
             request -> isAllowed(request, "metrics", "POST", RestPermissions.CLUSTER_CONFIGURATION_READ)
-    );
+    ));
 
     private static boolean isAllowed(ProxyRequestAdapter.ProxyRequest request, String path, String method, String permission) {
         return request.path().startsWith(path) && method.equals(request.method()) && (request.subject() != null && request.subject().isPermitted(permission));
     }
 
     private final DatanodeRestApiProxy proxyRequestAdapter;
-    private final boolean enableAllowlist;
+    private final DataNodeProxyAllowlist allowlist;
 
     @Inject
     public DataNodeRestApiProxyResource(DatanodeRestApiProxy proxyRequestAdapter,
                                         @Named("datanode_proxy_api_allowlist") boolean enableAllowlist) {
         this.proxyRequestAdapter = proxyRequestAdapter;
-        this.enableAllowlist = enableAllowlist;
+        this.allowlist = enableAllowlist ? RESTRICTED_ALLOWLIST : DataNodeProxyAllowlist.allowAll();
     }
 
 
@@ -121,14 +120,15 @@ public class DataNodeRestApiProxyResource extends RestResource {
 
     private Response request(ContainerRequestContext context, String path, String hostname) throws IOException {
         final var request = new ProxyRequestAdapter.ProxyRequest(context.getMethod(), path, context.getEntityStream(), hostname, context.getUriInfo().getQueryParameters(), getSubject());
-        if (enableAllowlist && allowList.stream().noneMatch(condition -> condition.test(request))) {
+
+        try {
+            final var response = proxyRequestAdapter.request(allowlist.authorize(request));
+            return Response.status(response.status()).entity(response.response()).type(response.contentType()).build();
+        } catch (RequestNotAllowedException e) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("This request is not allowed.")
                     .type(MediaType.TEXT_PLAIN_TYPE)
                     .build();
         }
-
-        final var response = proxyRequestAdapter.request(request);
-        return Response.status(response.status()).entity(response.response()).type(response.contentType()).build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/RequestNotAllowedException.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/RequestNotAllowedException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+public class RequestNotAllowedException extends Exception {
+    public RequestNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeApiProxyResourceTest.java
@@ -103,6 +103,22 @@ class DataNodeApiProxyResourceTest {
     }
 
     @Test
+    void allowlistBlocksPathTraversalOutOfAllowedPrefix() throws IOException {
+        final var adapter = new RecordingAdapter(null);
+        final Response response = resource(adapter, true).requestGet("_cluster/../../_nodes/stats", "myhost", requestContext);
+        assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(adapter.lastRequest).isNull();
+    }
+
+    @Test
+    void allowlistForwardsNormalizedPathForAllowedRequest() throws IOException {
+        final var adapter = new RecordingAdapter(OK_RESPONSE);
+        final Response response = resource(adapter, true).requestGet("_cluster/./health", "myhost", requestContext);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(adapter.lastRequest.path()).isEqualTo("_cluster/health");
+    }
+
+    @Test
     void allowlistBlocksMappingPost() throws IOException {
         when(requestContext.getMethod()).thenReturn("POST");
         final var adapter = new RecordingAdapter(null);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeProxyAllowlistTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/datanodes/DataNodeProxyAllowlistTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.datanodes;
+
+import org.graylog2.indexer.datanode.ProxyRequestAdapter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DataNodeProxyAllowlistTest {
+
+    // Mirrors the real "metrics" rule from DataNodeRestApiProxyResource: it's meant to permit read-only
+    // access to cluster configuration metrics, nothing else.
+    private static final DataNodeProxyAllowlist ALLOWLIST = new DataNodeProxyAllowlist(List.of(
+            request -> request.path().startsWith("metrics")
+    ));
+
+    private static ProxyRequestAdapter.ProxyRequest requestFor(String path) {
+        return new ProxyRequestAdapter.ProxyRequest("GET", path, InputStream.nullInputStream(), "myhost", null);
+    }
+
+    @Test
+    void permitsExactAllowedPrefix() throws RequestNotAllowedException {
+        assertThat(ALLOWLIST.authorize(requestFor("metrics"))).isNotNull();
+    }
+
+    @Test
+    void rejectsPathOutsideAllowlist() {
+        assertThatThrownBy(() -> ALLOWLIST.authorize(requestFor("management/stop")))
+                .isInstanceOf(RequestNotAllowedException.class);
+    }
+
+    /**
+     * Path traversal: "metrics/../management/stop" textually starts with "metrics", but a plain
+     * {@code startsWith("metrics")} check on the raw path would incorrectly permit it even though it
+     * actually resolves to "management/stop" — a destructive endpoint (it stops the data node, see
+     * DatanodeRestApiProxyVoidResponseTest.ManagementClient) that was never meant to be reachable here.
+     * Normalizing the path before matching closes this: the rule is checked against "management/stop",
+     * not the raw string, so it correctly fails to match and the request is rejected.
+     */
+    @Test
+    void pathTraversalIsNormalizedBeforeMatchingAndRejected() {
+        assertThatThrownBy(() -> ALLOWLIST.authorize(requestFor("metrics/../management/stop")))
+                .isInstanceOf(RequestNotAllowedException.class);
+    }
+
+    @Test
+    void normalizedPathIsForwardedWhenAllowed() throws RequestNotAllowedException {
+        final var authorized = ALLOWLIST.authorize(requestFor("metrics/./health"));
+        assertThat(authorized.path()).isEqualTo("metrics/health");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"..", "../metrics", "metrics/../..", "metrics/../../metrics"})
+    void rejectsPathsThatTraverseAboveRoot(String path) {
+        assertThat(DataNodeProxyAllowlist.normalize(path)).isEmpty();
+    }
+
+    @Test
+    void normalizeResolvesDotSegmentsWithoutTraversingAboveRoot() {
+        assertThat(DataNodeProxyAllowlist.normalize("metrics/../management/stop")).contains("management/stop");
+        assertThat(DataNodeProxyAllowlist.normalize("metrics/./health")).contains("metrics/health");
+        assertThat(DataNodeProxyAllowlist.normalize("metrics")).contains("metrics");
+    }
+}


### PR DESCRIPTION
Fix possible path traversal in datanode proxy resources.

## Description
Datanode proxy resources allow accessing datanode REST API or Opensearch APIs. There are sets of allowed patterns accessible via the proxy. But existing implementation allows unexpected path traversal and accessing non-allowed resources. 

The fix standardizes the allowlist handling for both proxy types and normalizes URLs to prevent path traversals. 

## Motivation and Context
Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/15029

## How Has This Been Tested?
Verified existing problem, added unit and integration tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

