### PR TITLE
Fail the AWS Kinesis input on unrecoverable AWS authorization denials (`7.1`)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -95,3 +95,33 @@ the role Graylog uses for the input before or immediately after upgrading.
 
 For more information, see the AWS [KCL 2.x to 3.x migration guide](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html).
 For the full list of IAM permissions required by KCL 3.x, see [IAM permissions for KCL 3.x](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html#kcl-migration-from-2-3-IAM-permissions).
+
+#### Required DynamoDB Permissions
+
+**This applies to every Kinesis/CloudWatch input, whether it is new or existed before 7.1**, so a policy written for
+an earlier Graylog release can look correct and still deny the input. A policy that grants only the actions KCL 2.x
+needed leaves the input logging an authorization error on a fixed schedule while consuming no records. Graylog now
+watches the two calls the consumer cannot work without, DynamoDB lease discovery (`Query`) and the Kinesis record
+fetch (`GetRecords`), and fails the input naming the denied action once one has been denied continuously for two
+minutes; a denial KCL works around, such as one affecting only lease rebalancing, still leaves the input running.
+
+In addition to the actions the lease table already needed (`CreateTable`, `DescribeTable`, `GetItem`, `PutItem`,
+`Scan`, `UpdateItem`, `DeleteItem`), KCL 3.x requires:
+
+- **`dynamodb:Query` on `arn:aws:dynamodb:<region>:<account>:table/graylog-aws-plugin-*/index/*`.** KCL 3.x discovers
+  leases through a global secondary index on the lease table. An index is a separate IAM resource from its table, so
+  granting `Query` on the table alone still denies this call.
+- **`dynamodb:UpdateTable` on `arn:aws:dynamodb:<region>:<account>:table/graylog-aws-plugin-*`.** KCL creates that
+  index on first start. If this is denied, KCL retries the call throughout startup and then aborts, so the input fails
+  with a generic initialization error rather than starting. That is outside the steady-state detection described above,
+  which watches denials of `Query` and `GetRecords` on a running input, but the input still fails visibly instead of
+  consuming nothing.
+
+KCL 3.x also adds two tables per input, `<application-name>-CoordinatorState` and `<application-name>-WorkerMetricStats`,
+which need the same item-level actions as the lease table (`GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Scan`) in
+addition to `DescribeTable`: KCL holds its leader lock in `-CoordinatorState` and writes worker metrics to
+`-WorkerMetricStats` every 30 seconds. KCL checks whether both tables exist on every start and treats anything other
+than "table not found" as a failure, so a policy scoped to the lease table alone prevents the input from starting.
+
+A policy whose resource is `arn:aws:dynamodb:<region>:<account>:table/graylog-aws-plugin-*` covers the lease table and
+both additional tables, because their names share that prefix.

--- a/changelog/unreleased/pr-26898.toml
+++ b/changelog/unreleased/pr-26898.toml
@@ -1,0 +1,26 @@
+type = "f"
+message = "Fail the AWS Kinesis/CloudWatch input instead of retrying forever when AWS denies a required permission."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15073"]
+pulls = ["26898"]
+
+details.user = """
+When the IAM role used by an AWS Kinesis/CloudWatch input was missing a required DynamoDB permission, the input logged
+an authorization error every few seconds indefinitely while consuming no records, and still reported as running.
+The input now reports a failure naming the denied action and resource, and stops its consumer, once a call it cannot
+work without has been denied for two minutes. Grant the missing permission, then stop and start the input. A denial
+the Kinesis Client Library works around, such as one affecting only lease rebalancing, is still logged but leaves the
+input running. KMS access failures on an encrypted stream (for example a disabled or deleted key) are treated the same
+way: restore access to the key, then stop and start the input.
+"""
+
+details.ops = """
+This changes what an incorrectly permissioned AWS Kinesis/CloudWatch input does: where it previously kept running while
+consuming nothing, its consumer now stops and the input reports a failure. Only the calls the consumer cannot work
+without trigger this, namely DynamoDB lease discovery and the Kinesis record fetch, so a denial the Kinesis Client
+Library works around leaves the input running. Note that KCL 3.x requires DynamoDB actions KCL 2.x did not, most
+notably `dynamodb:Query` on `table/graylog-aws-plugin-*/index/*` and `dynamodb:UpdateTable` on the lease table. See
+the AWS Kinesis/CloudWatch section of `UPGRADING.md` for the full list. This new fail-fast only fires on authorization
+denials of the operations it watches while the input is running; a denied `dynamodb:UpdateTable` instead aborts KCL
+startup, so that input fails with a generic initialization error rather than starting.
+"""

--- a/changelog/unreleased/pr-26898.toml
+++ b/changelog/unreleased/pr-26898.toml
@@ -2,7 +2,7 @@ type = "f"
 message = "Fail the AWS Kinesis/CloudWatch input instead of retrying forever when AWS denies a required permission."
 
 issues = ["Graylog2/graylog-plugin-enterprise#15073"]
-pulls = ["26898"]
+pulls = ["26898", "27263"]
 
 details.user = """
 When the IAM role used by an AWS Kinesis/CloudWatch input was missing a required DynamoDB permission, the input logged
@@ -10,8 +10,8 @@ an authorization error every few seconds indefinitely while consuming no records
 The input now reports a failure naming the denied action and resource, and stops its consumer, once a call it cannot
 work without has been denied for two minutes. Grant the missing permission, then stop and start the input. A denial
 the Kinesis Client Library works around, such as one affecting only lease rebalancing, is still logged but leaves the
-input running. KMS access failures on an encrypted stream (for example a disabled or deleted key) are treated the same
-way: restore access to the key, then stop and start the input.
+input running. On an encrypted stream, only a key that no longer exists fails the input, because a disabled key or a
+withdrawn key permission is usually restored without any change in Graylog, and those are logged and retried instead.
 """
 
 details.ops = """

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
@@ -108,13 +108,14 @@ public class AWSAuthorizationFailureDetector implements ExecutionInterceptor {
     private static final Set<String> TERMINAL_ERROR_CODES = Sets.union(CREDENTIAL_ERROR_CODES, Set.of(
             "AccessDeniedException",
             "AccessDenied",
-            // KMS failures on an encrypted stream that need an operator to act. KMSInvalidStateException is
-            // deliberately absent: its service documentation does not say which key states produce it, so we cannot
-            // show it is unrecoverable, and an allowlist should fail safe.
-            "KMSAccessDeniedException",
+            // The only KMS failures on an encrypted stream that cannot clear without an operator. KMSDisabledException,
+            // KMSAccessDeniedException and KMSInvalidStateException are deliberately absent because each names a state
+            // that routinely clears on its own - a CMK disabled during rotation, an expired grant or an edited key
+            // policy, an unidentified key state - and failing an input over one would stop a stream that recovers.
+            // The cost is that a deleted key reported as KMSAccessDeniedException rather than KMSNotFoundException is
+            // no longer caught here, since AWS documents that code as covering both.
             "KMSNotFoundException",
-            "KMSOptInRequired",
-            "KMSDisabledException"));
+            "KMSOptInRequired"));
 
     private final Consumer<Throwable> onTerminalFailure;
     private final LongSupplier nanoClock;

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.aws;
+
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+
+/**
+ * Watches an AWS client for authorization denials that no amount of retrying will fix, and reports one once an
+ * operation the consumer cannot work without has been denied for {@link #MIN_DENIAL_PERIOD}.
+ *
+ * <p>The Kinesis Client Library reschedules its own calls forever and only logs the failure, so a missing IAM
+ * permission produces an endless ERROR loop while the input consumes nothing. KCL exposes no hook for those failures,
+ * but we build the AWS clients it uses, so an interceptor on them sees every denial the service returns.
+ *
+ * <p>Only {@link #ESSENTIAL_OPERATIONS} are reported, because a denial alone does not mean the input is broken. KCL
+ * absorbs several denials and keeps ingesting - a stalled metadata migration, a lease-rebalancing scan, a table
+ * description it needs only for scan sizing - so reporting on any denial would stop inputs that are working.
+ *
+ * <p>Denials are tracked per operation, not per client: one client carries many schedules at very different rates, so
+ * state shared across operations would be cleared by healthy traffic before any threshold was reached. Note this keys
+ * on the operation <em>name</em> while IAM authorizes on (action, resource), so a permitted call to a different
+ * resource under the same operation name does clear the streak. Neither essential operation has a second resource on
+ * the clients we build.
+ *
+ * <p>The threshold is a duration rather than a number of attempts because cadences on one client differ by more than
+ * an order of magnitude, so a fixed count would mean seconds for one operation and many minutes for another.
+ *
+ * <p>Use one instance per client. Operation names are not unique across services, so a shared map could conflate two
+ * services' calls.
+ */
+public class AWSAuthorizationFailureDetector implements ExecutionInterceptor {
+
+    private static final Duration MIN_DENIAL_PERIOD = Duration.ofMinutes(2);
+
+    /**
+     * Deliberately longer than {@link #MIN_DENIAL_PERIOD}. If the two were equal, an operation retried at just over
+     * the threshold would restart its streak on every attempt and could never be reported at all.
+     */
+    private static final Duration STREAK_RESET_GAP = MIN_DENIAL_PERIOD.multipliedBy(2);
+
+    private static final int MAX_CAUSE_DEPTH = 10;
+
+    /**
+     * The operations whose denial KCL retries forever while surfacing nothing, and which the consumer cannot work
+     * without. Both are on fast retry paths - lease discovery every ~10s, record fetching every 1.5s - so the
+     * threshold takes many attempts rather than two.
+     *
+     * <p>Everything else is left alone deliberately. KCL absorbs a denied lease-rebalancing {@code Scan}, a
+     * scan-sizing {@code DescribeTable} or a single-table-migration {@code TransactWriteItems} and keeps delivering
+     * records, so reporting those stops inputs that are ingesting normally. Failures KCL does surface, such as a
+     * denied {@code GetShardIterator} aborting a shard consumer, already reach the input through
+     * {@code TaskExecutionListener}.
+     */
+    private static final Set<String> ESSENTIAL_OPERATIONS = Set.of(
+            // DynamoDB lease discovery, the call denied in the case this class exists for. KCL 3.x has no other way
+            // to learn which leases it has been assigned, so a worker denied this consumes nothing.
+            "Query",
+            // The Kinesis read path, including the KMS failures an encrypted stream returns through it.
+            // PrefetchRecordsPublisher swallows every SdkException and re-polls, so no task ever fails.
+            "GetRecords");
+
+    /**
+     * Credentials that AWS rejects outright. Terminal for the same reason a denied action is, but the remediation is
+     * different, so {@link #indicatesRejectedCredentials} lets the caller say so.
+     */
+    private static final Set<String> CREDENTIAL_ERROR_CODES = Set.of(
+            "UnrecognizedClientException",
+            "InvalidClientTokenId",
+            "InvalidSignatureException",
+            "SignatureDoesNotMatch");
+
+    /**
+     * Deliberately an allowlist. Expired session credentials and throttling also arrive as authorization-shaped
+     * errors but recover on their own, and failing an input over a credential rotation would be worse than the log
+     * spam this class exists to stop. The signature codes are included because a signature error that survives the
+     * SDK's own retry-and-clock-adjust means a bad key, not skew.
+     *
+     * <p>Derived from {@link #CREDENTIAL_ERROR_CODES} rather than repeating it, so the two cannot drift: a code in
+     * only one of them would either never be reported or be reported with the wrong remedy.
+     */
+    private static final Set<String> TERMINAL_ERROR_CODES = Sets.union(CREDENTIAL_ERROR_CODES, Set.of(
+            "AccessDeniedException",
+            "AccessDenied",
+            // KMS failures on an encrypted stream that need an operator to act. KMSInvalidStateException is
+            // deliberately absent: its service documentation does not say which key states produce it, so we cannot
+            // show it is unrecoverable, and an allowlist should fail safe.
+            "KMSAccessDeniedException",
+            "KMSNotFoundException",
+            "KMSOptInRequired",
+            "KMSDisabledException"));
+
+    private final Consumer<Throwable> onTerminalFailure;
+    private final LongSupplier nanoClock;
+    private final Map<String, DenialStreak> denialsByOperation = new ConcurrentHashMap<>();
+
+    /**
+     * @param onTerminalFailure called when a denial is judged unrecoverable. May be called more than once; the caller
+     *                          is responsible for acting at most once.
+     * @param nanoClock         monotonic clock, {@code System::nanoTime} outside tests.
+     */
+    public AWSAuthorizationFailureDetector(Consumer<Throwable> onTerminalFailure, LongSupplier nanoClock) {
+        this.onTerminalFailure = onTerminalFailure;
+        this.nanoClock = nanoClock;
+    }
+
+    /**
+     * Whether a denial means AWS rejected the credentials rather than that a permission is absent. The remediation
+     * differs, so the two must not share a failure message.
+     */
+    public static boolean indicatesRejectedCredentials(Throwable throwable) {
+        return denialWithCodeIn(throwable, CREDENTIAL_ERROR_CODES) != null;
+    }
+
+    @Override
+    public void onExecutionFailure(Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+        final String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
+        if (operation == null) {
+            // Fail closed. Unnamed calls sharing one bucket would let a success clear an unrelated denial, which is
+            // exactly what per-operation tracking exists to prevent. The SDK always names generated calls.
+            return;
+        }
+        recordFailure(operation, context.exception());
+    }
+
+    @Override
+    public void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes) {
+        final String operation = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
+        if (operation != null) {
+            // A success on an operation clears its streak. Kept per-operation so healthy traffic on one operation
+            // cannot clear a denied one sharing the same client.
+            denialsByOperation.remove(operation);
+        }
+    }
+
+    private void recordFailure(String operation, Throwable throwable) {
+        if (!ESSENTIAL_OPERATIONS.contains(operation)) {
+            return;
+        }
+        final AwsServiceException denial = denialWithCodeIn(throwable, TERMINAL_ERROR_CODES);
+        if (denial == null) {
+            return;
+        }
+        final long now = nanoClock.getAsLong();
+        final DenialStreak streak = denialsByOperation.compute(operation,
+                (ignored, current) -> current == null ? DenialStreak.first(now) : current.next(now));
+        if (streak.isTerminal()) {
+            onTerminalFailure.accept(denial);
+        }
+    }
+
+    /**
+     * The reported throwable is defensively unwrapped: the async SDK strips {@code CompletionException} before
+     * interceptors run, so in practice the denial arrives directly, but nothing guarantees that for every wrapper.
+     */
+    @Nullable
+    private static AwsServiceException denialWithCodeIn(Throwable throwable, Set<String> errorCodes) {
+        Throwable current = throwable;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
+            if (current instanceof AwsServiceException awsException
+                    && awsException.awsErrorDetails() != null
+                    // The JSON error unmarshaller leaves the code null when it cannot parse one (5xx/HTML/proxy body).
+                    // The terminal sets reject null, so guard before contains() rather than NPE into a new error loop.
+                    && awsException.awsErrorDetails().errorCode() != null
+                    && errorCodes.contains(awsException.awsErrorDetails().errorCode())) {
+                return awsException;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    /**
+     * An unbroken run of denials of one operation. A gap longer than {@link #STREAK_RESET_GAP} starts a new run, so
+     * denials that are genuinely occasional cannot accumulate into a failure over days.
+     */
+    private record DenialStreak(long firstNanos, long lastNanos) {
+
+        private static DenialStreak first(long nowNanos) {
+            return new DenialStreak(nowNanos, nowNanos);
+        }
+
+        private DenialStreak next(long nowNanos) {
+            if (nowNanos - lastNanos > STREAK_RESET_GAP.toNanos()) {
+                return first(nowNanos);
+            }
+            return new DenialStreak(firstNanos, nowNanos);
+        }
+
+        private boolean isTerminal() {
+            return lastNanos - firstNanos >= MIN_DENIAL_PERIOD.toNanos();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
@@ -18,8 +18,10 @@ package org.graylog.integrations.aws.transports;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
+import org.graylog.integrations.aws.AWSAuthorizationFailureDetector;
 import org.graylog.integrations.aws.AWSClientBuilderUtil;
 import org.graylog.integrations.aws.AWSMessageType;
 import org.graylog.integrations.aws.resources.requests.AWSRequest;
@@ -53,7 +55,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -77,7 +81,15 @@ public class KinesisConsumer implements Runnable {
     private final AWSRequest request;
     private final AWSClientBuilderUtil awsClientBuilderUtil;
     private final InputFailureRecorder inputFailureRecorder;
-    private Scheduler kinesisScheduler;
+
+    /**
+     * Monotonic clock handed to the authorization-failure detectors. {@code System::nanoTime} in production; a test
+     * passes a controllable clock to drive the denial threshold.
+     */
+    private final LongSupplier nanoClock;
+    private final AtomicBoolean authorizationFailureHandled = new AtomicBoolean();
+    // volatile: written on the KCL runner thread but read by the async stop() handoff, which needs to see it.
+    private volatile Scheduler kinesisScheduler;
 
     KinesisConsumer(NodeId nodeId,
                     KinesisTransport transport,
@@ -87,10 +99,12 @@ public class KinesisConsumer implements Runnable {
                     AWSMessageType awsMessageType,
                     int recordBatchSize, AWSRequest request,
                     AWSClientBuilderUtil awsClientBuilderUtil,
-                    InputFailureRecorder inputFailureRecorder) {
+                    InputFailureRecorder inputFailureRecorder,
+                    LongSupplier nanoClock) {
         Preconditions.checkArgument(StringUtils.isNotBlank(kinesisStreamName), "A Kinesis stream name is required.");
         Preconditions.checkNotNull(awsMessageType, "A AWSMessageType is required.");
 
+        this.nanoClock = requireNonNull(nanoClock, "nanoClock");
         this.nodeId = requireNonNull(nodeId, "nodeId");
         this.transport = transport;
         this.handleMessageCallback = handleMessageCallback;
@@ -109,24 +123,16 @@ public class KinesisConsumer implements Runnable {
         LOG.debug("Starting the Kinesis Consumer.");
         AwsCredentialsProvider credentialsProvider = awsClientBuilderUtil.createCredentialsProvider(request);
 
-        final Region region = Region.of(request.region());
+        final ClientBuilders clientBuilders = createClientBuilders(Region.of(request.region()), credentialsProvider);
 
-        final DynamoDbAsyncClientBuilder dynamoDbClientBuilder = DynamoDbAsyncClient.builder();
-        awsClientBuilderUtil.initializeBuilder(dynamoDbClientBuilder, request.dynamodbEndpoint(), region, credentialsProvider);
-        final DynamoDbAsyncClient dynamoClient = dynamoDbClientBuilder.build();
-
-        final CloudWatchAsyncClientBuilder cloudwatchClientBuilder = CloudWatchAsyncClient.builder();
-        awsClientBuilderUtil.initializeBuilder(cloudwatchClientBuilder, request.cloudwatchEndpoint(), region, credentialsProvider);
-        final CloudWatchAsyncClient cloudWatchClient = cloudwatchClientBuilder.build();
-
-        final KinesisAsyncClientBuilder kinesisAsyncClientBuilder = KinesisAsyncClient.builder();
-        awsClientBuilderUtil.initializeBuilder(kinesisAsyncClientBuilder, request.kinesisEndpoint(), region, credentialsProvider);
-        final KinesisAsyncClient kinesisAsyncClient = KinesisClientUtil.createKinesisAsyncClient(kinesisAsyncClientBuilder);
+        final DynamoDbAsyncClient dynamoClient = clientBuilders.dynamoDb().build();
+        final CloudWatchAsyncClient cloudWatchClient = clientBuilders.cloudWatch().build();
+        final KinesisAsyncClient kinesisAsyncClient = KinesisClientUtil.createKinesisAsyncClient(clientBuilders.kinesis());
 
         final String workerId = String.format(Locale.ENGLISH, "graylog-node-%s", nodeId.anonymize());
         LOG.debug("Using workerId [{}].", workerId);
 
-        // The application name needs to be unique per input/consumer.
+        // The application name is per stream, so two inputs on the same stream share a KCL lease table.
         final String applicationName = String.format(Locale.ENGLISH, "graylog-aws-plugin-%s", kinesisStreamName);
         LOG.debug("Using Kinesis applicationName [{}].", applicationName);
 
@@ -161,7 +167,7 @@ public class KinesisConsumer implements Runnable {
                     inputFailureRecorder.setFailing(KinesisConsumer.class,
                             String.format(Locale.ROOT, "Errors for Kinesis stream <%s>!", kinesisStreamName));
                 } else if (TaskOutcome.SUCCESSFUL.equals(input.taskOutcome()) && TaskType.PROCESS.equals(input.taskType())) {
-                    inputFailureRecorder.setRunning();
+                    recordTaskSuccess();
                 }
             }
         };
@@ -181,6 +187,92 @@ public class KinesisConsumer implements Runnable {
     }
 
     /**
+     * The three async client builders KCL needs, with an authorization-failure detector attached to the two clients
+     * whose denials are fatal. Extracted from {@link #run()} so a test can assert that wiring: which clients are
+     * watched, that each gets its own detector, and that CloudWatch gets none.
+     */
+    @VisibleForTesting
+    ClientBuilders createClientBuilders(Region region, AwsCredentialsProvider credentialsProvider) {
+        // One detector per client: operation names are not unique across services, so a shared map could conflate
+        // two services' calls.
+        final DynamoDbAsyncClientBuilder dynamoDbClientBuilder = DynamoDbAsyncClient.builder();
+        awsClientBuilderUtil.initializeBuilder(dynamoDbClientBuilder, request.dynamodbEndpoint(), region, credentialsProvider);
+        dynamoDbClientBuilder.overrideConfiguration(c -> c.addExecutionInterceptor(newAuthorizationFailureDetector()));
+
+        // No detector on CloudWatch: losing metrics is not a reason to fail an input that is otherwise ingesting.
+        final CloudWatchAsyncClientBuilder cloudwatchClientBuilder = CloudWatchAsyncClient.builder();
+        awsClientBuilderUtil.initializeBuilder(cloudwatchClientBuilder, request.cloudwatchEndpoint(), region, credentialsProvider);
+
+        final KinesisAsyncClientBuilder kinesisAsyncClientBuilder = KinesisAsyncClient.builder();
+        awsClientBuilderUtil.initializeBuilder(kinesisAsyncClientBuilder, request.kinesisEndpoint(), region, credentialsProvider);
+        kinesisAsyncClientBuilder.overrideConfiguration(c -> c.addExecutionInterceptor(newAuthorizationFailureDetector()));
+
+        return new ClientBuilders(dynamoDbClientBuilder, cloudwatchClientBuilder, kinesisAsyncClientBuilder);
+    }
+
+    private AWSAuthorizationFailureDetector newAuthorizationFailureDetector() {
+        return new AWSAuthorizationFailureDetector(this::handleAuthorizationFailure, nanoClock);
+    }
+
+    @VisibleForTesting
+    record ClientBuilders(DynamoDbAsyncClientBuilder dynamoDb,
+                          CloudWatchAsyncClientBuilder cloudWatch,
+                          KinesisAsyncClientBuilder kinesis) {
+    }
+
+    /**
+     * Clears a transient failure once KCL completes a record-processing task. Terminality is enforced by
+     * {@link InputFailureRecorder}, so a task completing concurrently with a terminal failure cannot report the input
+     * healthy again.
+     */
+    private void recordTaskSuccess() {
+        inputFailureRecorder.setRunning();
+    }
+
+    /**
+     * Fails the input and stops the KCL scheduler after an AWS authorization denial that retrying cannot fix. Without
+     * this, KCL retries such calls on a fixed schedule for as long as the input is running, logging an ERROR with a
+     * stack trace every time while consuming no records.
+     */
+    @VisibleForTesting
+    void handleAuthorizationFailure(Throwable cause) {
+        if (!authorizationFailureHandled.compareAndSet(false, true)) {
+            return;
+        }
+        // Terminal: this message has to replace any earlier transient failure, or the denied action and resource -
+        // the only actionable part - stay hidden behind a generic "Errors for Kinesis stream" message forever.
+        // The remediation differs for a rejected credential, so the two cases must not share a message.
+        final String remedy = AWSAuthorizationFailureDetector.indicatesRejectedCredentials(cause)
+                ? "AWS rejected the configured credentials. Correct them, then stop and start the input."
+                : "Retrying cannot resolve a missing permission. Grant it, then stop and start the input.";
+        inputFailureRecorder.setTerminallyFailing(KinesisConsumer.class, String.format(Locale.ROOT,
+                        "AWS authorization failure for Kinesis stream <%s>. Stopping the consumer. %s",
+                        kinesisStreamName, remedy), cause);
+
+        // stop() blocks for up to 20s. It runs here on the client's shared SDK response-completion pool
+        // (sdk-async-response), and on that pool's rejection path directly on the HTTP thread, so occupying one for
+        // that long would stall unrelated completions on the same client.
+        final Thread shutdownThread = new Thread(() -> {
+            try {
+                stop();
+            } catch (Exception e) {
+                LOG.error("Failed to stop the Kinesis consumer for stream <{}> after an AWS authorization failure.",
+                        kinesisStreamName, e);
+            }
+        }, shutdownThreadName(kinesisStreamName));
+        shutdownThread.setDaemon(true);
+        shutdownThread.start();
+    }
+
+    /**
+     * Per-stream so that concurrent failures are distinguishable in a thread dump.
+     */
+    @VisibleForTesting
+    static String shutdownThreadName(String kinesisStreamName) {
+        return String.format(Locale.ENGLISH, "aws-kinesis-auth-failure-shutdown-%s", kinesisStreamName);
+    }
+
+    /**
      * Stops the KinesisConsumer. Finishes processing the current batch of data already received from Kinesis
      * before shutting down.
      */
@@ -195,7 +287,11 @@ public class KinesisConsumer implements Runnable {
             } catch (ExecutionException e) {
                 LOG.error("Exception while executing graceful shutdown.", e);
             } catch (TimeoutException e) {
-                LOG.error("Timeout while waiting for shutdown.  Scheduler may not have exited.");
+                // Not necessarily a failure: KCL holds its scheduler lock across the whole of its initialization
+                // retry loop, so a stop requested while that is still running has to wait for it.
+                LOG.warn("Kinesis Consumer for stream <{}> did not shut down within {} seconds. Forcing shutdown, "
+                                + "which waits for any in-progress KCL initialization to finish.",
+                        kinesisStreamName, GRACEFUL_SHUTDOWN_TIMEOUT);
                 kinesisScheduler.shutdown();
             }
         }

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisTransport.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/transports/KinesisTransport.java
@@ -148,7 +148,8 @@ public class KinesisTransport extends ThrottleableTransport2 {
         final AWSMessageType awsMessageType = AWSMessageType.valueOf(configuration.getString(AWSCodec.CK_AWS_MESSAGE_TYPE));
 
         this.kinesisConsumer = new KinesisConsumer(nodeId, this, objectMapper, input::processRawMessage,
-                streamName, awsMessageType, batchSize, awsRequest, awsClientBuilderUtil, inputFailureRecorder);
+                streamName, awsMessageType, batchSize, awsRequest, awsClientBuilderUtil, inputFailureRecorder,
+                System::nanoTime);
 
         LOG.debug("Starting Kinesis reader thread for input {}", input.toIdentifier());
         executor.submit(this.kinesisConsumer);

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
@@ -78,6 +78,12 @@ public class InputStateListener {
                 notification.addNode(serverStatus.getNodeId().toString());
                 notification.addDetail("input_id", input.toIdentifier());
                 notification.addDetail("reason", ObjectUtils.defaultIfNull(state.getDetailedMessage(), ""));
+                if (event.oldState() == event.newState()) {
+                    // Same state with a changed message, i.e. a failure that retrying cannot resolve replacing an
+                    // earlier transient one. publishIfFirst() will not overwrite the stored reason, so retire the
+                    // stale notification first and let the actionable message re-raise it.
+                    notificationService.fixed(type, input.getId());
+                }
                 notificationService.publishIfFirst(notification);
                 break;
             case RUNNING:

--- a/graylog2-server/src/main/java/org/graylog2/plugin/IOState.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/IOState.java
@@ -88,9 +88,13 @@ public class IOState<T extends Stoppable> {
     }
 
     public void setState(Type state, String detailedMessage) {
+        // A changed message has to be published even when the state itself is unchanged: the notification, the system
+        // message and the persisted runtime state are all written by IOStateChangedEvent subscribers, so suppressing
+        // the event would leave a replacement message visible only to callers reading this object directly.
+        final boolean detailedMessageChanged = !Objects.equals(this.detailedMessage, detailedMessage);
         this.setDetailedMessage(detailedMessage);
 
-        if (this.state == state) {
+        if (this.state == state && !detailedMessageChanged) {
             return;
         }
         final IOStateChangedEvent<T> evt = IOStateChangedEvent.create(this.state, state, this);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/InputFailureRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/InputFailureRecorder.java
@@ -31,12 +31,21 @@ import javax.annotation.Nullable;
 public class InputFailureRecorder {
     private final IOState<MessageInput> inputState;
 
+    /**
+     * Set once a failure that retrying cannot resolve has been recorded. Guarded by {@code this} together with every
+     * state write, so that a concurrent {@link #setRunning()} cannot undo a terminal failure.
+     */
+    private boolean terminallyFailed = false;
+
     public InputFailureRecorder(IOState<MessageInput> inputState) {
         this.inputState = inputState;
     }
 
     /**
      * Set the input into the FAILING state.
+     * <p>
+     * Keeps the message of a failure that is already recorded: if the input is already FAILING, this call is a no-op.
+     * Use {@link #setTerminallyFailing} when the new message must win.
      * @param loggingClass the calling class which will be used to log the error
      * @param error the error message
      */
@@ -46,28 +55,59 @@ public class InputFailureRecorder {
 
     /**
      * Set the input into the FAILING state.
+     * <p>
+     * Keeps the message of a failure that is already recorded: if the input is already FAILING, this call is a no-op.
+     * Use {@link #setTerminallyFailing} when the new message must win.
      * @param loggingClass the calling class which will be used to log the error
      * @param error the error message
      * @param e the exception leading to the error
      */
-    public void setFailing(Class<?> loggingClass, String error, @Nullable Throwable e) {
-        if (inputState.getState().equals(IOState.Type.FAILING)) {
+    public synchronized void setFailing(Class<?> loggingClass, String error, @Nullable Throwable e) {
+        if (terminallyFailed || inputState.getState().equals(IOState.Type.FAILING)) {
             return;
         }
+        applyFailure(loggingClass, error, e);
+    }
+
+    /**
+     * Set the input into the FAILING state for a failure that retrying cannot resolve, replacing the message of any
+     * failure already recorded and blocking any later {@link #setRunning()}.
+     * <p>
+     * Use this when the message carries the only actionable detail, so that it is neither hidden behind an earlier
+     * transient message nor cleared by work that continues while the input drains. Like {@link #setFailing}, the first
+     * message wins: a second unrecoverable failure does not replace it.
+     * @param loggingClass the calling class which will be used to log the error
+     * @param error the error message
+     * @param e the exception leading to the error
+     */
+    public synchronized void setTerminallyFailing(Class<?> loggingClass, String error, @Nullable Throwable e) {
+        if (terminallyFailed) {
+            return;
+        }
+        terminallyFailed = true;
+        applyFailure(loggingClass, error, e);
+    }
+
+    private void applyFailure(Class<?> loggingClass, String error, @Nullable Throwable e) {
         if (e != null) {
-            inputState.setState(IOState.Type.FAILING, error + ": (" + e.getMessage() + ")");
+            inputState.setState(IOState.Type.FAILING, error + ": (" + (e.getMessage() != null ? e.getMessage() : e.toString()) + ")");
         } else {
             inputState.setState(IOState.Type.FAILING, error);
         }
-        LoggerFactory.getLogger(loggingClass).warn(error, e);
+        if (terminallyFailed) {
+            // ERROR, not WARN: this is the line that explains why an error loop stopped and why the input is down.
+            LoggerFactory.getLogger(loggingClass).error(error, e);
+        } else {
+            LoggerFactory.getLogger(loggingClass).warn(error, e);
+        }
     }
 
     /**
      * Set the input back into RUNNING state.
-     * Call this once the error has resolved itself.
+     * Call this once the error has resolved itself. Has no effect after {@link #setTerminallyFailing}.
      */
-    public void setRunning() {
-        if (inputState.getState() == IOState.Type.RUNNING) {
+    public synchronized void setRunning() {
+        if (terminallyFailed || inputState.getState() == IOState.Type.RUNNING) {
             return;
         }
         inputState.setState(IOState.Type.RUNNING);

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.aws;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AWSAuthorizationFailureDetectorTest {
+
+    private static final String QUERY = "Query";
+    private static final String GET_RECORDS = "GetRecords";
+    private static final String UPDATE_ITEM = "UpdateItem";
+
+    /**
+     * KCL schedules lease discovery - the call denied in the case this class exists for - at
+     * {@code leaseAssignmentIntervalMillis / 2 - 25}, which is 9975ms with KCL's defaults.
+     */
+    private static final Duration LEASE_DISCOVERY_INTERVAL = Duration.ofMillis(9975);
+
+    /**
+     * Spacing wide enough that a handful of denials crosses the two-minute threshold, and still short enough not to
+     * break the streak.
+     */
+    private static final Duration WIDE_SPACING = Duration.ofSeconds(20);
+
+    private final List<Throwable> reportedFailures = new ArrayList<>();
+    private final AtomicLong clock = new AtomicLong();
+
+    private final AWSAuthorizationFailureDetector detector =
+            new AWSAuthorizationFailureDetector(reportedFailures::add, clock::get);
+
+    @Test
+    void reportsOnceDenialsSpanTwoMinutes() {
+        final DynamoDbException denial = accessDenied(
+                "User: arn:aws:sts::123456789012:assumed-role/graylog/x is not authorized to perform: "
+                        + "dynamodb:Query on resource: arn:aws:dynamodb:eu-west-1:123456789012:"
+                        + "table/graylog-aws-plugin-test/index/LeaseOwnerToLeaseKeyIndex");
+
+        // 13 denials at the real cadence span 119.7s - just inside the floor.
+        for (int i = 0; i < 13; i++) {
+            recordFailure(QUERY, denial);
+            assertThat(reportedFailures).isEmpty();
+            advance(LEASE_DISCOVERY_INTERVAL);
+        }
+
+        recordFailure(QUERY, denial);
+
+        assertThat(reportedFailures).containsExactly(denial);
+    }
+
+    /**
+     * The property that makes the fix work at all: KCL drives many operations through one client, so a counter shared
+     * across operations is cleared by healthy traffic and never reaches any threshold.
+     */
+    @Test
+    void successOnAnotherOperationDoesNotClearTheStreak() {
+        final DynamoDbException denial = accessDenied("denied");
+
+        for (int i = 0; i < 14; i++) {
+            recordFailure(QUERY, denial);
+            // A permitted lease renewal succeeds roughly three times per denied discovery attempt.
+            recordSuccess(UPDATE_ITEM);
+            recordSuccess(UPDATE_ITEM);
+            recordSuccess(UPDATE_ITEM);
+            advance(LEASE_DISCOVERY_INTERVAL);
+        }
+
+        assertThat(reportedFailures).containsExactly(denial);
+    }
+
+    @Test
+    void successOnTheSameOperationClearsTheStreak() {
+        denyRepeatedly(QUERY, 13, LEASE_DISCOVERY_INTERVAL);
+
+        recordSuccess(QUERY);
+        denyRepeatedly(QUERY, 13, LEASE_DISCOVERY_INTERVAL);
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    /**
+     * KCL absorbs denials of these and keeps delivering records from the leases it already holds - a stalled metadata
+     * migration, a lease-rebalancing scan, a table description it needs only for scan sizing, worker metrics. Stopping
+     * an input that is still ingesting would be a worse bug than the log spam this class exists to stop, so only the
+     * operations the consumer cannot work without are reported. Twenty minutes of continuous denial here changes
+     * nothing.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"Scan", "UpdateItem"})
+    void neverReportsAnOperationKclAbsorbs(String operation) {
+        denyRepeatedly(operation, 60, WIDE_SPACING);
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    /**
+     * The Kinesis half of the essential set. {@code PrefetchRecordsPublisher} swallows every SDK exception and
+     * re-polls every 1.5s, so a denied fetch never fails a task and would otherwise leave the input reporting RUNNING
+     * while consuming nothing.
+     */
+    @Test
+    void reportsADeniedRecordFetch() {
+        denyRepeatedly(GET_RECORDS, 100, Duration.ofMillis(1500));
+
+        assertThat(reportedFailures).isNotEmpty();
+    }
+
+    /**
+     * An operation issued every 1.5s must not fail an input over a short-lived denial, such as the seconds of
+     * {@code AccessDeniedException} that IAM's eventual consistency can produce after a policy edit.
+     */
+    @Test
+    void doesNotReportDenialsThatStopInsideTwoMinutes() {
+        denyRepeatedly(QUERY, 60, Duration.ofMillis(1500));
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void doesNotReportASingleDenial() {
+        recordFailure(QUERY, accessDenied("denied"));
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void doesNotReportJustShortOfTheThreshold() {
+        final DynamoDbException denial = accessDenied("denied");
+
+        recordFailure(QUERY, denial);
+        advance(Duration.ofMinutes(2).minusNanos(1));
+        recordFailure(QUERY, denial);
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void reportsExactlyAtTheThreshold() {
+        final DynamoDbException denial = accessDenied("denied");
+
+        recordFailure(QUERY, denial);
+        advance(Duration.ofMinutes(2));
+        recordFailure(QUERY, denial);
+
+        assertThat(reportedFailures).containsExactly(denial);
+    }
+
+    /**
+     * The streak-break gap is deliberately wider than the reporting threshold. Were they equal, an operation retried
+     * at just over the threshold would restart its streak on every attempt and could never be reported.
+     */
+    @Test
+    void reportsAnOperationRetriedMoreSlowlyThanTheThreshold() {
+        final DynamoDbException denial = accessDenied("denied");
+
+        recordFailure(QUERY, denial);
+        advance(Duration.ofMinutes(3));
+        recordFailure(QUERY, denial);
+
+        assertThat(reportedFailures).containsExactly(denial);
+    }
+
+    /**
+     * Without this, denials that are genuinely occasional would accumulate over days into a failure.
+     */
+    @Test
+    void restartsTheStreakAfterALongGap() {
+        denyRepeatedly(QUERY, 5, WIDE_SPACING);
+
+        advance(Duration.ofMinutes(5));
+        denyRepeatedly(QUERY, 5, WIDE_SPACING);
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "AccessDeniedException",
+            "AccessDenied",
+            "UnrecognizedClientException",
+            "InvalidClientTokenId",
+            "InvalidSignatureException",
+            "SignatureDoesNotMatch",
+            "KMSAccessDeniedException",
+            "KMSNotFoundException",
+            "KMSOptInRequired",
+            "KMSDisabledException"})
+    void treatsDeniedActionsUnusableCredentialsAndUnusableKeysAsTerminal(String errorCode) {
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, withErrorCode(errorCode, "denied"));
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isNotEmpty();
+    }
+
+    /**
+     * Expired session credentials and throttling arrive as authorization-shaped errors but recover on their own.
+     * Failing an input over either would be a worse bug than the log spam this class exists to stop.
+     * {@code KMSInvalidStateException} is here because its service documentation does not say which key states
+     * produce it, so an allowlist has to fail safe.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ExpiredTokenException",
+            "ExpiredToken",
+            "ProvisionedThroughputExceededException",
+            "ThrottlingException",
+            "RequestLimitExceeded",
+            "KMSInvalidStateException"})
+    void neverReportsSelfHealingErrors(String errorCode) {
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, withErrorCode(errorCode, "retry later"));
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    /**
+     * Matching has to be exact: the allowlist carries the short code {@code AccessDenied}, which is a substring of
+     * unrelated error codes, so a prefix or substring test would treat those as terminal.
+     */
+    @Test
+    void matchesErrorCodesExactly() {
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, withErrorCode("AccessDeniedExceptionFoo", "denied"));
+            recordFailure(QUERY, withErrorCode("PreAccessDenied", "denied"));
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void detectsDenialsWrappedInACauseChain() {
+        final DynamoDbException denial = accessDenied("denied");
+
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, new CompletionException(denial));
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).contains(denial);
+    }
+
+    @Test
+    void ignoresFailuresThatAreNotAwsServiceExceptions() {
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, new IOException("connection reset"));
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void ignoresAwsExceptionsWithoutErrorDetails() {
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, AwsServiceException.builder().message("no details").build());
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void ignoresAwsExceptionsWithoutAnErrorCode() {
+        // The JSON error unmarshaller leaves the code null when it cannot parse one (5xx/HTML/proxy body). The
+        // terminal sets reject null, so a missing guard would NPE here rather than skip the exception.
+        final AwsServiceException noCode = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorMessage("no code").build())
+                .message("no code")
+                .build();
+        for (int i = 0; i < 10; i++) {
+            recordFailure(QUERY, noCode);
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    /**
+     * Fail closed. Unnamed calls sharing one bucket would let a success clear an unrelated denial, which is exactly
+     * what per-operation tracking exists to prevent.
+     */
+    @Test
+    void ignoresCallsWithNoOperationName() {
+        // Deliberately not stubbing exception(): failing closed means returning before the throwable is even
+        // inspected, and strict stubbing holds us to that.
+        final Context.FailedExecution failedExecution = mock(Context.FailedExecution.class);
+
+        for (int i = 0; i < 10; i++) {
+            detector.onExecutionFailure(failedExecution, new ExecutionAttributes());
+            advance(WIDE_SPACING);
+        }
+
+        assertThat(reportedFailures).isEmpty();
+    }
+
+    @Test
+    void distinguishesRejectedCredentialsFromAMissingPermission() {
+        assertThat(AWSAuthorizationFailureDetector.indicatesRejectedCredentials(
+                withErrorCode("SignatureDoesNotMatch", "bad key"))).isTrue();
+        assertThat(AWSAuthorizationFailureDetector.indicatesRejectedCredentials(
+                new CompletionException(withErrorCode("UnrecognizedClientException", "unknown key")))).isTrue();
+        assertThat(AWSAuthorizationFailureDetector.indicatesRejectedCredentials(
+                accessDenied("not authorized to perform: dynamodb:Query"))).isFalse();
+        assertThat(AWSAuthorizationFailureDetector.indicatesRejectedCredentials(
+                new IOException("connection reset"))).isFalse();
+    }
+
+    private void denyRepeatedly(String operation, int times, Duration spacing) {
+        for (int i = 0; i < times; i++) {
+            recordFailure(operation, accessDenied("denied"));
+            advance(spacing);
+        }
+    }
+
+    /**
+     * Drives the detector through the same {@link ExecutionInterceptor} hooks the SDK calls in production, so the tests
+     * exercise the wiring rather than any test-only entry point.
+     */
+    private void recordFailure(String operation, Throwable throwable) {
+        final Context.FailedExecution failedExecution = mock(Context.FailedExecution.class);
+        when(failedExecution.exception()).thenReturn(throwable);
+        detector.onExecutionFailure(failedExecution, attributesFor(operation));
+    }
+
+    private void recordSuccess(String operation) {
+        detector.afterExecution(mock(Context.AfterExecution.class), attributesFor(operation));
+    }
+
+    private void advance(Duration duration) {
+        clock.addAndGet(duration.toNanos());
+    }
+
+    private static ExecutionAttributes attributesFor(String operation) {
+        return new ExecutionAttributes().putAttribute(SdkExecutionAttribute.OPERATION_NAME, operation);
+    }
+
+    private static DynamoDbException accessDenied(String message) {
+        // DynamoDB answers IAM denials with HTTP 400 and the error code in the payload, so classification
+        // must key on the error code rather than the status code.
+        return (DynamoDbException) DynamoDbException.builder()
+                .statusCode(400)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDeniedException")
+                        .errorMessage(message)
+                        .build())
+                .message(message)
+                .build();
+    }
+
+    private static AwsServiceException withErrorCode(String errorCode, String message) {
+        return AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode(errorCode)
+                        .errorMessage(message)
+                        .build())
+                .message(message)
+                .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
@@ -217,10 +217,8 @@ class AWSAuthorizationFailureDetectorTest {
             "InvalidClientTokenId",
             "InvalidSignatureException",
             "SignatureDoesNotMatch",
-            "KMSAccessDeniedException",
             "KMSNotFoundException",
-            "KMSOptInRequired",
-            "KMSDisabledException"})
+            "KMSOptInRequired"})
     void treatsDeniedActionsUnusableCredentialsAndUnusableKeysAsTerminal(String errorCode) {
         for (int i = 0; i < 10; i++) {
             recordFailure(QUERY, withErrorCode(errorCode, "denied"));
@@ -233,8 +231,10 @@ class AWSAuthorizationFailureDetectorTest {
     /**
      * Expired session credentials and throttling arrive as authorization-shaped errors but recover on their own.
      * Failing an input over either would be a worse bug than the log spam this class exists to stop.
-     * {@code KMSInvalidStateException} is here because its service documentation does not say which key states
-     * produce it, so an allowlist has to fail safe.
+     * The KMS codes are here because each names a state an operator routinely clears without touching Graylog: a CMK
+     * disabled during rotation, an expired grant or an edited key policy, or a key state
+     * {@code KMSInvalidStateException} does not identify. Failing an input over any of them would stop a stream that
+     * recovers on its own.
      */
     @ParameterizedTest
     @ValueSource(strings = {
@@ -243,7 +243,9 @@ class AWSAuthorizationFailureDetectorTest {
             "ProvisionedThroughputExceededException",
             "ThrottlingException",
             "RequestLimitExceeded",
-            "KMSInvalidStateException"})
+            "KMSInvalidStateException",
+            "KMSAccessDeniedException",
+            "KMSDisabledException"})
     void neverReportsSelfHealingErrors(String errorCode) {
         for (int i = 0; i < 10; i++) {
             recordFailure(QUERY, withErrorCode(errorCode, "retry later"));

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerTest.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.kinesis.common.KinesisClientUtil;
 
 import java.time.Duration;
 import java.util.List;
@@ -139,6 +140,17 @@ class KinesisConsumerTest {
         assertThat(detectorsOn(builders.dynamoDb())).hasSize(1);
         assertThat(detectorsOn(builders.kinesis())).hasSize(1);
         assertThat(detectorsOn(builders.cloudWatch())).isEmpty();
+    }
+
+    /**
+     * Unlike master, this branch hands the Kinesis builder to KCL, which applies its own HTTP client builder before
+     * building the client. The detector has to survive that call, and nothing else here would notice KCL resetting
+     * the override configuration, so pin it.
+     */
+    @Test
+    void theKinesisDetectorSurvivesKclAdjustingTheBuilder() {
+        assertThat(detectorsOn(KinesisClientUtil.adjustKinesisClientBuilder(newClientBuilders().kinesis())))
+                .hasSize(1);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/transports/KinesisConsumerTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.integrations.aws.transports;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.integrations.aws.AWSAuthorizationFailureDetector;
+import org.graylog.integrations.aws.AWSClientBuilderUtil;
+import org.graylog.integrations.aws.AWSMessageType;
+import org.graylog.integrations.aws.resources.requests.AWSRequest;
+import org.graylog2.plugin.InputFailureRecorder;
+import org.graylog2.plugin.system.SimpleNodeId;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkExecutionAttribute;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class KinesisConsumerTest {
+
+    private static final String STREAM = "test-stream";
+
+    private final InputFailureRecorder inputFailureRecorder = mock(InputFailureRecorder.class);
+    private final AWSClientBuilderUtil awsClientBuilderUtil = mock(AWSClientBuilderUtil.class);
+    private final AtomicLong clock = new AtomicLong();
+
+    /**
+     * The load-bearing test for the whole feature: it drives a denial through the interceptor actually installed on
+     * the DynamoDB client, so it fails if the detector is not wired to {@code handleAuthorizationFailure} at all.
+     * Asserting that the interceptor merely exists leaves that possible.
+     */
+    @Test
+    void aDenialSeenByTheInstalledInterceptorFailsTheInput() {
+        final ExecutionInterceptor detector = detectorsOn(newClientBuilders().dynamoDb()).get(0);
+        final DynamoDbException denial = accessDeniedException();
+        final Context.FailedExecution failedExecution = mock(Context.FailedExecution.class);
+        when(failedExecution.exception()).thenReturn(denial);
+
+        detector.onExecutionFailure(failedExecution, attributesFor("Query"));
+        clock.addAndGet(Duration.ofMinutes(3).toNanos());
+        detector.onExecutionFailure(failedExecution, attributesFor("Query"));
+
+        verify(inputFailureRecorder).setTerminallyFailing(eq(KinesisConsumer.class), contains(STREAM), eq(denial));
+    }
+
+    @Test
+    void authorizationFailureFailsTheInputAndStopsTheConsumerOffTheCallbackThread() throws Exception {
+        final DynamoDbException denial = accessDeniedException();
+        final KinesisConsumer consumer = spy(newConsumer());
+        final AtomicReference<String> stopThreadName = new AtomicReference<>();
+        final CountDownLatch stopCalled = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            stopThreadName.set(Thread.currentThread().getName());
+            stopCalled.countDown();
+            return null;
+        }).when(consumer).stop();
+
+        consumer.handleAuthorizationFailure(denial);
+
+        // Terminal, so it has to replace any transient failure already recorded rather than be dropped.
+        verify(inputFailureRecorder).setTerminallyFailing(eq(KinesisConsumer.class), contains(STREAM), eq(denial));
+        assertThat(stopCalled.await(5, TimeUnit.SECONDS)).isTrue();
+        // stop() blocks for up to 20s on a shared SDK response-completion thread, so it must not run inline. The name
+        // carries the stream so that concurrent failures are distinguishable in a thread dump.
+        assertThat(stopThreadName.get()).isEqualTo(KinesisConsumer.shutdownThreadName(STREAM));
+    }
+
+    // Several tests here let the real stop() run on the shutdown thread. That is safe and immediate: the scheduler
+    // was never started, so stop() returns without touching it.
+
+    @Test
+    void handlesOnlyTheFirstAuthorizationFailure() {
+        final KinesisConsumer consumer = newConsumer();
+
+        consumer.handleAuthorizationFailure(accessDeniedException());
+        consumer.handleAuthorizationFailure(accessDeniedException());
+
+        verify(inputFailureRecorder, times(1)).setTerminallyFailing(any(), anyString(), any());
+    }
+
+    /**
+     * Granting a permission and correcting a rejected key are different actions, so the message must not tell the
+     * operator to grant something when AWS refused the credentials outright.
+     */
+    @Test
+    void namesTheCredentialsRatherThanAPermissionWhenAwsRejectsTheKey() {
+        final KinesisConsumer consumer = newConsumer();
+
+        consumer.handleAuthorizationFailure(withErrorCode("SignatureDoesNotMatch"));
+
+        verify(inputFailureRecorder).setTerminallyFailing(eq(KinesisConsumer.class), contains("credentials"), any());
+    }
+
+    /**
+     * The exclusions are the load-bearing part: sharing one detector across clients lets operation names collide
+     * between services, and watching CloudWatch would fail an input over lost metrics.
+     */
+    @Test
+    void watchesDynamoDbAndKinesisForAuthorizationFailuresButNotCloudWatch() {
+        final KinesisConsumer.ClientBuilders builders = newClientBuilders();
+
+        assertThat(detectorsOn(builders.dynamoDb())).hasSize(1);
+        assertThat(detectorsOn(builders.kinesis())).hasSize(1);
+        assertThat(detectorsOn(builders.cloudWatch())).isEmpty();
+    }
+
+    @Test
+    void givesEachWatchedClientItsOwnDetector() {
+        final KinesisConsumer.ClientBuilders builders = newClientBuilders();
+
+        assertThat(detectorsOn(builders.dynamoDb()).get(0))
+                .isNotSameAs(detectorsOn(builders.kinesis()).get(0));
+    }
+
+    private static List<ExecutionInterceptor> detectorsOn(SdkClientBuilder<?, ?> builder) {
+        return builder.overrideConfiguration().executionInterceptors().stream()
+                .filter(AWSAuthorizationFailureDetector.class::isInstance)
+                .toList();
+    }
+
+    private static ExecutionAttributes attributesFor(String operation) {
+        return new ExecutionAttributes().putAttribute(SdkExecutionAttribute.OPERATION_NAME, operation);
+    }
+
+    private KinesisConsumer.ClientBuilders newClientBuilders() {
+        return newConsumer().createClientBuilders(Region.EU_WEST_1, mock(AwsCredentialsProvider.class));
+    }
+
+    private static DynamoDbException accessDeniedException() {
+        return (DynamoDbException) DynamoDbException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("AccessDeniedException")
+                        .errorMessage("User: arn:aws:sts::1:assumed-role/graylog/x is not authorized to perform: "
+                                + "dynamodb:Query on resource: arn:aws:dynamodb:eu-west-1:1:"
+                                + "table/graylog-aws-plugin-test-stream/index/LeaseOwnerToLeaseKeyIndex")
+                        .build())
+                .message("not authorized")
+                .build();
+    }
+
+    private static DynamoDbException withErrorCode(String errorCode) {
+        return (DynamoDbException) DynamoDbException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode(errorCode)
+                        .errorMessage(errorCode)
+                        .build())
+                .message(errorCode)
+                .build();
+    }
+
+    private KinesisConsumer newConsumer() {
+        return new KinesisConsumer(
+                new SimpleNodeId("00000000-0000-0000-0000-000000000000"),
+                mock(KinesisTransport.class),
+                new ObjectMapper(),
+                rawMessage -> {},
+                STREAM,
+                AWSMessageType.KINESIS_RAW,
+                10_000,
+                mock(AWSRequest.class),
+                awsClientBuilderUtil,
+                inputFailureRecorder,
+                clock::get);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/InputStateListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/InputStateListenerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.inputs;
+
+import com.google.common.eventbus.EventBus;
+import org.graylog2.inputs.persistence.InputStateService;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.IOState;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.events.inputs.IOStateChangedEvent;
+import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.system.SimpleNodeId;
+import org.graylog2.shared.system.activities.ActivityWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InputStateListenerTest {
+
+    private static final String INPUT_ID = "6510deadbeefdeadbeefdead";
+
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private ActivityWriter activityWriter;
+    @Mock
+    private ServerStatus serverStatus;
+    @Mock
+    private InputStateService inputStateService;
+
+    private final MessageInput input = mock(MessageInput.class);
+    private InputStateListener listener;
+
+    @BeforeEach
+    void setUp() {
+        when(input.getId()).thenReturn(INPUT_ID);
+        when(serverStatus.getNodeId()).thenReturn(new SimpleNodeId("00000000-0000-0000-0000-000000000000"));
+        when(notificationService.buildNow()).thenReturn(mock(Notification.class, RETURNS_SELF));
+
+        listener = new InputStateListener(mock(EventBus.class), notificationService, activityWriter, serverStatus,
+                inputStateService);
+    }
+
+    /**
+     * A failure that retrying cannot resolve arrives while the input is already FAILING, so only the message changes.
+     * {@code publishIfFirst} will not overwrite the reason stored by the earlier transient failure, so the stale
+     * notification has to be retired first or the denied action and resource never reach the notification at all -
+     * the only surface a Cloud tenant can see.
+     */
+    @Test
+    void retiresTheStaleNotificationWhenOnlyTheMessageChanged() {
+        listener.inputStateChanged(eventFor(IOState.Type.FAILING, IOState.Type.FAILING));
+
+        final var order = inOrder(notificationService);
+        order.verify(notificationService).fixed(Notification.Type.INPUT_FAILING, INPUT_ID);
+        order.verify(notificationService).publishIfFirst(any());
+    }
+
+    @Test
+    void retiresTheStaleNotificationForARepeatedStartupFailure() {
+        listener.inputStateChanged(eventFor(IOState.Type.FAILED, IOState.Type.FAILED));
+
+        verify(notificationService).fixed(Notification.Type.INPUT_FAILED_TO_START, INPUT_ID);
+        verify(notificationService).publishIfFirst(any());
+    }
+
+    /**
+     * On a real transition there is nothing stale to retire: {@code publishIfFirst} stores the current message, so the
+     * extra delete would only cost a round trip and an audit event.
+     */
+    @Test
+    void doesNotRetireAnythingOnAStateTransition() {
+        listener.inputStateChanged(eventFor(IOState.Type.RUNNING, IOState.Type.FAILING));
+
+        verify(notificationService, never()).fixed(any(Notification.Type.class), anyString());
+        verify(notificationService).publishIfFirst(any());
+    }
+
+    private IOStateChangedEvent<MessageInput> eventFor(IOState.Type oldState, IOState.Type newState) {
+        // A mock event bus, so setting the message here does not re-enter the listener under test.
+        final IOState<MessageInput> state = new IOState<>(mock(EventBus.class), input, newState);
+        state.setDetailedMessage("AWS authorization failure for Kinesis input <test-stream>.");
+        return IOStateChangedEvent.create(oldState, newState, state);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/InputFailureRecorderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/InputFailureRecorderTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.plugin;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog2.plugin.events.inputs.IOStateChangedEvent;
+import org.graylog2.plugin.inputs.MessageInput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InputFailureRecorderTest {
+
+    private final EventBus eventBus = new EventBus();
+    private final StateChangeCollector stateChanges = new StateChangeCollector();
+    private final IOState<MessageInput> inputState =
+            new IOState<>(eventBus, mock(MessageInput.class), IOState.Type.RUNNING);
+    private final InputFailureRecorder recorder = new InputFailureRecorder(inputState);
+
+    @BeforeEach
+    void registerCollector() {
+        eventBus.register(stateChanges);
+    }
+
+    @Test
+    void setFailingKeepsTheMessageOfAFailureAlreadyRecorded() {
+        recorder.setFailing(getClass(), "first");
+        recorder.setFailing(getClass(), "second");
+
+        assertThat(inputState.getState()).isEqualTo(IOState.Type.FAILING);
+        assertThat(inputState.getDetailedMessage()).isEqualTo("first");
+    }
+
+    /**
+     * A terminal failure carries the only actionable detail - the denied action and resource - so it has to survive an
+     * earlier transient failure rather than be dropped by the de-duplication in {@code setFailing}.
+     */
+    @Test
+    void setTerminallyFailingReplacesTheMessageOfAFailureAlreadyRecorded() {
+        recorder.setFailing(getClass(), "Errors for Kinesis stream <test-stream>!");
+
+        recorder.setTerminallyFailing(getClass(), "AWS authorization failure",
+                new RuntimeException("not authorized to perform: dynamodb:Query"));
+
+        assertThat(inputState.getState()).isEqualTo(IOState.Type.FAILING);
+        assertThat(inputState.getDetailedMessage())
+                .isEqualTo("AWS authorization failure: (not authorized to perform: dynamodb:Query)");
+    }
+
+    /**
+     * The notification, the system message and the persisted runtime state are all written by
+     * {@link IOStateChangedEvent} subscribers, so a replacement message that publishes no event stays invisible
+     * everywhere except to callers reading the input state directly.
+     */
+    @Test
+    void publishesAnEventWhenATerminalMessageReplacesATransientOne() {
+        recorder.setFailing(getClass(), "Errors for Kinesis stream <test-stream>!");
+        assertThat(stateChanges.events).hasSize(1);
+
+        recorder.setTerminallyFailing(getClass(), "AWS authorization failure", null);
+
+        assertThat(stateChanges.events).hasSize(2);
+        assertThat(stateChanges.events.get(1).changedState().getDetailedMessage())
+                .isEqualTo("AWS authorization failure");
+    }
+
+    @Test
+    void publishesNoEventWhenNeitherStateNorMessageChanges() {
+        recorder.setFailing(getClass(), "same");
+        recorder.setFailing(getClass(), "same");
+
+        assertThat(stateChanges.events).hasSize(1);
+    }
+
+    @Test
+    void setTerminallyFailingMovesARunningInputToFailing() {
+        recorder.setTerminallyFailing(getClass(), "AWS authorization failure", null);
+
+        assertThat(inputState.getState()).isEqualTo(IOState.Type.FAILING);
+        assertThat(inputState.getDetailedMessage()).isEqualTo("AWS authorization failure");
+    }
+
+    /**
+     * Work that continues after a failure retrying cannot resolve - KCL keeps draining the leases it already holds -
+     * must not report the input healthy again, or it ends up displaying RUNNING with nothing behind it.
+     */
+    @Test
+    void setRunningDoesNotClearATerminalFailure() {
+        recorder.setTerminallyFailing(getClass(), "AWS authorization failure", null);
+
+        recorder.setRunning();
+
+        assertThat(inputState.getState()).isEqualTo(IOState.Type.FAILING);
+        assertThat(inputState.getDetailedMessage()).isEqualTo("AWS authorization failure");
+    }
+
+    /**
+     * The at-most-once property is the caller's to enforce, but the recorder must not turn a repeated report into a
+     * stream of state writes: every published event costs a system message, a notification rebuild and a Mongo upsert.
+     */
+    @Test
+    void setTerminallyFailingKeepsTheFirstTerminalMessage() {
+        recorder.setTerminallyFailing(getClass(), "first terminal failure", null);
+
+        recorder.setTerminallyFailing(getClass(), "second terminal failure", null);
+
+        assertThat(inputState.getDetailedMessage()).isEqualTo("first terminal failure");
+        assertThat(stateChanges.events).hasSize(1);
+    }
+
+    @Test
+    void setFailingDoesNotOverwriteATerminalFailure() {
+        recorder.setTerminallyFailing(getClass(), "AWS authorization failure", null);
+
+        recorder.setFailing(getClass(), "Errors for Kinesis stream <test-stream>!");
+
+        assertThat(inputState.getDetailedMessage()).isEqualTo("AWS authorization failure");
+    }
+
+    private static class StateChangeCollector {
+        private final List<IOStateChangedEvent<MessageInput>> events = new ArrayList<>();
+
+        @Subscribe
+        @SuppressWarnings("unused")
+        public void onStateChange(IOStateChangedEvent<MessageInput> event) {
+            events.add(event);
+        }
+    }
+}


### PR DESCRIPTION
Note: This is a backport of #26898 to `7.1`, but not a clean cherry-pick.

## Why 7.1 differs from 7.2

7.1 runs the same KCL 3.x and therefore has the same bug, but its Kinesis consumer is an older shape: 7.2 has reworked how the AWS clients are built, added the single-table migration, and gained an integration-test harness. The behavioural core, the denial detector and the failure recording, is byte-identical to `master`. Only the wiring around it is new work.

If the detector were attached incorrectly, the input would simply run without it and behave exactly as it does today, with nothing failing loudly to say so. A test for this is added.

The upgrade guidance is reworded for 7.1's feature set.

## What Circle will see

Their denial is `AccessDeniedException` on DynamoDB `Query`, a watched operation.

- After about two minutes of continuous denial, each affected input moves to `FAILING` with a message naming `dynamodb:Query` and the `LeaseOwnerToLeaseKeyIndex` ARN, and raises a system notification.
- The KCL scheduler stops, so the ~200/sec `Failed to execute lease discovery` loop ends. Bounded, not eliminated: roughly two minutes of denials per input per node, plus up to 20s of graceful-shutdown drain, then silence.
- **Ingestion is not restored.** That requires `dynamodb:Query` on `table/graylog-aws-plugin-*/index/*` granted on their role.
- After granting it, the input needs a manual stop and start. The terminal latch does not clear itself.
- Shards that never checkpointed resume at the stream tip, so the outage backlog is skipped for those. `KinesisConsumer` does not set `initialPositionInStream`, so KCL's `LATEST` default applies. Checkpointed shards replay from their checkpoint, within stream retention.

7.1 is the branch that reaches them. 7.0 ships KCL 2.6.1, which discovers leases by `Scan` and has no GSI, so this denial cannot occur there.

## Risk of blocking an input on a transient error

Once tripped, `terminallyFailed` latches: The consumer stays stopped until an operator restarts the input. Previously such a condition self-healed, at the cost of log spam. The exposure is therefore a correctly configured input stopping permanently over a temporary condition.

What makes that hard to hit: the streak needs at least two minutes between its first and last denial with **zero** successful calls in between. Expired session credentials, throttling and the recoverable KMS states are excluded from the allowlist for exactly this reason.

What remained: `KMSAccessDeniedException` and `KMSDisabledException` were terminal, and both are routine *temporary* states on a healthy SSE-KMS stream. Disabling a CMK is a standard rotation step, and a grant expiry or key-policy change during a deploy can exceed two minutes. They are therefore excluded, see below. `KMSNotFoundException` and `KMSOptInRequired` are genuinely unrecoverable, so terminal is correct for those. Harm is bounded by stream retention: a restart inside the retention window replays checkpointed shards.

## Excluding the recoverable codes

Fixed on `master` first as #27263 via #27265, now cherry-picked here: `KMSAccessDeniedException` and `KMSDisabledException` are out of the terminal list, `KMSNotFoundException` and `KMSOptInRequired` stay.

No effect on #15073. That denial is `AccessDeniedException` on DynamoDB `Query`, which stays terminal either way.

## Live validation

Validated on a sandcastle against the real KCL 3.4.2 lease discoverer querying the lease-owner GSI every ~10s, with a proxy in front of DynamoDB supplying the IAM denial the emulator cannot. A denied `Query` failed the input after 14 denials at +144s, matching the estimate of "the 14th attempt at about 130s"; a stop and start after clearing the issue resumed ingestion. `KMSDisabledException` ran 31 consecutive denials over five minutes without failing the input, while `KMSNotFoundException` failed it at 14 denials as a positive control.

Resolves Graylog2/graylog-plugin-enterprise#15073

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

