### PR TITLE
Improve event definition Tags validation UX

### DIFF
--- a/changelog/unreleased/issue-27215.toml
+++ b/changelog/unreleased/issue-27215.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Prevent event definition tags with invalid characters or excessive length from being added to the form."
+
+issues = ["27215"]
+pulls = ["27366"]

--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -300,9 +300,8 @@ type State = {
 };
 
 /**
- * The option filtering `Select` itself applies to the typed text. Exported so a caller can ask
- * the same question rather than approximating it: matchSorter also matches subsequences and
- * acronyms, which a substring test would disagree with.
+ * The option filtering `Select` applies to typed text. Exported so a caller can ask the same
+ * question: matchSorter also matches subsequences and acronyms, unlike a substring test.
  */
 export const matchOptions = (
   options: ReadonlyArray<Option>,
@@ -539,7 +538,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       ignoreAccents,
     } = this.props;
     const { customComponents, value, inputValue: uncontrolledInputValue } = this.state;
-    // A caller that passes `inputValue` owns the typed text; otherwise we track it ourselves.
+    // A caller passing `inputValue` owns the typed text.
     const inputValue = this.props.inputValue ?? uncontrolledInputValue;
 
     const formattedValue = this._formatInputValue(value);

--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -299,6 +299,18 @@ type State = {
   inputValue: string;
 };
 
