### PR TITLE
Adds bsSize props to Section component and extends options for titleAs

### DIFF
--- a/graylog2-web-interface/src/components/common/Section.tsx
+++ b/graylog2-web-interface/src/components/common/Section.tsx
@@ -20,11 +20,10 @@ import { Collapse } from '@mantine/core';
 
 import useDisclosure from 'util/hooks/useDisclosure';
 import sizeForMantine from 'theme/utils/sizeForMantine';
-import type { BsSize } from 'components/bootstrap/types';
 
 import IconButton from './IconButton';
 
-const Container = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: BsSize }>(
+const Container = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: SectionBsSize }>(
   ({ $collapsible, $opened, $bsSize, theme }) => css`
     background-color: ${theme.colors.section.filled.background};
     border: 1px solid ${theme.colors.section.filled.border};
@@ -34,7 +33,7 @@ const Container = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize:
   `,
 );
 
-const Header = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: BsSize }>(
+const Header = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: SectionBsSize }>(
   ({ $collapsible, $opened, $bsSize, theme }) => css`
     display: flex;
     justify-content: space-between;
@@ -59,6 +58,8 @@ const FlexWrapper = styled.div(
   `,
 );
 
+type SectionBsSize = 'md' | 'xs';
+
 type Props = React.PropsWithChildren<{
   title: string;
   titleAs?: 'h2' | 'h3' | 'h4' | 'h5';
@@ -72,7 +73,7 @@ type Props = React.PropsWithChildren<{
   disableCollapseButton?: boolean;
   collapseButtonPosition?: 'left' | 'right';
   className?: string;
-  bsSize?: BsSize;
+  bsSize?: SectionBsSize;
 }>;
 
 /**

--- a/graylog2-web-interface/src/components/common/Section.tsx
+++ b/graylog2-web-interface/src/components/common/Section.tsx
@@ -19,27 +19,29 @@ import styled, { css } from 'styled-components';
 import { Collapse } from '@mantine/core';
 
 import useDisclosure from 'util/hooks/useDisclosure';
+import sizeForMantine from 'theme/utils/sizeForMantine';
+import type { BsSize } from 'components/bootstrap/types';
 
 import IconButton from './IconButton';
 
-const Container = styled.div<{ $collapsible: boolean; $opened: boolean }>(
-  ({ $collapsible, $opened, theme }) => css`
+const Container = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: BsSize }>(
+  ({ $collapsible, $opened, $bsSize, theme }) => css`
     background-color: ${theme.colors.section.filled.background};
     border: 1px solid ${theme.colors.section.filled.border};
     border-radius: 10px;
-    padding: ${$collapsible && !$opened ? 0 : theme.spacings.md};
+    padding: ${$collapsible && !$opened ? 0 : theme.spacings[sizeForMantine($bsSize)]};
     margin-bottom: ${theme.spacings.xxs};
   `,
 );
 
-const Header = styled.div<{ $collapsible: boolean; $opened: boolean }>(
-  ({ $collapsible, $opened, theme }) => css`
+const Header = styled.div<{ $collapsible: boolean; $opened: boolean; $bsSize: BsSize }>(
+  ({ $collapsible, $opened, $bsSize, theme }) => css`
     display: flex;
     justify-content: space-between;
     gap: ${theme.spacings.xs};
     align-items: center;
     border-radius: 10px;
-    padding: ${$collapsible && !$opened ? theme.spacings.md : 0};
+    padding: ${$collapsible && !$opened ? theme.spacings[sizeForMantine($bsSize)] : 0};
     flex-wrap: wrap;
 
     &:hover {
@@ -59,7 +61,7 @@ const FlexWrapper = styled.div(
 
 type Props = React.PropsWithChildren<{
   title: string;
-  titleAs?: 'h2' | 'h3';
+  titleAs?: 'h2' | 'h3' | 'h4' | 'h5';
   header?: React.ReactNode;
   actions?: React.ReactNode;
   preHeaderSection?: React.ReactNode;
@@ -70,6 +72,7 @@ type Props = React.PropsWithChildren<{
   disableCollapseButton?: boolean;
   collapseButtonPosition?: 'left' | 'right';
   className?: string;
+  bsSize?: BsSize;
 }>;
 
 /**
@@ -89,6 +92,7 @@ const Section = ({
   collapseButtonPosition = 'left',
   children = null,
   className = undefined,
+  bsSize = 'md',
 }: Props) => {
   const [opened, { toggle }] = useDisclosure(!defaultClosed);
 
@@ -117,8 +121,8 @@ const Section = ({
   );
 
   return (
-    <Container $opened={opened} $collapsible={collapsible} className={className}>
-      <Header $opened={opened} $collapsible={collapsible} onClick={onHeaderClick}>
+    <Container $opened={opened} $collapsible={collapsible} className={className} $bsSize={bsSize}>
+      <Header $opened={opened} $collapsible={collapsible} onClick={onHeaderClick} $bsSize={bsSize}>
         <FlexWrapper>
           {collapseButtonPosition === 'left' && collapseButton}
           {preHeaderSection && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR 
adds a prop like bsSize and changes padding depending on the prop. It uses the same mapping as we have in buttons.
It  also can extens titleAs  to receive h4, h5 

## Motivation and Context
In the current implementation, we use the paddings theme.spacings.md, and in some cases it makes the container too big.
Check this PR
https://github.com/Graylog2/graylog-plugin-enterprise/pull/15118

We can't restyle it in my place of use because we have this padding for Container and Header depending on whether Section is expanded.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl