### PR TITLE
Add AWS Kinesis input permission checks

### DIFF
--- a/changelog/unreleased/pr-26878.toml
+++ b/changelog/unreleased/pr-26878.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Added needed input create permissions checks for the AWS CloudWatch and Kinesis input API endpoints."
+
+pulls = ["26878"]

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/api/CloudTrailResource.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/api/CloudTrailResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.Response;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.aws.AWS;
+import org.graylog.aws.inputs.cloudtrail.CloudTrailInput;
 import org.graylog.aws.inputs.cloudtrail.api.requests.CloudTrailCreateInputRequest;
 import org.graylog.aws.inputs.cloudtrail.api.requests.CloudTrailRequestImpl;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
@@ -72,6 +73,7 @@ public class CloudTrailResource extends AbstractInputsResource implements Plugin
     @Path("/check_credentials")
     @Operation(summary = "Validate input credentials")
     @NoAuditEvent("This does not change any data")
+    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + CloudTrailInput.TYPE})
     public String checkCredentials(@RequestBody(required = true)
                                    @Valid @NotNull CloudTrailRequestImpl request) throws Exception {
         return cloudTrailDriver.checkCredentials(request);
@@ -80,6 +82,7 @@ public class CloudTrailResource extends AbstractInputsResource implements Plugin
     @GET
     @Path("/getawsregions")
     @Operation(summary = "Get all available AWS regions")
+    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + CloudTrailInput.TYPE})
     public Map<String, String> getAWSRegions() {
         return AWS.buildRegionChoices();
     }
@@ -89,7 +92,7 @@ public class CloudTrailResource extends AbstractInputsResource implements Plugin
     @Path("/inputs")
     @Operation(summary = "Create a new CloudTrail input")
     @AuditEvent(type = IntegrationsAuditEventTypes.AWS_CLOUDTRAIL_INPUT_CREATE)
-    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":org.graylog.aws.inputs.cloudtrail.CloudTrailInput"})
+    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + CloudTrailInput.TYPE})
     public Response create(@Parameter @QueryParam("setup_wizard") @DefaultValue("false") boolean isSetupWizard,
                            @RequestBody(required = true)
                            @Valid @NotNull CloudTrailCreateInputRequest request) throws Exception {

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -42,6 +42,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
+import org.graylog.integrations.aws.inputs.AWSInput;
 import org.graylog.integrations.aws.resources.requests.AWSInputCreateRequest;
 import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
 import org.graylog.integrations.aws.resources.requests.KinesisRequest;
@@ -89,7 +90,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/regions")
     @Operation(summary = "Get all available AWS regions")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     public RegionsResponse getAwsRegions() {
         return awsService.getAvailableRegions();
     }
@@ -98,7 +99,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/cloudwatch/log_groups")
     @Operation(summary = "Get all available AWS CloudWatch log groups names for the specified region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public LogGroupsResponse getLogGroupNames(@RequestBody(required = true) @Valid @NotNull AWSRequestImpl request) {
         return cloudWatchService.getLogGroupNames(request);
@@ -108,7 +109,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/kinesis/streams")
     @Operation(summary = "Get all available Kinesis streams for the specified region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public StreamsResponse getKinesisStreams(@RequestBody(required = true) @Valid @NotNull AWSRequestImpl request) throws ExecutionException {
         return kinesisService.getKinesisStreamNames(request);
@@ -118,7 +119,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/kinesis/stream_arn")
     @Operation(summary = "Get stream ARN for the specified stream and region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public Response getStreamArn(@RequestBody(required = true) @Valid @NotNull KinesisRequest request) {
         String response;
@@ -140,7 +141,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
             @ApiResponse(responseCode = "202", description = "AWS log retrieval health check completed successfully",
                     content = @Content(schema = @Schema(implementation = KinesisHealthCheckResponse.class)))
     })
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public Response kinesisHealthCheck(@RequestBody(required = true) @Valid @NotNull KinesisRequest heathCheckRequest) throws ExecutionException, IOException {
 
@@ -153,7 +154,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/inputs")
     @Operation(summary = "Create a new AWS input.")
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_INPUT_CREATE)
-    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":org.graylog.integrations.aws.inputs.AWSInput"})
+    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     public Response create(@Parameter @QueryParam("setup_wizard") @DefaultValue("false") boolean isSetupWizard,
                            @RequestBody(required = true)
                            @Valid @NotNull AWSInputCreateRequest saveRequest) throws Exception {

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
@@ -32,6 +32,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
+import org.graylog.integrations.aws.inputs.AWSInput;
 import org.graylog.integrations.aws.resources.requests.CreateLogSubscriptionRequest;
 import org.graylog.integrations.aws.resources.requests.CreateRolePermissionRequest;
 import org.graylog.integrations.aws.resources.requests.KinesisNewStreamRequest;
@@ -44,6 +45,7 @@ import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +74,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_stream")
     @Operation(summary = "Step 1: Attempt to create a new kinesis stream and wait for it to be ready.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_STREAM)
     public KinesisNewStreamResponse createNewKinesisStream(@RequestBody(required = true)
                                                            @Valid @NotNull KinesisNewStreamRequest request) {
@@ -90,7 +92,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_subscription_policy")
     @Operation(summary = "Step 2: Create AWS IAM policy needed for CloudWatch to write logs to Kinesis")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_POLICY)
     public CreateRolePermissionResponse autoKinesisPermissions(@RequestBody(required = true)
                                                                @Valid @NotNull CreateRolePermissionRequest request) {
@@ -102,7 +104,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_subscription")
     @Operation(summary = "Step 3: Subscribe a Kinesis stream to a CloudWatch log group")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_SUBSCRIPTION)
     public CreateLogSubscriptionResponse createSubscription(@RequestBody(required = true)
                                                             @Valid @NotNull CreateLogSubscriptionRequest request) {


### PR DESCRIPTION
Added input create permission checks to the AWS input setup endpoints.

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/14948. 