### PR TITLE
Add AWS Kinesis input permission checks (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26878.toml
+++ b/changelog/unreleased/pr-26878.toml
@@ -1,0 +1,4 @@
+type = "fixed"
+message = "Added needed input create permissions checks for the AWS CloudWatch and Kinesis input API endpoints."
+
+pulls = ["26878"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -37,6 +37,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
+import org.graylog.integrations.aws.inputs.AWSInput;
 import org.graylog.integrations.aws.resources.requests.AWSInputCreateRequest;
 import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
 import org.graylog.integrations.aws.resources.requests.KinesisRequest;
@@ -84,7 +85,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/regions")
     @ApiOperation(value = "Get all available AWS regions")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     public RegionsResponse getAwsRegions() {
         return awsService.getAvailableRegions();
     }
@@ -93,7 +94,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/cloudwatch/log_groups")
     @ApiOperation(value = "Get all available AWS CloudWatch log groups names for the specified region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public LogGroupsResponse getLogGroupNames(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl request) {
         return cloudWatchService.getLogGroupNames(request);
@@ -103,7 +104,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/kinesis/streams")
     @ApiOperation(value = "Get all available Kinesis streams for the specified region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public StreamsResponse getKinesisStreams(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl request) throws ExecutionException {
         return kinesisService.getKinesisStreamNames(request);
@@ -113,7 +114,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Timed
     @Path("/kinesis/stream_arn")
     @ApiOperation(value = "Get stream ARN for the specified stream and region.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public Response getStreamArn(@ApiParam(name = "JSON body", required = true) @Valid @NotNull KinesisRequest request) {
         String response;
@@ -133,7 +134,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
             value = "Attempt to retrieve logs from the indicated AWS log group with the specified credentials.",
             response = KinesisHealthCheckResponse.class
     )
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @NoAuditEvent("This does not change any data")
     public Response kinesisHealthCheck(@ApiParam(name = "JSON body", required = true) @Valid @NotNull KinesisRequest heathCheckRequest) throws ExecutionException, IOException {
 
@@ -146,7 +147,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/inputs")
     @ApiOperation(value = "Create a new AWS input.")
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_INPUT_CREATE)
-    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":org.graylog.integrations.aws.inputs.AWSInput"})
+    @RequiresPermissions({RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     public Response create(@ApiParam @QueryParam("setup_wizard") @DefaultValue("false") boolean isSetupWizard,
                            @ApiParam(name = "JSON body", required = true)
                            @Valid @NotNull AWSInputCreateRequest saveRequest) throws Exception {

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
@@ -24,6 +24,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
+import org.graylog.integrations.aws.inputs.AWSInput;
 import org.graylog.integrations.aws.resources.requests.CreateLogSubscriptionRequest;
 import org.graylog.integrations.aws.resources.requests.CreateRolePermissionRequest;
 import org.graylog.integrations.aws.resources.requests.KinesisNewStreamRequest;
@@ -36,6 +37,7 @@ import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +77,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_stream")
     @ApiOperation(value = "Step 1: Attempt to create a new kinesis stream and wait for it to be ready.")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_STREAM)
     public KinesisNewStreamResponse createNewKinesisStream(@ApiParam(name = "JSON body", required = true)
                                                            @Valid @NotNull KinesisNewStreamRequest request) {
@@ -93,7 +95,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_subscription_policy")
     @ApiOperation(value = "Step 2: Create AWS IAM policy needed for CloudWatch to write logs to Kinesis")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_POLICY)
     public CreateRolePermissionResponse autoKinesisPermissions(@ApiParam(name = "JSON body", required = true)
                                                                @Valid @NotNull CreateRolePermissionRequest request) {
@@ -105,7 +107,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
     @Timed
     @Path("/create_subscription")
     @ApiOperation(value = "Step 3: Subscribe a Kinesis stream to a CloudWatch log group")
-    @RequiresPermissions(AWSPermissions.AWS_READ)
+    @RequiresPermissions({AWSPermissions.AWS_READ, RestPermissions.INPUTS_CREATE, RestPermissions.INPUT_TYPES_CREATE + ":" + AWSInput.TYPE})
     @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_SETUP_CREATE_SUBSCRIPTION)
     public CreateLogSubscriptionResponse createSubscription(@ApiParam(name = "JSON body", required = true)
                                                             @Valid @NotNull CreateLogSubscriptionRequest request) {


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/26878 to `7.0`.

Adjustments:
- Kept the Swagger 1.x annotations that `7.0` still uses, so only the permission annotations came over
- Dropped the CloudTrail endpoint changes, since `CloudTrailResource` does not exist on `7.0`
