### PR TITLE
Display more actions button on search page as solid button again.

### DIFF
--- a/graylog2-web-interface/src/components/common/MoreActions.tsx
+++ b/graylog2-web-interface/src/components/common/MoreActions.tsx
@@ -15,13 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import styled from 'styled-components';
 
 import { DropdownButton } from 'components/bootstrap';
-import type { StyleProps } from 'components/bootstrap/Button';
 
-import Icon from './Icon';
 import type { SizeProp } from './Icon';
+import Icon from './Icon';
 
 type MoreActionsIconProps = {
   size?: SizeProp;
@@ -31,7 +29,6 @@ export const MoreActionsIcon = ({ size = undefined }: MoreActionsIconProps) => <
 type MoreActionsMenuProps = {
   'aria-label'?: string;
   size?: SizeProp;
-  bsStyle?: StyleProps;
   className?: string;
   id?: string;
   keepMounted?: boolean;
@@ -39,13 +36,10 @@ type MoreActionsMenuProps = {
   title?: string;
   solid?: boolean;
 };
-const StyledDropdownButton = styled(DropdownButton)<{ $transparent?: boolean }>`
-  ${({ $transparent }) => ($transparent ? 'background-color: transparent;' : '')}
-`;
+
 export const MoreActionsMenu = ({
   'aria-label': ariaLabel,
   size = 'xs',
-  bsStyle = undefined,
   children = undefined,
   className = undefined,
   id = undefined,
@@ -54,10 +48,9 @@ export const MoreActionsMenu = ({
   title = 'More Actions',
   solid = false,
 }: React.PropsWithChildren<MoreActionsMenuProps>) => (
-  <StyledDropdownButton
-    $transparent={!solid}
+  <DropdownButton
     aria-label={ariaLabel}
-    bsStyle={bsStyle}
+    bsStyle={solid ? undefined : 'transparent'}
     buttonTitle={title}
     className={className}
     id={id}
@@ -67,5 +60,5 @@ export const MoreActionsMenu = ({
     title={<MoreActionsIcon size={size} />}
     withinPortal>
     {children}
-  </StyledDropdownButton>
+  </DropdownButton>
 );

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SearchActionsMenu.tsx
@@ -252,7 +252,7 @@ const SearchActionsMenu = () => {
         bsStyle="default"
         disabledInfo={isNew && 'Only saved searches can be shared.'}
       />
-      <MoreActionsMenu aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight>
+      <MoreActionsMenu aria-label="Open search actions dropdown" id="search-actions-dropdown" pullRight solid>
         <MenuItem onSelect={toggleMetadataEdit} disabled={!isAllowedToEdit} icon="edit">
           Edit metadata
         </MenuItem>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a small button styling issue on the search page.

Before
<img width="374" height="193" alt="image" src="https://github.com/user-attachments/assets/e5023217-cc4b-432e-9b24-a957172a504f" />

After
<img width="408" height="151" alt="image" src="https://github.com/user-attachments/assets/81bdee21-c8a5-4463-91cd-74934f43b981" />


/nocl - fixes unreleased regression