### PR TITLE
Fix Data Node byte metrics reported in GiB instead of bytes (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-25532.toml
+++ b/changelog/unreleased/issue-25532.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix Data Node memory, heap, and disk metrics being reported in GiB instead of bytes on the cluster configuration page."
+
+issues = ["25532"]
+pulls = ["26732"]

--- a/data-node/src/main/java/org/graylog/datanode/metrics/NodeMetricsCollector.java
+++ b/data-node/src/main/java/org/graylog/datanode/metrics/NodeMetricsCollector.java
@@ -45,6 +45,13 @@ public class NodeMetricsCollector {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Returns the raw, unconverted OpenSearch node stats keyed by {@link NodeStatMetrics#getFieldName()}.
+     * Byte metrics are kept in bytes here so that the metric-registry gauges (served by the
+     * {@code /rest/metrics/multiple} endpoint) stay consistent with their "*_in_bytes" names. Unit conversion
+     * to GiB/MiB for the metrics index and its dashboards is applied by the caller via
+     * {@link NodeStatMetrics#mapValue(String, Object)}.
+     */
     public Map<String, Object> getNodeMetrics(String node) {
         Map<String, Object> metrics = new HashMap<>();
 
@@ -59,7 +66,7 @@ public class NodeMetricsCollector {
                     .filter(m -> Objects.nonNull(m.getNodeStat()))
                     .forEach(metric -> {
                         try {
-                            metrics.put(metric.getFieldName(), metric.mapValue(nodeContext.read(metric.getNodeStat())));
+                            metrics.put(metric.getFieldName(), nodeContext.read(metric.getNodeStat()));
                         } catch (Exception e) {
                             log.error("Could not retrieve metric {} for node {}", metric.getFieldName(), node);
                         }

--- a/data-node/src/main/java/org/graylog/datanode/metrics/NodeStatMetrics.java
+++ b/data-node/src/main/java/org/graylog/datanode/metrics/NodeStatMetrics.java
@@ -96,6 +96,15 @@ public enum NodeStatMetrics {
         return mappingFunction.apply(value);
     }
 
+    /**
+     * Applies the metric's unit conversion (e.g. bytes to GiB) used when storing values in the metrics index
+     * and its dashboards. The metric-registry gauges, in contrast, expose the raw values so that their
+     * "*_in_bytes" names stay accurate.
+     */
+    public static Object mapValue(String fieldName, Object value) {
+        return valueOf(fieldName.toUpperCase(Locale.ROOT)).mapValue(value);
+    }
+
     public static String getMetricRegistryName(String fieldName) {
         NodeStatMetrics metric = valueOf(fieldName.toUpperCase(Locale.ROOT));
         return metric.getMetricRegistryName();

--- a/data-node/src/main/java/org/graylog/datanode/periodicals/MetricsCollector.java
+++ b/data-node/src/main/java/org/graylog/datanode/periodicals/MetricsCollector.java
@@ -141,7 +141,10 @@ public class MetricsCollector extends Periodical {
                 metrics.put("node", node);
                 addJvmMetrics(metrics);
                 Map<String, Object> nodeMetrics = nodeStatMetricsCollector.getNodeMetrics(node);
-                metrics.putAll(nodeMetrics);
+                // The metrics index and its dashboards expect memory/disk values converted to GiB/MiB.
+                for (Map.Entry<String, Object> entry : nodeMetrics.entrySet()) {
+                    metrics.put(entry.getKey(), NodeStatMetrics.mapValue(entry.getKey(), entry.getValue()));
+                }
                 final Map<String, Object> finalMetrics = metrics;
                 indexDocument(client, IndexRequest.of(i -> i
                         .index(configuration.getMetricsStream())
@@ -158,6 +161,8 @@ public class MetricsCollector extends Periodical {
                     ));
                 }
 
+                // Registry gauges are named after the raw OpenSearch stat paths (e.g. "..._in_bytes"), so they
+                // expose the raw, unconverted values.
                 nodeMetrics.forEach((key, value) -> {
                     opensearchMetrics.put(NodeStatMetrics.getMetricRegistryName(key), value);
                 });

--- a/data-node/src/test/java/org/graylog/datanode/metrics/NodeMetricsCollectorTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/metrics/NodeMetricsCollectorTest.java
@@ -45,8 +45,13 @@ public class NodeMetricsCollectorTest {
     @Test
     public void getNodeMetrics() {
         Map<String, Object> nodeMetrics = collector.getNodeMetrics(NODENAME);
+        // The collector returns the raw OpenSearch stat values. Unit conversion (bytes -> GiB/MiB) for the
+        // metrics index/dashboards is applied later, so byte metrics must stay in bytes here to match the
+        // "*_in_bytes" metric-registry gauges consumed by the /rest/metrics/multiple endpoint.
         assertThat(nodeMetrics.get("cpu_load")).isEqualTo(26.4873046875);
-        assertThat(nodeMetrics.get("disk_free")).isEqualTo(572.1824f);
+        assertThat(nodeMetrics.get("mem_total")).isEqualTo(34359738368L);
+        assertThat(nodeMetrics.get("disk_free")).isEqualTo(614376128512L);
+        assertThat(nodeMetrics.get("disk_used")).isEqualTo(994662584320L);
         String[] allMetrics = Arrays.stream(NodeStatMetrics.values()).map(NodeStatMetrics::getFieldName).toArray(String[]::new);
         assertThat(nodeMetrics).containsKeys(allMetrics);
     }

--- a/data-node/src/test/java/org/graylog/datanode/metrics/NodeStatMetricsTest.java
+++ b/data-node/src/test/java/org/graylog/datanode/metrics/NodeStatMetricsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.datanode.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeStatMetricsTest {
+
+    @Test
+    void registryNameMatchesRawOpenSearchStatPath() {
+        // The metric-registry gauges (served by /rest/metrics/multiple) are named after the raw OpenSearch
+        // stat path, so their values must stay in bytes to match the "_in_bytes" suffix.
+        assertThat(NodeStatMetrics.MEM_TOTAL.getMetricRegistryName()).isEqualTo("opensearch.os.mem.total_in_bytes");
+        assertThat(NodeStatMetrics.DISK_USED.getMetricRegistryName()).isEqualTo("opensearch.fs.total.total_in_bytes");
+    }
+
+    @Test
+    void mapValueConvertsByteMetricsToGibForTheIndex() {
+        // Values written to the metrics index / dashboards are converted to GiB.
+        assertThat(NodeStatMetrics.mapValue("mem_total", 34359738368L)).isEqualTo(32.0f);
+        assertThat(NodeStatMetrics.mapValue("disk_free", 614376128512L)).isEqualTo(572.1824f);
+    }
+
+    @Test
+    void mapValueLeavesNonByteMetricsUnchanged() {
+        assertThat(NodeStatMetrics.mapValue("cpu_load", 26.4873046875)).isEqualTo(26.4873046875);
+        assertThat(NodeStatMetrics.mapValue("index_total", 244589)).isEqualTo(244589);
+    }
+}


### PR DESCRIPTION
Note: This is a backport of #26732 to `7.1`.

Clean cherry-pick of `92eee3c02b`. The applied diff is identical to the master commit.

## What

The Data Node metrics served by `POST /api/datanodes/<host>/rest/metrics/multiple` reported memory, heap, and disk values in GiB even though the metric names end in `_in_bytes`. This change makes the registry gauges behind the endpoint expose raw byte values, while the metrics index and its dashboards keep the GiB/MiB scale.

## Why

Metrics whose names end in `_in_bytes` should report byte-scale values. Returning GiB was misleading for any consumer of the endpoint.

## How

One `NodeStatMetrics` enum fed two consumers. The two paths are now split: `NodeMetricsCollector` returns the raw OpenSearch values, and the GiB/MiB conversion is applied only when building the metrics index document. The registry gauges expose the raw byte values; the dashboards are unchanged.

## Details

Root cause: the byte metrics carried a `bytesToGb`/`bytesToMb` conversion intended for the `gl-datanode-metrics` index and its dashboards. `MetricsCollector` reused those already-converted values to populate the metric-registry gauges behind the endpoint, so the byte gauges returned GiB.

## How tested

Unit tests.

## How to test

Start a Data Node and send `POST /api/datanodes/<host>/rest/metrics/multiple` with:

```json
{"metrics":["opensearch.os.mem.total_in_bytes","opensearch.jvm.mem.heap_max_in_bytes","opensearch.fs.total.total_in_bytes"]}
```

Confirm the values are byte scale (billions). Then open the cluster configuration page and verify the Memory, JVM, and Storage columns show correct GB/MiB figures.

## Related

- #25532

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

