### PR TITLE
Upload web interface source maps to PostHog in release builds

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -61,6 +61,12 @@
         <skip.web.build>false</skip.web.build>
         <skip.web.tests>false</skip.web.tests>
 
+        <!-- Upload of web interface source maps to PostHog. Only runs in the "release" profile, and only when
+             POSTHOG_CLI_API_KEY is present in the environment and the web interface is being built. See the
+             "posthog-sourcemaps-disabled" and "posthog-sourcemaps-disabled-without-web-build" profiles. -->
+        <posthog.sourcemaps.skip>false</posthog.sourcemaps.skip>
+        <posthog.release.name>graylog-server</posthog.release.name>
+
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <!-- to work around filtering bug, which makes maven.build.timestamp inaccessible -->
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
@@ -1349,8 +1355,87 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!-- Make it obvious in the release build log when source maps are not being uploaded. -->
+                                <id>warn-about-skipped-posthog-sourcemap-upload</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:if="ant:if">
+                                        <condition property="posthog.sourcemaps.skipped">
+                                            <istrue value="${posthog.sourcemaps.skip}"/>
+                                        </condition>
+                                        <echo if:set="posthog.sourcemaps.skipped" level="warning"
+                                              message="POSTHOG_CLI_API_KEY is not set - skipping upload of web interface source maps to PostHog."/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <workingDirectory>${webInterface.path}</workingDirectory>
+                            <installDirectory>${webInterface.path}</installDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <!-- Stamp the bundled chunks with PostHog chunk IDs and upload their source maps, so
+                                     stack traces from released builds resolve to the original sources.
+
+                                     This runs against ${project.build.outputDirectory} instead of the webpack output
+                                     directory on purpose: the inject step rewrites the bundles, and PostHog can only
+                                     resolve a stack trace if the JavaScript we actually ship carries the chunk IDs.
+                                     Injecting the directory that maven-jar-plugin packages in the "package" phase
+                                     guarantees that, without depending on plugin ordering within "compile". -->
+                                <id>upload-web-sourcemaps-to-posthog</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${posthog.sourcemaps.skip}</skip>
+                                    <arguments>run posthog-cli sourcemap process --directory ${project.build.outputDirectory}/web-interface/assets --release-name ${posthog.release.name} --release-version ${project.version}</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- Disables the PostHog source map upload in the "release" profile when no API key is available.
+                 Maven cannot AND two profiles together, so the "release" profile gates its executions on the
+                 property this profile flips. -->
+            <id>posthog-sourcemaps-disabled</id>
+            <activation>
+                <property>
+                    <name>!env.POSTHOG_CLI_API_KEY</name>
+                </property>
+            </activation>
+            <properties>
+                <posthog.sourcemaps.skip>true</posthog.sourcemaps.skip>
+            </properties>
+        </profile>
+        <profile>
+            <!-- Without the web interface build there are no bundles to process, and no node/yarn installation to
+                 run the PostHog CLI with. Mirrors the activation of the "web-interface-build" profile. -->
+            <id>posthog-sourcemaps-disabled-without-web-build</id>
+            <activation>
+                <property>
+                    <name>skip.web.build</name>
+                </property>
+            </activation>
+            <properties>
+                <posthog.sourcemaps.skip>true</posthog.sourcemaps.skip>
+            </properties>
         </profile>
         <profile>
             <id>skip-web-interface-tests</id>

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -113,6 +113,7 @@
   "devDependencies": {
     "@cyclonedx/webpack-plugin": "^5.1.1",
     "@graylog/oxfmt-config": "^1.0.1",
+    "@posthog/cli": "^0.14.1",
     "@types/chroma-js": "^3.1.2",
     "@types/crossfilter": "0.0.38",
     "@types/express": "^5.0.6",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2483,6 +2483,13 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
+"@posthog/cli@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.npmjs.org/@posthog/cli/-/cli-0.14.1.tgz#a301df24dc307fbcf626ab9f53e0e558f24a42e6"
+  integrity sha512-gTzcKpl9TZLf0LrlLHEjChlPc9LIK1gdQG0alMnX6+b+W1mTD+6nTN0W/MeEzjT4DiKDeK8FPhc1n7dT1tWKFw==
+  dependencies:
+    detect-libc "^2.1.2"
+
 "@posthog/core@1.28.2":
   version "1.28.2"
   resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.28.2.tgz#9baf88b95f13d3a71a983cd644084ae61b820cba"
@@ -6208,6 +6215,11 @@ detect-libc@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
   integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
+detect-libc@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 detect-newline@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a `sourcemap process` (inject + upload) step to the `release` profile of the `graylog2-server` module, so exceptions captured by PostHog error tracking resolve to the original sources instead of minified bundles.

The step runs at `process-classes` against `target/classes/web-interface/assets` rather than the webpack output directory. The inject step rewrites the bundles to carry PostHog chunk IDs, and a stack trace only resolves if the JavaScript we actually ship carries them, so injecting the directory that maven-jar-plugin packages guarantees that without relying on plugin ordering inside `compile`.

The upload is gated on `POSTHOG_CLI_API_KEY` being present in the environment and on the web interface build being enabled. Maven cannot AND two profiles together, so this is expressed with two profiles that flip `posthog.sourcemaps.skip`. Release builds without credentials log a warning and continue, which keeps local `-Prelease` builds working.

CI additionally needs `POSTHOG_CLI_PROJECT_ID` and `POSTHOG_CLI_HOST`.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.