### PR TITLE
Use OR operator when add array value to query

### DIFF
--- a/changelog/unreleased/pr-27364.toml
+++ b/changelog/unreleased/pr-27364.toml
@@ -1,0 +1,5 @@
+type = "f"
+message = "Use OR when adding multiple values from an array field to the query."
+
+issues = ["Graylog2/graylog-plugin-enterprise#14322"]
+pulls = ["27364"]

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.ts
@@ -97,6 +97,27 @@ describe('AddToQueryHandler', () => {
     expect(updateQueryString).toHaveBeenCalledWith('anotherQueryId', 'foo:23 AND bar:42');
   });
 
+  it('combines array field values with OR', async () => {
+    const query = createQuery('anotherQueryId', 'foo:23');
+    const view = createViewWithQuery(query);
+    const state = { ...mockRootState, view: { view } } as RootState;
+    const dispatch = mockDispatch(state);
+
+    await dispatch(
+      AddToQueryHandler({
+        queryId: 'anotherQueryId',
+        field: 'associated_assets',
+        value: ['id1', 'id2', 'id3'],
+        type: new FieldType('associated-assets', [], []),
+      }),
+    );
+
+    expect(updateQueryString).toHaveBeenCalledWith(
+      'anotherQueryId',
+      'foo:23 AND (associated_assets:id1 OR associated_assets:id2 OR associated_assets:id3)',
+    );
+  });
+
   it('updates query string for multiple values from context', async () => {
     const query = createQuery('anotherQueryId', 'foo:23');
     const view = createViewWithQuery(query);

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.ts
@@ -39,9 +39,11 @@ const toPredicate = (field: string, value: string | number, type: FieldType) =>
 const formatNewQuery = (oldQuery: string, field: string, value: string | number, type: FieldType) =>
   addToQuery(oldQuery, toPredicate(field, value, type));
 
-type ValueToAdd = { field: string; value: string | number; type: FieldType };
+type QueryValue = string | number;
+type ValueToAdd = { field: string; value: QueryValue; type: FieldType };
+type ValueArgument = QueryValue | Array<QueryValue>;
 
-// Joins each value path entry with OR into a single bracketed clause, e.g. `(source:a OR target:a)`.
+// Joins predicates with OR into a single bracketed clause, e.g. `(source:a OR target:a)`.
 const orClause = (values: Array<ValueToAdd>) =>
   `(${concatQueryStrings(
     values.map(({ field, value, type }) => toPredicate(field, value, type)),
@@ -51,29 +53,42 @@ const orClause = (values: Array<ValueToAdd>) =>
 type Arguments = {
   queryId: string;
   field: string;
-  value?: string | number;
+  value?: ValueArgument;
   type: FieldType;
   contexts?: Partial<ActionContexts>;
 };
+
+const valuesFromPath = (contexts: Partial<ActionContexts>) => contexts.valuePath.map((path) => {
+  const [pathField, pathValue] = Object.entries(path)[0];
+
+  return { field: pathField, value: pathValue, type: fieldTypeFor(pathField, contexts?.fieldTypes) };
+})
+
+const valuesFromArray = (field: string, value: Array<QueryValue>, type: FieldType): Array<ValueToAdd> =>
+  value.map((arrayValue) => ({ field, value: arrayValue, type }))
 
 const AddToQueryHandler =
   ({ queryId, field, value = '', type, contexts }: Arguments) =>
   async (dispatch: ViewsDispatch, getState: () => RootState) => {
     const oldQuery = selectQueryString(queryId)(getState());
-    const multipleValues = hasMultipleValueForActions(contexts);
-    const valuesToAdd: Array<ValueToAdd> = uniq(
-      multipleValues
-        ? contexts.valuePath.map((path) => {
-            const [pathField, pathValue] = Object.entries(path)[0];
+    const hasMultipleValuesInPath = hasMultipleValueForActions(contexts);
+    const fieldValueIsArray = Array.isArray(value);
 
-            return { field: pathField, value: pathValue, type: fieldTypeFor(pathField, contexts?.fieldTypes) };
-          })
-        : [{ field, value, type }],
-    );
+    const getValues = () => {
+      if(hasMultipleValuesInPath) return valuesFromPath(contexts);
+      if(fieldValueIsArray) return valuesFromArray(field, value, type);
+
+      return [{ field, value, type }]
+    }
+
+    const valuesToAdd: Array<ValueToAdd> = uniq(getValues());
 
     let newQuery: string;
 
-    if (multipleValues && contexts?.valuePathOperator === 'EDGE') {
+    const shouldAddWithOr = (hasMultipleValuesInPath && contexts?.valuePathOperator === 'OR')
+      || (!hasMultipleValuesInPath && fieldValueIsArray && valuesToAdd.length > 1)
+
+    if (hasMultipleValuesInPath && contexts?.valuePathOperator === 'EDGE') {
       newQuery = addToQuery(
         oldQuery,
         edgeClause(
@@ -81,7 +96,7 @@ const AddToQueryHandler =
           { field: valuesToAdd[1].field, value: valuesToAdd[1].value },
         ),
       );
-    } else if (multipleValues && contexts?.valuePathOperator === 'OR') {
+    } else if (shouldAddWithOr) {
       newQuery = addToQuery(oldQuery, orClause(valuesToAdd));
     } else {
       newQuery = valuesToAdd.reduce(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates the "Add to query" value action to handle array field values individually. Multiple values are converted into predicates for the same field and combined in a parenthesized `OR` clause.

For example:

`associated_assets: id1, id2, id3`

is added as:

`(associated_assets:id1 OR associated_assets:id2 OR associated_assets:id3)`

Existing behavior for scalar values and aggregation value paths remains unchanged.

## Motivation and Context
fix: [#14322](https://github.com/Graylog2/graylog-plugin-enterprise/issues/14322)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have requested a documentation update.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

