### PR TITLE
Fix System Overview crash when loading notifications fails (`7.1`)

### DIFF
--- a/changelog/unreleased/fix-notifications-list-crash.toml
+++ b/changelog/unreleased/fix-notifications-list-crash.toml
@@ -1,0 +1,2 @@
+type = "f"
+message = "Fix crash of the System Overview page when loading the notifications list fails."

--- a/changelog/unreleased/pr-27045.toml
+++ b/changelog/unreleased/pr-27045.toml
@@ -1,2 +1,4 @@
 type = "f"
 message = "Fix crash of the System Overview page when loading the notifications list fails."
+
+pulls = ["27045"]

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.test.tsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import useNotifications from 'components/notifications/useNotifications';
+
+import NotificationsList from './NotificationsList';
+
+jest.mock('components/notifications/useNotifications');
+
+describe('<NotificationsList>', () => {
+  it('shows a loading indicator while notifications are being fetched', async () => {
+    asMock(useNotifications).mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<NotificationsList />);
+
+    await screen.findByText(/loading/i);
+  });
+
+  it('shows a loading indicator when fetching notifications failed', async () => {
+    asMock(useNotifications).mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<NotificationsList />);
+
+    await screen.findByText(/loading/i);
+  });
+
+  it('shows that there are no notifications', async () => {
+    asMock(useNotifications).mockReturnValue({ data: { total: 0, notifications: [] }, isLoading: false });
+
+    render(<NotificationsList />);
+
+    await screen.findByRole('heading', { name: /no notifications/i });
+  });
+});

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.tsx
@@ -51,7 +51,7 @@ const Notifications = ({ count, notifications }: { count: number; notifications:
 const NotificationsList = () => {
   const { data, isLoading } = useNotifications();
 
-  if (isLoading) {
+  if (isLoading || !data) {
     return <Spinner />;
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is fixing an issue we are seeing in the wild, where loading the System Overview page results in an exception being thrown.
`NotificationsList` destructured `{ total, notifications }` from the `useNotifications` result after only checking `isLoading`. With react-query v5, `isLoading` is `isPending && isFetching`, so a failed request leaves `isLoading` false while `data` stays `undefined`, crashing the whole System Overview page with "Cannot destructure property 'total' of 'e'".

Guard on `!data` as well, matching how `NotificationBadge` already consumes the same hook. The query polls every 3 seconds, so showing the spinner for the duration of a transient failure is preferable to defaulting to a count of zero, which would claim there are no notifications.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.