### PR TITLE
Fix metrics ism policy

### DIFF
--- a/changelog/unreleased/issue-27040.toml
+++ b/changelog/unreleased/issue-27040.toml
@@ -1,0 +1,8 @@
+type = "f"
+message = "Fixed Data Node metrics backing indices created by a rollover not being managed by the metrics ISM policy."
+
+details.user = """
+The `gl-datanode-metrics-ism` policy was created without an `ism_template`, so it was only attached to the backing indices of the `gl-datanode-metrics` data stream that existed at the time the policy was applied. Every backing index created by a later rollover stayed unmanaged, meaning the configured rollup and deletion never ran on it and indices and shards accumulated until they could trip `cluster.max_shards_per_node`. The policy now carries an `ism_template` for the metrics data stream, so OpenSearch attaches it to new backing indices automatically. Existing installations pick this up on the next Data Node restart, which rewrites the policy.
+"""
+
+issues = ["27040"]

--- a/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
+++ b/data-node/src/main/java/org/graylog/datanode/metrics/ConfigureMetricsIndexSettings.java
@@ -56,6 +56,8 @@ public class ConfigureMetricsIndexSettings implements StateMachineTracer<Opensea
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigureMetricsIndexSettings.class);
 
+    private static final int ISM_TEMPLATE_PRIORITY = 100;
+
     private final AtomicBoolean datastreamCreated = new AtomicBoolean(false);
 
     private final OpensearchProcess process;
@@ -146,11 +148,20 @@ public class ConfigureMetricsIndexSettings implements StateMachineTracer<Opensea
         Policy.State stateRollup = ismRollupState(stateDelete.name(), configuration);
         Policy.State stateOpen = ismOpenState(stateRollup.name());
 
