### PR TITLE
Add ED permission check to replay search button

### DIFF
--- a/changelog/unreleased/pr-27321.toml
+++ b/changelog/unreleased/pr-27321.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fixed replay search actions being visible to users without read access to the related event definition."
+
+issues = ["Graylog2/graylog-plugin-enterprise#13802"]
+pulls = ["27321", "Graylog2/graylog-plugin-enterprise#15534"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -20,7 +20,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import useHistory from 'routing/useHistory';
 import Routes from 'routing/Routes';
-import { LinkContainer, IfPermitted, ShareButton, ConfirmDialog } from 'components/common';
+import { IfPermitted, ShareButton, ConfirmDialog } from 'components/common';
 import { ButtonToolbar, MenuItem, DeleteMenuItem } from 'components/bootstrap';
 import useGetPermissionsByScope from 'hooks/useScopePermissions';
 import {
@@ -37,6 +37,7 @@ import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
 import { MoreActions } from 'components/common/EntityDataTable';
 import usePluggableEntitySharedActions from 'hooks/usePluggableEntitySharedActions';
+import LinkToReplaySearch from 'components/event-definitions/replay-search/LinkToReplaySearch';
 
 import type { EventDefinition } from '../event-definitions-types';
 import { isAggregationEventDefinition, isSystemEventDefinition } from '../event-definitions-types';
@@ -295,9 +296,7 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
                 anyPermissions>
                 <MenuItem divider />
               </IfPermitted>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.replay_search(eventDefinition.id)}>
-                <MenuItem>Replay Search</MenuItem>
-              </LinkContainer>
+              <LinkToReplaySearch eventDefinitionId={eventDefinition.id} isMenuitem />
             </>
           )}
           {moreActions}

--- a/graylog2-web-interface/src/components/event-definitions/replay-search/LinkToReplaySearch.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/replay-search/LinkToReplaySearch.tsx
@@ -24,21 +24,30 @@ import MenuItem from 'components/bootstrap/menuitem/MenuItem';
 
 type Props = {
   id?: string;
+  eventDefinitionId?: string;
   isEvent?: boolean;
   onClick?: () => void;
   isMenuitem?: boolean;
 };
