### PR TITLE
Change sigma specific logic for disabling condition select

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { defaultUser as mockDefaultUser } from 'defaultMockValues';
+
+import { asMock } from 'helpers/mocking';
+import useLocation from 'routing/useLocation';
+import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
+import usePluginEntities from 'hooks/usePluginEntities';
+import { simpleEventDefinition as mockEventDefinition } from 'fixtures/eventDefinition';
+
+import EventConditionForm from './EventConditionForm';
+
+jest.mock('routing/useLocation');
+jest.mock('logic/telemetry/useSendTelemetry');
+jest.mock('hooks/usePluginEntities');
+
+const StubFormComponent = () => <div>Stub Condition Form</div>;
+
+// Two distinct non-creatable types, so the assertions prove the guard keys off
+// `hideFromCreation` rather than off any particular type name. Plugin entities are mocked, so
+// these names are fixtures and need not match any registered condition type.
+const hiddenType1 = {
+  type: 'hidden-type-v1',
+  displayName: 'Hidden Type 1',
+  useCondition: () => true,
+  hideFromCreation: true,
+  formComponent: StubFormComponent,
+};
+
+const hiddenType2 = {
+  type: 'hidden-type-v2',
+  displayName: 'Hidden Type 2',
+  useCondition: () => true,
+  hideFromCreation: true,
+  formComponent: StubFormComponent,
+};
+
+const aggregationType = {
+  type: 'aggregation-v1',
+  displayName: 'Filter & Aggregation',
+  useCondition: () => true,
+  formComponent: StubFormComponent,
+};
+
+const mockValidation = { errors: {} };
+
+const renderConditionForm = (
+  props: Partial<React.ComponentProps<typeof EventConditionForm>> = {},
+  eventDefinitionTypes: Array<any> = [aggregationType],
+) => {
+  asMock(usePluginEntities).mockImplementation((entityKey) =>
+    entityKey === 'eventDefinitionTypes' ? eventDefinitionTypes : [],
+  );
+
+  return render(
+    <EventConditionForm
+      action="create"
+      eventDefinition={mockEventDefinition}
+      validation={mockValidation}
+      currentUser={mockDefaultUser}
+      onChange={jest.fn()}
+      canEdit
+      {...props}
+    />,
+  );
+};
+
+describe('EventConditionForm', () => {
+  beforeEach(() => {
+    asMock(useLocation).mockImplementation(() => ({
+      pathname: '/event-definitions',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'mock-key',
+    }));
+    asMock(useSendTelemetry).mockImplementation(() => jest.fn());
+  });
+
+  it('disables the select when editing a hideFromCreation type', async () => {
+    renderConditionForm(
+      {
+        action: 'edit',
+        eventDefinition: {
+          ...mockEventDefinition,
+          config: { ...mockEventDefinition.config, type: 'hidden-type-v2' },
+        },
+      },
+      [hiddenType2, aggregationType],
+    );
+
+    expect(await screen.findByLabelText('Condition Type')).toBeDisabled();
+  });
+
+  it('disables the select for a second, differently named hideFromCreation type', async () => {
+    renderConditionForm(
+      {
+        action: 'edit',
+        eventDefinition: {
+          ...mockEventDefinition,
+          config: { ...mockEventDefinition.config, type: 'hidden-type-v1' },
+        },
+      },
+      [hiddenType1, aggregationType],
+    );
+
+    expect(await screen.findByLabelText('Condition Type')).toBeDisabled();
+  });
+
+  it('leaves the select enabled when editing a normal creatable type', async () => {
+    renderConditionForm(
+      {
+        action: 'edit',
+        eventDefinition: {
+          ...mockEventDefinition,
+          config: { ...mockEventDefinition.config, type: 'aggregation-v1' },
+        },
+      },
+      [aggregationType],
+    );
+
+    expect(await screen.findByLabelText('Condition Type')).toBeEnabled();
+  });
+});

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.tsx
@@ -146,9 +146,10 @@ const EventConditionForm = ({
     () => eventDefinition._scope === 'ILLUMINATE' && action === 'edit',
     [action, eventDefinition._scope],
   );
-  const isSigma = useMemo(
-    () => eventDefinition.config.type === 'sigma-v1' && action === 'edit',
-    [action, eventDefinition.config.type],
+  // Types hidden from the creation wizard cannot have their condition type changed when being edited.
+  const isNonCreatableType = useMemo(
+    () => action === 'edit' && !!currentConditionPlugin?.hideFromCreation,
+    [action, currentConditionPlugin],
   );
 
   const isSystemEventDefinition = eventDefinition.config.type === SYSTEM_EVENT_DEFINITION_TYPE;
@@ -188,7 +189,7 @@ const EventConditionForm = ({
                 value={eventDefinition.config.type}
                 onChange={handleEventDefinitionTypeChange}
                 clearable={false}
-                disabled={disabledSelect || onlyFilters || isSigma}
+                disabled={disabledSelect || onlyFilters || isNonCreatableType}
                 required
               />
               <HelpBlock>{validation?.errors?.config?.[0] ?? 'Choose the type of Condition for this Event.'}</HelpBlock>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes specific `isSigma` logic to using `conditionPlugin.hideFromCreation`
/nocl refactoring

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
adding another type that needs to have the condition select disabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

