### PR TITLE
Complete Shiro 3.0.1 upgrade

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/sessions/SessionConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/sessions/SessionConverter.java
@@ -68,14 +68,12 @@ public class SessionConverter {
     }
 
     public static SimpleSession sessionDTOToSimpleSession(SessionDTO sessionDTO) {
-        final var simpleSession = new SimpleSession();
+        final var simpleSession = new SimpleSession(
+                sessionDTO.host().orElse(null), Date.from(sessionDTO.startTimestamp()));
         simpleSession.setId(sessionDTO.sessionId());
         simpleSession.setTimeout(sessionDTO.timeout());
-        simpleSession.setStartTimestamp(Date.from(sessionDTO.startTimestamp()));
         simpleSession.setLastAccessTime(Date.from(sessionDTO.lastAccessTime()));
         simpleSession.setExpired(sessionDTO.expired());
-
-        sessionDTO.host().ifPresent(simpleSession::setHost);
 
         if (sessionDTO.userId().isPresent() && sessionDTO.authenticationRealm().isPresent()) {
             simpleSession.setAttribute(DefaultSubjectContext.PRINCIPALS_SESSION_KEY, new SimplePrincipalCollection(

--- a/graylog2-server/src/test/java/org/graylog2/security/sessions/SessionConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/sessions/SessionConverterTest.java
@@ -76,11 +76,10 @@ class SessionConverterTest {
     void simpleSessionToSessionDTO() {
         final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 
-        final var simpleSession = new SimpleSession();
+        final var simpleSession = new SimpleSession(
+                "localhost", java.util.Date.from(now.minusSeconds(10)));
         simpleSession.setId("session-id");
-        simpleSession.setHost("localhost");
         simpleSession.setTimeout(10_000);
-        simpleSession.setStartTimestamp(java.util.Date.from(now.minusSeconds(10)));
         simpleSession.setLastAccessTime(java.util.Date.from(now));
         simpleSession.setExpired(false);
         simpleSession.setAttribute(SessionUtils.USERNAME_SESSION_KEY, "user-name");
@@ -106,9 +105,8 @@ class SessionConverterTest {
 
     @Test
     void failsForUnknownAttributes() {
-        final var simpleSession = new SimpleSession();
+        final var simpleSession = new SimpleSession("localhost");
         simpleSession.setId("session-id");
-        simpleSession.setHost("localhost");
         simpleSession.setAttribute("unknown-key", "some-value");
 
         assertThatThrownBy(() -> SessionConverter.simpleSessionToSessionDTOBuilder(simpleSession).build())
@@ -118,9 +116,8 @@ class SessionConverterTest {
 
     @Test
     void hasStrictPrincipalsHandlingg() {
-        final var simpleSession = new SimpleSession();
+        final var simpleSession = new SimpleSession("localhost");
         simpleSession.setId("session-id");
-        simpleSession.setHost("localhost");
 
         assertThat(SessionConverter.simpleSessionToSessionDTOBuilder(simpleSession).build().userId()).isEmpty();
 

--- a/graylog2-server/src/test/java/org/graylog2/security/sessions/SessionPersistenceIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/sessions/SessionPersistenceIT.java
@@ -80,8 +80,7 @@ class SessionPersistenceIT {
                 new SimpleAccount("test-user-id", null, "TestRealm").getPrincipals();
         final var testAuthContext = new TestSessionAuthContext("some-value");
 
-        final var session = new SimpleSession("localhost");
-        session.setStartTimestamp(Date.from(referenceTime));
+        final var session = new SimpleSession("localhost", Date.from(referenceTime));
         session.setTimeout(10_000L);
         session.setExpired(false);
         session.setLastAccessTime(Date.from(referenceTime.plusSeconds(1)));
@@ -127,8 +126,8 @@ class SessionPersistenceIT {
 
         final String sessionId = (String) sessionDAO().create(new SimpleSession("example.com"));
 
-        final var session = (SimpleSession) sessionDAO().readSession(sessionId);
-        session.setStartTimestamp(Date.from(referenceTime));
+        final var session = new SimpleSession("example.com", Date.from(referenceTime));
+        session.setId(sessionId);
         session.setTimeout(10_000L);
         session.setExpired(false);
         session.setLastAccessTime(Date.from(referenceTime.plusSeconds(1)));
@@ -188,8 +187,7 @@ class SessionPersistenceIT {
     void expireSession() {
         final var referenceTime = Instant.now().truncatedTo(ChronoUnit.MILLIS).minus(1, ChronoUnit.HOURS);
 
-        final var session = new SimpleSession("localhost");
-        session.setStartTimestamp(Date.from(referenceTime));
+        final var session = new SimpleSession("localhost", Date.from(referenceTime));
         session.setTimeout(10_000L);
         session.setExpired(false);
         session.setLastAccessTime(Date.from(referenceTime.plusSeconds(1)));

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <aws-kinesis-client.version>3.5.1</aws-kinesis-client.version>
         <aws-msk-iam-auth.version>2.3.7</aws-msk-iam-auth.version>
         <bouncycastle.version>1.85</bouncycastle.version>
+        <bouncycastle.provider.version>1.85.2</bouncycastle.provider.version>
         <caffeine.version>3.2.4</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <classgraph.version>4.8.192</classgraph.version>
@@ -733,7 +734,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
+                <version>${bouncycastle.provider.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
/nocl

## Description

Completes the Shiro 3.0.1 upgrade in #27177 by aligning the provider-only
Bouncy Castle patch and migrating `SimpleSession` initialization to Shiro 3's
constructor API.

## Motivation and Context

Shiro 3.0.1 requires `bcprov-jdk18on` 1.85.2, while Graylog's dependency
management selected 1.85 and failed `RequireUpperBoundDeps`. The companion
`bcpkix` and `bcutil` artifacts do not have a 1.85.2 release, so this keeps them
on 1.85 and manages only the provider at 1.85.2.

Shiro 3 also removed the public session host and start-time setters. The
conversion and persistence fixtures now initialize those values through the
supported constructor while preserving session IDs during DAO updates.

## How Has This Been Tested?

- `./mvnw --batch-mode --no-transfer-progress test -pl :graylog2-server -Dtest=SessionConverterTest -Dskip.web.build=true -Dmaven.javadoc.skip=true`
  on JDK 21: 4 tests passed; all 4,363 production and 1,308 test sources compiled.
- Enforcer, PMD, and forbidden-API checks passed; forbidden-API scanned 8,226
  production and 1,842 test classes with zero violations.
- The exact backend `clean verify` command reached the test suite after
  compilation; its Testcontainers cases could not run because the disposable
  remote environment has no Docker daemon, so a full-suite pass is not claimed.
- `git diff --check`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
