### PR TITLE
URL allowlist handling for Slack/Teams notifications (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26619.toml
+++ b/changelog/unreleased/pr-26619.toml
@@ -1,0 +1,5 @@
+type = "a"
+message = "Warn when Slack or Microsoft Teams notification webhook URLs are not in the URL allowlist. A future release will block non-allowlisted URLs."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14748"]
+pulls = ["26619"]

--- a/changelog/unreleased/pr-26619.toml
+++ b/changelog/unreleased/pr-26619.toml
@@ -1,5 +1,5 @@
 type = "a"
-message = "Warn when Slack or Microsoft Teams notification webhook URLs are not in the URL allowlist. A future release will block non-allowlisted URLs."
+message = "Warn when Slack or Microsoft Teams notification webhook URLs are not in the URL allowlist. Added a global option in System > Configurations > URL Allowlist to enforce the allowlist (block non-allowlisted URLs) for Slack and Teams notification webhooks."
 
 issues = ["Graylog2/graylog-plugin-enterprise#14748"]
-pulls = ["26619"]
+pulls = ["26619", "26814"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/SlackClient.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/SlackClient.java
@@ -46,7 +46,7 @@ public class SlackClient {
 
     @Inject
     public SlackClient(OkHttpClient httpClient, ObjectMapper objectMapper) {
-        this.httpClient = httpClient.newBuilder().followRedirects(false).build();
+        this.httpClient = httpClient;
         this.objectMapper = objectMapper;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotification.java
@@ -34,6 +34,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.utilities.StringUtils;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,7 @@ public class SlackEventNotification implements EventNotification {
     private final SlackClient slackClient;
     private final TemplateModelProvider templateModelProvider;
     private final EventProcedureProvider eventProcedureProvider;
+    private final UrlAllowlistValidator urlAllowlistValidator;
 
     @Inject
     public SlackEventNotification(EventNotificationService notificationCallbackService,
@@ -64,7 +66,8 @@ public class SlackEventNotification implements EventNotification {
                                   NotificationService notificationService,
                                   NodeId nodeId, SlackClient slackClient,
                                   TemplateModelProvider templateModelProvider,
-                                  EventProcedureProvider eventProcedureProvider) {
+                                  EventProcedureProvider eventProcedureProvider,
+                                  UrlAllowlistValidator urlAllowlistValidator) {
         this.notificationCallbackService = notificationCallbackService;
         this.templateEngine = requireNonNull(templateEngine);
         this.notificationService = requireNonNull(notificationService);
@@ -72,6 +75,7 @@ public class SlackEventNotification implements EventNotification {
         this.slackClient = requireNonNull(slackClient);
         this.templateModelProvider = templateModelProvider;
         this.eventProcedureProvider = eventProcedureProvider;
+        this.urlAllowlistValidator = requireNonNull(urlAllowlistValidator);
     }
 
     /**
@@ -84,6 +88,7 @@ public class SlackEventNotification implements EventNotification {
         LOG.debug("SlackEventNotification backlog size in method execute is [{}]", config.backlogSize());
 
         try {
+            urlAllowlistValidator.validateUrl(config.webhookUrl(), ctx);
             SlackMessage slackMessage = createSlackMessage(ctx, config);
             slackClient.send(slackMessage, config.webhookUrl());
         } catch (JsonProcessingException ex) {

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
@@ -33,6 +33,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.graylog2.web.customization.CustomizationConfig;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -59,6 +60,7 @@ public class TeamsEventNotification implements EventNotification {
     private final RequestClient requestClient;
     private final TemplateModelProvider templateModelProvider;
     private final CustomizationConfig customizationConfig;
+    private final UrlAllowlistValidator urlAllowlistValidator;
 
     @Inject
     public TeamsEventNotification(EventNotificationService notificationCallbackService,
@@ -67,7 +69,8 @@ public class TeamsEventNotification implements EventNotification {
                                   NotificationService notificationService,
                                   NodeId nodeId, RequestClient requestClient,
                                   TemplateModelProvider templateModelProvider,
-                                  CustomizationConfig customizationConfig) {
+                                  CustomizationConfig customizationConfig,
+                                  UrlAllowlistValidator urlAllowlistValidator) {
         this.notificationCallbackService = notificationCallbackService;
         this.objectMapperProvider = requireNonNull(objectMapperProvider);
         this.templateEngine = requireNonNull(templateEngine);
@@ -76,6 +79,7 @@ public class TeamsEventNotification implements EventNotification {
         this.requestClient = requireNonNull(requestClient);
         this.templateModelProvider = templateModelProvider;
         this.customizationConfig = customizationConfig;
+        this.urlAllowlistValidator = requireNonNull(urlAllowlistValidator);
     }
 
     /**
@@ -88,6 +92,7 @@ public class TeamsEventNotification implements EventNotification {
         LOG.debug("TeamsEventNotification backlog size in method execute is [{}]", config.backlogSize());
 
         try {
+            urlAllowlistValidator.validateUrl(config.webhookUrl(), ctx);
             TeamsMessage teamsMessage = createTeamsMessage(ctx, config);
             requestClient.send(objectMapperProvider.getForTimeZone(config.timeZone()).writeValueAsString(teamsMessage), config.webhookUrl());
         } catch (TemporaryEventNotificationException exp) {

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2.java
@@ -33,6 +33,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.utilities.StringUtils;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,19 +53,22 @@ public class TeamsEventNotificationV2 implements EventNotification {
     private final NodeId nodeId;
     private final RequestClient requestClient;
     private final TemplateModelProvider templateModelProvider;
+    private final UrlAllowlistValidator urlAllowlistValidator;
 
     @Inject
     public TeamsEventNotificationV2(EventNotificationService notificationCallbackService,
                                     @Named("JsonSafe") Engine jsonTemplateEngine,
                                     NotificationService notificationService,
                                     NodeId nodeId, RequestClient requestClient,
-                                    TemplateModelProvider templateModelProvider) {
+                                    TemplateModelProvider templateModelProvider,
+                                    UrlAllowlistValidator urlAllowlistValidator) {
         this.notificationCallbackService = notificationCallbackService;
         this.jsonTemplateEngine = requireNonNull(jsonTemplateEngine);
         this.notificationService = requireNonNull(notificationService);
         this.nodeId = requireNonNull(nodeId);
         this.requestClient = requireNonNull(requestClient);
         this.templateModelProvider = templateModelProvider;
+        this.urlAllowlistValidator = requireNonNull(urlAllowlistValidator);
     }
 
     /**
@@ -79,6 +83,7 @@ public class TeamsEventNotificationV2 implements EventNotification {
         LOG.debug("TeamsEventNotificationV2 backlog size in method execute is [{}]", config.backlogSize());
 
         try {
+            urlAllowlistValidator.validateUrl(config.webhookUrl(), ctx);
             final String requestBody = generateBody(ctx, config);
             requestClient.send(requestBody, config.webhookUrl());
         } catch (TemporaryEventNotificationException exp) {

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/util/RequestClient.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/util/RequestClient.java
@@ -37,7 +37,7 @@ public class RequestClient {
 
     @Inject
     public RequestClient(OkHttpClient httpClient) {
-        this.httpClient = httpClient;
+        this.httpClient = httpClient.newBuilder().followRedirects(false).build();
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/util/RequestClient.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/notifications/types/util/RequestClient.java
@@ -37,7 +37,7 @@ public class RequestClient {
 
     @Inject
     public RequestClient(OkHttpClient httpClient) {
-        this.httpClient = httpClient.newBuilder().followRedirects(false).build();
+        this.httpClient = httpClient;
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlist.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlist.java
@@ -35,18 +35,27 @@ public abstract class UrlAllowlist {
     @JsonProperty("disabled")
     public abstract boolean disabled();
 
+    // Temporary fix (PR #26814): only used by Slack and Teams notifications via UrlAllowlistValidator.
+    // TODO: Remove in a major release.
+    @JsonProperty("enforce_for_notifications")
+    public abstract boolean enforceForNotifications();
+
     @JsonCreator
     public static UrlAllowlist create(@JsonProperty("entries") List<AllowlistEntry> entries,
-                                      @JsonProperty("disabled") boolean disabled) {
+                                      @JsonProperty("disabled") boolean disabled,
+                                      @JsonProperty("enforce_for_notifications") boolean enforceForNotifications) {
         return builder().entries(entries)
                 .disabled(disabled)
+                .enforceForNotifications(enforceForNotifications)
                 .build();
     }
 
+    public static UrlAllowlist create(List<AllowlistEntry> entries, boolean disabled) {
+        return create(entries, disabled, false);
+    }
+
     public static UrlAllowlist createEnabled(List<AllowlistEntry> entries) {
-        return builder().entries(entries)
-                .disabled(false)
-                .build();
+        return create(entries, false, false);
     }
 
     public abstract Builder toBuilder();
@@ -75,6 +84,8 @@ public abstract class UrlAllowlist {
         public abstract Builder entries(List<AllowlistEntry> entries);
 
         public abstract Builder disabled(boolean disabled);
+
+        public abstract Builder enforceForNotifications(boolean enforceForNotifications);
 
         public abstract UrlAllowlist autoBuild();
 

--- a/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlistValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlistValidator.java
@@ -20,6 +20,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.NotificationTestData;
+import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,19 +39,32 @@ public class UrlAllowlistValidator {
         this.allowlistNotificationService = allowlistNotificationService;
     }
 
-    public void validateUrl(String url, EventNotificationContext ctx) {
+    /**
+     * Validates a notification webhook URL against the URL allowlist. If the URL is not allowlisted,
+     * a system notification is published (unless this is a test notification). When enforcement is
+     * enabled, throws {@link PermanentEventNotificationException}; otherwise logs a warning.
+     *
+     * @param url the webhook URL to validate
+     * @param ctx the event notification context
+     * @throws PermanentEventNotificationException if the URL is not allowlisted and enforcement is enabled
+     */
+    public void validateUrl(String url, EventNotificationContext ctx) throws PermanentEventNotificationException {
         if (!allowlistService.isAllowlisted(url)) {
-            LOG.warn("Notification is using a URL which is not allowlisted. " +
-                    "A future version of Graylog will block this request. [url: {}, notification: {}]",
-                    url, ctx.notificationId());
             if (!NotificationTestData.TEST_NOTIFICATION_ID.equals(ctx.notificationId())) {
                 final String eventDefTitle = ctx.eventDefinition().map(EventDefinitionDto::title).orElse("Unnamed");
                 final String description = "The alert notification " + eventDefTitle +
                         " is trying to access a URL which is not allowlisted. Please add it to the URL allowlist. " +
-                        "A future version of Graylog will block requests to non-allowlisted URLs. [url: " +
-                        url + "]";
+                        "[url: " + url + "]";
                 allowlistNotificationService.publishAllowlistFailure(description);
             }
+            if (allowlistService.getAllowlist().enforceForNotifications()) {
+                LOG.warn("Blocking notification because webhook URL is not allowlisted. " +
+                        "[url: {}, notification: {}]", url, ctx.notificationId());
+                throw new PermanentEventNotificationException("URL <" + url + "> is not allowlisted.");
+            }
+            LOG.warn("Notification is using a URL which is not allowlisted. " +
+                    "Enable \"Enforce for Slack & Teams notifications\" in System > Configurations > URL Allowlist to block non-allowlisted URLs. " +
+                    "[url: {}, notification: {}]", url, ctx.notificationId());
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlistValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/urlallowlist/UrlAllowlistValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.system.urlallowlist;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.graylog.events.notifications.EventNotificationContext;
+import org.graylog.events.notifications.NotificationTestData;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class UrlAllowlistValidator {
+    private static final Logger LOG = LoggerFactory.getLogger(UrlAllowlistValidator.class);
+
+    private final UrlAllowlistService allowlistService;
+    private final UrlAllowlistNotificationService allowlistNotificationService;
+
+    @Inject
+    public UrlAllowlistValidator(UrlAllowlistService allowlistService,
+                                 UrlAllowlistNotificationService allowlistNotificationService) {
+        this.allowlistService = allowlistService;
+        this.allowlistNotificationService = allowlistNotificationService;
+    }
+
+    public void validateUrl(String url, EventNotificationContext ctx) {
+        if (!allowlistService.isAllowlisted(url)) {
+            LOG.warn("Notification is using a URL which is not allowlisted. " +
+                    "A future version of Graylog will block this request. [url: {}, notification: {}]",
+                    url, ctx.notificationId());
+            if (!NotificationTestData.TEST_NOTIFICATION_ID.equals(ctx.notificationId())) {
+                final String eventDefTitle = ctx.eventDefinition().map(EventDefinitionDto::title).orElse("Unnamed");
+                final String description = "The alert notification " + eventDefTitle +
+                        " is trying to access a URL which is not allowlisted. Please add it to the URL allowlist. " +
+                        "A future version of Graylog will block requests to non-allowlisted URLs. [url: " +
+                        url + "]";
+                allowlistNotificationService.publishAllowlistFailure(description);
+            }
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SlackClientTest {
     @Rule
@@ -85,17 +84,6 @@ public class SlackClientTest {
 
         SlackClient slackClient = new SlackClient(httpClient, objectMapper);
         slackClient.send(getMessage(), server.url("/").toString());
-    }
-
-    @Test
-    public void doesNotFollowRedirects() {
-        server.enqueue(new MockResponse(302, Headers.of("Location", server.url("/redirected").toString()), ""));
-        server.enqueue(new MockResponse(200, Headers.of(), ""));
-
-        SlackClient slackClient = new SlackClient(httpClient, objectMapper);
-        assertThatThrownBy(() -> slackClient.send(getMessage(), server.url("/").toString()))
-                .isInstanceOf(PermanentEventNotificationException.class)
-                .hasMessageContaining("[2xx] but got [302]");
     }
 
     private SlackMessage getMessage() {

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
@@ -36,6 +36,7 @@ import org.graylog.events.processor.EventDefinitionDto;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.TestMessageFactory;
@@ -85,6 +86,9 @@ public class SlackEventNotificationTest {
     @Mock
     EventProcedureProvider mockEventProcedureProvider;
 
+    @Mock
+    UrlAllowlistValidator mockUrlAllowlistValidator;
+
     private SlackEventNotificationConfig slackEventNotificationConfig;
     private EventNotificationContext eventNotificationContext;
     private final MessageFactory messageFactory = new TestMessageFactory();
@@ -109,7 +113,8 @@ public class SlackEventNotificationTest {
                 nodeId,
                 mockSlackClient,
                 new TemplateModelProvider(CustomizationConfig.empty(), new ObjectMapperProvider(), new HttpConfiguration()),
-                mockEventProcedureProvider);
+                mockEventProcedureProvider,
+                mockUrlAllowlistValidator);
     }
 
     private void getDummySlackNotificationConfig() {

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
@@ -35,6 +35,7 @@ import org.graylog.integrations.notifications.types.util.RequestClient;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.TestMessageFactory;
@@ -81,6 +82,9 @@ public class TeamsEventNotificationTest {
     @Mock
     EventNotificationService notificationCallbackService;
 
+    @Mock
+    UrlAllowlistValidator mockUrlAllowlistValidator;
+
     private TeamsEventNotificationConfig teamsEventNotificationConfig;
     private EventNotificationContext eventNotificationContext;
     private final MessageFactory messageFactory = new TestMessageFactory();
@@ -104,7 +108,8 @@ public class TeamsEventNotificationTest {
                 nodeId,
                 mockrequestClient,
                 new TemplateModelProvider(customizationConfig, new ObjectMapperProvider(), new HttpConfiguration()),
-                customizationConfig);
+                customizationConfig,
+                mockUrlAllowlistValidator);
     }
 
     private void getDummyTeamsNotificationConfig() {
@@ -344,7 +349,8 @@ public class TeamsEventNotificationTest {
                 nodeId,
                 mockrequestClient,
                 new TemplateModelProvider(customizationConfig, new ObjectMapperProvider(), new HttpConfiguration()),
-                customizationConfig);
+                customizationConfig,
+                mockUrlAllowlistValidator);
 
         TeamsMessage actual = teamsEventNotification.createTeamsMessage(eventNotificationContext, TeamsEventNotificationConfig.builder().iconUrl(expectedImage).build());
         assertThat(actual.sections())

--- a/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2Test.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationV2Test.java
@@ -34,6 +34,7 @@ import org.graylog2.bindings.providers.JsonSafeEngineProvider;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
+import org.graylog2.system.urlallowlist.UrlAllowlistValidator;
 import org.graylog2.plugin.MessageFactory;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.TestMessageFactory;
@@ -179,6 +180,9 @@ public class TeamsEventNotificationV2Test {
     @Mock
     EventNotificationService notificationCallbackService;
 
+    @Mock
+    UrlAllowlistValidator mockUrlAllowlistValidator;
+
     private TeamsEventNotificationConfigV2 notificationConfig;
     private EventNotificationContext eventNotificationContext;
 
@@ -194,7 +198,8 @@ public class TeamsEventNotificationV2Test {
                 mockNotificationService,
                 nodeId,
                 mockrequestClient,
-                new TemplateModelProvider(CustomizationConfig.empty(), new ObjectMapperProvider(), new HttpConfiguration()));
+                new TemplateModelProvider(CustomizationConfig.empty(), new ObjectMapperProvider(), new HttpConfiguration()),
+                mockUrlAllowlistValidator);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/system/urlallowlist/UrlAllowlistValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/urlallowlist/UrlAllowlistValidatorTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.system.urlallowlist;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.notifications.EventNotificationContext;
+import org.graylog.events.notifications.NotificationTestData;
+import org.graylog.events.notifications.PermanentEventNotificationException;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.integrations.notifications.types.SlackEventNotificationConfig;
+import org.graylog2.plugin.Tools;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UrlAllowlistValidatorTest {
+
+    @Mock
+    private UrlAllowlistService allowlistService;
+
+    @Mock
+    private UrlAllowlistNotificationService allowlistNotificationService;
+
+    private UrlAllowlistValidator validator;
+
+    private static final String WEBHOOK_URL = "https://hooks.slack.com/services/test";
+
+    @BeforeEach
+    void setUp() {
+        validator = new UrlAllowlistValidator(allowlistService, allowlistNotificationService);
+    }
+
+    @Test
+    void doesNothingWhenUrlIsAllowlisted() {
+        when(allowlistService.isAllowlisted(WEBHOOK_URL)).thenReturn(true);
+
+        assertThatCode(() -> validator.validateUrl(WEBHOOK_URL, buildContext("notif-1")))
+                .doesNotThrowAnyException();
+
+        verify(allowlistNotificationService, never()).publishAllowlistFailure(anyString());
+    }
+
+    @Test
+    void warnsWhenNotAllowlistedAndEnforceDisabled() {
+        when(allowlistService.isAllowlisted(WEBHOOK_URL)).thenReturn(false);
+        when(allowlistService.getAllowlist()).thenReturn(allowlistWithEnforce(false));
+
+        assertThatCode(() -> validator.validateUrl(WEBHOOK_URL, buildContext("notif-1")))
+                .doesNotThrowAnyException();
+
+        verify(allowlistNotificationService).publishAllowlistFailure(anyString());
+    }
+
+    @Test
+    void throwsPermanentExceptionWhenEnforceEnabled() {
+        when(allowlistService.isAllowlisted(WEBHOOK_URL)).thenReturn(false);
+        when(allowlistService.getAllowlist()).thenReturn(allowlistWithEnforce(true));
+
+        assertThatThrownBy(() -> validator.validateUrl(WEBHOOK_URL, buildContext("notif-1")))
+                .isInstanceOf(PermanentEventNotificationException.class)
+                .hasMessageContaining(WEBHOOK_URL);
+
+        verify(allowlistNotificationService).publishAllowlistFailure(anyString());
+    }
+
+    @Test
+    void skipsSystemNotificationForTestNotifications() {
+        when(allowlistService.isAllowlisted(WEBHOOK_URL)).thenReturn(false);
+        when(allowlistService.getAllowlist()).thenReturn(allowlistWithEnforce(false));
+
+        assertThatCode(() -> validator.validateUrl(WEBHOOK_URL,
+                buildContext(NotificationTestData.TEST_NOTIFICATION_ID)))
+                .doesNotThrowAnyException();
+
+        verify(allowlistNotificationService, never()).publishAllowlistFailure(anyString());
+    }
+
+    @Test
+    void throwsButSkipsSystemNotificationForTestNotificationsWithEnforce() {
+        when(allowlistService.isAllowlisted(WEBHOOK_URL)).thenReturn(false);
+        when(allowlistService.getAllowlist()).thenReturn(allowlistWithEnforce(true));
+
+        assertThatThrownBy(() -> validator.validateUrl(WEBHOOK_URL,
+                buildContext(NotificationTestData.TEST_NOTIFICATION_ID)))
+                .isInstanceOf(PermanentEventNotificationException.class);
+
+        verify(allowlistNotificationService, never()).publishAllowlistFailure(anyString());
+    }
+
+    private static UrlAllowlist allowlistWithEnforce(boolean enforce) {
+        return UrlAllowlist.create(Collections.emptyList(), false, enforce);
+    }
+
+    private static EventNotificationContext buildContext(String notificationId) {
+        final EventDto eventDto = EventDto.builder()
+                .alert(true)
+                .eventDefinitionId("event-def-1")
+                .eventDefinitionType("test-v1")
+                .eventTimestamp(Tools.nowUTC())
+                .processingTimestamp(Tools.nowUTC())
+                .id("event-1")
+                .streams(ImmutableSet.of("stream-1"))
+                .message("test")
+                .source("source")
+                .keyTuple(ImmutableList.of())
+                .key("")
+                .priority(2)
+                .fields(ImmutableMap.of())
+                .build();
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .alert(true)
+                .id("event-def-1")
+                .title("Test Event Definition")
+                .description("test")
+                .config(new org.graylog.events.processor.EventProcessorConfig() {
+                    @Override public String type() { return "test-v1"; }
+                    @Override public org.graylog2.plugin.rest.ValidationResult validate(
+                            org.graylog.security.UserContext userContext) { return null; }
+                    @Override public org.graylog.events.contentpack.entities.EventProcessorConfigEntity toContentPackEntity(
+                            org.graylog2.contentpacks.EntityDescriptorIds entityDescriptorIds) { return null; }
+                })
+                .fieldSpec(com.google.common.collect.ImmutableMap.of())
+                .priority(2)
+                .keySpec(ImmutableList.of())
+                .notificationSettings(new org.graylog.events.notifications.EventNotificationSettings() {
+                    @Override public long gracePeriodMs() { return 0; }
+                    @Override public long backlogSize() { return 0; }
+                    @Override public Builder toBuilder() { return null; }
+                })
+                .build();
+
+        return EventNotificationContext.builder()
+                .notificationId(notificationId)
+                .notificationConfig(SlackEventNotificationConfig.builder()
+                        .webhookUrl(WEBHOOK_URL)
+                        .build())
+                .event(eventDto)
+                .eventDefinition(eventDefinitionDto)
+                .build();
+    }
+}

--- a/graylog2-web-interface/src/components/common/URLAllowListFormModal.tsx
+++ b/graylog2-web-interface/src/components/common/URLAllowListFormModal.tsx
@@ -40,7 +40,7 @@ type Props = {
 
 const URLAllowListFormModal = ({ newUrlEntry = '', urlType = undefined, onUpdate = () => {} }: Props) => {
   const prevNewUrlEntry = useRef<string>();
-  const [config, setConfig] = useState<AllowListConfig>({ entries: [], disabled: false });
+  const [config, setConfig] = useState<AllowListConfig>({ entries: [], disabled: false, enforce_for_notifications: false });
   const [isValid, setIsValid] = useState<boolean>(false);
   const [newUrlEntryId, setNewUrlEntryId] = useState<string | undefined>();
   const [showConfigModal, setShowConfigModal] = useState<boolean>(false);
@@ -71,6 +71,7 @@ const URLAllowListFormModal = ({ newUrlEntry = '', urlType = undefined, onUpdate
           },
         ],
         disabled: defaultUrlAllowListConfig.disabled,
+        enforce_for_notifications: defaultUrlAllowListConfig.enforce_for_notifications ?? false,
       };
       setNewUrlEntryId(id);
       setConfig(defaultConfig);
@@ -124,7 +125,7 @@ const URLAllowListFormModal = ({ newUrlEntry = '', urlType = undefined, onUpdate
   };
 
   if (urlAllowListConfig) {
-    const { entries, disabled } = config;
+    const { entries, disabled, enforce_for_notifications: enforceForNotifications } = config;
 
     return (
       <>
@@ -146,6 +147,7 @@ const URLAllowListFormModal = ({ newUrlEntry = '', urlType = undefined, onUpdate
             key={newUrlEntryId}
             urls={entries}
             disabled={disabled}
+            enforceForNotifications={enforceForNotifications}
             onUpdate={handleUpdate}
             newEntryId={newUrlEntryId}
           />

--- a/graylog2-web-interface/src/components/configurations/UrlAllowListConfig.tsx
+++ b/graylog2-web-interface/src/components/configurations/UrlAllowListConfig.tsx
@@ -98,7 +98,7 @@ const UrlAllowListConfig = () => {
     return <Spinner />;
   }
 
-  const { entries, disabled } = formConfig;
+  const { entries, disabled, enforce_for_notifications: enforceForNotifications } = formConfig;
 
   return (
     <div>
@@ -109,6 +109,15 @@ const UrlAllowListConfig = () => {
         the {productName} servers, they might be able to reach more sensitive systems than an external user would have
         access to, including AWS EC2 metadata, which can contain keys and other secrets, Elasticsearch and others.
         Allowlist administrative access is separate from data adapters and event notification configuration.
+      </p>
+      <p>
+        <b>Enforce for Slack &amp; Teams notifications</b>{' '}
+        <small className="text-muted">{enforceForNotifications ? '(Enabled)' : '(Disabled)'}</small>
+        <br />
+        <small>
+          When enabled, Slack and Microsoft Teams notifications will fail if their webhook URL is not in the URL
+          allowlist. When disabled, a warning is logged instead.
+        </small>
       </p>
       <Table striped bordered condensed className="top-margin">
         <thead>
@@ -136,7 +145,7 @@ const UrlAllowListConfig = () => {
           submitButtonDisabled={!isValid}
           submitButtonText="Update configuration">
           <h3>Allowlist URLs</h3>
-          <UrlAllowListForm urls={entries} disabled={disabled} onUpdate={update} />
+          <UrlAllowListForm urls={entries} disabled={disabled} enforceForNotifications={enforceForNotifications} onUpdate={update} />
         </BootstrapModalForm>
       )}
     </div>

--- a/graylog2-web-interface/src/components/configurations/UrlAllowListForm.tsx
+++ b/graylog2-web-interface/src/components/configurations/UrlAllowListForm.tsx
@@ -75,11 +75,12 @@ const debouncedValidateUrlEntry = debounce(validateUrlEntry, 200);
 type Props = {
   urls?: Array<Url>;
   disabled?: boolean;
+  enforceForNotifications?: boolean;
   onUpdate?: (config: AllowListConfig, valid: boolean) => void;
   newEntryId?: string;
 };
 
-const UrlAllowListForm = ({ urls = [], onUpdate = () => {}, disabled = false, newEntryId = undefined }: Props) => {
+const UrlAllowListForm = ({ urls = [], onUpdate = () => {}, disabled = false, enforceForNotifications = false, newEntryId = undefined }: Props) => {
   const productName = useProductName();
   const literal = 'literal';
   const regex = 'regex';
@@ -89,7 +90,7 @@ const UrlAllowListForm = ({ urls = [], onUpdate = () => {}, disabled = false, ne
   ];
   // eslint-disable-next-line prefer-const
   let inputs = {};
-  const [config, setConfig] = useState<AllowListConfig>({ entries: urls, disabled });
+  const [config, setConfig] = useState<AllowListConfig>({ entries: urls, disabled, enforce_for_notifications: enforceForNotifications });
   const [validationState, setValidationState] = useState({ errors: [] });
   const isInitialRender = useRef<boolean>(false);
 
@@ -272,6 +273,14 @@ const UrlAllowListForm = ({ urls = [], onUpdate = () => {}, disabled = false, ne
         checked={config.disabled}
         onChange={() => setConfig({ ...config, disabled: !config.disabled })}
         help={`Disable the allowlist functionality. Warning: Disabling this option will allow users to enter any URL in ${productName} entities, which may pose a security risk.`}
+      />
+      <Input
+        type="checkbox"
+        id="enforce-for-notifications"
+        label="Enforce for Slack & Teams notifications"
+        checked={config.enforce_for_notifications}
+        onChange={() => setConfig({ ...config, enforce_for_notifications: !config.enforce_for_notifications })}
+        help="When enabled, Slack and Microsoft Teams notifications will fail if their webhook URL is not in the URL allowlist. When disabled, a warning is logged instead."
       />
       <Button bsSize="sm" onClick={(event) => _onAdd(event)}>
         Add Url

--- a/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/SlackNotificationForm.tsx
+++ b/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/SlackNotificationForm.tsx
@@ -31,7 +31,7 @@ import {
   InputGroup,
   Row,
 } from 'components/bootstrap';
-import { ColorPickerPopover, TimezoneSelect } from 'components/common';
+import { ColorPickerPopover, TimezoneSelect, URLAllowListInput } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import DocumentationLink from 'components/support/DocumentationLink';
 import usePluggableLicenseCheck from 'hooks/usePluggableLicenseCheck';
@@ -159,6 +159,10 @@ class SlackNotificationForm extends React.Component<Props, any> {
     this.propagateChange(name, getValueFromInput(event.target));
   };
 
+  handleWebhookUrlChange = (event) => {
+    this.propagateChange('webhook_url', getValueFromInput(event.target));
+  };
+
   handleTimeZoneChange = (nextValue) => {
     this.propagateChange('time_zone', nextValue);
   };
@@ -191,16 +195,13 @@ class SlackNotificationForm extends React.Component<Props, any> {
           </div>
           <HelpBlock>Choose a color to use for this configuration.</HelpBlock>
         </FormGroup>
-        <Input
-          id="notification-webhookUrl"
-          name="webhook_url"
+        <URLAllowListInput
           label="Webhook URL"
-          type="text"
-          bsStyle={validation.errors.webhook_url ? 'error' : null}
-          help={validation?.errors?.webhook_url?.[0] || 'Slack "Incoming Webhook" URL'}
-          value={config.webhook_url || ''}
-          onChange={this.handleChange}
-          required
+          onChange={this.handleWebhookUrlChange}
+          validationState={validation.errors.webhook_url ? 'error' : null}
+          validationMessage={validation?.errors?.webhook_url?.[0] || 'Slack "Incoming Webhook" URL'}
+          url={config.webhook_url || ''}
+          autofocus={false}
         />
         <Input
           id="notification-channel"
@@ -247,6 +248,7 @@ class SlackNotificationForm extends React.Component<Props, any> {
               <input
                 id="toggle_backlog_size"
                 type="checkbox"
+                aria-label="Enable message backlog limit"
                 checked={isBacklogSizeEnabled}
                 onChange={this.toggleBacklogSize}
               />

--- a/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/TeamsNotificationForm.tsx
+++ b/graylog2-web-interface/src/integrations/event-notifications/event-notification-types/TeamsNotificationForm.tsx
@@ -21,7 +21,7 @@ import camelCase from 'lodash/camelCase';
 
 import { getValueFromInput } from 'util/FormsUtils';
 import { Input, Button, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup } from 'components/bootstrap';
-import { ColorPickerPopover, TimezoneSelect } from 'components/common';
+import { ColorPickerPopover, TimezoneSelect, URLAllowListInput } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import type { SelectCallback } from 'components/bootstrap/types';
 import DocsHelper from 'util/DocsHelper';
@@ -127,6 +127,10 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
     this.propagateChange(name, getValueFromInput(event.target));
   };
 
+  handleWebhookUrlChange = (event: any) => {
+    this.propagateChange('webhook_url', getValueFromInput(event.target));
+  };
+
   render() {
     const { config, validation } = this.props;
     const { isBacklogSizeEnabled, backlogSize } = this.state;
@@ -155,16 +159,13 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
           </div>
           <HelpBlock>Choose a color to use for this configuration.</HelpBlock>
         </FormGroup>
-        <Input
-          id="notification-webhookUrl"
-          name="webhook_url"
+        <URLAllowListInput
           label="Webhook URL"
-          type="text"
-          bsStyle={validation.errors.webhook_url ? 'error' : null}
-          help={get(validation, 'errors.webhook_url[0]', 'Teams "Incoming Webhook" URL')}
-          value={config.webhook_url || ''}
-          onChange={this.handleChange}
-          required
+          onChange={this.handleWebhookUrlChange}
+          validationState={validation.errors.webhook_url ? 'error' : null}
+          validationMessage={get(validation, 'errors.webhook_url[0]', 'Teams "Incoming Webhook" URL')}
+          url={config.webhook_url || ''}
+          autofocus={false}
         />
         <Input
           id="notification-customMessage"
@@ -196,6 +197,7 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
               <input
                 id="toggle_backlog_size"
                 type="checkbox"
+                aria-label="Enable message backlog limit"
                 checked={isBacklogSizeEnabled}
                 onChange={this.toggleBacklogSize}
               />

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.ts
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.ts
@@ -65,6 +65,7 @@ export type Url = {
 export type AllowListConfig = {
   entries: Array<Url>;
   disabled: boolean;
+  enforce_for_notifications: boolean;
 };
 export type PermissionsConfigType = {
   allow_sharing_with_everyone: boolean;


### PR DESCRIPTION
Note: This is a combined backport of #26619 and #26814 to `7.0`.

## Description
- Slack and Microsoft Teams notifications now check their webhook URL against the URL allowlist, via the new `UrlAllowlistValidator`. A system notification is raised and a warning logged when the URL is not allowlisted.
- Adds an `enforce_for_notifications` option to `System > Configuration > URL Allowlist` (default: disabled). When enabled, Slack/Teams notifications fail if their webhook URL is not allowlisted; when disabled, only a warning is logged.
- The Slack/Teams notification forms now use `URLAllowListInput` for the webhook URL, so users can add the URL to the allowlist inline.
- Removes the disabling of HTTP redirects in `SlackClient` and `RequestClient` (see https://github.com/Graylog2/graylog2-server/pull/26619#discussion_r3665836864).

## Motivation and Context
Partially addresses https://github.com/Graylog2/graylog-plugin-enterprise/issues/14748

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
