### PR TITLE
Feat/telemetry debug overlay

### DIFF
--- a/graylog2-web-interface/src/components/quick-jump/hooks/useNavItems.test.tsx
+++ b/graylog2-web-interface/src/components/quick-jump/hooks/useNavItems.test.tsx
@@ -22,6 +22,9 @@ import { usePluginExports } from 'views/test/testPlugins';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { adminUser } from 'fixtures/users';
 import { ScratchpadContext } from 'contexts/ScratchpadProvider';
+import AppConfig from 'util/AppConfig';
+import { isTelemetryDebugEnabled, setTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
+import { ACTION_TYPE } from 'components/quick-jump/Constants';
 
 import useNavItems from './useNavItems';
 
@@ -51,5 +54,44 @@ describe('useNavItems', () => {
   it('handles help menu items with `path`', () => {
     const { result } = renderHookWithDataRouter(() => useNavItems(), { wrapper: Wrapper });
     expect(result.current).toContainEqual({ 'link': '/path', 'title': 'Test Item', 'type': 'page' });
+  });
+
+  describe('telemetry debug overlay action', () => {
+    afterEach(() => {
+      setTelemetryDebugEnabled(false);
+      jest.restoreAllMocks();
+    });
+
+    it('offers a toggle action in development mode', () => {
+      jest.spyOn(AppConfig, 'gl2DevMode').mockReturnValue(true);
+      setTelemetryDebugEnabled(false);
+
+      const { result } = renderHookWithDataRouter(() => useNavItems(), { wrapper: Wrapper });
+
+      const item = result.current.find(({ title }) => title === 'Enable Telemetry Debug Overlay');
+
+      expect(item).toEqual(expect.objectContaining({ type: ACTION_TYPE }));
+
+      (item as { action: (args: object) => void }).action({});
+
+      expect(isTelemetryDebugEnabled()).toBe(true);
+    });
+
+    it('offers to disable the overlay while it is enabled', () => {
+      jest.spyOn(AppConfig, 'gl2DevMode').mockReturnValue(true);
+      setTelemetryDebugEnabled(true);
+
+      const { result } = renderHookWithDataRouter(() => useNavItems(), { wrapper: Wrapper });
+
+      expect(result.current.find(({ title }) => title === 'Disable Telemetry Debug Overlay')).toBeDefined();
+    });
+
+    it('is absent outside development mode', () => {
+      jest.spyOn(AppConfig, 'gl2DevMode').mockReturnValue(false);
+
+      const { result } = renderHookWithDataRouter(() => useNavItems(), { wrapper: Wrapper });
+
+      expect(result.current.find(({ title }) => title?.includes('Telemetry Debug Overlay'))).toBeUndefined();
+    });
   });
 });

--- a/graylog2-web-interface/src/components/quick-jump/hooks/useNavItems.ts
+++ b/graylog2-web-interface/src/components/quick-jump/hooks/useNavItems.ts
@@ -26,6 +26,7 @@ import AppConfig from 'util/AppConfig';
 import type { SearchResultItem } from 'components/quick-jump/Types';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { ScratchpadContext } from 'contexts/ScratchpadProvider';
+import { isTelemetryDebugEnabled, setTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
 
 const useEntityCreatorItems = () => {
   const { isPermitted } = usePermissions();
@@ -86,6 +87,19 @@ const useQuickJumpActions = (): SearchResultItem[] => {
         toggleScratchpad();
       },
     },
+    // The overlay itself works in any build (localStorage flag); only this discoverable entry
+    // point is limited to development mode.
+    ...(AppConfig.gl2DevMode()
+      ? [
+          {
+            type: ACTION_TYPE,
+            title: `${isTelemetryDebugEnabled() ? 'Disable' : 'Enable'} Telemetry Debug Overlay`,
+            action: () => {
+              setTelemetryDebugEnabled(!isTelemetryDebugEnabled());
+            },
+          },
+        ]
+      : []),
   ];
 };
 

