### PR TITLE
Reflect excluded streams in the Streams page archiving indicator (`7.1`)

### DIFF
--- a/changelog/unreleased/pr-26974.toml
+++ b/changelog/unreleased/pr-26974.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed the Streams page showing \"Archiving is enabled\" for streams that are excluded from archiving under Archive > Configuration > Streams to archive."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14996"]
+pulls = ["26974"]

--- a/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
+++ b/graylog2-web-interface/src/@types/graylog-web-plugin/index.d.ts
@@ -337,6 +337,12 @@ declare module 'graylog-web-plugin/plugin' {
     DataLakeStreamDeleteWarning: React.ComponentType;
   }
 
+  interface PluginArchive {
+    hooks: {
+      useExcludedStreams: () => Array<string>;
+    };
+  }
+
   type HelpMenuItem = {
     description: string;
     permissions?: Permission | Array<Permission>;
@@ -393,6 +399,7 @@ declare module 'graylog-web-plugin/plugin' {
      */
     pageNavigation?: Array<PageNavigation>;
     dataLake?: Array<PluginDataLake>;
+    archive?: Array<PluginArchive>;
     // Use this for stream-overview-only columns. Use `components.shared.entityTableElements`
     // when the extension should participate in the generic entity-table mechanism.
     'components.streams.overview.tableElements'?: Array<StreamsOverviewTableElement>;

--- a/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/DestinationIndexSetSection.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamDetails/routing-destination/DestinationIndexSetSection.tsx
@@ -26,6 +26,7 @@ import useIndexSetsList from 'components/indices/hooks/useIndexSetsList';
 import type { Stream } from 'stores/streams/StreamsStore';
 import NumberUtils from 'util/NumberUtils';
 import useStreamOutputFilters from 'components/streams/hooks/useStreamOutputFilters';
+import useExcludedArchiveStreams from 'components/streams/hooks/useExcludedArchiveStreams';
 import IndexSetArchivingCell from 'components/streams/StreamDetails/routing-destination/IndexSetArchivingCell';
 import IndexSetUpdateForm from 'components/streams/StreamDetails/routing-destination/IndexSetUpdateForm';
 import IndexSetFilters from 'components/streams/StreamDetails/routing-destination/IndexSetFilters';
@@ -53,9 +54,12 @@ const DestinationIndexSetSection = ({ stream }: Props) => {
   const productName = useProductName();
   const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
   const { data: indexSet, isInitialLoading: isLoadingIndexSet } = useSingleIndexSet(stream.index_set_id);
-  const archivingEnabled =
+  const excludedStreams = useExcludedArchiveStreams();
+  const indexSetArchivingEnabled =
     indexSet?.retention_strategy_class === ARCHIVE_RETENTION_STRATEGY ||
     indexSet?.data_tiering?.archive_before_deletion;
+  // A stream is only archived when its index set archives AND the stream is not excluded from archiving.
+  const archivingEnabled = Boolean(indexSetArchivingEnabled) && !excludedStreams.includes(stream.id);
   const {
     data: { indexSets },
   } = useIndexSetsList(false);

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.test.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import { asMock } from 'helpers/mocking';
+import useExcludedArchiveStreams from 'components/streams/hooks/useExcludedArchiveStreams';
+
+import ArchivingsCell from './ArchivingsCell';
+
+jest.mock('components/streams/hooks/useExcludedArchiveStreams');
+
+const stream = { id: 'stream-1', title: 'Test Stream', is_default: false, is_editable: true, index_set_id: 'is-1' } as any;
+const archivingIndexSet = { id: 'is-1', data_tiering: { archive_before_deletion: true } } as any;
+const nonArchivingIndexSet = { id: 'is-1', data_tiering: { archive_before_deletion: false } } as any;
+
+describe('ArchivingsCell (Streams)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMock(useExcludedArchiveStreams).mockReturnValue([]);
+  });
+
+  it('shows archiving enabled for the default stream when its index set archives', () => {
+    render(<ArchivingsCell stream={{ ...stream, is_default: true }} indexSets={[archivingIndexSet]} />);
+
+    expect(screen.getByTitle('Yes')).toBeInTheDocument();
+  });
+
+  it('shows archiving enabled for a non-editable stream when its index set archives', () => {
+    render(<ArchivingsCell stream={{ ...stream, is_editable: false }} indexSets={[archivingIndexSet]} />);
+
+    expect(screen.getByTitle('Yes')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the index set does not archive', () => {
+    render(<ArchivingsCell stream={stream} indexSets={[nonArchivingIndexSet]} />);
+
+    expect(screen.queryByTitle('Yes')).not.toBeInTheDocument();
+  });
+
+  it('shows archiving enabled when the index set archives and the stream is not excluded', () => {
+    render(<ArchivingsCell stream={stream} indexSets={[archivingIndexSet]} />);
+
+    expect(screen.getByTitle('Yes')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the index set archives but the stream is excluded', () => {
+    asMock(useExcludedArchiveStreams).mockReturnValue(['stream-1']);
+
+    render(<ArchivingsCell stream={stream} indexSets={[archivingIndexSet]} />);
+
+    expect(screen.queryByTitle('Yes')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for the default stream when it is excluded from archiving', () => {
+    asMock(useExcludedArchiveStreams).mockReturnValue(['stream-1']);
+
+    render(<ArchivingsCell stream={{ ...stream, is_default: true }} indexSets={[archivingIndexSet]} />);
+
+    expect(screen.queryByTitle('Yes')).not.toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.tsx
+++ b/graylog2-web-interface/src/components/streams/StreamsOverview/cells/ArchivingsCell.tsx
@@ -21,6 +21,7 @@ import type { Stream } from 'stores/streams/StreamsStore';
 import { StatusIcon, Tooltip } from 'components/common';
 import type { IndexSet } from 'stores/indices/IndexSetsStore';
 import { ARCHIVE_RETENTION_STRATEGY } from 'stores/indices/IndicesStore';
+import useExcludedArchiveStreams from 'components/streams/hooks/useExcludedArchiveStreams';
 
 type Props = {
   stream: Stream;
@@ -28,16 +29,16 @@ type Props = {
 };
 
 const ArchivingsCell = ({ stream, indexSets }: Props) => {
-  if (stream.is_default || !stream.is_editable) {
-    return null;
-  }
+  const excludedStreams = useExcludedArchiveStreams();
 
+  // No is_default/is_editable guard: archiving status applies to every stream, unlike the sibling action cells.
   const indexSet = indexSets.find((is) => is.id === stream.index_set_id);
 
-  const archivingEnabled = Boolean(
+  const indexSetArchivingEnabled = Boolean(
     (indexSet?.use_legacy_rotation && indexSet?.retention_strategy_class === ARCHIVE_RETENTION_STRATEGY) ||
     indexSet?.data_tiering?.archive_before_deletion,
   );
+  const archivingEnabled = indexSetArchivingEnabled && !excludedStreams.includes(stream.id);
 
   if (!archivingEnabled) {
     return null;

--- a/graylog2-web-interface/src/components/streams/hooks/useExcludedArchiveStreams.test.ts
+++ b/graylog2-web-interface/src/components/streams/hooks/useExcludedArchiveStreams.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import { asMock } from 'helpers/mocking';
+
+import useExcludedArchiveStreams from './useExcludedArchiveStreams';
+
+jest.mock('graylog-web-plugin/plugin', () => ({
+  PluginStore: { exports: jest.fn(() => []) },
+}));
+
+describe('useExcludedArchiveStreams', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when the archive plugin is not installed', () => {
+    asMock(PluginStore.exports).mockReturnValue([]);
+
+    const { result } = renderHook(() => useExcludedArchiveStreams());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns the excluded streams provided by the archive plugin', () => {
+    asMock(PluginStore.exports).mockReturnValue([{ hooks: { useExcludedStreams: () => ['stream-1', 'stream-2'] } }]);
+
+    const { result } = renderHook(() => useExcludedArchiveStreams());
+
+    expect(result.current).toEqual(['stream-1', 'stream-2']);
+  });
+});

--- a/graylog2-web-interface/src/components/streams/hooks/useExcludedArchiveStreams.ts
+++ b/graylog2-web-interface/src/components/streams/hooks/useExcludedArchiveStreams.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import usePluginEntities from 'hooks/usePluginEntities';
+
+const EMPTY_STREAMS: Array<string> = [];
+const fallbackUseExcludedArchiveStreams = (): Array<string> => EMPTY_STREAMS;
+
+const useExcludedArchiveStreams = (): Array<string> => {
+  const useExcludedStreams = usePluginEntities('archive')?.[0]?.hooks?.useExcludedStreams ?? fallbackUseExcludedArchiveStreams;
+
+  return useExcludedStreams();
+};
+
+export default useExcludedArchiveStreams;


### PR DESCRIPTION
Note: This is a backport of #26974 to `7.1`.


## What

Make the "Archiving is enabled" indicator on the Streams overview and stream details pages reflect the archive plugin's excluded-streams list, not just the index set's retention strategy.

## Why

The indicator was computed purely from the stream's index set (archive retention strategy, or data-tiering `archive_before_deletion`). It never consulted the archive plugin's `excluded_streams` list, so a stream excluded under **Archive > Configuration > Streams to archive** still showed as "Archiving is enabled". Reported in Graylog2/graylog-plugin-enterprise#14996.

## How

- Add `useExcludedArchiveStreams`, which reads the excluded list through a new `archive` plugin-store export. In open source (no archive plugin) it returns an empty list via a stable no-op fallback, so the hook is always called and rules-of-hooks is satisfied. Archiving is never enabled without the enterprise plugin anyway.
- Treat a stream as archived only when its index set archives **and** the stream is not in `excluded_streams`, in both `ArchivingsCell` (overview) and `DestinationIndexSetSection` (details). The details change also correctly gates the Data Lake warning, which keys off the same flag.
- Add the `PluginArchive` type to `@types/graylog-web-plugin`.

## Details

The enterprise side that provides the export is Graylog2/graylog-plugin-enterprise#15196. This PR degrades gracefully without it (indicator keeps its previous, index-set-only behavior), so there is no hard merge-order dependency.

## How tested

`yarn test` for `ArchivingsCell.test.tsx` (5 cases, incl. the excluded-stream regression) and `useExcludedArchiveStreams.test.ts` (2 cases) — all green.

Manual:

1. Enterprise installed, an index set using the Archive retention strategy (or data tiering with archive-before-delete), and a stream on that index set.
2. Streams page: the stream shows "Archiving is enabled".
3. **Archive > Configuration > Streams to archive**: uncheck that stream (adds it to `excluded_streams`).
4. Streams page: the indicator now clears; the stream details Index Set section shows "Archiving is disabled".
5. Re-check it: the indicator returns.
6. Default stream: when the default index set archives, the default stream now shows the indicator too (previously always hidden); excluding it clears it.

## Related

- Graylog2/graylog-plugin-enterprise#14996
- Graylog2/graylog-plugin-enterprise#15196 (enterprise counterpart)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.



/prd Graylog2/graylog-plugin-enterprise#15319
