### PR TITLE
Avoid duplicate searches and field type requests on welcome page

### DIFF
--- a/graylog2-web-interface/src/components/welcome/WelcomeMetricsRequests.test.tsx
+++ b/graylog2-web-interface/src/components/welcome/WelcomeMetricsRequests.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen, waitFor } from 'wrappedTestingLibrary';
+import { defaultUser } from 'defaultMockValues';
+
+import asMock from 'helpers/mocking/AsMock';
+import useCurrentUser from 'hooks/useCurrentUser';
+import useSearchConfiguration from 'hooks/useSearchConfiguration';
+import useViewsPlugin from 'views/test/testViewsPlugin';
+import fetch from 'logic/rest/FetchProvider';
+import type { SearchesConfig } from 'components/search/SearchConfig';
+
+import GeneralWelcomeMetrics from './GeneralWelcomeMetrics';
+
+jest.mock('hooks/useCurrentUser');
+jest.mock('hooks/useSearchConfiguration');
+jest.mock('logic/rest/FetchProvider', () => {
+  (window as unknown as { fetch: () => Promise<unknown> }).fetch = () =>
+    Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}), text: () => Promise.resolve('') });
+
+  return { ...jest.requireActual('logic/rest/FetchProvider'), __esModule: true, default: jest.fn() };
+});
+
+const SEARCH_ID = 'welcome-search-id';
+
+type FetchCall = [string, string, unknown?];
+
+const callsFor = (path: RegExp) => (asMock(fetch).mock.calls as Array<FetchCall>).filter(([, url]) => path.test(url));
+
+const searchesCreated = () => callsFor(/\/views\/search$/);
+const searchesExecuted = () => callsFor(/\/views\/search\/[^/]+\/execute$/);
+const fieldTypesRequested = () => callsFor(/\/views\/fields$/);
+
+describe('Welcome page metrics requests', () => {
+  useViewsPlugin();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMock(useCurrentUser).mockReturnValue(defaultUser);
+    asMock(useSearchConfiguration).mockReturnValue({ config: undefined, refresh: () => {}, isInitialLoading: false });
+    asMock(fetch).mockImplementation((_method: string, url: string, body?: unknown) => {
+      if (url.includes('/views/fields')) return Promise.resolve([]);
+
+      if (url.endsWith('/views/search')) {
+        const search = typeof body === 'string' ? JSON.parse(body) : body;
+
+        return Promise.resolve({ ...(search ?? {}), id: SEARCH_ID });
+      }
+
+      return Promise.resolve({});
+    });
+  });
+
+  const renderAndSettle = async () => {
+    const result = render(<GeneralWelcomeMetrics />);
+
+    await screen.findByText('Top 5 Sources');
+    await waitFor(() => {
+      expect(searchesExecuted().length).toBeGreaterThan(0);
+    });
+
+    return result;
+  };
+
+  it('creates and executes its search only once', async () => {
+    await renderAndSettle();
+
+    expect(searchesCreated()).toHaveLength(1);
+    expect(searchesExecuted()).toHaveLength(1);
+  });
+
+  it('does not request the same field types twice', async () => {
+    await renderAndSettle();
+
+    const requestedParameters = fieldTypesRequested().map(([, , body]) => JSON.stringify(body));
+
+    expect(requestedParameters).toHaveLength(new Set(requestedParameters).size);
+  });
+
+  it('does not recreate its search when the search configuration arrives late', async () => {
+    const { rerender } = await renderAndSettle();
+
+    asMock(useSearchConfiguration).mockReturnValue({
+      config: { query_time_range_limit: 'PT0S' } as SearchesConfig,
+      refresh: () => {},
+      isInitialLoading: false,
+    });
+
+    rerender(<GeneralWelcomeMetrics />);
+
+    await screen.findByText('Top 5 Sources');
+
+    expect(searchesCreated()).toHaveLength(1);
+    expect(searchesExecuted()).toHaveLength(1);
+  });
+});

