### PR TITLE
Fix event definition pages for users without edit permission

### DIFF
--- a/changelog/unreleased/issue-15398.toml
+++ b/changelog/unreleased/issue-15398.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix an empty action menu on the event definitions list for users without edit permission."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15398"]
+pulls = ["27360"]

--- a/changelog/unreleased/issue-15406.toml
+++ b/changelog/unreleased/issue-15406.toml
@@ -1,5 +1,5 @@
 type = "f"
-message = "Fix the event definition edit page loading indefinitely for users without edit permission."
+message = "Display a 404 page instead of loading indefinitely when the event definition edit page is opened by a user without edit permission."
 
 issues = ["Graylog2/graylog-plugin-enterprise#15406"]
 pulls = ["27360"]

--- a/changelog/unreleased/issue-15406.toml
+++ b/changelog/unreleased/issue-15406.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Fix the event definition edit page loading indefinitely for users without edit permission."
+
+issues = ["Graylog2/graylog-plugin-enterprise#15406"]
+pulls = ["27360"]

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionActions.tsx
@@ -35,6 +35,8 @@ import UserNotification from 'util/UserNotification';
 import useSendTelemetry from 'logic/telemetry/useSendTelemetry';
 import { TELEMETRY_EVENT_TYPE } from 'logic/telemetry/Constants';
 import useSelectedEntities from 'components/common/EntityDataTable/hooks/useSelectedEntities';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { isPermitted } from 'util/PermissionsMixin';
 import { MoreActions } from 'components/common/EntityDataTable';
 import usePluggableEntitySharedActions from 'hooks/usePluggableEntitySharedActions';
 
@@ -83,11 +85,21 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
   const [showEntityShareModal, setShowEntityShareModal] = useState(false);
   const sendTelemetry = useSendTelemetry();
   const { push } = useHistory();
+  const { permissions } = useCurrentUser();
   const { actions: pluggableActions, actionModals: pluggableActionModals } =
     usePluggableEntitySharedActions<EventDefinition>(eventDefinition, 'event_definition');
   const moreActions = [pluggableActions.length ? pluggableActions : null].filter(Boolean);
 
   const showActions = (): boolean => scopePermissions?.is_mutable;
