### PR TITLE
Prevent privilege escalation when assigning roles via `/authz/roles` (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-27154.toml
+++ b/changelog/unreleased/pr-27154.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Prevent users from assigning a role granting permissions they do not hold themselves through the role assignment endpoint."
+
+pulls = ["27154"]

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -57,6 +57,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.users.PaginatedUserService;
+import org.graylog2.users.PrivilegeEscalationGuard;
 import org.graylog2.users.UserOverviewDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,14 +99,17 @@ public class AuthzRolesResource extends RestResource {
     private final SearchQueryParser searchQueryParser;
     private final SearchQueryParser userSearchQueryParser;
     private final AuditEventSender auditEventSender;
+    private final PrivilegeEscalationGuard privilegeEscalationGuard;
 
     @Inject
     public AuthzRolesResource(
             PaginatedAuthzRolesService authzRolesService,
             PaginatedUserService paginatedUserService,
             UserService userService,
-            AuditEventSender auditEventSender) {
+            AuditEventSender auditEventSender,
+            PrivilegeEscalationGuard privilegeEscalationGuard) {
         this.auditEventSender = auditEventSender;
+        this.privilegeEscalationGuard = privilegeEscalationGuard;
         this.authzRolesService = authzRolesService;
         this.paginatedUserService = paginatedUserService;
         this.userService = userService;
@@ -240,7 +244,7 @@ public class AuthzRolesResource extends RestResource {
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
             @ApiParam(name = "usernames") Set<String> usernames,
             @Context UserContext userContext) {
-        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_UPDATE, roleId, usernames, Set::add);
+        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_UPDATE, roleId, usernames, Set::add, true);
     }
 
     @DELETE
@@ -251,14 +255,22 @@ public class AuthzRolesResource extends RestResource {
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
             @ApiParam(name = "username") @PathParam("username") @NotBlank String username,
             @Context UserContext userContext) {
-        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_DELETE, roleId, ImmutableSet.of(username), Set::remove);
+        updateUserRole(userContext, AuditEventTypes.ROLE_AUTHZ_DELETE, roleId, ImmutableSet.of(username), Set::remove, false);
     }
 
     interface UpdateRoles {
         boolean update(Set<String> roles, String roleId);
     }
 
