### PR TITLE
Align resource permissions for simulate and parse to `CREATE` permissions

### DIFF
--- a/changelog/unreleased/pr-27003.toml
+++ b/changelog/unreleased/pr-27003.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Align pipeline resource permissions for simulate and parse to CREATE permissions."
+
+issues = []
+pulls = ["27003"]

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
@@ -1,0 +1,4 @@
+package org.graylog.pipelines;
+
+public class PipelinePermissionTestsIT {
+}

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.pipelines;
 
 import net.bytebuddy.utility.RandomString;

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
@@ -19,6 +19,7 @@ package org.graylog.pipelines;
 import net.bytebuddy.utility.RandomString;
 import org.apache.http.HttpStatus;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineSource;
 import org.graylog.testing.completebackend.FullBackendTest;
 import org.graylog.testing.completebackend.GraylogBackendConfiguration;
 import org.graylog.testing.completebackend.apis.GraylogApiResponse;
@@ -27,6 +28,7 @@ import org.graylog.testing.completebackend.apis.Users;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
+import java.util.List;
 import java.util.Set;
 
 
@@ -40,11 +42,20 @@ public class PipelinePermissionTestsIT {
     @BeforeAll
     static void setUp(GraylogApis graylogApis) {
         api = graylogApis;
-        ruleCreatorRole = api.roles().create("custom_rule_creator", "test role for allowing rule creation", Set.of(
-                PipelineRestPermissions.PIPELINE_RULE_CREATE
+        ruleCreatorRole = api.roles().create("custom_pipeline_creator", "test role for allowing pipeline creation", Set.of(
+                PipelineRestPermissions.PIPELINE_CREATE
         ), false);
-        ruleCreator = api.users().generateUserWithDefaults("inputs.reader", RandomString.make(), ruleCreatorRole);
+        ruleCreator = api.users().generateUserWithDefaults("pipeline.creator", RandomString.make(), ruleCreatorRole);
         api.users().createUser(ruleCreator);
+    }
+
+    private String createPipelineSource(String ruleName) {
+        return """
+                pipeline "MyPipe"
+                stage 0 match either
+                rule "%s"
+                end
+                """.formatted(ruleName);
     }
 
     @AfterAll
@@ -55,15 +66,15 @@ public class PipelinePermissionTestsIT {
 
     @FullBackendTest
     void testParseNotPermittedForReader() {
-        api.forUser(Users.JOHN_DOE).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_UNAUTHORIZED);
+        api.forUser(Users.JOHN_DOE).pipelines().parse("Title", "Description", "pipeline \"test1\"\nstage 0 match either\nend", HttpStatus.SC_UNAUTHORIZED);
     }
 
     @FullBackendTest
     void testParsePermittedForAdmin() {
-        api.forUser(Users.LOCAL_ADMIN).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_OK);
+        api.forUser(Users.LOCAL_ADMIN).pipelines().parse("Title", "Description", "pipeline \"test2\"\nstage 0 match either\nend", HttpStatus.SC_OK);
     }
     @FullBackendTest
     void testParsePermittedForUser() {
-        api.forUser(ruleCreator).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_OK);
+        api.forUser(ruleCreator).pipelines().parse("Title", "Description", "pipeline \"test3\"\nstage 0 match either\nend", HttpStatus.SC_OK);
     }
 }

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
@@ -55,7 +55,7 @@ public class PipelinePermissionTestsIT {
 
     @FullBackendTest
     void testParseNotPermittedForReader() {
-        api.forUser(Users.JOHN_DOE).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_FORBIDDEN);
+        api.forUser(Users.JOHN_DOE).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_UNAUTHORIZED);
     }
 
     @FullBackendTest

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/PipelinePermissionTestsIT.java
@@ -1,4 +1,53 @@
 package org.graylog.pipelines;
 