--- a/graylog2-web-interface/src/components/welcome/hooks/useGeneralMetricsSearch.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useGeneralMetricsSearch.ts
@@ -110,7 +110,14 @@ const useGeneralMetricsSearch = (topSourcesOnly: boolean = false) => {
   const permittedAlertsEventsStreams = usePermittedAlertsEventsStreams();
   const timeRange = useMemo<RelativeTimeRangeWithEnd>(() => ({ type: 'relative', from: rangeSeconds }), [rangeSeconds]);
 
-  return useWelcomeSearch(buildEntries(permittedAlertsEventsStreams, timeRange, topSourcesOnly), timeRange);
+  // Building the entries assigns new widget ids, so the result has to be stable to avoid recreating the view
+  // (and the search on the server) on every render.
+  const entries = useMemo(
+    () => buildEntries(permittedAlertsEventsStreams, timeRange, topSourcesOnly),
+    [permittedAlertsEventsStreams, timeRange, topSourcesOnly],
+  );
+
+  return useWelcomeSearch(entries, timeRange);
 };
 
 export default useGeneralMetricsSearch;

--- a/graylog2-web-interface/src/components/welcome/hooks/usePermittedAlertsEventsStreams.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/usePermittedAlertsEventsStreams.ts
@@ -14,14 +14,23 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { useMemo } from 'react';
+
 import usePermissions from 'hooks/usePermissions';
 
 export const ALERTS_EVENTS_STREAMS = ['000000000000000000000003', '000000000000000000000002'];
 
+/**
+ * The returned array is memoized on purpose: it ends up as part of the welcome page's view definition, so a
+ * new array on every render would recreate that view (and with it a new search on the server).
+ */
 const usePermittedAlertsEventsStreams = () => {
   const { isPermitted } = usePermissions();
 
-  return ALERTS_EVENTS_STREAMS.filter((streamId) => isPermitted(`streams:read:${streamId}`));
+  return useMemo(
+    () => ALERTS_EVENTS_STREAMS.filter((streamId) => isPermitted(`streams:read:${streamId}`)),
+    [isPermitted],
+  );
 };
 
 export default usePermittedAlertsEventsStreams;

--- a/graylog2-web-interface/src/components/welcome/hooks/useWelcomeSearch.ts
+++ b/graylog2-web-interface/src/components/welcome/hooks/useWelcomeSearch.ts
@@ -14,6 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { useMemo } from 'react';
 import URI from 'urijs';
 
 import generateId from 'logic/generateId';
@@ -116,6 +117,10 @@ const buildView = (entries: Array<WelcomeSearchWidgetEntry>, timeRange: Relative
  * Security tab's search-backed widgets) that needs its own view/search built from a small widget set.
  */
 const useWelcomeSearch = (entries: Array<WelcomeSearchWidgetEntry>, timeRange: RelativeTimeRangeWithEnd) =>
-  useCreateSearch(buildView(entries, timeRange));
+  useCreateSearch(
+    // `useCreateSearch` creates a new search on the server for every new promise it receives, so the promise
+    // must only be recreated when the widgets or the time range actually change.
+    useMemo(() => buildView(entries, timeRange), [entries, timeRange]),
+  );
 
 export default useWelcomeSearch;

--- a/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/DefaultFieldTypesProvider.tsx
@@ -46,8 +46,11 @@ const DefaultFieldTypesProvider = ({ children }: { children: React.ReactElement 
   );
 
   useOnSearchExecution(() => {
-    refreshCurrentTypes();
-    refreshAllTypes();
+    // Both queries share the same key when the current query is not filtered by streams. Not cancelling an
+    // already running refetch makes the second call join the first one, instead of sending a second identical
+    // request.
+    refreshCurrentTypes({ cancelRefetch: false });
+    refreshAllTypes({ cancelRefetch: false });
   });
 
   return <FieldTypesContext.Provider value={fieldTypes}>{children}</FieldTypesContext.Provider>;

--- a/graylog2-web-interface/src/views/components/contexts/SearchPageAutoRefreshProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchPageAutoRefreshProvider.tsx
@@ -44,11 +44,14 @@ const SearchPageAutoRefreshProvider = ({ children }: React.PropsWithChildren) =>
     }
   }, [dispatch, jobIds]);
 
