### PR TITLE
Pass pivot field names as script params in scripted terms aggregations (`7.0`)

### DIFF
--- a/changelog/unreleased/pr-27211.toml
+++ b/changelog/unreleased/pr-27211.toml
@@ -1,0 +1,4 @@
+type = "s"
+message = "Fix Painless script injection via pivot field names in aggregations."
+
+pulls = ["27211"]

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandler.java
@@ -16,11 +16,10 @@
  */
 package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.aggregations.MissingBucketConstants;
+import org.graylog.plugins.views.search.aggregations.PivotKeyScript;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotSort;
@@ -30,6 +29,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.buckets.ValuesBucketOr
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.script.Script;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.script.ScriptType;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.Aggregation;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -48,7 +48,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
@@ -95,16 +94,8 @@ public class ESValuesHandler extends ESPivotBucketSpecHandler<Values> {
     }
 
     private Script scriptForPivots(Collection<String> pivots) {
-        final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
-                .map(bucket -> """
-                        (doc.containsKey('%1$s') && doc['%1$s'].size() > 0
-                        ? doc['%1$s'].size() > 1
-                            ? doc['%1$s']
-                            : String.valueOf(doc['%1$s'].value)
-                        : "%2$s")
-                        """.formatted(bucket, MissingBucketConstants.MISSING_BUCKET_NAME))
-                .collect(Collectors.toList()));
-        return new Script(scriptSource);
+        final PivotKeyScript script = PivotKeyScript.create(pivots, KEY_SEPARATOR_PHRASE);
+        return new Script(ScriptType.INLINE, "painless", script.source(), script.params());
     }
 
     private TermsAggregationBuilder applyOrdering(Pivot pivot, TermsAggregationBuilder terms, List<BucketOrder> ordering, ESGeneratedQueryContext queryContext) {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandlerTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESValuesHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.script.Script;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.graylog.storage.elasticsearch7.views.ESGeneratedQueryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ESValuesHandlerTest {
+    private ESValuesHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new ESValuesHandler();
+    }
+
+    private Script scriptForFields(final List<String> fields) {
+        final Values bucketSpec = Values.builder().fields(fields).limit(10).build();
+        final Pivot pivot = mock(Pivot.class);
+        when(pivot.sort()).thenReturn(List.of());
+
+        final BucketSpecHandler.CreatedAggregations<AggregationBuilder> aggregations = handler.doCreateAggregation(
+                BucketSpecHandler.Direction.Row, "agg-name", pivot, bucketSpec,
+                mock(ESGeneratedQueryContext.class), mock(Query.class));
+
+        assertThat(aggregations.leaf()).isInstanceOf(TermsAggregationBuilder.class);
+        return ((TermsAggregationBuilder) aggregations.leaf()).script();
+    }
+
+    @Test
+    void passesFieldNamesAsScriptParameters() {
+        final Script script = scriptForFields(List.of("source", "http.response.status_code"));
+
+        assertThat(script.getIdOrCode())
+                .doesNotContain("source")
+                .doesNotContain("http.response.status_code");
+        assertThat(script.getParams())
+                .containsEntry("field0", "source")
+                .containsEntry("field1", "http.response.status_code");
+    }
+
+    @Test
+    void generatesTheSameScriptSourceRegardlessOfTheFieldNames() {
+        assertThat(scriptForFields(List.of("source")).getIdOrCode())
+                .isEqualTo(scriptForFields(List.of("gl2_source_input")).getIdOrCode());
+    }
+}

--- a/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
+++ b/graylog-storage-opensearch2/src/main/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandler.java
@@ -16,11 +16,10 @@
  */
 package org.graylog.storage.opensearch2.views.searchtypes.pivot.buckets;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.aggregations.MissingBucketConstants;
+import org.graylog.plugins.views.search.aggregations.PivotKeyScript;
 import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
@@ -28,6 +27,7 @@ import org.graylog.plugins.views.search.searchtypes.pivot.buckets.ValuesBucketOr
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.BoolQueryBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.index.query.QueryBuilders;
 import org.graylog.shaded.opensearch2.org.opensearch.script.Script;
+import org.graylog.shaded.opensearch2.org.opensearch.script.ScriptType;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.Aggregation;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
 import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilders;
