### PR TITLE
Fix incorrect changelog name

### DIFF
--- a/changelog/unreleased/issue-15330.toml
+++ b/changelog/unreleased/issue-15330.toml
@@ -2,3 +2,4 @@ type = "s"
 message = "Fix NetFlow V9 loop with unreachable exit condition."
 
 issues = ["Graylog2/graylog-plugin-enterprise#15330"]
+pulls = ["27127"]


### PR DESCRIPTION
This was erroneously named in the original PR (https://github.com/Graylog2/graylog2-server/pull/27127), which was merged today. Noticed while creating the backports.

/nocl
