### PR TITLE
Fix: views fail to save with trend preference on Single Number widgets.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.tsx
@@ -24,6 +24,7 @@ import DecoratedValue from 'views/components/messagelist/decoration/DecoratedVal
 import CustomHighlighting from 'views/components/highlighting/CustomHighlighting';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
+import type { NumberAlignment } from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization, retrieveChartData } from 'views/components/aggregationbuilder/AggregationBuilder';
 import ElementDimensions from 'components/common/ElementDimensions';
@@ -107,6 +108,8 @@ const _extractFirstSeriesName = (config) => {
   return series.length === 0 ? undefined : series[0].function;
 };
 
+const DEFAULT_ALIGNMENT: NumberAlignment = 'bottom-right';
+
 const NumberVisualization = ({ config, fields, data, height: heightProp }: VisualizationComponentProps) => {
   const targetRef = useRef();
   const unitFeatureEnabled = useFeature(UNIT_FEATURE_FLAG);
@@ -116,6 +119,7 @@ const NumberVisualization = ({ config, fields, data, height: heightProp }: Visua
     (config.visualizationConfig as NumberVisualizationConfig) ?? NumberVisualizationConfig.create();
 
   const field = _extractFirstSeriesName(config);
+  const alignment = visualizationConfig.alignment ?? DEFAULT_ALIGNMENT;
 
   useEffect(onRenderComplete, [onRenderComplete]);
   const chartRows = retrieveChartData(data);
@@ -143,7 +147,7 @@ const NumberVisualization = ({ config, fields, data, height: heightProp }: Visua
     <ContainerComponent $height={heightProp} $trend={trend} data-testid="trend-background">
       <NumberBox resizeDelay={50}>
         {({ height, width }) => (
-          <AutoFontSizer height={height} width={width} alignment={visualizationConfig.alignment}>
+          <AutoFontSizer height={height} width={width} alignment={alignment}>
             <CustomHighlighting field={field} value={value}>
               <Value
                 field={field}
@@ -159,7 +163,7 @@ const NumberVisualization = ({ config, fields, data, height: heightProp }: Visua
       {visualizationConfig.trend && (
         <TrendBox>
           {({ height, width }) => (
-            <AutoFontSizer height={height} width={width} target={targetRef} alignment={visualizationConfig.alignment}>
+            <AutoFontSizer height={height} width={width} target={targetRef} alignment={alignment}>
               <Trend ref={targetRef} current={value} previous={previousValue} unit={unit} />
             </AutoFontSizer>
           )}

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.test.tsx
@@ -33,6 +33,9 @@ describe('Trend', () => {
     renderTrend({ previous: 23 });
 
     expect(await findTrend()).toMatch(/\+19/);
+    expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+      'Trend: +19 (+82.6%) compared to previous value of 23',
+    );
   });
 
   it('shows relative delta as percentage', async () => {
@@ -45,6 +48,9 @@ describe('Trend', () => {
     renderTrend();
 
     expect(await findTrend()).toMatch(/^0 \//);
+    expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+      'Trend: 0 (0.0%) compared to previous value of 42',
+    );
   });
 
   it('shows relative delta as percentage if values are equal', async () => {
@@ -57,6 +63,9 @@ describe('Trend', () => {
     renderTrend({ current: 23 });
 
     expect(await findTrend()).toMatch(/-19/);
+    expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+      'Trend: -19 (-45.2%) compared to previous value of 42',
+    );
   });
 
   it('shows negative relative delta as percentage', async () => {
@@ -69,6 +78,9 @@ describe('Trend', () => {
     renderTrend({ current: 23, previous: 0 });
 
     expect(await findTrend()).toMatch(/\+23/);
+    expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+      'Trend: +23 (--) compared to previous value of 0',
+    );
   });
 
   it('shows adequate results if previous value is NaN', async () => {
@@ -81,6 +93,9 @@ describe('Trend', () => {
     renderTrend({ current: 0, previous: 42 });
 
     expect(await findTrend()).toMatch(/-42 \/ -100\.0%/);
+    expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+      'Trend: -42 (-100.0%) compared to previous value of 42',
+    );
   });
 
   it('shows adequate results if current value is NaN', async () => {
@@ -103,6 +118,9 @@ describe('Trend', () => {
       const trendIcon = await screen.findByTestId('trend-icon');
 
       within(trendIcon).getByText('arrow_circle_down');
+      expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+        'Trend: -1 (-2.4%) compared to previous value of 42',
+      );
     });
 
     it('shows circle up if current values is higher', async () => {
@@ -110,6 +128,9 @@ describe('Trend', () => {
       const trendIcon = await screen.findByTestId('trend-icon');
 
       within(trendIcon).getByText('arrow_circle_up');
+      expect(await screen.findByTestId('trend-value')).toHaveAccessibleName(
+        'Trend: +1 (+2.4%) compared to previous value of 42',
+      );
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.tsx
@@ -98,7 +98,10 @@ const Trend = ({ current, previous, unit = undefined }: Props, ref: React.Forwar
   return (
     <TextContainer ref={ref}>
       <Icon name={trendIcon} data-testid="trend-icon" />{' '}
-      <span data-testid="trend-value" title={`Previous value: ${previousConverted}`}>
+      <span
+        data-testid="trend-value"
+        aria-label={`Trend: ${absoluteDifference} (${relativeDifference}) compared to previous value of ${previousConverted}`}
+        title={`Previous value: ${previousConverted}`}>
         {absoluteDifference} / {relativeDifference}
       </span>
     </TextContainer>

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.ts
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.ts
@@ -39,7 +39,7 @@ export default class NumberVisualizationConfig extends VisualizationConfig {
   constructor(
     trend: InternalState['trend'],
     trendPreference: InternalState['trendPreference'],
-    alignment: InternalState['alignment'] = 'bottom-right',
+    alignment: InternalState['alignment'] = undefined,
   ) {
     super();
     this._value = { trend, trendPreference, alignment };
@@ -53,7 +53,6 @@ export default class NumberVisualizationConfig extends VisualizationConfig {
     return this._value.trendPreference;
   }
 
-  // Where the value/trend are anchored within the widget. Defaults to 'bottom-right' for existing widgets.
   get alignment() {
     return this._value.alignment;
   }
@@ -66,7 +65,7 @@ export default class NumberVisualizationConfig extends VisualizationConfig {
   static create(
     trend: InternalState['trend'] = false,
     trendPreference: InternalState['trendPreference'] = 'NEUTRAL',
-    alignment: InternalState['alignment'] = 'bottom-right',
+    alignment: InternalState['alignment'] = undefined,
   ) {
     return new NumberVisualizationConfig(trend, trendPreference, alignment);
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Saving a dashboard with a Single Number widget failed with `Unable to map property alignment. Known properties include: trend, trend_preference`. This was caused by the widget config defaulting its (backend-unaware, internal-only) alignment setting to `bottom-right` and persisting it as part of the saved search. The default is now applied at render time instead of being stored in the widget config, so it's no longer sent to the backend.

Fixes #27270.
/nocl - fixes unreleased regression