### PR TITLE
Fix full page refresh when clicking plugin nav dropdown items

### DIFF
--- a/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.tsx
@@ -47,7 +47,7 @@ const NavigationLink = ({ Badge = undefined, description, path, topLevel = false
 
   return (
     <LinkContainer key={path} to={path} relativeActive {...rest}>
-      {topLevel ? <NavItem>{title}</NavItem> : <DropdownOption component="a">{title}</DropdownOption>}
+      {topLevel ? <NavItem>{title}</NavItem> : <DropdownOption>{title}</DropdownOption>}
     </LinkContainer>
   );
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`NavigationLink` rendered every non-top-level dropdown item (used by plugin nav dropdowns such as Enterprise/Security) with `component="a"` on `MenuItem`. PR #27194 added a dedicated `component === 'a'` branch to `MenuItem` for genuinely external links (the preflight/help menu), which unintentionally also matched these internal SPA links and routed them through a plain `<a>` instead of the react-router-aware `component={Link}` branch. Since `MenuItem`'s internal click handler discards the native `MouseEvent` before calling the `onClick` prop supplied by `LinkContainer`, `preventDefault()` was never invoked, so the browser followed the anchor's `href` and did a full page load.

Dropping `component="a"` for internal dropdown items lets them fall through to the `component={Link}` branch, restoring in-app routing.

/nocl Fixing unreleased change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.