### PR TITLE
Update Netty to 4.2.17

### DIFF
--- a/changelog/unreleased/pr-26911.toml
+++ b/changelog/unreleased/pr-26911.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Netty to 4.2.17."
+
+pulls = ["26911"]

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <mongodb-driver.version>5.9.1</mongodb-driver.version>
         <mongojack.version>5.1.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.81.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>5.4.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
Release notes: https://netty.io/news/2026/08/04/4-2-17-Final.html