-const LinkToReplaySearch = ({ isEvent = false, id = undefined, onClick = undefined, isMenuitem = false }: Props) => {
+const LinkToReplaySearch = ({
+  isEvent = false,
+  id = undefined,
+  eventDefinitionId = undefined,
+  onClick = undefined,
+  isMenuitem = false,
+}: Props) => {
   const { definitionId } = useParams<{ alertId?: string; definitionId?: string }>();
+  const replaySearchEventDefinitionId = eventDefinitionId || (!isEvent ? id || definitionId : undefined);
   const searchLink = isEvent
     ? Routes.ALERTS.replay_search(id)
-    : Routes.ALERTS.DEFINITIONS.replay_search(id || definitionId);
+    : Routes.ALERTS.DEFINITIONS.replay_search(replaySearchEventDefinitionId);
 
   return (
     <ReplaySearchButtonComponent
       searchLink={searchLink}
       onClick={onClick}
-      component={isMenuitem ? MenuItem : undefined}>
+      component={isMenuitem ? MenuItem : undefined}
+      eventDefinitionId={replaySearchEventDefinitionId}>
       Replay search
     </ReplaySearchButtonComponent>
   );

--- a/graylog2-web-interface/src/components/events/events/BulkActions.test.tsx
+++ b/graylog2-web-interface/src/components/events/events/BulkActions.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render, screen } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
+import * as Immutable from 'immutable';
 
 import BulkActions from 'components/events/events/BulkActions';
 import { asMock } from 'helpers/mocking';
@@ -24,6 +25,8 @@ import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSele
 import usePluginEntities from 'hooks/usePluginEntities';
 import type { EventAction } from 'views/types';
 import type { Event } from 'components/events/events/types';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { alice } from 'fixtures/users';
 
 jest.mock('hooks/usePluginEntities');
 jest.mock('components/common/EntityDataTable/hooks/useSelectedEntities');
@@ -51,6 +54,16 @@ const mockedSelectedEntitiesData = {
   '01HV0YS4GH0VC7DV6A2VGN1VJ0': getEvent('01HV0YS4GH0VC7DV6A2VGN1VJ0'),
 };
 
+const getReplayableEvent = (id: string): Event => ({
+  ...getEvent(id),
+  replay_info: {
+    timerange_start: '2024-01-01',
+    timerange_end: '2024-01-02',
+    query: 'source:example',
+    streams: ['000000000000000000000001'],
+  },
+});
+
 const mockedEventActions: Array<EventAction> = [
   {
     useCondition: () => true,
@@ -67,7 +80,8 @@ const mockedEventActions: Array<EventAction> = [
     modal: React.forwardRef(() => <b>I am a modal without a bulk</b>),
   },
 ];
-const renderBulkAction = () => render(<BulkActions selectedEntitiesData={mockedSelectedEntitiesData} />);
+const renderBulkAction = (selectedEntitiesData = mockedSelectedEntitiesData) =>
+  render(<BulkActions selectedEntitiesData={selectedEntitiesData} />);
 
 const openActionsDropdown = async () =>
   await userEvent.click(
@@ -112,5 +126,23 @@ describe('Events Bulk Action', () => {
 
     expect(notBulkComponent).not.toBeInTheDocument();
     expect(notBulkModal).not.toBeInTheDocument();
+  });
+
+  it('renders replay search for replayable events when user can read their event definition', async () => {
+    asMock(usePluginEntities).mockReturnValue([]);
+
+    render(
+      <CurrentUserContext.Provider
+        value={alice
+          .toBuilder()
+          .permissions(Immutable.List(['eventdefinitions:read:event_definition_id_1']))
+          .build()}>
+        <BulkActions selectedEntitiesData={{ event_id_1: getReplayableEvent('event_id_1') }} />
+      </CurrentUserContext.Provider>,
+    );
+
+    await openActionsDropdown();
+
+    await screen.findByRole('menuitem', { name: /replay search/i });
   });
 });

--- a/graylog2-web-interface/src/components/events/events/BulkActions.tsx
+++ b/graylog2-web-interface/src/components/events/events/BulkActions.tsx
@@ -34,7 +34,8 @@ const BulkActions = ({ selectedEntitiesData }: Props) => {
   const currentUser = useCurrentUser();
 
   const replayableEvents = events.filter(
-    (event) => !!event.replay_info && isPermitted(currentUser?.permissions, `eventdefinitions:read:${event.id}`),
+    (event) =>
+      !!event.replay_info && isPermitted(currentUser?.permissions, `eventdefinitions:read:${event.event_definition_id}`),
   );
   const onReplaySearchClick = useReplayBulkAction(replayableEvents);
 

--- a/graylog2-web-interface/src/components/events/events/hooks/useEventAction.tsx
+++ b/graylog2-web-interface/src/components/events/events/hooks/useEventAction.tsx
@@ -39,13 +39,14 @@ const useEventAction = (event: Event) => {
             isMenuitem
             onClick={() => sendEventActionTelemetry('REPLAY_SEARCH', false)}
             id={event.id}
+            eventDefinitionId={event.event_definition_id}
             isEvent
           />
         ) : null,
         pluggableActions.length && hasReplayInfo ? <MenuItem divider key="divider" /> : null,
         pluggableActions.length ? pluggableActions : null,
       ].filter(Boolean),
-    [sendEventActionTelemetry, event.id, hasReplayInfo, pluggableActions, isPermitted],
+    [sendEventActionTelemetry, event.event_definition_id, event.id, hasReplayInfo, pluggableActions, isPermitted],
   );
 
   return { moreActions, pluggableActionModals };

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.tsx
@@ -25,6 +25,8 @@ import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 import type { QueryString } from 'views/logic/queries/types';
 import type { FiltersType, SearchFilter } from 'views/types';
 import Store from 'logic/local-storage/Store';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { alice } from 'fixtures/users';
 
 import ReplaySearchButton from './ReplaySearchButton';
 
