### PR TITLE
Add `Content & Wording` page to design system

### DIFF
--- a/graylog2-web-interface/AGENTS.md
+++ b/graylog2-web-interface/AGENTS.md
@@ -87,6 +87,7 @@ yarn tsgo && yarn lint:changes && yarn test
 - Shared components live in - src/components/common.
 - Wrapped Mantine components live in src/components/common/bootstrap.
 - Check the [frontend documentation](https://graylog2.github.io/frontend-documentation) for available common components before creating new ones.
+- Consult the graylog-luma design system (`docs/graylog-luma/stories/`) for design and UI conventions that go beyond what's summarized in [CONTRIBUTING.md](./CONTRIBUTING.md). Read every file relevant to the change, not just `.mdx` docs — guidance and token values also live in plain `.tsx` companions and `.stories.tsx` component files.
 
 ## Testing Guidelines
 

--- a/graylog2-web-interface/CONTRIBUTING.md
+++ b/graylog2-web-interface/CONTRIBUTING.md
@@ -227,19 +227,12 @@ Test layout changes in Chrome, Firefox, and Safari. Larger layout changes should
 
 ## UI Styling
 
+The [graylog-luma design system](https://graylog2.github.io/design-system) — especially the **Foundation** and **Patterns** sections — documents conventions (spacing/typography tokens, form layout, entity-creation flows, content and writing rules) that go beyond what's summarized below.
+
 ### Styled Components
 
 - In styled components, prefer theme tokens over hard-coded style values when possible. This includes spacing via `theme.spacings`, colors via `theme.colors`, and typography values such as `theme.fonts.family` and `theme.fonts.size`.
 - To style a component, prefer wrapping that component with `styled(...)` instead of targeting it through selectors from a parent component.
-
-### Forms
-
-- Use vertically aligned labels and inputs (no horizontal forms without good reason).
-- Add helper text to inputs.
-- Show validation state only after changes or form submission.
-- Prefer our own `Select` component over the native one.
-- Avoid long forms in modals.
-- Mark optional fields with "(Optional)" in the label.
 
 ### Responsive Styles
 

--- a/graylog2-web-interface/docs/graylog-luma/stories/Foundation/ContentWriting.mdx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Foundation/ContentWriting.mdx
@@ -8,17 +8,17 @@ Guidelines for writing clear, consistent copy across Graylog.
 
 ## Capitalization
 
-Two casing styles are used, depending on the context: headlines and section titles use title case, everything else — buttons, links, body copy, and status or microcopy — stays in sentence case.
+Two casing styles are used, depending on the context: headlines and section titles use title case, everything else — buttons, links and body copy — stays in sentence case.
 
 ### Title Case (Headlines and Section Titles)
 
 - Capitalize the first and last word, plus all major words: nouns, verbs, adjectives, adverbs, pronouns, and subordinating conjunctions
 - Keep minor words lowercase — articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `but`, `or`, `nor`), and short prepositions (`in`, `on`, `at`, `to`, `of`, `for`, `with`, `as`) — unless they're the first or last word
-- Examples: "Log Sources", "Waiting for First Messages" (`for` stays lowercase because it's a short preposition, not the first or last word)
+- Examples: "Log Sources", "Waiting for First Messages"
 
 ### Sentence Case (Everything Else)
 
-- Buttons, links, body copy, and status or microcopy strings capitalize only the first word (and proper nouns)
+- Buttons, links and body copy capitalize only the first word (and proper nouns)
 - Example: a button reads "Configure sources", not "Configure Sources"
 
 ## Button Labels

--- a/graylog2-web-interface/docs/graylog-luma/stories/Foundation/ContentWriting.mdx
+++ b/graylog2-web-interface/docs/graylog-luma/stories/Foundation/ContentWriting.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Foundation/Content & Writing" />
+
+# Content & Writing
+
+Guidelines for writing clear, consistent copy across Graylog.
+
+## Capitalization
+
+Two casing styles are used, depending on the context: headlines and section titles use title case, everything else — buttons, links, body copy, and status or microcopy — stays in sentence case.
+
+### Title Case (Headlines and Section Titles)
+
+- Capitalize the first and last word, plus all major words: nouns, verbs, adjectives, adverbs, pronouns, and subordinating conjunctions
+- Keep minor words lowercase — articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `but`, `or`, `nor`), and short prepositions (`in`, `on`, `at`, `to`, `of`, `for`, `with`, `as`) — unless they're the first or last word
+- Examples: "Log Sources", "Waiting for First Messages" (`for` stays lowercase because it's a short preposition, not the first or last word)
+
+### Sentence Case (Everything Else)
+
+- Buttons, links, body copy, and status or microcopy strings capitalize only the first word (and proper nouns)
+- Example: a button reads "Configure sources", not "Configure Sources"
+
+## Button Labels
+
+Label a button with the action it performs, not a generic confirmation.
+
+- Name the action and, when useful, the object it acts on — e.g. "Create stream", "Delete input", "Save changes" instead of "Confirm", "OK", or "Submit"
+- Users encounter buttons out of context: scanning a page, tabbing through with a keyboard, or navigating with a screen reader that reads controls in isolation. A generic label forces them to backtrack to the surrounding text to know what will happen; a specific one doesn't
+- This matters most for destructive or hard-to-reverse actions, where a vague label increases the chance of a costly mistake


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a `Content & Wording` page to the design system, mainly to document which casing to use for headlines.
We are also extending the `AGENTS.md` and the `CONTRIBUTING.md` with a reference to the design system.

/nocl - extends documentation
