### PR TITLE
Fix NetFlow V9 loop with unreachable exit condition. (7.0)

### DIFF
--- a/changelog/unreleased/issue-15330.toml
+++ b/changelog/unreleased/issue-15330.toml
@@ -1,0 +1,5 @@
+type = "s"
+message = "Fix NetFlow V9 loop with unreachable exit condition."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15330"]
+pulls = ["27127"]

--- a/graylog2-server/src/main/java/org/graylog/plugins/netflow/v9/NetFlowV9Parser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/netflow/v9/NetFlowV9Parser.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import org.graylog.plugins.netflow.flows.CorruptFlowPacketException;
 import org.graylog.plugins.netflow.flows.EmptyTemplateException;
 import org.graylog.plugins.netflow.flows.InvalidFlowVersionException;
 import org.slf4j.Logger;
@@ -40,6 +41,10 @@ import java.util.Set;
 public class NetFlowV9Parser {
     private static final Logger LOG = LoggerFactory.getLogger(NetFlowV9Parser.class);
 
+    // A FlowSet's length includes its own 4-byte header (RFC 3954 Sec 5.1), so anything smaller
+    // cannot advance the reader index.
+    private static final int MIN_FLOWSET_LENGTH = 4;
+
     public static NetFlowV9Packet parsePacket(ByteBuf bb, NetFlowV9FieldTypeRegistry typeRegistry) {
         return parsePacket(bb, typeRegistry, Maps.newHashMap(), null);
     }
@@ -51,7 +56,16 @@ public class NetFlowV9Parser {
         final List<NetFlowV9Template> allTemplates = new ArrayList<>();
         NetFlowV9OptionTemplate optTemplate = optionTemplate;
         List<NetFlowV9BaseRecord> records = new ArrayList<>();
+        int previousStart = -1;
         while (bb.isReadable()) {
+            // Backstop in case a FlowSet parser ever returns without consuming input. A silent spin
+            // here is unrecoverable, so don't rely on every branch staying correct.
+            final int flowSetStart = bb.readerIndex();
+            if (flowSetStart == previousStart) {
+                LOG.error("Parser made no progress reading NetFlow V9 packet, discarding remaining bytes");
+                break;
+            }
+            previousStart = flowSetStart;
             bb.markReaderIndex();
             int flowSetId = bb.readUnsignedShort();
             if (flowSetId == 0) {
@@ -211,6 +225,7 @@ public class NetFlowV9Parser {
      */
     public static NetFlowV9OptionTemplate parseOptionTemplate(ByteBuf bb, NetFlowV9FieldTypeRegistry typeRegistry) {
         int length = bb.readUnsignedShort();
+        checkFlowSetLength(1, length);
         final int templateId = bb.readUnsignedShort();
 
         int optionScopeLength = bb.readUnsignedShort();
@@ -251,6 +266,7 @@ public class NetFlowV9Parser {
     public static Map.Entry<Integer, byte[]> parseOptionTemplateShallow(ByteBuf bb) {
         final int start = bb.readerIndex();
         int length = bb.readUnsignedShort();
+        checkFlowSetLength(1, length);
         final int templateId = bb.readUnsignedShort();
 
         int optionScopeLength = bb.readUnsignedShort();
@@ -297,6 +313,7 @@ public class NetFlowV9Parser {
         List<NetFlowV9BaseRecord> records = new ArrayList<>();
         int flowSetId = bb.readUnsignedShort();
         int length = bb.readUnsignedShort();
+        checkFlowSetLength(flowSetId, length);
         int end = bb.readerIndex() - 4 + length;
 
         List<NetFlowV9FieldDef> defs;
@@ -316,6 +333,13 @@ public class NetFlowV9Parser {
         int unitSize = 0;
         for (NetFlowV9FieldDef def : defs) {
             unitSize += def.length();
+        }
+
+        // A wire-supplied template whose fields sum to zero bytes makes the loop below append a
+        // record per pass without consuming anything, filling the heap rather than terminating.
+        if (unitSize <= 0) {
+            throw new CorruptFlowPacketException("Template " + flowSetId + " declares a zero-length record."
+                    + " Discarding packet.");
         }
 
         while (bb.readerIndex() < end && bb.readableBytes() >= unitSize) {
@@ -360,6 +384,7 @@ public class NetFlowV9Parser {
         final int start = bb.readerIndex();
         int usedTemplateId = bb.readUnsignedShort();
         int length = bb.readUnsignedShort();
+        checkFlowSetLength(usedTemplateId, length);
         int end = bb.readerIndex() - 4 + length;
         bb.readerIndex(end);
         return usedTemplateId;
@@ -375,7 +400,15 @@ public class NetFlowV9Parser {
         Map.Entry<Integer, byte[]> optTemplate = null;
         final Set<Integer> usedTemplates = Sets.newHashSet();
 
+        int previousStart = -1;
         while (buf.isReadable()) {
+            // See the equivalent guard in parsePacket.
+            final int flowSetStart = buf.readerIndex();
+            if (flowSetStart == previousStart) {
+                LOG.error("Parser made no progress reading NetFlow V9 packet, discarding remaining bytes");
+                break;
+            }
+            previousStart = flowSetStart;
             buf.markReaderIndex();
             int flowSetId = buf.readUnsignedShort();
             if (flowSetId == 0) {
@@ -392,5 +425,12 @@ public class NetFlowV9Parser {
         }
 
         return RawNetFlowV9Packet.create(header, dataLength, allTemplates, optTemplate, usedTemplates);
+    }
+
+    private static void checkFlowSetLength(int flowSetId, int length) {
+        if (length < MIN_FLOWSET_LENGTH) {
+            throw new CorruptFlowPacketException("FlowSet " + flowSetId + " declares length " + length
+                    + ", which is below the " + MIN_FLOWSET_LENGTH + " byte minimum. Discarding packet.");
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/netflow/v9/NetFlowV9ParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/netflow/v9/NetFlowV9ParserTest.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.netflow.v9;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import io.netty.buffer.Unpooled;
+import org.graylog.plugins.netflow.flows.CorruptFlowPacketException;
 import org.graylog.plugins.netflow.flows.EmptyTemplateException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -114,6 +116,81 @@ public class NetFlowV9ParserTest {
         final byte[] b = Resources.toByteArray(Resources.getResource("netflow-data/netflow-v9-3_incomplete.dat"));
         assertThatExceptionOfType(EmptyTemplateException.class)
                 .isThrownBy(() -> NetFlowV9Parser.parsePacket(Unpooled.wrappedBuffer(b), typeRegistry));
+    }
+
+    // Each case below used to rewind the reader index to the start of the FlowSet and spin forever.
+    // The timeouts fail the test rather than hanging the suite if that regresses.
+
+    // Only the version is validated, so sysUptime / unixSecs / sequence / sourceId are left zero.
+    private static final String HEADER_ONE_FLOWSET = "0009" + "0001" + "00000000" + "00000000" + "00000000" + "00000000";
+    private static final String HEADER_TWO_FLOWSETS = "0009" + "0002" + "00000000" + "00000000" + "00000000" + "00000000";
+
+    @Test(timeout = 5000)
+    public void parsePacketShallow_dataFlowSetWithZeroLength_isRejected() {
+        // FlowSet id 256 (any id above 1 is a data FlowSet), length 0
+        final byte[] b = hexToBytes(HEADER_ONE_FLOWSET + "0100" + "0000");
+
+        assertThatExceptionOfType(CorruptFlowPacketException.class)
+                .isThrownBy(() -> NetFlowV9Parser.parsePacketShallow(Unpooled.wrappedBuffer(b)));
+    }
+
+    @Test(timeout = 5000)
+    public void parsePacketShallow_optionTemplateWithZeroLength_isRejected() {
+        // FlowSet id 1 (options template), length 0, then template id and zero scope/option lengths
+        final byte[] b = hexToBytes(HEADER_ONE_FLOWSET + "0001" + "0000" + "0100" + "0000" + "0000");
+
+        assertThatExceptionOfType(CorruptFlowPacketException.class)
+                .isThrownBy(() -> NetFlowV9Parser.parsePacketShallow(Unpooled.wrappedBuffer(b)));
+    }
+
+    @Test(timeout = 5000)
+    public void parsePacketShallow_dataFlowSetWithHeaderOnlyLength_parsesCleanly() {
+        // Same packet except length 4: a FlowSet header and no records, which must still parse.
+        final byte[] b = hexToBytes(HEADER_ONE_FLOWSET + "0100" + "0004");
+
+        final RawNetFlowV9Packet packet = NetFlowV9Parser.parsePacketShallow(Unpooled.wrappedBuffer(b));
+
+        assertEquals(9, packet.header().version());
+        assertEquals(Collections.singleton(256), packet.usedTemplates());
+    }
+
+    @Test(timeout = 5000)
+    public void parsePacket_dataFlowSetWithZeroLength_isRejected() {
+        // The template for id 256 is needed so the record parser gets past its cache lookup.
+        final byte[] b = hexToBytes(HEADER_TWO_FLOWSETS
+                + "0000" + "0010" + "0100" + "0002" + "0008" + "0004" + "000c" + "0004"
+                + "0100" + "0000");
+
+        assertThatExceptionOfType(CorruptFlowPacketException.class)
+                .isThrownBy(() -> NetFlowV9Parser.parsePacket(Unpooled.wrappedBuffer(b), typeRegistry));
+    }
+
+    @Test(timeout = 5000)
+    public void parsePacket_optionTemplateWithZeroLength_isRejected() {
+        final byte[] b = hexToBytes(HEADER_ONE_FLOWSET + "0001" + "0000" + "0100" + "0000" + "0000");
+
+        assertThatExceptionOfType(CorruptFlowPacketException.class)
+                .isThrownBy(() -> NetFlowV9Parser.parsePacket(Unpooled.wrappedBuffer(b), typeRegistry));
+    }
+
+    @Test(timeout = 5000)
+    public void parsePacket_templateWithNoFields_isRejected() {
+        // Distinct from the length cases: the FlowSet length here is legitimate, but a template
+        // declaring zero fields makes each record occupy zero bytes, exhausting the heap.
+        final byte[] b = hexToBytes(HEADER_TWO_FLOWSETS
+                + "0000" + "0008" + "0100" + "0000"
+                + "0100" + "0008" + "00000000");
+
+        assertThatExceptionOfType(CorruptFlowPacketException.class)
+                .isThrownBy(() -> NetFlowV9Parser.parsePacket(Unpooled.wrappedBuffer(b), typeRegistry));
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        final byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
     }
 
     private String name(NetFlowV9FieldDef def) {


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/27127 to `7.0`.

Enterprise issue: https://github.com/Graylog2/graylog-plugin-enterprise/issues/15330

Manually merged areas:
- NetFlow V9 parser tests — 7.0 is still on JUnit 4, so the new regression tests use `@Test(timeout = 5000)` instead of JUnit 5's `@Timeout`.