@@ -50,6 +52,30 @@ describe('ReplaySearchButton', () => {
     render(<ReplaySearchButton />);
 
     await screen.findByRole('link', { name: /replay search/i });
+  });
+
+  it('renders play button when user can read the event definition', async () => {
+    render(
+      <CurrentUserContext.Provider
+        value={alice
+          .toBuilder()
+          .permissions(Immutable.List(['eventdefinitions:read:event-definition-id']))
+          .build()}>
+        <ReplaySearchButton eventDefinitionId="event-definition-id" />
+      </CurrentUserContext.Provider>,
+    );
+
+    await screen.findByRole('link', { name: /replay search/i });
+  });
+
+  it('does not render play button when user cannot read the event definition', () => {
+    render(
+      <CurrentUserContext.Provider value={alice}>
+        <ReplaySearchButton eventDefinitionId="event-definition-id" />
+      </CurrentUserContext.Provider>,
+    );
+
+    expect(screen.queryByRole('link', { name: /replay search/i })).not.toBeInTheDocument();
   });
 
   it('shows a tooltip when focused via keyboard', async () => {

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.tsx
@@ -23,6 +23,8 @@ import URI from 'urijs';
 import IconButton from 'components/common/IconButton';
 import Icon from 'components/common/Icon';
 import { LinkContainer } from 'components/common';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
 import SearchLink from 'views/logic/search/SearchLink';
 import Store from 'logic/local-storage/Store';
 import type { TimeRange } from 'views/logic/queries/Query';
@@ -92,17 +94,24 @@ export const ReplaySearchButtonComponent = ({
   onClick = undefined,
   component: Component = NeutralLink,
   newTab = false,
+  eventDefinitionId = undefined,
 }: {
   children?: React.ReactNode;
   searchLink: string;
   onClick?: () => void;
   component?: React.ComponentType<CustomComponentProps>;
   newTab?: boolean;
+  eventDefinitionId?: string;
 }) => {
+  const currentUser = useCurrentUser(false);
   const title = 'Replay search';
   const newTabProps = newTab
     ? { href: searchLink, target: '_blank' as const, rel: 'noopener noreferrer' as const }
     : {};
+
+  if (eventDefinitionId && !isPermitted(currentUser?.permissions, `eventdefinitions:read:${eventDefinitionId}`)) {
+    return null;
+  }
 
   const button = children ? (
     <Component title={title} onClick={onClick} {...newTabProps}>
@@ -124,6 +133,7 @@ type Props = {
   filters?: FiltersType;
   parameterBindings?: ParameterBindings;
   newTab?: boolean;
+  eventDefinitionId?: string;
 };
 
 const ReplaySearchButton = ({
@@ -135,6 +145,7 @@ const ReplaySearchButton = ({
   filters = undefined,
   parameterBindings = undefined,
   newTab = false,
+  eventDefinitionId = undefined,
 }: Props) => {
   const sessionId = useMemo(() => `replay-search-${generateId()}`, []);
   const searchLink = buildSearchLink(sessionId, timerange, queryString, streams, streamCategories, parameters, filters);
@@ -152,7 +163,14 @@ const ReplaySearchButton = ({
     }
   }, [sessionId, parameters, parameterBindings, filters]);
 
-  return <ReplaySearchButtonComponent searchLink={searchLink} onClick={onReplaySearch} newTab={newTab} />;
+  return (
+    <ReplaySearchButtonComponent
+      searchLink={searchLink}
+      onClick={onReplaySearch}
+      newTab={newTab}
+      eventDefinitionId={eventDefinitionId}
+    />
+  );
 };
 
 export default ReplaySearchButton;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds permission checks in places where we use replay search

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix: https://github.com/Graylog2/graylog-plugin-enterprise/issues/13802

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

/jpd https://github.com/Graylog2/graylog-plugin-enterprise/pull/15534