### PR TITLE
Fix CIDR trie lookups honoring TTLs

### DIFF
--- a/changelog/unreleased/pr-26854.toml
+++ b/changelog/unreleased/pr-26854.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed Enterprise MongoDB Data Adapter CIDR entries being cached up to one hour after their TTL had expired."
+
+pulls = ["26854"]

--- a/graylog2-server/src/main/java/org/graylog2/utilities/CIDRPatriciaTrie.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/CIDRPatriciaTrie.java
@@ -113,8 +113,20 @@ public class CIDRPatriciaTrie {
         }
     }
 
+    /**
+     * Returns the rangeName of the range with the longest prefix that contains the IP address, ignoring any
+     * range whose TTL has elapsed, or null if no live range contains it.
+     *
+     * <p>An expired range is skipped rather than terminating the search, so a lookup falls through to a
+     * shorter enclosing range that is still live.
+     *
+     * @param ip IP address to check against the collection of ranges
+     * @return the name of the longest-prefix live range containing the IP if one exists, null otherwise
+     * @see #longestPrefixRangeLookupWithTtl(String, long) to supply an explicit lookup time, or 0 to ignore
+     * expiry entirely
+     */
     public String longestPrefixRangeLookup(String ip) {
-        return longestPrefixRangeLookupWithTtl(ip, 0L);
+        return longestPrefixRangeLookupWithTtl(ip, DateTime.now(DateTimeZone.UTC).getMillis());
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/utilities/CIDRPatriciaTrieTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/CIDRPatriciaTrieTest.java
@@ -105,10 +105,12 @@ public class CIDRPatriciaTrieTest {
             // Copy should be a deep copy.
             assertThat(copy).isNotSameAs(trie);
             // No operations performed on the original trie, so all nodes should still exist in the trie.
+            // Probed with an explicit lookup time of 0 to ignore expiry: the point here is that cleanCopy
+            // did not mutate the original, not whether these nodes have expired (two of them have).
             assertThat(trie).satisfies(t -> {
-                assertThat(t.longestPrefixRangeLookup("192.168.1.100")).isEqualTo("IPv4 Range 1");
-                assertThat(t.longestPrefixRangeLookup("10.0.5.1")).isEqualTo("IPv4 Range 2");
-                assertThat(t.longestPrefixRangeLookup("35.139.253.123")).isEqualTo("IPv4 Range 3");
+                assertThat(t.longestPrefixRangeLookupWithTtl("192.168.1.100", 0L)).isEqualTo("IPv4 Range 1");
+                assertThat(t.longestPrefixRangeLookupWithTtl("10.0.5.1", 0L)).isEqualTo("IPv4 Range 2");
+                assertThat(t.longestPrefixRangeLookupWithTtl("35.139.253.123", 0L)).isEqualTo("IPv4 Range 3");
             });
             // Confirm two nodes with TTLs have been cleaned out of the copy and the one without a TTL has not.
             assertThat(copy).satisfies(t -> {
@@ -141,6 +143,52 @@ public class CIDRPatriciaTrieTest {
             assertThat(copy).isNotSameAs(trie);
             assertThat(trie.isEmpty()).isFalse();
             assertThat(copy.isEmpty()).isTrue();
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+    }
+
+    @Test
+    public void testLookupSkipsExpiredRange() {
+        try {
+            final CIDRPatriciaTrie trie = new CIDRPatriciaTrie();
+            final long expireAt = DateTime.now(DateTimeZone.UTC).getMillis() + 500L;
+            trie.insertCIDR("192.168.1.0/24", "Expiring Range", expireAt);
+            trie.insertCIDR("10.0.0.0/8", "Permanent Range");
+
+            // Before expiry both resolve.
+            assertThat(trie.longestPrefixRangeLookup("192.168.1.100")).isEqualTo("Expiring Range");
+            assertThat(trie.longestPrefixRangeLookup("10.0.5.1")).isEqualTo("Permanent Range");
+
+            DateTimeUtils.setCurrentMillisOffset(501);
+
+            // The expired range no longer matches, even though cleanCopy has not run and the node is
+            // still present in the trie.
+            assertThat(trie.longestPrefixRangeLookup("192.168.1.100")).isNull();
+            assertThat(trie.longestPrefixRangeLookupWithTtl("192.168.1.100", 0L)).isEqualTo("Expiring Range");
+
+            // A range without a TTL is unaffected.
+            assertThat(trie.longestPrefixRangeLookup("10.0.5.1")).isEqualTo("Permanent Range");
+        } finally {
+            DateTimeUtils.setCurrentMillisSystem();
+        }
+    }
+
+    @Test
+    public void testLookupFallsBackToLiveEnclosingRangeWhenLongestPrefixExpired() {
+        try {
+            final CIDRPatriciaTrie trie = new CIDRPatriciaTrie();
+            final long expireAt = DateTime.now(DateTimeZone.UTC).getMillis() + 500L;
+            trie.insertCIDR("10.1.2.0/24", "Specific Expiring", expireAt);
+            trie.insertCIDR("10.0.0.0/8", "Broad Permanent");
+
+            // The more specific range wins while it is live.
+            assertThat(trie.longestPrefixRangeLookup("10.1.2.42")).isEqualTo("Specific Expiring");
+
+            DateTimeUtils.setCurrentMillisOffset(501);
+
+            // Once it expires the search continues to the shorter enclosing range rather than giving up.
+            assertThat(trie.longestPrefixRangeLookup("10.1.2.42")).isEqualTo("Broad Permanent");
         } finally {
             DateTimeUtils.setCurrentMillisSystem();
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change default behavior of `CIDRPatriciaTrie.longestPrefixRangeLookup` to use `now` as the lookup time so that entries added with a TTL that has expired are properly ignored after expiry. Currently, only the enterprise `MongoDBDataAdapter` is affected (`CSVFileDataAdapter` entries cannot be added with a TTL) and the trie is automatically refreshed every hour, so an entry can only ever be at max 1 hour expired, but that's a long time. This change makes the expiry immediate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Respect TTL for values added to a MongoDBDataAdapter
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

