### PR TITLE
Fix extractor converter crash: checkbox Input never captured DOM node

### DIFF
--- a/changelog/unreleased/issue-27037.toml
+++ b/changelog/unreleased/issue-27037.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix crash when configuring an extractor converter (CSV, Split & Count, Lookup Table, Date). The checkbox `Input` did not capture its DOM node, so reading its checked state during render threw."
+
+issues = ["27037"]

--- a/changelog/unreleased/issue-27037.toml
+++ b/changelog/unreleased/issue-27037.toml
@@ -2,3 +2,4 @@ type = "f"
 message = "Fix crash when configuring an extractor converter (CSV, Split & Count, Lookup Table, Date). The checkbox `Input` did not capture its DOM node, so reading its checked state during render threw."
 
 issues = ["27037"]
+pulls = ["27135"]

--- a/graylog2-web-interface/src/components/bootstrap/Input.test.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
 
 import { Button } from 'components/bootstrap';
 
@@ -74,5 +75,18 @@ describe('Input', () => {
 
     await screen.findByText('The error message');
     await screen.findByText('The help text');
+  });
+
+  it('exposes the checkbox DOM state through `getChecked()`', async () => {
+    const inputRef = React.createRef<Input>();
+    render(<Input ref={inputRef} id="checkboxInput" type="checkbox" label="Toggle" defaultChecked />);
+
+    const checkbox = await screen.findByRole('checkbox');
+
+    expect(inputRef.current.getChecked()).toBe(true);
+
+    await userEvent.click(checkbox);
+
+    expect(inputRef.current.getChecked()).toBe(false);
   });
 });

--- a/graylog2-web-interface/src/components/bootstrap/Input.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.tsx
@@ -183,13 +183,21 @@ class Input extends React.Component<
         <InputWrapper className={wrapperClassName} wrapperAttributes={wrapperAttributes}>
           {buttonAfter ? (
             <InputGroup>
-              <Checkbox ref={this.input} {...controlProps}>
+              <Checkbox
+                ref={(ref) => {
+                  this.input = ref;
+                }}
+                {...controlProps}>
                 {label}
               </Checkbox>
               {buttonAfter && <InputGroup.Button>{buttonAfter}</InputGroup.Button>}
             </InputGroup>
           ) : (
-            <Checkbox ref={this.input} {...controlProps}>
+            <Checkbox
+              ref={(ref) => {
+                this.input = ref;
+              }}
+              {...controlProps}>
               {label}
             </Checkbox>
           )}


### PR DESCRIPTION
Fixes #27037

## What
Selecting or editing an extractor converter that has an enable checkbox — CSV to Fields, Split & Count, Lookup Table, Date — crashed the extractor UI with `TypeError: can't access property "checked", this.getInputDOMNode() is undefined`.

## Why
`Input`'s checkbox branch rendered `<Checkbox ref={this.input} …>`, passing the still-`undefined` instance field as the ref instead of a callback that assigns it. So `this.input` was never populated for checkbox-type `Input`s, and reading its checked state during render threw.

The converter configs read the enable-checkbox state during render via `this.converterEnabled.getChecked()` → `getInputDOMNode().checked`, so opening or creating any of them crashed. Regressed by #24097, which replaced the working callback ref with `ref={this.input}`.

## How
Use a callback ref (`ref={(ref) => { this.input = ref; }}`) for both `Checkbox` usages in `_renderCheckboxGroup`, matching the form-control and radio branches. The custom `Checkbox` (`React.forwardRef`) forwards the ref to the underlying `<input>`, so `this.input` becomes the DOM node and `getChecked()`/`getValue()` work again.

The single `Input.tsx` fix resolves all four affected converters, not just CSV.

## Details
`indeterminate` is not affected: it reaches `Checkbox` only through direct `Checkbox` usage (`CheckBoxGroup`, `ExpandableCheckboxListItem`), never through the `Input` adapter, so the callback ref introduces no regression there.

## How tested
- Live validated on a PR sandcastle (build `93441f2`, matches PR head). Opened the New extractor form and added each of the four affected converters (CSV to Fields, Split & Count, Lookup Table, Date). All four config panels render with the enable checkbox and their sub-fields, and no render-time `getInputDOMNode`/`checked` error is thrown. Each of these threw during render before the fix.
- `Input.test.tsx` 9/9 green; ESLint clean.

## How to test
1. System → Inputs → Manage Extractors for an input.
2. Create a new extractor, add a converter, select **CSV to Fields** — the config fields render instead of crashing.
3. Repeat with Split & Count, Lookup Table, and Date converters.
4. Open an existing extractor that already has a CSV to Fields converter and click Edit — it opens normally.

## Related
- #27037
- Regressed by #24097
