### PR TITLE
Reduce MongoDB round-trips during content installation 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -22,6 +22,7 @@ import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.ReplaceOptions;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.conversions.Bson;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
@@ -49,6 +50,7 @@ import static org.graylog2.database.utils.MongoUtils.insertedIdAsString;
 import static org.graylog2.database.utils.MongoUtils.stringIdsIn;
 import static org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory.createDefaultRateLimitedLog;
 
+@Singleton
 public class MongoDbPipelineService implements PipelineService {
     private static final RateLimitedLog log = createDefaultRateLimitedLog(MongoDbPipelineService.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
@@ -22,6 +22,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
 import org.graylog.plugins.pipelineprocessor.events.PipelineConnectionsChangedEvent;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
@@ -40,6 +41,7 @@ import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory.createDefaultRateLimitedLog;
 
+@Singleton
 public class MongoDbPipelineStreamConnectionsService implements PipelineStreamConnectionsService {
     private static final RateLimitedLog log = createDefaultRateLimitedLog(MongoDbPipelineStreamConnectionsService.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
@@ -23,6 +23,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.Sorts;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog.plugins.pipelineprocessor.events.RulesChangedEvent;
@@ -48,6 +49,7 @@ import static org.graylog2.plugin.utilities.ratelimitedlog.RateLimitedLogFactory
 /**
  * A RuleService backed by a MongoDB collection.
  */
+@Singleton
 public class MongoDbRuleService implements RuleService {
     private static final RateLimitedLog log = createDefaultRateLimitedLog(MongoDbRuleService.class);
 

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.InsertOneModel;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.conversions.Bson;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
@@ -54,6 +55,7 @@ import static com.mongodb.client.model.Filters.or;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+@Singleton
 public class DBGrantService {
     public static final String COLLECTION_NAME = "grants";
 

--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityRegistrar.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityRegistrar.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security.entities;
 
+import com.google.common.base.Suppliers;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -26,17 +27,18 @@ import org.graylog.grn.GRNTypes;
 import org.graylog2.plugin.database.users.User;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 @Singleton
 public class EntityRegistrar {
     private final GRNRegistry grnRegistry;
-    private final Provider<Set<EntityRegistrationHandler>> registrationHandlersProvider;
+    private final Supplier<Set<EntityRegistrationHandler>> registrationHandlers;
 
     @Inject
     public EntityRegistrar(GRNRegistry grnRegistry,
                            Provider<Set<EntityRegistrationHandler>> registrationHandlersProvider) {
         this.grnRegistry = grnRegistry;
-        this.registrationHandlersProvider = registrationHandlersProvider;
+        this.registrationHandlers = Suppliers.memoize(registrationHandlersProvider::get);
     }
 
     public void registerNewEventDefinition(String id, User user) {
@@ -64,11 +66,11 @@ public class EntityRegistrar {
     }
 
     public void registerNewEntity(GRN entityGRN, User user) {
-        registrationHandlersProvider.get().forEach(handler -> handler.handleRegistration(entityGRN, user));
+        registrationHandlers.get().forEach(handler -> handler.handleRegistration(entityGRN, user));
     }
 
     public void unregisterEntity(GRN entityGRN) {
-        registrationHandlersProvider.get().forEach(handler -> handler.handleUnregistration(entityGRN));
+        registrationHandlers.get().forEach(handler -> handler.handleUnregistration(entityGRN));
     }
 
     public void unregisterEntity(final String id, final GRNType grnType) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.result.InsertOneResult;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.graylog2.database.MongoCollection;
@@ -53,6 +54,7 @@ import static org.graylog2.indexer.indexset.fields.ExtendedIndexSetFields.FIELD_
 import static org.graylog2.indexer.indexset.fields.FieldTypeProfileField.FIELD_PROFILE_ID;
 import static org.graylog2.indexer.indexset.fields.IndexPrefixField.FIELD_INDEX_PREFIX;
 
+@Singleton
 public class MongoIndexSetService implements IndexSetService {
     public static final String COLLECTION_NAME = "index_sets";
     public static final String FIELD_TITLE = "title";

--- a/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
@@ -102,6 +102,9 @@ public class OutputServiceImpl implements OutputService {
 
     @Override
     public Set<Output> loadByIds(Collection<String> ids) {
+        if (ids.isEmpty()) {
+            return Set.of();
+        }
         final Map<String, AvailableOutputSummary> availableOutputs = messageOutputFactory.getAvailableOutputs();
         try (final var stream = MongoUtils.stream(collection.find(MongoUtils.stringIdsIn(ids)))) {
             return stream.map(output -> withEncryptedFields(output, availableOutputs)).collect(ImmutableSet.toImmutableSet());

--- a/graylog2-server/src/test/java/org/graylog/security/entities/EntityRegistrarTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/entities/EntityRegistrarTest.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class EntityRegistrarTest {
@@ -67,5 +69,21 @@ class EntityRegistrarTest {
         entityRegistrar.unregisterEntity("1234", GRNTypes.DASHBOARD);
         Mockito.verify(handler1).handleUnregistration(grnRegistry.newGRN(GRNTypes.DASHBOARD, "1234"));
         Mockito.verify(handler2).handleUnregistration(grnRegistry.newGRN(GRNTypes.DASHBOARD, "1234"));
+    }
+
+    @Test
+    void resolvesRegistrationHandlersOnlyOnce() {
+        final AtomicInteger resolutions = new AtomicInteger();
+        final EntityRegistrar registrar = new EntityRegistrar(grnRegistry, () -> {
+            resolutions.incrementAndGet();
+            return registrationHandlers;
+        });
+        final var user = mock(User.class);
+
+        registrar.registerNewEntity("1", user, GRNTypes.DASHBOARD);
+        registrar.registerNewEntity("2", user, GRNTypes.DASHBOARD);
+        registrar.unregisterEntity("1", GRNTypes.DASHBOARD);
+
+        assertThat(resolutions).hasValue(1);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/OutputServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/OutputServiceImplTest.java
@@ -51,6 +51,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -224,5 +225,12 @@ public class OutputServiceImplTest {
         assertThat(password.getString("encrypted_value")).isNotBlank();
         assertThat(password.getString("salt")).isNotBlank();
         assertThat(stored.toJson()).doesNotContain("s3cret");
+    }
+
+    @Test
+    public void loadByIdsWithNoIdsSkipsAvailableOutputLookup() {
+        assertThat(outputService.loadByIds(Collections.emptySet())).isEmpty();
+
+        verify(messageOutputFactory, never()).getAvailableOutputs();
     }
 }


### PR DESCRIPTION
## Description

Removes redundant MongoDB round trips on the entity creation path. Installing a large set of content (streams, index sets, dashboards, searches, event definitions) triggered tens of thousands of avoidable database calls, most of them re-creating indexes that already existed.

/nocl refactoring to improve performance

Three independent causes:

**Services with `createIndex` in their constructor were not singletons.** Guice rebuilt them on every injection, and each construction re-issued its index creation against MongoDB. Scoped `MongoDbPipelineService`, `MongoDbRuleService`, `MongoDbPipelineStreamConnectionsService`, `MongoIndexSetService` and `DBGrantService` to `@Singleton`. All are stateless DAOs with final fields and no event bus subscriptions.

**`EntityRegistrar` resolved its handler set per call.** It held a `Provider<Set<EntityRegistrationHandler>>` and called `get()` on every entity registration, so Guice rebuilt the whole multibound set, along with every handler and everything they inject, each time. The set is now resolved once via `Suppliers.memoize`. The `Provider` is kept so resolution stays lazy.

**`OutputServiceImpl.loadByIds` did expensive work for empty input.** It built the available-output summaries for every registered output type before querying, and some output configurations enumerate the full pipeline collection to populate their requested configuration. Stream loading calls this once per query and streams commonly have no outputs, so it now returns early when there are no ids.

## Motivation and Context

Content installation was dominated by database chatter rather than real work. Measured on a large install creating 66 index sets and 66 streams:

| | Before | After |
|---|---|---|
| `createIndex` share of all Mongo reads | 48% | low single digits |
| `DBGrantService` construction round trips | 21,744 | 4 |
| `MessageOutputFactory.getAvailableOutputs` calls | 18,515 | 0 |
| `MongoDbPipelineService.loadAll` calls | 15,126 | 0 |

Install wall time improved roughly 15%. The remaining cost is genuine I/O rather than repeated setup.

## How Has This Been Tested?

- JFR profiling of a full content install before and after each change, confirming the eliminated call counts above.
- New `EntityRegistrarTest.resolvesRegistrationHandlersOnlyOnce` asserts the handler set is resolved exactly once across multiple registrations.
- New `OutputServiceImplTest.loadByIdsWithNoIdsSkipsAvailableOutputLookup` asserts an empty id collection never touches the output factory.
- Existing `EntityRegistrarTest` and `OutputServiceImplTest` cases pass unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)