### PR TITLE
Cluster adapter provides count of manager-eligible nodes

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ClusterAdapterES7.java
@@ -327,6 +327,13 @@ public class ClusterAdapterES7 implements ClusterAdapter {
                 .orElseThrow(() -> new ElasticsearchException("Unable to retrieve shard stats."));
     }
 
+    @Override
+    public int countOfClusterManagerEligibleNodes() {
+        return (int) nodesInfo().values().stream()
+                .filter(node -> node.roles().contains("cluster_manager") || node.roles().contains("master"))
+                .count();
+    }
+
     private Optional<ClusterHealthResponse> clusterHealth() {
         try {
             final ClusterHealthRequest request = new ClusterHealthRequest()

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/ClusterAdapterOS2.java
@@ -336,6 +336,13 @@ public class ClusterAdapterOS2 implements ClusterAdapter {
                 .orElseThrow(() -> new ElasticsearchException("Unable to retrieve shard stats."));
     }
 
+    @Override
+    public int countOfClusterManagerEligibleNodes() {
+        return (int)nodesInfo().values().stream()
+                .filter(node -> node.roles().contains("cluster_manager") || node.roles().contains("master"))
+                .count();
+    }
+
     private Optional<ClusterHealthResponse> clusterHealth() {
         try {
             final ClusterHealthRequest request = new ClusterHealthRequest()

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ClusterAdapterOS.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ClusterAdapterOS.java
@@ -360,6 +360,13 @@ public class ClusterAdapterOS implements ClusterAdapter {
                 .orElseThrow(() -> new ElasticsearchException("Unable to retrieve shard stats."));
     }
 
+    @Override
+    public int countOfClusterManagerEligibleNodes() {
+        return (int)nodesInfo().values().stream()
+                .filter(node -> node.roles().contains("cluster_manager") || node.roles().contains("master"))
+                .count();
+    }
+
     private Optional<HealthResponse> clusterHealth() {
         final Time timeout = new Time.Builder().time(requestTimeout.toSeconds() + "s").build();
         try {

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/ClusterAdapterOSTest.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/ClusterAdapterOSTest.java
@@ -18,6 +18,7 @@ package org.graylog.storage.opensearch3;
 
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.io.Resources;
+import org.assertj.core.api.Assertions;
 import org.graylog.storage.opensearch3.testing.client.mock.ServerlessOpenSearchClient;
 import org.graylog2.indexer.cluster.health.ClusterShardAllocation;
 import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
@@ -45,6 +46,7 @@ class ClusterAdapterOSTest {
 
         final OfficialOpensearchClient client = ServerlessOpenSearchClient.builder()
                 .stubResponse("GET", "/_nodes/*", Resources.getResource("nodes-response-without-host-field.json"))
+                .stubResponse("GET", "/_nodes", Resources.getResource("nodes-response-without-host-field.json"))
                 .stubResponse("GET", "/_cat/nodes", Resources.getResource("cat_nodes.json"))
                 .stubResponse("GET", "/_cluster/settings", Resources.getResource("cluster_settings.json"))
                 .stubResponse("GET", "/_cat/allocation", Resources.getResource("cat_allocation.json"))
@@ -137,5 +139,11 @@ class ClusterAdapterOSTest {
         assertThat(clusterShardAllocation.nodeShardAllocations())
                 .extracting(NodeShardAllocation::shards)
                 .containsExactly(15, 16);
+    }
+
+    @Test
+    void testManagerEligibleNodesCount() {
+        Assertions.assertThat(clusterAdapter.countOfClusterManagerEligibleNodes())
+                .isEqualTo(3); // there are 3 nodes with role "master" in nodes-response-without-host-field.json
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
@@ -66,5 +66,10 @@ public interface ClusterAdapter {
 
     ShardStats shardStats();
 
+    /**
+     * The cluster health response has no such field, so implementations derive it from each node's roles.
+     */
+    int countOfClusterManagerEligibleNodes();
+
     Optional<HealthStatus> deflectorHealth(Collection<String> indices);
 }


### PR DESCRIPTION
/nocl this is just infrastructure for https://github.com/Graylog2/graylog-plugin-enterprise/pull/15041

## Description
Implement access to manager-eligible nodes count in all three storage modules. 

## Motivation and Context
Needed for https://github.com/Graylog2/graylog-plugin-enterprise/pull/15041

## How Has This Been Tested?
Added unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