+
+  // Every entry of the "more actions" menu is permission gated, so without any of them the menu would
+  // render as an empty dropdown box.
+  const hasMoreActions =
+    isPermitted(permissions, `eventdefinitions:edit:${eventDefinition.id}`) ||
+    isPermitted(permissions, 'eventdefinitions:create') ||
+    (showActions() && isPermitted(permissions, `eventdefinitions:delete:${eventDefinition.id}`)) ||
+    isAggregationEventDefinition(eventDefinition) ||
+    pluggableActions.length > 0;
 
   const getDeleteActionTitle = () => {
     if (isSystemEventDefinition(eventDefinition)) {
@@ -244,64 +256,66 @@ const EventDefinitionActions = ({ eventDefinition }: Props) => {
           onClick={handleShare}
           bsSize="xsmall"
         />
-        <MoreActions>
-          <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
-            <MenuItem onClick={onEditEventDefinition} data-testid="edit-button">
-              Edit
-            </MenuItem>
-          </IfPermitted>
-          <IfPermitted permissions="eventdefinitions:create">
-            {!isSystemEventDefinition(eventDefinition) && (
-              <MenuItem onClick={() => handleAction(DIALOG_TYPES.COPY, eventDefinition)}>Duplicate</MenuItem>
-            )}
-            <MenuItem divider />
-          </IfPermitted>
-          <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
-            <MenuItem
-              disabled={isSystemEventDefinition(eventDefinition)}
-              title={
-                isSystemEventDefinition(eventDefinition) ? 'System Event Definition cannot be disabled' : undefined
-              }
-              onClick={
-                isSystemEventDefinition(eventDefinition)
-                  ? undefined
-                  : () => handleAction(isEnabled ? DIALOG_TYPES.DISABLE : DIALOG_TYPES.ENABLE, eventDefinition)
-              }>
-              {isEnabled ? 'Disable' : 'Enable'}
-            </MenuItem>
-          </IfPermitted>
-          {showActions() && (
-            <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
+        {hasMoreActions && (
+          <MoreActions>
+            <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
+              <MenuItem onClick={onEditEventDefinition} data-testid="edit-button">
+                Edit
+              </MenuItem>
+            </IfPermitted>
+            <IfPermitted permissions="eventdefinitions:create">
+              {!isSystemEventDefinition(eventDefinition) && (
+                <MenuItem onClick={() => handleAction(DIALOG_TYPES.COPY, eventDefinition)}>Duplicate</MenuItem>
+              )}
               <MenuItem divider />
-              <DeleteMenuItem
+            </IfPermitted>
+            <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
+              <MenuItem
                 disabled={isSystemEventDefinition(eventDefinition)}
-                title={getDeleteActionTitle()}
+                title={
+                  isSystemEventDefinition(eventDefinition) ? 'System Event Definition cannot be disabled' : undefined
+                }
                 onClick={
                   isSystemEventDefinition(eventDefinition)
                     ? undefined
-                    : () => handleAction(DIALOG_TYPES.DELETE, eventDefinition)
-                }
-                data-testid="delete-button"
-              />
+                    : () => handleAction(isEnabled ? DIALOG_TYPES.DISABLE : DIALOG_TYPES.ENABLE, eventDefinition)
+                }>
+                {isEnabled ? 'Disable' : 'Enable'}
+              </MenuItem>
             </IfPermitted>
-          )}
-          {isAggregationEventDefinition(eventDefinition) && (
-            <>
-              <IfPermitted
-                permissions={[
-                  `eventdefinitions:edit:${eventDefinition.id}`,
-                  `eventdefinitions:delete:${eventDefinition.id}`,
-                ]}
-                anyPermissions>
+            {showActions() && (
+              <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
                 <MenuItem divider />
+                <DeleteMenuItem
+                  disabled={isSystemEventDefinition(eventDefinition)}
+                  title={getDeleteActionTitle()}
+                  onClick={
+                    isSystemEventDefinition(eventDefinition)
+                      ? undefined
+                      : () => handleAction(DIALOG_TYPES.DELETE, eventDefinition)
+                  }
+                  data-testid="delete-button"
+                />
               </IfPermitted>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.replay_search(eventDefinition.id)}>
-                <MenuItem>Replay Search</MenuItem>
-              </LinkContainer>
-            </>
-          )}
-          {moreActions}
-        </MoreActions>
+            )}
+            {isAggregationEventDefinition(eventDefinition) && (
+              <>
+                <IfPermitted
+                  permissions={[
+                    `eventdefinitions:edit:${eventDefinition.id}`,
+                    `eventdefinitions:delete:${eventDefinition.id}`,
+                  ]}
+                  anyPermissions>
+                  <MenuItem divider />
+                </IfPermitted>
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.replay_search(eventDefinition.id)}>
+                  <MenuItem>Replay Search</MenuItem>
+                </LinkContainer>
+              </>
+            )}
+            {moreActions}
+          </MoreActions>
+        )}
       </ButtonToolbar>
       {showDialog && (
         <ConfirmDialog

--- a/graylog2-web-interface/src/hooks/useHasEntityOwnership.ts
+++ b/graylog2-web-interface/src/hooks/useHasEntityOwnership.ts
@@ -14,31 +14,20 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
-import * as React from 'react';
+import { createGRN } from 'logic/permissions/GRN';
+import useCurrentUser from 'hooks/useCurrentUser';
+import { hasAdminPermission } from 'util/PermissionsMixin';
 
-import useHasEntityOwnership from 'hooks/useHasEntityOwnership';
+const useHasEntityOwnership = (id: string | undefined, type: string) => {
+  const currentUser = useCurrentUser();
 
-type ChildFun = (props: { disabled: boolean }) => React.ReactElement;
-
-type Props = {
-  children: ChildFun;
-  id?: string;
-  type: string;
-  hideChildren?: boolean;
-};
-
-const HasOwnership = ({ children, id = undefined, type, hideChildren = false }: Props) => {
-  const hasOwnership = useHasEntityOwnership(id, type);
-
-  if (typeof children !== 'function') {
-    throw new Error('Invalid prop: "children" must be a function.');
+  if (!currentUser) {
+    return false;
   }
 
-  if (hideChildren) {
-    return null;
-  }
+  const { grnPermissions = [], permissions } = currentUser;
 
-  return <>{children({ disabled: !hasOwnership })} </>;
+  return hasAdminPermission(permissions) || grnPermissions.includes(`entity:own:${createGRN(type, id)}`);
 };
 
-export default HasOwnership;
+export default useHasEntityOwnership;

--- a/graylog2-web-interface/src/hooks/usePluggableEntitySharedActions.tsx
+++ b/graylog2-web-interface/src/hooks/usePluggableEntitySharedActions.tsx
@@ -19,29 +19,26 @@ import { useRef } from 'react';
 
 import usePluginEntities from 'hooks/usePluginEntities';
 import type { EntitySharedAction, ModalHandler } from 'components/permissions/types';
-import { HasOwnership } from 'components/common';
+import useHasEntityOwnership from 'hooks/useHasEntityOwnership';
 
 function usePluggableEntitySharedActions<T>(entity: T, entityType: string, onCloseModal = undefined) {
   const modalRefs = useRef({});
   const pluginActions = usePluginEntities('components.shared.entityActions');
+  const hasOwnership = useHasEntityOwnership((entity as T & { id: string })?.id, entityType);
 
   const availableActions = pluginActions.filter((action) => (action.useCondition ? !!action.useCondition() : true));
 
-  const actions = availableActions.map((action: EntitySharedAction<T, ModalHandler>) => {
+  // Only actions the user can actually use are returned, so callers can tell from the length whether
+  // anything will render and avoid showing an empty menu.
+  const actions = (hasOwnership ? availableActions : []).map((action: EntitySharedAction<T, ModalHandler>) => {
     const { key, component: PluggableEntityAction } = action;
 
     return (
-      <HasOwnership key={`entity-action-${key}`} id={(entity as T & { id: string })?.id} type={entityType}>
-        {({ disabled }) =>
-          disabled ? null : (
-            <PluggableEntityAction
-              key={`entity-action-${key}`}
-              entity={entity}
-              modalRef={() => modalRefs.current[key]}
-            />
-          )
-        }
-      </HasOwnership>
+      <PluggableEntityAction
+        key={`entity-action-${key}`}
+        entity={entity}
+        modalRef={() => modalRefs.current[key]}
+      />
     );
   });
 

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.tsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.tsx
@@ -41,12 +41,20 @@ const EditEventDefinitionPage = () => {
   const [eventDefinition, setEventDefinition] = useState<EventDefinition>(undefined);
   const history = useHistory();
 
+  const canEdit = isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`);
+
   const goToOverview = useCallback(() => {
     history.push(Routes.ALERTS.DEFINITIONS.LIST);
   }, [history]);
 
   useEffect(() => {
-    if (isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`)) {
+    if (!canEdit) {
+      history.push(Routes.NOTFOUND);
+    }
+  }, [canEdit, history]);
+
+  useEffect(() => {
+    if (canEdit) {
       getEventDefinition(params.definitionId).then(
         (response) => {
           const eventDefinitionResponse = response.eventDefinition;
@@ -63,17 +71,13 @@ const EditEventDefinitionPage = () => {
         },
       );
     }
-  }, [params, currentUser, history]);
+  }, [canEdit, params.definitionId, history]);
 
   const streamsWithMissingPermissions = () => {
     const streams = eventDefinition?.config?.streams || [];
 
     return streams.filter((streamId) => !isPermitted(currentUser.permissions, `streams:read:${streamId}`));
   };
-
-  if (!isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`)) {
-    history.push(Routes.NOTFOUND);
-  }
 
   const missingStreams = streamsWithMissingPermissions();
 


### PR DESCRIPTION
Fixed the following issues found while testing with a reader user:

https://github.com/Graylog2/graylog-plugin-enterprise/issues/15406
https://github.com/Graylog2/graylog-plugin-enterprise/issues/15398

For 15406, the edit page now forwards to the Not Found page instead of loading forever. The permission check called `navigate()` from the render body, which React Router ignores, so the redirect never happened. It now runs in an effect.

<img width="1064" height="394" alt="image" src="https://github.com/user-attachments/assets/5e10eb41-4d79-4aeb-b72e-c2a3c709a7bb" />

For 15398, the action button is now hidden when the user has no permitted actions on that definition, instead of opening an empty menu. That also needed `usePluggableEntitySharedActions` to stop returning actions that render nothing, which clears the same empty menu on streams and event notifications.

<img width="1068" height="329" alt="image" src="https://github.com/user-attachments/assets/c359cb77-9807-49a3-aaa7-73b6e1fc1945" />

Both issues exist in 7.1 and 7.0, so this needs to be backported to both.

/jpd Graylog2/graylog-plugin-enterprise#15583

## Testing

1. Log in as an admin and share an event definition with a user that only has the Reader role, using the view capability.
2. Log in as that reader user and go to Alerts > Event Definitions.
3. Verify the shared definition's row shows no action menu button, instead of a button that opens an empty dropdown.
4. Visit `/alerts/definitions/<definition id>/edit` directly for that definition.
5. Verify the Not Found page is displayed, instead of the edit page spinning indefinitely.
6. Log back in as an admin and verify the row action menu still lists Edit, Duplicate, Enable/Disable, Delete and Replay Search, and that the edit page still loads.
