### PR TITLE
Fix invisible delete icon in `PaginatedItem`

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedItemOverview/PaginatedItem.tsx
+++ b/graylog2-web-interface/src/components/common/PaginatedItemOverview/PaginatedItem.tsx
@@ -48,7 +48,7 @@ const Description = styled.span`
 `;
 
 const StyledDeleteButton = styled(IconButton)`
-  flex: 0;
+  flex: 0 0 auto;
 `;
 
 const PaginatedItem = ({ item: { name, description }, onDeleteItem = undefined, item }: Props) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The delete icon in `PaginatedItem` rows was invisible. `StyledDeleteButton` set `flex: 0` on the `IconButton`, which resolves to `flex-basis: 0%`. Since https://github.com/Graylog2/graylog2-server/pull/26943, the `IconButton` now renders Mantine's `Button` (which sets `overflow: hidden`), the flex item's automatic minimum size no longer protects it from shrinking to its content size, so it collapsed to zero width.

Changed `flex: 0` to `flex: 0 0 auto` so the button keeps its intrinsic size instead of shrinking away.

/nocl - fixes unreleased change