### PR TITLE
Fix search filter identity in event definition form state (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-14990.toml
+++ b/changelog/unreleased/issue-14990.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed editing, excluding and removing search filters in event definitions when the filter is not saved in \"My Filters\"."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14990"]
+pulls = ["26866", "Graylog2/graylog-plugin-enterprise#15088"]

--- a/graylog2-web-interface/src/components/common/SearchFiltersFormControls.test.tsx
+++ b/graylog2-web-interface/src/components/common/SearchFiltersFormControls.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { useFormikContext } from 'formik';
+import type { OrderedMap } from 'immutable';
+
+import asMock from 'helpers/mocking/AsMock';
+import usePluginEntities from 'hooks/usePluginEntities';
+import type { SearchFilter } from 'components/event-definitions/event-definitions-types';
+
+import SearchFiltersFormControls from './SearchFiltersFormControls';
+
+jest.mock('hooks/usePluginEntities');
+
+// Renders the form state the pluggable search filter bar is working with. All filter actions (edit, negate,
+// remove) address a filter by its `frontendId`, so it has to match the key it is stored under.
+const FormStateProbe = () => {
+  const {
+    values: { searchFilters },
+  } = useFormikContext<{ searchFilters: OrderedMap<string, SearchFilter> }>();
+
+  return (
+    <ul>
+      {searchFilters
+        .entrySeq()
+        .map(([key, filter]) => (
+          <li key={key}>{`${filter.title}: ${key === filter.frontendId ? 'matching' : 'mismatching'}`}</li>
+        ))
+        .toArray()}
+    </ul>
+  );
+};
+
+describe('SearchFiltersFormControls', () => {
+  const filter = (overrides: Partial<SearchFilter>): SearchFilter => ({
+    id: undefined,
+    type: 'inlineQueryString',
+    title: 'Filter',
+    queryString: 'http_method:POST',
+    disabled: false,
+    negation: false,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    asMock(usePluginEntities).mockImplementation(
+      (entityKey) =>
+        ({
+          'eventDefinitions.components.searchForm': [() => ({ id: 'search-filters', component: FormStateProbe })],
+        })[entityKey],
+    );
+  });
+
+  it('keys referenced filters by their id', async () => {
+    render(
+      <SearchFiltersFormControls
+        filters={[filter({ id: 'filter-id', type: 'referenced', title: 'Referenced filter' })]}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText('Referenced filter: matching')).toBeInTheDocument();
+  });
+
+  it('assigns the same generated id as key and frontendId for filters without an id', async () => {
+    render(
+      <SearchFiltersFormControls
+        filters={[filter({ title: 'First inline filter' }), filter({ title: 'Second inline filter' })]}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText('First inline filter: matching')).toBeInTheDocument();
+    expect(await screen.findByText('Second inline filter: matching')).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/SearchFiltersFormControls.tsx
+++ b/graylog2-web-interface/src/components/common/SearchFiltersFormControls.tsx
@@ -38,7 +38,14 @@ function SearchFiltersFormControls({ filters, onChange, hideFiltersPreview = () 
 
   const initialFilters = useMemo(() => {
     const searchFilters = OrderedMap(
-      filters.map((filter) => [filter.id || uuidv4(), { frontendId: filter.id || uuidv4(), ...filter }]),
+      filters.map((filter) => {
+        // The map key and the `frontendId` must be identical, since all filter actions (edit, negate, remove)
+        // look up the filter by its `frontendId`. Filters without an `id` (e.g. inline filters which are not
+        // saved in "My Filters") would otherwise end up with two different generated ids.
+        const frontendId = filter.id || uuidv4();
+
+        return [frontendId, { ...filter, frontendId }];
+      }),
     );
 
     return { searchFilters };


### PR DESCRIPTION
Note: This is a backport of #26866 to `7.1`.

## Description

`SearchFiltersFormControls` builds the Formik state that the enterprise search filter bar operates on. It used two independent `uuidv4()` calls for the `OrderedMap` key and the entry's `frontendId`:

```tsx
filters.map((filter) => [filter.id || uuidv4(), { frontendId: filter.id || uuidv4(), ...filter }])
```

For a filter with an `id` both sides agree. For a filter *without* an `id` — an inline filter that was not saved to `My Filters` — the key and the `frontendId` end up being two different random UUIDs. Since every filter action in the enterprise plugin addresses a filter by its `frontendId`, all of them then operate on a key that does not exist:

- `updateFilters(selectedFilters.delete(frontendId))` → no-op, so **Remove does nothing**
- `updateFilter(frontendId, …)` → `OrderedMap.set` on an unknown key **appends** a new entry and leaves the original in place, so **Edit and Exclude produce a duplicate**

The fix generates the id once and uses it for both the key and `frontendId`, matching what the search page already does in the enterprise plugin's `bindings.tsx`.

## Motivation and Context

Fixes Graylog2/graylog-plugin-enterprise#14990.

Also affects the Anomaly Events form and `FormikSearchFiltersFormControls`, which use the same component. Present since the feature was added in #17879.

The companion Enterprise PR (Graylog2/graylog-plugin-enterprise#15088) stops an inline filter from losing its `id` when its query is edited, which is what put the event definition into the id-less state in the first place. This PR is the one that actually fixes the broken actions, including for inline filters that never had an `id` (content packs, Sigma-generated event definitions, filters copied from a search).

## How Has This Been Tested?

New unit test `SearchFiltersFormControls.test.tsx` renders the component with a stub pluggable control that reports whether each map key matches its entry's `frontendId`, covering both a referenced filter and filters without an `id`. It fails before the change and passes after.

Full enterprise `search-filter` suite still green (117 tests), `tsc --noEmit` and `lint` clean for the touched files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

