### PR TITLE
Feat/funnle visualization

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -124,6 +124,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.AreaVisualizat
 import org.graylog.plugins.views.search.views.widgets.aggregation.AutoIntervalDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.BarVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.DataTableVisualizationConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.aggregation.FunnelVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.HeatmapVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.LineVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.NetworkVisualizationConfigDTO;
@@ -345,6 +346,7 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(DataTableVisualizationConfigDTO.class);
         registerJacksonSubtype(ScatterVisualizationConfigDTO.class);
         registerJacksonSubtype(NetworkVisualizationConfigDTO.class);
+        registerJacksonSubtype(FunnelVisualizationConfigDTO.class);
     }
 
     private void registerParameterSubtypes() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/FunnelVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/FunnelVisualizationConfigDTO.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonTypeName(FunnelVisualizationConfigDTO.NAME)
+@JsonDeserialize(builder = FunnelVisualizationConfigDTO.Builder.class)
+public abstract class FunnelVisualizationConfigDTO implements VisualizationConfigDTO {
+    public static final String NAME = "funnel";
+
+    @JsonProperty("start_color")
+    public abstract String startColor();
+
+    @JsonProperty("end_color")
+    public abstract String endColor();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty("start_color")
+        public abstract Builder startColor(String startColor);
+
+        @JsonProperty("end_color")
+        public abstract Builder endColor(String endColor);
+
+        public abstract FunnelVisualizationConfigDTO build();
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_FunnelVisualizationConfigDTO.Builder()
+                    .startColor("#1F77B4")
+                    .endColor("#AEC7E8");
+        }
+    }
+}

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -96,6 +96,8 @@ import visualizationBindings from 'views/components/visualizations/bindings';
 import { AggregationWizard } from 'views/components/aggregationwizard';
 import { filterCloudValueActions } from 'util/conditional/filterValueActions';
 import DataTableVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/DataTableVisualizationConfig';
+import FunnelVisualization from 'views/components/visualizations/funnel/FunnelVisualization';
+import FunnelVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
 import ViewHeader from 'views/components/views/ViewHeader';
 import ScatterVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/ScatterVisualizationConfig';
 import ScatterVisualization from 'views/components/visualizations/scatter/ScatterVisualization';
@@ -156,6 +158,7 @@ VisualizationConfig.registerSubtype(HeatmapVisualization.type, HeatmapVisualizat
 VisualizationConfig.registerSubtype(NetworkGraphVisualization.type, NetworkVisualizationConfig);
 VisualizationConfig.registerSubtype(DataTable.type, DataTableVisualizationConfig);
 VisualizationConfig.registerSubtype(ScatterVisualization.type, ScatterVisualizationConfig);
+VisualizationConfig.registerSubtype(FunnelVisualization.type, FunnelVisualizationConfig);
 
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);

--- a/graylog2-web-interface/src/views/components/visualizations/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bindings.tsx
@@ -19,6 +19,7 @@ import { bindings as dataTable } from 'views/components/datatable';
 
 import areaChart from './area/bindings';
 import barChart from './bar/bindings';
+import funnelChart from './funnel/bindings';
 import heatmap from './heatmap/bindings';
 import lineChart from './line/bindings';
 import networkGraph from './network/bindings';
