### PR TITLE
Add DocsHelper pages for the warm tier setup guides

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.ts
+++ b/graylog2-web-interface/src/util/DocsHelper.ts
@@ -78,6 +78,8 @@ const defaultPages = {
   WELCOME: '', // Welcome page to the documentation
   DATA_TIERING: 'setting_up_graylog/data_tiering.htm',
   DATA_TIERING_WARM_TIER_SETUP: 'setting_up_graylog/data_tiering.htm#PrepareYourEnvironmentforaWarmTier',
+  DATA_TIERING_WARM_TIER_OPENSEARCH: 'setting_up_graylog/create_warm_tier_on_self-managed_opensearch.htm',
+  DATA_TIERING_WARM_TIER_DATA_NODE: 'setting_up_graylog/create_warm_tier_on_data_node.htm',
   SERVER_UNAVAILABLE: 'https://www.graylog.org/community-support',
   MCP_SERVER: 'setting_up_graylog/model_context_protocol__mcp__tools.htm',
 } as const;


### PR DESCRIPTION
Adds two `DocsHelper` page constants for the backend-specific warm tier setup guides, `DATA_TIERING_WARM_TIER_OPENSEARCH` and `DATA_TIERING_WARM_TIER_DATA_NODE`. Constants only, no behaviour change in core.

/nocl
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

