### PR TITLE
fix(notifications): label normal severity as Info

### DIFF
--- a/changelog/unreleased/issue-15348.toml
+++ b/changelog/unreleased/issue-15348.toml
@@ -1,0 +1,5 @@
+type = "changed"
+message = "System notifications with `normal` severity are now labeled \"Info\" instead of \"Normal\", in both the severity badge and the severity filter."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15348"]
+pulls = ["27354"]

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/NotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/NotificationsResource.java
@@ -96,7 +96,7 @@ public class NotificationsResource extends RestResource {
             EntityAttribute.builder().id(FIELD_SEVERITY).title("Severity")
                     .type(SearchQueryField.Type.STRING).sortable(true).filterable(true)
                     .filterOptions(Set.of(
-                            FilterOption.create("normal", "Normal"),
+                            FilterOption.create("normal", "Info"),
                             FilterOption.create("urgent", "Urgent")
                     )).build(),
             EntityAttribute.builder().id("title").title("Title")

--- a/graylog2-web-interface/src/components/notifications/SystemNotificationsTable/SystemNotificationsTable.test.tsx
+++ b/graylog2-web-interface/src/components/notifications/SystemNotificationsTable/SystemNotificationsTable.test.tsx
@@ -144,6 +144,19 @@ describe('SystemNotificationsTable', () => {
     expect(mockMutate).toHaveBeenCalledWith({ id: 'notif-1' });
   });
 
+  describe('severity label', () => {
+    it('labels a "normal" severity notification as "Info"', async () => {
+      asMock(useFetchEntities).mockReturnValue(mockFetchData([{ ...notif1, severity: 'normal' }]));
+
+      render(<SystemNotificationsTable />);
+
+      const row = await screen.findByTestId('table-row-notif-1');
+
+      await within(row).findByText('Info');
+      expect(within(row).queryByText('Normal')).not.toBeInTheDocument();
+    });
+  });
+
   describe('bulk actions', () => {
     it('renders bulk actions dropdown with a Dismiss item and no read-state items', async () => {
       asMock(useFetchEntities).mockReturnValue(mockFetchData([notif1]));

--- a/graylog2-web-interface/src/components/notifications/SystemNotificationsTable/cells/SeverityCell.tsx
+++ b/graylog2-web-interface/src/components/notifications/SystemNotificationsTable/cells/SeverityCell.tsx
@@ -24,12 +24,19 @@ const COLOR_BY_SEVERITY: Record<string, 'danger' | 'info' | 'default'> = {
   normal: 'info',
 };
 
+const LABEL_BY_SEVERITY: Record<string, string> = {
+  urgent: 'Urgent',
+  normal: 'Info',
+};
+
 type Props = { row: NotificationType };
 
 const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
 const SeverityCell = ({ row }: Props) => (
-  <Badge bsStyle={COLOR_BY_SEVERITY[row.severity] ?? 'default'}>{capitalize(row.severity)}</Badge>
+  <Badge bsStyle={COLOR_BY_SEVERITY[row.severity] ?? 'default'}>
+    {LABEL_BY_SEVERITY[row.severity] ?? capitalize(row.severity)}
+  </Badge>
 );
 
 export default SeverityCell;


### PR DESCRIPTION
## Description

The system notifications table shows severity as "Normal" or "Urgent". This changes the displayed label for `normal` severity notifications to "Info", since these are informational rather than alerts. The underlying severity value (`normal`) is unchanged in the API and database — only the displayed text changes, in both the severity badge and the severity filter dropdown on the same table.

## Motivation and Context

Fixes [Graylog2/graylog-plugin-enterprise#15348](https://github.com/Graylog2/graylog-plugin-enterprise/issues/15348). "Normal" reads oddly for a notification severity; "Info" better conveys that these are informational, not something requiring action.

## How Has This Been Tested?

Added a test case to `SystemNotificationsTable.test.tsx` asserting a `normal`-severity notification renders the badge text "Info" (not "Normal"). The existing `urgent` severity fixture continues to render "Urgent" unchanged.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
