### PR TITLE
fix:  Entity sharing enumerates every content pack entity on every share

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/SecurityModule.java
+++ b/graylog2-server/src/main/java/org/graylog/security/SecurityModule.java
@@ -70,7 +70,8 @@ public class SecurityModule extends PluginModule {
         OptionalBinder.newOptionalBinder(binder(), GranteeService.class)
                 .setDefault().to(DefaultGranteeService.class);
         OptionalBinder.newOptionalBinder(binder(), EntityDependencyResolver.class)
-                .setDefault().to(DefaultEntityDependencyResolver.class);
+                .setDefault().to(DefaultEntityDependencyResolver.class)
+                .in(Scopes.SINGLETON);
 
         addEntityRegistrationHandler(EntityOwnershipRegistrationHandler.class);
 

--- a/graylog2-server/src/main/java/org/graylog/security/entities/DefaultEntityDependencyResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/DefaultEntityDependencyResolver.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security.entities;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import jakarta.inject.Inject;
@@ -36,15 +37,20 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class DefaultEntityDependencyResolver implements EntityDependencyResolver {
+    // Matches the TTL already used for the equivalent cache in org.graylog2.lookup.Catalog.
+    private static final long ENTITY_EXCERPTS_CACHE_TTL_SECONDS = 5;
     private final ContentPackEntityResolver contentPackEntityResolver;
     private final GRNRegistry grnRegistry;
     private final GRNDescriptorService descriptorService;
     private final DBGrantService grantService;
+    private final Supplier<ImmutableMap<GRN, Optional<String>>> entityExcerptsSupplier;
 
     @Inject
     public DefaultEntityDependencyResolver(ContentPackEntityResolver contentPackEntityResolver,
@@ -55,6 +61,9 @@ public class DefaultEntityDependencyResolver implements EntityDependencyResolver
         this.grnRegistry = grnRegistry;
         this.descriptorService = descriptorService;
         this.grantService = grantService;
+        this.entityExcerptsSupplier = Suppliers.memoizeWithExpiration(
+                this::computeEntityExcerpts, ENTITY_EXCERPTS_CACHE_TTL_SECONDS, TimeUnit.SECONDS);
+
     }
 
     @Override
@@ -130,6 +139,10 @@ public class DefaultEntityDependencyResolver implements EntityDependencyResolver
     }
 
     private ImmutableMap<GRN, Optional<String>> entityExcerpts() {
+        return entityExcerptsSupplier.get();
+    }
+
+    private ImmutableMap<GRN, Optional<String>> computeEntityExcerpts() {
         // TODO: Replace entity excerpt usage with GRNDescriptors once we implemented GRN descriptors for every entity
         return contentPackEntityResolver.listAllEntityExcerpts().stream()
                 // TODO: Use the GRNRegistry instead of manually building a GRN. Requires all entity types to be in the registry.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for Entity sharing enumerates every content pack entity on every share

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#26896 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

