### PR TITLE
Use default cursor for charts in non-interactive mode.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.tsx
@@ -34,8 +34,8 @@ import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
 export type PlotLayout = Layout;
 
-const StyledPlot = styled(Plot)(
-  ({ theme }) => css`
+const StyledPlot = styled(Plot)<{ $interactive: boolean }>(
+  ({ theme, $interactive }) => css`
     .customPopover .popover-content {
       padding: 0;
     }
@@ -54,6 +54,13 @@ const StyledPlot = styled(Plot)(
         stroke: ${theme.colors.global.contentBackground} !important;
       }
     }
+
+    ${!$interactive &&
+    css`
+      .cursor-pointer {
+        cursor: default !important;
+      }
+    `}
   `,
 );
 
@@ -301,6 +308,7 @@ const GenericPlot = ({
 
   return (
     <StyledPlot
+      $interactive={interactive}
       data={plotChartData}
       useResizeHandler
       layout={plotLayoutWithRevision}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Search page widgets are displayed in a non-interactive mode in e.g. reports and the dashboard big display mode.
Before this change visualizations like the the area charts, displayed a pointer cursor on hover in some cases, indicating that you can click the chart. With this PR we should the default cursor on hover in non-interactive mode.

/nocl - small visual change
