### PR TITLE
fix(pipelines): sort pipeline stages numerically instead of lexically

### DIFF
--- a/changelog/unreleased/issue-24957.toml
+++ b/changelog/unreleased/issue-24957.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed pipeline stages in the Processing Timeline being sorted alphabetically instead of numerically, so stages such as 100 no longer display before 2."
+
+issues = ["24957"]
+pulls = ["27346"]

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.test.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.test.tsx
@@ -126,3 +126,29 @@ describe('PipelineListItem Pipeline Load cell', () => {
     expect(screen.getByLabelText(/Pipeline Load is unavailable/i)).toBeInTheDocument();
   });
 });
+
+describe('PipelineListItem stage list', () => {
+  beforeEach(() => {
+    asMock(useGetPermissionsByScope).mockReturnValue({
+      loadingScopePermissions: false,
+      scopePermissions: { is_mutable: true, is_deletable: true },
+      checkPermissions: jest.fn(),
+    });
+  });
+
+  it('renders stages in numeric order, not lexical order', () => {
+    const multiStagePipeline: PipelineType = {
+      ...pipeline,
+      stages: [
+        { stage: 100, match: 'EITHER', rules: [] },
+        { stage: 2, match: 'EITHER', rules: [] },
+      ],
+    };
+
+    renderListItem({ pipeline: multiStagePipeline, pipelines: [multiStagePipeline] });
+
+    const stageLabels = screen.getAllByText(/^Stage \d+$/).map((el) => el.textContent);
+
+    expect(stageLabels).toEqual(['Stage 2', 'Stage 100']);
+  });
+});

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
@@ -25,7 +25,6 @@ import { Button, Label } from 'components/bootstrap';
 import type { PipelineType } from 'components/pipelines/types';
 import type { PipelineConnectionsType } from 'hooks/usePipelineConnections';
 import type { Stream } from 'logic/streams/types';
-import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import useGetPermissionsByScope from 'hooks/useScopePermissions';
 import RuleDeprecationInfo from 'components/rules/RuleDeprecationInfo';
 import usePermissions from 'hooks/usePermissions';
@@ -122,7 +121,7 @@ const PipelineListItem = ({
           getStagesWithoutDuplicates(pipelineStages, usedStagesAcc),
         [],
       )
-      .sort(naturalSort)
+      .sort((a, b) => a - b)
       .map((usedStage) => {
         if (stageNumbers.indexOf(usedStage) === -1) {
           return (


### PR DESCRIPTION
## Description
Sorts pipeline stages numerically instead of lexically in the Processing Timeline view, so stages like 1, 2, 3, 100 display in the order they're actually processed.

## Motivation and Context
Pipeline stage numbers were sorted with `naturalSort` (an `Intl.Collator`-based string comparator), so a stage numbered 100 sorted before a stage numbered 2. Fixes #24957.

## How Has This Been Tested?
- Added a test asserting pipeline stages `[100, 2]` render in numeric order (`Stage 2`, then `Stage 100`).
- Ran the full `components/pipelines` Jest suite (58/58 passing).
- Lint and `tsc --noEmit` pass on the changed files.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
