### PR TITLE
Fixing expanded rows in inputs overview.

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputsOveriew/ColumnRenderers.tsx
+++ b/graylog2-web-interface/src/components/inputs/InputsOveriew/ColumnRenderers.tsx
@@ -31,7 +31,7 @@ import { InputStateBadge } from 'components/inputs';
 import Routes from 'routing/Routes';
 import { Link } from 'components/common';
 
-const EXPANDED_SECTION = 'EXPANDED_SECTION';
+const EXPANDED_SECTION = 'configuration';
 
 type Props = {
   inputTypes: InputTypesSummary;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes a regression introduced with https://github.com/Graylog2/graylog2-server/pull/26837. Before this fix an expanded row in the inputs overview was always empty.

/nocl - fixes unreleased regression