@@ -32,6 +33,7 @@ const visualizationBindings: Array<VisualizationType<any>> = [
   areaChart,
   barChart,
   dataTable,
+  funnelChart,
   heatmap,
   lineChart,
   networkGraph,

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelColorPickerField.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelColorPickerField.tsx
@@ -15,14 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React, { useCallback } from 'react';
-import { useFormikContext } from 'formik';
-import get from 'lodash/get';
+import { useField } from 'formik';
 import styled from 'styled-components';
 
 import type { CustomFieldComponentProps } from 'views/types';
-import type { WidgetConfigFormValues } from 'views/components/aggregationwizard';
 import ColorConfigurationPopover from 'views/components/aggregationwizard/ColorConfigurationPopover';
-
 import { DEFAULT_FUNNEL_START_COLOR } from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
 
 const Row = styled.div`
@@ -33,12 +30,12 @@ const Row = styled.div`
 `;
 
 const FunnelColorPickerField = ({ name, title, field }: CustomFieldComponentProps) => {
-  const { values, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
-  const curColor = (get(values, name) as string | undefined) ?? DEFAULT_FUNNEL_START_COLOR;
+  const [{ value }, , { setValue }] = useField<string>(name);
+  const curColor = value ?? DEFAULT_FUNNEL_START_COLOR;
 
   const onColorSelect = useCallback(
-    (color: string) => setFieldValue(name, color),
-    [name, setFieldValue],
+    (color: string) => setValue(color),
+    [setValue],
   );
 
   return (

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelColorPickerField.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelColorPickerField.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React, { useCallback } from 'react';
+import { useFormikContext } from 'formik';
+import get from 'lodash/get';
+import styled from 'styled-components';
+
+import type { CustomFieldComponentProps } from 'views/types';
+import type { WidgetConfigFormValues } from 'views/components/aggregationwizard';
+import ColorConfigurationPopover from 'views/components/aggregationwizard/ColorConfigurationPopover';
+
+import { DEFAULT_FUNNEL_START_COLOR } from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+`;
+
+const FunnelColorPickerField = ({ name, title, field }: CustomFieldComponentProps) => {
+  const { values, setFieldValue } = useFormikContext<WidgetConfigFormValues>();
+  const curColor = (get(values, name) as string | undefined) ?? DEFAULT_FUNNEL_START_COLOR;
+
+  const onColorSelect = useCallback(
+    (color: string) => setFieldValue(name, color),
+    [name, setFieldValue],
+  );
+
+  return (
+    <Row>
+      {title}
+      <ColorConfigurationPopover title={field.title} curColor={curColor} onColorSelect={onColorSelect} />
+    </Row>
+  );
+};
+
+export default FunnelColorPickerField;

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelVisualization.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled, { css, useTheme } from 'styled-components';
+import chroma from 'chroma-js';
+
+import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+import FunnelVisualizationConfig, {
+  DEFAULT_FUNNEL_START_COLOR,
+  DEFAULT_FUNNEL_END_COLOR,
+} from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
+import Tooltip from 'components/common/Tooltip';
+
+import { computeFunnelGeometry, LABEL_AREA, MIN_LABEL_PX } from './funnelGeometry';
+import { formatCount, subPartColors } from './buildStages';
+import useFunnelStages from './useFunnelStages';
+import useFunnelOnClickPopover from './useFunnelOnClickPopover';
+
+export const FUNNEL_VISUALIZATION_TYPE = 'funnel' as const;
+
+const Container = styled.div`
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const EmptyStateWrapper = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    padding: ${theme.spacings.md};
+    color: ${theme.colors.text.secondary};
+    text-align: center;
+  `,
+);
+
+type PartRect = { y: number; h: number; color: string; label: string; value: number };
+
+const FunnelVisualization = makeVisualization(({ config, data, width, height }: VisualizationComponentProps) => {
+  const theme = useTheme();
+  const { stages, rowFields, colFields } = useFunnelStages(config, data);
+  const { handleRectClick, popover } = useFunnelOnClickPopover();
+
+  if (!stages || width === 0 || height === 0) {
+    return <EmptyStateWrapper>No data to display. Add a grouping field and a metric.</EmptyStateWrapper>;
+  }
+
+  // ── Colors ──────────────────────────────────────────────────────────────
+  const vizConfig = config.visualizationConfig as FunnelVisualizationConfig | undefined;
+  const startColor = vizConfig?.startColor ?? DEFAULT_FUNNEL_START_COLOR;
+  const endColor = vizConfig?.endColor ?? DEFAULT_FUNNEL_END_COLOR;
+  const stageColors = chroma.scale([startColor, endColor]).mode('lab').colors(stages.length);
+
+  // ── Geometry ────────────────────────────────────────────────────────────
+  const { nW, stageH, top, nl, transitionPath } = computeFunnelGeometry(stages, width, height);
+
+  const layoutParts = (stageIdx: number): PartRect[] => {
+    const stage = stages[stageIdx];
+    const totalH = stageH(stageIdx);
+    const colors = subPartColors(stageColors[stageIdx], stage.parts.length);
+    let y = top(stageIdx);
+
+    return stage.parts.map((part, partIdx) => {
+      const h = (part.value / stage.value) * totalH;
+      const rect: PartRect = { y, h, color: colors[partIdx], label: part.label, value: part.value };
+      y += h;
+
+      return rect;
+    });
+  };
+
+  const rowField = rowFields[0] ?? '';
+  const colField = colFields[0] ?? '';
+
+  return (
+    <>
+      <Container>
+        <svg width={width} height={height}>
+          {/* ── Stage boxes ─────────────────────────────────────────────── */}
+          {stages.map((stage, i) => {
+            if (stage.parts.length === 0) {
+              return (
+                <rect
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                  x={nl(i)} y={top(i)} width={nW} height={stageH(i)}
+                  fill={stageColors[i]}
+                  style={{ cursor: 'pointer' }}
+                  onClick={(e) => handleRectClick(e, rowField, stage.label)}
+                />
+              );
+            }
+
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <g key={i}>
+                {layoutParts(i).map((pr, partIdx) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <g key={partIdx}>
+                    <Tooltip label={`${pr.label}: ${formatCount(pr.value)}`} withArrow position="top" disabled={pr.h >= MIN_LABEL_PX}>
+                      <rect
+                        x={nl(i)} y={pr.y} width={nW} height={pr.h}
+                        fill={pr.color}
+                        style={{ cursor: 'pointer' }}
+                        onClick={(e) => handleRectClick(e, colField, pr.label)}
+                      />
+                    </Tooltip>
+
+                    {pr.h >= MIN_LABEL_PX && (
+                      <text x={nl(i) + nW / 2} y={pr.y + pr.h / 2} textAnchor="middle" dominantBaseline="middle" fontSize="1em" fontWeight="500" fill="white" style={{ pointerEvents: 'none' }}>
+                        {`${pr.label}  ${formatCount(pr.value)}`}
+                      </text>
+                    )}
+                  </g>
+                ))}
+              </g>
+            );
+          })}
+
+          {/* ── Bezier transitions ──────────────────────────────────────── */}
+          {stages.slice(0, -1).map((_, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <path key={i} d={transitionPath(i)} fill={stageColors[i + 1]} />
+          ))}
+
+
+          {/* ── Stage labels (name + total count) ───────────────────────── */}
+          {stages.map((stage, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <g key={i} style={{ cursor: 'pointer' }} onClick={(e) => handleRectClick(e, rowField, stage.label)}>
+              <rect x={nl(i)} y={0} width={nW} height={LABEL_AREA} fill="transparent" />
+              <text x={nl(i) + nW / 2} y={20} textAnchor="middle" fontSize="0.75em" fill={theme.colors.text.secondary} style={{ pointerEvents: 'none' }}>
+                {stage.label}
+              </text>
+              <text x={nl(i) + nW / 2} y={52} textAnchor="middle" fontSize="1.5em" fontWeight="bold" fill={theme.colors.text.primary} style={{ pointerEvents: 'none' }}>
+                {formatCount(stage.value)}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </Container>
+
+      {/* Rendered outside Container so it isn't clipped by overflow:hidden */}
+      {popover}
+    </>
+  );
+}, FUNNEL_VISUALIZATION_TYPE);
+
+FunnelVisualization.displayName = 'FunnelVisualization';
+
+export default FunnelVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/FunnelVisualization.tsx
@@ -20,7 +20,8 @@ import chroma from 'chroma-js';
 
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
-import FunnelVisualizationConfig, {
+import type FunnelVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
+import {
   DEFAULT_FUNNEL_START_COLOR,
   DEFAULT_FUNNEL_END_COLOR,
 } from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/bindings.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/bindings.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { VisualizationType } from 'views/types';
+import type { WidgetConfigFormValues } from 'views/components/aggregationwizard';
+import FunnelVisualizationConfig, {
+  DEFAULT_FUNNEL_START_COLOR,
+  DEFAULT_FUNNEL_END_COLOR,
+} from 'views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig';
+
+import FunnelVisualization from './FunnelVisualization';
+import FunnelColorPickerField from './FunnelColorPickerField';
+
+type FunnelVisualizationConfigFormValues = {
+  startColor: string;
+  endColor: string;
+};
+
+const countGroupingFields = (formValues: WidgetConfigFormValues) =>
+  (formValues.groupBy?.groupings ?? []).reduce((total, grouping) => total + (grouping.fields?.length ?? 0), 0);
+
+const validate = (formValues: WidgetConfigFormValues) => {
+  if (countGroupingFields(formValues) < 1) {
+    return { type: 'Funnel requires at least one grouping field.' };
+  }
+
+  if ((formValues.metrics?.length ?? 0) > 1) {
+    return { type: 'Funnel supports only a single metric.' };
+  }
+
+  return {};
+};
+
+const funnelChart: VisualizationType<typeof FunnelVisualization.type, FunnelVisualizationConfig, FunnelVisualizationConfigFormValues> = {
+  type: FunnelVisualization.type,
+  displayName: 'Funnel',
+  component: FunnelVisualization,
+  config: {
+    createConfig: () => ({
+      startColor: DEFAULT_FUNNEL_START_COLOR,
+      endColor: DEFAULT_FUNNEL_END_COLOR,
+    }),
+    fromConfig: (vizConfig?: FunnelVisualizationConfig) => ({
+      startColor: vizConfig?.startColor ?? DEFAULT_FUNNEL_START_COLOR,
+      endColor: vizConfig?.endColor ?? DEFAULT_FUNNEL_END_COLOR,
+    }),
+    toConfig: (formValues: FunnelVisualizationConfigFormValues) =>
+      FunnelVisualizationConfig.create(formValues.startColor, formValues.endColor),
+    fields: [
+      {
+        type: 'custom',
+        name: 'startColor',
+        title: 'Start color',
+        id: 'funnel-start-color',
+        component: FunnelColorPickerField,
+      },
+      {
+        type: 'custom',
+        name: 'endColor',
+        title: 'End color',
+        id: 'funnel-end-color',
+        component: FunnelColorPickerField,
+      },
+    ],
+  },
+  validate,
+};
+
+export default funnelChart;

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/buildStages.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/buildStages.ts
@@ -23,6 +23,7 @@ import type { FunnelStage } from './types';
 export const formatCount = (n: number): string => {
   if (n >= 1_000_000) return `${+(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${+(n / 1_000).toFixed(1)}k`;
+
   return String(n);
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/buildStages.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/buildStages.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import chroma from 'chroma-js';
+
+import type { LeafPath } from 'views/components/visualizations/utils/extractLeafPaths';
+
+import type { FunnelStage } from './types';
+
+export const formatCount = (n: number): string => {
+  if (n >= 1_000_000) return `${+(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${+(n / 1_000).toFixed(1)}k`;
+  return String(n);
+};
+
+/** Generate N shades of a base color, from slightly darker to slightly lighter. */
+export const subPartColors = (base: string, n: number): string[] => {
+  if (n <= 1) return [base];
+
+  return chroma
+    .scale([chroma(base).darken(0.5), chroma(base).brighten(0.7)])
+    .mode('lab')
+    .colors(n);
+};
+
+/**
+ * Groups leaf paths into funnel stages.
+ *
+ * When column pivots are present each unique combination of row-pivot keys
+ * becomes one stage, and the column-pivot values become that stage's sub-parts.
+ * When there are no column pivots every path is its own single-part stage.
+ */
+export const buildStages = (
+  paths: LeafPath[],
+  displayKeys: string[][],
+  rowFieldCount: number,
+): FunnelStage[] => {
+  const hasColumnPivots = (displayKeys[0]?.length ?? 0) > rowFieldCount;
+
+  if (!hasColumnPivots) {
+    return paths
+      .map((path, i) => ({ label: displayKeys[i].join(' / '), value: path.value, parts: [] }))
+      .sort((a, b) => b.value - a.value);
+  }
+
+  // Preserve insertion order (pivot data comes back in a consistent order from
+  // the server) so sub-parts appear in the same order every render.
+  const stageMap = new Map<string, FunnelStage>();
+
+  paths.forEach((path, i) => {
+    const rowKeys = displayKeys[i].slice(0, rowFieldCount);
+    const colKeys = displayKeys[i].slice(rowFieldCount);
+    const stageKey = rowKeys.join('\0');
+
+    if (!stageMap.has(stageKey)) {
+      stageMap.set(stageKey, { label: rowKeys.join(' / '), value: 0, parts: [] });
+    }
+
+    const stage = stageMap.get(stageKey)!;
+    stage.value += path.value;
+    stage.parts.push({ label: colKeys.join(' / '), value: path.value });
+  });
+
+  return Array.from(stageMap.values()).sort((a, b) => b.value - a.value);
+};

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/funnelGeometry.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/funnelGeometry.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { FunnelStage } from './types';
+
+export const LABEL_AREA = 72; // px reserved at top for stage name + count
+export const NODE_RATIO = 0.55; // fraction of column width occupied by the stage rect
+export const FILL_RATIO = 0.88; // largest stage fills this fraction of the available height
+export const MIN_STAGE_PX = 4; // minimum stage rect height so tiny stages remain visible
+export const MIN_LABEL_PX = 22; // minimum sub-part height to show its inline label
+
+export type FunnelGeometry = {
+  colW: number;
+  nW: number;
+  stageH: (i: number) => number;
+  top: (i: number) => number;
+  bot: (i: number) => number;
+  nl: (i: number) => number;
+  nr: (i: number) => number;
+  bcx: (i: number) => number;
+  transitionPath: (i: number) => string;
+};
+
+/**
+ * Derives all layout helpers from the stage list and SVG dimensions.
+ * Returns a bag of pure functions so the SVG render stays declarative.
+ */
+export const computeFunnelGeometry = (stages: FunnelStage[], width: number, height: number): FunnelGeometry => {
+  const maxValue = stages[0].value;
+  const colW = width / stages.length;
+  const nW = colW * NODE_RATIO;
+  const shapeH = height - LABEL_AREA;
+  const centerY = LABEL_AREA + shapeH / 2;
+
+  const stageH = (i: number) => Math.max((stages[i].value / maxValue) * shapeH * FILL_RATIO, MIN_STAGE_PX);
+  const top = (i: number) => centerY - stageH(i) / 2;
+  const bot = (i: number) => centerY + stageH(i) / 2;
+  const nl = (i: number) => i * colW;
+  const nr = (i: number) => i * colW + nW;
+  const bcx = (i: number) => i * colW + nW + (colW - nW) / 2;
+
+  // Overlap 1px into both adjacent rects so sub-pixel anti-aliasing gaps are hidden.
+  const transitionPath = (i: number) => {
+    const lx = nr(i) - 1;
+    const rx = nl(i + 1) + 1;
+
+    return (
+      `M ${lx},${top(i)} ` +
+      `C ${bcx(i)},${top(i)} ${bcx(i)},${top(i + 1)} ${rx},${top(i + 1)} ` +
+      `L ${rx},${bot(i + 1)} ` +
+      `C ${bcx(i)},${bot(i + 1)} ${bcx(i)},${bot(i)} ${lx},${bot(i)} Z`
+    );
+  };
+
+  return { colW, nW, stageH, top, bot, nl, nr, bcx, transitionPath };
+};

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/types.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/types.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+export type SubPart = { label: string; value: number };
+export type FunnelStage = { label: string; value: number; parts: SubPart[] };
+export type ClickedItem = { el: Element; field: string; value: string };

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelOnClickPopover.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelOnClickPopover.tsx
@@ -66,6 +66,7 @@ const useFunnelOnClickPopover = (): Result => {
 
   const popover = (
     <OnClickPopoverWrapper
+      // eslint-disable-next-line react-hooks/refs
       ref={refs.setFloating}
       isPopoverOpen={!!clickedItem}
       onPopoverChange={(open) => { if (!open) setClickedItem(null); }}

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelOnClickPopover.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelOnClickPopover.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useMemo, useState } from 'react';
+import { useFloating } from '@floating-ui/react';
+
+import OnClickPopoverWrapper from 'views/components/visualizations/OnClickPopover/OnClickPopoverWrapper';
+import ValueActionsDropdown from 'views/components/visualizations/OnClickPopover/ValueActionsDropdown';
+import type { Step } from 'views/components/visualizations/OnClickPopover/Types';
+import { AdditionalContext } from 'views/logic/ActionContext';
+import useQueryFieldTypes from 'views/hooks/useQueryFieldTypes';
+
+import type { ClickedItem } from './types';
+
+type Result = {
+  handleRectClick: (e: React.MouseEvent<SVGElement>, field: string, value: string) => void;
+  popover: React.ReactNode;
+};
+
+/**
+ * Manages the field/value action popover triggered by clicking a funnel rect.
+ *
+ * Uses floating-ui (matching usePlotOnClickPopover) so the popover anchors to
+ * the clicked SVG element and renders outside the Container's overflow:hidden.
+ */
+const useFunnelOnClickPopover = (): Result => {
+  const types = useQueryFieldTypes();
+  const [clickedItem, setClickedItem] = useState<ClickedItem | null>(null);
+  // Real useState so setDummyStep satisfies ValueActionsDropdown's prop type.
+  const [, setDummyStep] = useState<Step>('values');
+
+  const { refs, floatingStyles } = useFloating({
+    placement: 'top-start',
+    elements: { reference: clickedItem?.el },
+    transform: false,
+  });
+
+  const additionalContextValue = useMemo(
+    () => ({
+      valuePath: clickedItem ? [{ [clickedItem.field]: clickedItem.value }] : [],
+      fieldTypes: types,
+    }),
+    [clickedItem, types],
+  );
+
+  const handleRectClick = (e: React.MouseEvent<SVGElement>, field: string, value: string) => {
+    const el = e.currentTarget;
+    // Preserve the same reference when clicking the same element — a new object
+    // would cause downstream hooks to reset their internal state.
+    setClickedItem((prev) => (prev?.el === el ? prev : { el, field, value }));
+  };
+
+  const popover = (
+    <OnClickPopoverWrapper
+      ref={refs.setFloating}
+      isPopoverOpen={!!clickedItem}
+      onPopoverChange={(open) => { if (!open) setClickedItem(null); }}
+      style={floatingStyles}>
+      {clickedItem && (
+        <AdditionalContext.Provider value={additionalContextValue}>
+          <ValueActionsDropdown
+            field={clickedItem.field}
+            value={clickedItem.value}
+            onActionRun={() => setClickedItem(null)}
+            setStep={setDummyStep}
+          />
+        </AdditionalContext.Provider>
+      )}
+    </OnClickPopoverWrapper>
+  );
+
+  return { handleRectClick, popover };
+};
+
+export default useFunnelOnClickPopover;

--- a/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelStages.ts
+++ b/graylog2-web-interface/src/views/components/visualizations/funnel/useFunnelStages.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useMemo } from 'react';
+
+import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
+import useMapKeys from 'views/components/visualizations/useMapKeys';
+import extractLeafPaths from 'views/components/visualizations/utils/extractLeafPaths';
+import type AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+
+import { buildStages } from './buildStages';
+import type { FunnelStage } from './types';
+
+type Result = {
+  stages: FunnelStage[] | null;
+  rowFields: string[];
+  colFields: string[];
+};
+
+const useFunnelStages = (config: AggregationWidgetConfig, data: VisualizationComponentProps['data']): Result => {
+  const rows = retrieveChartData(data);
+  const mapKeys = useMapKeys();
+
+  return useMemo(() => {
+    const rowFields = config.rowPivots.flatMap((p) => p.fields);
+    const colFields = config.columnPivots.flatMap((p) => p.fields);
+    const allFields = [...rowFields, ...colFields];
+
+    if (allFields.length === 0 || !rows) return { stages: null, rowFields, colFields };
+
+    const metric = config.series?.[0];
+    const paths = extractLeafPaths(rows, colFields.length, metric?.effectiveName);
+
+    if (paths.length === 0) return { stages: null, rowFields, colFields };
+
+    const displayKeys = paths.map((path) =>
+      path.keys.map((k, i) => String(mapKeys(k, allFields[i]) ?? k)),
+    );
+
+    return { stages: buildStages(paths, displayKeys, rowFields.length), rowFields, colFields };
+  }, [config, mapKeys, rows]);
+};
+
+export default useFunnelStages;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/FunnelVisualizationConfig.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import VisualizationConfig from './VisualizationConfig';
+
+export const DEFAULT_FUNNEL_START_COLOR = '#1F77B4';
+export const DEFAULT_FUNNEL_END_COLOR = '#AEC7E8';
+
+type FunnelVisualizationConfigJson = {
+  start_color: string;
+  end_color: string;
+};
+
+export default class FunnelVisualizationConfig extends VisualizationConfig {
+  private readonly _value: { startColor: string; endColor: string };
+
+  constructor(startColor: string, endColor: string) {
+    super();
+    this._value = { startColor, endColor };
+  }
+
+  get startColor() {
+    return this._value.startColor;
+  }
+
+  get endColor() {
+    return this._value.endColor;
+  }
+
+  static create(startColor: string, endColor: string) {
+    return new FunnelVisualizationConfig(startColor, endColor);
+  }
+
+  static empty() {
+    return FunnelVisualizationConfig.create(DEFAULT_FUNNEL_START_COLOR, DEFAULT_FUNNEL_END_COLOR);
+  }
+
+  toJSON(): FunnelVisualizationConfigJson {
+    return {
+      start_color: this._value.startColor,
+      end_color: this._value.endColor,
+    };
+  }
+
+  static fromJSON(_type: string, value: FunnelVisualizationConfigJson) {
+    return FunnelVisualizationConfig.create(value.start_color, value.end_color);
+  }
+}

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -5158,9 +5158,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001663, caniuse-lite@^1.0.30001759:
-  version "1.0.30001809"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz"
-  integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
+  version "1.0.30001802"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz"
+  integrity sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==
 
 canvas-fit@^1.5.0:
   version "1.5.0"
@@ -6345,9 +6345,9 @@ domhandler@^4.0.0, domhandler@^4.2.0:
     domelementtype "^2.2.0"
 
 dompurify@^3.0.0, dompurify@^3.3.2:
-  version "3.4.13"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
-  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -7235,7 +7235,7 @@ escodegen@^2.1.0:
     eslint "9.39.2"
     eslint-import-resolver-webpack "0.13.11"
     eslint-plugin-compat "7.0.2"
-    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-1ff51092-7c40-4e45-a515-7f44cd828f97-1786925664331/node_modules/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../../Library/Caches/Yarn/v6/npm-eslint-config-graylog-1.3.0-22564f9c-61e2-4431-94d4-5a957dbbedee-1787044073291/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.32.0"
     eslint-plugin-jest "29.16.0"
     eslint-plugin-jest-dom "5.10.1"
@@ -8836,11 +8836,11 @@ graphemer@^1.4.0:
     "@reduxjs/toolkit" "^2.5.1"
     "@tanstack/react-query" "5.101.4"
     "@types/react" "18.3.13"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-3abec284-7902-4a04-985a-b86ef6bc0a55-1786925664192/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-4a6ae35a-98aa-4fbf-bd54-6329415f9da6-1787044073273/node_modules/eslint-config-graylog"
     formik "2.4.9"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-3abec284-7902-4a04-985a-b86ef6bc0a55-1786925664192/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-7.2.0-SNAPSHOT-4a6ae35a-98aa-4fbf-bd54-6329415f9da6-1787044073273/node_modules/jest-preset-graylog"
     moment "2.30.1"
     moment-timezone "0.6.3"
     react "18.3.1"
@@ -15120,9 +15120,9 @@ tapable@^2.3.3:
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
 tar-fs@^2.0.0:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.5.tgz#33e9c29413dce0c58ada7ff77db4e5a30afffe70"
-  integrity sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
+  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -15130,9 +15130,9 @@ tar-fs@^2.0.0:
     tar-stream "^2.1.4"
 
 tar-fs@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.3.tgz#05668cc68a30741c3813f9c16593b8dec7dcbcd1"
-  integrity sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.1.tgz#4f164e59fb60f103d472360731e8c6bb4a7fe9ef"
+  integrity sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==
   dependencies:
     pump "^3.0.0"
     tar-stream "^3.1.5"


### PR DESCRIPTION
Description

Introduces a new SVG-based funnel chart as an aggregation widget type. Stages are derived from row pivots; column pivots produce sub-parts within each stage, shaded as tonal variants of the stage color. Bezier curves connect adjacent stages with a color matching the destination stage. Supports field/value click actions and hover tooltips on small sub-parts, matching the behavior of other visualization types.

The implementation is split into focused modules:
- FunnelVisualizationConfig.ts — frontend config model with startColor/endColor
- FunnelVisualizationConfigDTO.java — backend Jackson subtype for serialization
- buildStages.ts — maps pivot result rows into stage/sub-part data
- funnelGeometry.ts — pure layout functions (positions, bezier paths)
- useFunnelStages.ts — data hook
- useFunnelOnClickPopover.tsx — click-action popover hook
- FunnelColorPickerField.tsx — color configuration UI in the widget editor

Motivation and Context

Funnel charts are a common way to visualize drop-off across sequential stages (e.g. alert → acknowledged → resolved). Graylog had no built-in funnel widget type, requiring users to approximate this with bar charts.

How Has This Been Tested?

Manually tested in the browser: created funnel widgets with row-only pivots, row + column pivots, color customization, click actions on stages and sub-parts, and hover tooltips on small sub-parts. TypeScript compiler and ESLint pass clean.

Screenshots (if appropriate):

<img width="1738" height="531" alt="Bildschirmfoto 2026-08-18 um 09 53 14" src="https://github.com/user-attachments/assets/a835640f-923f-42ba-bc04-1d9df584f765" />

Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality

Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
