### PR TITLE
AD/LDAP team-sync: supporting method readEntryByDn (`7.1`)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/ldap/UnboundLDAPConnector.java
@@ -31,6 +31,7 @@ import com.unboundid.ldap.sdk.LDAPBindException;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.LDAPConnectionOptions;
 import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.LDAPSearchException;
 import com.unboundid.ldap.sdk.ResultCode;
 import com.unboundid.ldap.sdk.SearchRequest;
 import com.unboundid.ldap.sdk.SearchResult;
@@ -177,6 +178,37 @@ public class UnboundLDAPConnector {
         return searchResult.getSearchEntries().stream()
                 .map(entry -> createLDAPEntry(entry, uniqueIdAttribute))
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Reads a single entry by its DN, with {@link SearchScope#BASE} at that DN rather than a subtree search
+     * from a configured base. Callers that follow DN references out of their own search base need this - AD
+     * {@code memberOf} nesting, for example, can point at a group outside the configured group search base,
+     * and a subtree search from that base cannot see it.
+     *
+     * @return empty if nothing is readable at the DN: it does not exist, or it lives in a partition this
+     * connection cannot follow. Both are dead ends for the caller rather than failures.
+     */
+    public Optional<LDAPEntry> readEntryByDn(LDAPConnection connection,
+                                             String dn,
+                                             String uniqueIdAttribute,
+                                             Set<String> attributes) throws LDAPException {
+        final Filter filter = Filter.createPresenceFilter(OBJECT_CLASS_ATTRIBUTE);
+        final SearchRequest searchRequest =
+                new SearchRequest(dn, SearchScope.BASE, filter, buildLdapSearchBase(dn, filter, attributes));
+        searchRequest.setTimeLimitSeconds(requestTimeoutSeconds);
+
+        try {
+            return connection.search(searchRequest).getSearchEntries().stream()
+                    .findFirst()
+                    .map(entry -> createLDAPEntry(entry, uniqueIdAttribute));
+        } catch (LDAPSearchException e) {
+            if (ResultCode.NO_SUCH_OBJECT.equals(e.getResultCode()) || ResultCode.REFERRAL.equals(e.getResultCode())) {
+                LOG.debug("No entry readable at DN <{}>: {}", dn, e.getResultCode());
+                return Optional.empty();
+            }
+            throw e;
+        }
     }
 
     public List<LDAPEntry> searchPaginated(LDAPConnection connection,

--- a/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authservice/ldap/UnboundLDAPConnectorTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -134,6 +135,28 @@ public class UnboundLDAPConnectorTest extends AbstractLdapTestUnit {
         assertThat(new String(Base64.getDecoder().decode(entry.base64UniqueId()), StandardCharsets.UTF_8))
                 .isNotBlank()
                 .matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}");
+    }
+
+    @Test
+    public void readEntryByDnReadsAtTheDnItselfWithNoSearchBase() throws Exception {
+        // The point of this method: callers following DN references (AD memberOf nesting) need an entry that
+        // a subtree search from their configured base would not reach.
+        final Optional<LDAPEntry> entry = connector.readEntryByDn(connection,
+                "cn=John Doe,ou=users,dc=example,dc=com", "entryUUID",
+                ImmutableSet.of("cn", "uid", "entryUUID"));
+
+        assertThat(entry).isPresent();
+        assertThat(entry.get().dn()).isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+        assertThat(entry.get().firstAttributeValue("uid")).contains("john");
+    }
+
+    @Test
+    public void readEntryByDnReturnsEmptyForAMissingDnInsteadOfThrowing() throws Exception {
+        // A stale memberOf back-link pointing at a deleted group must be a dead end for the caller, not an
+        // exception that fails the whole login.
+        assertThat(connector.readEntryByDn(connection,
+                "cn=Does Not Exist,ou=users,dc=example,dc=com", "entryUUID", ImmutableSet.of("cn", "entryUUID")))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Note: This is a backport of #26947 to `7.1`.

/nocl  No user-facing behaviour on its own; changelog is in the linked enterprise PR

## Description

Adds `UnboundLDAPConnector.readEntryByDn`, needed by Graylog2/graylog-plugin-enterprise#15155.

Both existing search methods are `SearchScope.SUB` from a caller-supplied base, so a caller that follows a DN reference *out of* its own search base cannot read that entry at all. AD `memberOf` nesting does exactly that: a chain can pass through a group in another OU.

`readEntryByDn` reads at the DN itself with `SearchScope.BASE`. `noSuchObject` and `referral` come back as an empty `Optional` rather than an exception - a stale `memberOf` back-link pointing at a deleted group, or a DN in a domain this connection cannot follow, is a dead end for the caller, not a reason to fail the login it is running under.

The enterprise side uses it to fix org-wide AD reconciliation dropping team memberships reachable only through a group outside the configured group search base. Details and the live repro are in the linked PR. Nothing in this repo calls it yet, so there is no behaviour change here on its own.

## How Tested

- `UnboundLDAPConnectorTest`: **9 tests, 0 failures** against the in-process ApacheDS, including two new cases

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

/prd Graylog2/graylog-plugin-enterprise#15223