--- a/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugEntryRow.tsx
+++ b/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugEntryRow.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+
+import { Button, Label } from 'components/bootstrap';
+import copyToClipboard from 'util/copyToClipboard';
+import type { TelemetryDebugEntry, TelemetryDebugStatus } from 'logic/telemetry/debug/TelemetryDebugStore';
+import detectPiiSuspect from 'logic/telemetry/debug/piiHeuristics';
+
+type Props = {
+  entry: TelemetryDebugEntry;
+  /** Milliseconds since the previous (older) event, or null for the oldest one on record. */
+  deltaMs: number | null;
+  expanded: boolean;
+  onToggle: () => void;
+};
+
+const ClickableCell = styled.td`
+  cursor: pointer;
+`;
+
+const TimeCell = styled.td(
+  ({ theme }) => css`
+    font-family: ${theme.fonts.family.monospace};
+    font-size: ${theme.fonts.size.small};
+    white-space: nowrap;
+  `,
+);
+
+const PayloadBlock = styled.div(
+  ({ theme }) => css`
+    font-family: ${theme.fonts.family.monospace};
+    font-size: ${theme.fonts.size.small};
+    background: ${theme.colors.global.contentBackground};
+    border: 1px solid ${theme.colors.cards.border};
+    border-radius: ${theme.spacings.xs};
+    padding: ${theme.spacings.sm};
+    margin: ${theme.spacings.xs} 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+  `,
+);
+
+const SuspectValue = styled.span(
+  ({ theme }) => css`
+    color: ${theme.colors.variant.danger};
+    font-weight: bold;
+  `,
+);
+
+const STATUS_STYLE = {
+  sent: 'success',
+  suppressed: 'warning',
+  disabled: 'default',
+} as const satisfies Record<TelemetryDebugStatus, string>;
+
+const formatTime = (timestamp: number) => new Date(timestamp).toISOString().slice(11, 23);
+
+const PayloadLine = ({ property, value }: { property: string; value: unknown }) => {
+  const suspect = detectPiiSuspect(value);
+  const rendered = JSON.stringify(value);
+
+  return (
+    <div>
+      &quot;{property}&quot;: {suspect ? <SuspectValue title={`PII suspect: ${suspect}`}>{rendered}</SuspectValue> : rendered}
+    </div>
+  );
+};
+
+const TelemetryDebugEntryRow = ({ entry, deltaMs, expanded, onToggle }: Props) => {
+  const appActionValue = (entry.payload as { app_action_value?: string }).app_action_value;
+
+  return (
+    <>
+      <tr>
+        <TimeCell>
+          {formatTime(entry.timestamp)}
+          {deltaMs !== null && ` (+${deltaMs}ms)`}
+        </TimeCell>
+        <ClickableCell onClick={onToggle}>{entry.eventType}</ClickableCell>
+        <td>{appActionValue}</td>
+        <td>
+          <Label bsStyle={STATUS_STYLE[entry.status]} bsSize="xs">
+            {entry.status}
+          </Label>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={4}>
+            <PayloadBlock>
+              {Object.entries(entry.payload).map(([property, value]) => (
+                <PayloadLine key={property} property={property} value={value} />
+              ))}
+            </PayloadBlock>
+            <Button
+              bsSize="xsmall"
+              onClick={() =>
+                copyToClipboard(
+                  JSON.stringify(
+                    { eventType: entry.eventType, timestamp: entry.timestamp, status: entry.status, ...entry.payload },
+                    null,
+                    2,
+                  ),
+                )
+              }>
+              Copy event as JSON
+            </Button>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+};
+
+export default TelemetryDebugEntryRow;

--- a/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugOverlay.test.tsx
+++ b/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugOverlay.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, act } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import copyToClipboard from 'util/copyToClipboard';
+import { telemetryDebugStore, setTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
+
+import TelemetryDebugOverlay from './TelemetryDebugOverlay';
+
+jest.mock('util/copyToClipboard', () => jest.fn(() => Promise.resolve()));
+
+const record = (eventType: string, payload: object = {}, status: 'sent' | 'suppressed' | 'disabled' = 'disabled') =>
+  act(() => {
+    telemetryDebugStore.record(eventType, payload, status);
+  });
+
+const expandOverlay = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: /telemetry debug/i }));
+};
+
+describe('TelemetryDebugOverlay', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    telemetryDebugStore.clear();
+    setTelemetryDebugEnabled(true);
+  });
+
+  afterEach(() => {
+    act(() => {
+      setTelemetryDebugEnabled(false);
+      telemetryDebugStore.clear();
+    });
+  });
+
+  it('renders nothing while debugging is disabled', () => {
+    setTelemetryDebugEnabled(false);
+
+    render(<TelemetryDebugOverlay />);
+
+    expect(screen.queryByRole('button', { name: /telemetry debug/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a collapsed badge with the event count', () => {
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created');
+    record('Fleet Deleted');
+
+    expect(screen.getByRole('button', { name: /telemetry debug/i })).toHaveTextContent('2');
+  });
+
+  it('lists recorded events newest first with their status', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created', { fleet_id: 'f1' }, 'disabled');
+    record('Fleet Deleted', { fleet_id: 'f2' }, 'sent');
+
+    await expandOverlay(user);
+
+    const rows = screen.getAllByRole('row').slice(1); // skip the header row
+
+    expect(rows[0]).toHaveTextContent('Fleet Deleted');
+    expect(rows[0]).toHaveTextContent('sent');
+    expect(rows[1]).toHaveTextContent('Fleet Created');
+    expect(rows[1]).toHaveTextContent('disabled');
+  });
+
+  it('expands a row into the payload and copies it as JSON', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created', { fleet_id: 'f1', app_action_value: 'fleet-create-submit' });
+
+    await expandOverlay(user);
+    await user.click(screen.getByText('Fleet Created'));
+
+    expect(screen.getByText(/"fleet_id": "f1"/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /copy event as json/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(expect.stringContaining('"fleet_id": "f1"'));
+  });
+
+  it('filters events by name and payload content', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created', { fleet_id: 'f1' });
+    record('Collector Source Created', { source_type: 'journald' });
+
+    await expandOverlay(user);
+    await user.type(screen.getByRole('textbox', { name: /filter events/i }), 'journald');
+
+    expect(screen.getByText('Collector Source Created')).toBeInTheDocument();
+    expect(screen.queryByText('Fleet Created')).not.toBeInTheDocument();
+  });
+
+  it('pauses the view while the buffer keeps recording', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created');
+
+    await expandOverlay(user);
+    await user.click(screen.getByRole('button', { name: /pause/i }));
+
+    record('Fleet Deleted');
+
+    expect(screen.queryByText('Fleet Deleted')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /resume/i }));
+
+    expect(screen.getByText('Fleet Deleted')).toBeInTheDocument();
+  });
+
+  it('clears the buffer', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created');
+
+    await expandOverlay(user);
+    await user.click(screen.getByRole('button', { name: /clear/i }));
+
+    expect(screen.queryByText('Fleet Created')).not.toBeInTheDocument();
+    expect(screen.getByText(/no telemetry events recorded/i)).toBeInTheDocument();
+  });
+
+  it('exports the whole session as JSON', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Fleet Created', { fleet_id: 'f1' });
+    record('Fleet Deleted', { fleet_id: 'f2' });
+
+    await expandOverlay(user);
+    await user.click(screen.getByRole('button', { name: /export session/i }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(expect.stringContaining('"fleet_id": "f2"'));
+    expect(copyToClipboard).toHaveBeenCalledWith(expect.stringContaining('"fleet_id": "f1"'));
+  });
+
+  it('flags PII-suspect payload values with the matched rule', async () => {
+    const user = userEvent.setup();
+    render(<TelemetryDebugOverlay />);
+
+    record('Collector Onboarding Completed', { hostname: 'web-prod-01.example.com', fleet_id: 'f1' });
+
+    await expandOverlay(user);
+    await user.click(screen.getByText('Collector Onboarding Completed'));
+
+    expect(screen.getByTitle(/pii suspect: hostname/i)).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugOverlay.tsx
+++ b/graylog2-web-interface/src/components/telemetry-debug/TelemetryDebugOverlay.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useState, useSyncExternalStore } from 'react';
+import styled, { css } from 'styled-components';
+
+import { Button, Table } from 'components/bootstrap';
+import copyToClipboard from 'util/copyToClipboard';
+import type { TelemetryDebugEntry } from 'logic/telemetry/debug/TelemetryDebugStore';
+import { telemetryDebugStore, isTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
+
+import TelemetryDebugEntryRow from './TelemetryDebugEntryRow';
+
+const Badge = styled.button(
+  ({ theme }) => css`
+    position: fixed;
+    right: ${theme.spacings.md};
+    bottom: ${theme.spacings.md};
+    z-index: 1050;
+    border: 1px solid ${theme.colors.cards.border};
+    border-radius: ${theme.spacings.xs};
+    background: ${theme.colors.global.contentBackground};
+    color: ${theme.colors.text.primary};
+    padding: ${theme.spacings.xs} ${theme.spacings.sm};
+    font-size: ${theme.fonts.size.small};
+    box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
+  `,
+);
+
+const Drawer = styled.div(
+  ({ theme }) => css`
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 40vh;
+    z-index: 1050;
+    display: flex;
+    flex-direction: column;
+    background: ${theme.colors.global.contentBackground};
+    border-top: 2px solid ${theme.colors.cards.border};
+    box-shadow: 0 -2px 12px rgb(0 0 0 / 25%);
+  `,
+);
+
+const Toolbar = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    align-items: center;
+    gap: ${theme.spacings.sm};
+    padding: ${theme.spacings.xs} ${theme.spacings.sm};
+    border-bottom: 1px solid ${theme.colors.cards.border};
+  `,
+);
+
+const Title = styled.strong(
+  ({ theme }) => css`
+    font-size: ${theme.fonts.size.small};
+    margin-right: ${theme.spacings.sm};
+  `,
+);
+
+const FilterInput = styled.input(
+  ({ theme }) => css`
+    flex: 1;
+    max-width: 300px;
+    padding: 2px ${theme.spacings.xs};
+    border: 1px solid ${theme.colors.cards.border};
+    border-radius: ${theme.spacings.xs};
+    background: ${theme.colors.global.contentBackground};
+    color: ${theme.colors.text.primary};
+  `,
+);
+
+const Body = styled.div(
+  ({ theme }) => css`
+    overflow-y: auto;
+    padding: 0 ${theme.spacings.sm};
+  `,
+);
+
+const EmptyHint = styled.p(
+  ({ theme }) => css`
+    color: ${theme.colors.text.secondary};
+    padding: ${theme.spacings.md};
+    margin: 0;
+  `,
+);
+
+const Spacer = styled.div`
+  flex: 1;
+`;
+
+const matchesFilter = (entry: TelemetryDebugEntry, filter: string) => {
+  if (!filter) return true;
+
+  const needle = filter.toLowerCase();
+
+  return (
+    entry.eventType.toLowerCase().includes(needle) || JSON.stringify(entry.payload).toLowerCase().includes(needle)
+  );
+};
+
+/**
+ * Developer/QA overlay listing every telemetry event the app fires, with timing, payload, and
+ * whether it was actually sent. Renders nothing unless the debug flag is on (see
+ * TelemetryDebugStore); toggled via the dev-mode quick-jump action or localStorage.
+ */
+const TelemetryDebugOverlay = () => {
+  const enabled = useSyncExternalStore(telemetryDebugStore.subscribe, isTelemetryDebugEnabled);
+  const liveEntries = useSyncExternalStore(telemetryDebugStore.subscribe, telemetryDebugStore.getEntries);
+  const [open, setOpen] = useState(false);
+  const [frozenEntries, setFrozenEntries] = useState<TelemetryDebugEntry[] | null>(null);
+  const [filter, setFilter] = useState('');
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  if (!enabled) return null;
+
+  if (!open) {
+    return (
+      <Badge type="button" aria-label="Telemetry debug" onClick={() => setOpen(true)}>
+        Telemetry debug: {liveEntries.length}
+      </Badge>
+    );
+  }
+
+  const entries = frozenEntries ?? liveEntries;
+  // Newest first; deltas still relate each event to the one fired before it.
+  const visible = entries.filter((entry) => matchesFilter(entry, filter)).reverse();
+  const deltaFor = (entry: TelemetryDebugEntry) => {
+    const index = entries.findIndex(({ id }) => id === entry.id);
+
+    return index > 0 ? entry.timestamp - entries[index - 1].timestamp : null;
+  };
+
+  return (
+    <Drawer>
+      <Toolbar>
+        <Title>Telemetry Debug ({entries.length})</Title>
+        <FilterInput
+          type="text"
+          aria-label="Filter events"
+          placeholder="Filter by event name or payload..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        {frozenEntries ? (
+          <Button bsSize="xsmall" onClick={() => setFrozenEntries(null)}>
+            Resume
+          </Button>
+        ) : (
+          <Button bsSize="xsmall" onClick={() => setFrozenEntries(liveEntries)}>
+            Pause
+          </Button>
+        )}
+        <Button bsSize="xsmall" onClick={() => telemetryDebugStore.clear()}>
+          Clear
+        </Button>
+        <Button bsSize="xsmall" onClick={() => copyToClipboard(JSON.stringify(entries, null, 2))}>
+          Export session
+        </Button>
+        <Spacer />
+        <Button bsSize="xsmall" onClick={() => setOpen(false)}>
+          Collapse
+        </Button>
+      </Toolbar>
+      <Body>
+        {visible.length === 0 ? (
+          <EmptyHint>No telemetry events recorded yet — interact with the app to see them here.</EmptyHint>
+        ) : (
+          <Table condensed>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Event</th>
+                <th>Action</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((entry) => (
+                <TelemetryDebugEntryRow
+                  key={entry.id}
+                  entry={entry}
+                  deltaMs={deltaFor(entry)}
+                  expanded={expandedId === entry.id}
+                  onToggle={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+                />
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </Body>
+    </Drawer>
+  );
+};
+
+export default TelemetryDebugOverlay;

--- a/graylog2-web-interface/src/logic/telemetry/TelemetryProvider.test.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryProvider.test.tsx
@@ -22,6 +22,7 @@ import { asMock } from 'helpers/mocking';
 import useTelemetryData from 'logic/telemetry/useTelemetryData';
 import TelemetryContext from 'logic/telemetry/TelemetryContext';
 import TelemetryProvider from 'logic/telemetry/TelemetryProvider';
+import { telemetryDebugStore, setTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
 import { useUpdateTelemetrySettings } from 'logic/telemetry/useTelemetrySettings';
 
 const mockTelemetryData = {
@@ -83,5 +84,43 @@ describe('<TelemetryProvider>', () => {
     const consume = renderSUT();
 
     expect(consume).toHaveBeenCalledWith(expect.objectContaining({ sendTelemetry: expect.anything() }));
+  });
+
+  // In this suite telemetry is disabled (AppConfig.telemetry() is undefined), exercising the
+  // debug-only provider branch.
+  describe('debug store tap with disabled telemetry', () => {
+    afterEach(() => {
+      setTelemetryDebugEnabled(false);
+      telemetryDebugStore.clear();
+    });
+
+    it('records events as disabled while debugging is on', () => {
+      setTelemetryDebugEnabled(true);
+      asMock(useTelemetryData).mockReturnValue({ data: mockTelemetryData, isSuccess: true } as any);
+
+      const consume = renderSUT();
+      const { sendTelemetry } = consume.mock.calls[consume.mock.calls.length - 1][0];
+
+      sendTelemetry('Fleet Created', { fleet_id: 'f1' });
+
+      expect(telemetryDebugStore.getEntries()).toEqual([
+        expect.objectContaining({
+          eventType: 'Fleet Created',
+          payload: { fleet_id: 'f1' },
+          status: 'disabled',
+        }),
+      ]);
+    });
+
+    it('records nothing while debugging is off', () => {
+      asMock(useTelemetryData).mockReturnValue({ data: mockTelemetryData, isSuccess: true } as any);
+
+      const consume = renderSUT();
+      const { sendTelemetry } = consume.mock.calls[consume.mock.calls.length - 1][0];
+
+      sendTelemetry('Fleet Created', { fleet_id: 'f1' });
+
+      expect(telemetryDebugStore.getEntries()).toHaveLength(0);
+    });
   });
 });

--- a/graylog2-web-interface/src/logic/telemetry/TelemetryProvider.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryProvider.tsx
@@ -21,6 +21,7 @@ import { useTheme } from 'styled-components';
 import { getPathnameWithoutId } from 'util/URLUtils';
 import type { TelemetryEventType, TelemetryEvent } from 'logic/telemetry/TelemetryContext';
 import TelemetryContext from 'logic/telemetry/TelemetryContext';
+import { telemetryDebugStore } from 'logic/telemetry/debug/TelemetryDebugStore';
 import { useUpdateTelemetrySettings } from 'logic/telemetry/useTelemetrySettings';
 import TelemetryInfoModal from 'logic/telemetry/TelemetryInfoModal';
 import type { TelemetryDataType } from 'logic/telemetry/useTelemetryData';
@@ -108,7 +109,10 @@ const PostHogTelemetryProvider = ({ children }: { children: React.ReactElement }
 
   const TelemetryContextValue = useMemo(() => {
     const sendTelemetry = (eventType: TelemetryEventType, event: TelemetryEvent) => {
-      if (isPosthogLoaded() && globalProps) {
+      const willSend = isPosthogLoaded() && Boolean(globalProps);
+      telemetryDebugStore.record(eventType, event, willSend ? 'sent' : 'suppressed');
+
+      if (willSend) {
         try {
           posthog.capture(eventType, {
             ...event,
@@ -155,7 +159,23 @@ const PostHogTelemetryProvider = ({ children }: { children: React.ReactElement }
   );
 };
 
+// With telemetry disabled nothing ever leaves the browser, but the debug overlay still wants to
+// see what instrumentation would have fired — so the disabled branch records (and only records).
+const debugOnlyContextValue = {
+  sendTelemetry: (eventType: TelemetryEventType, event: TelemetryEvent) =>
+    telemetryDebugStore.record(eventType, event, 'disabled'),
+  sendErrorReport: () => {},
+};
+
+const DebugOnlyTelemetryProvider = ({ children }: { children: React.ReactNode }) => (
+  <TelemetryContext.Provider value={debugOnlyContextValue}>{children}</TelemetryContext.Provider>
+);
+
 const isTelemetryEnabled = AppConfig?.telemetry()?.enabled;
 const TelemetryProvider = ({ children }) =>
-  isTelemetryEnabled ? <PostHogTelemetryProvider>{children}</PostHogTelemetryProvider> : children;
+  isTelemetryEnabled ? (
+    <PostHogTelemetryProvider>{children}</PostHogTelemetryProvider>
+  ) : (
+    <DebugOnlyTelemetryProvider>{children}</DebugOnlyTelemetryProvider>
+  );
 export default TelemetryProvider;

--- a/graylog2-web-interface/src/logic/telemetry/TelemetryProviderDebugTap.test.tsx
+++ b/graylog2-web-interface/src/logic/telemetry/TelemetryProviderDebugTap.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, waitFor } from 'wrappedTestingLibrary';
+import { usePostHog } from 'posthog-js/react';
+
+import mockComponent from 'helpers/mocking/MockComponent';
+import { asMock } from 'helpers/mocking';
+import useTelemetryData from 'logic/telemetry/useTelemetryData';
+import TelemetryContext from 'logic/telemetry/TelemetryContext';
+import TelemetryProvider from 'logic/telemetry/TelemetryProvider';
+import { telemetryDebugStore, setTelemetryDebugEnabled } from 'logic/telemetry/debug/TelemetryDebugStore';
+
+// Telemetry must be enabled before TelemetryProvider is imported — the flag is read at module
+// load — so this suite carries its own AppConfig mock and covers the PostHog provider branch.
+jest.mock('util/AppConfig', () => ({
+  ...jest.requireActual('util/AppConfig').default,
+  telemetry: () => ({ enabled: true, api_key: 'key', host: 'host' }),
+  gl2ServerUrl: () => 'http://localhost:9000/api/',
+}));
+
+jest.mock('posthog-js/react');
+jest.mock('logic/telemetry/TelemetryInfoModal', () => mockComponent('MockTelemetryInfoModal'));
+jest.mock('./useTelemetryData');
+
+jest.mock('logic/telemetry/useTelemetrySettings', () => ({
+  useUpdateTelemetrySettings: jest.fn(() => ({
+    mutateAsync: jest.fn(() => Promise.resolve()),
+  })),
+}));
+
+jest.mock('hooks/useSystemDetails', () => () => ({ version: '7.1.0' }));
+
+jest.mock('@graylog/server-api', () => ({
+  Telemetry: {
+    get: jest.fn(),
+  },
+}));
+
+const mockTelemetryData = {
+  current_user: {
+    user: '1',
+  },
+  user_telemetry_settings: {
+    telemetry_permission_asked: true,
+    telemetry_enabled: true,
+  },
+  cluster: {
+    cluster_id: '1',
+  },
+  license: {},
+  plugin: {},
+  search_cluster: {},
+};
+
+const renderSUT = () => {
+  const consume = jest.fn();
+
+  render(
+    <TelemetryProvider>
+      <TelemetryContext.Consumer>{consume}</TelemetryContext.Consumer>
+    </TelemetryProvider>,
+  );
+
+  return consume;
+};
+
+const lastContext = (consume: jest.Mock) => consume.mock.calls[consume.mock.calls.length - 1][0];
+
+describe('TelemetryProvider debug tap (PostHog branch)', () => {
+  const capture = jest.fn();
+
+  const mockPostHog = (loaded: boolean) =>
+    asMock(usePostHog).mockReturnValue({
+      __loaded: loaded,
+      capture,
+      group: jest.fn(),
+      identify: jest.fn(),
+    } as unknown as ReturnType<typeof usePostHog>);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    setTelemetryDebugEnabled(true);
+    telemetryDebugStore.clear();
+    asMock(useTelemetryData).mockReturnValue({
+      data: mockTelemetryData,
+      isSuccess: true,
+      refetch: jest.fn(),
+    } as unknown as ReturnType<typeof useTelemetryData>);
+  });
+
+  afterEach(() => {
+    setTelemetryDebugEnabled(false);
+    telemetryDebugStore.clear();
+  });
+
+  it('records a captured event as sent', async () => {
+    mockPostHog(true);
+
+    const consume = renderSUT();
+
+    // globalProps resolve in an effect; the context value that captures is the post-effect one.
+    await waitFor(() => {
+      lastContext(consume).sendTelemetry('Fleet Created', { fleet_id: 'f1' });
+
+      expect(capture).toHaveBeenCalledWith('Fleet Created', expect.objectContaining({ fleet_id: 'f1' }));
+    });
+
+    expect(telemetryDebugStore.getEntries()).toContainEqual(
+      expect.objectContaining({
+        eventType: 'Fleet Created',
+        payload: { fleet_id: 'f1' },
+        status: 'sent',
+      }),
+    );
+  });
+
+  it('records a dropped event as suppressed while posthog is not loaded', () => {
+    mockPostHog(false);
+
+    const consume = renderSUT();
+
+    lastContext(consume).sendTelemetry('Fleet Created', { fleet_id: 'f1' });
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(telemetryDebugStore.getEntries()).toEqual([
+      expect.objectContaining({
+        eventType: 'Fleet Created',
+        payload: { fleet_id: 'f1' },
+        status: 'suppressed',
+      }),
+    ]);
+  });
+});

--- a/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.test.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import {
+  telemetryDebugStore,
+  isTelemetryDebugEnabled,
+  setTelemetryDebugEnabled,
+  TELEMETRY_DEBUG_STORAGE_KEY,
+  MAX_ENTRIES,
+} from './TelemetryDebugStore';
+
+describe('TelemetryDebugStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    telemetryDebugStore.clear();
+    setTelemetryDebugEnabled(true);
+  });
+
+  describe('enablement flag', () => {
+    it('persists to localStorage and reads back', () => {
+      setTelemetryDebugEnabled(false);
+
+      expect(localStorage.getItem(TELEMETRY_DEBUG_STORAGE_KEY)).toBe('false');
+      expect(isTelemetryDebugEnabled()).toBe(false);
+
+      setTelemetryDebugEnabled(true);
+
+      expect(localStorage.getItem(TELEMETRY_DEBUG_STORAGE_KEY)).toBe('true');
+      expect(isTelemetryDebugEnabled()).toBe(true);
+    });
+
+    it('defaults to disabled without a stored flag', () => {
+      localStorage.removeItem(TELEMETRY_DEBUG_STORAGE_KEY);
+      setTelemetryDebugEnabled(false);
+      localStorage.removeItem(TELEMETRY_DEBUG_STORAGE_KEY);
+
+      expect(isTelemetryDebugEnabled()).toBe(false);
+    });
+  });
+
+  describe('record', () => {
+    it('appends an entry with type, payload, status, id, and timestamp', () => {
+      telemetryDebugStore.record('Fleet Created', { fleet_id: 'f1' }, 'sent');
+
+      const entries = telemetryDebugStore.getEntries();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toEqual(
+        expect.objectContaining({
+          eventType: 'Fleet Created',
+          payload: { fleet_id: 'f1' },
+          status: 'sent',
+        }),
+      );
+      expect(typeof entries[0].id).toBe('number');
+      expect(typeof entries[0].timestamp).toBe('number');
+    });
+
+    it('assigns increasing ids', () => {
+      telemetryDebugStore.record('A', {}, 'sent');
+      telemetryDebugStore.record('B', {}, 'suppressed');
+
+      const [first, second] = telemetryDebugStore.getEntries();
+
+      expect(second.id).toBeGreaterThan(first.id);
+    });
+
+    it('does not record while debugging is disabled', () => {
+      setTelemetryDebugEnabled(false);
+
+      telemetryDebugStore.record('A', {}, 'sent');
+
+      expect(telemetryDebugStore.getEntries()).toHaveLength(0);
+    });
+
+    it('drops the oldest entries beyond the cap', () => {
+      for (let i = 0; i < MAX_ENTRIES + 1; i += 1) {
+        telemetryDebugStore.record(`event-${i}`, {}, 'sent');
+      }
+
+      const entries = telemetryDebugStore.getEntries();
+
+      expect(entries).toHaveLength(MAX_ENTRIES);
+      expect(entries[0].eventType).toBe('event-1');
+      expect(entries[entries.length - 1].eventType).toBe(`event-${MAX_ENTRIES}`);
+    });
+
+    it('returns a stable snapshot reference between mutations', () => {
+      telemetryDebugStore.record('A', {}, 'sent');
+
+      const first = telemetryDebugStore.getEntries();
+      const second = telemetryDebugStore.getEntries();
+
+      expect(first).toBe(second);
+
+      telemetryDebugStore.record('B', {}, 'sent');
+
+      expect(telemetryDebugStore.getEntries()).not.toBe(first);
+    });
+  });
+
+  describe('clear', () => {
+    it('empties the buffer', () => {
+      telemetryDebugStore.record('A', {}, 'sent');
+
+      telemetryDebugStore.clear();
+
+      expect(telemetryDebugStore.getEntries()).toHaveLength(0);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('notifies on record, clear, and flag changes until unsubscribed', () => {
+      const listener = jest.fn();
+      const unsubscribe = telemetryDebugStore.subscribe(listener);
+
+      telemetryDebugStore.record('A', {}, 'sent');
+      telemetryDebugStore.clear();
+      setTelemetryDebugEnabled(false);
+
+      expect(listener).toHaveBeenCalledTimes(3);
+
+      unsubscribe();
+      setTelemetryDebugEnabled(true);
+      telemetryDebugStore.record('B', {}, 'sent');
+
+      expect(listener).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.test.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.test.ts
@@ -122,6 +122,27 @@ describe('TelemetryDebugStore', () => {
     });
   });
 
+  describe('module duplication', () => {
+    // Plugin bundles compile their own copies of core modules (which is why TelemetryContext,
+    // useSendTelemetry, and App are singleton()-wrapped). A provider from one bundle must land
+    // its events in the same store an overlay from another bundle reads.
+    it('shares state across duplicate module copies', () => {
+      telemetryDebugStore.record('From First Copy', {}, 'sent');
+
+      let secondCopy: {
+        telemetryDebugStore: typeof telemetryDebugStore;
+        isTelemetryDebugEnabled: typeof isTelemetryDebugEnabled;
+      };
+      jest.isolateModules(() => {
+        secondCopy = jest.requireActual('./TelemetryDebugStore');
+      });
+
+      expect(secondCopy.telemetryDebugStore.getEntries()).toHaveLength(1);
+      expect(secondCopy.telemetryDebugStore.getEntries()[0].eventType).toBe('From First Copy');
+      expect(secondCopy.isTelemetryDebugEnabled()).toBe(true);
+    });
+  });
+
   describe('subscribe', () => {
     it('notifies on record, clear, and flag changes until unsubscribed', () => {
       const listener = jest.fn();

--- a/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+// 'sent' = posthog.capture ran; 'suppressed' = posthog gates dropped it; 'disabled' = telemetry
+// is turned off entirely and the event only exists for debugging.
+export type TelemetryDebugStatus = 'sent' | 'suppressed' | 'disabled';
+
+export type TelemetryDebugEntry = {
+  id: number;
+  timestamp: number;
+  eventType: string;
+  payload: object;
+  status: TelemetryDebugStatus;
+};
+
+export const TELEMETRY_DEBUG_STORAGE_KEY = 'gl.telemetry-debug';
+export const MAX_ENTRIES = 500;
+
+// The flag is mirrored into memory so the per-event hot path is a boolean check, not a
+// localStorage read.
+let enabled = false;
+let entries: TelemetryDebugEntry[] = [];
+let nextId = 1;
+const listeners = new Set<() => void>();
+
+try {
+  enabled = localStorage.getItem(TELEMETRY_DEBUG_STORAGE_KEY) === 'true';
+} catch {
+  // localStorage unavailable (e.g. privacy mode) — debugging simply stays off.
+}
+
+const notify = () => listeners.forEach((listener) => listener());
+
+export const isTelemetryDebugEnabled = () => enabled;
+
+export const setTelemetryDebugEnabled = (newEnabled: boolean) => {
+  enabled = newEnabled;
+
+  try {
+    localStorage.setItem(TELEMETRY_DEBUG_STORAGE_KEY, String(newEnabled));
+  } catch {
+    // Persistence is best-effort; the in-memory flag still applies for this session.
+  }
+
+  notify();
+};
+
+export const telemetryDebugStore = {
+  record: (eventType: string, payload: object, status: TelemetryDebugStatus) => {
+    if (!enabled) return;
+
+    entries = [...entries, { id: nextId, timestamp: Date.now(), eventType, payload, status }].slice(-MAX_ENTRIES);
+    nextId += 1;
+
+    notify();
+  },
+  getEntries: () => entries,
+  clear: () => {
+    entries = [];
+
+    notify();
+  },
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+
+    return () => listeners.delete(listener);
+  },
+};

--- a/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/TelemetryDebugStore.ts
@@ -14,6 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { singleton } from 'logic/singleton';
 
 // 'sent' = posthog.capture ran; 'suppressed' = posthog gates dropped it; 'disabled' = telemetry
 // is turned off entirely and the event only exists for debugging.
@@ -30,53 +31,63 @@ export type TelemetryDebugEntry = {
 export const TELEMETRY_DEBUG_STORAGE_KEY = 'gl.telemetry-debug';
 export const MAX_ENTRIES = 500;
 
-// The flag is mirrored into memory so the per-event hot path is a boolean check, not a
-// localStorage read.
-let enabled = false;
-let entries: TelemetryDebugEntry[] = [];
-let nextId = 1;
-const listeners = new Set<() => void>();
-
-try {
-  enabled = localStorage.getItem(TELEMETRY_DEBUG_STORAGE_KEY) === 'true';
-} catch {
-  // localStorage unavailable (e.g. privacy mode) — debugging simply stays off.
-}
-
-const notify = () => listeners.forEach((listener) => listener());
-
-export const isTelemetryDebugEnabled = () => enabled;
-
-export const setTelemetryDebugEnabled = (newEnabled: boolean) => {
-  enabled = newEnabled;
+const createTelemetryDebugStore = () => {
+  // The flag is mirrored into memory so the per-event hot path is a boolean check, not a
+  // localStorage read.
+  let enabled = false;
+  let entries: TelemetryDebugEntry[] = [];
+  let nextId = 1;
+  const listeners = new Set<() => void>();
 
   try {
-    localStorage.setItem(TELEMETRY_DEBUG_STORAGE_KEY, String(newEnabled));
+    enabled = localStorage.getItem(TELEMETRY_DEBUG_STORAGE_KEY) === 'true';
   } catch {
-    // Persistence is best-effort; the in-memory flag still applies for this session.
+    // localStorage unavailable (e.g. privacy mode) — debugging simply stays off.
   }
 
-  notify();
+  const notify = () => listeners.forEach((listener) => listener());
+
+  return {
+    isTelemetryDebugEnabled: () => enabled,
+    setTelemetryDebugEnabled: (newEnabled: boolean) => {
+      enabled = newEnabled;
+
+      try {
+        localStorage.setItem(TELEMETRY_DEBUG_STORAGE_KEY, String(newEnabled));
+      } catch {
+        // Persistence is best-effort; the in-memory flag still applies for this session.
+      }
+
+      notify();
+    },
+    telemetryDebugStore: {
+      record: (eventType: string, payload: object, status: TelemetryDebugStatus) => {
+        if (!enabled) return;
+
+        entries = [...entries, { id: nextId, timestamp: Date.now(), eventType, payload, status }].slice(-MAX_ENTRIES);
+        nextId += 1;
+
+        notify();
+      },
+      getEntries: () => entries,
+      clear: () => {
+        entries = [];
+
+        notify();
+      },
+      subscribe: (listener: () => void) => {
+        listeners.add(listener);
+
+        return () => listeners.delete(listener);
+      },
+    },
+  };
 };
 
-export const telemetryDebugStore = {
-  record: (eventType: string, payload: object, status: TelemetryDebugStatus) => {
-    if (!enabled) return;
-
-    entries = [...entries, { id: nextId, timestamp: Date.now(), eventType, payload, status }].slice(-MAX_ENTRIES);
-    nextId += 1;
-
-    notify();
-  },
-  getEntries: () => entries,
-  clear: () => {
-    entries = [];
-
-    notify();
-  },
-  subscribe: (listener: () => void) => {
-    listeners.add(listener);
-
-    return () => listeners.delete(listener);
-  },
-};
+// Plugin bundles compile their own copies of core modules, so the store state must live in the
+// cross-bundle singleton registry — a provider in one bundle records into the same buffer an
+// overlay from another bundle reads (same reason TelemetryContext and App are singletons).
+export const { isTelemetryDebugEnabled, setTelemetryDebugEnabled, telemetryDebugStore } = singleton(
+  'core.TelemetryDebugStore',
+  createTelemetryDebugStore,
+);

--- a/graylog2-web-interface/src/logic/telemetry/debug/piiHeuristics.test.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/piiHeuristics.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import detectPiiSuspect from './piiHeuristics';
+
+describe('detectPiiSuspect', () => {
+  it.each([
+    ['kay.roepke@example.com', 'email'],
+    ['192.168.1.42', 'ip-address'],
+    ['2001:db8::8a2e:370:7334', 'ip-address'],
+    ['0198c7c2-2c3e-7b90-8f6e-1a2b3c4d5e6f', 'uuid'],
+    ['5f3e4c5d6a7b8c9d0e1f2a3b', 'object-id'],
+    ['web-prod-01.internal.example.com', 'hostname'],
+    ['this is a rather long free text value that nobody should ever put into telemetry', 'free-text'],
+  ])('flags %s as %s', (value, rule) => {
+    expect(detectPiiSuspect(value)).toBe(rule);
+  });
+
+  it.each([
+    ['fleet-1'],
+    ['onboarding-generate'],
+    ['P30D'],
+    ['never'],
+    ['online-receiving'],
+    ['system/collectors/deployment'],
+    ['collectors-overview'],
+    ['short text'],
+  ])('does not flag %s', (value) => {
+    expect(detectPiiSuspect(value)).toBeNull();
+  });
+
+  it.each([[42], [true], [null], [undefined], [{ nested: true }]])('ignores non-string value %p', (value) => {
+    expect(detectPiiSuspect(value)).toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/logic/telemetry/debug/piiHeuristics.ts
+++ b/graylog2-web-interface/src/logic/telemetry/debug/piiHeuristics.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+export type PiiRule = 'email' | 'ip-address' | 'uuid' | 'object-id' | 'hostname' | 'free-text';
+
+const FREE_TEXT_MIN_LENGTH = 40;
+
+// Ordered from most to least specific — the first match names the rule.
+const RULES: Array<[PiiRule, RegExp]> = [
+  ['email', /^[^\s@]+@[^\s@]+\.[^\s@]+$/],
+  ['uuid', /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i],
+  ['object-id', /^[0-9a-f]{24}$/i],
+  ['ip-address', /^(\d{1,3}(\.\d{1,3}){3}|[0-9a-f:]*:[0-9a-f:]+)$/i],
+  // Dot-separated labels ending in an alphabetic TLD, e.g. host.example.com.
+  ['hostname', /^[a-z0-9-]+(\.[a-z0-9-]+)*\.[a-z]{2,}$/i],
+];
+
+/**
+ * Heuristically classifies a telemetry payload value as potentially personally identifying.
+ * Returns the name of the matched rule, or null when the value looks harmless. Deliberately
+ * conservative about paths and enum-like strings: slashes and short texts never match.
+ */
+const detectPiiSuspect = (value: unknown): PiiRule | null => {
+  if (typeof value !== 'string') return null;
+
+  // Path-like values (app_pathname etc.) are expected and would otherwise trip the hostname rule.
+  if (value.includes('/')) return null;
+
+  const match = RULES.find(([, pattern]) => pattern.test(value));
+  if (match) return match[0];
+
+  if (value.length >= FREE_TEXT_MIN_LENGTH && value.includes(' ')) return 'free-text';
+
+  return null;
+};
+
+export default detectPiiSuspect;

--- a/graylog2-web-interface/src/routing/App.tsx
+++ b/graylog2-web-interface/src/routing/App.tsx
@@ -26,6 +26,7 @@ import Navigation from 'components/navigation/Navigation';
 import ReportedErrorBoundary from 'components/errors/ReportedErrorBoundary';
 import RuntimeErrorBoundary from 'components/errors/RuntimeErrorBoundary';
 import NavigationTelemetry from 'logic/telemetry/NavigationTelemetry';
+import TelemetryDebugOverlay from 'components/telemetry-debug/TelemetryDebugOverlay';
 import HotkeysProvider from 'contexts/HotkeysProvider';
 import HotkeysModalContainer from 'components/hotkeys/HotkeysModalContainer';
 import PageContextProviders from 'components/page/contexts/PageContextProviders';
@@ -96,6 +97,7 @@ const App = () => (
                     </ReportedErrorBoundary>
                   </AppLayout>
                   <HotkeysModalContainer />
+                  <TelemetryDebugOverlay />
                 </>
               </ScratchpadProvider>
             </HotkeysProvider>


### PR DESCRIPTION
/nocl development tooling

It can be cumbersome to debug telemetry events during development, and having telemetry enabled to check the central repository has delays and isn't the most agile way to testing changes.

This enables seeing telemetry events in an overlay pane even if telemetry is globally disabled.
It can be enabled/disabled with a Quick Jump action in development builds.

<img width="2059" height="1177" alt="image" src="https://github.com/user-attachments/assets/653f5254-560e-45b2-b375-6aaf8235e40f" />
