### PR TITLE
Fix crash when displaying values containing BigInts

### DIFF
--- a/changelog/unreleased/pr-27058.toml
+++ b/changelog/unreleased/pr-27058.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fixed a crash when displaying values which contain integers exceeding the safe integer range, e.g. in the pipeline rule simulator output."
+
+pulls = ["27058"]

--- a/graylog2-web-interface/src/components/rules/RuleSimulation.test.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleSimulation.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import RuleSimulation from 'components/rules/RuleSimulation';
+import { PipelineRulesContext } from 'components/rules/RuleContext';
+
+jest.mock('components/rules/rule-builder/RuleBuilderContext', () => ({
+  useRuleBuilder: () => ({ useHighlightedOutput: [undefined, () => {}] }),
+}));
+
+// Integers outside of the safe range are parsed as BigInt from API responses.
+const bigInteger = BigInt('12345678901234567890');
+
+const rule = { id: 'rule-id', title: 'My rule', rule_builder: { conditions: [], actions: [] } };
+
+const ruleSimulationResult = {
+  fields: { message: 'Some message' },
+  simulator_condition_variables: { 1: bigInteger },
+  simulator_action_variables: [{ 1: bigInteger }],
+};
+
+const contextValue = {
+  rule,
+  simulateRule: () => {},
+  rawMessageToSimulate: 'message: test',
+  setRawMessageToSimulate: () => {},
+  ruleSimulationResult,
+  setRuleSimulationResult: () => {},
+};
+
+describe('RuleSimulation', () => {
+  it('renders simulation output containing integers which exceed the safe integer range', async () => {
+    render(
+      <PipelineRulesContext.Provider value={contextValue}>
+        <RuleSimulation rule={rule as any} />
+      </PipelineRulesContext.Provider>,
+    );
+
+    const conditionsOutput = await screen.findByTestId('conditions-output');
+
+    expect(conditionsOutput).toHaveTextContent('12345678901234567890');
+
+    const actionsOutput = await screen.findByTestId('actions-output');
+
+    expect(actionsOutput).toHaveTextContent('12345678901234567890');
+  });
+});

--- a/graylog2-web-interface/src/components/rules/RuleSimulation.tsx
+++ b/graylog2-web-interface/src/components/rules/RuleSimulation.tsx
@@ -23,6 +23,7 @@ import type { RuleType } from 'components/rules/hooks/useRules';
 import useLocation from 'routing/useLocation';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { getPathnameWithoutId } from 'util/URLUtils';
+import * as JSON from 'util/json';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 
 import { PipelineRulesContext, SimulationFieldType } from './RuleContext';

--- a/graylog2-web-interface/src/components/search/MessageShow.test.tsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.test.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import MessageShow from 'components/search/MessageShow';
+
+const message = {
+  id: 'deadbeef',
+  index: 'graylog_0',
+  fields: {
+    message: 'Some message',
+    // Integers outside of the safe range are parsed as BigInt from API responses.
+    event: { record_id: BigInt('12345678901234567890') },
+  },
+};
+
+describe('MessageShow', () => {
+  it('renders field values containing integers which exceed the safe integer range', async () => {
+    render(<MessageShow message={message} />);
+
+    await screen.findByText('{"record_id":12345678901234567890}');
+  });
+});

--- a/graylog2-web-interface/src/util/StringUtils.test.ts
+++ b/graylog2-web-interface/src/util/StringUtils.test.ts
@@ -92,6 +92,16 @@ describe('stringify', () => {
 
     expect(result).toBe('undefined');
   });
+
+  it('stringifies integers which exceed the safe integer range', () => {
+    // API responses are parsed with BigInt support, so any integer outside of the safe range
+    // ends up as a BigInt in the values we are rendering.
+    const bigInteger = BigInt('12345678901234567890');
+
+    expect(StringUtils.stringify({ id: bigInteger })).toBe('{"id":12345678901234567890}');
+    expect(StringUtils.stringify([bigInteger])).toBe('[12345678901234567890]');
+    expect(StringUtils.stringify(bigInteger)).toBe('12345678901234567890');
+  });
 });
 
 describe('replaceSpaces', () => {

--- a/graylog2-web-interface/src/util/StringUtils.ts
+++ b/graylog2-web-interface/src/util/StringUtils.ts
@@ -14,6 +14,8 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import * as JSON from 'util/json';
+
 const StringUtils = {
   tempDocument: document.createElement('textarea'),
   capitalizeFirstLetter(text: string) {


### PR DESCRIPTION
**Note:** This needs a backport to `7.1`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since #23432 all REST responses are parsed with BigInt support, so every integer outside the safe integer range arrives as a `BigInt`.
`StringUtils.stringify()` still used the global `JSON.stringify`, which throws for those values:

    TypeError: Do not know how to serialize a BigInt

On the pipeline rule details page the rule simulation runs on mount and its result is rendered through `MessageShow`, which stringifies each field value with `StringUtils.stringify()`. A simulated message with a field value containing a large integer therefore broke the whole page render.

Use the BigInt-aware `stringify` from `util/json` instead. Its output is identical to the native one for all other values.

`RuleSimulation` stringifies the simulator condition/action variables from the simulation response directly, where even a plain `BigInt` value throws, so switch that over as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.