### PR TITLE
fix datanode migration page shown unnecessarily

### DIFF
--- a/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.test.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { renderHook } from 'wrappedTestingLibrary/hooks';
+
+import { asMock } from 'helpers/mocking';
+import { adminUser } from 'fixtures/users';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { MIGRATION_STATE } from 'components/datanode/Constants';
+import type { MigrationState, MigrationStateItem } from 'components/datanode/Types';
+
+import useMigrationState from './useMigrationState';
+import useRunsWithDataNode from './useRunsWithDataNode';
+import useShowDatanodeMigration from './useShowDatanodeMigration';
+
+jest.mock('hooks/useCurrentUser');
+jest.mock('./useMigrationState');
+jest.mock('./useRunsWithDataNode');
+
+const migrationState = (state: MigrationStateItem): MigrationState => ({ state, next_steps: [] });
+
+const mockState = ({
+  runsWithDataNode,
+  state = MIGRATION_STATE.NEW.key,
+}: {
+  runsWithDataNode: boolean | undefined;
+  state?: MigrationStateItem;
+}) => {
+  asMock(useRunsWithDataNode).mockReturnValue({ data: runsWithDataNode, isLoading: false });
+  asMock(useMigrationState).mockReturnValue({ currentStep: migrationState(state), isLoading: false });
+};
+
+describe('useShowDatanodeMigration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMock(useCurrentUser).mockReturnValue(adminUser);
+  });
+
+  it('shows the migration when Data Node is not used', () => {
+    mockState({ runsWithDataNode: false });
+
+    const { result } = renderHook(() => useShowDatanodeMigration());
+
+    expect(result.current.showDatanodeMigration).toBe(true);
+  });
+
+  it('does not show the migration while the configured search backend is unknown', () => {
+    mockState({ runsWithDataNode: undefined });
+
+    const { result } = renderHook(() => useShowDatanodeMigration());
+
+    expect(result.current.showDatanodeMigration).toBe(false);
+  });
+
+  it('does not treat entering the migration as resumable after switching to Data Node', () => {
+    mockState({ runsWithDataNode: true, state: MIGRATION_STATE.MIGRATION_WELCOME_PAGE.key });
+
+    const { result } = renderHook(() => useShowDatanodeMigration());
+
+    expect(result.current.showDatanodeMigration).toBe(false);
+  });
+
+  it('keeps the migration accessible for finalization after switching to Data Node', () => {
+    mockState({ runsWithDataNode: true, state: MIGRATION_STATE.RESTART_GRAYLOG.key });
+
+    const { result } = renderHook(() => useShowDatanodeMigration());
+
+    expect(result.current.showDatanodeMigration).toBe(true);
+  });
+});

--- a/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
+++ b/graylog2-web-interface/src/components/datanode/hooks/useShowDatanodeMigration.ts
@@ -14,8 +14,7 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import { useMemo } from 'react';
-
+import { MIGRATION_STATE } from 'components/datanode/Constants';
 import { isPermitted } from 'util/PermissionsMixin';
 import useCurrentUser from 'hooks/useCurrentUser';
 
@@ -27,16 +26,19 @@ const useShowDatanodeMigration = (): {
   showDatanodeMigration: boolean;
 } => {
   const { permissions } = useCurrentUser();
-  const canStartDataNode = useMemo(() => isPermitted(permissions, 'datanode:start'), [permissions]);
+  const canStartDataNode = isPermitted(permissions, 'datanode:start');
 
   const { data: isDatanodeConfiguredAndUsed } = useRunsWithDataNode({ enabled: canStartDataNode });
 
   const { currentStep } = useMigrationState({ enabled: canStartDataNode });
-  const noMigrationInProgress = !currentStep || currentStep?.state === 'NEW' || currentStep?.state === 'FINISHED';
+  const migrationNeedsFinalization = currentStep?.state === MIGRATION_STATE.RESTART_GRAYLOG.key;
+  const shouldShowDatanodeMigration =
+    isDatanodeConfiguredAndUsed === false ||
+    (isDatanodeConfiguredAndUsed === true && migrationNeedsFinalization);
 
   return {
-    isDatanodeConfiguredAndUsed: canStartDataNode && !!isDatanodeConfiguredAndUsed,
-    showDatanodeMigration: canStartDataNode && (!isDatanodeConfiguredAndUsed || !noMigrationInProgress),
+    isDatanodeConfiguredAndUsed: canStartDataNode && isDatanodeConfiguredAndUsed === true,
+    showDatanodeMigration: canStartDataNode && shouldShowDatanodeMigration,
   };
 };
 


### PR DESCRIPTION
/nocl

## Description
Fix the Data Node Migration tab remaining visible on installations already using Data Nodes by no longer treating every unfinished migration state as active. 

The tab is now shown only when the installation is not using Data Nodes or when a migration in RESTART_GRAYLOG still requires finalization, and remains hidden while the backend status is unresolved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/15400

## Screenshots (if appropriate):
<img width="2156" height="415" alt="Screenshot 2026-09-02 at 15 28 13" src="https://github.com/user-attachments/assets/b4051083-15aa-4a5d-bf74-ffbe9eaa7f21" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

