### PR TITLE
Generate MCP tool schemas lazily instead of in the constructor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
@@ -19,7 +19,8 @@ package org.graylog.mcp.server;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.graylog.mcp.config.McpConfiguration;
 import org.graylog.mcp.tools.PermissionHelper;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -42,8 +43,8 @@ public abstract class Tool<P, O> {
     private final String name;
     private final String title;
     private final String description;
-    private final Map<String, Object> inputSchema;
-    private final Map<String, Object> outputSchema;
+    private final Supplier<Map<String, Object>> inputSchema;
+    private final Supplier<Map<String, Object>> outputSchema;
 
     @Deprecated
     protected Tool(
@@ -85,21 +86,21 @@ public abstract class Tool<P, O> {
         this.objectMapper = objectMapper;
         this.clusterConfigService = clusterConfigService;
 
-        // Get the schema generator with all contributed modules
-        SchemaGenerator generator = schemaGeneratorProvider.get();
-
-        // we can precompute the schema for our parameters, it's statically known
-        final var inputSchemaNode = generator.generateSchema(parameterType.getType());
-        // MCP requires every tool to declare an input schema; a parameterless tool gets an empty object schema.
-        this.inputSchema = inputSchemaNode.isEmpty()
-                ? Map.of("type", "object")
-                : objectMapper.convertValue(inputSchemaNode, new TypeReference<Map<String, Object>>() {});
-        // if our tool produces anything other than a String, we want to create a JSON schema for it
-        if (String.class.equals(outputType.getType())) {
-            this.outputSchema = null;
-        } else {
-            this.outputSchema = objectMapper.convertValue(generator.generateSchema(outputType.getType()), new TypeReference<Map<String, Object>>() {});
-        }
+        // Computed on first use, not in the constructor: a schema can derive from DB state that migrations
+        // seed only after tools are constructed. Baking it eagerly risks freezing an empty, invalid schema.
+        // First use happens after seeding; memoize still generates it exactly once.
+        this.inputSchema = Suppliers.memoize(() -> {
+            final var inputSchemaNode = schemaGeneratorProvider.get().generateSchema(parameterType.getType());
+            // An input schema is required even for a parameterless tool: an empty object schema.
+            return inputSchemaNode.isEmpty()
+                    ? Map.of("type", "object")
+                    : objectMapper.convertValue(inputSchemaNode, new TypeReference<Map<String, Object>>() {});
+        });
+        // String-output tools have no output schema; memoize caches that null correctly too.
+        this.outputSchema = Suppliers.memoize(() -> String.class.equals(outputType.getType())
+                ? null
+                : objectMapper.convertValue(schemaGeneratorProvider.get().generateSchema(outputType.getType()),
+                        new TypeReference<Map<String, Object>>() {}));
     }
 
     protected boolean isOutputSchemaEnabled() {
@@ -130,12 +131,12 @@ public abstract class Tool<P, O> {
 
     @JsonProperty
     public Map<String, Object> inputSchema() {
-        return inputSchema;
+        return inputSchema.get();
     }
 
     @JsonProperty
     public Optional<Map<String, Object>> outputSchema() {
-        return Optional.ofNullable(outputSchema);
+        return Optional.ofNullable(outputSchema.get());
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
+++ b/graylog2-server/src/main/java/org/graylog/mcp/server/Tool.java
@@ -86,14 +86,12 @@ public abstract class Tool<P, O> {
         this.objectMapper = objectMapper;
         this.clusterConfigService = clusterConfigService;
 
-        // Computed on first use, not in the constructor: a schema can derive from DB state that migrations
-        // seed only after tools are constructed. Baking it eagerly risks freezing an empty, invalid schema.
-        // First use happens after seeding; memoize still generates it exactly once.
+        // Lazily compute the schema on first use to avoid a GL-startup race with migrations that seed its data.
         this.inputSchema = Suppliers.memoize(() -> {
             final var inputSchemaNode = schemaGeneratorProvider.get().generateSchema(parameterType.getType());
-            // An input schema is required even for a parameterless tool: an empty object schema.
+            final Map<String, Object> emptySchema = Map.of("type", "object");
             return inputSchemaNode.isEmpty()
-                    ? Map.of("type", "object")
+                    ? emptySchema
                     : objectMapper.convertValue(inputSchemaNode, new TypeReference<Map<String, Object>>() {});
         });
         // String-output tools have no output schema; memoize caches that null correctly too.

--- a/graylog2-server/src/test/java/org/graylog/mcp/server/ToolLazySchemaTest.java
+++ b/graylog2-server/src/test/java/org/graylog/mcp/server/ToolLazySchemaTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.mcp.server;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.mcp.tools.PermissionHelper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * A tool's input/output schema is generated on first access, not in the constructor. Some schemas
+ * derive from mutable DB state that startup migrations seed only after tools are constructed.
+ * Generating in the constructor could freeze an empty, invalid schema whenever a tool is built before
+ * the seeder runs, cached for the life of the process. Deferring to first use (after seeding) avoids
+ * that; it is still generated exactly once.
+ */
+class ToolLazySchemaTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    void doesNotConsultTheSchemaGeneratorUntilFirstAccess() {
+        final SchemaGeneratorProvider provider = spy(new SchemaGeneratorProvider(Set.of()));
+
+        final Tool<TestParameters, String> tool = new TestTool(objectMapper, provider);
+
+        // Constructing the tool must not reach the generator — and therefore not the DB-backed schema
+        // modules — because construction can precede the migrations that seed what they read.
+        verify(provider, never()).get();
+
+        final Map<String, Object> first = tool.inputSchema();
+        assertThat(first).containsEntry("type", "object");
+
+        // Generated once, then memoized: the same instance returns and the generator is not consulted again.
+        final Map<String, Object> second = tool.inputSchema();
+        assertThat(second).isSameAs(first);
+        verify(provider, times(1)).get();
+    }
+
+    private static final class TestTool extends Tool<TestParameters, String> {
+        private TestTool(ObjectMapper objectMapper, SchemaGeneratorProvider schemaGeneratorProvider) {
+            super(new TypeReference<>() {}, new TypeReference<>() {}, "test_tool", "Test tool",
+                    "A tool used only by this test.", objectMapper, null, schemaGeneratorProvider);
+        }
+
+        @Override
+        public Set<String> checkedPermissions() {
+            return Set.of();
+        }
+
+        @Override
+        public String apply(PermissionHelper permissionHelper, TestParameters parameters) {
+            return "ok";
+        }
+    }
+
+    private static final class TestParameters {
+        @JsonProperty("query")
+        public String query() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Description
Generate MCP tool input and output JSON schemas lazily on first access, memoized, instead of eagerly in the `Tool` base-class constructor. `inputSchema()`/`outputSchema()` now return from `Suppliers.memoize(...)` suppliers; the schema generator, parameter type, and output type are captured for that deferred call. Each schema is still generated exactly once.

## Motivation and Context
Building the schema in the constructor couples it to whatever database state exists at construction time. A tool can be constructed before the standard migrations that seed the data its schema derives from have run, freezing an empty and invalid schema (for example an empty `oneOf: []`, which violates JSON Schema draft 2020-12) that is then cached for the process lifetime. Because it depends on a startup ordering race, the failures are intermittent and restart-dependent. Deferring generation to first use (after seeding) avoids this.

Fixes #27280

/nocl wip

## How Has This Been Tested?
Added `ToolLazySchemaTest` asserting that constructing a tool never consults the schema generator and that the schema is generated exactly once and memoized (same instance returned, generator consulted once). Existing MCP tool tests (`ToolOutputSchemaComplianceTest`, `McpServiceTest`) still pass. Also verified the full reactor compiles and the downstream tool-schema tests that exercise DB-derived schemas pass against this change.

## Screenshots (if appropriate):
N/A (backend-only change).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
