### PR TITLE
Fix issue when reset layout in case of default layout already in use

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/ColumnsVisibilitySelect.tsx
@@ -77,9 +77,10 @@ const ColumnListItem = <Entity extends EntityBase>({ column }: { column: Column<
 type Props<Entity> = {
   onResetLayoutPreferences: () => void;
   table: Table<Entity>;
+  hasColumnLayoutPreferences: boolean;
 };
 
-const ColumnsVisibilitySelect = <Entity extends EntityBase>({ table, onResetLayoutPreferences }: Props<Entity>) => (
+const ColumnsVisibilitySelect = <Entity extends EntityBase>({ table, onResetLayoutPreferences, hasColumnLayoutPreferences }: Props<Entity>) => (
   <StyledDropdownButton
     title="Columns"
     withinPortal
@@ -97,7 +98,7 @@ const ColumnsVisibilitySelect = <Entity extends EntityBase>({ table, onResetLayo
         <ColumnListItem<Entity> column={column} key={column.id} />
       ))}
     <MenuItem divider />
-    <DeleteMenuItem onSelect={onResetLayoutPreferences} closeMenuOnClick>
+    <DeleteMenuItem disabled={!hasColumnLayoutPreferences} onSelect={onResetLayoutPreferences} closeMenuOnClick>
       <Icon name="reopen_window" /> Reset all columns
     </DeleteMenuItem>
   </StyledDropdownButton>

--- a/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
+++ b/graylog2-web-interface/src/components/common/EntityDataTable/EntityDataTable.tsx
@@ -301,6 +301,9 @@ const EntityDataTable = <Entity extends EntityBase, Meta = unknown>({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const headerGroups = useMemo(() => table.getHeaderGroups(), [columnOrder]);
 
+  const hasColumnLayoutPreferences =
+    Object.keys(layoutPreferences?.attributes ?? {}).length > 0 || (layoutPreferences?.order?.length ?? 0) > 0;
+
   const resetLayoutPreferences = useCallback(() => {
     onResetLayoutPreferences().then(() => {
       setInternalAttributeColumnOrder(defaultColumnOrder);
@@ -335,6 +338,7 @@ const EntityDataTable = <Entity extends EntityBase, Meta = unknown>({
                       <ColumnsVisibilitySelect<Entity>
                         table={table}
                         onResetLayoutPreferences={resetLayoutPreferences}
+                        hasColumnLayoutPreferences={hasColumnLayoutPreferences}
                       />
                     )}
                   </ButtonGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PR disables reset button in case if default layout preferences are in use 

## Motivation and Context

When a user clicks more than 2 times in a row on the reset button, the BE request fails and. error message appears. The reason is that BE deletes preferences when the user click first time and can't find this table oreferences in DB for the second time. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/nocl