### PR TITLE
Fix stale table/cache/adapter refetch throwing a 404 after a rename

### DIFF
--- a/changelog/unreleased/pr-27359.toml
+++ b/changelog/unreleased/pr-27359.toml
@@ -1,0 +1,4 @@
+type = "f"
+message = "Fix a false error toast when renaming a lookup table, cache, or data adapter and saving."
+
+pulls = ["27359"]

--- a/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
@@ -103,8 +103,6 @@ export function useUpdateLookupTable() {
         queryKey: ['lookup-tables'],
         refetchType: 'active',
       });
-      // The edit form navigates away right after this; on a rename an active refetch
-      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['lookup-table-details'],
         refetchType: 'none',
@@ -296,8 +294,6 @@ export function useUpdateCache() {
         queryKey: ['all-caches'],
         refetchType: 'active',
       });
-      // The edit form navigates away right after this; on a rename an active refetch
-      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['cache-details'],
         refetchType: 'none',
@@ -424,8 +420,6 @@ export function useUpdateAdapter() {
         queryKey: ['all-data-adapters'],
         refetchType: 'active',
       });
-      // The edit form navigates away right after this; on a rename an active refetch
-      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['data-adapter-details'],
         refetchType: 'none',

--- a/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/hooks/useLookupTablesAPI.tsx
@@ -103,9 +103,11 @@ export function useUpdateLookupTable() {
         queryKey: ['lookup-tables'],
         refetchType: 'active',
       });
+      // The edit form navigates away right after this; on a rename an active refetch
+      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['lookup-table-details'],
-        refetchType: 'active',
+        refetchType: 'none',
       });
     },
     onError: (error: Error) => UserNotification.error(error.message),
@@ -294,9 +296,11 @@ export function useUpdateCache() {
         queryKey: ['all-caches'],
         refetchType: 'active',
       });
+      // The edit form navigates away right after this; on a rename an active refetch
+      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['cache-details'],
-        refetchType: 'active',
+        refetchType: 'none',
       });
     },
     onError: (error: Error) => UserNotification.error(error.message),
@@ -420,9 +424,11 @@ export function useUpdateAdapter() {
         queryKey: ['all-data-adapters'],
         refetchType: 'active',
       });
+      // The edit form navigates away right after this; on a rename an active refetch
+      // loses the race and 404s under the pre-rename identifier.
       queryClient.invalidateQueries({
         queryKey: ['data-adapter-details'],
-        refetchType: 'active',
+        refetchType: 'none',
       });
     },
     onError: (error: Error) => UserNotification.error(error.message),


### PR DESCRIPTION
While I was testing https://github.com/Graylog2/graylog2-server/pull/27289 I ran into an error when saving a lookup table while renaming it. The save goes through, but an error toast comes up right behind the success toast saying `Failed to fetch lookup table: HTTP 404 Not Found`. It turned out to have nothing to do with that PR, so I'm opening this one to fix it. Renaming a cache or a data adapter and saving hits the same thing.

`useUpdateLookupTable`, `useUpdateCache`, and `useUpdateAdapter` each invalidate their `*-details` query with `refetchType: 'active'` in `onSuccess`. That forces an immediate refetch of the edit form's own details query before the form redirects to the overview page. Since that query is keyed off the route's `idOrName` param, which still holds the pre-rename name, the identifier no longer resolves once the rename lands and the refetch 404s while the form is unmounting.

<img width="557" height="265" alt="image" src="https://github.com/user-attachments/assets/358cc443-2798-42dd-8258-d85d73bdfe8a" />

The fix switches those three invalidations to `refetchType: 'none'`, so the query gets marked stale instead of being refetched immediately. The list level invalidations are untouched, so renamed rows still update right away in each overview list, and nothing else reads the `*-details` queries at that point.

Fixes an issue that existed in 7.1.
