### PR TITLE
Add Space char to Lucene query escaping

### DIFF
--- a/changelog/unreleased/pr-27029.toml
+++ b/changelog/unreleased/pr-27029.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Add Space char to Lucene query escaping. It probably was simply missing until now, adding it also prevents malicious injection."
+
+pulls = ["27029"]

--- a/changelog/unreleased/pr-27029.toml
+++ b/changelog/unreleased/pr-27029.toml
@@ -1,4 +1,4 @@
 type = "f"
-message = "Add Space char to Lucene query escaping. It probably was simply missing until now, adding it also prevents malicious injection."
+message = "Add Space char to Lucene query escaping."
 
 pulls = ["27029"]

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -277,8 +277,8 @@ public class MoreSearch {
             for (char c : searchString.toCharArray()) {
                 // These characters are part of the query syntax and must be escaped
                 if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':'
-                        || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
-                        || c == '*' || c == '?' || c == '|' || c == '&' || c == '/') {
+                        || c == '^' || c == '[' || c == ']' || c == '"' || c == '{' || c == '}' || c == '~'
+                        || c == '*' || c == '?' || c == '|' || c == '&' || c == '/' || c == ' ') {
                     result.append('\\');
                 }
                 result.append(c);

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -271,14 +271,23 @@ public class MoreSearch {
      * @return String where those characters that Lucene expects to be escaped are escaped by a
      * preceding <code>\</code>
      */
+    private static final String SPECIAL_CHARS = "\\+-!():^[]\"{}~|& ";
+    private static final String SPECIAL_CHARS_WITH_WILDCARDS = SPECIAL_CHARS + "*?";
+
     public static String luceneEscape(String searchString) {
+        return luceneEscape(SPECIAL_CHARS_WITH_WILDCARDS,  searchString);
+    }
+
+    public static String luceneEscapeButNotIncludingWildcards(String searchString) {
+        return luceneEscape(SPECIAL_CHARS, searchString);
+    }
+
+    private static String luceneEscape(final String charsToEscape, String searchString) {
         StringBuilder result = new StringBuilder();
         if (searchString != null) {
             for (char c : searchString.toCharArray()) {
                 // These characters are part of the query syntax and must be escaped
-                if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':'
-                        || c == '^' || c == '[' || c == ']' || c == '"' || c == '{' || c == '}' || c == '~'
-                        || c == '*' || c == '?' || c == '|' || c == '&' || c == '/' || c == ' ') {
+                if (charsToEscape.indexOf(c) >= 0) {
                     result.append('\\');
                 }
                 result.append(c);

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -272,10 +272,10 @@ public class MoreSearch {
      * preceding <code>\</code>
      */
     private static final String SPECIAL_CHARS = "\\+-!():^[]\"{}~|&/ ";
-    private static final String SPECIAL_CHARS_WITH_WILDCARDS = SPECIAL_CHARS + "*?";
+    private static final String SPECIAL_CHARS_INCLUDING_WILDCARDS = SPECIAL_CHARS + "*?";
 
     public static String luceneEscape(String searchString) {
-        return luceneEscape(SPECIAL_CHARS_WITH_WILDCARDS,  searchString);
+        return luceneEscape(SPECIAL_CHARS_INCLUDING_WILDCARDS,  searchString);
     }
 
     public static String luceneEscapeButNotIncludingWildcards(String searchString) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -271,7 +271,7 @@ public class MoreSearch {
      * @return String where those characters that Lucene expects to be escaped are escaped by a
      * preceding <code>\</code>
      */
-    private static final String SPECIAL_CHARS = "\\+-!():^[]\"{}~|& ";
+    private static final String SPECIAL_CHARS = "\\+-!():^[]\"{}~|&/ ";
     private static final String SPECIAL_CHARS_WITH_WILDCARDS = SPECIAL_CHARS + "*?";
 
     public static String luceneEscape(String searchString) {

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -238,7 +238,7 @@ public class AggregationEventProcessorTest {
         );
         sourceMessagesWithAggregation(groupByFields, 1, emptyList());
 
-        String expectedQueryString = "(aQueryString) AND ((group_field_one:\"\\\" \\\" \\* \\& \\? \\- \\\\\") AND (group_field_two:\"\\/ \\/ \\~ \\| \\[\\]\\{\\}\"))";
+        String expectedQueryString = "(aQueryString) AND ((group_field_one:\"\\\"\\ \\\"\\ \\*\\ \\&\\ \\?\\ \\-\\ \\\\\") AND (group_field_two:\"\\/\\ \\/\\ \\~\\ \\|\\ \\[\\]\\{\\}\"))";
         verify(moreSearch).scrollQuery(eq(expectedQueryString), any(), any(), any(), any(), eq(1), any());
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/search/EventsFilterBuilderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/EventsFilterBuilderTest.java
@@ -76,7 +76,7 @@ class EventsFilterBuilderTest {
                 .extraFilters(Map.of(EventDto.FIELD_TAGS, Set.of("phish\"ing OR alert:true")))
                 .build();
 
-        assertThat(build(filter)).isEqualTo(EVENT_DEFINITION_ID_CLAUSE + " AND (tags:\"phish\\\"ing OR alert\\:true\")");
+        assertThat(build(filter)).isEqualTo(EVENT_DEFINITION_ID_CLAUSE + " AND (tags:\"phish\\\"ing\\ OR\\ alert\\:true\")");
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.events.search;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MoreSearchTest {
+
+    // --- boundary conditions ---
+
+    @Test
+    void nullInputReturnsEmptyString() {
+        assertThat(MoreSearch.luceneEscape(null)).isEqualTo("");
+    }
+
+    @Test
+    void emptyInputReturnsEmptyString() {
+        assertThat(MoreSearch.luceneEscape("")).isEqualTo("");
+    }
+
+    @Test
+    void plainAlphanumericInputIsUnchanged() {
+        assertThat(MoreSearch.luceneEscape("fooBar123")).isEqualTo("fooBar123");
+    }
+
+    // --- pre-existing special characters ---
+
+    @ParameterizedTest(name = "char ''{0}'' is escaped to ''{1}''")
+    @CsvSource({
+            "\\,   \\\\",
+            "+,    \\+",
+            "-,    \\-",
+            "!,    \\!",
+            "(,    \\(",
+            "),    \\)",
+            ":,    \\:",
+            "^,    \\^",
+            "[,    \\[",
+            "],    \\]",
+            "{,    \\{",
+            "},    \\}",
+            "~,    \\~",
+            "*,    \\*",
+            "?,    \\?",
+            "|,    \\|",
+            "&,    \\&",
+            "/,    \\/",
+    })
+    void preExistingSpecialCharactersAreEscaped(String input, String expected) {
+        assertThat(MoreSearch.luceneEscape(input)).isEqualTo(expected);
+    }
+
+    // --- double-quote: was escaped via '\"', now via '"' (same char, same behavior) ---
+
+    @Test
+    void doubleQuoteIsEscaped() {
+        // '"' and '\"' are identical Java char literals — the recent cleanup did not change behavior.
+        assertThat(MoreSearch.luceneEscape("\"")).isEqualTo("\\\"");
+    }
+
+    @Test
+    void doubleQuoteInsideStringIsEscaped() {
+        assertThat(MoreSearch.luceneEscape("say \"hello\"")).isEqualTo("say\\ \\\"hello\\\"");
+    }
+
+    // --- space: newly escaped as of the change ---
+
+    @Test
+    void spaceIsEscaped() {
+        assertThat(MoreSearch.luceneEscape(" ")).isEqualTo("\\ ");
+    }
+
+    @Test
+    void spaceInsideStringIsEscaped() {
+        assertThat(MoreSearch.luceneEscape("hello world")).isEqualTo("hello\\ world");
+    }
+
+    @Test
+    void multipleSpacesAreAllEscaped() {
+        assertThat(MoreSearch.luceneEscape("a b c")).isEqualTo("a\\ b\\ c");
+    }
+
+    // --- combined / real-world inputs ---
+
+    @Test
+    void streamIdWithoutSpecialCharsIsUnchanged() {
+        // MongoDB ObjectIds are 24 hex chars — no special characters, no spaces.
+        assertThat(MoreSearch.luceneEscape("5e8c1d2f3a4b5c6d7e8f9a0b")).isEqualTo("5e8c1d2f3a4b5c6d7e8f9a0b");
+    }
+
+    @Test
+    void ipAddressWithSlashIsEscaped() {
+        // e.g. CIDR used in watchlist
+        assertThat(MoreSearch.luceneEscape("10.0.0.0/8")).isEqualTo("10.0.0.0\\/8");
+    }
+
+    @Test
+    void usernameWithSpaceIsEscaped() {
+        // user names can contain spaces; the escaped form is safe inside a quoted phrase query
+        assertThat(MoreSearch.luceneEscape("John Doe")).isEqualTo("John\\ Doe");
+    }
+
+    @Test
+    void tagWithSpaceIsEscaped() {
+        // tags can be multi-word; callers wrap the result in quotes, so "multi\ word" still matches
+        assertThat(MoreSearch.luceneEscape("multi word tag")).isEqualTo("multi\\ word\\ tag");
+    }
+
+    @Test
+    void wildcardTermWithSpaceProducesSingleEscapedTerm() {
+        // ExclusionQuery uses luceneEscape for wildcard values (not quoted). Before the change, "foo bar*"
+        // would have produced "foo bar*" (two Lucene terms). Now it produces "foo\ bar*" (one term).
+        assertThat(MoreSearch.luceneEscape("foo bar*")).isEqualTo("foo\\ bar\\*");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/MoreSearchTest.java
@@ -72,7 +72,7 @@ class MoreSearchTest {
 
     @Test
     void doubleQuoteIsEscaped() {
-        // '"' and '\"' are identical Java char literals — the recent cleanup did not change behavior.
+        // '"' and '\"' are identical Java char literals.
         assertThat(MoreSearch.luceneEscape("\"")).isEqualTo("\\\"");
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The escaping of values into Lucene queries did not escape the Space character until now which could lead to unwanted Lucene queries (maybe even malicious injection).

This PR adds the char adds tests and adjusts existing tests that contain space chars but now have to check for the escaped char, too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

