### PR TITLE
Enable `onboarding_experience` feature flag by default.

### DIFF
--- a/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
+++ b/graylog2-server/src/main/resources/org/graylog2/featureflag/feature-flag.config
@@ -121,6 +121,9 @@ collector_otlp_traffic_dump=off
 # Enable the new Collectors
 collectors=on
 
+# Enable new onboarding welcome page
+onboarding_experience=on
+
 # Use new sidebar for investigations instead of legacy drawer
 investigation_right_sidebar=on
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR enables the `onboarding_experience` feature flag to show the new onboarding welcome page.

/nocl - part of other PRs