### PR TITLE
Replacing `www.example.com` in OkHttp Client test to fix flakiness

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -360,9 +360,9 @@ public class OkHttpClientProviderTest {
     /**
      * {@code 203.0.113.10} is a documentation-only address (RFC 5737 TEST-NET-3): it needs no DNS lookup
      * and can never resolve to a real host, unlike the {@code www.example.com} this class used to target
-     * -- {@link ProxySelectorProvider#get()} resolves the request host on every {@code select()} call, so
-     * a real hostname made this suite depend on live DNS and it was disabled for years over the resulting
-     * flakiness (Graylog2/graylog2-server#7644, #7799).
+     * -- the {@code ProxySelector} returned by {@link ProxySelectorProvider#get()} resolves the request
+     * host on every {@code select()} call, so a real hostname made this suite depend on live DNS and it
+     * was disabled for years over the resulting flakiness (Graylog2/graylog2-server#7644, #7799).
      */
     private Request request() {
         return new Request.Builder().url("http://203.0.113.10/").get().build();

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -29,7 +29,6 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -41,7 +40,6 @@ import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 public class OkHttpClientProviderTest {
     private final MockWebServer server = new MockWebServer();
 
@@ -62,7 +60,7 @@ public class OkHttpClientProviderTest {
                 .hasSize(1)
                 .first()
                 .matches(proxy -> proxy.type() == Proxy.Type.DIRECT);
-        assertThat(client.proxySelector().select(URI.create("http://www.example.com/")))
+        assertThat(client.proxySelector().select(URI.create("http://203.0.113.10/")))
                 .hasSize(1)
                 .first()
                 .matches(proxy -> proxy.equals(server.getProxyAddress()));
@@ -86,7 +84,6 @@ public class OkHttpClientProviderTest {
     }
 
     @Test
-    @Disabled
     public void testSuccessfulProxyConnectionWithoutAuthentication() throws IOException, InterruptedException {
         server.enqueue(successfulMockResponse());
 
@@ -100,7 +97,7 @@ public class OkHttpClientProviderTest {
         final RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
         assertThat(recordedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(recordedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(recordedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
     }
 
     @Test
@@ -119,12 +116,12 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
 
@@ -144,17 +141,16 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
 
     @Test
-    @Disabled
     public void testFailingProxyConnectionWithoutAuthentication() throws IOException, InterruptedException {
         server.enqueue(failedMockResponse());
 
@@ -169,7 +165,7 @@ public class OkHttpClientProviderTest {
         final RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
         assertThat(recordedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(recordedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(recordedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
     }
 
     @Test
@@ -188,12 +184,12 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
 
@@ -222,13 +218,13 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("", "password"));
 
         assertThat(response.code()).isEqualTo(401);
@@ -247,13 +243,13 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", ""));
 
         assertThat(response.code()).isEqualTo(401);
@@ -272,13 +268,13 @@ public class OkHttpClientProviderTest {
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(unauthenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(unauthenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
         assertThat(authenticatedRequest.getUrl().encodedPath()).isEqualTo("/");
-        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.HOST)).isEqualTo("203.0.113.10");
         assertThat(authenticatedRequest.getHeaders().get(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("", ""));
 
         assertThat(response.code()).isEqualTo(401);
@@ -301,13 +297,13 @@ public class OkHttpClientProviderTest {
         OkHttpClientProvider spyClientProvider = Mockito.spy(provider);
 
         final OkHttpClient client = spyClientProvider.get();
-        assertThat(client.proxySelector().select(URI.create("http://www.example.com/")))
+        assertThat(client.proxySelector().select(URI.create("http://203.0.113.10/")))
                 .hasSize(1)
                 .first()
                 .matches(proxy -> proxy.equals(server.getProxyAddress()));
 
         Mockito.doReturn(testProxyAddress).when(spyProxyProvider).getProxyAddress();
-        assertThat(client.proxySelector().select(URI.create("http://www.example.com/")))
+        assertThat(client.proxySelector().select(URI.create("http://203.0.113.10/")))
                 .hasSize(1)
                 .first()
                 .matches(proxy -> proxy.equals(testProxy));
@@ -361,7 +357,14 @@ public class OkHttpClientProviderTest {
         return provider.get();
     }
 
+    /**
+     * {@code 203.0.113.10} is a documentation-only address (RFC 5737 TEST-NET-3): it needs no DNS lookup
+     * and can never resolve to a real host, unlike the {@code www.example.com} this class used to target
+     * -- {@link ProxySelectorProvider#get()} resolves the request host on every {@code select()} call, so
+     * a real hostname made this suite depend on live DNS and it was disabled for years over the resulting
+     * flakiness (Graylog2/graylog2-server#7644, #7799).
+     */
     private Request request() {
-        return new Request.Builder().url("http://www.example.com/").get().build();
+        return new Request.Builder().url("http://203.0.113.10/").get().build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, in the `OkHttpClientProviderTest`, a dummy value of `www.example.com` was used for testing proxy configuration. This lead to unnecessary DNS lookups (in `ProxySelectorProvider`'s implementation of `ProxySelector#select`) and therefore flakiness. This change is now replacing this with the use of an IP (that is designated for use in tests) and reenables the test.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

