### PR TITLE
Show Outputs and Pipelines counts for the default stream

### DIFF
--- a/changelog/unreleased/pr-26971.toml
+++ b/changelog/unreleased/pr-26971.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Show the Outputs and Pipelines count columns for the default stream in the Streams overview."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14572"]
+pulls = ["26971"]

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedOutputsActions.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedOutputsActions.test.tsx
@@ -29,12 +29,12 @@ describe('ExpandedOutputsActions', () => {
     expect(manageOutputsLink).toHaveAttribute('href', `/streams/${stream.id}/view?segment=destinations`);
   });
 
-  it('disables the button when the stream is the default stream', async () => {
+  it('keeps Manage Outputs enabled for the default stream (#14572)', async () => {
     render(<ExpandedOutputsActions stream={{ ...stream, is_default: true }} />);
 
-    const manageOutputsButton = await screen.findByRole('button', { name: /manage outputs/i });
+    const manageOutputsLink = await screen.findByRole('link', { name: /manage outputs/i });
 
-    expect(manageOutputsButton).toBeDisabled();
+    expect(manageOutputsLink).toHaveAttribute('href', `/streams/${stream.id}/view?segment=destinations`);
   });
 
   it('disables the button when the stream is not editable', async () => {

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedOutputsActions.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/ExpandedOutputsActions.tsx
@@ -28,7 +28,7 @@ type Props = {
 const ExpandedOutputsActions = ({ stream }: Props) => (
   <IfPermitted permissions={[`streams:edit:${stream.id}`]}>
     <LinkContainer to={`${Routes.stream_view(stream.id)}?segment=destinations`}>
-      <Button bsStyle="link" bsSize="xsmall" disabled={stream.is_default || !stream.is_editable}>
+      <Button bsStyle="link" bsSize="xsmall" disabled={!stream.is_editable}>
         Manage Outputs
       </Button>
     </LinkContainer>

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
@@ -30,7 +30,6 @@ const OutputsCell = ({ stream }: Props) => {
   const buttonRef = useRef();
   const { toggleSection, expandedSections } = useExpandedSections();
 
-  // Show the count for the default stream too - it can have outputs attached (#14572).
   if (!stream.is_editable) {
     return null;
   }

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/OutputsCell.tsx
@@ -30,7 +30,8 @@ const OutputsCell = ({ stream }: Props) => {
   const buttonRef = useRef();
   const { toggleSection, expandedSections } = useExpandedSections();
 
-  if (stream.is_default || !stream.is_editable) {
+  // Show the count for the default stream too - it can have outputs attached (#14572).
+  if (!stream.is_editable) {
     return null;
   }
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.test.tsx
@@ -39,7 +39,7 @@ describe('PipelinesCell (Streams)', () => {
     asMock(useExpandedSections).mockReturnValue({ toggleSection, expandedSections: {} });
   });
 
-  it('renders nothing for the default stream', () => {
+  it('renders the count for the default stream (#14572)', () => {
     asMock(useStreamMetricsFor).mockReturnValue({
       metrics: { pipelines: ['p-1'] },
       isInitialLoading: false,
@@ -48,7 +48,7 @@ describe('PipelinesCell (Streams)', () => {
 
     render(<PipelinesCell stream={{ ...stream, is_default: true } as any} />);
 
-    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
   it('renders nothing when the stream is not editable', () => {

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
@@ -33,7 +33,8 @@ const PipelinesCell = ({ stream }: Props) => {
   const { metrics, isInitialLoading, isError } = useStreamMetricsFor(stream.id);
   const { toggleSection, expandedSections } = useExpandedSections();
 
-  if (stream.is_default || !stream.is_editable) {
+  // Show the count for the default stream too - pipelines can connect to it (#14572).
+  if (!stream.is_editable) {
     return null;
   }
 

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/PipelinesCell.tsx
@@ -33,7 +33,6 @@ const PipelinesCell = ({ stream }: Props) => {
   const { metrics, isInitialLoading, isError } = useStreamMetricsFor(stream.id);
   const { toggleSection, expandedSections } = useExpandedSections();
 
-  // Show the count for the default stream too - pipelines can connect to it (#14572).
   if (!stream.is_editable) {
     return null;
   }


### PR DESCRIPTION
## What
Show the **Outputs** and **Pipelines** count columns for the default stream in the Streams overview table, and make the expanded **Manage Outputs** button consistent with the rest of the UI for the default stream.

## Why
Outputs and pipelines attached to the default stream were never displayed in the overview, even though other streams show them (Graylog2/graylog-plugin-enterprise#14572). The default stream can have outputs attached, and pipelines very commonly connect to it, so the empty columns were misleading.

## How
`OutputsCell` and `PipelinesCell` bailed out with a copy-pasted guard `stream.is_default || !stream.is_editable`, inherited from the bulk column-addition in #19763. The `is_default` clause was never appropriate for these two columns (unlike stream rules/status/archiving, which are genuinely N/A for the default stream). Dropped the `is_default` clause, keeping `!stream.is_editable`.

`ExpandedOutputsActions` (the **Manage Outputs** button in the expanded Outputs cell) carried the same guard and was disabled for the default stream — inconsistent with the row action-menu's Manage Outputs item and the Data Routing page, which both already allow managing default-stream outputs. Dropped the `is_default` clause there too.

## Details
- The default stream is editable (`NonDeletableSystemScope` is mutable), so it renders; truly non-editable system streams remain hidden via the retained `!is_editable` clause.
- Managing outputs on the default stream is fully supported (the backend's `StreamOutputResource` has no default-stream guard), so enabling the Manage Outputs button exposes no new capability — it just removes an inconsistency.
- The backend already returns outputs and pipeline connections for the default stream with no special-casing, so no server change is needed.
- `RoutingPipelinesCell` already renders for the default stream, so this makes the three "attachable to default" columns consistent.

## How tested
Updated `PipelinesCell.test.tsx` to assert the count renders for the default stream, and `ExpandedOutputsActions.test.tsx` to assert Manage Outputs stays enabled for the default stream.

Manual:
1. Add an output to the default stream (Stream → Data Routing → Destinations) and connect a pipeline to it.
2. Open the Streams overview: the default stream row now shows non-zero **Outputs** and **Pipelines** count badges, and expanding them lists the entries.
3. Expand the Outputs cell on the default stream row and confirm the **Manage Outputs** button is enabled and links to Data Routing → Destinations.

## Related
- Fixes Graylog2/graylog-plugin-enterprise#14572

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