+        // The ISM template makes OpenSearch attach this policy to backing indices created by future rollovers.
+        // Without it, only the backing indices existing at policy creation time are managed and everything rolled
+        // over later silently accumulates without rollup or deletion.
+        // OpenSearch matches the pattern against the data stream name, not against the physical .ds-* index name.
+        // It has to be the exact stream name: a prefix wildcard would also match the rollup target index
+        // (metrics_daily_index), which is a plain index this policy must not manage.
+        final Policy.IsmTemplate ismTemplate =
+                new Policy.IsmTemplate(ImmutableList.of(configuration.getMetricsStream()), ISM_TEMPLATE_PRIORITY);
+
         Policy policy = new Policy(null,
                 "Manages rollover, rollup and deletion of data note metrics indices",
                 null,
                 stateOpen.name(), ImmutableList.of(stateOpen, stateRollup, stateDelete),
-                null);
+                ImmutableList.of(ismTemplate));
 
         try {
             LOGGER.debug("Creating ISM configuration for metrics data stream {}",

--- a/graylog-storage-opensearch3/pom.xml
+++ b/graylog-storage-opensearch3/pom.xml
@@ -113,6 +113,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-joda-time</artifactId>
             <version>${assertj-joda-time.version}</version>

--- a/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ism/IsmApi.java
+++ b/graylog-storage-opensearch3/src/main/java/org/graylog/storage/opensearch3/ism/IsmApi.java
@@ -72,6 +72,18 @@ public class IsmApi {
                 "Unable to add policy to index");
     }
 
+    /**
+     * Returns the ISM explain output for the given index, which reports whether the index is managed and by which
+     * policy. The response is keyed by index name, with the policy id below the (literal, dotted) key
+     * {@code index.plugins.index_state_management.policy_id}.
+     */
+    public Optional<JsonNode> explainIndex(String index) {
+        final Request request = os3request("GET", "explain/" + index, null);
+        return perform(request,
+                new TypeReference<JsonNode>() {},
+                "Unable to explain index");
+    }
+
     public void removePolicyFromIndex(String index) {
         final Request request = os3request("POST", "remove/" + index, null);
         perform(request,

--- a/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/DataStreamAdapterOSIT.java
+++ b/graylog-storage-opensearch3/src/test/java/org/graylog/storage/opensearch3/DataStreamAdapterOSIT.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.storage.opensearch3;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.storage.opensearch3.ism.IsmApi;
 import org.graylog.storage.opensearch3.testing.OpenSearchInstance;
@@ -27,10 +28,13 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.indices.DataStream;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class DataStreamAdapterOSIT {
 
@@ -39,8 +43,10 @@ public class DataStreamAdapterOSIT {
 
     ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
+    IsmApi ismApi = new IsmApi(openSearchInstance.getOfficialOpensearchClient(), objectMapper);
+
     DataStreamAdapterOS dataStreamAdapter = new DataStreamAdapterOS(openSearchInstance.getOfficialOpensearchClient(),
-            new IsmApi(openSearchInstance.getOfficialOpensearchClient(), objectMapper));
+            ismApi);
 
 
     @Test
@@ -81,5 +87,79 @@ public class DataStreamAdapterOSIT {
 
     }
 
+    /**
+     * A policy without an {@code ism_template} is only attached to the backing indices that exist when it is applied.
+     * Every index created by a later rollover stays unmanaged, so no rollup or deletion ever runs on it.
+     *
+     * @see <a href="https://github.com/Graylog2/graylog2-server/issues/27040">#27040</a>
+     */
+    @Test
+    public void testBackingIndexCreatedByRolloverIsManagedAutomatically() {
+        // must not overlap the index template pattern of the other test in this class
+        final String stream = "ismtemplatedatastream";
+        final String templateName = stream + "-template";
+        final String policyId = "graylog-ism-template-test-policy";
+
+        final Template template = new Template(List.of(stream + "*"), new Template.Mappings(Map.of()), 1L,
+                new Template.Settings(Map.of("number_of_replicas", 0)));
+        assertThat(dataStreamAdapter.ensureDataStreamTemplate(templateName, template, "timestamp")).isTrue();
+        dataStreamAdapter.createDataStream(stream);
+
+        try {
+            dataStreamAdapter.applyIsmPolicy(stream, IsmPolicyTest.createTestPolicyWithIsmTemplate(policyId, stream));
+
+            // the stored policy must carry the ism_template, otherwise OpenSearch has no way to attach it to
+            // backing indices created later on
+            assertThat(ismApi.getPolicy(policyId)).hasValueSatisfying(stored ->
+                    assertThat(stored.policy().ismTemplate()).singleElement().satisfies(ismTemplate ->
+                            // OpenSearch matches the pattern against the data stream name, not the .ds-* index name
+                            assertThat(ismTemplate.indexPatterns()).containsExactly(stream)));
+
+            final List<String> initialBackingIndices = backingIndices(stream);
+            assertThat(initialBackingIndices).hasSize(1);
+
+            // this one is managed because applyIsmPolicy() attaches the policy to it explicitly
+            await().atMost(1, TimeUnit.MINUTES).pollInterval(1, TimeUnit.SECONDS).untilAsserted(() ->
+                    assertThat(managingPolicyOf(initialBackingIndices.get(0))).isEqualTo(policyId));
+
+            final String rolledOverIndex = rollover(stream);
+            assertThat(rolledOverIndex).isNotIn(initialBackingIndices);
+
+            // nothing attaches the policy to the new index explicitly - only the ism_template can do that
+            await().atMost(2, TimeUnit.MINUTES).pollInterval(2, TimeUnit.SECONDS).untilAsserted(() ->
+                    assertThat(managingPolicyOf(rolledOverIndex)).isEqualTo(policyId));
+        } finally {
+            dataStreamAdapter.deleteDataStream(stream);
+            dataStreamAdapter.deleteIsmPolicy(policyId);
+            dataStreamAdapter.deleteDataStreamTemplate(templateName);
+        }
+    }
+
+    /**
+     * @return the id of the ISM policy managing the index, or {@code null} if the index is not managed
+     */
+    @Nullable
+    private String managingPolicyOf(String index) {
+        return ismApi.explainIndex(index)
+                .map(explain -> explain.path(index).path("index.plugins.index_state_management.policy_id"))
+                .filter(JsonNode::isTextual)
+                .map(JsonNode::asText)
+                .orElse(null);
+    }
+
+    private String rollover(String dataStream) {
+        return openSearchInstance.getOfficialOpensearchClient().execute(
+                () -> openSearchInstance.getOfficialOpensearchClient().sync().indices()
+                        .rollover(r -> r.alias(dataStream)).newIndex(),
+                "Unable to roll over data stream " + dataStream);
+    }
+
+    private List<String> backingIndices(String dataStream) {
+        return dataStreamAdapter.getDataStream(dataStream).stream()
+                .filter(ds -> ds.name().equals(dataStream))
+                .findFirst()
+                .map(ds -> ds.indices().stream().map(idx -> idx.indexName()).toList())
+                .orElseThrow(() -> new IllegalStateException("Data stream " + dataStream + " not found"));
+    }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/datastream/policy/Policy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/datastream/policy/Policy.java
@@ -31,7 +31,7 @@ public record Policy(@Nullable String policyId,
                      @Nullable String lastUpdatedTime,
                      @Nonnull String defaultState,
                      @Nonnull List<State> states,
-                     @Nullable IsmTemplate ismTemplate) {
+                     @Nullable List<IsmTemplate> ismTemplate) {
 
     public Policy(@Nonnull String description, @Nonnull String defaultState, @Nonnull List<State> states) {
         this(null, description, null, defaultState, states, null);
@@ -49,7 +49,12 @@ public record Policy(@Nullable String policyId,
     /**
      * ISM Template property with index pattern and priority. This must be specified in order for automatically rolled-over
      * data streams indexes to continue to be managed by the policy.
+     * <p>
+     * For data stream backing indices, OpenSearch matches these patterns against the <em>data stream name</em>, not
+     * against the physical {@code .ds-*} index name. A pattern should therefore be as specific as possible, so that it
+     * doesn't accidentally match unrelated indices sharing the data stream's name prefix.
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record IsmTemplate(List<String> indexPatterns, int priority) {
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/datastream/policy/IsmPolicyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/datastream/policy/IsmPolicyTest.java
@@ -39,6 +39,19 @@ public class IsmPolicyTest {
         return new IsmPolicy("graylog-ism-test-policy", policy);
     }
 
+    /**
+     * Same as {@link #createSimpleTestPolicy()}, but with an ISM template, which is what makes OpenSearch attach the
+     * policy to backing indices created by later data stream rollovers.
+     */
+    public static IsmPolicy createTestPolicyWithIsmTemplate(String policyId, String indexPattern) {
+        Policy.State deleteState = deleteState();
+        Policy.State initialState = transitionState(deleteState.name());
+        Policy policy = new Policy(null, "Test Policy", null, initialState.name(),
+                ImmutableList.of(initialState, deleteState),
+                ImmutableList.of(new Policy.IsmTemplate(ImmutableList.of(indexPattern), 100)));
+        return new IsmPolicy(policyId, policy);
+    }
+
     private static Policy.State transitionState(String nextState) {
         final List<Action> actions = ImmutableList.of();
         final List<Policy.Transition> transitions = ImmutableList.of(
@@ -83,6 +96,30 @@ public class IsmPolicyTest {
               }
             }""";
 
+    String ismTemplatePolicyJson = """
+            {
+              "_id" : "graylog-ism-test-policy",
+              "policy" : {
+                "description" : "Test Policy",
+                "last_updated_time" : 1755678598000,
+                "last_updated_time_in_millis" : "2026-08-20T08:29:58.000Z",
+                "default_state" : "delete",
+                "states" : [ {
+                  "name" : "delete",
+                  "actions" : [ {
+                    "delete" : { }
+                  } ],
+                  "transitions" : [ ]
+                } ],
+                "ism_template" : [ {
+                  "index_patterns" : [ "test-data-stream" ],
+                  "priority" : 100,
+                  "last_updated_time" : 1755678598000,
+                  "last_updated_time_in_millis" : "2026-08-20T08:29:58.000Z"
+                } ]
+              }
+            }""";
+
 
     @Test
     public void testPolicySerializationWorks() throws IOException {
@@ -96,6 +133,32 @@ public class IsmPolicyTest {
         ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final IsmPolicy policy = objectMapper.readValue(simpleTestPolicyJson, IsmPolicy.class);
         assertThat(policy.policy().states()).hasSize(2);
+    }
+
+    @Test
+    public void testIsmTemplateSerializationWorks() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = objectMapper.writeValueAsString(
+                createTestPolicyWithIsmTemplate("graylog-ism-test-policy", "test-data-stream"));
+
+        assertThat(objectMapper.readTree(json).at("/policy/ism_template/0/index_patterns/0").asText())
+                .isEqualTo("test-data-stream");
+        assertThat(objectMapper.readTree(json).at("/policy/ism_template/0/priority").asInt()).isEqualTo(100);
+    }
+
+    /**
+     * OpenSearch always returns {@code ism_template} as an array and adds a {@code last_updated_time} to each entry,
+     * even when the policy was created with a single template object.
+     */
+    @Test
+    public void testIsmTemplateDeserializationWorks() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final IsmPolicy policy = objectMapper.readValue(ismTemplatePolicyJson, IsmPolicy.class);
+
+        assertThat(policy.policy().ismTemplate()).singleElement().satisfies(ismTemplate -> {
+            assertThat(ismTemplate.indexPatterns()).containsExactly("test-data-stream");
+            assertThat(ismTemplate.priority()).isEqualTo(100);
+        });
     }
 
 }


### PR DESCRIPTION
## Description
The `gl-datanode-metrics-ism` policy was created without an `ism_template`, so it was only attached to the backing indices of the `gl-datanode-metrics` data stream that existed at the time the policy was applied. Every backing index created by a later rollover stayed unmanaged, meaning the configured rollup and deletion never ran on it and indices and shards accumulated until they could trip `cluster.max_shards_per_node`. The policy now carries an `ism_template` for the metrics data stream, so OpenSearch attaches it to new backing indices automatically. Existing installations pick this up on the next Data Node restart, which rewrites the policy.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/15363

## Motivation and Context
fixes #27040 

## How Has This Been Tested?
added tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

