### PR TITLE
Fix MCP ping returning -32603 instead of an empty result

### DIFF
--- a/changelog/unreleased/issue-27066.toml
+++ b/changelog/unreleased/issue-27066.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix MCP `ping` request returning an internal error (-32603) instead of an empty result."
+
+issues = ["27066"]
+pulls = [""]

--- a/changelog/unreleased/issue-27066.toml
+++ b/changelog/unreleased/issue-27066.toml
@@ -2,4 +2,4 @@ type = "f"
 message = "Fix MCP `ping` request returning an internal error (-32603) instead of an empty result."
 
 issues = ["27066"]
-pulls = [""]
+pulls = ["27123"]

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/McpRestResource.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/McpRestResource.java
@@ -153,7 +153,9 @@ public class McpRestResource extends RestResource {
             if (result.isPresent() && LOG.isTraceEnabled()) {
                 LOG.trace("Successfully handled JSON-RPC request: {}", result.get());
             }
-            return Response.ok(new McpSchema.JSONRPCResponse("2.0", id, result.orElse(null), null))
+            // Empty result (e.g. ping): substitute an empty map; both the MCP spec and JSONRPCResponse require a result
+            final Object responseResult = result.isPresent() ? result.get() : Map.of();
+            return Response.ok(new McpSchema.JSONRPCResponse("2.0", id, responseResult, null))
                     .header(HEADER_MCP_SESSION_ID, sessionId)
                     .build();
         } catch (McpError e) {

--- a/graylog2-server/src/test/java/org/graylog/mcp/server/McpRestResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/server/McpRestResourceTest.java
@@ -16,12 +16,26 @@
  */
 package org.graylog.mcp.server;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 import org.graylog.mcp.config.McpConfiguration;
 import org.graylog.security.certutil.InMemoryClusterConfigService;
+import org.graylog2.plugin.database.users.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class McpRestResourceTest {
 
@@ -48,6 +62,44 @@ public class McpRestResourceTest {
     public void getDisabledWithClusterConfig() {
         final Response response = resource.get();
         Assertions.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void pingReturnsEmptyResultInsteadOf500() throws Exception {
+        // Regression test for https://github.com/Graylog2/graylog2-server/issues/27066
+        // The ping utility yields an empty Optional, which must still serialize as a valid JSON-RPC "result": {}
+        final InMemoryClusterConfigService clusterConfigService = new InMemoryClusterConfigService();
+        clusterConfigService.write(McpConfiguration.create(true, false, false));
+
+        final McpService mcpService = mock(McpService.class);
+        final McpSchema.JSONRPCRequest pingRequest =
+                new McpSchema.JSONRPCRequest("2.0", McpSchema.METHOD_PING, 2, null);
+        when(mcpService.parseMessage(any())).thenReturn(pingRequest);
+        when(mcpService.handle(any(), any(), any(), any(), any())).thenReturn(Optional.empty());
+
+        final McpRestResource pingResource = new McpRestResource(clusterConfigService, mcpService, mock(SecurityContext.class)) {
+            @Override
+            protected User getCurrentUser() {
+                return mock(User.class);
+            }
+        };
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final Response response = pingResource.post(
+                MediaType.APPLICATION_JSON,
+                ProtocolVersions.MCP_2025_06_18,
+                null,
+                null,
+                objectMapper.createObjectNode()
+                        .put("jsonrpc", "2.0")
+                        .put("id", 2)
+                        .put("method", McpSchema.METHOD_PING));
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.getEntity()).isInstanceOf(McpSchema.JSONRPCResponse.class);
+        final McpSchema.JSONRPCResponse jsonRpcResponse = (McpSchema.JSONRPCResponse) response.getEntity();
+        assertThat(jsonRpcResponse.error()).isNull();
+        assertThat(jsonRpcResponse.result()).isEqualTo(Map.of());
     }
 
 }


### PR DESCRIPTION
## Description

`McpService.handle()` returns `Optional.empty()` for the `ping` utility. In `McpRestResource.post()`, `result.orElse(null)` then passed `null` as both the result and the error to the `McpSchema.JSONRPCResponse` constructor, whose SDK validation requires exactly one of the two to be non-null. The resulting `IllegalArgumentException` was caught by the generic handler and returned as `HTTP 500` / JSON-RPC `-32603 "MCP responses MUST either have a result or error"`.

This substitutes an empty map when `handle()` yields no result body, so `ping` returns the spec-required `"result": {}`. An empty map is used because the SDK has no empty `McpSchema.Result` type, `Map.of()` serialises reliably to `{}` under Graylog's JAX-RS `ObjectMapper`, and it matches what the MCP Java SDK's own server returns for `ping`.

## Motivation and Context

Clients that use `ping` for liveness checks saw every probe fail. `-32603` is an internal error, which clients treat as a genuine connection failure and reconnect, so Graylog's MCP tools became intermittently unavailable.

Fixes #27066

## How Has This Been Tested?

- Added `McpRestResourceTest#pingReturnsEmptyResultInsteadOf500`, which drives `post()` for a `ping` and asserts `HTTP 200` with `result == {}` and no error.
- Verified live against a local server: `ping` returned `HTTP 500` / `-32603` before the fix and `HTTP 200` / `{"jsonrpc":"2.0","id":2,"result":{}}` after.

## Screenshots (if appropriate):

N/A — backend-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)