### PR TITLE
Stop ClusterEventService instances in ClusterEventServicePerformanceTest

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServicePerformanceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServicePerformanceTest.java
@@ -31,17 +31,19 @@ import org.graylog2.plugin.system.SimpleNodeId;
 import org.graylog2.security.RestrictedChainingClassLoader;
 import org.graylog2.security.SafeClasses;
 import org.graylog2.shared.plugins.ChainingClassLoader;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -54,12 +56,12 @@ class ClusterEventServicePerformanceTest {
     private static final int CONSUMER_COUNT = 10;
     private static final int PRODUCER_COUNT = 5;
     private static final int EVENTS_PER_PRODUCER = 1000;
-    private final AtomicBoolean running = new AtomicBoolean(true);
     private final ThreadFactory threadFactory = r -> {
         Thread t = new Thread(r);
         t.setDaemon(true);
         return t;
     };
+    private final List<ClusterEventService> services = new ArrayList<>();
     private MongoDBTestService mongodb;
     private MongoJackObjectMapperProvider objectMapperProvider;
     private Offset offset;
@@ -70,6 +72,17 @@ class ClusterEventServicePerformanceTest {
         this.mongodb = mongodb;
         this.objectMapperProvider = objectMapperProvider;
         this.offset = new OffsetFromCurrentMongoDBTimeProvider(mongodb.mongoConnection()).get();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        // Stop all services before the MongoDB client gets closed. Otherwise the service threads keep retrying
+        // against the closed client for the rest of the JVM's lifetime, flooding the logs.
+        services.forEach(ClusterEventService::stopAsync);
+        for (final var service : services) {
+            service.awaitTerminated(10, TimeUnit.SECONDS);
+        }
+        services.clear();
     }
 
     class EventSubscriber {
@@ -105,13 +118,11 @@ class ClusterEventServicePerformanceTest {
         final var producerStopwatch = Stopwatch.createStarted();
         final var consumerStopwatch = Stopwatch.createStarted();
 
-        final var totalCount = 2 * (2 * CONSUMER_COUNT + 2 * PRODUCER_COUNT);
-        final var threadPool = Executors.newFixedThreadPool(totalCount, threadFactory);
+        final var threadPool = Executors.newFixedThreadPool(PRODUCER_COUNT, threadFactory);
         for (int i = 0; i < CONSUMER_COUNT; i++) {
             final var serverEventBus = new EventBus();
             final var clusterEventBus = new ClusterEventBus();
-            final var periodical = createClusterEventService(new SimpleNodeId("consumer-" + i), serverEventBus, clusterEventBus);
-            threadPool.submit(periodical::run);
+            services.add(createClusterEventService(new SimpleNodeId("consumer-" + i), serverEventBus, clusterEventBus));
 
             serverEventBus.register(new EventSubscriber(consumerCountdown::countDown));
         }
@@ -120,9 +131,7 @@ class ClusterEventServicePerformanceTest {
             final var serverEventBus = new EventBus();
             final var clusterEventBus = new ClusterEventBus();
             final var nodeId = new SimpleNodeId("producer-" + i);
-            final var periodical = createClusterEventService(nodeId, serverEventBus, clusterEventBus);
-
-            threadPool.submit(periodical::run);
+            services.add(createClusterEventService(nodeId, serverEventBus, clusterEventBus));
 
             threadPool.submit(() -> {
                 for (int count = 0; count < EVENTS_PER_PRODUCER; count++) {
@@ -138,7 +147,7 @@ class ClusterEventServicePerformanceTest {
         assertThat(consumerCountdown.await(10, TimeUnit.MINUTES)).as("Consumer latch has not timed out").isTrue();
         LOG.info("Consumers have finished, took: " + consumerStopwatch.elapsed(TimeUnit.MILLISECONDS) + "ms.");
 
-        running.set(false);
+        threadPool.shutdown();
 
         printStatistics(mongodb.mongoDatabase());
     }


### PR DESCRIPTION
The test started 15 ClusterEventService instances via startAsync() but never stopped them. Once MongoDBExtension closed the MongoDB client after the test, the leaked service threads kept retrying against the closed client for the rest of the (reused) surefire JVM's lifetime, flooding CI build logs with thousands of "Error while reading cluster events from MongoDB, retrying." warnings, one per second per thread.

Track all started services and stop them in an @AfterEach teardown before the client gets closed.

Also remove the redundant threadPool.submit(periodical::run) calls. startAsync() already runs the polling loop on the service's own execution thread, so each instance was running its loop twice concurrently.

Avoids around 6k log statements in the CI logs:

```
2026-08-06T15:31:49.8712410Z java.lang.IllegalStateException: state should be: open
2026-08-06T15:31:49.8713303Z    at com.mongodb.assertions.Assertions.isTrue(Assertions.java:91)
2026-08-06T15:31:49.8714262Z    at com.mongodb.internal.connection.BaseCluster.selectServer(BaseCluster.java:143)
2026-08-06T15:31:49.8715680Z    at com.mongodb.internal.connection.SingleServerCluster.selectServer(SingleServerCluster.java:47)
2026-08-06T15:31:49.8716910Z    at com.mongodb.internal.binding.ClusterBinding.getReadConnectionSource(ClusterBinding.java:69)
2026-08-06T15:31:49.8718146Z    at com.mongodb.client.internal.ClientSessionBinding.getConnectionSource(ClientSessionBinding.java:109)
2026-08-06T15:31:49.8719478Z    at com.mongodb.client.internal.ClientSessionBinding.getReadConnectionSource(ClientSessionBinding.java:87)
2026-08-06T15:31:49.8720385Z    at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:169)
2026-08-06T15:31:49.8721403Z    at com.mongodb.internal.operation.SyncOperationHelper.withSourceAndConnection(SyncOperationHelper.java:138)
2026-08-06T15:31:49.8722372Z    at com.mongodb.internal.operation.FindOperation.lambda$execute$2(FindOperation.java:304)
2026-08-06T15:31:49.8723196Z    at com.mongodb.internal.operation.SyncOperationHelper.lambda$decorateReadWithRetries$14(SyncOperationHelper.java:338)
2026-08-06T15:31:49.8724043Z    at com.mongodb.internal.async.function.RetryingSyncSupplier.get(RetryingSyncSupplier.java:67)
2026-08-06T15:31:49.8724868Z    at com.mongodb.internal.operation.FindOperation.execute(FindOperation.java:316)
2026-08-06T15:31:49.8725509Z    at com.mongodb.internal.operation.FindOperation.execute(FindOperation.java:70)
2026-08-06T15:31:49.8726218Z    at com.mongodb.client.internal.MongoClusterImpl$OperationExecutorImpl.execute(MongoClusterImpl.java:439)
2026-08-06T15:31:49.8726965Z    at com.mongodb.client.internal.MongoIterableImpl.execute(MongoIterableImpl.java:156)
2026-08-06T15:31:49.8727647Z    at com.mongodb.client.internal.MongoIterableImpl.iterator(MongoIterableImpl.java:116)
2026-08-06T15:31:49.8728291Z    at org.graylog2.events.ClusterEventService.run(ClusterEventService.java:126)
2026-08-06T15:31:49.8729063Z    at com.google.common.util.concurrent.AbstractExecutionThreadService$1.lambda$doStart$1(AbstractExecutionThreadService.java:55)
2026-08-06T15:31:49.8729881Z    at com.google.common.util.concurrent.Callables.lambda$threadRenaming$1(Callables.java:104)
2026-08-06T15:31:49.8730467Z    at java.base/java.lang.Thread.run(Thread.java:1583)
```

/nocl test infrastructure