### PR TITLE
Remove AWS SDK v1 from the AWS plugin and bump amqp-client to 5.34.0

### DIFF
--- a/changelog/unreleased/bump-amqp-client-5.34.0.toml
+++ b/changelog/unreleased/bump-amqp-client-5.34.0.toml
@@ -1,0 +1,2 @@
+type = "security"
+message = "Bump `com.rabbitmq:amqp-client` from 5.29.0 to 5.34.0, fixing CVE-2026-63335 (malformed body frame DoS), CVE-2026-63336 (`useSslProtocol()` defaults to a trust-everything TLS manager, enabling MITM), and CVE-2026-69220 (pre-auth stack overflow from unbounded recursion on nested AMQP tables)."

--- a/changelog/unreleased/remove-aws-sdk-v1.toml
+++ b/changelog/unreleased/remove-aws-sdk-v1.toml
@@ -1,0 +1,2 @@
+type = "security"
+message = "Remove the last uses of AWS SDK v1 (`com.amazonaws`) from the AWS plugin, replacing them with AWS SDK v2 (`software.amazon.awssdk`), which the rest of the codebase already uses. AWS SDK v1 entered maintenance mode and its EC2/EOL date has passed."

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -754,6 +754,10 @@
             <artifactId>sts</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
@@ -923,47 +927,6 @@
             <version>2.0.2</version>
         </dependency>
 
-        <!-- AWS plugin -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ec2</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-server/src/main/java/org/graylog/aws/AWS.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/AWS.java
@@ -16,8 +16,9 @@
  */
 package org.graylog.aws;
 
-import com.amazonaws.regions.Regions;
 import com.google.common.collect.Maps;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.RegionMetadata;
 
 import java.util.Map;
 
