### PR TITLE
Encrypt MessageOutput configuration fields marked isEncrypted (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-26626.toml
+++ b/changelog/unreleased/issue-26626.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Encrypt `MessageOutput` configuration fields marked with `isEncrypted=true` before persisting them, instead of storing the secret in plain text."
+
+issues = ["26626"]
+pulls = ["27104"]

--- a/graylog2-server/src/main/java/org/graylog2/inputs/encryption/EncryptedInputConfigs.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/encryption/EncryptedInputConfigs.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.inputs.encryption;
 
+import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.security.encryption.EncryptedValue;
@@ -57,8 +58,14 @@ public class EncryptedInputConfigs {
      * Returns the names of those fields in an input configuration that are expected to hold {@link EncryptedValue}s.
      */
     public static Set<String> getEncryptedFields(@Nonnull MessageInput.Config messageInputConfig) {
-        return messageInputConfig.combinedRequestedConfiguration()
-                .getFields()
+        return getEncryptedFields(messageInputConfig.combinedRequestedConfiguration());
+    }
+
+    /**
+     * Returns the names of those fields in a configuration request that are expected to hold {@link EncryptedValue}s.
+     */
+    public static Set<String> getEncryptedFields(@Nonnull ConfigurationRequest configurationRequest) {
+        return configurationRequest.getFields()
                 .values()
                 .stream()
                 .filter(ConfigurationField::isEncrypted)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.outputs;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -41,13 +42,16 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.inputs.encryption.EncryptedInputConfigs;
 import org.graylog2.outputs.MessageOutputFactory;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.rest.models.streams.outputs.OutputListResponse;
 import org.graylog2.rest.models.streams.outputs.requests.CreateOutputRequest;
 import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 import org.graylog2.rest.resources.streams.outputs.AvailableOutputSummary;
+import org.graylog2.security.encryption.EncryptedValue;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.OutputService;
@@ -66,12 +70,15 @@ import java.util.Set;
 public class OutputResource extends RestResource {
     private final OutputService outputService;
     private final MessageOutputFactory messageOutputFactory;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public OutputResource(OutputService outputService,
-                          MessageOutputFactory messageOutputFactory) {
+                          MessageOutputFactory messageOutputFactory,
+                          ObjectMapper objectMapper) {
         this.outputService = outputService;
         this.messageOutputFactory = messageOutputFactory;
+        this.objectMapper = objectMapper;
     }
 
     @GET
@@ -135,7 +142,7 @@ public class OutputResource extends RestResource {
         final CreateOutputRequest createOutputRequest = CreateOutputRequest.create(
                 csor.title(),
                 csor.type(),
-                ConfigurationMapConverter.convertValues(csor.configuration(), outputSummary.requestedConfiguration()),
+                convertConfiguration(csor.configuration(), outputSummary.requestedConfiguration()),
                 csor.streams()
         );
 
@@ -209,12 +216,44 @@ public class OutputResource extends RestResource {
         if (deltas.containsKey("configuration")) {
             @SuppressWarnings("unchecked")
             final Map<String, Object> configuration = (Map<String, Object>) deltas.get("configuration");
-            // Merge with existing configuration to avoid losing fields not included in the update.
-            final Map<String, Object> mergedConfiguration = new HashMap<>(oldOutput.getConfiguration());
-            mergedConfiguration.putAll(ConfigurationMapConverter.convertValues(configuration, outputSummary.requestedConfiguration()));
+            final Map<String, Object> converted = convertConfiguration(configuration, outputSummary.requestedConfiguration());
+            // Merge with existing configuration to avoid losing fields not included in the update. This also honors the
+            // keep_value/delete_value markers of encrypted fields against the stored EncryptedValue.
+            final Map<String, Object> mergedConfiguration = EncryptedInputConfigs.merge(oldOutput.getConfiguration(), converted);
             deltas.put("configuration", mergedConfiguration);
         }
 
         return this.outputService.update(outputId, deltas);
+    }
+
+    /**
+     * Coerces the raw configuration values to their requested types. Encrypted fields carry a
+     * {@code {set_value=...}}/{@code {keep_value}}/{@code {delete_value}} marker that is converted into an
+     * {@link EncryptedValue} instead of being stringified, so secrets are encrypted before being persisted.
+     */
+    private Map<String, Object> convertConfiguration(Map<String, Object> configuration,
+                                                     ConfigurationRequest requestedConfiguration) throws ValidationException {
+        final Set<String> encryptedFields = EncryptedInputConfigs.getEncryptedFields(requestedConfiguration);
+
+        // Non-encrypted fields go through the regular type coercion.
+        final Map<String, Object> plainFields = new HashMap<>(configuration);
+        encryptedFields.forEach(plainFields::remove);
+        final Map<String, Object> converted = new HashMap<>(
+                ConfigurationMapConverter.convertValues(plainFields, requestedConfiguration));
+
+        for (String field : encryptedFields) {
+            if (configuration.containsKey(field)) {
+                try {
+                    converted.put(field, objectMapper.convertValue(configuration.get(field), EncryptedValue.class));
+                } catch (IllegalArgumentException e) {
+                    // convertValue wraps the mapping failure, which would otherwise surface as a 500. The message is
+                    // intentionally generic because the rejected value can contain the secret.
+                    throw new ValidationException(field,
+                            "Invalid value for encrypted field. Expected one of set_value, keep_value or delete_value.");
+                }
+            }
+        }
+
+        return converted;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.streams;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -32,11 +33,18 @@ import org.graylog2.database.MongoCollections;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.events.ClusterEventBus;
+import org.graylog2.inputs.encryption.EncryptedInputConfigs;
+import org.graylog2.outputs.MessageOutputFactory;
 import org.graylog2.outputs.events.OutputChangedEvent;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.rest.models.streams.outputs.requests.CreateOutputRequest;
+import org.graylog2.rest.resources.streams.outputs.AvailableOutputSummary;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueMapperConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,16 +57,25 @@ import java.util.stream.Collectors;
 import static org.graylog2.database.utils.MongoUtils.idEq;
 
 public class OutputServiceImpl implements OutputService {
+    private static final Logger LOG = LoggerFactory.getLogger(OutputServiceImpl.class);
+
     private final StreamService streamService;
     private final ClusterEventBus clusterEventBus;
+    private final MessageOutputFactory messageOutputFactory;
+    private final ObjectMapper objectMapper;
     private final MongoCollection<OutputImpl> collection;
     private final MongoCollection<Document> rawCollection;
 
     @Inject
     public OutputServiceImpl(MongoCollections mongoCollections,
                              StreamService streamService,
-                             ClusterEventBus clusterEventBus) {
+                             ClusterEventBus clusterEventBus,
+                             MessageOutputFactory messageOutputFactory,
+                             ObjectMapper objectMapper) {
         this.streamService = streamService;
+        this.messageOutputFactory = messageOutputFactory;
+        this.objectMapper = objectMapper.copy();
+        EncryptedValueMapperConfig.enableDatabase(this.objectMapper);
         final String collectionName = OutputImpl.class.getAnnotation(DbEntity.class).collection();
         this.collection = mongoCollections.nonEntityCollection(collectionName, OutputImpl.class);
         this.rawCollection = mongoCollections.nonEntityCollection(collectionName, Document.class);
@@ -67,22 +84,28 @@ public class OutputServiceImpl implements OutputService {
 
     @Override
     public Output load(String streamOutputId) throws NotFoundException {
-        final Output output = collection.find(idEq(streamOutputId)).first();
+        final OutputImpl output = collection.find(idEq(streamOutputId)).first();
         if (output == null) {
             throw new NotFoundException("Couldn't find output with id " + streamOutputId);
         }
 
-        return output;
+        return withEncryptedFields(output);
     }
 
     @Override
     public Set<Output> loadAll() {
-        return ImmutableSet.copyOf(collection.find());
+        final Map<String, AvailableOutputSummary> availableOutputs = messageOutputFactory.getAvailableOutputs();
+        try (final var stream = MongoUtils.stream(collection.find())) {
+            return stream.map(output -> withEncryptedFields(output, availableOutputs)).collect(ImmutableSet.toImmutableSet());
+        }
     }
 
     @Override
     public Set<Output> loadByIds(Collection<String> ids) {
-        return ImmutableSet.copyOf(collection.find(MongoUtils.stringIdsIn(ids)));
+        final Map<String, AvailableOutputSummary> availableOutputs = messageOutputFactory.getAvailableOutputs();
+        try (final var stream = MongoUtils.stream(collection.find(MongoUtils.stringIdsIn(ids)))) {
+            return stream.map(output -> withEncryptedFields(output, availableOutputs)).collect(ImmutableSet.toImmutableSet());
+        }
     }
 
     @Override
@@ -126,7 +149,7 @@ public class OutputServiceImpl implements OutputService {
             this.clusterEventBus.post(OutputChangedEvent.create(updatedOutput.getId()));
         }
 
-        return updatedOutput;
+        return updatedOutput == null ? null : withEncryptedFields(updatedOutput);
     }
 
     @Override
@@ -153,5 +176,53 @@ public class OutputServiceImpl implements OutputService {
         } else {
             throw new IllegalArgumentException("Supplied output must be of implementation type OutputImpl, not " + output.getClass());
         }
+    }
+
+    private Set<String> getEncryptedFields(String type, Map<String, AvailableOutputSummary> availableOutputs) {
+        final AvailableOutputSummary summary = availableOutputs.get(type);
+        if (summary == null) {
+            return Set.of();
+        }
+        return EncryptedInputConfigs.getEncryptedFields(summary.requestedConfiguration());
+    }
+
+    private Output withEncryptedFields(OutputImpl output) {
+        return withEncryptedFields(output, messageOutputFactory.getAvailableOutputs());
+    }
+
+    /**
+     * Converts the raw {@code {encrypted_value, salt}} sub-documents stored in MongoDB back into {@link EncryptedValue}
+     * objects for those configuration fields declared as encrypted. This ensures secrets are masked in API responses
+     * and exposed as {@link EncryptedValue} to running outputs.
+     */
+    private Output withEncryptedFields(OutputImpl output, Map<String, AvailableOutputSummary> availableOutputs) {
+        final Set<String> encryptedFields = getEncryptedFields(output.getType(), availableOutputs);
+        if (encryptedFields.isEmpty()) {
+            return output;
+        }
+        final Map<String, Object> originalConfig = output.getConfiguration();
+        if (originalConfig == null || originalConfig.isEmpty()) {
+            return output;
+        }
+
+        boolean modified = false;
+        final Map<String, Object> newConfig = new HashMap<>(originalConfig);
+        for (String field : encryptedFields) {
+            final Object raw = newConfig.get(field);
+            if (raw != null && !(raw instanceof EncryptedValue)) {
+                try {
+                    newConfig.put(field, objectMapper.convertValue(raw, EncryptedValue.class));
+                    modified = true;
+                } catch (IllegalArgumentException e) {
+                    // Values written before encryption support was added are left untouched. Logged at debug because
+                    // this repeats on every load and the operator can only fix it by re-entering the secret.
+                    LOG.debug("Failed to convert field '{}' to EncryptedValue for output '{}': {}", field, output.getId(), e.getMessage());
+                }
+            }
+        }
+        return modified
+                ? OutputImpl.create(output.getId(), output.getTitle(), output.getType(), output.getCreatorUserId(),
+                newConfig, output.getCreatedAt(), output.getContentPack())
+                : output;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
@@ -37,6 +37,7 @@ import org.graylog2.database.MongoCollections;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.outputs.LoggingOutput;
+import org.graylog2.outputs.MessageOutputFactory;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Output;
@@ -75,6 +76,8 @@ public class OutputFacadeTest {
 
     @Mock
     private StreamService streamService;
+    @Mock
+    private MessageOutputFactory messageOutputFactory;
     private Set<PluginMetaData> pluginMetaData;
     private OutputService outputService;
     private OutputFacade facade;
@@ -86,7 +89,9 @@ public class OutputFacadeTest {
         outputService = new OutputServiceImpl(
                 mongoCollections,
                 streamService,
-                new ClusterEventBus());
+                new ClusterEventBus(),
+                messageOutputFactory,
+                objectMapper);
         pluginMetaData = new HashSet<>();
         outputFactories = new HashMap<>();
         outputFactories2 = new HashMap<>();

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/outputs/OutputResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/outputs/OutputResourceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.resources.system.outputs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.outputs.MessageOutputFactory;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -27,6 +28,9 @@ import org.graylog2.plugin.streams.Output;
 import org.graylog2.rest.resources.streams.outputs.AvailableOutputSummary;
 import org.graylog2.security.WithAuthorization;
 import org.graylog2.security.WithAuthorizationExtension;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.streams.OutputService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,8 +41,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,9 +65,11 @@ class OutputResourceTest {
 
     OutputResource outputResource;
 
+    final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
     @BeforeEach
     void setUp() {
-        outputResource = new OutputResource(outputService, messageOutputFactory);
+        outputResource = new OutputResource(outputService, messageOutputFactory, objectMapper);
     }
 
     @Test
@@ -143,5 +151,80 @@ class OutputResourceTest {
         assertThat(savedConfig)
                 .containsEntry("hostname", "new-host.example.com")
                 .containsEntry("port", 9999);
+    }
+
+    @Test
+    void updateEncryptsSetValueMarkerInsteadOfStoringPlaintext() throws ValidationException, NotFoundException {
+        final String outputId = "output-id-1";
+        final String outputType = "custom.EncryptedOutput";
+
+        when(existingOutput.getType()).thenReturn(outputType);
+        when(existingOutput.getConfiguration()).thenReturn(Map.of());
+        when(outputService.load(outputId)).thenReturn(existingOutput);
+        stubEncryptedOutput(outputType);
+
+        final Map<String, Object> deltas = new HashMap<>();
+        deltas.put("configuration", new HashMap<>(Map.of("password", Map.of("set_value", "mySecretPassword"))));
+
+        outputResource.update(outputId, deltas);
+
+        final Map<String, Object> savedConfig = captureSavedConfiguration(outputId);
+        assertThat(savedConfig.get("password"))
+                .isInstanceOfSatisfying(EncryptedValue.class, ev -> assertThat(ev.isSet()).isTrue());
+        assertThat(savedConfig.get("password").toString()).doesNotContain("mySecretPassword");
+    }
+
+    @Test
+    void updateWithKeepValuePreservesStoredSecret() throws ValidationException, NotFoundException {
+        final String outputId = "output-id-1";
+        final String outputType = "custom.EncryptedOutput";
+
+        final EncryptedValue storedSecret = new EncryptedValueService(UUID.randomUUID().toString()).encrypt("stored");
+        when(existingOutput.getType()).thenReturn(outputType);
+        when(existingOutput.getConfiguration()).thenReturn(Map.of("password", storedSecret));
+        when(outputService.load(outputId)).thenReturn(existingOutput);
+        stubEncryptedOutput(outputType);
+
+        final Map<String, Object> deltas = new HashMap<>();
+        deltas.put("configuration", new HashMap<>(Map.of("password", Map.of("keep_value", true))));
+
+        outputResource.update(outputId, deltas);
+
+        final Map<String, Object> savedConfig = captureSavedConfiguration(outputId);
+        assertThat(savedConfig.get("password")).isEqualTo(storedSecret);
+    }
+
+    @Test
+    void updateRejectsUnreadableEncryptedValueWithValidationException() throws NotFoundException {
+        final String outputId = "output-id-1";
+        final String outputType = "custom.EncryptedOutput";
+
+        when(existingOutput.getType()).thenReturn(outputType);
+        when(outputService.load(outputId)).thenReturn(existingOutput);
+        stubEncryptedOutput(outputType);
+
+        // The API masks secrets as {"is_set": true}, which the deserializer cannot read back.
+        final Map<String, Object> deltas = new HashMap<>();
+        deltas.put("configuration", new HashMap<>(Map.of("password", Map.of("is_set", true))));
+
+        assertThatThrownBy(() -> outputResource.update(outputId, deltas))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    private void stubEncryptedOutput(String outputType) {
+        final ConfigurationRequest configRequest = new ConfigurationRequest();
+        configRequest.addField(new TextField("password", "Password", "", "Secret",
+                ConfigurationField.Optional.OPTIONAL, true));
+        when(messageOutputFactory.getAvailableOutputs()).thenReturn(Map.of(outputType,
+                AvailableOutputSummary.create("Encrypted", outputType, "Encrypted", "", configRequest)));
+    }
+
+    private Map<String, Object> captureSavedConfiguration(String outputId) throws ValidationException, NotFoundException {
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Map<String, Object>> deltasCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(outputService).update(eq(outputId), deltasCaptor.capture());
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> savedConfig = (Map<String, Object>) deltasCaptor.getValue().get("configuration");
+        return savedConfig;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/OutputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/OutputServiceImplTest.java
@@ -17,13 +17,24 @@
 package org.graylog2.streams;
 
 import com.google.common.collect.ImmutableSet;
+import org.bson.Document;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.events.ClusterEventBus;
+import org.graylog2.outputs.MessageOutputFactory;
 import org.graylog2.outputs.events.OutputChangedEvent;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.streams.Output;
+import org.graylog2.rest.models.streams.outputs.requests.CreateOutputRequest;
+import org.graylog2.rest.resources.streams.outputs.AvailableOutputSummary;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,11 +44,15 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(MongoDBExtension.class)
@@ -48,15 +63,29 @@ public class OutputServiceImplTest {
     private StreamService streamService;
     @Mock
     private ClusterEventBus clusterEventBus;
+    @Mock
+    private MessageOutputFactory messageOutputFactory;
 
     private OutputServiceImpl outputService;
+    private MongoCollections mongoCollections;
 
     @BeforeEach
     public void setUp(MongoCollections mongoCollections) throws Exception {
+        this.mongoCollections = mongoCollections;
         outputService = new OutputServiceImpl(
                 mongoCollections,
                 streamService,
-                clusterEventBus);
+                clusterEventBus,
+                messageOutputFactory,
+                new ObjectMapperProvider().get());
+    }
+
+    private void stubEncryptedPasswordField(String outputType) {
+        final ConfigurationRequest request = new ConfigurationRequest();
+        request.addField(new TextField("password", "Password", "", "Secret",
+                ConfigurationField.Optional.OPTIONAL, true));
+        when(messageOutputFactory.getAvailableOutputs()).thenReturn(Map.of(outputType,
+                AvailableOutputSummary.create("Encrypted", outputType, "Encrypted", "", request)));
     }
 
     @Test
@@ -124,5 +153,76 @@ public class OutputServiceImplTest {
         outputService.update(outputId, Collections.singletonMap("title", "Some other Title"));
 
         verify(clusterEventBus).post(OutputChangedEvent.create(outputId));
+    }
+
+    @Test
+    @MongoDBFixtures("encrypted-output.json")
+    public void loadConvertsStoredEncryptedFieldToEncryptedValue() throws Exception {
+        stubEncryptedPasswordField("custom.EncryptedOutput");
+
+        final Output output = outputService.load("5b927d32a7c8644ed44576ee");
+
+        assertThat(output.getConfiguration().get("password"))
+                .isInstanceOfSatisfying(EncryptedValue.class, ev -> assertThat(ev.isSet()).isTrue());
+        // Non-encrypted fields are left untouched.
+        assertThat(output.getConfiguration().get("host")).isEqualTo("example.com");
+    }
+
+    @Test
+    @MongoDBFixtures("encrypted-output.json")
+    public void updateReturnsOutputWithEncryptedFieldConverted() {
+        stubEncryptedPasswordField("custom.EncryptedOutput");
+
+        final Output updated = outputService.update("5b927d32a7c8644ed44576ee",
+                Collections.singletonMap("title", "Renamed"));
+
+        // The returned output must expose the secret as an EncryptedValue so the API response masks it
+        // instead of leaking the stored ciphertext and salt.
+        assertThat(updated.getConfiguration().get("password")).isInstanceOf(EncryptedValue.class);
+    }
+
+    @Test
+    @MongoDBFixtures("encrypted-output.json")
+    public void loadLeavesConfigUntouchedWhenNoEncryptedFieldsDeclared() throws Exception {
+        // messageOutputFactory returns no matching output type -> no encrypted fields known.
+        final Output output = outputService.load("5b927d32a7c8644ed44576ee");
+
+        assertThat(output.getConfiguration().get("password")).isInstanceOf(Map.class);
+    }
+
+    @Test
+    @MongoDBFixtures("single-output.json")
+    public void updatePersistsEncryptedFieldAsCiphertextNotPlaintext() {
+        final String outputId = "5b927d32a7c8644ed44576ed";
+        // The resource hands the service a merged configuration in which encrypted fields are already EncryptedValues.
+        final EncryptedValue secret = new EncryptedValueService(UUID.randomUUID().toString()).encrypt("s3cret");
+        outputService.update(outputId, Map.of("configuration", new HashMap<>(Map.of("password", secret))));
+
+        final Document stored = mongoCollections.nonEntityCollection("outputs", Document.class)
+                .find(MongoUtils.idEq(outputId)).first();
+        final Document password = stored.get("configuration", Document.class).get("password", Document.class);
+
+        // Database serialization must store the {encrypted_value, salt} sub-document, never {is_set} or plaintext.
+        assertThat(password.getString("encrypted_value")).isNotBlank();
+        assertThat(password.getString("salt")).isNotBlank();
+        assertThat(stored.toJson()).doesNotContain("s3cret");
+    }
+
+    @Test
+    public void createPersistsEncryptedFieldAsCiphertextNotPlaintext() throws Exception {
+        // The resource hands the service a configuration in which encrypted fields are already EncryptedValues.
+        final EncryptedValue secret = new EncryptedValueService(UUID.randomUUID().toString()).encrypt("s3cret");
+        final Output created = outputService.create(
+                CreateOutputRequest.create("Encrypted", "custom.EncryptedOutput",
+                        new HashMap<>(Map.of("password", secret)), Set.of()), "admin");
+
+        final Document stored = mongoCollections.nonEntityCollection("outputs", Document.class)
+                .find(MongoUtils.idEq(created.getId())).first();
+        final Document password = stored.get("configuration", Document.class).get("password", Document.class);
+
+        // Database serialization must store the {encrypted_value, salt} sub-document, never {is_set} or plaintext.
+        assertThat(password.getString("encrypted_value")).isNotBlank();
+        assertThat(password.getString("salt")).isNotBlank();
+        assertThat(stored.toJson()).doesNotContain("s3cret");
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/streams/encrypted-output.json
+++ b/graylog2-server/src/test/resources/org/graylog2/streams/encrypted-output.json
@@ -1,0 +1,15 @@
+{
+  "outputs": [
+    {
+      "_id" : { "$oid" : "5b927d32a7c8644ed44576ee" },
+      "title" : "Encrypted",
+      "type" : "custom.EncryptedOutput",
+      "creator_user_id" : "admin",
+      "configuration" : {
+        "host" : "example.com",
+        "password" : { "encrypted_value" : "cipher", "salt" : "salty" }
+      },
+      "created_at" : { "$date" : "2018-09-07T13:29:22.589Z" }
+    }
+  ]
+}


### PR DESCRIPTION
Note: This is a backport of #27104 to `7.1`.

## What

Encrypt `MessageOutput` configuration fields declared with `isEncrypted=true` before persisting them, instead of storing the raw `{set_value=...}` marker as plain text.

## Why

Fixes #26626. Encrypted output config fields were stored in plain text **and corrupted**: the frontend sends the value wrapped as `{set_value=<password>}`, but the output path stringified it via `ConfigurationMapConverter` (`String.valueOf({set_value=...})`), so MongoDB ended up with the literal `"{set_value=mySecretPassword}"`. Reopening the output also displayed the wrapper. This made the `isEncrypted` flag ineffective for output plugins and stored secrets at rest — a compliance/security problem.

Inputs already handle this; outputs were missing the equivalent conversion.

## How

Mirror the input handling at the two seams outputs lacked:

- `OutputResource` converts the encrypted-field markers into `EncryptedValue` on create/update (instead of letting `ConfigurationMapConverter` stringify them), and honors `keep_value`/`delete_value` against the stored secret via `EncryptedInputConfigs.merge`.
- `OutputServiceImpl` converts the stored `{encrypted_value, salt}` documents back into `EncryptedValue` on load/update, so secrets are masked as `{is_set: true}` in API responses and exposed as `EncryptedValue` to running outputs.

## Details

- `EncryptedInputConfigs.getEncryptedFields` gains a `ConfigurationRequest` overload so the field detection is reused for outputs (the existing `MessageInput.Config` overload delegates to it).
- Plugin authors read the secret via `Configuration.getEncryptedValue(key)` + `EncryptedValueService.decrypt`, identical to the input contract.
- Pre-existing outputs still holding the corrupt plaintext marker will fail conversion on load (logged as a warning, field left untouched) and need the secret re-entered. A one-off backfill migration could be a follow-up.
- Scope is core outputs only; no enterprise change.

## How tested

- New `OutputResourceTest` cases: `set_value` marker is encrypted (plaintext never survives), `keep_value` preserves the stored secret, `delete_value` unsets it.
- New `OutputServiceImplTest` cases: stored `{encrypted_value, salt}` is converted to `EncryptedValue` on load and on the update response; non-encrypted fields untouched.
- Existing output/encryption tests still pass (`OutputServiceImplTest`, `OutputResourceTest`, `OutputFacadeTest`, `EncryptedInputConfigsTest`).

Live-validated end to end on a local dev server. No shipping output declares an `isEncrypted` field, so a temporary `isEncrypted` `TextField` was added to `LoggingOutput`, then exercised over the REST API with the stored/returned values inspected in MongoDB. The same scenario was run on `master` as a before baseline:

| Step | `master` (before) | This PR (after) |
| --- | --- | --- |
| Stored value in `outputs` after create | literal `'{set_value=mySecretPassword123}'` (plaintext) | `{ encrypted_value: "8018…", salt: "c715…" }` |
| Create / GET / PUT API response | — | masked as `{ is_set: true }`, no ciphertext or salt |
| Update with `keep_value` | — | ciphertext and salt unchanged (secret preserved) |
| Update with a new `set_value` | — | re-encrypted with a fresh salt |
| Update with `delete_value` | — | secret unset |

No secret or salt is ever returned by the API on create, load, or update.

## How to test

1. Create a plugin output with a `TextField` declared `isEncrypted=true`.
2. Create the output from the UI, enter a password, save.
3. Inspect the `outputs` collection: the field is now `{ "encrypted_value": "...", "salt": "..." }`, not `{set_value=...}`.
4. Reopen the output: the secret shows as set/masked rather than the raw wrapper.

## Related

Closes #26626
