### PR TITLE
Move welcome page queries toggle to System > Configurations.

### DIFF
--- a/changelog/unreleased/pr-26961.toml
+++ b/changelog/unreleased/pr-26961.toml
@@ -1,4 +1,4 @@
 type = "a"
-message = "Add metrics widgets (message, alert, and event counts, plus top sources) to the welcome page, configurable via a new \"welcome_page_metrics_enabled\" server setting."
+message = "Add metrics widgets (message, alert, and event counts, plus top sources) to the welcome page. The underlying queries can be disabled cluster-wide under System → Configurations → Welcome Page for users concerned about performance."
 
 pulls = ["26961"]

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -517,13 +517,6 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
     private boolean globalInputsOnly = false;
 
     @Documentation("""
-            Show the metrics widgets (message, alert, and event counts) on the welcome page.
-            Default: true
-            """)
-    @Parameter(value = "welcome_page_metrics_enabled")
-    private boolean welcomePageMetricsEnabled = true;
-
-    @Documentation("""
             This parameter defines the maximum size in bytes of cluster events. When it is exceeded, oldest events will
             be overwritten. This should be as small as possible (for performance), but large enough to hold events long
             enough for all nodes to process them.
@@ -958,9 +951,5 @@ public class Configuration extends CaConfiguration implements CommonNodeConfigur
 
     public boolean isGlobalInputsOnly() {
         return globalInputsOnly;
-    }
-
-    public boolean isWelcomePageMetricsEnabled() {
-        return welcomePageMetricsEnabled;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/WelcomePageConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/WelcomePageConfiguration.java
@@ -16,6 +16,6 @@
  */
 package org.graylog2.configuration;
 
-public record WelcomePageConfiguration(boolean disableQueries) {
+public record WelcomePageConfiguration(boolean disableMetrics) {
     public static final WelcomePageConfiguration DEFAULT = new WelcomePageConfiguration(false);
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/WelcomePageConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/WelcomePageConfiguration.java
@@ -14,14 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-export type ValidationState = 'error' | 'success' | 'warning';
-export type TimeUnit = 'NANOSECONDS' | 'MICROSECONDS' | 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS';
+package org.graylog2.configuration;
 
-export type MarkdownConfigType = {
-  allow_all_image_sources: boolean;
-  allowed_image_sources: string;
-};
-
-export type WelcomePageConfigType = {
-  disable_queries: boolean;
-};
+public record WelcomePageConfiguration(boolean disableQueries) {
+    public static final WelcomePageConfiguration DEFAULT = new WelcomePageConfiguration(false);
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -106,7 +106,6 @@ public class AppConfigResource {
                 .put("contentStream", toPrettyJsonString((contentStreamConfiguration.contentStreamFrontendSettings())))
                 .put("branding", toPrettyJsonString(customizationConfig))
                 .put("globalInputsOnly", configuration.isGlobalInputsOnly())
-                .put("welcomePageMetricsEnabled", configuration.isWelcomePageMetricsEnabled())
                 .build();
         return templateEngine.transform(template, model);
     }

--- a/graylog2-server/src/main/resources/web-interface/config.js.template
+++ b/graylog2-server/src/main/resources/web-interface/config.js.template
@@ -8,6 +8,5 @@ window.appConfig = {
   telemetry: ${telemetry},
   contentStream: ${contentStream},
   branding: ${branding},
-  globalInputsOnly: ${globalInputsOnly},
-  welcomePageMetricsEnabled: ${welcomePageMetricsEnabled}
+  globalInputsOnly: ${globalInputsOnly}
 };

--- a/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-AppConfig.js
+++ b/graylog2-web-interface/packages/jest-preset-graylog/lib/setup-files/mock-AppConfig.js
@@ -29,7 +29,6 @@ const mockAppConfig = {
   pluginUISettings: jest.fn(() => ({})),
   branding: jest.fn(),
   globalInputsOnly: jest.fn(() => false),
-  welcomePageMetricsEnabled: jest.fn(() => true),
 };
 
 jest.mock('util/AppConfig', () => mockAppConfig);

--- a/graylog2-web-interface/src/components/common/types.ts
+++ b/graylog2-web-interface/src/components/common/types.ts
@@ -23,5 +23,5 @@ export type MarkdownConfigType = {
 };
 
 export type WelcomePageConfigType = {
-  disable_queries: boolean;
+  disable_metrics: boolean;
 };

--- a/graylog2-web-interface/src/components/configurations/ConfigurationTypes.ts
+++ b/graylog2-web-interface/src/components/configurations/ConfigurationTypes.ts
@@ -28,6 +28,7 @@ enum ConfigurationType {
   GLOBAL_PROCESSING_RULE_CONFIG = 'org.graylog2.shared.buffers.processors.TimeStampConfig',
   MCP_CONFIG = 'org.graylog.mcp.config.McpConfiguration',
   MARKDOWN_CONFIG = 'org.graylog2.configuration.MarkdownConfiguration',
+  WELCOME_PAGE_CONFIG = 'org.graylog2.configuration.WelcomePageConfiguration',
 }
 export default ConfigurationType;
 export { ConfigurationType };

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
@@ -54,7 +54,7 @@ describe('WelcomePageConfig', () => {
   it('renders current configuration', async () => {
     render(<WelcomePageConfig />);
 
-    await screen.findByText('Welcome page queries:');
+    await screen.findByText('Welcome page metrics:');
     await screen.findByText('Enabled');
   });
 
@@ -65,7 +65,7 @@ describe('WelcomePageConfig', () => {
 
     await userEvent.click(editButton);
 
-    await userEvent.click(await screen.findByLabelText(/enable welcome page queries/i, { selector: 'input' }));
+    await userEvent.click(await screen.findByLabelText(/enable welcome page metrics/i, { selector: 'input' }));
 
     await userEvent.click(await screen.findByRole('button', { name: /update configuration/i }));
 

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
@@ -24,7 +24,7 @@ import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 
 import WelcomePageConfig from './WelcomePageConfig';
 
-const mockConfig = { disable_queries: false };
+const mockConfig = { disable_metrics: false };
 
 const mockList = jest.fn().mockResolvedValue(undefined);
 const mockUpdate = jest.fn().mockResolvedValue(undefined);
@@ -71,7 +71,7 @@ describe('WelcomePageConfig', () => {
 
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith('org.graylog2.configuration.WelcomePageConfiguration', {
-        disable_queries: true,
+        disable_metrics: true,
       });
     });
   });

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import MockStore from 'helpers/mocking/StoreMock';
+import asMock from 'helpers/mocking/AsMock';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+
+import WelcomePageConfig from './WelcomePageConfig';
+
+const mockConfig = { disable_queries: false };
+
+const mockList = jest.fn().mockResolvedValue(undefined);
+const mockUpdate = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('logic/telemetry/useSendTelemetry');
+jest.mock('stores/configurations/ConfigurationsStore', () => ({
+  ConfigurationsStore: MockStore([
+    'getInitialState',
+    () => ({
+      configuration: {
+        'org.graylog2.configuration.WelcomePageConfiguration': mockConfig,
+      },
+    }),
+  ]),
+  ConfigurationsActions: {
+    list: (...args: unknown[]) => mockList(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+describe('WelcomePageConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMock(useSendTelemetry).mockReturnValue(jest.fn());
+  });
+
+  it('renders current configuration', async () => {
+    render(<WelcomePageConfig />);
+
+    await screen.findByText('Welcome page queries:');
+    await screen.findByText('Enabled');
+  });
+
+  it('saves updated configuration', async () => {
+    render(<WelcomePageConfig />);
+
+    const editButton = await screen.findByRole('button', { name: /edit configuration/i });
+
+    await userEvent.click(editButton);
+
+    await userEvent.click(await screen.findByLabelText(/enable welcome page queries/i, { selector: 'input' }));
+
+    await userEvent.click(await screen.findByRole('button', { name: /update configuration/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('org.graylog2.configuration.WelcomePageConfiguration', {
+        disable_queries: true,
+      });
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
@@ -53,7 +53,7 @@ const LabelSpan = styled.span(
 );
 
 const configType = ConfigurationType.WELCOME_PAGE_CONFIG;
-const DEFAULT_CONFIG: WelcomePageConfigType = { disable_queries: false };
+const DEFAULT_CONFIG: WelcomePageConfigType = { disable_metrics: false };
 
 type FormValues = { queries_enabled: boolean };
 
@@ -71,7 +71,7 @@ const WelcomePageConfig = () => {
       const config = getConfig(configType, configuration) ?? DEFAULT_CONFIG;
 
       setViewConfig(config);
-      setFormConfig({ queries_enabled: !config.disable_queries });
+      setFormConfig({ queries_enabled: !config.disable_metrics });
     });
   }, [configuration]);
 
@@ -82,14 +82,14 @@ const WelcomePageConfig = () => {
       app_action_value: 'configuration-save',
     });
 
-    ConfigurationsActions.update(configType, { disable_queries: !values.queries_enabled }).then(() => {
+    ConfigurationsActions.update(configType, { disable_metrics: !values.queries_enabled }).then(() => {
       setShowModal(false);
     });
   };
 
   const resetConfig = () => {
     setShowModal(false);
-    setFormConfig({ queries_enabled: !viewConfig.disable_queries });
+    setFormConfig({ queries_enabled: !viewConfig.disable_metrics });
   };
 
   return (
@@ -107,7 +107,7 @@ const WelcomePageConfig = () => {
         <>
           <StyledDefList>
             <dt>Welcome page metrics:</dt>
-            <dd>{viewConfig.disable_queries ? 'Disabled' : 'Enabled'}</dd>
+            <dd>{viewConfig.disable_metrics ? 'Disabled' : 'Enabled'}</dd>
           </StyledDefList>
 
           <IfPermitted permissions="clusterconfigentry:edit">

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
@@ -39,7 +39,7 @@ const StyledDefList = styled.dl.attrs({ className: 'deflist' })(
     &&.deflist {
       dd {
         padding-left: ${theme.spacings.md};
-        margin-left: 400px;
+        margin-left: 200px;
       }
     }
   `,
@@ -95,14 +95,18 @@ const WelcomePageConfig = () => {
   return (
     <div>
       <h2>Welcome Page</h2>
-      <p>Configure whether the metrics widgets on the welcome page run their underlying queries.</p>
+      <p>
+        The welcome page can show widgets with message, alert, and event counts, plus a top sources chart. On large or
+        busy clusters, these queries add extra load every time a user opens the welcome page. Disable them below if you
+        want to avoid that load. The widgets will be hidden and their queries will not run.
+      </p>
 
       {!viewConfig ? (
         <Spinner />
       ) : (
         <>
           <StyledDefList>
-            <dt>Welcome page queries:</dt>
+            <dt>Welcome page metrics:</dt>
             <dd>{viewConfig.disable_queries ? 'Disabled' : 'Enabled'}</dd>
           </StyledDefList>
 
@@ -135,8 +139,8 @@ const WelcomePageConfig = () => {
                           type="checkbox"
                           name="queries_enabled"
                           id="queries_enabled"
-                          label={<LabelSpan>Enable welcome page queries</LabelSpan>}
-                          help="If disabled, the metrics widgets on the welcome page will not run their underlying queries. Disable this if you are concerned about the performance impact of these queries."
+                          label={<LabelSpan>Enable welcome page metrics</LabelSpan>}
+                          help="If disabled, the message, alert, and event count widgets and the top sources chart will be hidden from the welcome page, and their underlying queries will not run. Turn this off on large or busy clusters to reduce query load."
                         />
                       </Col>
                     </Row>

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
@@ -33,6 +33,7 @@ import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useLocation from 'routing/useLocation';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import type { WelcomePageConfigType } from 'components/common/types';
+import { DEFAULT_WELCOME_PAGE_CONFIG } from 'logic/welcome/welcomePageConfig';
 
 const StyledDefList = styled.dl.attrs({ className: 'deflist' })(
   ({ theme }) => css`
@@ -53,7 +54,6 @@ const LabelSpan = styled.span(
 );
 
 const configType = ConfigurationType.WELCOME_PAGE_CONFIG;
-const DEFAULT_CONFIG: WelcomePageConfigType = { disable_metrics: false };
 
 type FormValues = { metrics_enabled: boolean };
 
@@ -68,7 +68,7 @@ const WelcomePageConfig = () => {
 
   useEffect(() => {
     ConfigurationsActions.list(configType).then(() => {
-      const config = getConfig(configType, configuration) ?? DEFAULT_CONFIG;
+      const config = getConfig(configType, configuration) ?? DEFAULT_WELCOME_PAGE_CONFIG;
 
       setViewConfig(config);
       setFormConfig({ metrics_enabled: !config.disable_metrics });

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
@@ -55,7 +55,7 @@ const LabelSpan = styled.span(
 const configType = ConfigurationType.WELCOME_PAGE_CONFIG;
 const DEFAULT_CONFIG: WelcomePageConfigType = { disable_metrics: false };
 
-type FormValues = { queries_enabled: boolean };
+type FormValues = { metrics_enabled: boolean };
 
 const WelcomePageConfig = () => {
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -71,7 +71,7 @@ const WelcomePageConfig = () => {
       const config = getConfig(configType, configuration) ?? DEFAULT_CONFIG;
 
       setViewConfig(config);
-      setFormConfig({ queries_enabled: !config.disable_metrics });
+      setFormConfig({ metrics_enabled: !config.disable_metrics });
     });
   }, [configuration]);
 
@@ -82,14 +82,14 @@ const WelcomePageConfig = () => {
       app_action_value: 'configuration-save',
     });
 
-    ConfigurationsActions.update(configType, { disable_metrics: !values.queries_enabled }).then(() => {
+    ConfigurationsActions.update(configType, { disable_metrics: !values.metrics_enabled }).then(() => {
       setShowModal(false);
     });
   };
 
   const resetConfig = () => {
     setShowModal(false);
-    setFormConfig({ queries_enabled: !viewConfig.disable_metrics });
+    setFormConfig({ metrics_enabled: !viewConfig.disable_metrics });
   };
 
   return (
@@ -137,8 +137,8 @@ const WelcomePageConfig = () => {
                       <Col sm={12}>
                         <FormikInput
                           type="checkbox"
-                          name="queries_enabled"
-                          id="queries_enabled"
+                          name="metrics_enabled"
+                          id="metrics_enabled"
                           label={<LabelSpan>Enable welcome page metrics</LabelSpan>}
                           help="If disabled, the message, alert, and event count widgets and the top sources chart will be hidden from the welcome page, and their underlying queries will not run. Turn this off on large or busy clusters to reduce query load."
                         />

--- a/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/WelcomePageConfig.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { Form, Formik } from 'formik';
+
+import { Button, Col, Modal, Row } from 'components/bootstrap';
+import FormikInput from 'components/common/FormikInput';
+import Spinner from 'components/common/Spinner';
+import { ModalSubmit, IfPermitted } from 'components/common';
+import { ConfigurationsActions, ConfigurationsStore } from 'stores/configurations/ConfigurationsStore';
+import { ConfigurationType } from 'components/configurations/ConfigurationTypes';
+import { getConfig } from 'components/configurations/helpers';
+import { useStore } from 'stores/connect';
+import type { Store } from 'stores/StoreTypes';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
+import useLocation from 'routing/useLocation';
+import { getPathnameWithoutId } from 'util/URLUtils';
+import type { WelcomePageConfigType } from 'components/common/types';
+
+const StyledDefList = styled.dl.attrs({ className: 'deflist' })(
+  ({ theme }) => css`
+    &&.deflist {
+      dd {
+        padding-left: ${theme.spacings.md};
+        margin-left: 400px;
+      }
+    }
+  `,
+);
+
+const LabelSpan = styled.span(
+  ({ theme }) => css`
+    margin-left: ${theme.spacings.sm};
+    font-weight: bold;
+  `,
+);
+
+const configType = ConfigurationType.WELCOME_PAGE_CONFIG;
+const DEFAULT_CONFIG: WelcomePageConfigType = { disable_queries: false };
+
+type FormValues = { queries_enabled: boolean };
+
+const WelcomePageConfig = () => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [viewConfig, setViewConfig] = useState<WelcomePageConfigType | undefined>(undefined);
+  const [formConfig, setFormConfig] = useState<FormValues | undefined>(undefined);
+  const configuration = useStore(ConfigurationsStore as Store<Record<string, any>>, (state) => state?.configuration);
+
+  const sendTelemetry = useSendTelemetry();
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    ConfigurationsActions.list(configType).then(() => {
+      const config = getConfig(configType, configuration) ?? DEFAULT_CONFIG;
+
+      setViewConfig(config);
+      setFormConfig({ queries_enabled: !config.disable_queries });
+    });
+  }, [configuration]);
+
+  const saveConfig = (values: FormValues) => {
+    sendTelemetry(TELEMETRY_EVENT_TYPE.CONFIGURATIONS.WELCOME_PAGE_UPDATED, {
+      app_pathname: getPathnameWithoutId(pathname),
+      app_section: 'welcome-page',
+      app_action_value: 'configuration-save',
+    });
+
+    ConfigurationsActions.update(configType, { disable_queries: !values.queries_enabled }).then(() => {
+      setShowModal(false);
+    });
+  };
+
+  const resetConfig = () => {
+    setShowModal(false);
+    setFormConfig({ queries_enabled: !viewConfig.disable_queries });
+  };
+
+  return (
+    <div>
+      <h2>Welcome Page</h2>
+      <p>Configure whether the metrics widgets on the welcome page run their underlying queries.</p>
+
+      {!viewConfig ? (
+        <Spinner />
+      ) : (
+        <>
+          <StyledDefList>
+            <dt>Welcome page queries:</dt>
+            <dd>{viewConfig.disable_queries ? 'Disabled' : 'Enabled'}</dd>
+          </StyledDefList>
+
+          <IfPermitted permissions="clusterconfigentry:edit">
+            <p>
+              <Button
+                type="button"
+                bsSize="xs"
+                bsStyle="info"
+                onClick={() => {
+                  setShowModal(true);
+                }}>
+                Edit configuration
+              </Button>
+            </p>
+          </IfPermitted>
+
+          <Modal show={showModal && !!formConfig} onHide={resetConfig}>
+            <Formik onSubmit={saveConfig} initialValues={formConfig}>
+              {({ isSubmitting }) => (
+                <Form>
+                  <Modal.Header>
+                    <Modal.Title>Update Welcome Page Configuration</Modal.Title>
+                  </Modal.Header>
+
+                  <Modal.Body>
+                    <Row>
+                      <Col sm={12}>
+                        <FormikInput
+                          type="checkbox"
+                          name="queries_enabled"
+                          id="queries_enabled"
+                          label={<LabelSpan>Enable welcome page queries</LabelSpan>}
+                          help="If disabled, the metrics widgets on the welcome page will not run their underlying queries. Disable this if you are concerned about the performance impact of these queries."
+                        />
+                      </Col>
+                    </Row>
+                  </Modal.Body>
+
+                  <Modal.Footer>
+                    <ModalSubmit
+                      onCancel={resetConfig}
+                      isSubmitting={isSubmitting}
+                      isAsyncSubmit
+                      submitLoadingText="Update configuration"
+                      submitButtonText="Update configuration"
+                    />
+                  </Modal.Footer>
+                </Form>
+              )}
+            </Formik>
+          </Modal>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default WelcomePageConfig;

--- a/graylog2-web-interface/src/components/configurations/bindings.ts
+++ b/graylog2-web-interface/src/components/configurations/bindings.ts
@@ -26,6 +26,7 @@ import DecoratorsConfig from 'components/configurations/DecoratorsConfig';
 import PermissionsConfig from 'components/configurations/PermissionsConfig';
 import UserConfig from 'components/configurations/UserConfig';
 import MarkdownConfig from 'components/configurations/MarkdownConfig';
+import WelcomePageConfig from 'components/configurations/WelcomePageConfig';
 import McpConfig from 'components/configurations/McpConfig';
 import PasswordComplexityConfig from 'components/configurations/PasswordComplexityConfig';
 
@@ -110,6 +111,14 @@ const bindings: PluginExports = {
       props: {
         ConfigurationComponent: MarkdownConfig,
         title: 'Markdown',
+      },
+    },
+    {
+      name: 'Welcome Page',
+      SectionComponent: ConfigurationSection,
+      props: {
+        ConfigurationComponent: WelcomePageConfig,
+        title: 'Welcome Page',
       },
     },
     {

--- a/graylog2-web-interface/src/components/welcome/Welcome.tsx
+++ b/graylog2-web-interface/src/components/welcome/Welcome.tsx
@@ -26,13 +26,13 @@ import ContentStreamContainer from 'components/content-stream/ContentStreamConta
 import useProductName from 'brand-customization/useProductName';
 import { hasAdminPermission } from 'util/PermissionsMixin';
 import useFeature from 'hooks/useFeature';
-import AppConfig from 'util/AppConfig';
 
 import LastOpenList from './LastOpenList';
 import FavoriteItemsList from './FavoriteItemsList';
 import RecentActivityList from './RecentActivityList';
 import OnboardingBanner from './OnboardingBanner';
 import WelcomeMetrics from './WelcomeMetrics';
+import useWelcomePageQueriesDisabled from './hooks/useWelcomePageQueriesDisabled';
 
 import SectionGrid from '../common/Section/SectionGrid';
 import useCurrentUser from '../../hooks/useCurrentUser';
@@ -69,13 +69,14 @@ const Welcome = () => {
   const { permissions, readOnly, id: userId, startpage } = useCurrentUser();
   const isAdmin = hasAdminPermission(permissions);
   const onboardingEnabled = useFeature('onboarding_experience');
+  const welcomePageQueriesDisabled = useWelcomePageQueriesDisabled();
 
   return (
     <>
       <PageHeader title={`Welcome to ${productName}!`}>
         <ChangeStartPageHelper userId={userId} readOnly={readOnly} startpage={startpage} />
       </PageHeader>
-      {AppConfig.welcomePageMetricsEnabled() && <WelcomeMetrics />}
+      {!welcomePageQueriesDisabled && <WelcomeMetrics />}
       {onboardingEnabled && <OnboardingBanner />}
       <SectionGrid $columns="1fr 1fr 1fr">
         <StyledSectionComponent title="Favorite Items">

--- a/graylog2-web-interface/src/components/welcome/Welcome.tsx
+++ b/graylog2-web-interface/src/components/welcome/Welcome.tsx
@@ -32,7 +32,7 @@ import FavoriteItemsList from './FavoriteItemsList';
 import RecentActivityList from './RecentActivityList';
 import OnboardingBanner from './OnboardingBanner';
 import WelcomeMetrics from './WelcomeMetrics';
-import useWelcomePageQueriesDisabled from './hooks/useWelcomePageQueriesDisabled';
+import useWelcomePageConfig from './hooks/useWelcomePageConfig';
 
 import SectionGrid from '../common/Section/SectionGrid';
 import useCurrentUser from '../../hooks/useCurrentUser';
@@ -69,14 +69,14 @@ const Welcome = () => {
   const { permissions, readOnly, id: userId, startpage } = useCurrentUser();
   const isAdmin = hasAdminPermission(permissions);
   const onboardingEnabled = useFeature('onboarding_experience');
-  const welcomePageQueriesDisabled = useWelcomePageQueriesDisabled();
+  const { widgetsEnabled } = useWelcomePageConfig();
 
   return (
     <>
       <PageHeader title={`Welcome to ${productName}!`}>
         <ChangeStartPageHelper userId={userId} readOnly={readOnly} startpage={startpage} />
       </PageHeader>
-      {!welcomePageQueriesDisabled && <WelcomeMetrics />}
+      {widgetsEnabled && <WelcomeMetrics />}
       {onboardingEnabled && <OnboardingBanner />}
       <SectionGrid $columns="1fr 1fr 1fr">
         <StyledSectionComponent title="Favorite Items">

--- a/graylog2-web-interface/src/components/welcome/Welcome.tsx
+++ b/graylog2-web-interface/src/components/welcome/Welcome.tsx
@@ -69,14 +69,14 @@ const Welcome = () => {
   const { permissions, readOnly, id: userId, startpage } = useCurrentUser();
   const isAdmin = hasAdminPermission(permissions);
   const onboardingEnabled = useFeature('onboarding_experience');
-  const { widgetsEnabled } = useWelcomePageConfig();
+  const { metricsEnabled } = useWelcomePageConfig();
 
   return (
     <>
       <PageHeader title={`Welcome to ${productName}!`}>
         <ChangeStartPageHelper userId={userId} readOnly={readOnly} startpage={startpage} />
       </PageHeader>
-      {widgetsEnabled && <WelcomeMetrics />}
+      {metricsEnabled && <WelcomeMetrics />}
       {onboardingEnabled && <OnboardingBanner />}
       <SectionGrid $columns="1fr 1fr 1fr">
         <StyledSectionComponent title="Favorite Items">

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
@@ -22,7 +22,11 @@ import type { WelcomePageConfigType } from 'components/common/types';
 import { useStore } from 'stores/connect';
 import type { Store } from 'stores/StoreTypes';
 
-const useWelcomePageQueriesDisabled = (): boolean => {
+type WelcomePageConfig = { widgetsEnabled: boolean };
+
+const ENABLE_QUERIES_BY_DEFAULT = true;
+
+const useWelcomePageConfig = (): WelcomePageConfig => {
   const configuration = useStore(
     ConfigurationsStore as Store<Record<string, any>>,
     (state) => state?.configuration[ConfigurationType.WELCOME_PAGE_CONFIG] as WelcomePageConfigType,
@@ -32,7 +36,9 @@ const useWelcomePageQueriesDisabled = (): boolean => {
     ConfigurationsActions.list(ConfigurationType.WELCOME_PAGE_CONFIG);
   }, []);
 
-  return configuration?.disable_queries ?? false;
+  const disableQueries = configuration?.disable_queries;
+
+  return { widgetsEnabled: disableQueries === undefined ? ENABLE_QUERIES_BY_DEFAULT : !disableQueries };
 };
 
-export default useWelcomePageQueriesDisabled;
+export default useWelcomePageConfig;

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
@@ -19,12 +19,11 @@ import { useEffect } from 'react';
 import { ConfigurationType } from 'components/configurations/ConfigurationTypes';
 import { ConfigurationsStore, ConfigurationsActions } from 'stores/configurations/ConfigurationsStore';
 import type { WelcomePageConfigType } from 'components/common/types';
+import { DEFAULT_WELCOME_PAGE_CONFIG } from 'logic/welcome/welcomePageConfig';
 import { useStore } from 'stores/connect';
 import type { Store } from 'stores/StoreTypes';
 
 type WelcomePageConfig = { metricsEnabled: boolean };
-
-const ENABLE_METRICS_BY_DEFAULT = true;
 
 const useWelcomePageConfig = (): WelcomePageConfig => {
   const configuration = useStore(
@@ -36,11 +35,9 @@ const useWelcomePageConfig = (): WelcomePageConfig => {
     ConfigurationsActions.list(ConfigurationType.WELCOME_PAGE_CONFIG);
   }, []);
 
-  const disableMetricsPreference = configuration?.disable_metrics;
+  const disableMetrics = configuration?.disable_metrics ?? DEFAULT_WELCOME_PAGE_CONFIG.disable_metrics;
 
-  return {
-    metricsEnabled: disableMetricsPreference === undefined ? ENABLE_METRICS_BY_DEFAULT : !disableMetricsPreference,
-  };
+  return { metricsEnabled: !disableMetrics };
 };
 
 export default useWelcomePageConfig;

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
@@ -22,9 +22,9 @@ import type { WelcomePageConfigType } from 'components/common/types';
 import { useStore } from 'stores/connect';
 import type { Store } from 'stores/StoreTypes';
 
-type WelcomePageConfig = { widgetsEnabled: boolean };
+type WelcomePageConfig = { metricsEnabled: boolean };
 
-const ENABLE_QUERIES_BY_DEFAULT = true;
+const ENABLE_METRICS_BY_DEFAULT = true;
 
 const useWelcomePageConfig = (): WelcomePageConfig => {
   const configuration = useStore(
@@ -39,7 +39,7 @@ const useWelcomePageConfig = (): WelcomePageConfig => {
   const disableMetricsPreference = configuration?.disable_metrics;
 
   return {
-    widgetsEnabled: disableMetricsPreference === undefined ? ENABLE_QUERIES_BY_DEFAULT : !disableMetricsPreference,
+    metricsEnabled: disableMetricsPreference === undefined ? ENABLE_METRICS_BY_DEFAULT : !disableMetricsPreference,
   };
 };
 

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageConfig.ts
@@ -36,9 +36,11 @@ const useWelcomePageConfig = (): WelcomePageConfig => {
     ConfigurationsActions.list(ConfigurationType.WELCOME_PAGE_CONFIG);
   }, []);
 
-  const disableQueries = configuration?.disable_queries;
+  const disableMetricsPreference = configuration?.disable_metrics;
 
-  return { widgetsEnabled: disableQueries === undefined ? ENABLE_QUERIES_BY_DEFAULT : !disableQueries };
+  return {
+    widgetsEnabled: disableMetricsPreference === undefined ? ENABLE_QUERIES_BY_DEFAULT : !disableMetricsPreference,
+  };
 };
 
 export default useWelcomePageConfig;

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageQueriesDisabled.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomePageQueriesDisabled.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useEffect } from 'react';
+
+import { ConfigurationType } from 'components/configurations/ConfigurationTypes';
+import { ConfigurationsStore, ConfigurationsActions } from 'stores/configurations/ConfigurationsStore';
+import type { WelcomePageConfigType } from 'components/common/types';
+import { useStore } from 'stores/connect';
+import type { Store } from 'stores/StoreTypes';
+
+const useWelcomePageQueriesDisabled = (): boolean => {
+  const configuration = useStore(
+    ConfigurationsStore as Store<Record<string, any>>,
+    (state) => state?.configuration[ConfigurationType.WELCOME_PAGE_CONFIG] as WelcomePageConfigType,
+  );
+
+  useEffect(() => {
+    ConfigurationsActions.list(ConfigurationType.WELCOME_PAGE_CONFIG);
+  }, []);
+
+  return configuration?.disable_queries ?? false;
+};
+
+export default useWelcomePageQueriesDisabled;

--- a/graylog2-web-interface/src/logic/telemetry/Constants.ts
+++ b/graylog2-web-interface/src/logic/telemetry/Constants.ts
@@ -260,6 +260,7 @@ export const TELEMETRY_EVENT_TYPE = {
     GEOLOCATION_CONFIGURATION_UPDATED: 'Configurations Geolocation Configuration Updated',
     MARKDOWN_UPDATED: 'Configurations Markdown Updated',
     PASSWORD_COMPLEXITY_UPDATED: 'Configurations Password Complexity Updated',
+    WELCOME_PAGE_UPDATED: 'Configurations Welcome Page Updated',
   },
   INPUTS: {
     INPUT_SELECTED: 'Inputs Input Selected',

--- a/graylog2-web-interface/src/logic/welcome/welcomePageConfig.ts
+++ b/graylog2-web-interface/src/logic/welcome/welcomePageConfig.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import type { WelcomePageConfigType } from 'components/common/types';
+
+export const DEFAULT_WELCOME_PAGE_CONFIG: WelcomePageConfigType = { disable_metrics: false };

--- a/graylog2-web-interface/src/util/AppConfig.ts
+++ b/graylog2-web-interface/src/util/AppConfig.ts
@@ -78,7 +78,6 @@ export type AppConfigs = {
   contentStream: { refresh_interval: string; rss_url: string };
   branding: Branding | undefined;
   globalInputsOnly: boolean;
-  welcomePageMetricsEnabled: boolean;
 };
 
 declare global {
@@ -155,10 +154,6 @@ const AppConfig = {
 
   globalInputsOnly(): boolean {
     return appConfig().globalInputsOnly;
-  },
-
-  welcomePageMetricsEnabled(): boolean {
-    return appConfig().welcomePageMetricsEnabled ?? true;
   },
 };
 


### PR DESCRIPTION
## Description

## Motivation and Context

Replaces the `welcome_page_metrics_enabled` server-config flag added in #26961 with a proper cluster-wide setting: a new "Welcome Page" section under System → Configurations with an "Enable welcome page queries" toggle. The original setting required a config-file edit and node restart, but the actual requirement was for admins to disable the welcome page's underlying metrics queries live, cluster-wide, if they're concerned about the performance impact.