@@ -40,15 +41,15 @@ public class AWS {
      * Build a list of region choices with both a value (persisted in configuration) and display value (shown to the user).
      *
      * The display value is formatted nicely: "EU (London): eu-west-2"
-     * The value is eventually passed to Regions.fromName() to get the actual region object: eu-west-2
+     * The value is eventually passed to Region.of() to get the actual region object: eu-west-2
      * @return a choices map with configuration value map keys and display value map values.
      */
     public static Map<String, String> buildRegionChoices() {
         Map<String, String> regions = Maps.newHashMap();
-        for (Regions region : Regions.values()) {
-
-            String displayValue = f("%s: %s", region.getDescription(), region.getName());
-            regions.put(region.getName(), displayValue);
+        for (Region region : Region.regions()) {
+            RegionMetadata regionMetadata = RegionMetadata.of(region);
+            String displayValue = f("%s: %s", regionMetadata.description(), region.id());
+            regions.put(region.id(), displayValue);
         }
         return regions;
     }

--- a/graylog2-server/src/main/java/org/graylog/aws/AWSProxyConfigurationProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/AWSProxyConfigurationProvider.java
@@ -54,7 +54,7 @@ public class AWSProxyConfigurationProvider implements Provider<ApacheHttpClient.
         return httpClientBuilder;
     }
 
-    static ProxyConfiguration buildProxyConfiguration(URI proxyUri) {
+    public static ProxyConfiguration buildProxyConfiguration(URI proxyUri) {
         ProxyConfiguration.Builder proxyConfigBuilder = ProxyConfiguration.builder();
 
         if (proxyUri.getUserInfo() != null && !proxyUri.getUserInfo().isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
@@ -17,32 +17,18 @@
 package org.graylog.aws.auth;
 
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
-import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.StringUtils;
 import org.graylog.aws.config.AWSPluginConfiguration;
+import org.graylog.integrations.aws.AWSAuthFactory;
 import org.graylog2.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.graylog2.shared.utilities.StringUtils.f;
 
-public class AWSAuthProvider implements AWSCredentialsProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(AWSAuthProvider.class);
-    private final Configuration configuration;
-
-    private final AWSCredentialsProvider credentials;
+public class AWSAuthProvider implements AwsCredentialsProvider {
+    private final AwsCredentialsProvider credentials;
 
     public AWSAuthProvider(Configuration configuration, AWSPluginConfiguration awsConfig) {
         this(configuration, awsConfig, null, null, null, null);
@@ -54,70 +40,38 @@ public class AWSAuthProvider implements AWSCredentialsProvider {
                            @Nullable String secretKey,
                            @Nullable String region,
                            @Nullable String assumeRoleArn) {
-        this.configuration = configuration;
-        this.credentials = this.resolveAuthentication(awsConfig, accessKey, secretKey, region, assumeRoleArn);
+        this.credentials = new AWSAuthFactory().create(
+                configuration.isCloud(),
+                region,
+                resolveAccessKey(configuration, awsConfig, accessKey, secretKey),
+                resolveSecretKey(configuration, awsConfig, accessKey, secretKey),
+                assumeRoleArn);
     }
 
-    private AWSCredentialsProvider resolveAuthentication(AWSPluginConfiguration config,
-                                                         @Nullable String accessKey,
-                                                         @Nullable String secretKey,
-                                                         @Nullable String region,
-                                                         @Nullable String assumeRoleArn) {
-
-        AWSCredentialsProvider awsCredentials = configuration.isCloud() ?
-                getCloudAwsCredentialsProvider(accessKey, secretKey) :
-                getStdAwsCredentialsProvider(config, accessKey, secretKey);
-
-        if (!isNullOrEmpty(assumeRoleArn) && !isNullOrEmpty(region)) {
-            LOG.debug("Creating cross account assume role credentials");
-            return this.getSTSCredentialsProvider(awsCredentials, region, assumeRoleArn);
-        } else {
-            return awsCredentials;
+    // The cloud codepath requires an explicit access/secret key (validated by AWSAuthFactory) and never falls back
+    // to the AWS Plugin configuration, matching the original v1 behavior.
+    private static String resolveAccessKey(Configuration configuration, AWSPluginConfiguration awsConfig,
+                                           @Nullable String accessKey, @Nullable String secretKey) {
+        if (!configuration.isCloud() && (isNullOrEmpty(accessKey) || isNullOrEmpty(secretKey)) && hasPluginConfigCredentials(configuration, awsConfig)) {
+            return awsConfig.accessKey();
         }
+        return accessKey;
     }
 
-    private AWSCredentialsProvider getStdAwsCredentialsProvider(AWSPluginConfiguration config, String accessKey, String secretKey) {
-        AWSCredentialsProvider awsCredentials;
-        if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {
-            awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
-            LOG.debug("Using input specific config");
-        } else if (!isNullOrEmpty(config.accessKey()) && !isNullOrEmpty(config.secretKey(configuration.getPasswordSecret()))) {
-            awsCredentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.accessKey(), config.secretKey(configuration.getPasswordSecret())));
-            LOG.debug("Using AWS Plugin config");
-        } else {
-            awsCredentials = new DefaultAWSCredentialsProviderChain();
-            LOG.debug("Using Default Provider Chain");
+    private static String resolveSecretKey(Configuration configuration, AWSPluginConfiguration awsConfig,
+                                           @Nullable String accessKey, @Nullable String secretKey) {
+        if (!configuration.isCloud() && (isNullOrEmpty(accessKey) || isNullOrEmpty(secretKey)) && hasPluginConfigCredentials(configuration, awsConfig)) {
+            return awsConfig.secretKey(configuration.getPasswordSecret());
         }
-        return awsCredentials;
+        return secretKey;
     }
 
-    private AWSCredentialsProvider getCloudAwsCredentialsProvider(String accessKey, String secretKey) {
-        Preconditions.checkArgument(StringUtils.isNotBlank(accessKey), "Access key is required.");
-        Preconditions.checkArgument(StringUtils.isNotBlank(secretKey), "Secret key is required.");
-        return new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
-    }
-
-    private AWSCredentialsProvider getSTSCredentialsProvider(AWSCredentialsProvider awsCredentials, String region, String assumeRoleArn) {
-        AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(awsCredentials)
-                .build();
-        String roleSessionName = f("API_KEY_%s@ACCOUNT_%s",
-                awsCredentials.getCredentials().getAWSAccessKeyId(),
-                stsClient.getCallerIdentity(new GetCallerIdentityRequest()).getAccount());
-        LOG.debug("Cross account role session name: " + roleSessionName);
-        return new STSAssumeRoleSessionCredentialsProvider.Builder(assumeRoleArn, roleSessionName)
-                .withStsClient(stsClient)
-                .build();
+    private static boolean hasPluginConfigCredentials(Configuration configuration, AWSPluginConfiguration awsConfig) {
+        return !isNullOrEmpty(awsConfig.accessKey()) && !isNullOrEmpty(awsConfig.secretKey(configuration.getPasswordSecret()));
     }
 
     @Override
-    public AWSCredentials getCredentials() {
-        return this.credentials.getCredentials();
-    }
-
-    @Override
-    public void refresh() {
-        this.credentials.refresh();
+    public AwsCredentials resolveCredentials() {
+        return credentials.resolveCredentials();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/aws/config/AWSPluginConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/config/AWSPluginConfiguration.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.aws.config;
 
-import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -27,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import org.graylog2.security.AESTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -96,18 +96,19 @@ public abstract class AWSPluginConfiguration {
     }
 
     @JsonIgnore
-    public List<Regions> getLookupRegions() {
+    public List<Region> getLookupRegions() {
         if (lookupRegions() == null || lookupRegions().isEmpty()) {
             return Collections.emptyList();
         }
 
-        ImmutableList.Builder<Regions> builder = ImmutableList.<Regions>builder();
+        ImmutableList.Builder<Region> builder = ImmutableList.<Region>builder();
 
         String[] regions = lookupRegions().split(",");
         for (String regionName : regions) {
-            try {
-                builder.add(Regions.fromName(regionName.trim()));
-            } catch (IllegalArgumentException e) {
+            final Region region = Region.of(regionName.trim());
+            if (Region.regions().contains(region)) {
+                builder.add(region);
+            } else {
                 LOG.info("Cannot translate [{}] into AWS region. Make sure it is a correct region code like for example 'us-west-1'.", regionName);
             }
         }

--- a/graylog2-server/src/main/java/org/graylog/aws/config/Proxy.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/config/Proxy.java
@@ -16,20 +16,16 @@
  */
 package org.graylog.aws.config;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.ClientConfigurationFactory;
-import okhttp3.HttpUrl;
-
 import jakarta.validation.constraints.NotNull;
+import okhttp3.HttpUrl;
+import org.graylog.aws.AWSProxyConfigurationProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 public class Proxy {
 
-    public static ClientConfiguration forAWS(@NotNull HttpUrl proxyUrl) {
-        return new ClientConfigurationFactory().getConfig()
-                .withProxyHost(proxyUrl.host())
-                .withProxyPort(proxyUrl.port())
-                .withProxyUsername(proxyUrl.username())
-                .withProxyPassword(proxyUrl.password());
+    public static ApacheHttpClient.Builder forAWS(@NotNull HttpUrl proxyUrl) {
+        return ApacheHttpClient.builder()
+                .proxyConfiguration(AWSProxyConfigurationProvider.buildProxyConfiguration(proxyUrl.uri()));
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailInput.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.aws.inputs.cloudtrail;
 
-import com.amazonaws.regions.Regions;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
 import jakarta.inject.Inject;
@@ -33,6 +32,7 @@ import org.graylog2.plugin.inputs.CloudCompatible;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import software.amazon.awssdk.regions.Region;
 
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class CloudTrailInput extends MessageInput {
     public static final String CK_AWS_SQS_REGION = "aws_sqs_region";
     public static final String CK_AWS_S3_REGION = "aws_s3_region";
     public static final String CK_ASSUME_ROLE_ARN = "aws_assume_role_arn";
-    private static final Regions DEFAULT_REGION = Regions.US_EAST_1;
+    private static final Region DEFAULT_REGION = Region.US_EAST_1;
     public static final String CK_OVERRIDE_SOURCE = "override_source";
     public static final String CK_POLLING_INTERVAL = "polling_interval";
     public static final String CK_SQS_MESSAGE_BATCH_SIZE = "sqs_message_batch_size";
@@ -128,7 +128,7 @@ public class CloudTrailInput extends MessageInput {
             r.addField(new DropdownField(
                     CK_AWS_SQS_REGION,
                     "AWS SQS Region",
-                    DEFAULT_REGION.getName(),
+                    DEFAULT_REGION.id(),
                     regionChoices,
                     "The AWS region the SQS queue is in.",
                     ConfigurationField.Optional.NOT_OPTIONAL
@@ -136,7 +136,7 @@ public class CloudTrailInput extends MessageInput {
             r.addField(new DropdownField(
                     CK_AWS_S3_REGION,
                     "AWS S3 Region",
-                    DEFAULT_REGION.getName(),
+                    DEFAULT_REGION.id(),
                     regionChoices,
                     "The AWS region the S3 bucket is in.",
                     ConfigurationField.Optional.NOT_OPTIONAL

--- a/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/inputs/cloudtrail/CloudTrailTransport.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.aws.inputs.cloudtrail;
 
-import com.amazonaws.regions.Regions;
 import com.codahale.metrics.MetricSet;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,6 +48,7 @@ import org.graylog2.security.encryption.EncryptedValueService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -68,7 +68,7 @@ import static org.graylog.aws.inputs.cloudtrail.CloudTrailInput.CK_POLLING_INTER
 public class CloudTrailTransport extends ThrottleableTransport2 {
     private static final Logger LOG = LoggerFactory.getLogger(CloudTrailTransport.class);
     public static final String NAME = "AWSCloudTrail";
-    private static final Regions DEFAULT_REGION = Regions.US_EAST_1;
+    private static final Region DEFAULT_REGION = Region.US_EAST_1;
     private final LocalMetricRegistry localRegistry;
     private final ScheduledExecutorService executorService;
     private final SQSClientFactory sqsClientFactory;
@@ -137,8 +137,8 @@ public class CloudTrailTransport extends ThrottleableTransport2 {
         }
 
         final String assumeRoleArn = input.getConfiguration().getString(CK_ASSUME_ROLE_ARN);
-        final String sqsRegionName = input.getConfiguration().getString(CK_AWS_SQS_REGION, DEFAULT_REGION.getName());
-        final String s3RegionName = input.getConfiguration().getString(CK_AWS_S3_REGION, DEFAULT_REGION.getName());
+        final String sqsRegionName = input.getConfiguration().getString(CK_AWS_SQS_REGION, DEFAULT_REGION.id());
+        final String s3RegionName = input.getConfiguration().getString(CK_AWS_S3_REGION, DEFAULT_REGION.id());
 
         LOG.debug("Using SQS region: {}, S3 region: {}", sqsRegionName, s3RegionName);
 

--- a/graylog2-server/src/main/java/org/graylog/aws/processors/instancelookup/InstanceLookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog/aws/processors/instancelookup/InstanceLookupTable.java
@@ -16,24 +16,23 @@
  */
 package org.graylog.aws.processors.instancelookup;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.DescribeNetworkInterfacesResult;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.InstanceNetworkInterface;
-import com.amazonaws.services.ec2.model.InstancePrivateIpAddress;
-import com.amazonaws.services.ec2.model.NetworkInterface;
-import com.amazonaws.services.ec2.model.NetworkInterfacePrivateIpAddress;
-import com.amazonaws.services.ec2.model.Reservation;
-import com.amazonaws.services.ec2.model.Tag;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.HttpUrl;
 import org.graylog.aws.auth.AWSAuthProvider;
 import org.graylog.aws.config.Proxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.DescribeNetworkInterfacesResponse;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.InstanceNetworkInterface;
+import software.amazon.awssdk.services.ec2.model.InstancePrivateIpAddress;
+import software.amazon.awssdk.services.ec2.model.NetworkInterface;
+import software.amazon.awssdk.services.ec2.model.NetworkInterfacePrivateIpAddress;
+import software.amazon.awssdk.services.ec2.model.Reservation;
+import software.amazon.awssdk.services.ec2.model.Tag;
 
 import jakarta.inject.Singleton;
 
@@ -57,75 +56,75 @@ public class InstanceLookupTable {
 
     // TODO METRICS
 
-    public void reload(List<Regions> regions, AWSAuthProvider awsAuthProvider, HttpUrl proxyUrl) {
+    public void reload(List<Region> regions, AWSAuthProvider awsAuthProvider, HttpUrl proxyUrl) {
         LOG.debug("Reloading AWS instance lookup table.");
 
         ImmutableMap.Builder<String, Instance> ec2InstancesBuilder = ImmutableMap.<String, Instance>builder();
         ImmutableMap.Builder<String, NetworkInterface> networkInterfacesBuilder = ImmutableMap.<String, NetworkInterface>builder();
 
-        for (Regions region : regions) {
+        for (Region region : regions) {
             try {
-                AmazonEC2 ec2Client;
+                Ec2Client ec2Client;
 
                 if (proxyUrl != null) {
-                    ec2Client = AmazonEC2Client.builder()
-                            .withCredentials(awsAuthProvider)
-                            .withRegion(region)
-                            .withClientConfiguration(Proxy.forAWS(proxyUrl))
+                    ec2Client = Ec2Client.builder()
+                            .credentialsProvider(awsAuthProvider)
+                            .region(region)
+                            .httpClientBuilder(Proxy.forAWS(proxyUrl))
                             .build();
                 } else {
-                    ec2Client = AmazonEC2Client.builder()
-                            .withCredentials(awsAuthProvider)
-                            .withRegion(region)
+                    ec2Client = Ec2Client.builder()
+                            .credentialsProvider(awsAuthProvider)
+                            .region(region)
                             .build();
                 }
 
                 // Load network interfaces
-                LOG.debug("Requesting AWS network interface descriptions in [{}].", region.getName());
-                DescribeNetworkInterfacesResult interfaces = ec2Client.describeNetworkInterfaces();
-                for (NetworkInterface iface : interfaces.getNetworkInterfaces()) {
-                    LOG.debug("Discovered network interface [{}].", iface.getNetworkInterfaceId());
+                LOG.debug("Requesting AWS network interface descriptions in [{}].", region.id());
+                DescribeNetworkInterfacesResponse interfaces = ec2Client.describeNetworkInterfaces();
+                for (NetworkInterface iface : interfaces.networkInterfaces()) {
+                    LOG.debug("Discovered network interface [{}].", iface.networkInterfaceId());
 
                     // Add all private IP addresses.
-                    for (final NetworkInterfacePrivateIpAddress privateIp : iface.getPrivateIpAddresses()) {
-                        LOG.debug("Network interface [{}] has private IP: {}", iface.getNetworkInterfaceId(), privateIp);
-                        networkInterfacesBuilder.put(privateIp.getPrivateIpAddress(), iface);
+                    for (final NetworkInterfacePrivateIpAddress privateIp : iface.privateIpAddresses()) {
+                        LOG.debug("Network interface [{}] has private IP: {}", iface.networkInterfaceId(), privateIp);
+                        networkInterfacesBuilder.put(privateIp.privateIpAddress(), iface);
                     }
 
                     // Add public IP address.
-                    if (iface.getAssociation() != null) {
-                        String publicIp = iface.getAssociation().getPublicIp();
-                        LOG.debug("Network interface [{}] has public IP: {}", iface.getNetworkInterfaceId(), publicIp);
+                    if (iface.association() != null) {
+                        String publicIp = iface.association().publicIp();
+                        LOG.debug("Network interface [{}] has public IP: {}", iface.networkInterfaceId(), publicIp);
                         networkInterfacesBuilder.put(publicIp, iface);
                     }
                 }
 
                 // Load EC2 instances
-                LOG.debug("Requesting EC2 instance descriptions in [{}].", region.getName());
-                DescribeInstancesResult ec2Result = ec2Client.describeInstances();
-                for (Reservation reservation : ec2Result.getReservations()) {
-                    LOG.debug("Fetching instances for reservation [{}].", reservation.getReservationId());
-                    for (final Instance instance : reservation.getInstances()) {
-                        LOG.debug("Discovered EC2 instance [{}].", instance.getInstanceId());
+                LOG.debug("Requesting EC2 instance descriptions in [{}].", region.id());
+                DescribeInstancesResponse ec2Result = ec2Client.describeInstances();
+                for (Reservation reservation : ec2Result.reservations()) {
+                    LOG.debug("Fetching instances for reservation [{}].", reservation.reservationId());
+                    for (final Instance instance : reservation.instances()) {
+                        LOG.debug("Discovered EC2 instance [{}].", instance.instanceId());
 
                         // Add all private IP addresses.
-                        for (InstanceNetworkInterface iface : instance.getNetworkInterfaces()) {
-                            for (InstancePrivateIpAddress privateIp : iface.getPrivateIpAddresses()) {
-                                LOG.debug("EC2 instance [{}] has private IP: {}", instance.getInstanceId(), privateIp.getPrivateIpAddress());
-                                ec2InstancesBuilder.put(privateIp.getPrivateIpAddress(), instance);
+                        for (InstanceNetworkInterface iface : instance.networkInterfaces()) {
+                            for (InstancePrivateIpAddress privateIp : iface.privateIpAddresses()) {
+                                LOG.debug("EC2 instance [{}] has private IP: {}", instance.instanceId(), privateIp.privateIpAddress());
+                                ec2InstancesBuilder.put(privateIp.privateIpAddress(), instance);
                             }
                         }
 
                         // Add public IP address.
-                        String publicIp = instance.getPublicIpAddress();
+                        String publicIp = instance.publicIpAddress();
                         if (publicIp != null) {
-                            LOG.debug("EC2 instance [{}] has public IP: {}", instance.getInstanceId(), publicIp);
+                            LOG.debug("EC2 instance [{}] has public IP: {}", instance.instanceId(), publicIp);
                             ec2InstancesBuilder.put(publicIp, instance);
                         }
                     }
                 }
             } catch (Exception e) {
-                LOG.error("Error when trying to refresh AWS instance lookup table in [{}]", region.getName(), e);
+                LOG.error("Error when trying to refresh AWS instance lookup table in [{}]", region.id(), e);
             }
         }
 
@@ -141,7 +140,7 @@ public class InstanceLookupTable {
             if (ec2Instances.containsKey(ip)) {
                 Instance instance = ec2Instances.get(ip);
                 LOG.debug("Found IP [{}] in EC2 instance lookup table.", ip);
-                return new DiscoveredEC2Instance(instance.getInstanceId(), getNameOfInstance(instance));
+                return new DiscoveredEC2Instance(instance.instanceId(), getNameOfInstance(instance));
             }
 
             // If it's not an EC2 instance, we might still find it in our list of network interfaces.
@@ -172,15 +171,15 @@ public class InstanceLookupTable {
     // Format is "ELB [name]" where "name" can only be a-z, A-Z and hyphens.
     private String getELBNameFromInterface(NetworkInterface iface) {
         try {
-            String[] parts = iface.getDescription().split(" ");
+            String[] parts = iface.description().split(" ");
             if (parts.length == 2) {
                 return parts[1];
             } else {
-                LOG.warn("Unexpected ELB name in network interface description: [{}]", iface.getDescription());
+                LOG.warn("Unexpected ELB name in network interface description: [{}]", iface.description());
                 return "unknown-name";
             }
         } catch (Exception e) {
-            LOG.warn("Could not get ELB name from network interface description. Description was [{}]", iface.getDescription(), e);
+            LOG.warn("Could not get ELB name from network interface description. Description was [{}]", iface.description(), e);
             return "unknown-name";
         }
     }
@@ -196,12 +195,12 @@ public class InstanceLookupTable {
      */
     private InstanceType determineType(NetworkInterface iface) {
         String ownerId;
-        if (iface.getAssociation() != null) {
-            ownerId = iface.getAssociation().getIpOwnerId();
-        } else if (iface.getRequesterId().equals("amazon-rds")) {
+        if (iface.association() != null) {
+            ownerId = iface.association().ipOwnerId();
+        } else if (iface.requesterId().equals("amazon-rds")) {
             ownerId = "amazon-rds";
         } else {
-            LOG.debug("AWS network interface with no association: [{}]", iface.getDescription());
+            LOG.debug("AWS network interface with no association: [{}]", iface.description());
             return InstanceType.UNKNOWN;
         }
 
@@ -218,9 +217,9 @@ public class InstanceLookupTable {
     }
 
     private String getNameOfInstance(Instance x) {
-        for (Tag tag : x.getTags()) {
-            if ("Name".equals(tag.getKey())) {
-                return tag.getValue();
+        for (Tag tag : x.tags()) {
+            if ("Name".equals(tag.key())) {
+                return tag.value();
             }
         }
 

--- a/graylog2-server/src/test/java/org/graylog/aws/AWSTest.java
+++ b/graylog2-server/src/test/java/org/graylog/aws/AWSTest.java
@@ -32,12 +32,12 @@ public class AWSTest {
         Map<String, String> regionChoices = AWS.buildRegionChoices();
 
         // Check format of random region.
-        assertTrue(regionChoices.containsValue("EU (London): eu-west-2"));
+        assertTrue(regionChoices.containsValue("Europe (London): eu-west-2"));
         assertTrue(regionChoices.containsKey("eu-west-2"));
 
         // Verify that the Gov regions are present.
-        //"us-gov-west-1" -> "AWS GovCloud (US): us-gov-west-1"
-        assertTrue(regionChoices.containsValue("AWS GovCloud (US): us-gov-west-1"));
+        //"us-gov-west-1" -> "AWS GovCloud (US-West): us-gov-west-1"
+        assertTrue(regionChoices.containsValue("AWS GovCloud (US-West): us-gov-west-1"));
         assertTrue(regionChoices.containsKey("us-gov-west-1"));
         assertTrue(regionChoices.containsValue("AWS GovCloud (US-East): us-gov-east-1"));
         assertTrue(regionChoices.containsKey("us-gov-east-1"));

--- a/graylog2-server/src/test/java/org/graylog/aws/auth/AWSAuthProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/aws/auth/AWSAuthProviderTest.java
@@ -46,8 +46,8 @@ public class AWSAuthProviderTest {
 
         AWSAuthProvider authProvider = createForConfig(config);
 
-        assertThat(authProvider.getCredentials().getAWSSecretKey()).isEqualTo("aVerySecretKey");
-        assertThat(authProvider.getCredentials().getAWSAccessKeyId()).isEqualTo("MyAccessKey");
+        assertThat(authProvider.resolveCredentials().secretAccessKey()).isEqualTo("aVerySecretKey");
+        assertThat(authProvider.resolveCredentials().accessKeyId()).isEqualTo("MyAccessKey");
     }
 
     private AWSAuthProvider createForConfig(AWSPluginConfiguration config) {

--- a/graylog2-server/src/test/java/org/graylog/aws/config/AWSPluginConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/aws/config/AWSPluginConfigurationTest.java
@@ -16,8 +16,8 @@
  */
 package org.graylog.aws.config;
 
-import com.amazonaws.regions.Regions;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.regions.Region;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.aws.config.AWSPluginConfiguration.createDefault;
@@ -30,7 +30,7 @@ public class AWSPluginConfigurationTest {
                 .lookupRegions("us-west-1,eu-west-1 ,  us-east-1 ")
                 .build();
 
-        assertThat(config.getLookupRegions()).containsExactly(Regions.US_WEST_1, Regions.EU_WEST_1, Regions.US_EAST_1);
+        assertThat(config.getLookupRegions()).containsExactly(Region.US_WEST_1, Region.EU_WEST_1, Region.US_EAST_1);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -305,13 +305,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>${aws-java-sdk-1.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-storage</artifactId>
                 <version>${gcs.version}</version>
@@ -886,6 +879,11 @@
                                              megabytes to our production artifacts and must be avoided. -->
                                         <exclude>com.amazonaws:aws-java-sdk-bundle</exclude>
                                         <exclude>software.amazon.awssdk:bundle</exclude>
+                                        <!-- The AWS plugin has been fully migrated to AWS SDK v2 (software.amazon.awssdk).
+                                             Ban the v1 SDK to prevent it from creeping back in. Note: this only bans the
+                                             "aws-java-sdk-*" artifacts; it does not affect com.amazonaws:dynamodb-lock-client,
+                                             an unrelated utility used by the Kinesis Client Library that is itself built on SDK v2. -->
+                                        <exclude>com.amazonaws:aws-java-sdk-*</exclude>
                                         <!-- Ban some javax dependencies after the move to jakarta -->
                                         <exclude>javax.inject:*</exclude>
                                         <exclude>javax.ws.rs:javax.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <opensearch.shaded.version>2.19.3-1</opensearch.shaded.version>
         <opensearch.client.version>3.2.0</opensearch.client.version>
         <airline.version>3.2.0</airline.version>
-        <amqp-client.version>5.29.0</amqp-client.version>
+        <amqp-client.version>5.34.0</amqp-client.version>
         <antlr.version>4.13.2</antlr.version>
         <apache-directory-version>2.1.7</apache-directory-version>
         <apache-httpclient.version>4.5.14</apache-httpclient.version>


### PR DESCRIPTION
## Description

Two independent changes bundled on this branch:

1. **Remove AWS SDK v1 from the AWS plugin.** The legacy `org.graylog.aws.*` plugin was the last part of the codebase still on AWS SDK v1 (`com.amazonaws`); everything else (Kinesis, CloudWatch, S3 GeoIP, SQS/SNS, CloudTrail's auth/proxy layer) was already on SDK v2. `AWSAuthProvider` now implements SDK v2's `AwsCredentialsProvider` and delegates to `AWSAuthFactory` (the same factory used elsewhere in the codebase); `Proxy` builds an SDK v2 `ApacheHttpClient.Builder`; `InstanceLookupTable`'s EC2 client (`AmazonEC2Client`) is replaced with `Ec2Client`, same logic, v2 accessors. Added the missing `software.amazon.awssdk:ec2` dependency and a `com.amazonaws:aws-java-sdk-*` ban to stop v1 from creeping back in.
2. **Bump `com.rabbitmq:amqp-client` from 5.29.0 to 5.34.0**, fixing three CVEs: CVE-2026-63335 (malformed body frame DoS), CVE-2026-63336 (`useSslProtocol()` defaults to a trust-everything TLS manager — directly reachable, `AmqpConsumer.java` calls this exact overload whenever TLS is enabled on an AMQP input), and CVE-2026-69220 (pre-auth stack overflow from unbounded recursion on nested AMQP tables).

## Motivation and Context

- AWS SDK v1 is in maintenance mode past its EOL date; removing the last dependency on it closes that off entirely.
- The three AMQP CVEs are real and, for CVE-2026-63336, directly exploitable in this codebase's own TLS-enabled AMQP path.

## How Has This Been Tested?

**SDK v1 removal:**
- Clean compile and clean `test-compile` with license headers + `forbiddenapis` + enforcer (including the new v1 ban), all passing.
- Full `org.graylog.aws.*` unit-test suite: 39/39 passing.
- Manual smoke test against a real AWS EC2 instance: launched a tagged `t3.micro`, ran the migrated `InstanceLookupTable` against it directly, confirmed it correctly resolved both the instance's private and public IP to its `Name` tag via the real `describeNetworkInterfaces`/`describeInstances` v2 API calls, then terminated the instance.
- `grep`/`mvn dependency:tree` sweep confirms zero remaining `com.amazonaws:aws-java-sdk-*` references (the only remaining `com.amazonaws`-groupId artifact anywhere is the unrelated `dynamodb-lock-client`, pulled in transitively by the Kinesis Client Library, which is itself built on SDK v2).

**AMQP bump:**
- Verified as a pure drop-in: every intermediate version bump on `master` (5.29.0→5.30.0→5.31.0→5.32.0) was a one-line `pom.xml` change with zero source changes, and `AmqpConsumer.java`/`AmqpTransport.java` are unchanged between this branch and `master`.
- `AmqpTransportIT` (real RabbitMQ container via Testcontainers): 2/2 passing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

Note on the two checklist items above: no new tests were added for the SDK v1 removal — the existing test suite (39 tests) was updated to match the new SDK v2 API surface and still fully covers the same code paths. One user-visible text change is worth flagging for review: AWS's own SDK v2 region metadata uses different display names than v1 (e.g. `"EU (London)"` → `"Europe (London)"`), visible in the AWS plugin's region dropdowns — `AWSTest` was updated to match; this isn't a bug in the migration, just AWS's own naming change between SDK versions.
