### PR TITLE
Fix IPFIX loop with unreachable exit condition (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-26910.toml
+++ b/changelog/unreleased/pr-26910.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Fix IPFIX loop with unreachable exit condition."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15003"]
+pulls = ["26910"]

--- a/graylog2-server/src/main/java/org/graylog/integrations/ipfix/IpfixParser.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/ipfix/IpfixParser.java
@@ -60,6 +60,10 @@ public class IpfixParser {
     private static final int SETID_TEMPLATE = 2;
     private static final int SETID_OPTIONSTEMPLATE = 3;
     private static final String HOW_TO_FIX_MISSING_FIELD_DEF_ERROR = "To fix this error, update the IPFIX field definitions template file to include a definition for this ID.";
+    // subTemplateList records can nest (RFC 6313), and the referenced template id is read off the wire, so a crafted
+    // packet can make a template reference itself and recurse ~once per 4 bytes. Bound the depth so a malformed packet
+    // cannot exhaust the stack. Legitimate nesting is only a few levels deep.
+    private static final int MAX_SUBTEMPLATE_DEPTH = 16;
 
     private final InformationElementDefinitions infoElemDefs;
 
@@ -80,7 +84,9 @@ public class IpfixParser {
      */
     public MessageDescription shallowParseMessage(ByteBuf packet) {
         final ByteBuf buffer = packet.readSlice(MessageHeader.LENGTH);
-        LOG.debug("Shallow parse header\n{}", ByteBufUtil.prettyHexDump(buffer));
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Shallow parse header\n{}", ByteBufUtil.prettyHexDump(buffer));
+        }
         final MessageHeader header = parseMessageHeader(buffer);
         final MessageDescription messageDescription = new MessageDescription(header);
 
@@ -232,15 +238,22 @@ public class IpfixParser {
      * @return
      */
     public IpfixMessage parseMessage(ByteBuf packet) {
-        LOG.debug("Attempting to parse message.");
-        LOG.debug("IPFIX message\n{}", ByteBufUtil.prettyHexDump(packet));
+        LOG.trace("Attempting to parse message.");
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("IPFIX message\n{}", ByteBufUtil.prettyHexDump(packet));
+        }
         final IpfixMessage.Builder builder = IpfixMessage.builder();
         final ByteBuf headerBuffer = packet.readSlice(MessageHeader.LENGTH);
-        LOG.debug("Message header buffer\n{}", ByteBufUtil.prettyHexDump(headerBuffer));
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Message header buffer\n{}", ByteBufUtil.prettyHexDump(headerBuffer));
+        }
         final MessageHeader header = parseMessageHeader(headerBuffer);
         // sanity check: we need the complete packet in the buffer
         if (header.length() > packet.readableBytes() + MessageHeader.LENGTH) {
-            LOG.error("Buffer does not contain expected IPFIX message:\n{}", ByteBufUtil.prettyHexDump(packet));
+            LOG.error("Buffer does not contain the complete IPFIX message");
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Incomplete IPFIX message:\n{}", ByteBufUtil.prettyHexDump(packet));
+            }
             throw new IpfixException("Buffer does not contain the complete IPFIX message");
         }
         // loop over all the contained sets in the message
@@ -249,7 +262,9 @@ public class IpfixParser {
         while (packet.isReadable()) {
             final int setId = packet.readUnsignedShort();
             final int setLength = packet.readUnsignedShort();
-            LOG.debug("Set id {} buffer\n{}", setId, ByteBufUtil.prettyHexDump(packet, packet.readerIndex() - 4, setLength));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Set id {} buffer\n{}", setId, ByteBufUtil.prettyHexDump(packet, packet.readerIndex() - 4, setLength));
+            }
             // the buffer limited to the declared length of the set.
             final ByteBuf setContent = packet.readSlice(setLength - 4);
             switch (setId) {
@@ -332,6 +347,14 @@ public class IpfixParser {
      * @return collection of parsed flows
      */
     public Set<Flow> parseDataSet(ImmutableList<InformationElement> informationElements, Map<Integer, TemplateRecord> templateMap, ByteBuf setContent) {
+        return parseDataSet(informationElements, templateMap, setContent, 0);
+    }
+
+    private Set<Flow> parseDataSet(ImmutableList<InformationElement> informationElements, Map<Integer, TemplateRecord> templateMap, ByteBuf setContent, int depth) {
+        if (depth > MAX_SUBTEMPLATE_DEPTH) {
+            LOG.error("subTemplateList nesting exceeds maximum {} levels, discarding remaining nested data", MAX_SUBTEMPLATE_DEPTH);
+            return ImmutableSet.of();
+        }
         ImmutableSet.Builder<Flow> flowBuilder = ImmutableSet.builder();
 
         // Padding: data records have no header and no fixed length, but the end of a data set (which are non-delimited series of data records), there _may_ be padding
@@ -341,8 +364,15 @@ public class IpfixParser {
         // Thus, it is much simpler to catch the exception and return the flows we have collected so far.
 
         int flowNum = 1;
+        int previousStart = -1;
         readFlows:
         while (setContent.isReadable()) {
+            final int setStart = setContent.readerIndex();
+            if (setStart == previousStart) {
+                LOG.error("Parser made no progress reading flow data set, discarding remaining bytes");
+                break readFlows;
+            }
+            previousStart = setStart;
             try {
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Parsing flow {}", flowNum);
@@ -356,7 +386,9 @@ public class IpfixParser {
                         LOG.error("Unable to find info element definition due to incomplete field definitions: id [{}] PEN [{}]. " +
                                         HOW_TO_FIX_MISSING_FIELD_DEF_ERROR,
                                 informationElement.id(), informationElement.enterpriseNumber());
-                        continue readFlows; // skip this element, since the template cannot be obtained for it.
+                        final int skipLength = informationElement.length() == 65535 ? getVarLength(setContent) : informationElement.length();
+                        setContent.skipBytes(skipLength);
+                        continue;
                     }
                     switch (desc.dataType()) {
                         // these are special because they can use reduced-size encoding (RFC 7011 Sec 6.2)
@@ -534,10 +566,19 @@ public class IpfixParser {
                                         element.id(), element.enterpriseNumber());
                                 break;
                             } else {
+                                if (element.length() == 0) {
+                                    LOG.error("basicList element declares zero length for id [{}] PEN [{}], discarding basicList",
+                                            element.id(), element.enterpriseNumber());
+                                    break;
+                                }
                                 LOG.warn("Skipping basicList data ({} bytes)", informationElement.length());
                                 while (listBuffer.isReadable()) {
+                                    final int before = listBuffer.readerIndex();
                                     // simply discard the bytes for now
                                     listBuffer.skipBytes(element.length());
+                                    if (listBuffer.readerIndex() == before) {
+                                        throw new IpfixException("basicList element consumed no bytes, discarding set");
+                                    }
                                 }
                             }
                             break;
@@ -568,7 +609,6 @@ public class IpfixParser {
                             int length = informationElement.length() == 65535 ? getVarLength(setContent) : setContent.readUnsignedByte();
                             // adjust length for semantic + templateId
                             length -= 3;
-                            LOG.debug("Remaining data buffer:\n{}", ByteBufUtil.prettyHexDump(setContent));
                             // TODO add to field somehow
                             final short semantic = setContent.readUnsignedByte();
                             final int templateId = setContent.readUnsignedShort();
@@ -582,7 +622,7 @@ public class IpfixParser {
                             // if this is not readable, it's an empty list
                             final ImmutableList.Builder<Flow> flowsBuilder = ImmutableList.builder();
                             if (listContent.isReadable()) {
-                                flowsBuilder.addAll(parseDataSet(templateRecord.informationElements(), templateMap, listContent));
+                                flowsBuilder.addAll(parseDataSet(templateRecord.informationElements(), templateMap, listContent, depth + 1));
                             }
                             final ImmutableList<Flow> flows = flowsBuilder.build();
                             // flatten arrays and fields into the field name until we have support for nested objects

--- a/graylog2-server/src/main/java/org/graylog/integrations/ipfix/codecs/IpfixCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/ipfix/codecs/IpfixCodec.java
@@ -142,7 +142,9 @@ public class IpfixCodec extends AbstractCodec implements MultiMessageCodec {
      * @return
      */
     private static String toMessageString(Flow record) {
-        LOG.debug("IPFIX message being assembled from flow record [{}].", record.fields());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("IPFIX message being assembled from flow record [{}].", record.fields());
+        }
         final ImmutableMap<String, Object> fields = record.fields();
         final long packetCount = (long) fields.getOrDefault("packetDeltaCount", 0L);
         long octetCount = (long) fields.getOrDefault("octetDeltaCount", 0L);

--- a/graylog2-server/src/test/java/org/graylog/integrations/ipfix/IpfixParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/ipfix/IpfixParserTest.java
@@ -18,7 +18,9 @@ package org.graylog.integrations.ipfix;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import com.google.common.primitives.Bytes;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -39,6 +41,95 @@ public class IpfixParserTest {
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test(timeout = 5000)
+    public void parseMessage_undefinedInformationElement_doesNotLoop() {
+        final byte[] packetBytes = hexToBytes("000a00240000000000000001000000000002000c0100000103e800040100000841414141");
+        final ByteBuf packet = Unpooled.wrappedBuffer(packetBytes);
+        final IpfixMessage message = new IpfixParser(definitions).parseMessage(packet);
+        assertThat(message).isNotNull();
+        assertThat(message.flows()).hasSize(1);
+        assertThat(message.flows().getFirst().fields()).isEmpty();
+    }
+
+    @Test(timeout = 5000)
+    public void parseMessage_undefinedInformationElement_fixedLength_doesNotCorruptSubsequentField() {
+        // Template: IE 1000 (len=4, undefined) + IE 8 (sourceIPv4Address, len=4, defined)
+        // Data record: 4 junk bytes for IE 1000, then 192.168.1.1 for IE 8
+        final byte[] packetBytes = hexToBytes("000a002c000000000000000100000000000200100100000203e8000400080004" +
+                "0100000c41414141c0a80101");
+        final ByteBuf packet = Unpooled.wrappedBuffer(packetBytes);
+        final IpfixMessage message = new IpfixParser(definitions).parseMessage(packet);
+        assertThat(message).isNotNull();
+        assertThat(message.flows()).hasSize(1);
+        assertThat(message.flows().getFirst().fields()).containsEntry("sourceIPv4Address", "192.168.1.1");
+    }
+
+    @Test(timeout = 5000)
+    public void parseMessage_undefinedInformationElement_variableLength_doesNotCorruptSubsequentField() {
+        // Template: IE 1000 (len=65535 var-length, undefined) + IE 8 (sourceIPv4Address, len=4, defined)
+        // Data record: 0x04 (var-length prefix=4) + 4 junk bytes, then 192.168.1.1 for IE 8
+        final byte[] packetBytes = hexToBytes("000a002d000000000000000100000000000200100100000203e8ffff00080004" +
+                "0100000d0441414141c0a80101");
+        final ByteBuf packet = Unpooled.wrappedBuffer(packetBytes);
+        final IpfixMessage message = new IpfixParser(definitions).parseMessage(packet);
+        assertThat(message).isNotNull();
+        assertThat(message.flows()).hasSize(1);
+        assertThat(message.flows().getFirst().fields()).containsEntry("sourceIPv4Address", "192.168.1.1");
+    }
+
+    @Test(timeout = 5000)
+    public void parseMessage_basicListZeroLengthElement_doesNotLoop() {
+        final byte[] packetBytes = hexToBytes("000a00270000000000000001000000000002000c01000001012300080100000b06000001000041");
+        final ByteBuf packet = Unpooled.wrappedBuffer(packetBytes);
+        final IpfixMessage message = new IpfixParser(definitions).parseMessage(packet);
+        assertThat(message).isNotNull();
+        assertThat(message.flows()).hasSize(1);
+        assertThat(message.flows().getFirst().fields()).isEmpty();
+    }
+
+    @Test(timeout = 5000)
+    public void parseMessage_deeplyNestedSubTemplateList_doesNotOverflowStack() {
+        // A subTemplateList template that references itself recurses once per nesting level. Without a depth bound a
+        // crafted packet exhausts the stack (StackOverflowError); the parser must bail cleanly at MAX_SUBTEMPLATE_DEPTH.
+        final ByteBuf packet = Unpooled.wrappedBuffer(nestedSubTemplateListPacket(5000));
+        final IpfixMessage message = new IpfixParser(definitions).parseMessage(packet);
+        assertThat(message).isNotNull();
+    }
+
+    private static byte[] hexToBytes(final String hex) {
+        final int len = hex.length();
+        final byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4) + Character.digit(hex.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+    private static byte[] u16(int v) {
+        return new byte[]{(byte) (v >> 8), (byte) v};
+    }
+
+    private static byte[] varLen(int n) {
+        return n < 255 ? new byte[]{(byte) n} : Bytes.concat(new byte[]{(byte) 0xff}, u16(n));
+    }
+
+    // An IPFIX message whose template 256 is a single subTemplateList (IE 292) referencing template 256, nested `depth`
+    // levels deep — the self-recursive parse path guarded by MAX_SUBTEMPLATE_DEPTH.
+    private static byte[] nestedSubTemplateListPacket(int depth) {
+        byte[] level = new byte[0];
+        for (int i = 0; i < depth; i++) {
+            final byte[] content = Bytes.concat(new byte[]{0x00}, u16(256), level); // semantic + templateId + nested list
+            level = Bytes.concat(varLen(content.length), content);
+        }
+        final byte[] dataSet = Bytes.concat(u16(256), u16(4 + level.length), level);
+        final byte[] template = Bytes.concat(u16(256), u16(1), u16(292), u16(0xffff));
+        final byte[] templateSet = Bytes.concat(u16(2), u16(4 + template.length), template);
+        final byte[] body = Bytes.concat(templateSet, dataSet);
+        final byte[] header = Bytes.concat(u16(10), u16(16 + body.length),
+                new byte[]{0, 0, 0, 1}, new byte[]{0, 0, 0, 1}, new byte[]{0, 0, 0, 1});
+        return Bytes.concat(header, body);
+    }
 
     @Test
     public void shallowParsePacket() throws IOException {


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/26910 to `7.0`.

Manually merged areas:
- IPFIX parser tests: `7.0` has not had the JUnit 4 to 6 migration (https://github.com/Graylog2/graylog2-server/pull/24012), so the new regression tests use JUnit 4's `@Test(timeout = 5000)` rather than `@Timeout(value = 5, unit = SECONDS, threadMode = SEPARATE_THREAD)`. JUnit 4 also runs a timed test on its own thread, so the non-termination guard behaves the same.

The parser and codec changes cherry-picked cleanly. No production-code differences from the master version.

I ran `IpfixParserTest` against my local 7.0 checkout and all 10 tests pass.
