### PR TITLE
Improve paddings in chart legends.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/PlotLegend.tsx
@@ -64,25 +64,33 @@ const VariableContainer = styled.div<{ $height: number; $width: number }>(
   `,
 );
 
-const LegendContainer = styled.div`
-  padding: 5px;
+const LegendContainerBase = styled.div(
+  ({ theme }) => css`
+    padding: ${theme.spacings.xxs};
+  `,
+);
+
+const LegendContainer = styled(LegendContainerBase)`
   max-height: 100px;
   overflow: auto;
 `;
 
-const Legend = styled.div`
-  display: table;
-  width: 100%;
-`;
+const Legend = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacings.xxs};
+    width: 100%;
+  `,
+);
 
-const LegendRow = styled.div`
-  display: table-row;
-`;
-
-const LegendCell = styled.div`
-  padding: 4px;
-  display: table-cell;
-`;
+const LegendRow = styled.div(
+  ({ theme }) => css`
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: ${theme.spacings.xs};
+  `,
+);
 
 const LegendEntryContainer = styled.div`
   display: flex;
@@ -179,9 +187,9 @@ const TableCell = ({ value, fieldTypes, labelFields }: TableCellProps) => {
   });
 
   return (
-    <LegendCell key={value}>
+    <div key={value}>
       <LegendEntry labelsWithField={labelsWithField} value={value} />
-    </LegendCell>
+    </div>
   );
 };
 
@@ -208,11 +216,14 @@ const InteractiveLegend = ({ config, fieldTypes, labelFields, labels }: LegendCo
   );
 };
 
-const FlexLegendContainer = styled.div`
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-`;
+const FlexLegendContainer = styled(LegendContainerBase)(
+  ({ theme }) => css`
+    display: flex;
+    column-gap: ${theme.spacings.xs};
+    row-gap: ${theme.spacings.xxs};
+    flex-wrap: wrap;
+  `,
+);
 
 const NoninteractiveLegend = ({ config, fieldTypes, labels, labelFields }: LegendComponentProps) => {
   const _labelFields = useMemo(() => labelFields(config), [config, labelFields]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR slightly improves the paddings used in chart legends.

**Before** - interactive mode
<img width="422" height="172" alt="image" src="https://github.com/user-attachments/assets/06b4b583-5973-4e43-b04b-57060b2ff6e7" />
- legend items and legend container have padding, which results in not needed white space at the bottom of the legend
- relatively large gap between rows

**After** - interactive mode
<img width="430" height="176" alt="image" src="https://github.com/user-attachments/assets/e1e781f4-eadf-4c5e-8b41-04b78d9aabdd" />

------

**Before** - non-interactive mode
<img width="432" height="230" alt="image" src="https://github.com/user-attachments/assets/6418ab6a-92bf-40f3-9f37-b392da6c139b" />
- relatively large gap between rows, 
- legend container has no padding which can result in text overflow issues like this one:

<img width="279" height="106" alt="image" src="https://github.com/user-attachments/assets/dd9ab18d-409d-435a-9542-dd030981a691" />


**After** - non-interactive mode
<img width="432" height="196" alt="image" src="https://github.com/user-attachments/assets/5c57e3d7-28a7-40d0-bc85-57c92b987e7c" />

/nocl - small visual improvement