### PR TITLE
Guard against a pre-existing non-TTL index in ensureTTLIndex

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/indices/MongoDbIndexTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/indices/MongoDbIndexTools.java
@@ -52,8 +52,11 @@ public class MongoDbIndexTools {
             final Set<String> keySet = document.get(INDEX_DOCUMENT_KEY, Document.class).keySet();
             if (keySet.contains(fieldUpdatedAt)) {
                 // Since MongoDB 5.0 this is an Integer. Used to be a Long ¯\_(ツ)_/¯
-                final long expireAfterSeconds = document.get("expireAfterSeconds", Number.class).longValue();
-                if (Objects.equals(expireAfterSeconds, indexOptions.getExpireAfter(TimeUnit.SECONDS))) {
+                // A plain index carries no expireAfterSeconds at all. That is what deployments have which
+                // created the index before it gained a TTL, so it needs replacing rather than keeping.
+                final Number expireAfterSeconds = document.get("expireAfterSeconds", Number.class);
+                if (expireAfterSeconds != null
+                        && Objects.equals(expireAfterSeconds.longValue(), indexOptions.getExpireAfter(TimeUnit.SECONDS))) {
                     return;
                 }
                 collection.dropIndex(updatedAtKey);

--- a/graylog2-server/src/test/java/org/graylog2/database/indices/MongoDbIndexToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/indices/MongoDbIndexToolsTest.java
@@ -34,7 +34,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -140,5 +143,47 @@ class MongoDbIndexToolsTest {
         toTest.prepareIndices("id", List.of("summary"), List.of("summary"));
         verify(db).dropIndex(Indexes.ascending("summary"));
         verify(db).createIndex(eq(Indexes.ascending("summary")), argThat(indexOptions -> indexOptions.getCollation().getLocale().equals("en")));
+    }
+
+    @Test
+    void createsTTLIndexIfDoesNotExist() {
+        MongoDbIndexTools.ensureTTLIndex(db, Duration.ofSeconds(72), "updated_at");
+
+        verify(db).createIndex(eq(Indexes.ascending("updated_at")),
+                argThat(indexOptions -> Objects.equals(indexOptions.getExpireAfter(TimeUnit.SECONDS), 72L)));
+    }
+
+    @Test
+    void doesNotTouchTTLIndexWithMatchingExpiry() {
+        rawdb.createIndex(Indexes.ascending("updated_at"), new IndexOptions().expireAfter(72L, TimeUnit.SECONDS));
+
+        MongoDbIndexTools.ensureTTLIndex(db, Duration.ofSeconds(72), "updated_at");
+
+        verify(db, never()).dropIndex(any(Bson.class));
+        verify(db, never()).createIndex(any(Bson.class), any(IndexOptions.class));
+    }
+
+    @Test
+    void replacesTTLIndexWithChangedExpiry() {
+        rawdb.createIndex(Indexes.ascending("updated_at"), new IndexOptions().expireAfter(72L, TimeUnit.SECONDS));
+
+        MongoDbIndexTools.ensureTTLIndex(db, Duration.ofSeconds(3600), "updated_at");
+
+        verify(db).dropIndex(Indexes.ascending("updated_at"));
+        verify(db).createIndex(eq(Indexes.ascending("updated_at")),
+                argThat(indexOptions -> Objects.equals(indexOptions.getExpireAfter(TimeUnit.SECONDS), 3600L)));
+    }
+
+    @Test
+    void replacesPlainIndexWithTTLIndex() {
+        // Deployments that created the index before it gained a TTL have a plain index on the field. Such an
+        // index carries no expireAfterSeconds at all, so it must be replaced rather than kept.
+        rawdb.createIndex(Indexes.ascending("updated_at"));
+
+        MongoDbIndexTools.ensureTTLIndex(db, Duration.ofSeconds(72), "updated_at");
+
+        verify(db).dropIndex(Indexes.ascending("updated_at"));
+        verify(db).createIndex(eq(Indexes.ascending("updated_at")),
+                argThat(indexOptions -> Objects.equals(indexOptions.getExpireAfter(TimeUnit.SECONDS), 72L)));
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ensureTTLIndex` read `expireAfterSeconds` off any index whose key contains the field and dereferenced it unconditionally. A plain index carries no `expireAfterSeconds` at all, so pointing the helper at a collection that already had one like that threw an NPE during service construction, i.e. at server startup. Such an index is now replaced with the TTL one instead.

Every current caller created its index as a TTL index from the start, so the gap was latent until a collection with an existing plain index needed bounding.

/nocl No user-facing change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.