### PR TITLE
Add support for Elasticsearch in data node index version checks

### DIFF
--- a/data-node/src/main/java/org/graylog/datanode/filesystem/index/IndicesDirectoryParseResult.java
+++ b/data-node/src/main/java/org/graylog/datanode/filesystem/index/IndicesDirectoryParseResult.java
@@ -40,43 +40,47 @@ public record IndicesDirectoryParseResult(IndexerDirectoryInformation info,
     /**
      * Whether the given opensearch version is able to open everything in this directory.
      * <p>
-     * An index can be opened by the opensearch release that created it and by the following one, and by no other:
+     * An index can be opened by the opensearch generation that created it and by the following one, and by no other:
      * a newer release reads it and migrates it forward, an older one cannot read it at all. That makes the answer
      * asymmetric, which is why {@code OpensearchUtils#isCompatible} is not enough here — it treats a candidate one
      * generation <em>behind</em> the data as acceptable, and picking such a candidate leaves opensearch unable to
      * open its own indices.
      * <p>
+     * The comparison runs on {@link OpensearchUtils#generation(Version) generations} rather than on major versions,
+     * so data written by elasticsearch 7.x counts as the opensearch 1.x generation it shares its index format with.
+     * <p>
      * A directory we can't extract any version from imposes no constraint. That means a corrupt or partial directory
      * is not silently narrowed down here; the preflight check reports it with a message naming the actual indices.
      */
     public boolean canBeOpenedBy(String opensearchVersion) {
-        final Long parsed = majorVersionOrNull(opensearchVersion);
+        final Long parsed = generationOrNull(opensearchVersion);
         if (parsed == null) {
             return true;
         }
-        final long candidateMajor = parsed;
-        return dataMajorVersions()
-                .allMatch(dataMajor -> candidateMajor == dataMajor || candidateMajor == dataMajor + 1);
+        final long candidateGeneration = parsed;
+        return dataGenerations()
+                .allMatch(dataGeneration -> candidateGeneration == dataGeneration
+                        || candidateGeneration == dataGeneration + 1);
     }
 
     /**
-     * The distinct opensearch major versions that wrote this directory, taken from the node and index state files.
+     * The distinct index generations that wrote this directory, taken from the node and index state files.
      */
-    private Stream<Long> dataMajorVersions() {
+    private Stream<Long> dataGenerations() {
         return info.nodes().stream()
                 .flatMap(node -> Stream.concat(
                         Stream.ofNullable(node.nodeVersion()),
                         node.indices().stream().map(IndexInformation::indexVersionCreated)))
                 .filter(Objects::nonNull)
-                .map(IndicesDirectoryParseResult::majorVersionOrNull)
+                .map(IndicesDirectoryParseResult::generationOrNull)
                 .filter(Objects::nonNull)
                 .distinct();
     }
 
     @Nullable
-    private static Long majorVersionOrNull(String version) {
+    private static Long generationOrNull(String version) {
         try {
-            return Version.parse(version).majorVersion();
+            return OpensearchUtils.generation(Version.parse(version));
         } catch (Exception e) {
             LOG.warn("Failed to parse opensearch version {}, ignoring it when deciding which distribution can open "
                     + "the data directory", version, e);

--- a/data-node/src/main/java/org/graylog/datanode/filesystem/index/OpensearchUtils.java
+++ b/data-node/src/main/java/org/graylog/datanode/filesystem/index/OpensearchUtils.java
@@ -20,6 +20,16 @@ import com.github.zafarkhaja.semver.Version;
 
 public class OpensearchUtils {
 
+    /**
+     * The last elasticsearch major version, which wrote the same Lucene 8 index format as opensearch 1.x.
+     */
+    private static final long LEGACY_ES_MAJOR_SHARING_OPENSEARCH1_FORMAT = 7;
+
+    /**
+     * The opensearch major version that shares its index format with elasticsearch 7.x.
+     */
+    private static final long OPENSEARCH_MAJOR_SHARING_ES7_FORMAT = 1;
+
     // OpenSearch 2.x/3.x version IDs are stored as raw integer ^ MASK; legacy ES IDs are stored as-is.
     // Encoding: major * 1_000_000 + minor * 10_000 + patch * 100 + build
     public static String versionStringFromId(int id) {
@@ -28,11 +38,28 @@ public class OpensearchUtils {
     }
 
     /**
-     * Two OpenSearch versions are compatible if their major versions differ by at most one,
-     * mirroring OpenSearch's own Version.isCompatible() contract for versions >= 3.
+     * The index generation a version belongs to.
+     * <p>
+     * Version numbers alone don't tell generations apart: an index written by elasticsearch 7.x has the same format
+     * as one written by opensearch 1.x, because opensearch 1.0 forked from elasticsearch 7.10 and every 7.x release
+     * wrote the Lucene 8 format that opensearch 1.x kept writing. Comparing the raw majors puts the two six
+     * generations apart, which is why comparisons of node and index versions have to run on the generation instead.
+     * <p>
+     * Elasticsearch 6.x and older wrote Lucene 7, which has no opensearch counterpart. Those keep their own major
+     * version, stay incompatible with everything shipped here, and are already rejected by the index readers.
+     */
+    public static long generation(Version version) {
+        return version.majorVersion() == LEGACY_ES_MAJOR_SHARING_OPENSEARCH1_FORMAT
+                ? OPENSEARCH_MAJOR_SHARING_ES7_FORMAT
+                : version.majorVersion();
+    }
+
+    /**
+     * Two versions are compatible if their generations differ by at most one, mirroring OpenSearch's own
+     * Version.isCompatible() contract for versions >= 3.
      */
     public static boolean isCompatible(Version current, Version node) {
-        final long diff = current.majorVersion() - node.majorVersion();
+        final long diff = generation(current) - generation(node);
         return diff >= -1 && diff <= 1;
     }
 

--- a/data-node/src/test/java/org/graylog/datanode/bootstrap/preflight/OpensearchDataDirCompatibilityCheckTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/bootstrap/preflight/OpensearchDataDirCompatibilityCheckTest.java
@@ -136,6 +136,29 @@ class OpensearchDataDirCompatibilityCheckTest {
     }
 
     /**
+     * Elasticsearch 7.x wrote the Lucene 8 index format that opensearch 1.x kept writing, so it has to count as that
+     * generation instead of as a major version six generations away.
+     */
+    @Test
+    void testIsCompatibleTreatsElasticsearch7AsTheOpensearch1Generation() {
+        // same generation as opensearch 1.x
+        Assertions.assertThat(isCompatible("1.3.0", "7.10.2")).isTrue();
+        Assertions.assertThat(isCompatible("7.17.0", "1.0.0")).isTrue();
+        Assertions.assertThat(isCompatible("7.0.0", "7.17.9")).isTrue();
+
+        // one generation apart, which is what an in-place migration to a 2.x datanode runs into
+        Assertions.assertThat(isCompatible("2.19.0", "7.10.2")).isTrue();
+        Assertions.assertThat(isCompatible("7.10.2", "2.19.0")).isTrue();
+
+        // two generations apart: opensearch 3.x cannot read Lucene 8
+        Assertions.assertThat(isCompatible("3.5.0", "7.10.2")).isFalse();
+
+        // elasticsearch 6.x wrote Lucene 7 and has no opensearch counterpart
+        Assertions.assertThat(isCompatible("2.19.0", "6.8.23")).isFalse();
+        Assertions.assertThat(isCompatible("1.3.0", "6.8.23")).isFalse();
+    }
+
+    /**
      * There is one error per incompatible index, so a real cluster can produce thousands. The abort message has to
      * stay a readable size while the log keeps the complete list.
      */

--- a/data-node/src/test/java/org/graylog/datanode/configuration/OpensearchVersionSelectorImplTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/configuration/OpensearchVersionSelectorImplTest.java
@@ -113,6 +113,22 @@ class OpensearchVersionSelectorImplTest {
     }
 
     /**
+     * In-place migration from an elasticsearch 7.x cluster. Its Lucene 8 data belongs to the opensearch 1.x
+     * generation, so the compatibility distribution can adopt it and the current one cannot.
+     */
+    @Test
+    void testElasticsearch7DataIsAdoptedByTheCompatDistribution() throws URISyntaxException {
+        Assertions.assertThat(select(fixture("elasticsearch7"), null, false).version()).isEqualTo(COMPAT);
+    }
+
+    @Test
+    void testRecordedCurrentVersionCannotOpenElasticsearch7Data() throws URISyntaxException {
+        Assertions.assertThatThrownBy(() -> select(fixture("elasticsearch7"), CURRENT, false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot open the data directory");
+    }
+
+    /**
      * In-place migration from a current-generation cluster: the data was written by 3.x and has no recorded version.
      * The compatibility distribution cannot read it, so "stay on the oldest" must not apply here.
      */

--- a/data-node/src/test/java/org/graylog/datanode/filesystem/index/OpensearchDataDirCompatibilityServiceTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/filesystem/index/OpensearchDataDirCompatibilityServiceTest.java
@@ -77,6 +77,34 @@ class OpensearchDataDirCompatibilityServiceTest {
     }
 
     /**
+     * Elasticsearch 7.x wrote the same Lucene 8 segments as opensearch 1.x, so its data is one generation behind the
+     * compatibility distribution and perfectly usable — even though 7 and 2 are five major versions apart. This is
+     * the in-place migration from an elasticsearch cluster.
+     */
+    @Test
+    void testElasticsearch7DataIsCompatibleWithTheCompatDistribution() throws URISyntaxException {
+        final OpensearchDataDirCompatibility compatibility = serviceFor(fixture("elasticsearch7"), "2.19.0").check();
+
+        Assertions.assertThat(compatibility.requiredDistribution()).isEqualTo(RequiredOpensearchDistribution.COMPAT);
+        Assertions.assertThat(compatibility.errors()).isEmpty();
+        Assertions.assertThat(compatibility.isCompatible()).isTrue();
+    }
+
+    /**
+     * Two generations ahead of the data: opensearch 3.x dropped the Lucene 8 format, so elasticsearch 7 data is an
+     * error there.
+     */
+    @Test
+    void testElasticsearch7DataIsNotCompatibleWithTheCurrentDistribution() throws URISyntaxException {
+        final OpensearchDataDirCompatibility compatibility = serviceFor(fixture("elasticsearch7"), "3.5.0").check();
+
+        Assertions.assertThat(compatibility.isCompatible()).isFalse();
+        Assertions.assertThat(compatibility.errors())
+                .anySatisfy(error -> Assertions.assertThat(error)
+                        .isEqualTo("Current version 3.5.0 of Opensearch is not compatible with index version 7.10.0"));
+    }
+
+    /**
      * Elasticsearch 6 wrote Lucene 7 segments, out of reach for both distributions, so this is the case that does produce
      * an error.
      */


### PR DESCRIPTION
## Description
To calculate index version compatibility, we previously only compared major versions. This breaks for elasticsearch 7.x indices which should still be supported, but have a major version of 7.

This fixes this behavior, equating Elasticsearch 7.x indices to 1.x indices

/nocl fixes bug introduced during development phase

## Motivation and Context
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/15308

## How Has This Been Tested?
added tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

