### PR TITLE
Replace Array.reduce with Object.fromEntries for object construction

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstall.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstall.tsx
@@ -90,16 +90,15 @@ class ContentPackInstall extends React.Component<ContentPackInstallProps, State>
     }
   };
 
-  _convertedParameters = (): { [parameterName: string]: string } =>
-    Object.keys(this.state.parameterInput).reduce((result, paramName) => {
-      const newResult = result;
-      const paramType = this.props.contentPack.parameters.find((parameter) => parameter.name === paramName).type;
-      const value = ContentPackUtils.convertValue(paramType, this.state.parameterInput[paramName]);
+  _convertedParameters = (): { [parameterName: string]: ReturnType<typeof ValueRefHelper.createValueRef> } =>
+    Object.fromEntries(
+      Object.keys(this.state.parameterInput).map((paramName) => {
+        const paramType = this.props.contentPack.parameters.find((parameter) => parameter.name === paramName).type;
+        const value = ContentPackUtils.convertValue(paramType, this.state.parameterInput[paramName]);
 
-      newResult[paramName] = ValueRefHelper.createValueRef(paramType, value);
-
-      return newResult;
-    }, {});
+        return [paramName, ValueRefHelper.createValueRef(paramType, value)];
+      }),
+    );
 
   _getValue = (name: string, value: string) => {
     this.setState(({ parameterInput }) => ({ parameterInput: { ...parameterInput, [name]: value } }));

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.tsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.tsx
@@ -205,17 +205,16 @@ class ContentPackSelection extends React.Component<
       return;
     }
 
-    const filtered = Object.keys(entities).reduce((result, type) => {
-      const filteredEntities = cloneDeep(result);
+    const filtered = Object.fromEntries(
+      Object.keys(entities).map((type) => [
+        type,
+        entities[type].filter((entity) => {
+          const regexp = RegExp(filter, 'i');
 
-      filteredEntities[type] = entities[type].filter((entity) => {
-        const regexp = RegExp(filter, 'i');
-
-        return regexp.test(entity.title);
-      });
-
-      return filteredEntities;
-    }, {});
+          return regexp.test(entity.title);
+        }),
+      ]),
+    );
 
     this.setState({ filteredEntities: filtered, isFiltered: true, filter: filter });
   };