+  // `AutoRefreshProvider` only seeds its state from `defaultRefreshConfig` when it mounts, so it needs to be
+  // remounted once the minimum refresh interval has been loaded. That is only relevant when auto refresh is
+  // requested through the URL, otherwise `refreshConfig` stays `null` either way and remounting would throw
+  // away and rebuild the complete search page, causing a second search execution and duplicate requests.
+  const providerKey = autoRefresh && isLoadingMinimumRefresh ? 'loading' : 'ready';
+
   return (
-    <AutoRefreshProvider
-      key={isLoadingMinimumRefresh ? 'loading' : 'ready'}
-      defaultRefreshConfig={refreshConfig}
-      onRefresh={onRefresh}>
+    <AutoRefreshProvider key={providerKey} defaultRefreshConfig={refreshConfig} onRefresh={onRefresh}>
       {children}
     </AutoRefreshProvider>
   );

--- a/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/useFieldTypes.ts
@@ -68,17 +68,29 @@ const normalizeTimeRange = (timerange: TimeRange, userTz: string): TimeRange => 
   }
 };
 
+// An empty list of streams results in the same request as no streams at all, so both need to end up with the
+// same query key. Otherwise we would keep two cache entries around and issue two identical requests for them.
+const normalizeStreams = (streams: Array<string>) => (streams?.length > 0 ? streams : undefined);
+
+type RefetchOptions = { cancelRefetch?: boolean };
+
 const useFieldTypes = (
   streams: Array<string>,
   timerange: TimeRange,
   enabled: boolean = true,
-): { data: FieldTypeMapping[]; refetch: () => void; isLoading?: boolean; isFetching?: boolean } => {
+): {
+  data: FieldTypeMapping[];
+  refetch: (options?: RefetchOptions) => void;
+  isLoading?: boolean;
+  isFetching?: boolean;
+} => {
   const { userTimezone } = useUserDateTime();
   const _timerange = useMemo(() => normalizeTimeRange(timerange, userTimezone), [timerange, userTimezone]);
+  const _streams = useMemo(() => normalizeStreams(streams), [streams]);
 
   return useQuery({
-    queryKey: ['fieldTypes', streams, _timerange],
-    queryFn: () => fetchAllFieldTypes(streams, _timerange),
+    queryKey: ['fieldTypes', _streams, _timerange],
+    queryFn: () => fetchAllFieldTypes(_streams, _timerange),
     staleTime: 30000,
     refetchOnWindowFocus: false,
     gcTime: 0,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The welcome page executed each of its searches twice and requested field types repeatedly with identical parameters due to inefficient remounting/querying mechanics in various places.

- `SearchPageAutoRefreshProvider` keyed `AutoRefreshProvider` on the load state of the minimum refresh interval, remounting the complete search page once that request finished. Only remount when auto refresh is actually requested through the URL.
- The welcome page rebuilt its view (including new widget ids) on every render, so `useCreateSearch` created a new search on the server each time. Memoize the streams, the widget entries and the view promise. Although with React Compiler `useMemo` is not required in many cases, it can be used explicitly when dependencies are not stable.
- `useFieldTypes` kept separate cache entries for `undefined` and `[]` streams, although both result in the same request. Normalize them.
- `DefaultFieldTypesProvider` refetched the same query twice per search execution. Let the second refetch join the first one instead of cancelling and restarting it.

/nocl Internal refactoring/Fixing WIP feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.