-    private void updateUserRole(UserContext userContext, String auditEventType, String roleId, Set<String> usernames, UpdateRoles rolesUpdater) {
+    /**
+     * @param guardPrivilegeEscalation whether the caller must hold every permission the role grants. Required
+     *                                 when assigning a role, since {@code roles:assign} on a role would
+     *                                 otherwise be enough to hand out permissions the caller does not have.
+     *                                 Un-assigning reduces privileges, so it stays unguarded - otherwise an
+     *                                 over-privileged user could never be demoted by a less privileged admin.
+     */
+    private void updateUserRole(UserContext userContext, String auditEventType, String roleId, Set<String> usernames,
+                                UpdateRoles rolesUpdater, boolean guardPrivilegeEscalation) {
         usernames.forEach(username -> {
             checkPermission(USERS_ROLESEDIT, username);
 
@@ -273,6 +285,9 @@ public class AuthzRolesResource extends RestResource {
             } else {
                 roleName = authzRoleDTO.get().name();
                 checkPermission(RestPermissions.ROLES_ASSIGN, roleName);
+                if (guardPrivilegeEscalation) {
+                    privilegeEscalationGuard.validatePermissions(authzRoleDTO.get().permissions(), userContext);
+                }
             }
             Set<String> roles = user.getRoleIds();
             rolesUpdater.update(roles, roleId);

--- a/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security.authzroles;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import org.bson.types.ObjectId;
 import org.graylog.security.UserContext;
@@ -23,23 +24,30 @@ import org.graylog2.audit.AuditEventSender;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.search.SearchQueryParser;
+import org.graylog2.security.SecurityTestUtils;
 import org.graylog2.security.WithAuthorization;
 import org.graylog2.security.WithAuthorizationExtension;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.users.PaginatedUserService;
+import org.graylog2.users.PrivilegeEscalationGuard;
+import org.graylog2.users.RoleService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,9 +66,18 @@ class AuthzRolesResourceTest {
     private SearchQueryParser userSearchQueryParser;
     @Mock
     AuditEventSender auditEventSender;
+    @Mock
+    private RoleService roleService;
 
-    @InjectMocks
     private AuthzRolesResource classUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        // A real PrivilegeEscalationGuard is used on purpose: these tests are about the permission semantics
+        // the resource enforces. `validatePermissions` never touches the RoleService.
+        classUnderTest = new AuthzRolesResource(authzolesService, paginatedUserService, userService,
+                auditEventSender, new PrivilegeEscalationGuard(roleService));
+    }
 
     @Test
     @WithAuthorization(permissions = "roles:read:reader")
@@ -133,5 +150,82 @@ class AuthzRolesResourceTest {
         when(userService.load(eq("johnny"))).thenReturn(user);
 
         assertThrows(ForbiddenException.class, () -> classUnderTest.addUser(idHexString, Set.of("johnny"), mock(UserContext.class)));
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // A role granting more than the caller holds may not be assigned, even with `roles:assign` on it.
+    // ----------------------------------------------------------------------------------------------------
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:assign:admin", "streams:read"})
+    void addingUserToRoleSucceedsWhenCurrentUserHoldsAllPermissionsGrantedByTheRole() {
+        final String roleId = new ObjectId().toHexString();
+        final AuthzRoleDTO adminRole = mock(AuthzRoleDTO.class);
+        when(adminRole.name()).thenReturn("admin");
+        when(adminRole.permissions()).thenReturn(Set.of("streams:read"));
+        when(authzolesService.get(eq(roleId))).thenReturn(Optional.of(adminRole));
+
+        final User user = mock(User.class);
+        when(userService.load(eq("johnny"))).thenReturn(user);
+
+        classUnderTest.addUser(roleId, Set.of("johnny"), SecurityTestUtils.getUserContext());
+
+        verify(user).setRoleIds(eq(Set.of(roleId)));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:assign:admin"})
+    void addingUserToRoleFailsWhenRoleGrantsAPermissionCurrentUserLacks() throws ValidationException {
+        // Holding `roles:assign` on the admin role is not enough to make somebody an admin.
+        final String roleId = new ObjectId().toHexString();
+        final AuthzRoleDTO adminRole = mock(AuthzRoleDTO.class);
+        when(adminRole.name()).thenReturn("admin");
+        when(adminRole.permissions()).thenReturn(Set.of("*"));
+        when(authzolesService.get(eq(roleId))).thenReturn(Optional.of(adminRole));
+
+        final User user = mock(User.class);
+        when(userService.load(eq("johnny"))).thenReturn(user);
+
+        assertThatThrownBy(() -> classUnderTest.addUser(roleId, Set.of("johnny"), SecurityTestUtils.getUserContext()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("*");
+
+        verify(user, never()).setRoleIds(any());
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:assign:admin", "streams:*"})
+    void addingUserToRoleFailsOnASinglePermissionTheCurrentUserLacks() {
+        final String roleId = new ObjectId().toHexString();
+        final AuthzRoleDTO adminRole = mock(AuthzRoleDTO.class);
+        when(adminRole.name()).thenReturn("admin");
+        when(adminRole.permissions()).thenReturn(Set.of("streams:read", "inputs:create"));
+        when(authzolesService.get(eq(roleId))).thenReturn(Optional.of(adminRole));
+
+        final User user = mock(User.class);
+        when(userService.load(eq("johnny"))).thenReturn(user);
+
+        assertThatThrownBy(() -> classUnderTest.addUser(roleId, Set.of("johnny"), SecurityTestUtils.getUserContext()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("inputs:create")
+                .hasMessageNotContaining("streams:read");
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:assign:admin"})
+    void removingUserFromRoleDoesNotRequireThePermissionsGrantedByTheRole() {
+        // Un-assigning a role reduces privileges, so it must not be gated on holding the role's permissions -
+        // otherwise an over-privileged user could never be demoted by a less privileged administrator.
+        final String roleId = new ObjectId().toHexString();
+        final AuthzRoleDTO adminRole = mock(AuthzRoleDTO.class);
+        when(adminRole.name()).thenReturn("admin");
+        when(authzolesService.get(eq(roleId))).thenReturn(Optional.of(adminRole));
+
+        final User user = mock(User.class);
+        when(userService.load(eq("johnny"))).thenReturn(user);
+
+        assertThatCode(() -> classUnderTest.removeUser(roleId, "johnny", SecurityTestUtils.getUserContext()))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
**Note:** This is a backport of #27154 to `7.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`PUT /authz/roles/{roleId}/assignees` assigned a role to a user without checking that the caller holds the permissions that role grants. Holding `users:rolesedit` on the target user plus `roles:assign` on the role was enough to grant permissions the caller does not have themselves - for example adding somebody (or oneself) to a role carrying `*`.

`RolesResource` and `UsersResource` already run requested permissions through `PrivilegeEscalationGuard`; this closes the equivalent gap on the remaining role-assignment endpoint.

Un-assigning stays unguarded: removing a role reduces privileges, and gating it would stop a less privileged administrator from demoting an over-privileged user. Since `addUser` and `removeUser` share `updateUserRole`, the check is switched by an explicit parameter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.