### PR TITLE
Fixing not needed horizontal scrollbar in `EntityDataTable` for tables that have no actions column.

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/Constants.ts
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/Constants.ts
@@ -28,6 +28,8 @@ export const BULK_SELECT_COL_ID = 'bulk-select';
 
 export const ACTIONS_COL_ID = 'actions';
 
+export const RESIZE_HIT_AREA_OVERHANG = 7;
+
 export const UTILITY_COLUMNS = new Set([BULK_SELECT_COL_ID, ACTIONS_COL_ID]);
 
 export const ATTRIBUTE_STATUS = {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -355,6 +355,7 @@ const EntityDataTable = <Entity extends EntityBase, Meta = unknown>({
                     $scrollContainerWidth={scrollContainerWidth}>
                     <InnerContainer>
                       <Table<Entity>
+                        columnWidths={columnWidths}
                         expandedSectionRenderers={expandedSectionRenderers}
                         headerGroups={headerGroups}
                         rowOverride={rowOverride}

--- a/graylog2-web-interface/src/components/common/EntityDataTable/Table.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/Table.tsx
@@ -58,11 +58,13 @@ const StyledTable = styled(BaseTable)(
 
 const Td = styled.td<{
   $colId: string;
+  $hideEmptyTailBorder: boolean;
   $hidePadding: boolean;
+  $isLastVisibleColumn: boolean;
   $pinningPosition: ColumnPinningPosition;
   $textAlign: string;
 }>(
-  ({ $colId, $hidePadding, $pinningPosition, $textAlign }) => css`
+  ({ $colId, $hideEmptyTailBorder, $hidePadding, $isLastVisibleColumn, $pinningPosition, $textAlign, theme }) => css`
     word-break: break-word;
     ${$textAlign &&
     css`
@@ -94,10 +96,25 @@ const Td = styled.td<{
         padding: 0;
       }
     `}
+
+    ${$hideEmptyTailBorder &&
+    css`
+      &&& {
+        border-right: none;
+      }
+    `}
+
+    ${$isLastVisibleColumn &&
+    css`
+      && {
+        border-right-color: ${theme.colors.table.row.divider};
+      }
+    `}
   `,
 );
 
 type Props<Entity extends EntityBase> = {
+  columnWidths: { [colId: string]: number };
   expandedSectionRenderers: ExpandedSectionRenderers<Entity> | undefined;
   rowOverride?: RowOverride<Entity>;
   headerGroups: Array<HeaderGroup<Entity>>;
@@ -105,6 +122,7 @@ type Props<Entity extends EntityBase> = {
 };
 
 const Table = <Entity extends EntityBase>({
+  columnWidths,
   expandedSectionRenderers,
   rowOverride = undefined,
   headerGroups,
@@ -114,9 +132,13 @@ const Table = <Entity extends EntityBase>({
 
   const isRowExpanded = (rowId: string) => !!expandedSections?.[rowId];
 
+  const isTailColumnEmpty = !columnWidths[ACTIONS_COL_ID];
+  const leafHeaders = headerGroups[headerGroups.length - 1]?.headers ?? [];
+  const lastVisibleColumnId = isTailColumnEmpty ? leafHeaders[leafHeaders.length - 2]?.column.id : undefined;
+
   return (
     <StyledTable condensed bordered>
-      <TableHead headerGroups={headerGroups} />
+      <TableHead columnWidths={columnWidths} headerGroups={headerGroups} />
       {rows.map((row) => {
         const visibleCells = row.getVisibleCells();
         const visibleCellCount = visibleCells.length;
@@ -127,6 +149,8 @@ const Table = <Entity extends EntityBase>({
             <Td
               key={cell.id}
               $colId={cell.column.id}
+              $hideEmptyTailBorder={cell.column.id === ACTIONS_COL_ID && isTailColumnEmpty}
+              $isLastVisibleColumn={cell.column.id === lastVisibleColumnId}
               $pinningPosition={cell.column.getIsPinned()}
               $hidePadding={columnMeta?.hideCellPadding}
               $textAlign={columnMeta?.columnRenderer?.textAlign}>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
@@ -27,7 +27,7 @@ import {
   columnTransition,
   displayScrollRightIndicatorVar,
 } from 'components/common/EntityDataTable/CSSVariables';
-import { ACTIONS_COL_ID } from 'components/common/EntityDataTable/Constants';
+import { ACTIONS_COL_ID, RESIZE_HIT_AREA_OVERHANG } from 'components/common/EntityDataTable/Constants';
 import ScrollShadow from 'theme/box-shadows/ScrollShadow';
 import useForceUpdate from 'util/hooks/useForceUpdate';
 import zIndices from 'theme/z-indices';
@@ -99,16 +99,23 @@ export const Th = styled.th<{
         display: var(${displayScrollRightIndicatorVar}, none);
       }
     `}
+
+    ${$hideEmptyTailBorder &&
+    css`
+      && {
+        border-right: none;
+      }
+    `}
   `,
 );
 
-const ResizeHitArea = styled.div<{ $isResizing: boolean }>(
-  ({ theme, $isResizing }) => css`
+const ResizeHitArea = styled.div<{ $isResizing: boolean; $constrainOverhang: boolean }>(
+  ({ theme, $isResizing, $constrainOverhang }) => css`
     position: absolute;
     top: 0;
     bottom: 0;
-    right: -7px;
-    width: 14px;
+    right: ${$constrainOverhang ? 0 : -RESIZE_HIT_AREA_OVERHANG}px;
+    width: ${RESIZE_HIT_AREA_OVERHANG * 2}px;
     cursor: col-resize;
     touch-action: none;
     user-select: none;

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
@@ -127,7 +127,7 @@ const ResizeHitArea = styled.div<{ $isResizing: boolean; $constrainOverhang: boo
     top: 0;
     bottom: 0;
     right: ${$constrainOverhang ? 0 : -RESIZE_HIT_AREA_OVERHANG}px;
-    width: ${RESIZE_HIT_AREA_OVERHANG * 2}px;
+    width: ${RESIZE_HIT_AREA_OVERHANG * ($constrainOverhang ? 1 : 2)}px;
     cursor: col-resize;
     touch-action: none;
     user-select: none;
@@ -138,12 +138,18 @@ const ResizeHitArea = styled.div<{ $isResizing: boolean; $constrainOverhang: boo
       position: absolute;
       top: 0;
       bottom: 0;
-      left: 50%;
       width: 3px;
       transform: translateX(-50%);
       background-color: ${theme.colors.variant.info};
       opacity: ${$isResizing ? 1 : 0};
       transition: opacity 0.15s ease-in-out;
+      ${$constrainOverhang
+        ? css`
+            right: -2px;
+          `
+        : css`
+            left: 50%;
+          `};
     }
 
     &:hover::after {

--- a/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/TableHead.tsx
@@ -46,12 +46,23 @@ const Thead = styled.thead(
 
 export const Th = styled.th<{
   $colId: string;
+  $hideEmptyTailBorder: boolean;
+  $hideEmptyTailPinShadow: boolean;
   $hidePadding: boolean;
   $pinningPosition: ColumnPinningPosition;
   $revealHeaderActions: boolean;
   $zIndex: number;
 }>(
-  ({ $colId, $hidePadding, $pinningPosition, $revealHeaderActions, $zIndex, theme }) => css`
+  ({
+    $colId,
+    $hideEmptyTailBorder,
+    $hideEmptyTailPinShadow,
+    $hidePadding,
+    $pinningPosition,
+    $revealHeaderActions,
+    $zIndex,
+    theme,
+  }) => css`
     position: relative;
     padding: 0 !important;
     z-index: ${$pinningPosition ? zIndices.tableHeaderCellPinned : $zIndex};
@@ -78,6 +89,7 @@ export const Th = styled.th<{
           position: sticky;
           ${$pinningPosition === 'left' ? 'left' : 'right'}: 0;
           ${$pinningPosition === 'right' &&
+          !$hideEmptyTailPinShadow &&
           css`
             box-shadow: inset -1px 0 0 ${theme.colors.table.row.divider};
           `}
@@ -148,8 +160,17 @@ const ResizeCursorGlobalStyle = createGlobalStyle`
   }
 `;
 
-const TableHeaderCell = <Entity extends EntityBase>({ header }: { header: Header<Entity, unknown> }) => {
+const TableHeaderCell = <Entity extends EntityBase>({
+  header,
+  isTailColumnEmpty,
+  constrainResizeOverhang,
+}: {
+  header: Header<Entity, unknown>;
+  isTailColumnEmpty: boolean;
+  constrainResizeOverhang: boolean;
+}) => {
   const columnMeta = header.column.columnDef.meta as ColumnMetaContext<Entity>;
+  const isActionsColumn = header.column.id === ACTIONS_COL_ID;
   const forceUpdate = useForceUpdate();
   const [isHoveringResizeHandle, setIsHoveringResizeHandle] = useState(false);
 
@@ -177,6 +198,8 @@ const TableHeaderCell = <Entity extends EntityBase>({ header }: { header: Header
       key={header.id}
       colSpan={header.colSpan}
       $colId={header.column.id}
+      $hideEmptyTailBorder={isActionsColumn && isTailColumnEmpty}
+      $hideEmptyTailPinShadow={isActionsColumn && !header.column.columnDef.header}
       $hidePadding={columnMeta?.hideCellPadding}
       $pinningPosition={header.column.getIsPinned()}
       $zIndex={zIndices.tableHeaderCell - header.index}
@@ -189,6 +212,7 @@ const TableHeaderCell = <Entity extends EntityBase>({ header }: { header: Header
           onMouseEnter={() => setIsHoveringResizeHandle(true)}
           onMouseLeave={() => setIsHoveringResizeHandle(false)}
           $isResizing={header.column.getIsResizing()}
+          $constrainOverhang={constrainResizeOverhang}
           role="separator"
           aria-label={`Resize ${columnMeta?.label ?? header.column.id} column`}
           title={`Resize ${columnMeta?.label ?? header.column.id} column`}
@@ -199,20 +223,30 @@ const TableHeaderCell = <Entity extends EntityBase>({ header }: { header: Header
 };
 
 type Props<Entity extends EntityBase> = {
+  columnWidths: { [colId: string]: number };
   headerGroups: Array<HeaderGroup<Entity>>;
 };
 
-const TableHead = <Entity extends EntityBase>({ headerGroups }: Props<Entity>) => (
-  <Thead>
-    <ResizeCursorGlobalStyle />
-    {headerGroups.map((headerGroup) => (
-      <tr key={headerGroup.id}>
-        {headerGroup.headers.map((header) => (
-          <TableHeaderCell key={header.id} header={header} />
-        ))}
-      </tr>
-    ))}
-  </Thead>
-);
+const TableHead = <Entity extends EntityBase>({ columnWidths, headerGroups }: Props<Entity>) => {
+  const isTailColumnEmpty = !columnWidths[ACTIONS_COL_ID];
+
+  return (
+    <Thead>
+      <ResizeCursorGlobalStyle />
+      {headerGroups.map((headerGroup) => (
+        <tr key={headerGroup.id}>
+          {headerGroup.headers.map((header, index) => (
+            <TableHeaderCell
+              key={header.id}
+              header={header}
+              isTailColumnEmpty={isTailColumnEmpty}
+              constrainResizeOverhang={isTailColumnEmpty && index === headerGroup.headers.length - 2}
+            />
+          ))}
+        </tr>
+      ))}
+    </Thead>
+  );
+};
 
 export default TableHead;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes an issue with the `EntityDataTable` where tables, which have no action column, could have an unnecessary scroll bar. This was caused by the overflowing resize handle and the table border.

<img width="103" height="171" alt="image" src="https://github.com/user-attachments/assets/b994219e-7e4c-4d83-be5f-00edc5d8bad2" />

The way we define the table border is currently comparable complex, because we need to define the border in a way that works with pinned columns.

/nocl - fixes unreleased regression