### PR TITLE
Remove input create request logging (7.0)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -152,8 +152,7 @@ public class AWSService {
             final MessageInput messageInput = messageInputFactory.create(inputCreateRequest, user.getName(), nodeId.getNodeId(), isSetupWizard);
             messageInput.checkConfiguration();
             final Input input = this.inputService.create(messageInput.asMap());
-            final String newInputId = inputService.save(input);
-            LOG.debug("New AWS input created. id [{}] request [{}]", newInputId, request);
+            inputService.save(input);
             return input;
         } catch (NoSuchInputTypeException e) {
             LOG.error("There is no such input type registered.", e);


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/26788 to `7.0`.

/nocl logging change

/prd https://github.com/Graylog2/graylog-plugin-enterprise/pull/15390

Manually merged areas:
- `CloudTrailDriver` does not exist on 7.0, so that half of the change was dropped.
- `AWSService` conflicted because 7.0 returns the created input directly, while master re-reads it with `inputService.find(newInputId)`. I kept the 7.0 return as-is and only removed the log line. The saved-ID local was used solely by that log, so it collapsed into a plain `inputService.save(input)`.

The end result is the same as the master PR: no input create request is logged anywhere.
