### PR TITLE
Use consistent table row background colors, regardless of the parent background color.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Table.tsx
+++ b/graylog2-web-interface/src/components/bootstrap/Table.tsx
@@ -64,6 +64,7 @@ const StyledTable = styled(MantineTable)<StyledProps>(
     line-height: inherit;
     border-collapse: separate;
     border-spacing: 0;
+    background-color: ${theme.colors.global.contentBackground};
 
     ${$bordered &&
     css`
@@ -112,7 +113,7 @@ const StyledTable = styled(MantineTable)<StyledProps>(
     }
 
     & tbody > tr {
-      background-color: ${theme.colors.global.contentBackground};
+      background-color: ${theme.colors.table.row.background};
       transition: ${TABLE_ROW_HOVER_TRANSITION};
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some cases, tables are displayed on a gray background. This affects the table row colors because they use transparent backgrounds.

Before
<img width="934" height="370" alt="image" src="https://github.com/user-attachments/assets/e562fab1-2305-4b74-bcbd-c834a0bc589a" />

With this PR, we always use `theme.colors.global.contentBackground` (white in light mode) as the table background to ensure that table colors are displayed consistently, regardless of the surrounding background.

After:
<img width="924" height="361" alt="image" src="https://github.com/user-attachments/assets/82603740-c5c1-4c9b-9186-dfd2847bdada" />


/nocl - small visual improvement