### PR TITLE
Use OR semantics when filtering events by multiple tags

### DIFF
--- a/changelog/unreleased/pr-25896.toml
+++ b/changelog/unreleased/pr-25896.toml
@@ -1,4 +1,4 @@
 type = "a"
 message = "Ability to assign tags to event definitions."
 
-pulls = ["25896", "25940", "26079", "26841"]
+pulls = ["25896", "25940", "26079", "26841", "27145"]

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -197,7 +197,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         // the frontend adds a tags attribute with a custom filter_component (EventDefinitionTagsFilter).
         // Including it in both places would cause a duplicate column.
         // extraSearchFields makes `tags:phishing` work in the search bar (OR-joined by SearchQueryParser)
-        // while the filter UI applies multi-tag AND via the predicate in `getPage`.
+        // while the filter UI applies multi-tag OR via the predicate in `getPage`.
         // tactics_techniques is also registered here so API search (`tactics_techniques:T1059`) works,
         // without exposing it as a default column on the Event Definitions list (gated to enterprise UI).
         this.dbQueryCreator = new DbQueryCreator(EventDefinitionDto.FIELD_TITLE, attributes,
@@ -247,7 +247,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
                         .filter(v -> !v.isBlank())
                         .toList();
         if (!tagFilters.isEmpty()) {
-            predicate = predicate.and(event -> event.tags().containsAll(tagFilters));
+            predicate = predicate.and(event -> tagFilters.stream().anyMatch(event.tags()::contains));
         }
 
         // Strip tags filters before passing to DbQueryCreator (tags are handled by predicate above)

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsFilterBuilder.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsFilterBuilder.java
@@ -91,14 +91,14 @@ public class EventsFilterBuilder {
             }
         }
 
-        // Multi-tag filter uses AND semantics (match events tagged with ALL selected values),
-        // matching GitHub-style label filtering. Cross-attribute filters are AND'd via the
+        // Multi-tag filter uses OR semantics (match events tagged with ANY of the selected values),
+        // matching every other multi-value filter. Cross-attribute filters are AND'd via the
         // outer joiningQueriesWithAND at the bottom of build().
         final Set<String> tags = parameters.filter().extraFilters().getOrDefault(EventDto.FIELD_TAGS, Set.of());
         if (!tags.isEmpty()) {
             filterBuilder.add(tags.stream()
                     .map(tagFilter -> EventDto.FIELD_TAGS + ":" + quote(luceneEscape(tagFilter)))
-                    .collect(joiningQueriesWithAND));
+                    .collect(joiningQueriesWithOR));
         }
 
         switch (parameters.filter().alerts()) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -133,7 +134,42 @@ public interface MoreSearchAdapter {
                 .build();
     }
 
