### PR TITLE
Recalculate size of number in number widget when number changes.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.tsx
@@ -87,7 +87,7 @@ const _multiplierForElement = (element, targetWidth, targetHeight) => {
 
 const isValidFontSize = (fontSize) => fontSize !== 0 && Number.isFinite(fontSize);
 
-const useAutoFontSize = (target, _container, height, width) => {
+const useAutoFontSize = (target, _container, height, width, children) => {
   const [fontSize, setFontSize] = useState(20);
 
   useLayoutEffect(() => {
@@ -120,14 +120,14 @@ const useAutoFontSize = (target, _container, height, width) => {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setFontSize(newFontSize);
     }
-  }, [target, _container, fontSize, height, width]);
+  }, [target, _container, fontSize, height, width, children]);
 
   return fontSize;
 };
 
 const AutoFontSizer = ({ children, target = null, height, width, alignment = undefined }: Props) => {
   const _container = useRef<HTMLElement | undefined>();
-  const fontSize = useAutoFontSize(target, _container, height, width);
+  const fontSize = useAutoFontSize(target, _container, height, width, children);
   const _mixedContainer: { current } = _container;
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently we adjusted the `CHILD_SIZE_RATIO` in the `AutoFontSizer`, which required changing the number font size calculation. These changes introduced a regression. 

When the number of the single number widget changed, due to a new search, it did not recalculate its size. If the number changed from e.g. 100 to 10.000, there was a chance that the new number will be cut off.

This PR fixes the issue by recalculating the number size when the number changes.

Before:
<img width="616" height="427" alt="single number widget issue before" src="https://github.com/user-attachments/assets/060da4db-b797-42bd-a108-bfb9a7f74834" />


After:
<img width="616" height="427" alt="single number widget issue after" src="https://github.com/user-attachments/assets/1c7f2c70-8baf-47b9-b36b-fc0850059bf4" />



/nocl - fixes unreleased regression
