### PR TITLE
Check per-table read permission in lookup table tester

### DIFF
--- a/changelog/unreleased/pr-26915.toml
+++ b/changelog/unreleased/pr-26915.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Check read permission for the requested lookup table in the lookup table tester endpoints."
+
+pulls = ["26915"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -71,6 +71,7 @@ public class LookupTableTesterResource extends RestResource {
     }
 
     private LookupTableTesterResponse doTestLookupTable(String string, String lookupTableName) {
+        validateUserHasAccessToLookupTable(lookupTableName);
         if (!lookupTableService.hasTable(lookupTableName)) {
             return LookupTableTesterResponse.error("Lookup table <" + lookupTableName + "> doesn't exist");
         }
@@ -83,5 +84,10 @@ public class LookupTableTesterResource extends RestResource {
         }
 
         return LookupTableTesterResponse.result(string, result);
+    }
+
+    private void validateUserHasAccessToLookupTable(@NotEmpty String lookupTableName) {
+        final var table = lookupTableService.getTable(lookupTableName);
+        checkPermission(RestPermissions.LOOKUP_TABLES_READ, table.id());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -54,8 +54,8 @@ public class LookupTableTesterResource extends RestResource {
 
     @GET
     @Timed
-    public LookupTableTesterResponse grokTest(@QueryParam("lookup_table_name") @NotEmpty String lookupTableName,
-                                              @QueryParam("string") @NotEmpty String string) {
+    public LookupTableTesterResponse testLookupTable(@QueryParam("lookup_table_name") @NotEmpty String lookupTableName,
+                                                     @QueryParam("string") @NotEmpty String string) {
         return doTestLookupTable(string, lookupTableName);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -18,7 +18,6 @@ package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.lookup.LookupTableService;
 import org.graylog2.plugin.lookup.LookupResult;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -88,6 +88,10 @@ public class LookupTableTesterResource extends RestResource {
 
     private void validateUserHasAccessToLookupTable(@NotEmpty String lookupTableName) {
         final var table = lookupTableService.getTable(lookupTableName);
-        checkPermission(RestPermissions.LOOKUP_TABLES_READ, table.id());
+        // Tables which aren't loaded can't be read through the tester either, so the caller only gets to know that
+        // the lookup didn't return anything.
+        if (table != null) {
+            checkPermission(RestPermissions.LOOKUP_TABLES_READ, table.id());
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -65,7 +65,6 @@ public class LookupTableTesterResource extends RestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @NoAuditEvent("only used to test lookup tables")
-    @RequiresPermissions(RestPermissions.LOOKUP_TABLES_READ)
     public LookupTableTesterResponse testLookupTable(@Valid @NotNull LookupTableTestRequest lookupTableTestRequest) {
         return doTestLookupTable(lookupTableTestRequest.string(), lookupTableTestRequest.lookupTableName());
     }
@@ -88,8 +87,6 @@ public class LookupTableTesterResource extends RestResource {
 
     private void validateUserHasAccessToLookupTable(@NotEmpty String lookupTableName) {
         final var table = lookupTableService.getTable(lookupTableName);
-        // Tables which aren't loaded can't be read through the tester either, so the caller only gets to know that
-        // the lookup didn't return anything.
         if (table != null) {
             checkPermission(RestPermissions.LOOKUP_TABLES_READ, table.id());
         }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.tools;
+
+import jakarta.ws.rs.ForbiddenException;
+import org.apache.shiro.subject.Subject;
+import org.graylog2.lookup.LookupTable;
+import org.graylog2.lookup.LookupTableService;
+import org.graylog2.plugin.lookup.LookupResult;
+import org.graylog2.rest.models.tools.requests.LookupTableTestRequest;
+import org.graylog2.rest.resources.tools.responses.LookupTableTesterResponse;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LookupTableTesterResourceTest {
+    private static final String TABLE_NAME = "secret-table";
+    private static final String TABLE_ID = "54e3deadbeefdeadbeef0001";
+    private static final String OTHER_TABLE_ID = "54e3deadbeefdeadbeef0002";
+
+    private LookupTableService lookupTableService;
+    private Subject subject;
+    private LookupTableTesterResource resource;
+
+    @BeforeEach
+    void setUp() {
+        lookupTableService = mock(LookupTableService.class);
+        subject = mock(Subject.class);
+        resource = new LookupTableTesterResource(lookupTableService) {
+            @Override
+            protected Subject getSubject() {
+                return subject;
+            }
+        };
+    }
+
+    @Test
+    void getRejectsUserWithoutReadPermissionForTable() {
+        final LookupTable table = existingTable();
+
+        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
+                .isInstanceOf(ForbiddenException.class);
+
+        verify(table, never()).lookup(any());
+    }
+
+    @Test
+    void postRejectsUserWithoutReadPermissionForTable() {
+        final LookupTable table = existingTable();
+
+        assertThatThrownBy(() -> resource.testLookupTable(LookupTableTestRequest.create("foo", TABLE_NAME)))
+                .isInstanceOf(ForbiddenException.class);
+
+        verify(table, never()).lookup(any());
+    }
+
+    @Test
+    void rejectsUserWithReadPermissionForDifferentTable() {
+        existingTable();
+        grantReadPermissionFor(OTHER_TABLE_ID);
+
+        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void rejectsUserWithoutInstanceScopedReadPermission() {
+        existingTable();
+        when(subject.isPermitted(RestPermissions.LOOKUP_TABLES_READ)).thenReturn(true);
+
+        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void getReturnsLookupResultForUserWithReadPermissionForTable() {
+        final LookupTable table = existingTable();
+        when(table.lookup("foo")).thenReturn(LookupResult.single("bar"));
+        grantReadPermissionFor(TABLE_ID);
+
+        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, " foo ");
+
+        assertThat(response.error()).isFalse();
+        assertThat(response.empty()).isFalse();
+        assertThat(response.key()).isEqualTo(" foo ");
+        assertThat(response.value()).isEqualTo("bar");
+    }
+
+    @Test
+    void postReturnsLookupResultForUserWithReadPermissionForTable() {
+        final LookupTable table = existingTable();
+        when(table.lookup("foo")).thenReturn(LookupResult.single("bar"));
+        grantReadPermissionFor(TABLE_ID);
+
+        final LookupTableTesterResponse response =
+                resource.testLookupTable(LookupTableTestRequest.create("foo", TABLE_NAME));
+
+        assertThat(response.error()).isFalse();
+        assertThat(response.empty()).isFalse();
+        assertThat(response.key()).isEqualTo("foo");
+        assertThat(response.value()).isEqualTo("bar");
+    }
+
+    @Test
+    void returnsEmptyResultWhenLookupHasNoValue() {
+        final LookupTable table = existingTable();
+        when(table.lookup("foo")).thenReturn(LookupResult.empty());
+        grantReadPermissionFor(TABLE_ID);
+
+        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, "foo");
+
+        assertThat(response.error()).isFalse();
+        assertThat(response.empty()).isTrue();
+        assertThat(response.value()).isNull();
+    }
+
+    private LookupTable existingTable() {
+        final LookupTable table = mock(LookupTable.class);
+        when(table.id()).thenReturn(TABLE_ID);
+        when(lookupTableService.getTable(TABLE_NAME)).thenReturn(table);
+        when(lookupTableService.hasTable(TABLE_NAME)).thenReturn(true);
+        when(lookupTableService.newBuilder()).thenReturn(new LookupTableService.Builder(lookupTableService));
+        return table;
+    }
+
+    private void grantReadPermissionFor(String tableId) {
+        when(subject.isPermitted(RestPermissions.LOOKUP_TABLES_READ + ":" + tableId)).thenReturn(true);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
@@ -136,6 +136,17 @@ class LookupTableTesterResourceTest {
         assertThat(response.value()).isNull();
     }
 
+    @Test
+    void returnsErrorResponseForUnknownLookupTable() {
+        when(lookupTableService.getTable(TABLE_NAME)).thenReturn(null);
+        when(lookupTableService.hasTable(TABLE_NAME)).thenReturn(false);
+
+        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, "foo");
+
+        assertThat(response.error()).isTrue();
+        assertThat(response.errorMessage()).contains(TABLE_NAME);
+    }
+
     private LookupTable existingTable() {
         final LookupTable table = mock(LookupTable.class);
         when(table.id()).thenReturn(TABLE_ID);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/LookupTableTesterResourceTest.java
@@ -26,29 +26,47 @@ import org.graylog2.rest.resources.tools.responses.LookupTableTesterResponse;
 import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class LookupTableTesterResourceTest {
-    private static final String TABLE_NAME = "secret-table";
-    private static final String TABLE_ID = "54e3deadbeefdeadbeef0001";
-    private static final String OTHER_TABLE_ID = "54e3deadbeefdeadbeef0002";
-
+    @Mock
     private LookupTableService lookupTableService;
+
+    @Mock
+    private LookupTable table;
+
     private Subject subject;
     private LookupTableTesterResource resource;
+    private final String tableName = "foo-table";
+    private final String someKey = "some-key";
+    private final String staticResponse = "foo";
 
     @BeforeEach
     void setUp() {
-        lookupTableService = mock(LookupTableService.class);
+        when(lookupTableService.getTable(tableName)).thenReturn(table);
+        lenient().when(lookupTableService.hasTable(tableName)).thenReturn(true);
+
+        final var tableBuilderMock = mock(LookupTableService.Builder.class);
+        lenient().when(tableBuilderMock.lookupTable(tableName)).thenReturn(tableBuilderMock);
+
+        final var lookupTableFunc = mock(LookupTableService.Function.class);
+        lenient().when(lookupTableFunc.lookup(anyString())).thenReturn(LookupResult.single(staticResponse));
+        lenient().when(tableBuilderMock.build()).thenReturn(lookupTableFunc);
+
+        lenient().when(lookupTableService.newBuilder()).thenReturn(tableBuilderMock);
+        when(table.id()).thenReturn(tableName);
         subject = mock(Subject.class);
-        resource = new LookupTableTesterResource(lookupTableService) {
+        this.resource = new LookupTableTesterResource(lookupTableService) {
             @Override
             protected Subject getSubject() {
                 return subject;
@@ -57,106 +75,47 @@ class LookupTableTesterResourceTest {
     }
 
     @Test
-    void getRejectsUserWithoutReadPermissionForTable() {
-        final LookupTable table = existingTable();
+    void rejectTestingLookupTableUserHasNoAccessTo() {
+        setUserIsPermittedForLookupTable(false);
 
-        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
-                .isInstanceOf(ForbiddenException.class);
-
-        verify(table, never()).lookup(any());
+        assertThrows(ForbiddenException.class, () -> resource.testLookupTable(tableName, someKey));
+        assertThrows(ForbiddenException.class, () -> resource.testLookupTable(LookupTableTestRequest.create(someKey, tableName)));
     }
 
     @Test
-    void postRejectsUserWithoutReadPermissionForTable() {
-        final LookupTable table = existingTable();
+    void performTestingLookupIfUserHasAccessToTable() {
+        setUserIsPermittedForLookupTable(true);
 
-        assertThatThrownBy(() -> resource.testLookupTable(LookupTableTestRequest.create("foo", TABLE_NAME)))
-                .isInstanceOf(ForbiddenException.class);
-
-        verify(table, never()).lookup(any());
+        assertThat(resource.testLookupTable(tableName, someKey))
+                .satisfies(this::assertSuccessfulResponse);
+        assertThat(resource.testLookupTable(LookupTableTestRequest.create(someKey, tableName)))
+                .satisfies(this::assertSuccessfulResponse);
     }
 
     @Test
-    void rejectsUserWithReadPermissionForDifferentTable() {
-        existingTable();
-        grantReadPermissionFor(OTHER_TABLE_ID);
+    void returnsErrorResponseIfUserHasAccessButTableDoesNotExists() {
+        setUserIsPermittedForLookupTable(true);
+        when(lookupTableService.hasTable(tableName)).thenReturn(false);
 
-        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
-                .isInstanceOf(ForbiddenException.class);
+        assertThat(resource.testLookupTable(tableName, someKey))
+                .satisfies(this::assertErrorResponse);
+        assertThat(resource.testLookupTable(LookupTableTestRequest.create(someKey, tableName)))
+                .satisfies(this::assertErrorResponse);
     }
 
-    @Test
-    void rejectsUserWithoutInstanceScopedReadPermission() {
-        existingTable();
-        when(subject.isPermitted(RestPermissions.LOOKUP_TABLES_READ)).thenReturn(true);
-
-        assertThatThrownBy(() -> resource.grokTest(TABLE_NAME, "foo"))
-                .isInstanceOf(ForbiddenException.class);
+    private void setUserIsPermittedForLookupTable(boolean permitted) {
+        when(subject.isPermitted(RestPermissions.LOOKUP_TABLES_READ + ":" + tableName)).thenReturn(permitted);
     }
 
-    @Test
-    void getReturnsLookupResultForUserWithReadPermissionForTable() {
-        final LookupTable table = existingTable();
-        when(table.lookup("foo")).thenReturn(LookupResult.single("bar"));
-        grantReadPermissionFor(TABLE_ID);
-
-        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, " foo ");
-
+    private void assertSuccessfulResponse(LookupTableTesterResponse response) {
         assertThat(response.error()).isFalse();
         assertThat(response.empty()).isFalse();
-        assertThat(response.key()).isEqualTo(" foo ");
-        assertThat(response.value()).isEqualTo("bar");
+        assertThat(response.key()).isEqualTo(someKey);
+        assertThat(response.value()).isEqualTo(staticResponse);
     }
 
-    @Test
-    void postReturnsLookupResultForUserWithReadPermissionForTable() {
-        final LookupTable table = existingTable();
-        when(table.lookup("foo")).thenReturn(LookupResult.single("bar"));
-        grantReadPermissionFor(TABLE_ID);
-
-        final LookupTableTesterResponse response =
-                resource.testLookupTable(LookupTableTestRequest.create("foo", TABLE_NAME));
-
-        assertThat(response.error()).isFalse();
-        assertThat(response.empty()).isFalse();
-        assertThat(response.key()).isEqualTo("foo");
-        assertThat(response.value()).isEqualTo("bar");
-    }
-
-    @Test
-    void returnsEmptyResultWhenLookupHasNoValue() {
-        final LookupTable table = existingTable();
-        when(table.lookup("foo")).thenReturn(LookupResult.empty());
-        grantReadPermissionFor(TABLE_ID);
-
-        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, "foo");
-
-        assertThat(response.error()).isFalse();
-        assertThat(response.empty()).isTrue();
-        assertThat(response.value()).isNull();
-    }
-
-    @Test
-    void returnsErrorResponseForUnknownLookupTable() {
-        when(lookupTableService.getTable(TABLE_NAME)).thenReturn(null);
-        when(lookupTableService.hasTable(TABLE_NAME)).thenReturn(false);
-
-        final LookupTableTesterResponse response = resource.grokTest(TABLE_NAME, "foo");
-
+    private void assertErrorResponse(LookupTableTesterResponse response) {
         assertThat(response.error()).isTrue();
-        assertThat(response.errorMessage()).contains(TABLE_NAME);
-    }
-
-    private LookupTable existingTable() {
-        final LookupTable table = mock(LookupTable.class);
-        when(table.id()).thenReturn(TABLE_ID);
-        when(lookupTableService.getTable(TABLE_NAME)).thenReturn(table);
-        when(lookupTableService.hasTable(TABLE_NAME)).thenReturn(true);
-        when(lookupTableService.newBuilder()).thenReturn(new LookupTableService.Builder(lookupTableService));
-        return table;
-    }
-
-    private void grantReadPermissionFor(String tableId) {
-        when(subject.isPermitted(RestPermissions.LOOKUP_TABLES_READ + ":" + tableId)).thenReturn(true);
+        assertThat(response.errorMessage()).isEqualTo("Lookup table <" + tableName + "> doesn't exist");
     }
 }


### PR DESCRIPTION
**Note:** This needs to be backported to previous, supported version.

## Description
## Motivation and Context

Prior to this PR, a user without read access to a specific lookup table could use the tester endpoint to extract data from it, due to a missing permissions check.

The lookup table tester endpoints (`GET`/`POST /tools/lookup_table_tester`) now resolve the requested lookup table and check `lookuptables:read` for its id before performing the lookup.

Previously the `GET` variant required no permission beyond authentication, and the `POST` variant only required the unscoped `lookuptables:read` permission. Since the instance-scoped check now covers both endpoints, the unscoped `@RequiresPermissions` annotation on `POST` was dropped, so users who only hold a grant for an individual table can use the tester for that table.

Table names which don't resolve to a loaded lookup table keep returning the existing "doesn't exist" response instead of failing the permission check, which cannot leak data: the lookup resolves the table through the same service and returns an error result when it isn't loaded.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.