### PR TITLE
Display alert histogram as area chart instead of line chart.

### DIFF
--- a/graylog2-web-interface/src/components/events/EventsHistogram.tsx
+++ b/graylog2-web-interface/src/components/events/EventsHistogram.tsx
@@ -38,7 +38,7 @@ import type { UserDateTimeContextType } from 'contexts/UserDateTimeContext';
 import useOnRefresh from 'components/common/PaginatedEntityTable/useOnRefresh';
 
 const config = AggregationWidgetConfig.builder()
-  .visualization('line')
+  .visualization('area')
   .rowPivots([Pivot.create(['timestamp'], DateType)])
   .columnPivots([Pivot.createValues(['type'])])
   .series([Series.forFunction('count()')])
@@ -69,6 +69,7 @@ const generateChart = (
     name: type,
     x,
     y,
+    fill: 'tozeroy',
     originalName: type,
     line: {
       shape: 'linear',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


This PR contains a small change to display the alert histogram as an area chart instead of a line chart.

Related to https://github.com/Graylog2/graylog-plugin-enterprise/issues/15477
/nocl - small visual change