### PR TITLE
Fix cancellation of system job scheduler jobs (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-27080.toml
+++ b/changelog/unreleased/issue-27080.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed cancellation of jobs running on the system job scheduler. Clicking Cancel on a cancelable system job (e.g. \"Recalculate index ranges\") failed with a 404 and the job kept running; it now stops at its next cancellation check."
+
+issues = ["27080"]
+pulls = ["27087"]

--- a/graylog2-server/src/main/java/org/graylog/scheduler/system/SystemJobManager.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/system/SystemJobManager.java
@@ -20,6 +20,7 @@ import com.mongodb.client.model.Filters;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
 import org.graylog.scheduler.DBSystemJobTriggerService;
 import org.graylog.scheduler.JobTriggerDto;
 import org.graylog.scheduler.JobTriggerStatus;
@@ -38,6 +39,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.graylog2.database.utils.MongoUtils.idEq;
 import static org.graylog2.shared.utilities.StringUtils.requireNonBlank;
 
 @Singleton
@@ -129,9 +131,27 @@ public class SystemJobManager {
     }
 
     public Optional<SystemJobSummary> getRunningJob(String id) {
-        return triggerService.get(requireNonBlank(id, "id can't be blank"))
+        // A trigger ID is a Mongo ObjectId; a non-ObjectId id can't match a running job, so treat it as not found.
+        if (!ObjectId.isValid(requireNonBlank(id, "id can't be blank"))) {
+            return Optional.empty();
+        }
+        return triggerService.get(id)
                 .filter(trigger -> trigger.status() == JobTriggerStatus.RUNNING)
                 .map(this::toSystemJobInfo);
+    }
+
+    /**
+     * Requests cancellation of the system job with the given trigger ID by setting the trigger's cancel flag. The
+     * running job stops at its next check of {@link SystemJobContext#isCancelled()}. A non-ObjectId id, or an id with
+     * no matching trigger, is a no-op; a blank id is rejected. Callers are responsible for permission checks and for
+     * verifying that the job is cancelable (see {@link SystemJobSummary#isCancelable()}).
+     */
+    public void cancel(String id) {
+        // A trigger ID is a Mongo ObjectId; a non-ObjectId id can't match a job, so there's nothing to cancel.
+        if (!ObjectId.isValid(requireNonBlank(id, "id can't be blank"))) {
+            return;
+        }
+        triggerService.cancelTriggerByQuery(idEq(id));
     }
 
     private Map<String, SystemJobSummary> getJobsByQuery(Bson query) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/SystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/SystemJobResource.java
@@ -213,30 +213,44 @@ public class SystemJobResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.SYSTEM_JOB_STOP)
     public SystemJobSummary cancel(@Parameter(name = "jobId", required = true) @PathParam("jobId") @NotEmpty String jobId) {
-        LegacySystemJob systemJob = legacySystemJobManager.getRunningJobs().get(jobId);
-        if (systemJob == null) {
-            throw new NotFoundException("No system job with ID <" + jobId + "> found");
+        final LegacySystemJob systemJob = legacySystemJobManager.getRunningJobs().get(jobId);
+        if (systemJob != null) {
+            checkPermission(RestPermissions.SYSTEMJOBS_DELETE, systemJob.getClassName());
+
+            if (systemJob.isCancelable()) {
+                systemJob.requestCancel();
+            } else {
+                throw new ForbiddenException("System job with ID <" + jobId + "> cannot be cancelled");
+            }
+
+            return SystemJobSummary.create(
+                    systemJob.getId(),
+                    systemJob.getDescription(),
+                    systemJob.getClassName(),
+                    systemJob.getInfo(),
+                    nodeId.getNodeId(),
+                    systemJob.getStartedAt(),
+                    systemJob.getProgress(),
+                    systemJob.isCancelable(),
+                    systemJob.providesProgress()
+            );
         }
 
-        checkPermission(RestPermissions.SYSTEMJOBS_DELETE, systemJob.getClassName());
+        // Not a legacy job: try the system job scheduler.
+        // Jobs with their own JobResourceHandler are cancelled through that handler instead, so it can apply its own
+        // permission checks. Mirrors the guard in list() and get().
+        final SystemJobSummary summary = systemJobManager.getRunningJob(jobId)
+                .filter(job -> !jobResourceHandlerService.handlesJobType(job.jobType()))
+                .orElseThrow(() -> new NotFoundException("No system job with ID <" + jobId + "> found"));
 
-        if (systemJob.isCancelable()) {
-            systemJob.requestCancel();
-        } else {
+        checkPermission(RestPermissions.SYSTEMJOBS_DELETE, summary.jobType());
+
+        if (!summary.isCancelable()) {
             throw new ForbiddenException("System job with ID <" + jobId + "> cannot be cancelled");
         }
 
-        return SystemJobSummary.create(
-                systemJob.getId(),
-                systemJob.getDescription(),
-                systemJob.getClassName(),
-                systemJob.getInfo(),
-                nodeId.getNodeId(),
-                systemJob.getStartedAt(),
-                systemJob.getProgress(),
-                systemJob.isCancelable(),
-                systemJob.providesProgress()
-        );
+        systemJobManager.cancel(jobId);
+        return summary;
     }
 
     @DELETE

--- a/graylog2-server/src/test/java/org/graylog/scheduler/system/SystemJobManagerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/scheduler/system/SystemJobManagerTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 @ExtendWith(MongoDBExtension.class)
 class SystemJobManagerTest {
@@ -209,6 +210,37 @@ class SystemJobManagerTest {
     void getRunningJobReturnsEmptyForNonExistentId() {
         // Use a valid ObjectId format that doesn't exist in the database
         assertThat(systemJobManager.getRunningJob("000000000000000000000000")).isEmpty();
+    }
+
+    @Test
+    void getRunningJobReturnsEmptyForNonObjectIdId() {
+        // A legacy job UUID (or any non-ObjectId string) must not throw; it simply has no running scheduler job.
+        assertThat(systemJobManager.getRunningJob("11111111-2222-3333-4444-555555555555")).isEmpty();
+    }
+
+    @Test
+    void cancelSetsCancelFlagOnTrigger() {
+        systemJobManager.submit(TestSystemJobConfig.create("cancel-me"));
+        final var locked = triggerService.nextRunnableTrigger();
+        assertThat(locked).isPresent();
+        assertThat(locked.get().isCancelled()).isFalse();
+        final var triggerId = locked.get().id();
+
+        systemJobManager.cancel(triggerId);
+
+        assertThat(triggerService.get(triggerId))
+                .hasValueSatisfying(trigger -> assertThat(trigger.isCancelled()).isTrue());
+    }
+
+    @Test
+    void cancelIsNoOpForNonExistentId() {
+        assertThatCode(() -> systemJobManager.cancel("000000000000000000000000")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void cancelIsNoOpForNonObjectIdId() {
+        // A legacy job UUID (or any non-ObjectId string) must not throw; there is no scheduler job to cancel.
+        assertThatCode(() -> systemJobManager.cancel("11111111-2222-3333-4444-555555555555")).doesNotThrowAnyException();
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/jobs/SystemJobResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/jobs/SystemJobResourceTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog2.rest.resources.system.jobs;
+
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
+import org.apache.shiro.subject.Subject;
+import org.graylog.scheduler.rest.JobResourceHandlerService;
+import org.graylog.scheduler.system.SystemJobManager;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.rest.models.system.SystemJobSummary;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.system.jobs.LegacySystemJobFactory;
+import org.graylog2.system.jobs.LegacySystemJobManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the regression fixed in #27080: {@code cancel} on a system-scheduler job must reach {@link SystemJobManager}
+ * rather than 404 on the legacy-only path. The pre-fix resource consulted only {@link LegacySystemJobManager}.
+ */
+@ExtendWith(MockitoExtension.class)
+class SystemJobResourceTest {
+    private static final String SCHEDULER_JOB_ID = "6890abcdef0123456789abcd";
+    private static final String HANDLER_MANAGED_JOB_TYPE = "archive-create-execution-v1";
+
+    @Mock
+    private LegacySystemJobFactory legacySystemJobFactory;
+    @Mock
+    private LegacySystemJobManager legacySystemJobManager;
+    @Mock
+    private SystemJobManager systemJobManager;
+    @Mock
+    private NodeId nodeId;
+    @Mock
+    private JobResourceHandlerService jobResourceHandlerService;
+
+    // Allow all permissions by default; individual tests flip this to deny.
+    private Predicate<String> permissionCheck = permission -> true;
+
+    private Subject subject;
+    private SystemJobResource resource;
+
+    @BeforeEach
+    void setUp() {
+        // RestResource relies on statically-provided fields; an injector must be present during construction.
+        GuiceInjectorHolder.createInjector(Collections.emptyList());
+        // Lenient: not every test reaches a permission check, and a denied check reads getPrincipal() for its log.
+        subject = mock(Subject.class);
+        lenient().when(subject.isPermitted(anyString()))
+                .thenAnswer(invocation -> permissionCheck.test(invocation.getArgument(0)));
+        lenient().when(subject.getPrincipal()).thenReturn("test-user");
+        resource = new TestResource();
+    }
+
+    @Test
+    void cancelReachesSchedulerForCancelableJob() {
+        when(legacySystemJobManager.getRunningJobs()).thenReturn(Collections.emptyMap());
+        final SystemJobSummary summary = schedulerSummary(true);
+        when(systemJobManager.getRunningJob(SCHEDULER_JOB_ID)).thenReturn(Optional.of(summary));
+
+        final SystemJobSummary result = resource.cancel(SCHEDULER_JOB_ID);
+
+        assertThat(result).isEqualTo(summary);
+        verify(systemJobManager).cancel(SCHEDULER_JOB_ID);
+    }
+
+    @Test
+    void cancelRejectsNonCancelableSchedulerJob() {
+        when(legacySystemJobManager.getRunningJobs()).thenReturn(Collections.emptyMap());
+        when(systemJobManager.getRunningJob(SCHEDULER_JOB_ID)).thenReturn(Optional.of(schedulerSummary(false)));
+
+        assertThatThrownBy(() -> resource.cancel(SCHEDULER_JOB_ID)).isInstanceOf(ForbiddenException.class);
+
+        verify(systemJobManager, never()).cancel(anyString());
+    }
+
+    @Test
+    void cancelReturnsNotFoundWhenNoSuchJob() {
+        when(legacySystemJobManager.getRunningJobs()).thenReturn(Collections.emptyMap());
+        when(systemJobManager.getRunningJob(SCHEDULER_JOB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> resource.cancel(SCHEDULER_JOB_ID)).isInstanceOf(NotFoundException.class);
+
+        verify(systemJobManager, never()).cancel(anyString());
+    }
+
+    @Test
+    void cancelLeavesHandlerManagedJobToItsOwnHandler() {
+        // A job type with its own JobResourceHandler must not be cancelled here: the handler applies the plugin's own
+        // permission checks, and ClusterSystemJobResource only falls through to it when every node reports not-found.
+        when(legacySystemJobManager.getRunningJobs()).thenReturn(Collections.emptyMap());
+        when(systemJobManager.getRunningJob(SCHEDULER_JOB_ID)).thenReturn(Optional.of(handlerManagedSummary()));
+        when(jobResourceHandlerService.handlesJobType(HANDLER_MANAGED_JOB_TYPE)).thenReturn(true);
+
+        assertThatThrownBy(() -> resource.cancel(SCHEDULER_JOB_ID)).isInstanceOf(NotFoundException.class);
+
+        verify(systemJobManager, never()).cancel(anyString());
+    }
+
+    @Test
+    void cancelChecksDeletePermissionOnSchedulerJob() {
+        permissionCheck = permission -> false;
+        when(legacySystemJobManager.getRunningJobs()).thenReturn(Collections.emptyMap());
+        when(systemJobManager.getRunningJob(SCHEDULER_JOB_ID)).thenReturn(Optional.of(schedulerSummary(true)));
+
+        assertThatThrownBy(() -> resource.cancel(SCHEDULER_JOB_ID)).isInstanceOf(ForbiddenException.class);
+
+        verify(systemJobManager, never()).cancel(anyString());
+    }
+
+    private static SystemJobSummary handlerManagedSummary() {
+        return SystemJobSummary.create(SCHEDULER_JOB_ID, "Archive create", HANDLER_MANAGED_JOB_TYPE, "",
+                "node-1", null, 0, true, true);
+    }
+
+    private static SystemJobSummary schedulerSummary(boolean cancelable) {
+        // name() is the job type used for the permission check.
+        return SystemJobSummary.create(SCHEDULER_JOB_ID, "Rebuild index ranges", "rebuild-index-ranges", "",
+                "node-1", null, 0, cancelable, true);
+    }
+
+    private class TestResource extends SystemJobResource {
+        TestResource() {
+            super(legacySystemJobFactory, legacySystemJobManager, systemJobManager, nodeId, jobResourceHandlerService);
+        }
+
+        @Override
+        protected Subject getSubject() {
+            return subject;
+        }
+    }
+}


### PR DESCRIPTION
Note: This is a backport of #27087 to `7.1`.

## What

Make the Cancel button work for jobs running on the system job scheduler.

## Why

Cancelling a system-scheduler job that reports `isCancelable(true)` (today only `RebuildIndexRangesJob`) failed with a 404 and "Unable to cancel the job", and the job kept running. `SystemJobResource#cancel` only read `LegacySystemJobManager`, so no path set the system job trigger's cancel flag.

Closes #27080.

## How

- Add `SystemJobManager#cancel(id)`, which sets the trigger's cancel flag via `DBSystemJobTriggerService#cancelTriggerByQuery`.
- Wire it into the scheduler branch of `SystemJobResource#cancel`. The running job stops at its next `SystemJobContext#isCancelled()` check.

## Details

- Permission and cancelable enforcement stay in the resource, mirroring the legacy branch: `SYSTEMJOBS_DELETE` is checked against the job type, a non-cancelable job returns `403`, and an unknown id returns `404`.
- Job types that register their own `JobResourceHandler` (enterprise archive and data lake) are filtered out of the scheduler branch, as `list()` and `get()` already do, so they keep being cancelled through their handler and its permission checks.
- `ClusterSystemJobResource` needs no change: its existing per-node fan-out already reaches the fixed endpoint, and the cancel is a node-independent Mongo flag.
- This never worked for scheduler jobs; it is not a regression. #24497 wired `list()` and `get()` to the new scheduler but left `cancel()` on the legacy manager, and #24763 then shipped the first cancelable scheduler job. Follow-up #27089 removes that per-verb drift.
- Cancel semantics in the shared `DBJobTriggerService` (queued and retry cases) are tracked separately in #27084.

## How tested

- `SystemJobManagerTest` and `SystemJobResourceTest` cover the cancel path, the unknown-id and non-ObjectId no-ops, the `403`/`404` cases, and the handler-managed carve-out. 19/19 green.
- Live-validated against a running server with real MongoDB and OpenSearch: cancelling a running `Rebuild index ranges` job now returns `200` and sets `is_cancelled=true` on the trigger (was `404`); an unknown id returns `404`; a non-cancelable running job returns `403`.

## How to test

1. Open System / Indices and choose "Recalculate index ranges" (`POST /system/indices/ranges/rebuild`).
2. Open System / Overview while the job runs and click Cancel.
3. The request succeeds and the job stops instead of failing with "Unable to cancel the job".

## Related

- #27080
- #27084 (follow-up: cancel semantics in the shared scheduler)
- #27089 (follow-up: unify system jobs onto the `JobResourceHandler` path)



## Backport notes

- Clean cherry-pick of `3aa592f042`. All five files are byte-identical to `master`.
- The earlier attempt (#27242) had to carry `JobResourceHandlerService#handlesJobType` as a separate prerequisite commit and drop the comment referring to the `list()`/`get()` guard, because #27056 was not on `7.1`. That prerequisite is now backported (#27243), so this PR needs neither adaptation.
- `SystemJobManagerTest` and `SystemJobResourceTest`: 19/19 green, same count as `master`.