+    /**
+     * Comparison prefix an {@code extraFilters} value may carry. Declared longest-first so {@code <=}
+     * is matched before {@code <}.
+     */
+    enum RangeOperator {
+        LTE("<="), GTE(">="), LT("<"), GT(">");
+
+        private final String prefix;
+
+        RangeOperator(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String prefix() {
+            return prefix;
+        }
+    }
+
+    record RangeValue(RangeOperator operator, String value) {}
+
+    /**
+     * Splits a range-style {@code extraFilters} value (e.g. {@code >=5.0}) into its operator and bare
+     * value, or empty if it carries no comparison prefix. Storage adapters share this so the prefix
+     * parsing lives in one place and only the mapping to each backend's query builder is duplicated —
+     * that part cannot be shared, since the query types differ per backend.
+     */
+    static Optional<RangeValue> parseRangeValue(String value) {
+        for (final RangeOperator operator : RangeOperator.values()) {
+            if (value.startsWith(operator.prefix())) {
+                return Optional.of(new RangeValue(operator, value.substring(operator.prefix().length())));
+            }
+        }
+        return Optional.empty();
+    }
+
     static boolean isRangeValue(String value) {
-        return value.startsWith("<=") || value.startsWith(">=") || value.startsWith("<") || value.startsWith(">");
+        return parseRangeValue(value).isPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/rest/EventDefinitionsResourceTest.java
@@ -18,9 +18,12 @@ package org.graylog.events.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import jakarta.ws.rs.ForbiddenException;
 import org.apache.shiro.subject.Subject;
 import org.assertj.core.api.Assertions;
+import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.graylog.events.context.EventDefinitionContextService;
 import org.graylog.events.notifications.EventNotificationSettings;
@@ -35,11 +38,14 @@ import org.graylog.plugins.views.startpage.recentActivities.RecentActivityServic
 import org.graylog.security.UserContext;
 import org.graylog.security.shares.EntitySharesService;
 import org.graylog2.audit.AuditEventSender;
+import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.rest.models.SortOrder;
 import org.graylog2.shared.security.RestPermissions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -47,10 +53,14 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -192,6 +202,36 @@ public class EventDefinitionsResourceTest {
         resource.suggestTags("", 0);
 
         verify(dbService).suggestTags(eq(""), eq(1));
+    }
+
+    @Test
+    public void getPageMatchesDefinitionsHavingAnyOfTheFilteredTags() {
+        when(subject.isPermitted(anyString())).thenReturn(true);
+        when(contextService.contextFor(anyList()))
+                .thenReturn(ImmutableMap.of(EventDefinitionContextService.SCHEDULER_KEY, ImmutableMap.of()));
+        when(dbService.searchPaginated(any(Bson.class), any(), any(), anyInt(), anyInt()))
+                .thenReturn(new PaginatedList<>(List.of(), 0, 1, 50));
+
+        resource.getPage(1, 50, "", List.of("tags:phishing", "tags:exfil"), "title", SortOrder.ASCENDING);
+
+        @SuppressWarnings("unchecked") final ArgumentCaptor<Predicate<EventDefinitionDto>> predicate =
+                ArgumentCaptor.forClass(Predicate.class);
+        verify(dbService).searchPaginated(any(Bson.class), predicate.capture(), any(), anyInt(), anyInt());
+
+        Assertions.assertThat(predicate.getValue().test(withTags("phishing"))).isTrue();
+        Assertions.assertThat(predicate.getValue().test(withTags("exfil"))).isTrue();
+        Assertions.assertThat(predicate.getValue().test(withTags("phishing", "exfil"))).isTrue();
+        // A definition carrying one filtered tag matches even alongside unrelated tags.
+        Assertions.assertThat(predicate.getValue().test(withTags("exfil", "malware"))).isTrue();
+        Assertions.assertThat(predicate.getValue().test(withTags("malware"))).isFalse();
+        Assertions.assertThat(predicate.getValue().test(withTags())).isFalse();
+    }
+
+    static EventDefinitionDto withTags(String... tags) {
+        return eventDefinitionDto(mock(EventProcessorConfig.class)).toBuilder()
+                .id("54e3deadbeefdeadbeefaffe")
+                .tags(ImmutableSet.copyOf(tags))
+                .build();
     }
 
     static EventDefinitionDto eventDefinitionDto(EventProcessorConfig config) {

--- a/graylog2-server/src/test/java/org/graylog/events/search/EventsFilterBuilderTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/search/EventsFilterBuilderTest.java
@@ -44,14 +44,26 @@ class EventsFilterBuilderTest {
     }
 
     @Test
-    void buildWithMultipleTagFiltersJoinsWithAND() {
+    void buildWithMultipleTagFiltersJoinsWithOR() {
         // LinkedHashSet keeps insertion order so the assertion against the full query string is
         // deterministic — EventsFilterBuilder iterates the tag set as-is.
         final var filter = EventsSearchFilter.builder()
                 .extraFilters(Map.of(EventDto.FIELD_TAGS, new LinkedHashSet<>(List.of("phishing", "exfil"))))
                 .build();
 
-        assertThat(build(filter)).isEqualTo(EVENT_DEFINITION_ID_CLAUSE + " AND (tags:\"phishing\" AND tags:\"exfil\")");
+        assertThat(build(filter)).isEqualTo(EVENT_DEFINITION_ID_CLAUSE + " AND (tags:\"phishing\" OR tags:\"exfil\")");
+    }
+
+    @Test
+    void buildAndsTagsClauseWithOtherAttributeFilters() {
+        // Tags OR internally, but the tags clause as a whole still ANDs with other attributes.
+        final var filter = EventsSearchFilter.builder()
+                .priority(Set.of("high"))
+                .extraFilters(Map.of(EventDto.FIELD_TAGS, new LinkedHashSet<>(List.of("phishing", "exfil"))))
+                .build();
+
+        assertThat(build(filter)).isEqualTo(EVENT_DEFINITION_ID_CLAUSE
+                + " AND (priority:3) AND (tags:\"phishing\" OR tags:\"exfil\")");
     }
 
     @Test


### PR DESCRIPTION
Shifts multi-tag filtering from AND to OR, matching every other multi-value filter.

- `EventsFilterBuilder`: tag terms are joined with OR
- `EventDefinitionsResource.getPage`: tag predicate is "has any of" instead of "has all of"
- `MoreSearchAdapter.parseRangeValue`: `extraFilters` range-prefix parsing moved out of the per-backend storage adapters
- Cross-attribute filters are still AND'd

Tags are unreleased, so the PR is appended to that feature's existing changelog entry.

/jpd Graylog2/graylog-plugin-enterprise#15353
