### PR TITLE
Do not fail a Kinesis input on a recoverable KMS failure

### DIFF
--- a/changelog/unreleased/pr-26898.toml
+++ b/changelog/unreleased/pr-26898.toml
@@ -10,8 +10,8 @@ an authorization error every few seconds indefinitely while consuming no records
 The input now reports a failure naming the denied action and resource, and stops its consumer, once a call it cannot
 work without has been denied for two minutes. Grant the missing permission, then stop and start the input. A denial
 the Kinesis Client Library works around, such as one affecting only lease rebalancing, is still logged but leaves the
-input running. KMS access failures on an encrypted stream (for example a disabled or deleted key) are treated the same
-way: restore access to the key, then stop and start the input.
+input running. On an encrypted stream, only a key that no longer exists fails the input, because a disabled key or a
+withdrawn key permission is usually restored without any change in Graylog, and those are logged and retried instead.
 """
 
 details.ops = """

--- a/changelog/unreleased/pr-26898.toml
+++ b/changelog/unreleased/pr-26898.toml
@@ -2,7 +2,7 @@ type = "f"
 message = "Fail the AWS Kinesis/CloudWatch input instead of retrying forever when AWS denies a required permission."
 
 issues = ["Graylog2/graylog-plugin-enterprise#15073"]
-pulls = ["26898"]
+pulls = ["26898", "27263"]
 
 details.user = """
 When the IAM role used by an AWS Kinesis/CloudWatch input was missing a required DynamoDB permission, the input logged

--- a/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
+++ b/graylog2-server/src/main/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetector.java
@@ -108,13 +108,14 @@ public class AWSAuthorizationFailureDetector implements ExecutionInterceptor {
     private static final Set<String> TERMINAL_ERROR_CODES = Sets.union(CREDENTIAL_ERROR_CODES, Set.of(
             "AccessDeniedException",
             "AccessDenied",
-            // KMS failures on an encrypted stream that need an operator to act. KMSInvalidStateException is
-            // deliberately absent: its service documentation does not say which key states produce it, so we cannot
-            // show it is unrecoverable, and an allowlist should fail safe.
-            "KMSAccessDeniedException",
+            // The only KMS failures on an encrypted stream that cannot clear without an operator. KMSDisabledException,
+            // KMSAccessDeniedException and KMSInvalidStateException are deliberately absent because each names a state
+            // that routinely clears on its own - a CMK disabled during rotation, an expired grant or an edited key
+            // policy, an unidentified key state - and failing an input over one would stop a stream that recovers.
+            // The cost is that a deleted key reported as KMSAccessDeniedException rather than KMSNotFoundException is
+            // no longer caught here, since AWS documents that code as covering both.
             "KMSNotFoundException",
-            "KMSOptInRequired",
-            "KMSDisabledException"));
+            "KMSOptInRequired"));
 
     private final Consumer<Throwable> onTerminalFailure;
     private final LongSupplier nanoClock;

--- a/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/integrations/aws/AWSAuthorizationFailureDetectorTest.java
@@ -217,10 +217,8 @@ class AWSAuthorizationFailureDetectorTest {
             "InvalidClientTokenId",
             "InvalidSignatureException",
             "SignatureDoesNotMatch",
-            "KMSAccessDeniedException",
             "KMSNotFoundException",
-            "KMSOptInRequired",
-            "KMSDisabledException"})
+            "KMSOptInRequired"})
     void treatsDeniedActionsUnusableCredentialsAndUnusableKeysAsTerminal(String errorCode) {
         for (int i = 0; i < 10; i++) {
             recordFailure(QUERY, withErrorCode(errorCode, "denied"));
@@ -233,8 +231,10 @@ class AWSAuthorizationFailureDetectorTest {
     /**
      * Expired session credentials and throttling arrive as authorization-shaped errors but recover on their own.
      * Failing an input over either would be a worse bug than the log spam this class exists to stop.
-     * {@code KMSInvalidStateException} is here because its service documentation does not say which key states
-     * produce it, so an allowlist has to fail safe.
+     * The KMS codes are here because each names a state an operator routinely clears without touching Graylog: a CMK
+     * disabled during rotation, an expired grant or an edited key policy, or a key state
+     * {@code KMSInvalidStateException} does not identify. Failing an input over any of them would stop a stream that
+     * recovers on its own.
      */
     @ParameterizedTest
     @ValueSource(strings = {
@@ -243,7 +243,9 @@ class AWSAuthorizationFailureDetectorTest {
             "ProvisionedThroughputExceededException",
             "ThrottlingException",
             "RequestLimitExceeded",
-            "KMSInvalidStateException"})
+            "KMSInvalidStateException",
+            "KMSAccessDeniedException",
+            "KMSDisabledException"})
     void neverReportsSelfHealingErrors(String errorCode) {
         for (int i = 0; i < 10; i++) {
             recordFailure(QUERY, withErrorCode(errorCode, "retry later"));


### PR DESCRIPTION
Closes #27263

## What

Stops treating `KMSDisabledException` and `KMSAccessDeniedException` as unrecoverable, so a Kinesis input on an encrypted stream is no longer failed for a KMS condition that clears on its own. 

## How

Removed both codes from `TERMINAL_ERROR_CODES` in `AWSAuthorizationFailureDetector`. They now take the same path as any other denial the Kinesis Client Library works around: logged, and retried until access returns.

## How Tested

Moving the two codes from `treatsDeniedActionsUnusableCredentialsAndUnusableKeysAsTerminal` to `neverReportsSelfHealingErrors` failed exactly two parameterized cases and nothing else, which is the red this change is meant to turn green.

## Related

- Follows up #26898
- Graylog2/graylog-plugin-enterprise#15073
- Needs to land before the `7.1` backport #27261, which will be updated to match so both branches keep an identical code list

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
