### PR TITLE
Add lucene-backward-codecs to the server classpath

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -414,6 +414,11 @@
             <version>${lucene.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-backward-codecs</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
         </dependency>


### PR DESCRIPTION
## Motivation

Reading a Lucene index/segment written by an older Lucene *major* version requires
`lucene-backward-codecs` on the classpath. Concretely, OpenSearch 2.x writes Lucene 9
segments (codec `Lucene912`), and reading those with the server's Lucene 10 (`lucene-core`
ships only `Lucene104`) fails with:

    org.apache.lucene.index.IndexFormatTooOldException: Could not load codec 'Lucene912'.
    An SPI class of type org.apache.lucene.codecs.Codec with name 'Lucene912' does not exist.
    The current classpath supports the following names: [Lucene104].

This must live on the **server** classpath, next to `lucene-core`: Lucene's `Codec` SPI
registry is bound to `lucene-core`'s class loader. Providing `lucene-backward-codecs` only
from a plugin (loaded in an isolated child class loader) leaves the older codecs invisible
to the SPI at read time — the plugin's copy is never resolved.

## Approach

Add `lucene-backward-codecs` (managed at `${lucene.version}`) as a dependency of
`graylog2-server`, alongside the existing `lucene-core`/`lucene-analysis-common`
dependencies, so it is shaded into `graylog.jar` and available to the codec SPI for every
consumer of the server classpath.

This is a prerequisite for the OpenSearch-snapshot archiving feature (Graylog2/graylog-plugin-enterprise#14922),
which reads OS 2.x (Lucene 9) snapshot segments directly with Lucene. That feature previously declared
the dependency in its own plugin, where the SPI could not see it.

/nocl