--- a/graylog2-web-interface/src/components/lookup-tables/adapter-form/AdapterFormFields.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapter-form/AdapterFormFields.tsx
@@ -34,14 +34,9 @@ function AdapterFormFields() {
 
   const _runValidations = useCallback(() => {
     validateDataAdapter(values).then((resp: { errors: validationErrorsType }) => {
-      const auxErrors = Object.keys(resp.errors).reduce((acc, key) => {
-        // eslint-disable-next-line no-param-reassign
-        if (errors[key]) acc[key] = errors[key];
-        // eslint-disable-next-line no-param-reassign
-        else acc[key] = resp.errors[key][0];
-
-        return acc;
-      }, {});
+      const auxErrors = Object.fromEntries(
+        Object.keys(resp.errors).map((key) => [key, errors[key] || resp.errors[key][0]]),
+      );
 
       const configErrors = configRef?.current?.validate?.() || {};
       setErrors({ ...auxErrors, ...configErrors });

--- a/graylog2-web-interface/src/components/lookup-tables/cache-form/CacheFormFields.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/cache-form/CacheFormFields.tsx
@@ -34,14 +34,9 @@ function CacheFormFields() {
 
   const _runValidations = useCallback(() => {
     validateCache(values).then((resp: { errors: validationErrorsType }) => {
-      const auxErrors = Object.keys(resp.errors).reduce((acc, key) => {
-        // eslint-disable-next-line no-param-reassign
-        if (errors[key]) acc[key] = errors[key];
-        // eslint-disable-next-line no-param-reassign
-        else acc[key] = resp.errors[key][0];
-
-        return acc;
-      }, {});
+      const auxErrors = Object.fromEntries(
+        Object.keys(resp.errors).map((key) => [key, errors[key] || resp.errors[key][0]]),
+      );
 
       const configErrors = configRef?.current?.validate?.() || {};
       setErrors({ ...auxErrors, ...configErrors });

--- a/graylog2-web-interface/src/pages/EditContentPackPage.tsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.tsx
@@ -67,12 +67,12 @@ const EditContentPackPage = () => {
 
     const groupedContentPackEntities = groupBy(contentPackEntities, 'type.name');
 
-    return Object.keys(entityIndex).reduce((result, entityType) => {
-      /* eslint-disable-next-line no-param-reassign */
-      result[entityType] = entityIndex[entityType].concat(groupedContentPackEntities[entityType] || []);
-
-      return result;
-    }, {});
+    return Object.fromEntries(
+      Object.keys(entityIndex).map((entityType) => [
+        entityType,
+        entityIndex[entityType].concat(groupedContentPackEntities[entityType] || []),
+      ]),
+    );
   }, [contentPack, entityIndex, contentPackEntities]);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -57,6 +57,7 @@ export function useStore(store, propsMapper = id) {
         storeStateRef.current = newState;
       }
     });
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setStoreState(store.getInitialState?.());
 
     return unsub;

--- a/graylog2-web-interface/src/stores/connect.tsx
+++ b/graylog2-web-interface/src/stores/connect.tsx
@@ -133,8 +133,8 @@ function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores,
       super(props);
 
       // Retrieving initial state from each configured store
-      const storeStates = Object.keys(stores)
-        .map((key) => {
+      const storeStates = Object.fromEntries(
+        Object.keys(stores).map((key) => {
           const store = stores[key];
 
           if (store === undefined || !isFunction(store.getInitialState)) {
@@ -149,8 +149,8 @@ function connect<C extends React.ComponentType<React.ComponentProps<C>>, Stores,
           const state = store.getInitialState();
 
           return [key, state];
-        })
-        .reduce((prev, [key, state]) => ({ ...prev, [key as string]: state }), {});
+        }),
+      );
 
       this.state = { ...this.state, ...storeStates };
     }

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.ts
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.ts
@@ -92,9 +92,7 @@ export const NodesStore = singletonStore('core.Nodes', () =>
             this.nodes = {};
 
             if (response.nodes) {
-              this.nodes = response.nodes
-                .map<[string, NodeInfo]>((node) => [node.node_id, node])
-                .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+              this.nodes = Object.fromEntries(response.nodes.map<[string, NodeInfo]>((node) => [node.node_id, node]));
 
               this.clusterId = this._clusterId();
               this.nodeCount = this._nodeCount();

--- a/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
+++ b/graylog2-web-interface/src/views/components/aggregationwizard/visualization/VisualizationElement.ts
@@ -76,12 +76,13 @@ const hasErrors = (errors: {}) => Object.values(errors).filter((value) => value 
 const validateConfig = (visualizationType: VisualizationType<any>, config: VisualizationConfigFormValues) => {
   const { fields = [] } = visualizationType.config;
 
-  return fields
-    .filter((field) => 'required' in field && field.required)
-    .filter((field) => !field.isShown || field.isShown(config))
-    .filter(({ name }) => config[name] === undefined || config[name] === '')
-    .map(({ name, title }) => ({ [name]: `${title} is required.` }))
-    .reduce((prev, cur) => ({ ...prev, ...cur }), {});
+  return Object.fromEntries(
+    fields
+      .filter((field) => 'required' in field && field.required)
+      .filter((field) => !field.isShown || field.isShown(config))
+      .filter(({ name }) => config[name] === undefined || config[name] === '')
+      .map(({ name, title }) => [name, `${title} is required.`]),
+  );
 };
 
 const validate = (formValues: WidgetConfigFormValues) => {

--- a/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/TitleCell.tsx
+++ b/graylog2-web-interface/src/views/components/dashboard/DashboardsOverview/TitleCell.tsx
@@ -22,9 +22,7 @@ import { HoverForHelp, Link } from 'components/common';
 import Routes from 'routing/Routes';
 
 const missingRequirements = (requires: Requirements, requirementsProvided: Array<string>) =>
-  Object.entries(requires)
-    .filter(([require]) => !requirementsProvided.includes(require))
-    .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+  Object.fromEntries(Object.entries(requires).filter(([require]) => !requirementsProvided.includes(require)));
 
 const RequirementsList = ({ requirements }: { requirements: Requirements }) => (
   <div>

--- a/graylog2-web-interface/src/views/hooks/RequirementsProvided.tsx
+++ b/graylog2-web-interface/src/views/hooks/RequirementsProvided.tsx
@@ -22,9 +22,7 @@ import type { ViewHook, ViewHookArguments } from 'views/logic/hooks/ViewHook';
 import type { Requirements } from 'views/logic/views/View';
 
 const _missingRequirements = (requirements: Requirements, requirementsProvided: string | string[]): Requirements =>
-  Object.entries(requirements)
-    .filter(([require]) => !requirementsProvided.includes(require))
-    .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+  Object.fromEntries(Object.entries(requirements).filter(([require]) => !requirementsProvided.includes(require)));
 
 const RequirementsProvided: ViewHook = async ({ view, executionState }: ViewHookArguments) => {
   const providedRequirements = PluginStore.exports('views.requires.provided');

--- a/graylog2-web-interface/src/views/logic/searchresulttransformers/PivotTransformer.ts
+++ b/graylog2-web-interface/src/views/logic/searchresulttransformers/PivotTransformer.ts
@@ -14,7 +14,4 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-export default (data) =>
-  data
-    .map((result) => [result.name || result.id, result])
-    .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+export default (data) => Object.fromEntries(data.map((result) => [result.name || result.id, result]));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Converts reduce-based object-building patterns (accumulator initialized as {}, one key added per array element) to Object.fromEntries(array.map(...)), matching this repo's documented preference in AGENTS.md.

/nocl Internal refactoring.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.