+import net.bytebuddy.utility.RandomString;
+import org.apache.http.HttpStatus;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
+import org.graylog.testing.completebackend.FullBackendTest;
+import org.graylog.testing.completebackend.GraylogBackendConfiguration;
+import org.graylog.testing.completebackend.apis.GraylogApiResponse;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.Users;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Set;
+
+
+@GraylogBackendConfiguration
 public class PipelinePermissionTestsIT {
+    private static GraylogApis api;
+
+    private static Users.User ruleCreator;
+    private static GraylogApiResponse ruleCreatorRole;
+
+    @BeforeAll
+    static void setUp(GraylogApis graylogApis) {
+        api = graylogApis;
+        ruleCreatorRole = api.roles().create("custom_rule_creator", "test role for allowing rule creation", Set.of(
+                PipelineRestPermissions.PIPELINE_RULE_CREATE
+        ), false);
+        ruleCreator = api.users().generateUserWithDefaults("inputs.reader", RandomString.make(), ruleCreatorRole);
+        api.users().createUser(ruleCreator);
+    }
+
+    @AfterAll
+    void tearDown() {
+        api.users().deleteUser(ruleCreator.username());
+        api.roles().delete(ruleCreatorRole.properJSONPath().read("name", String.class));
+    }
+
+    @FullBackendTest
+    void testParseNotPermittedForReader() {
+        api.forUser(Users.JOHN_DOE).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_FORBIDDEN);
+    }
+
+    @FullBackendTest
+    void testParsePermittedForAdmin() {
+        api.forUser(Users.LOCAL_ADMIN).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_OK);
+    }
+    @FullBackendTest
+    void testParsePermittedForUser() {
+        api.forUser(ruleCreator).pipelines().parse("Title", "Description", "Source", HttpStatus.SC_OK);
+    }
 }

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
@@ -57,7 +57,7 @@ public class RulePermissionTestsIT {
 
     @FullBackendTest
     void testParseNotPermittedForReader() {
-        api.forUser(Users.JOHN_DOE).rules().parse(VALID_RULE_SOURCE, HttpStatus.SC_FORBIDDEN);
+        api.forUser(Users.JOHN_DOE).rules().parse(VALID_RULE_SOURCE, HttpStatus.SC_UNAUTHORIZED);
     }
 
     @FullBackendTest
@@ -72,7 +72,7 @@ public class RulePermissionTestsIT {
 
     @FullBackendTest
     void testSimulateNotPermittedForReader() {
-        api.forUser(Users.JOHN_DOE).rules().simulate(VALID_MESSAGE, VALID_RULE_SOURCE, HttpStatus.SC_FORBIDDEN);
+        api.forUser(Users.JOHN_DOE).rules().simulate(VALID_MESSAGE, VALID_RULE_SOURCE, HttpStatus.SC_UNAUTHORIZED);
     }
 
     @FullBackendTest

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
@@ -1,0 +1,71 @@
+package org.graylog.pipelines;
+
+import net.bytebuddy.utility.RandomString;
+import org.apache.http.HttpStatus;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
+import org.graylog.testing.completebackend.FullBackendTest;
+import org.graylog.testing.completebackend.GraylogBackendConfiguration;
+import org.graylog.testing.completebackend.apis.GraylogApiResponse;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.Users;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Set;
+
+@GraylogBackendConfiguration
+public class RulePermissionTestsIT {
+    private static final String VALID_RULE_SOURCE = "rule \"test\"\nwhen\n  true\nthen\nend";
+    private static final String VALID_MESSAGE = "test message";
+
+    private static GraylogApis api;
+
+    private static Users.User ruleCreator;
+    private static GraylogApiResponse ruleCreatorRole;
+
+    @BeforeAll
+    static void setUp(GraylogApis graylogApis) {
+        api = graylogApis;
+        ruleCreatorRole = api.roles().create("custom_rule_creator", "test role for allowing rule creation", Set.of(
+                PipelineRestPermissions.PIPELINE_RULE_CREATE
+        ), false);
+        ruleCreator = api.users().generateUserWithDefaults("rule.creator", RandomString.make(), ruleCreatorRole);
+        api.users().createUser(ruleCreator);
+    }
+
+    @AfterAll
+    void tearDown() {
+        api.users().deleteUser(ruleCreator.username());
+        api.roles().delete(ruleCreatorRole.properJSONPath().read("name", String.class));
+    }
+
+    @FullBackendTest
+    void testParseNotPermittedForReader() {
+        api.forUser(Users.JOHN_DOE).rules().parse(VALID_RULE_SOURCE, HttpStatus.SC_FORBIDDEN);
+    }
+
+    @FullBackendTest
+    void testParsePermittedForAdmin() {
+        api.forUser(Users.LOCAL_ADMIN).rules().parse(VALID_RULE_SOURCE, HttpStatus.SC_OK);
+    }
+
+    @FullBackendTest
+    void testParsePermittedForUser() {
+        api.forUser(ruleCreator).rules().parse(VALID_RULE_SOURCE, HttpStatus.SC_OK);
+    }
+
+    @FullBackendTest
+    void testSimulateNotPermittedForReader() {
+        api.forUser(Users.JOHN_DOE).rules().simulate(VALID_MESSAGE, VALID_RULE_SOURCE, HttpStatus.SC_FORBIDDEN);
+    }
+
+    @FullBackendTest
+    void testSimulatePermittedForAdmin() {
+        api.forUser(Users.LOCAL_ADMIN).rules().simulate(VALID_MESSAGE, VALID_RULE_SOURCE, HttpStatus.SC_OK);
+    }
+
+    @FullBackendTest
+    void testSimulatePermittedForUser() {
+        api.forUser(ruleCreator).rules().simulate(VALID_MESSAGE, VALID_RULE_SOURCE, HttpStatus.SC_OK);
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/RulePermissionTestsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.pipelines;
 
 import net.bytebuddy.utility.RandomString;

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.pipelines;
 
 import net.bytebuddy.utility.RandomString;

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
@@ -36,6 +36,7 @@ import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
 @GraylogBackendConfiguration
 public class SimulatorPermissionTestsIT {
     private static final Map<String, Object> TEST_MESSAGE = Map.of(
+                "_id", "1",
             "message", "test message",
             "source", "test"
     );
@@ -64,7 +65,7 @@ public class SimulatorPermissionTestsIT {
 
     @FullBackendTest
     void testSimulateNotPermittedForReader() {
-        api.forUser(Users.JOHN_DOE).simulator().simulate(DEFAULT_STREAM_ID, TEST_MESSAGE, HttpStatus.SC_FORBIDDEN);
+        api.forUser(Users.JOHN_DOE).simulator().simulate(DEFAULT_STREAM_ID, TEST_MESSAGE, HttpStatus.SC_UNAUTHORIZED);
     }
 
     @FullBackendTest

--- a/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/pipelines/SimulatorPermissionTestsIT.java
@@ -1,0 +1,63 @@
+package org.graylog.pipelines;
+
+import net.bytebuddy.utility.RandomString;
+import org.apache.http.HttpStatus;
+import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
+import org.graylog.testing.completebackend.FullBackendTest;
+import org.graylog.testing.completebackend.GraylogBackendConfiguration;
+import org.graylog.testing.completebackend.apis.GraylogApiResponse;
+import org.graylog.testing.completebackend.apis.GraylogApis;
+import org.graylog.testing.completebackend.apis.Users;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.graylog2.plugin.streams.Stream.DEFAULT_STREAM_ID;
+
+@GraylogBackendConfiguration
+public class SimulatorPermissionTestsIT {
+    private static final Map<String, Object> TEST_MESSAGE = Map.of(
+            "message", "test message",
+            "source", "test"
+    );
+
+    private static GraylogApis api;
+
+    private static Users.User simulatorUser;
+    private static GraylogApiResponse simulatorRole;
+
+    @BeforeAll
+    static void setUp(GraylogApis graylogApis) {
+        api = graylogApis;
+        simulatorRole = api.roles().create("custom_simulator", "test role for allowing pipeline simulation", Set.of(
+                PipelineRestPermissions.PIPELINE_RULE_CREATE,
+                RestPermissions.STREAMS_READ
+        ), false);
+        simulatorUser = api.users().generateUserWithDefaults("simulator.user", RandomString.make(), simulatorRole);
+        api.users().createUser(simulatorUser);
+    }
+
+    @AfterAll
+    void tearDown() {
+        api.users().deleteUser(simulatorUser.username());
+        api.roles().delete(simulatorRole.properJSONPath().read("name", String.class));
+    }
+
+    @FullBackendTest
+    void testSimulateNotPermittedForReader() {
+        api.forUser(Users.JOHN_DOE).simulator().simulate(DEFAULT_STREAM_ID, TEST_MESSAGE, HttpStatus.SC_FORBIDDEN);
+    }
+
+    @FullBackendTest
+    void testSimulatePermittedForAdmin() {
+        api.forUser(Users.LOCAL_ADMIN).simulator().simulate(DEFAULT_STREAM_ID, TEST_MESSAGE, HttpStatus.SC_OK);
+    }
+
+    @FullBackendTest
+    void testSimulatePermittedForUser() {
+        api.forUser(simulatorUser).simulator().simulate(DEFAULT_STREAM_ID, TEST_MESSAGE, HttpStatus.SC_OK);
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog2/inputs/InputPermissionsIT.java
+++ b/full-backend-tests/src/test/java/org/graylog2/inputs/InputPermissionsIT.java
@@ -56,14 +56,14 @@ public class InputPermissionsIT {
         roleInputsReader = apis.roles().create("custom_inputs_reader", "inputs reader can only see inputs", Set.of(
                 RestPermissions.INPUTS_READ
         ), false);
-        inputsReader = createUser("inputs.reader", roleInputsReader);
+        inputsReader = apis.users().generateUserWithDefaults("inputs.reader", RandomString.make(), roleInputsReader);
 
         roleInputsCreator = apis.roles().create("custom_inputs_creator", "inputs creator can only create inputs", Set.of(
                 RestPermissions.INPUTS_READ,
                 RestPermissions.INPUTS_CREATE,
                 RestPermissions.INPUT_TYPES_CREATE
         ), false);
-        inputsCreator = createUser("inputs.creator", roleInputsCreator);
+        inputsCreator = apis.users().generateUserWithDefaults("inputs.creator", RandomString.make(), roleInputsCreator);
 
         roleRestrictedInputsCreator = apis.roles().create("custom_restricted_inputs_creator", "inputs creator can only create certain inputs", Set.of(
                 RestPermissions.INPUTS_READ,
@@ -72,7 +72,7 @@ public class InputPermissionsIT {
                 RestPermissions.INPUT_TYPES_CREATE + ":org.graylog2.inputs.gelf.tcp.GELFTCPInput"
 
         ), false);
-        restrictedInputsCreator = createUser("restricted.inputs.creator", roleRestrictedInputsCreator);
+        restrictedInputsCreator = apis.users().generateUserWithDefaults("restricted.inputs.creator", RandomString.make(), roleRestrictedInputsCreator);
 
         waitForRolesCacheRefresh();
 
@@ -95,12 +95,6 @@ public class InputPermissionsIT {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static Users.User createUser(String username, GraylogApiResponse... roles) {
-        return new Users.User(username, RandomString.make(), "<Generated>", username,
-                username + "@graylog", false, 30_0000, "Europe/Vienna",
-                Arrays.stream(roles).map(role -> role.properJSONPath().read("name", String.class)).toList(), List.of());
     }
 
     @AfterAll

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/PipelineResource.java
@@ -173,6 +173,7 @@ public class PipelineResource extends RestResource implements PluginRestResource
     @POST
     @Path("/parse")
     @NoAuditEvent("only used to parse a pipeline, no changes made in the system")
+    @RequiresPermissions(PipelineRestPermissions.PIPELINE_CREATE)
     public PipelineSource parse(@Parameter(name = "pipeline", required = true) @NotNull PipelineSource pipelineSource) throws ParseException {
         checkReservedName(pipelineSource);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
@@ -156,6 +156,7 @@ public class RuleResource extends RestResource implements PluginRestResource {
     @POST
     @Path("/parse")
     @NoAuditEvent("only used to parse a rule, no changes made in the system")
+    @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_CREATE)
     public RuleSource parse(@Parameter(name = "rule", required = true) @NotNull RuleSource ruleSource) throws ParseException {
         final Rule rule = pipelineRuleService.parseRuleOrThrow(ruleSource.id(), ruleSource.source(), true);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
@@ -173,6 +174,7 @@ public class RuleResource extends RestResource implements PluginRestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/simulate")
     @NoAuditEvent("only used to test a rule, no changes made in the system")
+    @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_CREATE)
     public Message simulate(
             @Parameter(name = "request", required = true) @NotNull SimulateRuleRequest request
     ) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -75,7 +75,7 @@ public class SimulatorResource extends RestResource implements PluginRestResourc
 
     @Operation(summary = "Simulate the execution of the pipeline message processor")
     @POST
-    @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_READ)
+    @RequiresPermissions(PipelineRestPermissions.PIPELINE_RULE_CREATE)
     @NoAuditEvent("only used to test pipelines, no changes made in the system")
     public SimulationResponse simulate(@Parameter(name = "simulation", required = true) @NotNull SimulationRequest request) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, request.streamId());

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/GraylogApis.java
@@ -70,6 +70,8 @@ public class GraylogApis implements GraylogRestApi {
     private final EventDefinitions eventDefinitions;
     private final Dashboards dashboards;
     private final Pipelines pipelines;
+    private final Rules rules;
+    private final Simulator simulator;
     private final Inputs inputs;
     private final Roles roles;
 
@@ -95,6 +97,8 @@ public class GraylogApis implements GraylogRestApi {
         this.eventDefinitions = new EventDefinitions(this);
         this.dashboards = new Dashboards(this);
         this.pipelines = new Pipelines(this);
+        this.rules = new Rules(this);
+        this.simulator = new Simulator(this);
         this.inputs = new Inputs(this);
         this.roles = new Roles(this);
     }
@@ -176,6 +180,14 @@ public class GraylogApis implements GraylogRestApi {
 
     public Pipelines pipelines() {
         return pipelines;
+    }
+
+    public Rules rules() {
+        return rules;
+    }
+
+    public Simulator simulator() {
+        return simulator;
     }
 
     public Inputs inputs() {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Pipelines.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Pipelines.java
@@ -72,6 +72,21 @@ public class Pipelines {
                 .statusCode(200);
     }
 
+    public ValidatableResponse parse(String source) {
+        return parse("", "", source, HttpStatus.SC_OK);
+    }
+
+    public ValidatableResponse parse(String title, String description, String source, int expectedStatus) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .body(new CreatePipelineRequest(title, description, source))
+                .post(URL_PREFIX + "/parse")
+                .then()
+                .log().ifError()
+                .statusCode(expectedStatus);
+    }
+
     public ValidatableResponse delete(String id) {
         return api.delete(url(id), HttpStatus.SC_NO_CONTENT);
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Pipelines.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Pipelines.java
@@ -72,8 +72,8 @@ public class Pipelines {
                 .statusCode(200);
     }
 
-    public ValidatableResponse parse(String source) {
-        return parse("", "", source, HttpStatus.SC_OK);
+    public ValidatableResponse parse(String title, String description, String source) {
+        return parse(title, description, source, HttpStatus.SC_OK);
     }
 
     public ValidatableResponse parse(String title, String description, String source, int expectedStatus) {

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Rules.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Rules.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.completebackend.apis;
+
+import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpStatus;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class Rules {
+    private static final String URL_PREFIX = "/system/pipelines/rule";
+    private final GraylogApis api;
+
+    public Rules(GraylogApis api) {
+        this.api = api;
+    }
+
+    public ValidatableResponse parse(String source) {
+        return parse(source, HttpStatus.SC_OK);
+    }
+
+    public ValidatableResponse parse(String source, int expectedStatus) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .body(Map.of("source", source))
+                .post(URL_PREFIX + "/parse")
+                .then()
+                .log().ifError()
+                .statusCode(expectedStatus);
+    }
+
+    public ValidatableResponse simulate(String message, String ruleSource) {
+        return simulate(message, ruleSource, HttpStatus.SC_OK);
+    }
+
+    public ValidatableResponse simulate(String message, String ruleSource, int expectedStatus) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .body(Map.of("message", message, "rule_source", Map.of("source", ruleSource)))
+                .post(URL_PREFIX + "/simulate")
+                .then()
+                .log().ifError()
+                .statusCode(expectedStatus);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Simulator.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Simulator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.testing.completebackend.apis;
+
+import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpStatus;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class Simulator {
+    private static final String URL_PREFIX = "/system/pipelines/simulate";
+    private final GraylogApis api;
+
+    public Simulator(GraylogApis api) {
+        this.api = api;
+    }
+
+    public ValidatableResponse simulate(String streamId, Map<String, Object> message) {
+        return simulate(streamId, message, HttpStatus.SC_OK);
+    }
+
+    public ValidatableResponse simulate(String streamId, Map<String, Object> message, int expectedStatus) {
+        return given()
+                .spec(api.requestSpecification())
+                .when()
+                .body(Map.of("stream_id", streamId, "message", message))
+                .post(URL_PREFIX)
+                .then()
+                .log().ifError()
+                .statusCode(expectedStatus);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Users.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/apis/Users.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 import jakarta.ws.rs.core.Response;
+import net.bytebuddy.utility.RandomString;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
@@ -62,6 +64,12 @@ public class Users implements GraylogRestApi {
                 .statusCode(201);
 
         return getUserInfo(user.username);
+    }
+
+    public User generateUserWithDefaults(String username, String password, GraylogApiResponse... roles) {
+        return new User(username, password, "<Generated>", username,
+                username + "@graylog", false, 30_0000, "Europe/Vienna",
+                Arrays.stream(roles).map(role -> role.properJSONPath().read("name", String.class)).toList(), List.of());
     }
 
     public void deleteUser(String username) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

After some internal discussion, it was decided that the permissions for simulating and parsing pipeline rules should only be used by a user that has the `CREATE` permissions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Adding permission checks via annotations is more configuration than actual code. So there is no test in code but only manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

