### PR TITLE
Metrics can now throw AuthorizationException - resource filters them

### DIFF
--- a/changelog/unreleased/pr-27279.toml
+++ b/changelog/unreleased/pr-27279.toml
@@ -1,5 +1,0 @@
-type = "f"
-message = "Add missing permission checks to Alerts page count tiles for investigations, assets and system alerts."
-
-issues = ["graylog-plugin-enterprise#15475"]
-pulls = ["27279", "graylog-plugin-enterprise#15480"]

--- a/changelog/unreleased/pr-27279.toml
+++ b/changelog/unreleased/pr-27279.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Add missing permission checks to Alerts page count tiles for investigations, assets and system alerts."
+
+issues = ["graylog-plugin-enterprise#15475"]
+pulls = ["27279", "graylog-plugin-enterprise#15480"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/entities/preferences/EntityListPreferencesResource.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.subject.Subject;
 import org.graylog.security.UserContext;
@@ -58,6 +59,7 @@ import org.graylog2.shared.rest.PublicCloudAPI;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @RequiresAuthentication
 @PublicCloudAPI
@@ -188,17 +190,25 @@ public class EntityListPreferencesResource {
                 .getPredefinedForEntityList(entityListId)
                 .stream()
                 .sorted(Comparator.nullsFirst(Comparator.comparing(pref -> pref.preferences().priority())))
-                .map(pref -> new PredefinedLayoutVariant(
-                        pref.preferencesId().layoutVariant(),
-                        pref.preferencesId().entityListId(),
-                        pref.preferences().displayName(),
-                        pref.preferences().metrics()
+                .map(pref -> {
+                            try {
+                                final List<MetricValue> metrics = pref.preferences().metrics()
                                 .stream()
                                 .map(metricName -> metricProviders
                                         .getOrDefault(metricName, (tr, sub) -> new MetricValue(0L, "", metricName))
                                         .compute(timeRange, subject))
-                                .toList())
+                                        .toList();
+                                return new PredefinedLayoutVariant(
+                                        pref.preferencesId().layoutVariant(),
+                                        pref.preferencesId().entityListId(),
+                                        pref.preferences().displayName(),
+                                        metrics);
+                            } catch (AuthorizationException aux) {
+                                return null;
+                            }
+                        }
                 )
+                .filter(Objects::nonNull)
                 .toList();
 
     }


### PR DESCRIPTION
## Description
Metrics can now throw AuthorizationException - resource filters them.
/jpd Graylog2/graylog-plugin-enterprise#15480
/nocl -> not released functionality

## Motivation and Context
Needed to fix https://github.com/Graylog2/graylog-plugin-enterprise/issues/15475 and problems with rendering Alerts page for users with limited permissions (On the Alerts page, clicking on tiles like "Investigations" or "Assets" without required permissions will end up with an error). 

## How Has This Been Tested?
See https://github.com/Graylog2/graylog-plugin-enterprise/pull/15480

## Screenshots (if appropriate):
See https://github.com/Graylog2/graylog-plugin-enterprise/pull/15480

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

