### PR TITLE
Fix file_log receiver config generator for Windows

### DIFF
--- a/changelog/unreleased/pr-26916.toml
+++ b/changelog/unreleased/pr-26916.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix running the `file_log` receiver on Windows."
+
+issues = ["collector#90"]
+pulls = ["26916"]

--- a/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/config/receiver/FilelogReceiverConfig.java
@@ -135,6 +135,17 @@ public abstract class FilelogReceiverConfig implements CollectorReceiverConfig, 
 
         public abstract Builder storage(String storage);
 
-        public abstract FilelogReceiverConfig build();
+        abstract FilelogReceiverConfig autoBuild();
+
+        public FilelogReceiverConfig build(CollectorOSType osType) {
+            // The file_log receiver doesn't support the "include_file_owner_name" and "include_file_owner_group_name"
+            // options on Windows. Setting the values to true would fail the OTel collector startup.
+            // See: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver#configuration
+            if (CollectorOSType.WINDOWS.equals(osType)) {
+                includeFileOwnerName(false);
+                includeFileOwnerGroupName(false);
+            }
+            return autoBuild();
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/FileSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/FileSourceConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.FilelogReceiverConfig;
@@ -61,12 +62,12 @@ public abstract class FileSourceConfig implements SourceConfig {
     }
 
     @Override
-    public Optional<CollectorReceiverConfig> toReceiverConfig(String id) {
+    public Optional<CollectorReceiverConfig> toReceiverConfig(String id, CollectorOSType osType) {
         return Optional.of(FilelogReceiverConfig.builder(id)
                 .startAt(readMode())
                 .include(paths())
                 .includeFilePath(true)
-                .build());
+                .build(osType));
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/JournaldSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/JournaldSourceConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.JournaldReceiverConfig;
@@ -63,7 +64,7 @@ public abstract class JournaldSourceConfig implements SourceConfig {
     }
 
     @Override
-    public Optional<CollectorReceiverConfig> toReceiverConfig(String id) {
+    public Optional<CollectorReceiverConfig> toReceiverConfig(String id, CollectorOSType osType) {
         return Optional.of(JournaldReceiverConfig.builder(id)
                 .startAt(readMode())
                 .priority(JournaldReceiverConfig.Priority.valueOf(priority().toUpperCase(Locale.ROOT)))

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/SourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/SourceConfig.java
@@ -18,6 +18,7 @@ package org.graylog.collectors.db;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 
 import java.util.Optional;
@@ -39,5 +40,5 @@ public interface SourceConfig {
      */
     void validate();
 
-    Optional<CollectorReceiverConfig> toReceiverConfig(String id);
+    Optional<CollectorReceiverConfig> toReceiverConfig(String id, CollectorOSType osType);
 }

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/SourceDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/SourceDTO.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import jakarta.annotation.Nullable;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog2.database.BuildableMongoEntity;
 
@@ -55,9 +56,9 @@ public abstract class SourceDTO implements BuildableMongoEntity<SourceDTO, Sourc
         return AutoValue_SourceDTO.Builder.create();
     }
 
-    public Optional<CollectorReceiverConfig> toReceiverConfig() {
+    public Optional<CollectorReceiverConfig> toReceiverConfig(CollectorOSType osType) {
         if (enabled()) {
-            return config().toReceiverConfig(id());
+            return config().toReceiverConfig(id(), osType);
         }
         return Optional.empty();
     }

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/UnknownSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/UnknownSourceConfig.java
@@ -19,6 +19,7 @@ package org.graylog.collectors.db;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 
 import java.util.LinkedHashMap;
@@ -53,7 +54,7 @@ public class UnknownSourceConfig implements SourceConfig {
     }
 
     @Override
-    public Optional<CollectorReceiverConfig> toReceiverConfig(String id) {
+    public Optional<CollectorReceiverConfig> toReceiverConfig(String id, CollectorOSType osType) {
         return Optional.empty();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/db/WindowsEventLogSourceConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.collectors.CollectorOSType;
 import org.graylog.collectors.CollectorReadMode;
 import org.graylog.collectors.config.receiver.CollectorReceiverConfig;
 import org.graylog.collectors.config.receiver.WindowsEventLogReceiverConfig;
@@ -59,7 +60,7 @@ public abstract class WindowsEventLogSourceConfig implements SourceConfig {
     }
 
     @Override
-    public Optional<CollectorReceiverConfig> toReceiverConfig(String id) {
+    public Optional<CollectorReceiverConfig> toReceiverConfig(String id, CollectorOSType osType) {
         return Optional.of(WindowsEventLogReceiverConfig.builder(id)
                 .channels(channels())
                 .includeDefaultChannels(includeDefaultChannels())

--- a/graylog2-server/src/main/java/org/graylog/collectors/opamp/OpAmpService.java
+++ b/graylog2-server/src/main/java/org/graylog/collectors/opamp/OpAmpService.java
@@ -387,7 +387,7 @@ public class OpAmpService {
         final Map<String, CollectorPipelineConfig> pipelines = Maps.newHashMap();
 
         sources.stream().filter(SourceDTO::enabled).forEach(source -> {
-            final var receiverConfig = source.toReceiverConfig()
+            final var receiverConfig = source.toReceiverConfig(osType)
                     .filter(config -> config.osSupport().contains(osType))
                     .orElse(null);
 

--- a/graylog2-server/src/test/java/org/graylog/collectors/config/receiver/FilelogReceiverConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/config/receiver/FilelogReceiverConfigTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.collectors.config.receiver;
+
+import org.graylog.collectors.CollectorOSType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilelogReceiverConfigTest {
+
+    private static FilelogReceiverConfig.Builder minimalBuilder() {
+        return FilelogReceiverConfig.builder("abc123")
+                .include(List.of("/var/log/example.log"));
+    }
+
+    @Test
+    void windowsDisablesFileOwnerOptions() {
+        // The file_log receiver fails collector startup on Windows when the file owner options are enabled.
+        final var config = minimalBuilder().build(CollectorOSType.WINDOWS);
+
+        assertThat(config.includeFileOwnerName()).isFalse();
+        assertThat(config.includeFileOwnerGroupName()).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CollectorOSType.class, mode = EnumSource.Mode.EXCLUDE, names = {"WINDOWS", "UNKNOWN"})
+    void otherOsTypesKeepFileOwnerOptionsEnabled(CollectorOSType osType) {
+        final var config = minimalBuilder().build(osType);
+
+        assertThat(config.includeFileOwnerName()).isTrue();
+        assertThat(config.includeFileOwnerGroupName()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CollectorOSType.class, mode = EnumSource.Mode.EXCLUDE, names = {"WINDOWS", "UNKNOWN"})
+    void explicitlyDisabledFileOwnerOptionsAreNotOverridden(CollectorOSType osType) {
+        final var config = minimalBuilder()
+                .includeFileOwnerName(false)
+                .includeFileOwnerGroupName(false)
+                .build(osType);
+
+        assertThat(config.includeFileOwnerName()).isFalse();
+        assertThat(config.includeFileOwnerGroupName()).isFalse();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/collectors/opamp/OpAmpServiceBuildCollectorConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog/collectors/opamp/OpAmpServiceBuildCollectorConfigTest.java
@@ -23,6 +23,7 @@ import org.graylog.collectors.config.TLSConfigurationSettings;
 import org.graylog.collectors.config.exporter.OtlpExporterConfig;
 import org.graylog.collectors.config.exporter.OtlpHttpExporterConfig;
 import org.graylog.collectors.config.processor.ResourceProcessorConfig;
+import org.graylog.collectors.config.receiver.FilelogReceiverConfig;
 import org.graylog.collectors.db.FileSourceConfig;
 import org.graylog.collectors.db.JournaldSourceConfig;
 import org.graylog.collectors.db.SourceDTO;
@@ -209,6 +210,24 @@ class OpAmpServiceBuildCollectorConfigTest {
         assertThat(config.receivers()).containsOnlyKeys("file_log/enabled");
         assertThat(config.processors()).containsOnlyKeys("resource/enabled");
         assertThat(config.service().pipelines()).containsOnlyKeys("logs/enabled");
+    }
+
+    @Test
+    void fileLogReceiverDisablesFileOwnerOptionsOnWindows() {
+        // The file_log receiver fails collector startup on Windows when the file owner options are enabled.
+        final var windowsConfig = OpAmpService.buildCollectorConfig(
+                FLEET_ID, List.of(fileSource("abc123")), CollectorOSType.WINDOWS, exporterConfig());
+
+        final var windowsReceiver = (FilelogReceiverConfig) windowsConfig.receivers().get("file_log/abc123");
+        assertThat(windowsReceiver.includeFileOwnerName()).isFalse();
+        assertThat(windowsReceiver.includeFileOwnerGroupName()).isFalse();
+
+        final var linuxConfig = OpAmpService.buildCollectorConfig(
+                FLEET_ID, List.of(fileSource("abc123")), CollectorOSType.LINUX, exporterConfig());
+
+        final var linuxReceiver = (FilelogReceiverConfig) linuxConfig.receivers().get("file_log/abc123");
+        assertThat(linuxReceiver.includeFileOwnerName()).isTrue();
+        assertThat(linuxReceiver.includeFileOwnerGroupName()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
The receiver doesn't support enabling the "include_file_owner_name" and "include_file_owner_group_name" options on Windows.

We now pass the CollectorOSType into the SourceConfig#toReceiverConfig method so we can adjust the config based on the operating system.

Fixes Graylog2/collector#90
