### PR TITLE
Allow non-admin users to dismiss onboarding info on welcome screen.

### DIFF
--- a/graylog2-web-interface/src/components/welcome/OnboardingBanner.test.tsx
+++ b/graylog2-web-interface/src/components/welcome/OnboardingBanner.test.tsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
 import Immutable from 'immutable';
 import type { Permission } from 'graylog-web-plugin/plugin';
 
@@ -25,9 +26,14 @@ import useCurrentUser from 'hooks/useCurrentUser';
 import useOnboardingEligibility from 'components/welcome/hooks/useOnboardingEligibility';
 import { adminUser } from 'fixtures/users';
 import type User from 'logic/users/User';
+import Store from 'logic/local-storage/Store';
 
 jest.mock('hooks/useCurrentUser');
 jest.mock('components/welcome/hooks/useOnboardingEligibility');
+jest.mock('logic/local-storage/Store', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
 
 const userWithPermissions = (permissions: Array<string>): User =>
   adminUser
@@ -40,6 +46,7 @@ const CONTACT_ADMIN_MESSAGE = /please contact an administrator so they can begin
 beforeEach(() => {
   asMock(useCurrentUser).mockReturnValue(userWithPermissions(['inputs:read']));
   asMock(useOnboardingEligibility).mockReturnValue({ data: { status: 'setup' }, isLoading: false });
+  asMock(Store.get).mockReturnValue(undefined);
 });
 
 describe('OnboardingBanner', () => {
@@ -67,6 +74,26 @@ describe('OnboardingBanner', () => {
 
   it('renders nothing while eligibility is loading', () => {
     asMock(useOnboardingEligibility).mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<OnboardingBanner />);
+
+    expect(screen.queryByText(CONTACT_ADMIN_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it('allows dismissing the banner, persisting the choice', async () => {
+    render(<OnboardingBanner />);
+
+    const alert = await screen.findByText(CONTACT_ADMIN_MESSAGE);
+    const dismissButton = await screen.findByRole('button', { name: /close alert/i });
+
+    await userEvent.click(dismissButton);
+
+    expect(alert).not.toBeInTheDocument();
+    expect(Store.set).toHaveBeenCalledWith('welcome-onboarding-banner-dismissed', true);
+  });
+
+  it('does not show the banner again if it was already dismissed', () => {
+    asMock(Store.get).mockReturnValue(true);
 
     render(<OnboardingBanner />);
 

--- a/graylog2-web-interface/src/components/welcome/OnboardingBanner.tsx
+++ b/graylog2-web-interface/src/components/welcome/OnboardingBanner.tsx
@@ -15,26 +15,47 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
+import { useState } from 'react';
+import { styled } from 'styled-components';
 
-import { Alert } from 'components/bootstrap';
+import { Alert, Row, Col } from 'components/bootstrap';
 import useProductName from 'brand-customization/useProductName';
 import useCurrentUser from 'hooks/useCurrentUser';
 import { isAnyPermitted } from 'util/PermissionsMixin';
 import { REQUIRED_PERMISSIONS } from 'components/welcome/Constants';
+import Store from 'logic/local-storage/Store';
 
 import useOnboardingEligibility from './hooks/useOnboardingEligibility';
+
+const ONBOARDING_BANNER_DISMISSED_KEY = 'welcome-onboarding-banner-dismissed';
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+`;
 
 const OnboardingBanner = () => {
   const productName = useProductName();
   const { permissions } = useCurrentUser();
   const { data } = useOnboardingEligibility();
+  const [onboardingBannerDismissed, setOnboardingBannerDismissed] = useState(
+    !!Store.get(ONBOARDING_BANNER_DISMISSED_KEY),
+  );
 
-  if (!isAnyPermitted(permissions, REQUIRED_PERMISSIONS) && data?.status === 'setup') {
+  const onDismiss = () => {
+    Store.set(ONBOARDING_BANNER_DISMISSED_KEY, true);
+    setOnboardingBannerDismissed(true);
+  };
+
+  if (!onboardingBannerDismissed && !isAnyPermitted(permissions, REQUIRED_PERMISSIONS) && data?.status === 'setup') {
     return (
-      <Alert bsStyle="info">
-        {productName} is not currently receiving any log data - please contact an administrator so they can begin
-        setting up ingestion.
-      </Alert>
+      <Row className="content">
+        <Col xs={12}>
+          <StyledAlert bsStyle="info" onDismiss={onDismiss}>
+            {productName} is not currently receiving any log data - please contact an administrator so they can begin
+            setting up ingestion.
+          </StyledAlert>
+        </Col>
+      </Row>
     );
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We recently added an onboarding page for admins that links to collector and input setup. Until onboarding is finished (or dismissed by an admin), non-admin users see an info banner on the welcome page.

This PR makes that banner dismissible.

<img width="1296" height="322" alt="image" src="https://github.com/user-attachments/assets/e7a0e5dd-1bbb-421b-a19a-b8cd4d48539a" />

Related to https://github.com/Graylog2/graylog-plugin-enterprise/issues/15255
/nocl - part of onboarding screen changes