### PR TITLE
Prevent privilege escalation when creating/updating users (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26883.toml
+++ b/changelog/unreleased/pr-26883.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Prevent users from assigning permissions or roles they do not hold themselves when creating or updating a user."
+
+pulls = ["26883"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -98,6 +98,7 @@ import org.graylog2.shared.users.Role;
 import org.graylog2.shared.users.UserManagementService;
 import org.graylog2.users.PaginatedUserService;
 import org.graylog2.users.PasswordComplexityConfig;
+import org.graylog2.users.PrivilegeEscalationGuard;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.RoleServiceImpl;
 import org.graylog2.users.UserConfiguration;
@@ -156,6 +157,7 @@ public class UsersResource extends RestResource {
     private final SearchQueryParser searchQueryParser;
     private final UserSessionTerminationService sessionTerminationService;
     private final DefaultSecurityManager securityManager;
+    private final PrivilegeEscalationGuard privilegeEscalationGuard;
     private final GlobalAuthServiceConfig globalAuthServiceConfig;
     private final ClusterConfigService clusterConfigService;
     private final AuditEventSender auditEventSender;
@@ -177,7 +179,8 @@ public class UsersResource extends RestResource {
                          DefaultSecurityManager securityManager,
                          GlobalAuthServiceConfig globalAuthServiceConfig,
                          ClusterConfigService clusterConfigService,
-                         AuditEventSender auditEventSender) {
+                         AuditEventSender auditEventSender,
+                         PrivilegeEscalationGuard privilegeEscalationGuard) {
         this.userManagementService = userManagementService;
         this.accessTokenService = accessTokenService;
         this.roleService = roleService;
@@ -185,6 +188,7 @@ public class UsersResource extends RestResource {
         this.paginatedUserService = paginatedUserService;
         this.sessionTerminationService = sessionTerminationService;
         this.securityManager = securityManager;
+        this.privilegeEscalationGuard = privilegeEscalationGuard;
         this.searchQueryParser = new SearchQueryParser(UserOverviewDTO.FIELD_FULL_NAME, SEARCH_FIELD_MAPPING);
         this.globalAuthServiceConfig = globalAuthServiceConfig;
         this.clusterConfigService = clusterConfigService;
@@ -380,7 +384,7 @@ public class UsersResource extends RestResource {
     })
     @AuditEvent(type = AuditEventTypes.USER_CREATE)
     public Response create(@ApiParam(name = "JSON body", value = "Must contain username, full_name, email, password and a list of permissions.", required = true)
-                               @Valid @NotNull CreateUserRequest cr,
+                           @Valid @NotNull CreateUserRequest cr,
                            @Context UserContext userContext) throws ValidationException {
         if (isUserNameInUse(cr.username())) {
             final String msg = "Cannot create user " + cr.username() + ". Username is already taken.";
@@ -390,6 +394,7 @@ public class UsersResource extends RestResource {
         if (rolesContainAdmin(cr.roles()) && cr.isServiceAccount()) {
             throw new BadRequestException("Cannot assign Admin role to service account");
         }
+        privilegeEscalationGuard.validatePermissionsAndRoles(cr, userContext);
         validatePasswordComplexity(cr.password());
 
         // Create user.
@@ -425,6 +430,8 @@ public class UsersResource extends RestResource {
 
         return Response.created(userUri).build();
     }
+
+
 
     @GET
     @RequiresPermissions(RestPermissions.USERS_CREATE)
@@ -537,10 +544,10 @@ public class UsersResource extends RestResource {
         final User user = loadUserById(userId);
         final String username = user.getName();
         checkPermission(USERS_EDIT, username);
-
         if (user.isReadOnly()) {
             throw new BadRequestException("Cannot modify readonly user " + username);
         }
+
         // We only allow setting a subset of the fields in ChangeUserRequest
         if (!user.isExternalUser()) {
             if (cr.email() != null) {
@@ -552,11 +559,13 @@ public class UsersResource extends RestResource {
         }
         final boolean permitted = isPermitted(USERS_PERMISSIONSEDIT, user.getName());
         if (permitted && cr.permissions() != null) {
+            privilegeEscalationGuard.validatePermissions(cr.permissions(), userContext);
             user.setPermissions(getEffectiveUserPermissions(user, cr.permissions()));
         }
 
         if (isPermitted(USERS_ROLESEDIT, user.getName())) {
-            checkAdminRoleForServiceAccount(cr, user);
+            validateAdminRoleNotGrantedToServiceAccount(cr, user);
+            privilegeEscalationGuard.validateRolePermissions(cr.roles(), userContext);
             setUserRoles(cr.roles(), user, userContext);
         }
 
@@ -614,7 +623,7 @@ public class UsersResource extends RestResource {
         return roles != null && roles.stream().anyMatch(RoleServiceImpl.ADMIN_ROLENAME::equalsIgnoreCase);
     }
 
-    private void checkAdminRoleForServiceAccount(ChangeUserRequest cr, User user) {
+    private void validateAdminRoleNotGrantedToServiceAccount(ChangeUserRequest cr, User user) {
         if (user.isServiceAccount() && rolesContainAdmin(cr.roles())) {
             throw new BadRequestException("Cannot assign Admin role to service account");
         }
@@ -665,12 +674,14 @@ public class UsersResource extends RestResource {
     public void editPermissions(@ApiParam(name = "username", value = "The name of the user to modify.", required = true)
                                 @PathParam("username") String username,
                                 @ApiParam(name = "JSON body", value = "The list of permissions to assign to the user.", required = true)
-                                @Valid @NotNull PermissionEditRequest permissionRequest) throws ValidationException {
+                                @Valid @NotNull PermissionEditRequest permissionRequest,
+                                @Context UserContext userContext) throws ValidationException {
         final User user = userManagementService.load(username);
         if (user == null) {
             throw new NotFoundException("Couldn't find user " + username);
         }
 
+        privilegeEscalationGuard.validatePermissions(permissionRequest.permissions(), userContext);
         user.setPermissions(getEffectiveUserPermissions(user, permissionRequest.permissions()));
         userManagementService.save(user);
     }

--- a/graylog2-server/src/main/java/org/graylog2/users/PrivilegeEscalationGuard.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/PrivilegeEscalationGuard.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import org.graylog.security.UserContext;
+import org.graylog2.rest.models.users.requests.CreateUserRequest;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.graylog2.shared.security.RestPermissions.ROLES_READ;
+import static org.graylog2.shared.utilities.StringUtils.f;
+
+public class PrivilegeEscalationGuard {
+    private final RoleService roleService;
+
+    @Inject
+    public PrivilegeEscalationGuard(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+    public void validatePermissionsAndRoles(@NotNull CreateUserRequest cr, UserContext userContext) {
+        validatePermissionsAndRoles(cr.roles(), cr.permissions(), userContext);
+    }
+
+    public void validateRolePermissions(List<String> requestRoles, UserContext userContext) {
+        validatePermissionsAndRoles(requestRoles, List.of(), userContext);
+    }
+
+    private void validatePermissionsAndRoles(List<String> requestRoles, List<String> requestPermissions, UserContext userContext) {
+        try {
+            final var rolePermissions = extractPermissionsFromRoles(requestRoles, userContext::isPermitted);
+            final var joinedPermissions = Stream.concat(rolePermissions.stream(), requestPermissions.stream()).collect(Collectors.toSet());
+            validatePermissions(joinedPermissions, userContext);
+        } catch (org.graylog2.database.NotFoundException e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    public void validatePermissions(Collection<String> permissions, UserContext userContext) {
+        final var missingPermissions = permissionsCurrentUserMisses(permissions, userContext);
+        if (!missingPermissions.isEmpty()) {
+            throw new BadRequestException(f("Cannot assign permissions/roles to new user that current user does not have: %s", String.join(", ", missingPermissions)));
+        }
+    }
+
+    private Set<String> extractPermissionsFromRoles(List<String> requestRoles, BiPredicate<String, String> isPermitted) throws org.graylog2.database.NotFoundException {
+        final var normalizedRoles = Optional.ofNullable(requestRoles).orElse(Collections.emptyList());
+        final var deniedRoles = normalizedRoles
+                .stream()
+                .filter(role -> !isPermitted.test(ROLES_READ, role))
+                .toList();
+        if (!deniedRoles.isEmpty()) {
+            throw new ForbiddenException(f("Not allowed to read roles: %s", String.join(", ", deniedRoles)));
+        }
+        final var roles = roleService.loadByNames(normalizedRoles);
+        return roles.stream()
+                .flatMap(role -> role.getPermissions().stream())
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> permissionsCurrentUserMisses(Collection<String> requestPermissions, UserContext user) {
+        final var normalizedPermissions = Optional.ofNullable(requestPermissions).orElse(Collections.emptyList());
+        return normalizedPermissions.stream()
+                .filter(permission -> !user.isPermitted(permission))
+                .collect(Collectors.toSet());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleService.java
@@ -22,6 +22,7 @@ import org.graylog2.shared.users.Role;
 
 import jakarta.validation.ConstraintViolation;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ public interface RoleService {
     Role loadById(String roleId) throws NotFoundException;
 
     Role load(String roleName) throws NotFoundException;
+    Set<Role> loadByNames(Collection<String> roleNames) throws NotFoundException;
 
     boolean exists(String roleName);
 

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
@@ -43,14 +43,19 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.in;
+import static org.graylog2.shared.utilities.StringUtils.f;
 
 public class RoleServiceImpl implements RoleService {
     private static final Logger log = LoggerFactory.getLogger(RoleServiceImpl.class);
@@ -151,6 +156,21 @@ public class RoleServiceImpl implements RoleService {
             throw new NotFoundException("No role found with name " + roleName);
         }
         return role;
+    }
+
+    @Override
+    public Set<Role> loadByNames(Collection<String> roleNames) throws NotFoundException {
+        final var normalizedRoleNames = roleNames.stream()
+                .map(roleName -> roleName.toLowerCase(Locale.ENGLISH))
+                .collect(Collectors.toSet());
+        final Set<Role> roles = collection.find(in(NAME_LOWER, normalizedRoleNames)).into(new HashSet<>());
+        final var retrievedRoles = roles.stream().map(Role::getName).map(name -> name.toLowerCase(Locale.ENGLISH)).collect(Collectors.toSet());
+        final var missingRoles = Sets.difference(normalizedRoleNames, retrievedRoles);
+        if (!missingRoles.isEmpty()) {
+            throw new NotFoundException(f("No roles found with names %s", String.join(", ", missingRoles)));
+        }
+
+        return roles;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
@@ -48,11 +48,13 @@ import org.graylog2.security.hashing.SHA1HashPasswordAlgorithm;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.ChangeUserRequest;
 import org.graylog2.shared.users.Role;
 import org.graylog2.shared.users.UserManagementService;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.users.PaginatedUserService;
 import org.graylog2.users.PasswordComplexityConfig;
+import org.graylog2.users.PrivilegeEscalationGuard;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.UserConfiguration;
 import org.graylog2.users.UserImpl;
@@ -77,6 +79,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.shared.security.RestPermissions.ROLES_READ;
 import static org.graylog2.shared.security.RestPermissions.USERS_TOKENCREATE;
 import static org.graylog2.shared.security.RestPermissions.USERS_TOKENREMOVE;
 import static org.junit.Assert.assertEquals;
@@ -86,6 +89,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -149,6 +153,7 @@ public class UsersResourceTest {
         lenient().when(userContext.getUser()).thenReturn(user);
         lenient().when(user.getName()).thenReturn("username");
         lenient().when(user.getId()).thenReturn("userId");
+        lenient().when(userContext.isPermitted(ROLES_READ, TestUsersResource.ALLOWED_ROLE)).thenReturn(true);
     }
 
     /**
@@ -184,9 +189,11 @@ public class UsersResourceTest {
         Role adminRole = mock(Role.class);
         when(adminRole.getId()).thenReturn(new ObjectId().toHexString());
         when(adminRole.getName()).thenReturn("admin");
+        when(userContext.isPermitted(ROLES_READ, TestUsersResource.ALLOWED_ROLE)).thenReturn(true);
+        when(userContext.isPermitted(ROLES_READ, forbiddenRole)).thenReturn(true);
 
         when(roleService.loadAllLowercaseNameMap()).thenReturn(Map.of(ALLOWED_ROLE_LOWER_CASE, readerRole, "admin", adminRole));
-        when(userManagementService.create()).thenReturn(userImplFactory.create(new HashMap<>()));
+        when(userManagementService.create()).thenReturn(userImplFactory.create(Map.of()));
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
 
         ForbiddenException exception = assertThrows(ForbiddenException.class, () -> usersResource.create(buildCreateUserRequest(List.of(TestUsersResource.ALLOWED_ROLE, forbiddenRole), PASSWORD), userContext));
@@ -221,9 +228,136 @@ public class UsersResourceTest {
     @Test
     public void createFailureOnWrongRoleAssignPermission() {
         String testRole = "forbiddenRole";
+        lenient().when(userContext.isPermitted(ROLES_READ, testRole)).thenReturn(true);
         when(userManagementService.create()).thenReturn(userImplFactory.create(new HashMap<>()));
         when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
         assertThrows(BadRequestException.class, () -> usersResource.create(buildCreateUserRequest(List.of(testRole), PASSWORD), userContext));
+    }
+
+    @Test
+    public void createFailsWhenAssigningPermissionTheCreatingUserDoesNotHave() throws NotFoundException {
+        // The creating user is allowed to create users, but does not hold `inputs:create` itself.
+        lenient().when(subject.isPermitted(RestPermissions.USERS_CREATE)).thenReturn(true);
+        lenient().when(subject.isPermitted(RestPermissions.INPUTS_CREATE)).thenReturn(false);
+
+        lenient().when(roleService.loadAllLowercaseNameMap()).thenReturn(Map.of());
+        lenient().when(userManagementService.create()).thenReturn(userImplFactory.create(new HashMap<>()));
+        lenient().when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
+
+        final var creator = userImplFactory.create(Map.of(UserImpl.USERNAME, "creator"));
+        lenient().when(userService.loadById("creator")).thenReturn(creator);
+        lenient().when(subject.getPrincipal()).thenReturn(creator.getName());
+
+        final CreateUserRequest request = buildCreateUserRequest(List.of(), PASSWORD, List.of(RestPermissions.INPUTS_CREATE));
+        assertThrows(BadRequestException.class, () -> usersResource.create(request, userContext));
+    }
+
+    @Test
+    public void createFailsWhenAssigningRoleContainingPermissionTheCreatingUserDoesNotHave() throws NotFoundException {
+        // The role itself is assignable by the creating user, but it grants `inputs:create`, which the creating user
+        // does not hold itself.
+        final Role roleWithInputsCreate = mock(Role.class);
+        lenient().when(roleWithInputsCreate.getId()).thenReturn(new ObjectId().toHexString());
+        lenient().when(roleWithInputsCreate.getName()).thenReturn(TestUsersResource.ALLOWED_ROLE);
+        lenient().when(roleWithInputsCreate.getPermissions()).thenReturn(Set.of(RestPermissions.INPUTS_CREATE));
+
+        lenient().when(subject.isPermitted(RestPermissions.USERS_CREATE)).thenReturn(true);
+        lenient().when(subject.isPermitted(RestPermissions.INPUTS_CREATE)).thenReturn(false);
+
+        lenient().when(roleService.loadByNames(List.of(TestUsersResource.ALLOWED_ROLE))).thenReturn(Set.of(roleWithInputsCreate));
+        lenient().when(roleService.loadAllLowercaseNameMap()).thenReturn(Map.of(TestUsersResource.ALLOWED_ROLE, roleWithInputsCreate));
+        lenient().when(userManagementService.create()).thenReturn(userImplFactory.create(new HashMap<>()));
+        lenient().when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
+
+        final var creator = userImplFactory.create(Map.of(UserImpl.USERNAME, "creator"));
+        lenient().when(userService.loadById("creator")).thenReturn(creator);
+        lenient().when(subject.getPrincipal()).thenReturn(creator.getName());
+
+        final CreateUserRequest request = buildCreateUserRequest(List.of(TestUsersResource.ALLOWED_ROLE), PASSWORD, List.of());
+        final var exception = assertThrows(BadRequestException.class, () -> usersResource.create(request, userContext));
+        assertThat(exception).hasMessage("Cannot assign permissions/roles to new user that current user does not have: inputs:create");
+    }
+
+    @Test
+    public void createSucceedsWithoutRoles() throws ValidationException, NotFoundException {
+        lenient().when(subject.isPermitted(RestPermissions.USERS_CREATE)).thenReturn(true);
+        lenient().when(roleService.loadAllIdMap()).thenReturn(Map.of());
+        when(userManagementService.create()).thenReturn(userImplFactory.create(new HashMap<>()));
+
+        final var creator = userImplFactory.create(Map.of(UserImpl.USERNAME, "creator"));
+        lenient().when(userService.loadById("creator")).thenReturn(creator);
+        lenient().when(subject.getPrincipal()).thenReturn(creator.getName());
+
+        // `roles` is @Nullable in CreateUserRequest, so the validation must cope with a missing list.
+        final Response response = usersResource.create(buildCreateUserRequest(null, PASSWORD, List.of()), userContext);
+
+        assertEquals(201, response.getStatus());
+        verify(userManagementService).create(isA(UserImpl.class), eq(creator));
+    }
+
+    @Test
+    public void changeUserSucceedsWithoutPermissionsAndRoles() throws ValidationException, NotFoundException {
+        final String userId = "targetId";
+        final var targetUser = userImplFactory.create(Map.of(UserImpl.USERNAME, "target"));
+        when(userManagementService.loadById(userId)).thenReturn(targetUser);
+        when(subject.isPermitted(RestPermissions.USERS_EDIT + ":target")).thenReturn(true);
+        lenient().when(roleService.loadAllIdMap()).thenReturn(Map.of());
+
+        // Both `permissions` and `roles` are @Nullable in ChangeUserRequest, so a request that touches neither must not
+        // fail the validation.
+        final var request = ChangeUserRequest.create(EMAIL, FIRST_NAME, LAST_NAME, null, TIMEZONE, null, null, null, null);
+        usersResource.changeUser(userId, request, userContext);
+
+        verify(userManagementService).update(targetUser, request);
+    }
+
+    @Test
+    public void changeUserFailsWhenAssigningPermissionTheEditingUserDoesNotHave() throws ValidationException {
+        final String userId = "targetId";
+        final var targetUser = userImplFactory.create(Map.of(UserImpl.USERNAME, "target"));
+        when(userManagementService.loadById(userId)).thenReturn(targetUser);
+        when(subject.isPermitted(RestPermissions.USERS_EDIT + ":target")).thenReturn(true);
+        // The editing user is allowed to edit permissions, so the submitted list would be applied.
+        lenient().when(subject.isPermitted(RestPermissions.USERS_PERMISSIONSEDIT + ":target")).thenReturn(true);
+
+        // The editing user holds `streams:read`, but not `inputs:create`.
+        lenient().when(userContext.isPermitted(RestPermissions.STREAMS_READ)).thenReturn(true);
+        lenient().when(userContext.isPermitted(RestPermissions.INPUTS_CREATE)).thenReturn(false);
+
+        final var request = buildChangeUserRequest(null, List.of(RestPermissions.STREAMS_READ, RestPermissions.INPUTS_CREATE));
+        final var exception = assertThrows(BadRequestException.class, () -> usersResource.changeUser(userId, request, userContext));
+
+        assertThat(exception)
+                .hasMessageContaining(RestPermissions.INPUTS_CREATE)
+                .hasMessageNotContaining(RestPermissions.STREAMS_READ);
+        verify(userManagementService, never()).update(isA(UserImpl.class), isA(ChangeUserRequest.class));
+    }
+
+    @Test
+    public void changeUserFailsWhenAssigningRoleContainingPermissionTheEditingUserDoesNotHave() throws NotFoundException, ValidationException {
+        final String userId = "targetId";
+        final var targetUser = userImplFactory.create(Map.of(UserImpl.USERNAME, "target"));
+        when(userManagementService.loadById(userId)).thenReturn(targetUser);
+        when(subject.isPermitted(RestPermissions.USERS_EDIT + ":target")).thenReturn(true);
+
+        // The editing user is allowed to edit roles, and the role itself is assignable by them.
+        lenient().when(subject.isPermitted(RestPermissions.USERS_ROLESEDIT + ":target")).thenReturn(true);
+
+        final Role roleWithInputsCreate = mock(Role.class);
+        lenient().when(roleWithInputsCreate.getId()).thenReturn(new ObjectId().toHexString());
+        lenient().when(roleWithInputsCreate.getName()).thenReturn(TestUsersResource.ALLOWED_ROLE);
+        lenient().when(roleWithInputsCreate.getPermissions()).thenReturn(Set.of(RestPermissions.INPUTS_CREATE));
+        // The role is looked up by its lowercased name, no matter how the request spells it.
+        lenient().when(roleService.loadByNames(List.of(TestUsersResource.ALLOWED_ROLE))).thenReturn(Set.of(roleWithInputsCreate));
+        lenient().when(roleService.loadAllLowercaseNameMap()).thenReturn(Map.of(TestUsersResource.ALLOWED_ROLE, roleWithInputsCreate));
+
+        lenient().when(userContext.isPermitted(RestPermissions.INPUTS_CREATE)).thenReturn(false);
+
+        final var request = buildChangeUserRequest(List.of(TestUsersResource.ALLOWED_ROLE), null);
+        final var exception = assertThrows(BadRequestException.class, () -> usersResource.changeUser(userId, request, userContext));
+
+        assertThat(exception).hasMessageContaining(RestPermissions.INPUTS_CREATE);
+        verify(userManagementService, never()).update(isA(UserImpl.class), isA(ChangeUserRequest.class));
     }
 
     @Test
@@ -447,9 +581,17 @@ public class UsersResourceTest {
         return user;
     }
 
+    private ChangeUserRequest buildChangeUserRequest(List<String> roles, List<String> permissions) {
+        return ChangeUserRequest.create(EMAIL, FIRST_NAME, LAST_NAME, permissions, TIMEZONE, null, null, roles, null);
+    }
+
     private CreateUserRequest buildCreateUserRequest(List<String> roles, String password) {
+        return buildCreateUserRequest(roles, password, Collections.emptyList());
+    }
+
+    private CreateUserRequest buildCreateUserRequest(List<String> roles, String password, List<String> permissions) {
         return CreateUserRequest.create(USERNAME, password, EMAIL,
-                FIRST_NAME, LAST_NAME, Collections.singletonList(""),
+                FIRST_NAME, LAST_NAME, permissions,
                 TIMEZONE, SESSION_TIMEOUT,
                 new DashboardStartPage("dashboard-id"), roles, false);
     }
@@ -520,7 +662,7 @@ public class UsersResourceTest {
                                  DefaultSecurityManager securityManager, GlobalAuthServiceConfig globalAuthServiceConfig,
                                  ClusterConfigService clusterConfigService, UserService userService) {
             super(userManagementService, paginatedUserService, accessTokenService, roleService, sessionService,
-                    sessionTerminationService, securityManager, globalAuthServiceConfig, clusterConfigService, mock(AuditEventSender.class));
+                    sessionTerminationService, securityManager, globalAuthServiceConfig, clusterConfigService, mock(AuditEventSender.class), new PrivilegeEscalationGuard(roleService));
             this.subject = subject;
             super.configuration = configuration;
             super.userService = userService;

--- a/graylog2-server/src/test/java/org/graylog2/users/PrivilegeEscalationGuardTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/PrivilegeEscalationGuardTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.users;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import org.graylog.security.UserContext;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.rest.models.users.requests.CreateUserRequest;
+import org.graylog2.shared.users.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.graylog2.shared.security.RestPermissions.INPUTS_CREATE;
+import static org.graylog2.shared.security.RestPermissions.ROLES_READ;
+import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PrivilegeEscalationGuardTest {
+
+    private static final String MISSING_PERMISSIONS_PREFIX =
+            "Cannot assign permissions/roles to new user that current user does not have: ";
+    private static final String DASHBOARDS_CREATE = "dashboards:create";
+
+    // Role names are deliberately spelled in mixed/upper case, because the validator is expected to normalize them.
+    private static final String READER_ROLE = "Reader";
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    @Mock
+    private RoleService roleService;
+    @Mock
+    private UserContext userContext;
+
+    private PrivilegeEscalationGuard validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new PrivilegeEscalationGuard(roleService);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // validatePermissions - the plain "does the current user hold these permissions?" check
+    // ----------------------------------------------------------------------------------------------------
+
+    @Test
+    void validatePermissionsPassesWhenCurrentUserHoldsAllOfThem() {
+        currentUserHolds(STREAMS_READ, INPUTS_CREATE);
+
+        assertThatCode(() -> validator.validatePermissions(List.of(STREAMS_READ, INPUTS_CREATE), userContext))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validatePermissionsRejectsPermissionTheCurrentUserMisses() {
+        currentUserHolds(STREAMS_READ);
+
+        assertThatThrownBy(() -> validator.validatePermissions(List.of(STREAMS_READ, INPUTS_CREATE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MISSING_PERMISSIONS_PREFIX + INPUTS_CREATE);
+    }
+
+    @Test
+    void validatePermissionsReportsEveryMissingPermissionAndNoHeldOnes() {
+        currentUserHolds(STREAMS_READ);
+
+        assertThatThrownBy(() -> validator.validatePermissions(
+                List.of(STREAMS_READ, INPUTS_CREATE, DASHBOARDS_CREATE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                // The missing permissions are collected into an unordered Set, so only membership is guaranteed.
+                .hasMessageContaining(INPUTS_CREATE)
+                .hasMessageContaining(DASHBOARDS_CREATE)
+                .hasMessageNotContaining(STREAMS_READ);
+    }
+
+    @Test
+    void validatePermissionsMentionsARepeatedMissingPermissionOnlyOnce() {
+        assertThatThrownBy(() -> validator.validatePermissions(List.of(INPUTS_CREATE, INPUTS_CREATE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MISSING_PERMISSIONS_PREFIX + INPUTS_CREATE);
+    }
+
+    @Test
+    void validatePermissionsAcceptsEmptyCollection() {
+        assertThatCode(() -> validator.validatePermissions(List.of(), userContext)).doesNotThrowAnyException();
+
+        verifyNoInteractions(userContext);
+    }
+
+    @Test
+    void validatePermissionsAcceptsNullCollection() {
+        // `ChangeUserRequest.permissions()` is @Nullable, so the validator must cope with a missing list.
+        assertThatCode(() -> validator.validatePermissions(null, userContext)).doesNotThrowAnyException();
+
+        verifyNoInteractions(userContext);
+    }
+
+    @Test
+    void validatePermissionsChecksPermissionStringsVerbatim() {
+        // Graylog resolves user permissions case-sensitively (CaseSensitiveWildcardPermission), so unlike role
+        // names, permission strings must be passed through untouched.
+        final String mixedCasePermission = "Streams:Read:ABC123";
+        currentUserHolds(mixedCasePermission);
+
+        assertThatCode(() -> validator.validatePermissions(List.of(mixedCasePermission), userContext))
+                .doesNotThrowAnyException();
+
+        verify(userContext).isPermitted(mixedCasePermission);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // validateRolePermissions - expands the requested roles and checks the permissions they grant
+    // ----------------------------------------------------------------------------------------------------
+
+    @Test
+    void validateRolePermissionsPassesWhenCurrentUserHoldsEveryPermissionGrantedByTheRoles() throws NotFoundException {
+        final Role readerRole = roleGranting(STREAMS_READ);
+        allowReadingRoles(READER_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE))).thenReturn(Set.of(readerRole));
+        currentUserHolds(STREAMS_READ);
+
+        assertThatCode(() -> validator.validateRolePermissions(List.of(READER_ROLE), userContext))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateRolePermissionsRejectsPermissionGrantedByRoleThatCurrentUserMisses() throws NotFoundException {
+        final Role readerRole = roleGranting(INPUTS_CREATE);
+        allowReadingRoles(READER_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE))).thenReturn(Set.of(readerRole));
+
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(READER_ROLE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MISSING_PERMISSIONS_PREFIX + INPUTS_CREATE);
+    }
+
+    @Test
+    void validateRolePermissionsAggregatesPermissionsAcrossAllRequestedRoles() throws NotFoundException {
+        final Role readerRole = roleGranting(STREAMS_READ);
+        final Role adminRole = roleGranting(INPUTS_CREATE);
+        allowReadingRoles(READER_ROLE, ADMIN_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE, ADMIN_ROLE)))
+                .thenReturn(Set.of(readerRole, adminRole));
+        currentUserHolds(STREAMS_READ);
+
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(READER_ROLE, ADMIN_ROLE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(INPUTS_CREATE)
+                .hasMessageNotContaining(STREAMS_READ);
+    }
+
+    @Test
+    void validateRolePermissionsPassesForRolesThatGrantNothing() throws NotFoundException {
+        final Role emptyRole = roleGranting();
+        allowReadingRoles(READER_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE))).thenReturn(Set.of(emptyRole));
+
+        assertThatCode(() -> validator.validateRolePermissions(List.of(READER_ROLE), userContext))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateRolePermissionsLooksUpRolesByTheirLowercasedName() throws NotFoundException {
+        allowReadingRoles(READER_ROLE, ADMIN_ROLE);
+        when(roleService.loadByNames(any())).thenReturn(Set.of());
+
+        validator.validateRolePermissions(List.of(READER_ROLE, ADMIN_ROLE), userContext);
+
+        verify(roleService).loadByNames(List.of(READER_ROLE, ADMIN_ROLE));
+    }
+
+    @Test
+    void validateRolePermissionsChecksReadAccessUsingTheLowercasedRoleName() throws NotFoundException {
+        allowReadingRoles(ADMIN_ROLE);
+        when(roleService.loadByNames(List.of(ADMIN_ROLE))).thenReturn(Set.of());
+
+        validator.validateRolePermissions(List.of(ADMIN_ROLE), userContext);
+
+        verify(userContext).isPermitted(ROLES_READ, ADMIN_ROLE);
+    }
+
+    @Test
+    void validateRolePermissionsDeniesRolesTheCurrentUserCannotRead() {
+        allowReadingRoles(READER_ROLE);
+
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(READER_ROLE, ADMIN_ROLE), userContext))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Not allowed to read roles: " + ADMIN_ROLE);
+    }
+
+    @Test
+    void validateRolePermissionsListsEveryUnreadableRole() {
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(ADMIN_ROLE, READER_ROLE), userContext))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Not allowed to read roles: " + ADMIN_ROLE + ", " + READER_ROLE);
+    }
+
+    @Test
+    void validateRolePermissionsDoesNotLoadRolesWhenReadAccessIsDenied() {
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(ADMIN_ROLE), userContext))
+                .isInstanceOf(ForbiddenException.class);
+
+        verifyNoInteractions(roleService);
+    }
+
+    @Test
+    void validateRolePermissionsAcceptsNullRoleList() throws NotFoundException {
+        // `ChangeUserRequest.roles()` is @Nullable, so a request that touches no roles must not fail.
+        when(roleService.loadByNames(List.of())).thenReturn(Set.of());
+
+        assertThatCode(() -> validator.validateRolePermissions(null, userContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateRolePermissionsAcceptsEmptyRoleList() throws NotFoundException {
+        when(roleService.loadByNames(List.of())).thenReturn(Set.of());
+
+        assertThatCode(() -> validator.validateRolePermissions(List.of(), userContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateRolePermissionsTranslatesUnknownRolesIntoBadRequest() throws NotFoundException {
+        final NotFoundException notFound = new NotFoundException("Couldn't find roles");
+        allowReadingRoles(ADMIN_ROLE);
+        when(roleService.loadByNames(List.of(ADMIN_ROLE))).thenThrow(notFound);
+
+        assertThatThrownBy(() -> validator.validateRolePermissions(List.of(ADMIN_ROLE), userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasCause(notFound);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // validatePermissionsAndRoles - the combined check used when creating a user
+    // ----------------------------------------------------------------------------------------------------
+
+    @Test
+    void validatePermissionsAndRolesPassesWhenCurrentUserHoldsRoleAndDirectPermissions() throws NotFoundException {
+        final Role readerRole = roleGranting(STREAMS_READ);
+        allowReadingRoles(READER_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE))).thenReturn(Set.of(readerRole));
+        currentUserHolds(STREAMS_READ, DASHBOARDS_CREATE);
+
+        final var request = createUserRequest(List.of(READER_ROLE), List.of(DASHBOARDS_CREATE));
+
+        assertThatCode(() -> validator.validatePermissionsAndRoles(request, userContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validatePermissionsAndRolesRejectsDirectPermissionTheCurrentUserMisses() throws NotFoundException {
+        final Role readerRole = roleGranting(STREAMS_READ);
+        allowReadingRoles(READER_ROLE);
+        when(roleService.loadByNames(List.of(READER_ROLE))).thenReturn(Set.of(readerRole));
+        currentUserHolds(STREAMS_READ);
+
+        final var request = createUserRequest(List.of(READER_ROLE), List.of(INPUTS_CREATE));
+
+        assertThatThrownBy(() -> validator.validatePermissionsAndRoles(request, userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MISSING_PERMISSIONS_PREFIX + INPUTS_CREATE);
+    }
+
+    @Test
+    void validatePermissionsAndRolesRejectsPermissionLaunderedThroughARole() throws NotFoundException {
+        // The role is readable, but it grants the wildcard permission, which the creating user does not hold.
+        // This is the escalation the validator exists to prevent.
+        final Role adminRole = roleGranting("*");
+        allowReadingRoles(ADMIN_ROLE);
+        when(roleService.loadByNames(List.of(ADMIN_ROLE))).thenReturn(Set.of(adminRole));
+
+        final var request = createUserRequest(List.of(ADMIN_ROLE), List.of());
+
+        assertThatThrownBy(() -> validator.validatePermissionsAndRoles(request, userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(MISSING_PERMISSIONS_PREFIX + "*");
+    }
+
+    @Test
+    void validatePermissionsAndRolesReportsMissingRoleAndDirectPermissionsTogether() throws NotFoundException {
+        final Role adminRole = roleGranting(INPUTS_CREATE);
+        allowReadingRoles(ADMIN_ROLE);
+        when(roleService.loadByNames(List.of(ADMIN_ROLE))).thenReturn(Set.of(adminRole));
+
+        final var request = createUserRequest(List.of(ADMIN_ROLE), List.of(DASHBOARDS_CREATE));
+
+        assertThatThrownBy(() -> validator.validatePermissionsAndRoles(request, userContext))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(INPUTS_CREATE)
+                .hasMessageContaining(DASHBOARDS_CREATE);
+    }
+
+    @Test
+    void validatePermissionsAndRolesAcceptsRequestWithoutRoles() throws NotFoundException {
+        // `roles` is @Nullable in CreateUserRequest.
+        when(roleService.loadByNames(List.of())).thenReturn(Set.of());
+        currentUserHolds(STREAMS_READ);
+
+        final var request = createUserRequest(null, List.of(STREAMS_READ));
+
+        assertThatCode(() -> validator.validatePermissionsAndRoles(request, userContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validatePermissionsAndRolesAcceptsRequestWithoutRolesOrPermissions() throws NotFoundException {
+        when(roleService.loadByNames(List.of())).thenReturn(Set.of());
+
+        final var request = createUserRequest(null, List.of());
+
+        assertThatCode(() -> validator.validatePermissionsAndRoles(request, userContext)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validatePermissionsAndRolesPropagatesForbiddenForUnreadableRoles() {
+        final var request = createUserRequest(List.of(ADMIN_ROLE), List.of());
+
+        assertThatThrownBy(() -> validator.validatePermissionsAndRoles(request, userContext))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("Not allowed to read roles: " + ADMIN_ROLE);
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------------------------------------
+
+    private Role roleGranting(String... permissions) {
+        final Role role = mock(Role.class);
+        when(role.getPermissions()).thenReturn(Set.of(permissions));
+        return role;
+    }
+
+    private void allowReadingRoles(String... normalizedRoleNames) {
+        for (final String roleName : normalizedRoleNames) {
+            when(userContext.isPermitted(ROLES_READ, roleName)).thenReturn(true);
+        }
+    }
+
+    private void currentUserHolds(String... permissions) {
+        for (final String permission : permissions) {
+            when(userContext.isPermitted(permission)).thenReturn(true);
+        }
+    }
+
+    private CreateUserRequest createUserRequest(List<String> roles, List<String> permissions) {
+        return CreateUserRequest.create("jane", "password", "jane@graylog.com", "Jane", "Doe",
+                permissions, "Europe/Berlin", 1000L, null, roles, false);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/RoleServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/RoleServiceImplTest.java
@@ -23,10 +23,12 @@ import jakarta.validation.Validator;
 import org.assertj.core.api.Assertions;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog2.database.MongoCollections;
+import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.Role;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -38,7 +40,6 @@ import java.util.Set;
 
 @ExtendWith(MongoDBExtension.class)
 class RoleServiceImplTest {
-
     @Test
     void testChangeEvents(MongoCollections mongoCollections) throws ValidationException {
         final EventsCollector eventsCollector = new EventsCollector();
@@ -60,6 +61,62 @@ class RoleServiceImplTest {
                 .hasSize(4) // two built-in roles, Admin and Reader + whatever we add here
                 .map(RoleChangedEvent::roleName)
                 .contains("Admin", "Reader", "inputs_manager", "inputs_reader");
+    }
+
+    @Test
+    void loadByNamesIgnoresCasingOfRequestedNames(MongoCollections mongoCollections) throws ValidationException, NotFoundException {
+        final RoleService service = createService(mongoCollections);
+        service.save(createRole("Inputs_Manager", "manages inputs", Set.of(RestPermissions.INPUTS_READ, RestPermissions.INPUTS_CREATE), false));
+
+        // The built-in roles are stored as `Admin`/`Reader`, so lowercased names must find them as well.
+        Assertions.assertThat(service.loadByNames(List.of("inputs_manager", "admin", "reader")))
+                .map(Role::getName)
+                .containsExactlyInAnyOrder("Inputs_Manager", "Admin", "Reader");
+    }
+
+    @Test
+    void loadByNamesFindsRolesRequestedWithTheirStoredCasing(MongoCollections mongoCollections) throws NotFoundException {
+        final RoleService service = createService(mongoCollections);
+
+        Assertions.assertThat(service.loadByNames(List.of("Admin")))
+                .map(Role::getName)
+                .containsExactly("Admin");
+    }
+
+    @Test
+    void loadByNamesThrowsNotFoundExceptionForUnknownRole(MongoCollections mongoCollections) {
+        final RoleService service = createService(mongoCollections);
+
+        Assertions.assertThatThrownBy(() -> service.loadByNames(List.of("admin", "does_not_exist")))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("does_not_exist");
+    }
+
+    @Test
+    void loadByNamesThrowsNotFoundExceptionNamingEveryMissingRole(MongoCollections mongoCollections) throws ValidationException {
+        final RoleService service = createService(mongoCollections);
+        service.save(createRole("Inputs_Manager", "manages inputs", Set.of(RestPermissions.INPUTS_READ), false));
+
+        // Two of the four requested roles exist, so the exception must name the other two - and only those.
+        Assertions.assertThatThrownBy(() -> service.loadByNames(List.of("admin", "inputs_manager", "missing_one", "Missing_Two")))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("missing_one")
+                .hasMessageContaining("missing_two")
+                .hasMessageNotContaining("admin")
+                .hasMessageNotContaining("inputs_manager");
+    }
+
+    @Test
+    void loadByNamesReturnsNoRolesForEmptyRequest(MongoCollections mongoCollections) throws NotFoundException {
+        final RoleService service = createService(mongoCollections);
+
+        Assertions.assertThat(service.loadByNames(List.of())).isEmpty();
+    }
+
+    @Nonnull
+    private static RoleService createService(MongoCollections mongoCollections) {
+        return new RoleServiceImpl(mongoCollections, new Permissions(Collections.emptySet()),
+                Mockito.mock(Validator.class), new ClusterEventBus());
     }
 
     @Nonnull


### PR DESCRIPTION
**Note:** This is a backport of #26883 to `7.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The following ways for elevating privileges have been identified:
  - A user holding only `users:create` was able to create another user with more permissions than they hold themselves (including `*`), either by supplying the permissions directly or by assigning a role that grants them.
  - A user holding only `users:edit:<id>` was able to update permissions/roles of a user, providing them with more permissions (including `*`) than they hold themselves
  - A user holding only `users:permissionsedit` was able to update permissions/roles of a user (including themselves), providing them with more permissions (including `*`) than they hold themselves

All of the aforementioned endpoints now collect the permissions requested for the new/updated user, resolve the permissions granted by the requested roles, and refuses the request with a `BadRequestException` if the current user is missing at least one of them. Reading the requested roles additionally requires `roles:read` on each role.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/15085.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.