### PR TITLE
Fix leading slash in CEF source field

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/cef/codec/CEFCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/cef/codec/CEFCodec.java
@@ -186,7 +186,7 @@ public class CEFCodec extends AbstractCodec {
             remoteAddress = address.getInetSocketAddress();
         }
 
-        return remoteAddress == null ? "unknown" : remoteAddress.getAddress().toString();
+        return remoteAddress == null ? "unknown" : remoteAddress.getAddress().getHostAddress();
     }
 
     @Nullable

--- a/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/cef/codec/CEFCodecTest.java
@@ -63,8 +63,7 @@ public class CEFCodecTest {
 
         final RawMessage rawMessage = new RawMessage(new byte[0], new InetSocketAddress("128.66.23.42", 12345));
 
-        // The hostname is unresolved, so we have to add the leading slash. Oh, Java...
-        assertEquals("/128.66.23.42", codec.decideSource(cefMessage, rawMessage));
+        assertEquals("128.66.23.42", codec.decideSource(cefMessage, rawMessage));
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix CEF TCP and UDP inputs storing the `source` field with a leading slash.

The source address is now obtained using `InetAddress.getHostAddress()`, which returns the bare IP address instead of the `hostname/ip` representation produced by `InetAddress.toString()`.

## Motivation and Context

Fixes #27227.

CEF inputs can currently store values such as `/172.66.40.61` in the `source` field instead of the bare IP address `172.66.40.61`.

This change makes the CEF source format consistent with the expected IP address representation.

## How Has This Been Tested?

Added/updated the existing `CEFCodecTest` to expect the source IP without the leading slash.

The test was first run with the existing behavior and passed. After changing the expected value to the desired behavior, the test failed as expected. After changing `InetAddress.toString()` to `InetAddress.getHostAddress()`, the test passed.

Tested with:

`CEFCodecTest#decideSourceWithoutDeviceAddressReturnsRawMessageRemoteAddress`

## Screenshots (if appropriate):

Not applicable.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change)
* [ ] Refactoring (non-breaking change)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have requested a documentation update.
* [x] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