+/**
+ * The option filtering `Select` itself applies to the typed text. Exported so a caller can ask
+ * the same question rather than approximating it: matchSorter also matches subsequences and
+ * acronyms, which a substring test would disagree with.
+ */
+export const matchOptions = (
+  options: ReadonlyArray<Option>,
+  query: string,
+  { displayKey = 'label', ignoreAccents = true }: { displayKey?: string; ignoreAccents?: boolean } = {},
+): Array<Option> =>
+  matchSorter(options as Array<Option>, query, { keys: [displayKey, 'label'], keepDiacritics: !ignoreAccents });
+
 const getCustomComponents = (
   inputProps?: { [key: string]: any },
   optionRenderer?: (option: Option) => React.ReactElement,
@@ -556,12 +568,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     const customFilter = this.createCustomFilter();
 
     const sortedOptions =
-      !async && inputValue
-        ? matchSorter(rawOptions, inputValue, {
-            keys: [displayKey, 'label'],
-            keepDiacritics: !ignoreAccents,
-          })
-        : rawOptions;
+      !async && inputValue ? matchOptions(rawOptions, inputValue, { displayKey, ignoreAccents }) : rawOptions;
 
     const mergedComponents = {
       ..._components,

--- a/graylog2-web-interface/src/components/common/Select/Select.tsx
+++ b/graylog2-web-interface/src/components/common/Select/Select.tsx
@@ -282,6 +282,8 @@ export type Props<OptionValue> = {
   async?: boolean;
   total?: number;
   onInputChange?: (newValue: string, actionMeta: InputActionMeta) => void;
+  /** Controls the typed text. When omitted, the input manages its own. */
+  inputValue?: string;
   loadOptions?: () => void;
 };
 
@@ -361,6 +363,7 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
     async: false,
     total: 0,
     onInputChange: undefined,
+    inputValue: undefined,
     loadOptions: undefined,
     forwardedRef: undefined,
   };
@@ -523,7 +526,9 @@ class Select<OptionValue> extends React.Component<Props<OptionValue>, State> {
       theme,
       ignoreAccents,
     } = this.props;
-    const { customComponents, value, inputValue } = this.state;
+    const { customComponents, value, inputValue: uncontrolledInputValue } = this.state;
+    // A caller that passes `inputValue` owns the typed text; otherwise we track it ourselves.
+    const inputValue = this.props.inputValue ?? uncontrolledInputValue;
 
     const formattedValue = this._formatInputValue(value);
 

--- a/graylog2-web-interface/src/components/common/index.tsx
+++ b/graylog2-web-interface/src/components/common/index.tsx
@@ -165,3 +165,4 @@ export { default as SearchFiltersFormControls } from './SearchFiltersFormControl
 export { default as ModalButtonToolbar } from './ModalButtonToolbar';
 export { default as AccessibleCard } from './AccessibleCard';
 export { default as StatCard } from './StatCard/StatCard';
+export { default as useChipInput } from './useChipInput';

--- a/graylog2-web-interface/src/components/common/useChipInput.ts
+++ b/graylog2-web-interface/src/components/common/useChipInput.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import { useState } from 'react';
+import type { InputActionMeta } from 'react-select';
+
+// Unit-separator character. Callers restrict values to characters that can't include it, so it is
+// safe as the delimiter `Select` uses to (de)serialize a multi value.
+export const VALUE_DELIMITER = '\x1F';
+
+type Options = {
+  /** The committed values, in order. */
+  values: ReadonlyArray<string>;
+  onChange: (next: string[]) => void;
+  /** Applied to typed text and to committed values before anything else looks at them. */
+  normalize: (raw: string) => string;
+  /** Why this value can't be added, or null when it is acceptable. */
+  validate: (candidate: string) => string | null;
+  /**
+   * Why the text typed so far can't be added, or null to say nothing yet. Defaults to
+   * `validate`. Override where the typed text isn't always a candidate value, such as a field
+   * whose input doubles as a search over the options.
+   */
+  validateInput?: (candidate: string, raw: string) => string | null;
+  max: number;
+  /** Describes a set of already-committed values that don't pass `validate`. */
+  describeInvalid: (invalid: ReadonlyArray<string>) => string | null;
+  describeDuplicate: (candidate: string) => string;
+  /**
+   * Withhold the create affordance for a reason that isn't a validation failure, such as the
+   * value already existing as a selectable option. Unlike `validate`, this produces no message.
+   */
+  suppressCreate?: (raw: string, candidate: string) => boolean;
+  /**
+   * Notified whenever the typed text changes, including when it is cleared on commit. Lets a
+   * caller drive option loading without reading `input` back out of the hook, which would order
+   * the options after the hook call that needs them.
+   */
+  onInputChanged?: (value: string) => void;
+};
+
+/**
+ * Shared behavior for a `Select` used as a chip/token input, where a value the server would
+ * reject must never become a chip.
+ *
+ * A rejected value stays in the input with a message naming the reason, rather than being
+ * committed and flagged afterwards, and the menu is held shut while it is rejected so it can't
+ * cover that message.
+ */
+const useChipInput = ({
+  values,
+  onChange,
+  normalize,
+  validate,
+  validateInput,
+  max,
+  describeInvalid,
+  describeDuplicate,
+  suppressCreate,
+  onInputChanged,
+}: Options) => {
+  const [input, setInput] = useState('');
+  // Duplicates are only wrong at commit time — typing "auth" on the way to "authentication"
+  // shouldn't read as an error — so they're flagged on Enter/Tab/blur rather than live.
+  const [duplicateAttempt, setDuplicateAttempt] = useState<string | null>(null);
+
+  const candidate = normalize(input);
+  const isAtMax = values.length >= max;
+  const inputMessage = candidate ? (validateInput ?? validate)(candidate, input) : null;
+
+  const handleChange = (joined: string) => {
+    const raw = joined ? joined.split(VALUE_DELIMITER) : [];
+    const normalized = raw.map(normalize).filter((value) => value.length > 0);
+
+    onChange(Array.from(new Set(normalized)).slice(0, max));
+    // A value was just committed, so the typed text is spent.
+    setInput('');
+    onInputChanged?.('');
+    setDuplicateAttempt(null);
+  };
+
+  const handleInputChange = (value: string, actionMeta?: InputActionMeta) => {
+    if (actionMeta?.action !== 'input-change') return;
+
+    setInput(value);
+    onInputChanged?.(value);
+    // The user is editing, so any duplicate warning is stale. It re-evaluates on the next
+    // commit attempt.
+    setDuplicateAttempt(null);
+  };
+
+  // react-select rejects a duplicate with no chip and no callback, so it has to be flagged here
+  // or the value would simply vanish with no explanation.
+  const flagDuplicateAttempt = () => {
+    if (candidate && values.includes(candidate)) {
+      setDuplicateAttempt(candidate);
+    }
+  };
+
+  const isValidNewOption = (raw: string) => {
+    const value = normalize(raw ?? '');
+
+    return (
+      value.length > 0 &&
+      validate(value) === null &&
+      !isAtMax &&
+      // Replaces react-select's own duplicate check, which this overrides.
+      !values.includes(value) &&
+      !suppressCreate?.(raw, value)
+    );
+  };
+
+  // Values that fail `validate` can no longer be committed, so this only catches values that
+  // reached the form another way, such as an entity created through the API.
+  const invalidValues = values.filter((value) => validate(value) !== null);
+
+  const messages = [
+    describeInvalid(invalidValues),
+    inputMessage,
+    duplicateAttempt ? describeDuplicate(duplicateAttempt) : null,
+  ].filter((message): message is string => !!message);
+
+  return {
+    input,
+    candidate,
+    isAtMax,
+    messages,
+    setDuplicateAttempt,
+    flagDuplicateAttempt,
+    /** Spread onto `Select`. Anything here can be overridden by the caller. */
+    selectProps: {
+      delimiter: VALUE_DELIMITER,
+      value: values.join(VALUE_DELIMITER),
+      inputValue: input,
+      onChange: handleChange,
+      onInputChange: handleInputChange,
+      onBlur: flagDuplicateAttempt,
+    },
+    /**
+     * Spread onto `Select` through a cast: `Select`'s Props type doesn't surface these, but it
+     * passes unknown props through to react-select.
+     */
+    reactSelectProps: {
+      isValidNewOption,
+      // An open menu covers the message saying why the value was rejected.
+      menuIsOpen: inputMessage ? false : undefined,
+    } as object,
+  };
+};
+
+export default useChipInput;
+export type { Options as UseChipInputOptions };

--- a/graylog2-web-interface/src/components/common/useChipInput.ts
+++ b/graylog2-web-interface/src/components/common/useChipInput.ts
@@ -17,49 +17,27 @@
 import { useState } from 'react';
 import type { InputActionMeta } from 'react-select';
 
-// Unit-separator character. Callers restrict values to characters that can't include it, so it is
-// safe as the delimiter `Select` uses to (de)serialize a multi value.
+// Unit separator; callers restrict values to characters that exclude it.
 export const VALUE_DELIMITER = '\x1F';
 
 type Options = {
-  /** The committed values, in order. */
   values: ReadonlyArray<string>;
   onChange: (next: string[]) => void;
-  /** Applied to typed text and to committed values before anything else looks at them. */
   normalize: (raw: string) => string;
   /** Why this value can't be added, or null when it is acceptable. */
   validate: (candidate: string) => string | null;
-  /**
-   * Why the text typed so far can't be added, or null to say nothing yet. Defaults to
-   * `validate`. Override where the typed text isn't always a candidate value, such as a field
-   * whose input doubles as a search over the options.
-   */
+  /** Same, for text still being typed. Defaults to `validate`. */
   validateInput?: (candidate: string, raw: string) => string | null;
   max: number;
-  /** Describes a set of already-committed values that don't pass `validate`. */
   describeInvalid: (invalid: ReadonlyArray<string>) => string | null;
   describeDuplicate: (candidate: string) => string;
-  /**
-   * Withhold the create affordance for a reason that isn't a validation failure, such as the
-   * value already existing as a selectable option. Unlike `validate`, this produces no message.
-   */
+  /** Withhold the create affordance without producing a message. */
   suppressCreate?: (raw: string, candidate: string) => boolean;
-  /**
-   * Notified whenever the typed text changes, including when it is cleared on commit. Lets a
-   * caller drive option loading without reading `input` back out of the hook, which would order
-   * the options after the hook call that needs them.
-   */
+  /** Lets a caller load options from the typed text without ordering them after this hook. */
   onInputChanged?: (value: string) => void;
 };
 
-/**
- * Shared behavior for a `Select` used as a chip/token input, where a value the server would
- * reject must never become a chip.
- *
- * A rejected value stays in the input with a message naming the reason, rather than being
- * committed and flagged afterwards, and the menu is held shut while it is rejected so it can't
- * cover that message.
- */
+/** Shared behavior for a `Select` used as a chip input, where an invalid value never becomes a chip. */
 const useChipInput = ({
   values,
   onChange,
@@ -73,8 +51,7 @@ const useChipInput = ({
   onInputChanged,
 }: Options) => {
   const [input, setInput] = useState('');
-  // Duplicates are only wrong at commit time — typing "auth" on the way to "authentication"
-  // shouldn't read as an error — so they're flagged on Enter/Tab/blur rather than live.
+  // Flagged on commit, not live: typing "auth" toward "authentication" shouldn't read as an error.
   const [duplicateAttempt, setDuplicateAttempt] = useState<string | null>(null);
 
   const candidate = normalize(input);
@@ -86,7 +63,6 @@ const useChipInput = ({
     const normalized = raw.map(normalize).filter((value) => value.length > 0);
 
     onChange(Array.from(new Set(normalized)).slice(0, max));
-    // A value was just committed, so the typed text is spent.
     setInput('');
     onInputChanged?.('');
     setDuplicateAttempt(null);
@@ -97,13 +73,10 @@ const useChipInput = ({
 
     setInput(value);
     onInputChanged?.(value);
-    // The user is editing, so any duplicate warning is stale. It re-evaluates on the next
-    // commit attempt.
     setDuplicateAttempt(null);
   };
 
-  // react-select rejects a duplicate with no chip and no callback, so it has to be flagged here
-  // or the value would simply vanish with no explanation.
+  // react-select rejects a duplicate with no chip and no callback, so it would vanish unexplained.
   const flagDuplicateAttempt = () => {
     if (candidate && values.includes(candidate)) {
       setDuplicateAttempt(candidate);
@@ -123,8 +96,7 @@ const useChipInput = ({
     );
   };
 
-  // Values that fail `validate` can no longer be committed, so this only catches values that
-  // reached the form another way, such as an entity created through the API.
+  // Only catches values that reached the form another way, such as through the API.
   const invalidValues = values.filter((value) => validate(value) !== null);
 
   const messages = [
@@ -140,7 +112,7 @@ const useChipInput = ({
     messages,
     setDuplicateAttempt,
     flagDuplicateAttempt,
-    /** Spread onto `Select`. Anything here can be overridden by the caller. */
+    /** Spread onto `Select`. */
     selectProps: {
       delimiter: VALUE_DELIMITER,
       value: values.join(VALUE_DELIMITER),
@@ -149,10 +121,7 @@ const useChipInput = ({
       onInputChange: handleInputChange,
       onBlur: flagDuplicateAttempt,
     },
-    /**
-     * Spread onto `Select` through a cast: `Select`'s Props type doesn't surface these, but it
-     * passes unknown props through to react-select.
-     */
+    /** Spread onto `Select` too; cast because its Props type doesn't surface these. */
     reactSelectProps: {
       isValidNewOption,
       // An open menu covers the message saying why the value was rejected.

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
@@ -77,15 +77,24 @@ describe('TagsEditor', () => {
     expect(onChange).toHaveBeenLastCalledWith(['phishing']);
   });
 
-  it('does not offer an "Add" affordance for a duplicate (case-insensitive)', async () => {
+  it('does not offer a create affordance for a duplicate (case-insensitive)', async () => {
     render(<Harness initial={['phishing']} />);
 
     const input = screen.getByRole('combobox');
     await userEvent.type(input, 'PHISHING');
 
-    // react-select's CreatableSelect compares case-insensitively against selected values,
-    // so the "Add ..." option is suppressed when the typed input matches an existing tag.
-    expect(screen.queryByText(/Add "PHISHING"/i)).not.toBeInTheDocument();
+    // Values are lowercased before the duplicate check, so this matches the existing tag.
+    expect(screen.queryByText(/Create "/i)).not.toBeInTheDocument();
+  });
+
+  it('does not offer a create affordance duplicating an existing suggestion', async () => {
+    mockedSuggestTags.mockResolvedValue({ tags: ['phishing'] });
+    render(<Harness />);
+
+    await userEvent.type(screen.getByRole('combobox'), 'phishing');
+
+    expect(await screen.findByText('phishing')).toBeInTheDocument();
+    expect(screen.queryByText(/Create "/i)).not.toBeInTheDocument();
   });
 
   describe('autocomplete', () => {
@@ -228,6 +237,32 @@ describe('TagsEditor', () => {
       await userEvent.type(input, 'phishing');
 
       expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('reports a tag that reached the form already invalid', async () => {
+      render(<Harness initial={['bad tag']} />);
+
+      expect(await screen.findByText(/Tag "bad tag" contains invalid characters/i)).toBeInTheDocument();
+    });
+
+    it('reports a too-long tag once, not also as invalid characters', async () => {
+      render(<Harness initial={[`${'a'.repeat(129)} x`]} />);
+
+      expect(await screen.findByText(/exceeds the maximum length/i)).toBeInTheDocument();
+      expect(screen.queryByText(/contains invalid characters/i)).not.toBeInTheDocument();
+    });
+
+    it('says so at the tag cap instead of silently refusing', async () => {
+      const full = Array.from({ length: 64 }, (_, i) => `tag-${i}`);
+      const onChange = jest.fn();
+      render(<Harness initial={full} onChange={onChange} />);
+
+      expect(await screen.findByText(/Maximum of 64 tags reached/i)).toBeInTheDocument();
+
+      await userEvent.type(screen.getByRole('combobox'), 'one-more');
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('commits the value once the user corrects it', async () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.test.tsx
@@ -145,6 +145,106 @@ describe('TagsEditor', () => {
     });
   });
 
+  describe('rejecting invalid values', () => {
+    it.each([
+      ['invalid characters', 'phish:ing'],
+      ['a space', 'phish ing'],
+      ['a non-ASCII character', 'tag-täg'],
+      ['excessive length', 'a'.repeat(129)],
+    ])('does not commit a tag with %s', async (_label, raw) => {
+      const onChange = jest.fn();
+      render(<Harness onChange={onChange} />);
+
+      await userEvent.type(screen.getByRole('combobox'), raw);
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('leaves the rejected value in the input so it can be corrected in place', async () => {
+      render(<Harness />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.type(input, 'phish:ing');
+      await userEvent.keyboard('{Enter}');
+
+      expect(input).toHaveValue('phish:ing');
+    });
+
+    it('drops the validation message when the input is cleared', async () => {
+      render(<Harness />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.type(input, 'phish:ing');
+
+      expect(await screen.findByText(/contains invalid characters/i)).toBeInTheDocument();
+
+      await userEvent.clear(input);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/contains invalid characters/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes the options menu so it cannot cover the message', async () => {
+      render(<Harness />);
+      const input = screen.getByRole('combobox');
+
+      // The menu opens for a value that is still valid, which is what would cover the message.
+      await userEvent.type(input, 'phishing');
+
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+
+      await userEvent.type(input, ':');
+
+      expect(await screen.findByText(/contains invalid characters/i)).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('No options')).not.toBeInTheDocument();
+    });
+
+    it('keeps the rejected value and its message after the field loses focus', async () => {
+      render(<Harness />);
+      const input = screen.getByRole('combobox');
+
+      await userEvent.type(input, 'phish:ing');
+      await userEvent.tab();
+
+      expect(input).toHaveValue('phish:ing');
+      expect(await screen.findByText(/contains invalid characters/i)).toBeInTheDocument();
+    });
+
+    it('reopens the menu after refocusing once the value is corrected', async () => {
+      render(<Harness />);
+      const input = screen.getByRole('combobox');
+
+      await userEvent.type(input, 'phish:ing');
+      await userEvent.tab();
+      await userEvent.click(input);
+      await userEvent.clear(input);
+      await userEvent.type(input, 'phishing');
+
+      expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('commits the value once the user corrects it', async () => {
+      const onChange = jest.fn();
+      render(<Harness onChange={onChange} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.type(input, 'phish:ing');
+      await userEvent.keyboard('{Enter}');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'phishing');
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).toHaveBeenLastCalledWith(['phishing']);
+    });
+  });
+
   describe('validation messages', () => {
     it('surfaces an invalid-characters message when committing a tag with disallowed chars', async () => {
       render(<Harness />);
@@ -238,6 +338,14 @@ describe('TagsEditor', () => {
       await userEvent.keyboard('{Tab}');
 
       expect(await screen.findByText(/exceeds the maximum length of 128 characters/i)).toBeInTheDocument();
+    });
+
+    it('flags an invalid value while typing, before any commit attempt', async () => {
+      render(<Harness />);
+
+      await userEvent.type(screen.getByRole('combobox'), 'phish:ing');
+
+      expect(await screen.findByText(/Tag "phish:ing" contains invalid characters/i)).toBeInTheDocument();
     });
 
     it('clears the validation message as soon as the user edits the input', async () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
@@ -79,12 +79,20 @@ const buildInvalidCharsMessage = (tagsList: ReadonlyArray<string>): string | nul
   );
 };
 
+// Rejected values never become chips, so the reason has to be stated against the typed text.
+const buildInputMessage = (raw: string): string | null => {
+  const candidate = normalizeTag(raw);
+  if (!candidate) return null;
+  if (isTooLong(candidate)) return buildTooLongMessage([candidate]);
+  if (hasInvalidChars(candidate)) return buildInvalidCharsMessage([candidate]);
+
+  return null;
+};
+
 const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) => {
   const [input, setInput] = useState('');
-  // Track only duplicate-commit attempts here. Invalid-character and over-length values are
-  // committed by react-select (they land in `tags`), so they're already covered by the
-  // categorization below. Duplicates are silently rejected by react-select, so we need to
-  // surface them explicitly.
+  // Duplicates are only wrong at commit time — typing "auth" on the way to "authentication"
+  // shouldn't read as an error — so they're flagged on Enter/Tab/blur rather than live.
   const [duplicateAttempt, setDuplicateAttempt] = useState<string | null>(null);
   const [debouncedInput] = useDebouncedValue(input, DEBOUNCE_MS);
 
@@ -111,9 +119,8 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
     setDuplicateAttempt(null);
   };
 
-  // react-select silently rejects duplicates with no chip and no callback — flag those on
-  // Enter/Tab/blur so the user gets explicit feedback. (Invalid-character and over-length
-  // values do commit, so the chip-categorization below already covers them.)
+  // react-select rejects duplicates with no chip and no callback — flag those on Enter/Tab/blur
+  // so the user gets explicit feedback.
   const flagDuplicateAttempt = () => {
     const trimmed = input.trim();
     if (!trimmed) return;
@@ -124,14 +131,17 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
     }
   };
 
-  // Each committed tag falls into at most one failure bucket so messages stay focused per
-  // failure mode (too long, invalid chars, duplicate).
+  // Invalid values can no longer be committed, so these buckets only catch tags that reached the
+  // form another way, such as a definition created through the API. Each tag falls into at most
+  // one bucket so messages stay focused per failure mode.
   const tooLongTags = tags.filter(isTooLong);
   const invalidCharTags = tags.filter((tag) => !isTooLong(tag) && hasInvalidChars(tag));
   const messages = [
     buildTooLongMessage(tooLongTags),
     buildInvalidCharsMessage(invalidCharTags),
+    buildInputMessage(input),
     duplicateAttempt ? `Tag "${duplicateAttempt}" has already been added.` : null,
+    tags.length > MAX_TAGS ? `No more than ${MAX_TAGS} tags can be added.` : null,
   ].filter((m): m is string => m !== null);
 
   const localValidationError =
@@ -147,22 +157,38 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
   return (
     <FormGroup controlId="event-definition-tags" validationState={combinedError ? 'error' : null}>
       <Select
-        // `Select`'s Props type doesn't surface a couple of react-select props we need here
-        // (`inputValue`, `onKeyDown`), but it spreads unknown props through at runtime, so
-        // we cast just these to satisfy tsc without altering behavior.
-        // - `inputValue` — fully control the typed text so react-select's internal blur /
-        //   menu-close clears can be ignored (otherwise Tab/blur drops the user's text on a
-        //   duplicate).
-        // - `onKeyDown` — flag a duplicate-commit attempt on Enter / Tab so the error
-        //   message surfaces even when react-select silently rejects the commit.
+        // Neither of these is in `Select`'s Props type, but `Select` spreads unknown props
+        // through to react-select, so the cast exists only to satisfy tsc.
+        // - `menuIsOpen` — keep the menu shut while the value is invalid, since an open menu
+        //   covers the message saying why it was rejected.
+        // - `onKeyDown` — react-select rejects a duplicate with no chip and no callback, so
+        //   Enter / Tab has to flag it explicitly.
         {...({
-          inputValue: input,
           onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === 'Tab') {
               flagDuplicateAttempt();
             }
           },
+          // An invalid value has nothing to suggest, and leaving the menu open would cover the
+          // message explaining why it was rejected.
+          menuIsOpen: buildInputMessage(input) ? false : undefined,
+          isValidNewOption: (value: string) => {
+            const candidate = normalizeTag(value ?? '');
+
+            return (
+              candidate.length > 0 &&
+              !isTooLong(candidate) &&
+              !hasInvalidChars(candidate) &&
+              // Replaces react-select's default duplicate check, which this prop overrides.
+              !tags.includes(candidate) &&
+              !suggestions.some((option) => option.value === candidate) &&
+              tags.length < MAX_TAGS
+            );
+          },
         } as object)}
+        // Own the typed text so react-select's blur / menu-close clears don't drop a rejected
+        // value before the user can correct it.
+        inputValue={input}
         inputId="event-definition-tags"
         aria-label="Event Definition Tags"
         multi

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
@@ -83,8 +83,7 @@ const validateTag = (tag: string): string | null => {
 };
 
 const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) => {
-  // Mirrors the typed text purely to drive suggestions, so the options are built before the hook
-  // call that needs them.
+  // Mirrors the typed text so suggestions are built before the hook call that needs them.
   const [query, setQuery] = useState('');
   const [debouncedQuery] = useDebouncedValue(query, DEBOUNCE_MS);
 
@@ -96,7 +95,7 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
     enabled: !disabled,
   });
   const isAtMax = tags.length >= MAX_TAGS;
-  // At the cap a pick would be dropped by the hook's slice, so disable rather than swallow it.
+  // At the cap a pick would be sliced off, so disable rather than swallow it.
   const suggestions = (data?.tags ?? [])
     .filter((s: string) => !tags.includes(s))
     .map((value: string) => ({ value, label: value, disabled: isAtMax }));
@@ -108,7 +107,7 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
     validate: validateTag,
     max: MAX_TAGS,
     onInputChanged: setQuery,
-    // Each tag falls into at most one bucket so messages stay focused per failure mode.
+    // At most one bucket per tag, so a message names one failure mode.
     describeInvalid: (invalid) =>
       [
         buildTooLongMessage(invalid.filter(isTooLong)),
@@ -117,7 +116,7 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
         .filter(Boolean)
         .join(' ') || null,
     describeDuplicate: (tag) => `Tag "${tag}" has already been added.`,
-    // An existing tag is already offered as a suggestion, so a Create row would duplicate it.
+    // Already offered as a suggestion, so a Create row would duplicate it.
     suppressCreate: (_raw, candidate) => suggestions.some((option) => option.value === candidate),
   });
 
@@ -137,8 +136,7 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
       <Select
         {...selectProps}
         {...reactSelectProps}
-        // Not in `Select`'s Props type, so cast to satisfy tsc. react-select rejects a duplicate
-        // with no chip and no callback, so Enter / Tab has to flag it explicitly.
+        // Not in `Select`'s Props type, so cast to satisfy tsc.
         {...({
           onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === 'Tab') {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/TagsEditor.tsx
@@ -21,7 +21,7 @@ import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { EventsDefinitions } from '@graylog/server-api';
 
 import { FormGroup } from 'components/bootstrap';
-import { InputDescription, Select } from 'components/common';
+import { InputDescription, Select, useChipInput } from 'components/common';
 import useDebouncedValue from 'hooks/useDebouncedValue';
 
 // Mirror of TagNormalizer on the server. Keep in sync.
@@ -36,10 +36,6 @@ const VALID_TAG_PATTERN = /^[a-z0-9_.-]+$/;
 
 const SUGGESTION_LIMIT = 50;
 const DEBOUNCE_MS = 300;
-
-// Unit-separator character; can't appear in a tag value (validation restricts tags to
-// [a-z0-9_.-]) so it's safe to use as the delimiter Select uses to (de)serialize multi values.
-const VALUE_DELIMITER = '\x1F';
 
 type Props = {
   tags: ReadonlyArray<string>;
@@ -79,75 +75,57 @@ const buildInvalidCharsMessage = (tagsList: ReadonlyArray<string>): string | nul
   );
 };
 
-// Rejected values never become chips, so the reason has to be stated against the typed text.
-const buildInputMessage = (raw: string): string | null => {
-  const candidate = normalizeTag(raw);
-  if (!candidate) return null;
-  if (isTooLong(candidate)) return buildTooLongMessage([candidate]);
-  if (hasInvalidChars(candidate)) return buildInvalidCharsMessage([candidate]);
+const validateTag = (tag: string): string | null => {
+  if (isTooLong(tag)) return buildTooLongMessage([tag]);
+  if (hasInvalidChars(tag)) return buildInvalidCharsMessage([tag]);
 
   return null;
 };
 
 const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) => {
-  const [input, setInput] = useState('');
-  // Duplicates are only wrong at commit time — typing "auth" on the way to "authentication"
-  // shouldn't read as an error — so they're flagged on Enter/Tab/blur rather than live.
-  const [duplicateAttempt, setDuplicateAttempt] = useState<string | null>(null);
-  const [debouncedInput] = useDebouncedValue(input, DEBOUNCE_MS);
+  // Mirrors the typed text purely to drive suggestions, so the options are built before the hook
+  // call that needs them.
+  const [query, setQuery] = useState('');
+  const [debouncedQuery] = useDebouncedValue(query, DEBOUNCE_MS);
 
   const { data, isFetching } = useQuery({
-    queryKey: ['event-definitions', 'tag-suggestions', debouncedInput],
-    queryFn: () => EventsDefinitions.suggestTags(debouncedInput, SUGGESTION_LIMIT),
+    queryKey: ['event-definitions', 'tag-suggestions', debouncedQuery],
+    queryFn: () => EventsDefinitions.suggestTags(debouncedQuery, SUGGESTION_LIMIT),
     placeholderData: keepPreviousData,
     staleTime: 30_000,
     enabled: !disabled,
   });
+  const isAtMax = tags.length >= MAX_TAGS;
+  // At the cap a pick would be dropped by the hook's slice, so disable rather than swallow it.
   const suggestions = (data?.tags ?? [])
     .filter((s: string) => !tags.includes(s))
-    .map((value: string) => ({ value, label: value }));
+    .map((value: string) => ({ value, label: value, disabled: isAtMax }));
 
-  const handleChange = (joined: string) => {
-    const raw = joined ? joined.split(VALUE_DELIMITER) : [];
-    const normalized = raw.map(normalizeTag).filter((value) => value.length > 0);
-    const deduped = Array.from(new Set(normalized));
+  const { messages, flagDuplicateAttempt, selectProps, reactSelectProps } = useChipInput({
+    values: tags,
+    onChange,
+    normalize: normalizeTag,
+    validate: validateTag,
+    max: MAX_TAGS,
+    onInputChanged: setQuery,
+    // Each tag falls into at most one bucket so messages stay focused per failure mode.
+    describeInvalid: (invalid) =>
+      [
+        buildTooLongMessage(invalid.filter(isTooLong)),
+        buildInvalidCharsMessage(invalid.filter((tag) => !isTooLong(tag) && hasInvalidChars(tag))),
+      ]
+        .filter(Boolean)
+        .join(' ') || null,
+    describeDuplicate: (tag) => `Tag "${tag}" has already been added.`,
+    // An existing tag is already offered as a suggestion, so a Create row would duplicate it.
+    suppressCreate: (_raw, candidate) => suggestions.some((option) => option.value === candidate),
+  });
 
-    onChange(deduped.slice(0, MAX_TAGS));
-    // A tag was just committed — clear the typed text. react-select's internal blur/clear
-    // events are ignored below, so this is now the only path that empties the input.
-    setInput('');
-    setDuplicateAttempt(null);
-  };
-
-  // react-select rejects duplicates with no chip and no callback — flag those on Enter/Tab/blur
-  // so the user gets explicit feedback.
-  const flagDuplicateAttempt = () => {
-    const trimmed = input.trim();
-    if (!trimmed) return;
-
-    const normalized = normalizeTag(trimmed);
-    if (tags.includes(normalized)) {
-      setDuplicateAttempt(normalized);
-    }
-  };
-
-  // Invalid values can no longer be committed, so these buckets only catch tags that reached the
-  // form another way, such as a definition created through the API. Each tag falls into at most
-  // one bucket so messages stay focused per failure mode.
-  const tooLongTags = tags.filter(isTooLong);
-  const invalidCharTags = tags.filter((tag) => !isTooLong(tag) && hasInvalidChars(tag));
-  const messages = [
-    buildTooLongMessage(tooLongTags),
-    buildInvalidCharsMessage(invalidCharTags),
-    buildInputMessage(input),
-    duplicateAttempt ? `Tag "${duplicateAttempt}" has already been added.` : null,
-    tags.length > MAX_TAGS ? `No more than ${MAX_TAGS} tags can be added.` : null,
-  ].filter((m): m is string => m !== null);
-
+  const allMessages = [...messages, isAtMax ? `Maximum of ${MAX_TAGS} tags reached.` : null].filter(Boolean);
   const localValidationError =
-    messages.length === 0 ? null : (
+    allMessages.length === 0 ? null : (
       <>
-        {messages.map((m) => (
+        {allMessages.map((m) => (
           <div key={m}>{m}</div>
         ))}
       </>
@@ -157,55 +135,22 @@ const TagsEditor = ({ tags, onChange, disabled = false, error = null }: Props) =
   return (
     <FormGroup controlId="event-definition-tags" validationState={combinedError ? 'error' : null}>
       <Select
-        // Neither of these is in `Select`'s Props type, but `Select` spreads unknown props
-        // through to react-select, so the cast exists only to satisfy tsc.
-        // - `menuIsOpen` — keep the menu shut while the value is invalid, since an open menu
-        //   covers the message saying why it was rejected.
-        // - `onKeyDown` — react-select rejects a duplicate with no chip and no callback, so
-        //   Enter / Tab has to flag it explicitly.
+        {...selectProps}
+        {...reactSelectProps}
+        // Not in `Select`'s Props type, so cast to satisfy tsc. react-select rejects a duplicate
+        // with no chip and no callback, so Enter / Tab has to flag it explicitly.
         {...({
           onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === 'Tab') {
               flagDuplicateAttempt();
             }
           },
-          // An invalid value has nothing to suggest, and leaving the menu open would cover the
-          // message explaining why it was rejected.
-          menuIsOpen: buildInputMessage(input) ? false : undefined,
-          isValidNewOption: (value: string) => {
-            const candidate = normalizeTag(value ?? '');
-
-            return (
-              candidate.length > 0 &&
-              !isTooLong(candidate) &&
-              !hasInvalidChars(candidate) &&
-              // Replaces react-select's default duplicate check, which this prop overrides.
-              !tags.includes(candidate) &&
-              !suggestions.some((option) => option.value === candidate) &&
-              tags.length < MAX_TAGS
-            );
-          },
         } as object)}
-        // Own the typed text so react-select's blur / menu-close clears don't drop a rejected
-        // value before the user can correct it.
-        inputValue={input}
         inputId="event-definition-tags"
         aria-label="Event Definition Tags"
         multi
         allowCreate
-        delimiter={VALUE_DELIMITER}
         options={suggestions}
-        value={tags.join(VALUE_DELIMITER)}
-        onChange={handleChange}
-        onInputChange={(value, actionMeta) => {
-          if (actionMeta?.action === 'input-change') {
-            setInput(value);
-            // The user is editing — clear any stale duplicate warning. It re-evaluates on
-            // the next commit attempt.
-            setDuplicateAttempt(null);
-          }
-        }}
-        onBlur={flagDuplicateAttempt}
         isLoading={isFetching}
         disabled={disabled}
         placeholder="e.g. authentication, brute-force, compliance"


### PR DESCRIPTION
Improve the experience for validation of Tags by preventing invalid tags from even being added into the field as chips.

Previously, invalid tags could be entered and added, and then they would appear as a full chip in the Tags select field. A validation message would appear below them in red indicating which tag was invalid. But the fact that they were allowed to be added was a bit of an invalid signal despite the validation message below.

Now tags with invalid characters can't even be added at all, so it's not even possible to get into an invalid state with these. When an invalid tag is entered, the validation message will immediately show below, and the tag cannot be added. (Tags only support lowercase letters, digits, hyphens, underscores and dots, so spaces, special characters and non-ASCII characters are not allowed, and a tag cannot exceed 128 characters.)

Before

<img width="1091" height="362" alt="image" src="https://github.com/user-attachments/assets/63d8db75-5347-44ef-becb-f6ccd05fabee" />

After
<img width="1258" height="402" alt="image" src="https://github.com/user-attachments/assets/06056138-a67f-447f-b7c8-215e2e2ae732" />

Part of https://github.com/Graylog2/graylog-plugin-enterprise/pull/15594

Fixes https://github.com/Graylog2/graylog2-server/issues/27215
