### PR TITLE
Update Netty to 4.1.136

### DIFF
--- a/changelog/unreleased/pr-26912.toml
+++ b/changelog/unreleased/pr-26912.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Update Netty to 4.1.136."
+
+pulls = ["26912"]

--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,8 @@
         <mongodb-driver.version>5.5.1</mongodb-driver.version>
         <mongojack.version>5.0.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.135.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.77.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.136.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.78.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.12.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <opentelemetry.version>1.32.0</opentelemetry.version>


### PR DESCRIPTION
Also update tcnative version to match the version Netty uses.

Release notes: https://netty.io/news/2026/07/09/4-1-136-Final.html