@@ -45,7 +45,6 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class OSValuesHandler extends OSPivotBucketSpecHandler<Values> {
@@ -91,16 +90,8 @@ public class OSValuesHandler extends OSPivotBucketSpecHandler<Values> {
     }
 
     private Script scriptForPivots(Collection<String> pivots) {
-        final String scriptSource = Joiner.on(KEY_SEPARATOR_PHRASE).join(pivots.stream()
-                .map(bucket -> """
-                        (doc.containsKey('%1$s') && doc['%1$s'].size() > 0
-                        ? doc['%1$s'].size() > 1
-                            ? doc['%1$s']
-                            : String.valueOf(doc['%1$s'].value)
-                        : "%2$s")
-                        """.formatted(bucket, MissingBucketConstants.MISSING_BUCKET_NAME))
-                .collect(Collectors.toList()));
-        return new Script(scriptSource);
+        final PivotKeyScript script = PivotKeyScript.create(pivots, KEY_SEPARATOR_PHRASE);
+        return new Script(ScriptType.INLINE, "painless", script.source(), script.params());
     }
 
     @Override

--- a/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandlerTest.java
+++ b/graylog-storage-opensearch2/src/test/java/org/graylog/storage/opensearch2/views/searchtypes/pivot/buckets/OSValuesHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.storage.opensearch2.views.searchtypes.pivot.buckets;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpecHandler;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.buckets.Values;
+import org.graylog.shaded.opensearch2.org.opensearch.script.Script;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.AggregationBuilder;
+import org.graylog.shaded.opensearch2.org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.graylog.storage.opensearch2.views.OSGeneratedQueryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OSValuesHandlerTest {
+    private OSValuesHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new OSValuesHandler();
+    }
+
+    private Script scriptForFields(final List<String> fields) {
+        final Values bucketSpec = Values.builder().fields(fields).limit(10).build();
+        final Pivot pivot = mock(Pivot.class);
+        when(pivot.sort()).thenReturn(List.of());
+
+        final BucketSpecHandler.CreatedAggregations<AggregationBuilder> aggregations = handler.doCreateAggregation(
+                BucketSpecHandler.Direction.Row, "agg-name", pivot, bucketSpec,
+                mock(OSGeneratedQueryContext.class), mock(Query.class));
+
+        assertThat(aggregations.leaf()).isInstanceOf(TermsAggregationBuilder.class);
+        return ((TermsAggregationBuilder) aggregations.leaf()).script();
+    }
+
+    @Test
+    void passesFieldNamesAsScriptParameters() {
+        final Script script = scriptForFields(List.of("source", "http.response.status_code"));
+
+        assertThat(script.getIdOrCode())
+                .doesNotContain("source")
+                .doesNotContain("http.response.status_code");
+        assertThat(script.getParams())
+                .containsEntry("field0", "source")
+                .containsEntry("field1", "http.response.status_code");
+    }
+
+    @Test
+    void generatesTheSameScriptSourceRegardlessOfTheFieldNames() {
+        assertThat(scriptForFields(List.of("source")).getIdOrCode())
+                .isEqualTo(scriptForFields(List.of("gl2_source_input")).getIdOrCode());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/PivotKeyScript.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/aggregations/PivotKeyScript.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.aggregations;
+
+import com.google.common.base.Joiner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Painless script which concatenates the values of the given fields into a single composite bucket key, used by the
+ * scripted terms aggregations of the search backends.
+ * <p>
+ * Field names are never interpolated into the script source: they are passed as script parameters instead. Besides
+ * making field names harmless, this keeps the script source identical for all pivots with the same number of fields,
+ * which avoids a script compilation per field combination.
+ */
+public record PivotKeyScript(String source, Map<String, Object> params) {
+    private static final String FIELD_PARAM_PREFIX = "field";
+    private static final String MISSING_VALUE_PARAM = "missingValue";
+
+    private static final String FIELD_EXPRESSION = """
+            (doc.containsKey(params.%1$s) && doc[params.%1$s].size() > 0
+            ? doc[params.%1$s].size() > 1
+                ? doc[params.%1$s]
+                : String.valueOf(doc[params.%1$s].value)
+            : params.%2$s)
+            """;
+
+    /**
+     * @param fields             the fields whose values make up the composite bucket key
+     * @param keySeparatorPhrase the script expression joining two field values, including the key separator
+     */
+    public static PivotKeyScript create(final Collection<String> fields, final String keySeparatorPhrase) {
+        final Map<String, Object> params = new LinkedHashMap<>();
+        final List<String> expressions = new ArrayList<>(fields.size());
+        for (final String field : fields) {
+            final String fieldParam = FIELD_PARAM_PREFIX + expressions.size();
+            params.put(fieldParam, field);
+            expressions.add(FIELD_EXPRESSION.formatted(fieldParam, MISSING_VALUE_PARAM));
+        }
+        params.put(MISSING_VALUE_PARAM, MissingBucketConstants.MISSING_BUCKET_NAME);
+
+        return new PivotKeyScript(Joiner.on(keySeparatorPhrase).join(expressions), Map.copyOf(params));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/aggregations/PivotKeyScriptTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/aggregations/PivotKeyScriptTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.aggregations;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PivotKeyScriptTest {
+    private static final String KEY_SEPARATOR_PHRASE = " + \"\u2E31\" + ";
+
+    @Test
+    void passesFieldNamesAsParametersInsteadOfInterpolatingThemIntoTheSource() {
+        final PivotKeyScript script = PivotKeyScript.create(List.of("source", "http.response.status_code"),
+                KEY_SEPARATOR_PHRASE);
+
+        assertThat(script.source())
+                .doesNotContain("source")
+                .doesNotContain("http.response.status_code")
+                .contains("doc[params.field0]")
+                .contains("doc[params.field1]")
+                .contains("params.missingValue");
+
+        assertThat(script.params()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "field0", "source",
+                "field1", "http.response.status_code",
+                "missingValue", MissingBucketConstants.MISSING_BUCKET_NAME));
+    }
+
+    @Test
+    void joinsFieldExpressionsWithTheKeySeparatorPhrase() {
+        assertThat(PivotKeyScript.create(List.of("a"), KEY_SEPARATOR_PHRASE).source())
+                .doesNotContain(KEY_SEPARATOR_PHRASE);
+        assertThat(PivotKeyScript.create(List.of("a", "b"), KEY_SEPARATOR_PHRASE).source())
+                .containsOnlyOnce(KEY_SEPARATOR_PHRASE);
+        assertThat(PivotKeyScript.create(List.of("a", "b", "c"), KEY_SEPARATOR_PHRASE).source())
+                .contains(KEY_SEPARATOR_PHRASE);
+    }
+
+    @Test
+    void generatesIdenticalSourceForDifferentFieldsOfTheSameCardinality() {
+        assertThat(PivotKeyScript.create(List.of("source", "message"), KEY_SEPARATOR_PHRASE).source())
+                .as("the script source must be reusable so that the backend does not compile one script per field combination")
+                .isEqualTo(PivotKeyScript.create(List.of("timestamp", "gl2_source_input"), KEY_SEPARATOR_PHRASE).source());
+    }
+
+    @Test
+    void keepsDuplicateFieldsAsSeparateParameters() {
+        final PivotKeyScript script = PivotKeyScript.create(List.of("source", "source"), KEY_SEPARATOR_PHRASE);
+
+        assertThat(script.params()).containsEntry("field0", "source");
+        assertThat(script.params()).containsEntry("field1", "source");
+    }
+}


### PR DESCRIPTION
**Note:** This is a backport of #27211 to `7.0`.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The scripted terms aggregation used for `values` pivots interpolated user-supplied field names directly into the Painless script source in all three indexer backends (ES7, OS2, OS3). A field name could therefore break out of the surrounding string literal and have arbitrary Painless expressions evaluated per document.

Field names are now passed as script parameters instead of being embedded in the source. The generated expression is otherwise unchanged, so bucket keys, missing-value handling and sorting behave as before.

As a side effect the script source no longer varies with the field names, so the backend compiles one script per field count instead of one per field combination, which relieves the dynamic script compilation limit.

Fixes Graylog2/graylog-plugin-enterprise#15388.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.