### PR TITLE
Use filtered pagination totals in list responses

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -159,7 +159,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
 
 
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.delegate(), attributes, settings);
+                result.pagination().total(), sort, order, result.delegate(), attributes, settings);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/inputs/diagnosis/InputRoutingRulesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/diagnosis/InputRoutingRulesService.java
@@ -181,7 +181,7 @@ public class InputRoutingRulesService {
                 new PaginatedList<>(pageSlice, total, page, perPage);
 
         return PageListResponse.create(query, paginatedList.pagination(),
-                paginatedList.grandTotal().orElse(0L), sort, order, paginatedList.delegate(), PIPELINE_ATTRIBUTES, PIPELINE_SETTINGS);
+                paginatedList.pagination().total(), sort, order, paginatedList.delegate(), PIPELINE_ATTRIBUTES, PIPELINE_SETTINGS);
     }
 
     public PageListResponse<InputStreamRulesResponse> getStreamRulesPage(
@@ -237,7 +237,7 @@ public class InputRoutingRulesService {
                 new PaginatedList<>(pageSlice, total, page, perPage);
 
         return PageListResponse.create(query, paginatedList.pagination(),
-                paginatedList.grandTotal().orElse(0L), sort, order, paginatedList.delegate(), STREAM_RULE_ATTRIBUTES, STREAM_RULE_SETTINGS);
+                paginatedList.pagination().total(), sort, order, paginatedList.delegate(), STREAM_RULE_ATTRIBUTES, STREAM_RULE_SETTINGS);
     }
 
     private Comparator<StreamPipelineRulesResponse> getPipelineRulesComparator(String sort) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/datanodes/DatanodeResource.java
@@ -112,6 +112,6 @@ public class DatanodeResource extends RestResource {
 
 
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+                result.pagination().total(), sort, order, result.stream().toList(), attributes, settings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/mongodb/MongodbClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/mongodb/MongodbClusterResource.java
@@ -153,7 +153,7 @@ public class MongodbClusterResource extends RestResource {
         final SearchQuery parsedQuery = searchQueryParser.parse(query);
         final PaginatedList<MongodbNode> result = mongodbNodesSearchService.search(parsedQuery, sort, order, page, perPage);
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+                result.pagination().total(), sort, order, result.stream().toList(), attributes, settings);
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamPipelineRulesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamPipelineRulesResource.java
@@ -128,6 +128,6 @@ public class StreamPipelineRulesResource extends RestResource {
 
         return PageListResponse.create(
                 query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.delegate(), attributes, settings);
+                result.pagination().total(), sort, order, result.delegate(), attributes, settings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -169,7 +169,7 @@ public class ClusterResource extends RestResource {
         final SearchQuery searchQuery = searchQueryParser.parse(query);
         final PaginatedList<ServerNodeDto> result = serverNodePaginatedService.searchPaginated(searchQuery, order.toBsonSort(sort), page, perPage);
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+                result.pagination().total(), sort, order, result.stream().toList(), attributes, settings);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/OutdatedIndexResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/OutdatedIndexResource.java
@@ -164,7 +164,7 @@ public class OutdatedIndexResource extends RestResource {
         final SearchQuery parsedQuery = searchQueryParser.parse(query);
         final PaginatedList<OutdatedIndex> result = outdatedIndexSearchService.search(parsedQuery, sort, order, page, perPage);
         return PageListResponse.create(query, result.pagination(),
-                result.grandTotal().orElse(0L), sort, order, result.stream().toList(), attributes, settings);
+                result.pagination().total(), sort, order, result.stream().toList(), attributes, settings);
     }
 
     @POST

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/mongodb/MongodbClusterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/mongodb/MongodbClusterResourceTest.java
@@ -19,10 +19,13 @@ package org.graylog2.rest.resources.mongodb;
 import jakarta.ws.rs.core.Response;
 import org.bson.Document;
 import org.graylog2.cluster.nodes.mongodb.MongodbClusterCommand;
+import org.graylog2.cluster.nodes.mongodb.MongodbNode;
 import org.graylog2.cluster.nodes.mongodb.MongodbNodesProvider;
+import org.graylog2.rest.models.SortOrder;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +34,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class MongodbClusterResourceTest {
+
+    @Test
+    void listNodesReportsFilteredTotalIndependentOfPageSize() throws Exception {
+        final MongodbNodesProvider provider = mock(MongodbNodesProvider.class);
+        when(provider.get()).thenReturn(List.of(
+                new MongodbNode("1", "alpha", "PRIMARY"),
+                new MongodbNode("2", "beta", "SECONDARY"),
+                new MongodbNode("3", "gamma", "SECONDARY")));
+        final MongodbClusterResource resource = new MongodbClusterResource(provider, mock(MongodbClusterCommand.class));
+
+        final var all = resource.listNodes(1, 1, "", "name", SortOrder.ASCENDING);
+        assertThat(all.elements()).hasSize(1);
+        assertThat(all.total()).isEqualTo(3);
+        assertThat(all.paginationInfo().total()).isEqualTo(3);
+
+        final var filtered = resource.listNodes(1, 1, "role:SECONDARY", "name", SortOrder.ASCENDING);
+        assertThat(filtered.elements()).hasSize(1);
+        assertThat(filtered.total()).isEqualTo(2);
+        assertThat(filtered.paginationInfo().total()).isEqualTo(2);
+
+        final var empty = resource.listNodes(1, 1, "name:missing", "name", SortOrder.ASCENDING);
+        assertThat(empty.elements()).isEmpty();
+        assertThat(empty.total()).isZero();
+    }
 
     @Test
     void profilingStatus_reportsSlowMs_whenAllNodesAgree() {


### PR DESCRIPTION
## Description

Use pagination().total() when constructing PageListResponse in eight list-response paths across seven services/resources. This keeps the response total consistent with its filtered pagination metadata.

## Motivation and Context

Fixes #27024. With three MongoDB nodes, filtering to the two SECONDARY nodes and requesting a page of size one currently returns total=3 alongside pagination.total=2. The response should report total=2. The Lucene-backed result does populate grandTotal, so the failure on current master is an unfiltered total, not an unconditional zero.

## How Has This Been Tested?

The new MongoDB resource regression fails before the fix (expected 2, got 3) and passes afterward. It covers unfiltered, filtered and empty results with page size one. Seven tests passed across MongodbClusterResourceTest, PageListResponseTest and InputRoutingRulesServiceTest on Liberica JDK 21:

```sh
./mvnw -B -ntp test -pl :graylog2-server -am -Dtest=MongodbClusterResourceTest,PageListResponseTest,InputRoutingRulesServiceTest -Dsurefire.failIfNoSpecifiedTests=false -Dskip.web.build=true -Dmaven.javadoc.skip=true
```

Local build limitation: the standard command first failed on existing Error Prone NullArgumentForNonNullParameter diagnostics in unrelated source files. To run the regression in isolation, that checker alone was temporarily disabled in the parent compiler configuration for both the red and green runs. The parent POM was restored and is not part of this change. A clean standard build/full suite has not been verified; this remains a draft.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Refactoring
- [ ] Breaking change

## Checklist

- [x] Added regression coverage.
- [x] Read the contribution guidelines.
- [ ] Full standard build and checks pass.

