### PR TITLE
Event Definitions - Retain selected sharing info across navigation (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-14480.toml
+++ b/changelog/unreleased/issue-14480.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Keep the share settings of an event definition populated when navigating between wizard steps."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14480"]
+pulls = ["26990"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/ShareForm.tsx
@@ -49,6 +49,7 @@ const ShareForm = ({ onChange, eventDefinition }: Props) => {
           entityType="event_definition"
           entityTitle=""
           dependenciesGRN={[...streamDependenciesGRN, ...notificationDependenciesGRN]}
+          defaultSharePayload={eventDefinition.share_request}
         />
       </Col>
     </Row>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions-types.ts
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions-types.ts
@@ -17,6 +17,7 @@
 import type { SyntheticEvent } from 'react';
 
 import type { StepsType } from 'components/common/Wizard';
+import type { EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import type { LookupTableParameterJson } from 'views/logic/parameters/LookupTableParameter';
 import { SYSTEM_EVENT_DEFINITION_TYPE } from 'components/event-definitions/constants';
 
@@ -111,6 +112,7 @@ export type EventDefinition = {
   matched_at: string;
   scheduler: Scheduler;
   event_summary_template: string;
+  share_request?: EntitySharePayload;
 };
 
 export type EventDefinitionFormControlsProps = {

--- a/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.test.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.test.tsx
@@ -76,7 +76,40 @@ describe('EntityCreateShareFormGroup', () => {
     render(<SUT />);
 
     await waitFor(() => {
-      expect(EntityShareActions.prepare).toHaveBeenCalledWith(mockEntity.entityType, '', mockEntity.entityId, {});
+      expect(EntityShareActions.prepare).toHaveBeenCalledWith(mockEntity.entityType, '', mockEntity.entityId, {
+        prepare_request: null,
+      });
+    });
+  });
+
+  it('restores a previously made selection from the default share payload', async () => {
+    const selected_grantee_capabilities = createEntityShareState.selectedGranteeCapabilities.merge({
+      [everyone.id]: viewer.id,
+    });
+
+    render(<SUT defaultSharePayload={{ selected_grantee_capabilities }} />);
+
+    await waitFor(() => {
+      expect(EntityShareActions.prepare).toHaveBeenCalledWith(mockEntity.entityType, '', mockEntity.entityId, {
+        selected_grantee_capabilities,
+        prepare_request: null,
+      });
+    });
+  });
+
+  it('re-runs the dependency check when restoring a selection', async () => {
+    const selected_grantee_capabilities = createEntityShareState.selectedGranteeCapabilities.merge({
+      [everyone.id]: viewer.id,
+    });
+    const dependenciesGRN = ['grn::::stream:stream-id'];
+
+    render(<SUT defaultSharePayload={{ selected_grantee_capabilities }} dependenciesGRN={dependenciesGRN} />);
+
+    await waitFor(() => {
+      expect(EntityShareActions.prepare).toHaveBeenCalledWith(mockEntity.entityType, '', mockEntity.entityId, {
+        selected_grantee_capabilities,
+        prepare_request: dependenciesGRN,
+      });
     });
   });
 

--- a/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.tsx
+++ b/graylog2-web-interface/src/components/permissions/EntityCreateShareFormGroup.tsx
@@ -16,7 +16,6 @@
  */
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import isEmpty from 'lodash/isEmpty';
 
 import type SharedEntity from 'logic/permissions/SharedEntity';
 import { useStore } from 'stores/connect';
@@ -88,9 +87,13 @@ const EntityCreateShareFormGroup = ({
 
   useEffect(() => {
     const { selected_collections: _, ...rest } = defaultSharePayload ?? {};
+    // Restoring a selection has to re-run the dependency check, or the missing dependency
+    // warnings shown before would silently disappear.
+    const hasSelection = (rest.selected_grantee_capabilities?.size ?? 0) > 0;
+    const prepare_request = hasSelection && dependenciesGRN?.length ? dependenciesGRN : null;
 
-    EntityShareDomain.prepare(entityType, entityTitle, entityGRN, rest);
-  }, [entityType, entityTitle, entityGRN, defaultSharePayload]);
+    EntityShareDomain.prepare(entityType, entityTitle, entityGRN, { ...rest, prepare_request });
+  }, [entityType, entityTitle, entityGRN, defaultSharePayload, dependenciesGRN]);
 
   const resetSelection = () => {
     setDisableSubmit(false);
@@ -122,7 +125,7 @@ const EntityCreateShareFormGroup = ({
 
     setDisableSubmit(true);
 
-    const prepare_request = isEmpty(newSelectedCapabilities) ? null : dependenciesGRN;
+    const prepare_request = (newSelectedCapabilities?.size ?? 0) > 0 ? dependenciesGRN : null;
     const payload: EntitySharePayload = {
       selected_grantee_capabilities: newSelectedCapabilities,
       prepare_request,
@@ -198,6 +201,8 @@ const EntityCreateShareFormGroup = ({
             availableGrantees={entityShareState.availableGrantees}
           />
           {PluggableEntityShareFormGroup && (
+            /* Resolved from the plugin store at render time and cannot be hoisted. */
+            /* eslint-disable-next-line react-hooks/static-components */
             <PluggableEntityShareFormGroup
               entityType={entityType}
               onChange={handleAdditionalFormChange}


### PR DESCRIPTION
Note: This is a backport of #26990 to `7.1`.

> **Backport notes**
>
> - Scoped to the fix itself. The purely cosmetic type cleanups from the original PR (dropping the now-redundant `EventDefinition & { share_request? }` intersection in `EventDefinitionFormContainer.tsx`, `EventDefinitionSummary.tsx`, and `useEventDefinitionCommonSteps.tsx`) were left out — they are no-ops here, and touching `EventDefinitionFormContainer.tsx` makes Reviewbot flag a pre-existing `react-hooks/set-state-in-effect` violation in that file that master fixed in a separate, unrelated commit.
> - The new `EventDefinitionFormContainer` test case was omitted: it depends on the master-only `useEntityShareState` refactor (`prepare().then(setEntityShareState)`), whereas this branch reads share state from the reflux `EntityShareStore` and that test file mocks `stores/connect` non-reactively, so any adaptation would pass even with the fix reverted. The fix is covered by the two new `EntityCreateShareFormGroup` tests, which assert the restored `selected_grantee_capabilities` and the re-run dependency check.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Keep the share settings of an event definition from getting cleared when navigating between wizard steps.

This turned out to affect all event definitions, not just sigma.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/14480

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.


