### PR TITLE
Prevent privilege escalation when assigning roles via `/authz/roles` (`6.3`)

### DIFF
--- a/changelog/unreleased/pr-27154.toml
+++ b/changelog/unreleased/pr-27154.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Prevent users from assigning a role granting permissions they do not hold themselves through the role assignment endpoint."
+
+pulls = ["27154"]

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -36,9 +36,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog.security.UserContext;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.PaginatedList;
@@ -53,6 +55,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.users.PaginatedUserService;
+import org.graylog2.users.PrivilegeEscalationGuard;
 import org.graylog2.users.UserOverviewDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,9 +95,12 @@ public class AuthzRolesResource extends RestResource {
     private final UserService userService;
     private final SearchQueryParser searchQueryParser;
     private final SearchQueryParser userSearchQueryParser;
+    private final PrivilegeEscalationGuard privilegeEscalationGuard;
 
     @Inject
-    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService, PaginatedUserService paginatedUserService, UserService userService) {
+    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService, PaginatedUserService paginatedUserService, UserService userService,
+                              PrivilegeEscalationGuard privilegeEscalationGuard) {
+        this.privilegeEscalationGuard = privilegeEscalationGuard;
         this.authzRolesService = authzRolesService;
         this.paginatedUserService = paginatedUserService;
         this.userService = userService;
@@ -223,8 +229,9 @@ public class AuthzRolesResource extends RestResource {
     @Path("{roleId}/assignees")
     public void addUser(
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
-            @ApiParam(name = "usernames") Set<String> usernames) throws ValidationException {
-        updateUserRole(roleId, usernames, Set::add);
+            @ApiParam(name = "usernames") Set<String> usernames,
+            @Context UserContext userContext) throws ValidationException {
+        updateUserRole(roleId, usernames, Set::add, userContext, true);
     }
 
     @DELETE
@@ -233,15 +240,24 @@ public class AuthzRolesResource extends RestResource {
     @AuditEvent(type = AuditEventTypes.ROLE_MEMBERSHIP_DELETE)
     public void removeUser(
             @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
-            @ApiParam(name = "username") @PathParam("username") @NotBlank String username) throws ValidationException {
-        updateUserRole(roleId, ImmutableSet.of(username), Set::remove);
+            @ApiParam(name = "username") @PathParam("username") @NotBlank String username,
+            @Context UserContext userContext) throws ValidationException {
+        updateUserRole(roleId, ImmutableSet.of(username), Set::remove, userContext, false);
     }
 
     interface UpdateRoles {
         boolean update(Set<String> roles, String roleId);
     }
 
-    private void updateUserRole(String roleId, Set<String> usernames, UpdateRoles rolesUpdater) {
+    /**
+     * @param guardPrivilegeEscalation whether the caller must hold every permission the role grants. Required
+     *                                 when assigning a role, since `roles:edit` on a role would otherwise be
+     *                                 enough to hand out permissions the caller does not have. Un-assigning
+     *                                 reduces privileges, so it stays unguarded - otherwise an over-privileged
+     *                                 user could never be demoted by a less privileged administrator.
+     */
+    private void updateUserRole(String roleId, Set<String> usernames, UpdateRoles rolesUpdater,
+                                UserContext userContext, boolean guardPrivilegeEscalation) {
         usernames.forEach(username -> {
             checkPermission(USERS_ROLESEDIT, username);
 
@@ -252,6 +268,9 @@ public class AuthzRolesResource extends RestResource {
             authzRolesService.get(roleId)
                     .ifPresentOrElse(role -> {
                         checkPermission(RestPermissions.ROLES_EDIT, role.name());
+                        if (guardPrivilegeEscalation) {
+                            privilegeEscalationGuard.validatePermissions(role.permissions(), userContext);
+                        }
                     }, () -> {
                         throw new NotFoundException("Cannot find role with id: " + roleId);
                     });

--- a/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/authzroles/AuthzRolesResourceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.security.authzroles;
+
+import jakarta.ws.rs.BadRequestException;
+import org.bson.types.ObjectId;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.security.SecurityTestUtils;
+import org.graylog2.security.WithAuthorization;
+import org.graylog2.security.WithAuthorizationExtension;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.PaginatedUserService;
+import org.graylog2.users.PrivilegeEscalationGuard;
+import org.graylog2.users.RoleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(WithAuthorizationExtension.class)
+class AuthzRolesResourceTest {
+
+    // On this branch the membership endpoints are gated on `roles:edit` - the separate `roles:assign`
+    // permission is a later change that is not part of this security fix.
+    private static final String TARGET_USER = "johnny";
+
+    @Mock
+    private PaginatedAuthzRolesService authzRolesService;
+    @Mock
+    private PaginatedUserService paginatedUserService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private RoleService roleService;
+
+    private AuthzRolesResource classUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        // A real PrivilegeEscalationGuard is used on purpose: these tests are about the permission semantics
+        // the resource enforces. `validatePermissions` never touches the RoleService.
+        classUnderTest = new AuthzRolesResource(authzRolesService, paginatedUserService, userService,
+                new PrivilegeEscalationGuard(roleService));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:edit:admin", "streams:read"})
+    void addingUserToRoleSucceedsWhenCurrentUserHoldsAllPermissionsGrantedByTheRole() throws Exception {
+        final String roleId = givenRole("admin", Set.of("streams:read"));
+        final User user = givenTargetUser();
+
+        classUnderTest.addUser(roleId, Set.of(TARGET_USER), SecurityTestUtils.getUserContext(userService));
+
+        verify(user).setRoleIds(eq(Set.of(roleId)));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:edit:admin"})
+    void addingUserToRoleFailsWhenRoleGrantsAPermissionCurrentUserLacks() throws Exception {
+        // Holding `roles:edit` on the admin role is not enough to make somebody an admin.
+        final String roleId = givenRole("admin", Set.of("*"));
+        final User user = givenTargetUser();
+
+        assertThatThrownBy(() -> classUnderTest.addUser(
+                roleId, Set.of(TARGET_USER), SecurityTestUtils.getUserContext(userService)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("*");
+
+        verify(user, never()).setRoleIds(any());
+        verify(userService, never()).save(any(User.class));
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:edit:admin", "streams:*"})
+    void addingUserToRoleFailsOnASinglePermissionTheCurrentUserLacks() throws Exception {
+        final String roleId = givenRole("admin", Set.of("streams:read", "inputs:create"));
+        givenTargetUser();
+
+        assertThatThrownBy(() -> classUnderTest.addUser(
+                roleId, Set.of(TARGET_USER), SecurityTestUtils.getUserContext(userService)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("inputs:create")
+                .hasMessageNotContaining("streams:read");
+    }
+
+    @Test
+    @WithAuthorization(permissions = {"users:rolesedit:johnny", "roles:edit:admin"})
+    void removingUserFromRoleDoesNotRequireThePermissionsGrantedByTheRole() throws Exception {
+        // Un-assigning a role reduces privileges, so it must not be gated on holding the role's permissions -
+        // otherwise an over-privileged user could never be demoted by a less privileged administrator.
+        final String roleId = givenRole("admin", null);
+        givenTargetUser();
+
+        assertThatCode(() -> classUnderTest.removeUser(
+                roleId, TARGET_USER, SecurityTestUtils.getUserContext(userService)))
+                .doesNotThrowAnyException();
+    }
+
+    private String givenRole(String name, Set<String> permissions) {
+        final String roleId = new ObjectId().toHexString();
+        final AuthzRoleDTO role = mock(AuthzRoleDTO.class);
+        when(role.name()).thenReturn(name);
+        if (permissions != null) {
+            when(role.permissions()).thenReturn(permissions);
+        }
+        when(authzRolesService.get(eq(roleId))).thenReturn(Optional.of(role));
+        return roleId;
+    }
+
+    private User givenTargetUser() {
+        final User user = mock(User.class);
+        when(userService.load(eq(TARGET_USER))).thenReturn(user);
+        return user;
+    }
+}


### PR DESCRIPTION
**Note:** This is a backport of #27154 to `6.3`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`PUT /authz/roles/{roleId}/assignees` assigned a role to a user without checking that the caller holds the permissions that role grants. Holding `users:rolesedit` on the target user plus `roles:assign` on the role was enough to grant permissions the caller does not have themselves - for example adding somebody (or oneself) to a role carrying `*`.

`RolesResource` and `UsersResource` already run requested permissions through `PrivilegeEscalationGuard`; this closes the equivalent gap on the remaining role-assignment endpoint.

Un-assigning stays unguarded: removing a role reduces privileges, and gating it would stop a less privileged administrator from demoting an over-privileged user. Since `addUser` and `removeUser` share `updateUserRole`, the check is switched by an explicit parameter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.