### PR TITLE
fix(pipelines): sort pipeline stages numerically instead of lexically (`7.1`)

### DIFF
--- a/changelog/unreleased/issue-24957.toml
+++ b/changelog/unreleased/issue-24957.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed pipeline stages in the Processing Timeline being sorted alphabetically instead of numerically, so stages such as 100 no longer display before 2."
+
+issues = ["24957"]
+pulls = ["27346"]

--- a/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineListItem.tsx
@@ -25,7 +25,6 @@ import { Button, Label } from 'components/bootstrap';
 import type { PipelineType } from 'components/pipelines/types';
 import type { PipelineConnectionsType } from 'hooks/usePipelineConnections';
 import type { Stream } from 'logic/streams/types';
-import { defaultCompare as naturalSort } from 'logic/DefaultCompare';
 import useGetPermissionsByScope from 'hooks/useScopePermissions';
 import RuleDeprecationInfo from 'components/rules/RuleDeprecationInfo';
 import usePermissions from 'hooks/usePermissions';
@@ -97,7 +96,7 @@ const PipelineListItem = ({ pipeline, pipelines, connections, streams, onDeleteP
           getStagesWithoutDuplicates(pipelineStages, usedStagesAcc),
         [],
       )
-      .sort(naturalSort)
+      .sort((a, b) => a - b)
       .map((usedStage) => {
         if (stageNumbers.indexOf(usedStage) === -1) {
           return (


### PR DESCRIPTION
Note: This is a backport of #27346 to `7.1`.

## Description
Sorts pipeline stages numerically instead of lexically in the Processing Timeline view, so stages like 1, 2, 3, 100 display in the order they're actually processed.

## Motivation and Context
Pipeline stage numbers were sorted with `naturalSort` (an `Intl.Collator`-based string comparator), so a stage numbered 100 sorted before a stage numbered 2. Fixes #24957.

## How Has This Been Tested?
Clean cherry-pick of `f98d5c5` onto `7.1` — no adaptation needed.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
