### PR TITLE
Remove changelog entry for unreleased streams metric columns fix

### DIFF
--- a/changelog/unreleased/issue-26724.toml
+++ b/changelog/unreleased/issue-26724.toml
@@ -1,5 +1,0 @@
-type = "fixed"
-message = "Fixed metric columns in the Streams overview (message count, processing time) not showing data after being added to the view without a page reload."
-
-issues = ["26724"]
-pulls = ["26824"]


### PR DESCRIPTION
## Description

Removes `changelog/unreleased/issue-26724.toml`, added by #26824.

## Motivation and Context

The metric columns in the streams overview have not shipped in a released version yet — the feature itself is still in `changelog/unreleased/` (`pr-26555.toml`) and only appears in `7.2.0-alpha` tags. The fix and the feature would land in the same release notes, so the changelog would describe a bug no released version had.

Follow-up to #26824.

/nocl